### PR TITLE
Add internationalization package to prepare for localization

### DIFF
--- a/packages/smooth_app/analysis_options.yaml
+++ b/packages/smooth_app/analysis_options.yaml
@@ -11,6 +11,8 @@ analyzer:
     - "bin/cache/**"
     - "lib/i18n/messages_*.dart"
     - "lib/src/http/**"
+    # ignore generated code from flutter intl plugin
+    - "lib/generated/intl/messages_*.dart"
 
 linter:
   rules:

--- a/packages/smooth_app/ios/Runner/Info.plist
+++ b/packages/smooth_app/ios/Runner/Info.plist
@@ -41,5 +41,9 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>en</string>
+	</array>
 </dict>
 </plist>

--- a/packages/smooth_app/ios/Runner/Info.plist
+++ b/packages/smooth_app/ios/Runner/Info.plist
@@ -44,6 +44,8 @@
 	<key>CFBundleLocalizations</key>
 	<array>
 		<string>en</string>
+		<string>ja</string>
+		<string>zh-Hant</string>
 	</array>
 </dict>
 </plist>

--- a/packages/smooth_app/lib/bottom_sheet_views/user_preferences_view.dart
+++ b/packages/smooth_app/lib/bottom_sheet_views/user_preferences_view.dart
@@ -42,15 +42,18 @@ class UserPreferencesView extends StatelessWidget {
                           ),
                         ),
                         Column(
-                            mainAxisSize: MainAxisSize.min,
-                            children: List<Widget>.generate(
-                                UserPreferencesVariableExtension
-                                        .getMandatoryVariables()
-                                    .length,
-                                (int index) => _generateMandatoryRow(
-                                    UserPreferencesVariableExtension
-                                            .getMandatoryVariables()
-                                        .elementAt(index)))),
+                          mainAxisSize: MainAxisSize.min,
+                          children: List<Widget>.generate(
+                            UserPreferencesVariableExtension
+                                    .getMandatoryVariables()
+                                .length,
+                            (int index) => _generateMandatoryRow(
+                              UserPreferencesVariableExtension
+                                      .getMandatoryVariables()
+                                  .elementAt(index),
+                            ),
+                          ),
+                        ),
                         Container(
                           padding: const EdgeInsets.symmetric(horizontal: 20.0),
                           margin: const EdgeInsets.only(top: 20.0),
@@ -60,15 +63,18 @@ class UserPreferencesView extends StatelessWidget {
                           ),
                         ),
                         Column(
-                            mainAxisSize: MainAxisSize.min,
-                            children: List<Widget>.generate(
-                                UserPreferencesVariableExtension
-                                        .getAccountableVariables()
-                                    .length,
-                                (int index) => _generateMandatoryRow(
-                                    UserPreferencesVariableExtension
-                                            .getAccountableVariables()
-                                        .elementAt(index)))),
+                          mainAxisSize: MainAxisSize.min,
+                          children: List<Widget>.generate(
+                            UserPreferencesVariableExtension
+                                    .getAccountableVariables()
+                                .length,
+                            (int index) => _generateMandatoryRow(
+                              UserPreferencesVariableExtension
+                                      .getAccountableVariables()
+                                  .elementAt(index),
+                            ),
+                          ),
+                        ),
                         SizedBox(
                           height: MediaQuery.of(context).size.height * 0.15,
                         )

--- a/packages/smooth_app/lib/bottom_sheet_views/user_preferences_view.dart
+++ b/packages/smooth_app/lib/bottom_sheet_views/user_preferences_view.dart
@@ -3,6 +3,7 @@ import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/user_preferences_model.dart';
+import 'package:smooth_app/generated/l10n.dart';
 import 'package:smooth_app/temp/user_preferences.dart';
 import 'package:smooth_ui_library/buttons/smooth_main_button.dart';
 import 'package:smooth_ui_library/widgets/smooth_toggle.dart';
@@ -16,103 +17,102 @@ class UserPreferencesView extends StatelessWidget {
   Widget build(BuildContext context) {
     return Material(
       child: ChangeNotifierProvider<UserPreferencesModel>(
-          create: (BuildContext context) => UserPreferencesModel(),
-          child: Container(
-            height: MediaQuery.of(context).size.height * 0.9,
-            child: Stack(
-              children: <Widget>[
-                Column(
-                  mainAxisSize: MainAxisSize.max,
-                  mainAxisAlignment: MainAxisAlignment.end,
-                  children: <Widget>[
-                    Container(
-                      height: MediaQuery.of(context).size.height * 0.9,
-                      child: ListView(
-                        controller: _scrollController,
-                        shrinkWrap: true,
-                        scrollDirection: Axis.vertical,
-                        children: <Widget>[
-                          Container(
-                            padding:
-                                const EdgeInsets.symmetric(horizontal: 20.0),
-                            margin: const EdgeInsets.only(top: 20.0),
-                            child: Text(
-                              'Mandatory',
-                              style: Theme.of(context).textTheme.headline1,
-                            ),
+        create: (BuildContext context) => UserPreferencesModel(),
+        child: Container(
+          height: MediaQuery.of(context).size.height * 0.9,
+          child: Stack(
+            children: <Widget>[
+              Column(
+                mainAxisSize: MainAxisSize.max,
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: <Widget>[
+                  Container(
+                    height: MediaQuery.of(context).size.height * 0.9,
+                    child: ListView(
+                      controller: _scrollController,
+                      shrinkWrap: true,
+                      scrollDirection: Axis.vertical,
+                      children: <Widget>[
+                        Container(
+                          padding: const EdgeInsets.symmetric(horizontal: 20.0),
+                          margin: const EdgeInsets.only(top: 20.0),
+                          child: Text(
+                            S.of(context).mandatory,
+                            style: Theme.of(context).textTheme.headline1,
                           ),
-                          Column(
-                              mainAxisSize: MainAxisSize.min,
-                              children: List<Widget>.generate(
-                                  UserPreferencesVariableExtension
-                                          .getMandatoryVariables()
-                                      .length,
-                                  (int index) => _generateMandatoryRow(
-                                      UserPreferencesVariableExtension
-                                              .getMandatoryVariables()
-                                          .elementAt(index)))),
-                          Container(
-                            padding:
-                                const EdgeInsets.symmetric(horizontal: 20.0),
-                            margin: const EdgeInsets.only(top: 20.0),
-                            child: Text(
-                              'Accountable',
-                              style: Theme.of(context).textTheme.headline1,
-                            ),
-                          ),
-                          Column(
-                              mainAxisSize: MainAxisSize.min,
-                              children: List<Widget>.generate(
-                                  UserPreferencesVariableExtension
-                                          .getAccountableVariables()
-                                      .length,
-                                  (int index) => _generateMandatoryRow(
-                                      UserPreferencesVariableExtension
-                                              .getAccountableVariables()
-                                          .elementAt(index)))),
-                          SizedBox(
-                            height: MediaQuery.of(context).size.height * 0.15,
-                          )
-                        ],
-                      ),
-                    ),
-                  ],
-                ),
-                Column(
-                  mainAxisSize: MainAxisSize.max,
-                  mainAxisAlignment: MainAxisAlignment.end,
-                  children: <Widget>[
-                    ClipRect(
-                      child: BackdropFilter(
-                        filter: ImageFilter.blur(
-                          sigmaX: 4.0,
-                          sigmaY: 4.0,
                         ),
-                        child: Container(
-                          color: Colors.black12,
-                          padding: const EdgeInsets.symmetric(
-                              horizontal: 12.0, vertical: 20.0),
-                          child: Consumer<UserPreferencesModel>(
-                            builder: (BuildContext context,
-                                UserPreferencesModel userPreferencesModel,
-                                Widget child) {
-                              return SmoothMainButton(
-                                text: 'Save',
-                                onPressed: () {
-                                  userPreferencesModel.saveUserPreferences();
-                                  Navigator.pop(context);
-                                },
-                              );
-                            },
+                        Column(
+                            mainAxisSize: MainAxisSize.min,
+                            children: List<Widget>.generate(
+                                UserPreferencesVariableExtension
+                                        .getMandatoryVariables()
+                                    .length,
+                                (int index) => _generateMandatoryRow(
+                                    UserPreferencesVariableExtension
+                                            .getMandatoryVariables()
+                                        .elementAt(index)))),
+                        Container(
+                          padding: const EdgeInsets.symmetric(horizontal: 20.0),
+                          margin: const EdgeInsets.only(top: 20.0),
+                          child: Text(
+                            S.of(context).accountable,
+                            style: Theme.of(context).textTheme.headline1,
                           ),
+                        ),
+                        Column(
+                            mainAxisSize: MainAxisSize.min,
+                            children: List<Widget>.generate(
+                                UserPreferencesVariableExtension
+                                        .getAccountableVariables()
+                                    .length,
+                                (int index) => _generateMandatoryRow(
+                                    UserPreferencesVariableExtension
+                                            .getAccountableVariables()
+                                        .elementAt(index)))),
+                        SizedBox(
+                          height: MediaQuery.of(context).size.height * 0.15,
+                        )
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+              Column(
+                mainAxisSize: MainAxisSize.max,
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: <Widget>[
+                  ClipRect(
+                    child: BackdropFilter(
+                      filter: ImageFilter.blur(
+                        sigmaX: 4.0,
+                        sigmaY: 4.0,
+                      ),
+                      child: Container(
+                        color: Colors.black12,
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 12.0, vertical: 20.0),
+                        child: Consumer<UserPreferencesModel>(
+                          builder: (BuildContext context,
+                              UserPreferencesModel userPreferencesModel,
+                              Widget child) {
+                            return SmoothMainButton(
+                              text: S.of(context).saveButtonText,
+                              onPressed: () {
+                                userPreferencesModel.saveUserPreferences();
+                                Navigator.pop(context);
+                              },
+                            );
+                          },
                         ),
                       ),
                     ),
-                  ],
-                ),
-              ],
-            ),
-          )),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
     );
   }
 
@@ -130,9 +130,11 @@ class UserPreferencesView extends StatelessWidget {
           Text(variable.name),
           Consumer<UserPreferencesModel>(
             builder: (BuildContext context,
-              UserPreferencesModel userPreferencesModel, Widget child) {
+                UserPreferencesModel userPreferencesModel, Widget child) {
               return SmoothToggle(
-                value: userPreferencesModel.dataLoaded ? userPreferencesModel.getVariable(variable) : userPreferencesModel.dataLoaded,
+                value: userPreferencesModel.dataLoaded
+                    ? userPreferencesModel.getVariable(variable)
+                    : userPreferencesModel.dataLoaded,
                 onChanged: (bool newValue) {
                   userPreferencesModel.setVariable(variable, newValue);
                 },

--- a/packages/smooth_app/lib/generated/intl/messages_all.dart
+++ b/packages/smooth_app/lib/generated/intl/messages_all.dart
@@ -1,0 +1,63 @@
+// DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
+// This is a library that looks up messages for specific locales by
+// delegating to the appropriate library.
+
+// Ignore issues from commonly used lints in this file.
+// ignore_for_file:implementation_imports, file_names, unnecessary_new
+// ignore_for_file:unnecessary_brace_in_string_interps, directives_ordering
+// ignore_for_file:argument_type_not_assignable, invalid_assignment
+// ignore_for_file:prefer_single_quotes, prefer_generic_function_type_aliases
+// ignore_for_file:comment_references
+
+import 'dart:async';
+
+import 'package:intl/intl.dart';
+import 'package:intl/message_lookup_by_library.dart';
+import 'package:intl/src/intl_helpers.dart';
+
+import 'messages_en.dart' as messages_en;
+
+typedef Future<dynamic> LibraryLoader();
+Map<String, LibraryLoader> _deferredLibraries = {
+  'en': () => new Future.value(null),
+};
+
+MessageLookupByLibrary _findExact(String localeName) {
+  switch (localeName) {
+    case 'en':
+      return messages_en.messages;
+    default:
+      return null;
+  }
+}
+
+/// User programs should call this before using [localeName] for messages.
+Future<bool> initializeMessages(String localeName) async {
+  var availableLocale = Intl.verifiedLocale(
+    localeName,
+    (locale) => _deferredLibraries[locale] != null,
+    onFailure: (_) => null);
+  if (availableLocale == null) {
+    return new Future.value(false);
+  }
+  var lib = _deferredLibraries[availableLocale];
+  await (lib == null ? new Future.value(false) : lib());
+  initializeInternalMessageLookup(() => new CompositeMessageLookup());
+  messageLookup.addLocale(availableLocale, _findGeneratedMessagesFor);
+  return new Future.value(true);
+}
+
+bool _messagesExistFor(String locale) {
+  try {
+    return _findExact(locale) != null;
+  } catch (e) {
+    return false;
+  }
+}
+
+MessageLookupByLibrary _findGeneratedMessagesFor(String locale) {
+  var actualLocale = Intl.verifiedLocale(locale, _messagesExistFor,
+      onFailure: (_) => null);
+  if (actualLocale == null) return null;
+  return _findExact(actualLocale);
+}

--- a/packages/smooth_app/lib/generated/intl/messages_all.dart
+++ b/packages/smooth_app/lib/generated/intl/messages_all.dart
@@ -16,16 +16,24 @@ import 'package:intl/message_lookup_by_library.dart';
 import 'package:intl/src/intl_helpers.dart';
 
 import 'messages_en.dart' as messages_en;
+import 'messages_ja.dart' as messages_ja;
+import 'messages_zh_Hant.dart' as messages_zh_hant;
 
 typedef Future<dynamic> LibraryLoader();
 Map<String, LibraryLoader> _deferredLibraries = {
   'en': () => new Future.value(null),
+  'ja': () => new Future.value(null),
+  'zh_Hant': () => new Future.value(null),
 };
 
 MessageLookupByLibrary _findExact(String localeName) {
   switch (localeName) {
     case 'en':
       return messages_en.messages;
+    case 'ja':
+      return messages_ja.messages;
+    case 'zh_Hant':
+      return messages_zh_hant.messages;
     default:
       return null;
   }

--- a/packages/smooth_app/lib/generated/intl/messages_en.dart
+++ b/packages/smooth_app/lib/generated/intl/messages_en.dart
@@ -1,0 +1,39 @@
+// DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
+// This is a library that provides messages for a en locale. All the
+// messages from the main program should be duplicated here with the same
+// function name.
+
+// Ignore issues from commonly used lints in this file.
+// ignore_for_file:unnecessary_brace_in_string_interps, unnecessary_new
+// ignore_for_file:prefer_single_quotes,comment_references, directives_ordering
+// ignore_for_file:annotate_overrides,prefer_generic_function_type_aliases
+// ignore_for_file:unused_import, file_names
+
+import 'package:intl/intl.dart';
+import 'package:intl/message_lookup_by_library.dart';
+
+final messages = new MessageLookup();
+
+typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
+
+class MessageLookup extends MessageLookupByLibrary {
+  String get localeName => 'en';
+
+  final messages = _notInlinedMessages(_notInlinedMessages);
+  static _notInlinedMessages(_) => <String, Function> {
+    "accountable" : MessageLookupByLibrary.simpleMessage("Accountable"),
+    "categories" : MessageLookupByLibrary.simpleMessage("Categories"),
+    "collaborationPage" : MessageLookupByLibrary.simpleMessage("Collaboration Page"),
+    "mandatory" : MessageLookupByLibrary.simpleMessage("Mandatory"),
+    "organizationPage" : MessageLookupByLibrary.simpleMessage("Organization Page"),
+    "preferencesText" : MessageLookupByLibrary.simpleMessage("My Preferences"),
+    "saveButtonText" : MessageLookupByLibrary.simpleMessage("Save"),
+    "scanProductTitle" : MessageLookupByLibrary.simpleMessage("Scan products"),
+    "searchHintText" : MessageLookupByLibrary.simpleMessage("Enter a barcode, category or product name"),
+    "searchTitle" : MessageLookupByLibrary.simpleMessage("Search.\nFind the perfect product"),
+    "showAll" : MessageLookupByLibrary.simpleMessage("showAll"),
+    "testerSettingTitle" : MessageLookupByLibrary.simpleMessage("Testers settings"),
+    "trackingPage" : MessageLookupByLibrary.simpleMessage("Tracking Page"),
+    "useMLKitText" : MessageLookupByLibrary.simpleMessage("Use ML Kit powered scanner")
+  };
+}

--- a/packages/smooth_app/lib/generated/intl/messages_ja.dart
+++ b/packages/smooth_app/lib/generated/intl/messages_ja.dart
@@ -1,0 +1,39 @@
+// DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
+// This is a library that provides messages for a ja locale. All the
+// messages from the main program should be duplicated here with the same
+// function name.
+
+// Ignore issues from commonly used lints in this file.
+// ignore_for_file:unnecessary_brace_in_string_interps, unnecessary_new
+// ignore_for_file:prefer_single_quotes,comment_references, directives_ordering
+// ignore_for_file:annotate_overrides,prefer_generic_function_type_aliases
+// ignore_for_file:unused_import, file_names
+
+import 'package:intl/intl.dart';
+import 'package:intl/message_lookup_by_library.dart';
+
+final messages = new MessageLookup();
+
+typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
+
+class MessageLookup extends MessageLookupByLibrary {
+  String get localeName => 'ja';
+
+  final messages = _notInlinedMessages(_notInlinedMessages);
+  static _notInlinedMessages(_) => <String, Function> {
+    "accountable" : MessageLookupByLibrary.simpleMessage("Accountable"),
+    "categories" : MessageLookupByLibrary.simpleMessage("カテゴリ"),
+    "collaborationPage" : MessageLookupByLibrary.simpleMessage("Collaboration Page"),
+    "mandatory" : MessageLookupByLibrary.simpleMessage("Mandatory"),
+    "organizationPage" : MessageLookupByLibrary.simpleMessage("Organization Page"),
+    "preferencesText" : MessageLookupByLibrary.simpleMessage("My Preferences"),
+    "saveButtonText" : MessageLookupByLibrary.simpleMessage("セーブ"),
+    "scanProductTitle" : MessageLookupByLibrary.simpleMessage("プロダクトをスキャン"),
+    "searchHintText" : MessageLookupByLibrary.simpleMessage("バーコード、カテゴリや食品の名前を入力"),
+    "searchTitle" : MessageLookupByLibrary.simpleMessage("Search.\nFind the perfect product"),
+    "showAll" : MessageLookupByLibrary.simpleMessage("すべてを表示"),
+    "testerSettingTitle" : MessageLookupByLibrary.simpleMessage("テスター設定"),
+    "trackingPage" : MessageLookupByLibrary.simpleMessage("Tracking Page"),
+    "useMLKitText" : MessageLookupByLibrary.simpleMessage("ML Kitスキャナーを利用する")
+  };
+}

--- a/packages/smooth_app/lib/generated/intl/messages_zh_Hant.dart
+++ b/packages/smooth_app/lib/generated/intl/messages_zh_Hant.dart
@@ -1,0 +1,39 @@
+// DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
+// This is a library that provides messages for a zh_Hant locale. All the
+// messages from the main program should be duplicated here with the same
+// function name.
+
+// Ignore issues from commonly used lints in this file.
+// ignore_for_file:unnecessary_brace_in_string_interps, unnecessary_new
+// ignore_for_file:prefer_single_quotes,comment_references, directives_ordering
+// ignore_for_file:annotate_overrides,prefer_generic_function_type_aliases
+// ignore_for_file:unused_import, file_names
+
+import 'package:intl/intl.dart';
+import 'package:intl/message_lookup_by_library.dart';
+
+final messages = new MessageLookup();
+
+typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
+
+class MessageLookup extends MessageLookupByLibrary {
+  String get localeName => 'zh_Hant';
+
+  final messages = _notInlinedMessages(_notInlinedMessages);
+  static _notInlinedMessages(_) => <String, Function> {
+    "accountable" : MessageLookupByLibrary.simpleMessage("Accountable"),
+    "categories" : MessageLookupByLibrary.simpleMessage("種類"),
+    "collaborationPage" : MessageLookupByLibrary.simpleMessage("Collaboration Page"),
+    "mandatory" : MessageLookupByLibrary.simpleMessage("Mandatory"),
+    "organizationPage" : MessageLookupByLibrary.simpleMessage("Organization Page"),
+    "preferencesText" : MessageLookupByLibrary.simpleMessage("偏好"),
+    "saveButtonText" : MessageLookupByLibrary.simpleMessage("儲存"),
+    "scanProductTitle" : MessageLookupByLibrary.simpleMessage("掃描產品"),
+    "searchHintText" : MessageLookupByLibrary.simpleMessage("輸入條碼、種類或產品"),
+    "searchTitle" : MessageLookupByLibrary.simpleMessage("Search.\nFind the perfect product"),
+    "showAll" : MessageLookupByLibrary.simpleMessage("全部表示"),
+    "testerSettingTitle" : MessageLookupByLibrary.simpleMessage("測試者設定"),
+    "trackingPage" : MessageLookupByLibrary.simpleMessage("Tracking Page"),
+    "useMLKitText" : MessageLookupByLibrary.simpleMessage("利用ML Kit掃描器")
+  };
+}

--- a/packages/smooth_app/lib/generated/l10n.dart
+++ b/packages/smooth_app/lib/generated/l10n.dart
@@ -180,6 +180,8 @@ class AppLocalizationDelegate extends LocalizationsDelegate<S> {
   List<Locale> get supportedLocales {
     return const <Locale>[
       Locale.fromSubtags(languageCode: 'en'),
+      Locale.fromSubtags(languageCode: 'ja'),
+      Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant'),
     ];
   }
 

--- a/packages/smooth_app/lib/generated/l10n.dart
+++ b/packages/smooth_app/lib/generated/l10n.dart
@@ -1,0 +1,203 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'intl/messages_all.dart';
+
+// **************************************************************************
+// Generator: Flutter Intl IDE plugin
+// Made by Localizely
+// **************************************************************************
+
+// ignore_for_file: non_constant_identifier_names, lines_longer_than_80_chars
+
+class S {
+  S();
+  
+  static S current;
+  
+  static const AppLocalizationDelegate delegate =
+    AppLocalizationDelegate();
+
+  static Future<S> load(Locale locale) {
+    final name = (locale.countryCode?.isEmpty ?? false) ? locale.languageCode : locale.toString();
+    final localeName = Intl.canonicalizedLocale(name); 
+    return initializeMessages(localeName).then((_) {
+      Intl.defaultLocale = localeName;
+      S.current = S();
+      
+      return S.current;
+    });
+  } 
+
+  static S of(BuildContext context) {
+    return Localizations.of<S>(context, S);
+  }
+
+  /// `Search.\nFind the perfect product`
+  String get searchTitle {
+    return Intl.message(
+      'Search.\nFind the perfect product',
+      name: 'searchTitle',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Enter a barcode, category or product name`
+  String get searchHintText {
+    return Intl.message(
+      'Enter a barcode, category or product name',
+      name: 'searchHintText',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Categories`
+  String get categories {
+    return Intl.message(
+      'Categories',
+      name: 'categories',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `showAll`
+  String get showAll {
+    return Intl.message(
+      'showAll',
+      name: 'showAll',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Scan products`
+  String get scanProductTitle {
+    return Intl.message(
+      'Scan products',
+      name: 'scanProductTitle',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Testers settings`
+  String get testerSettingTitle {
+    return Intl.message(
+      'Testers settings',
+      name: 'testerSettingTitle',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Use ML Kit powered scanner`
+  String get useMLKitText {
+    return Intl.message(
+      'Use ML Kit powered scanner',
+      name: 'useMLKitText',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Organization Page`
+  String get organizationPage {
+    return Intl.message(
+      'Organization Page',
+      name: 'organizationPage',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Collaboration Page`
+  String get collaborationPage {
+    return Intl.message(
+      'Collaboration Page',
+      name: 'collaborationPage',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Tracking Page`
+  String get trackingPage {
+    return Intl.message(
+      'Tracking Page',
+      name: 'trackingPage',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `My Preferences`
+  String get preferencesText {
+    return Intl.message(
+      'My Preferences',
+      name: 'preferencesText',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Mandatory`
+  String get mandatory {
+    return Intl.message(
+      'Mandatory',
+      name: 'mandatory',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Accountable`
+  String get accountable {
+    return Intl.message(
+      'Accountable',
+      name: 'accountable',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Save`
+  String get saveButtonText {
+    return Intl.message(
+      'Save',
+      name: 'saveButtonText',
+      desc: '',
+      args: [],
+    );
+  }
+}
+
+class AppLocalizationDelegate extends LocalizationsDelegate<S> {
+  const AppLocalizationDelegate();
+
+  List<Locale> get supportedLocales {
+    return const <Locale>[
+      Locale.fromSubtags(languageCode: 'en'),
+    ];
+  }
+
+  @override
+  bool isSupported(Locale locale) => _isSupported(locale);
+  @override
+  Future<S> load(Locale locale) => S.load(locale);
+  @override
+  bool shouldReload(AppLocalizationDelegate old) => false;
+
+  bool _isSupported(Locale locale) {
+    if (locale != null) {
+      for (var supportedLocale in supportedLocales) {
+        if (supportedLocale.languageCode == locale.languageCode) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+}

--- a/packages/smooth_app/lib/l10n/intl_en.arb
+++ b/packages/smooth_app/lib/l10n/intl_en.arb
@@ -1,0 +1,17 @@
+{
+  "@@locale": "en",
+  "searchTitle": "Search.\nFind the perfect product",
+  "searchHintText": "Enter a barcode, category or product name",
+  "categories": "Categories",
+  "showAll": "showAll",
+  "scanProductTitle": "Scan products",
+  "testerSettingTitle": "Testers settings",
+  "useMLKitText": "Use ML Kit powered scanner",
+  "organizationPage": "Organization Page",
+  "collaborationPage": "Collaboration Page",
+  "trackingPage": "Tracking Page",
+  "preferencesText": "My Preferences",
+  "mandatory": "Mandatory",
+  "accountable": "Accountable",
+  "saveButtonText": "Save"
+}

--- a/packages/smooth_app/lib/l10n/intl_ja.arb
+++ b/packages/smooth_app/lib/l10n/intl_ja.arb
@@ -1,0 +1,17 @@
+{
+  "@@locale": "ja",
+  "searchTitle": "Search.\nFind the perfect product",
+  "searchHintText": "バーコード、カテゴリや食品の名前を入力",
+  "categories": "カテゴリ",
+  "showAll": "すべてを表示",
+  "scanProductTitle": "プロダクトをスキャン",
+  "testerSettingTitle": "テスター設定",
+  "useMLKitText": "ML Kitスキャナーを利用する",
+  "organizationPage": "Organization Page",
+  "collaborationPage": "Collaboration Page",
+  "trackingPage": "Tracking Page",
+  "preferencesText": "My Preferences",
+  "mandatory": "Mandatory",
+  "accountable": "Accountable",
+  "saveButtonText": "セーブ"
+}

--- a/packages/smooth_app/lib/l10n/intl_zh_Hant.arb
+++ b/packages/smooth_app/lib/l10n/intl_zh_Hant.arb
@@ -1,0 +1,17 @@
+{
+  "@@locale": "zh_Hant",
+  "searchTitle": "Search.\nFind the perfect product",
+  "searchHintText": "輸入條碼、種類或產品",
+  "categories": "種類",
+  "showAll": "全部表示",
+  "scanProductTitle": "掃描產品",
+  "testerSettingTitle": "測試者設定",
+  "useMLKitText": "利用ML Kit掃描器",
+  "organizationPage": "Organization Page",
+  "collaborationPage": "Collaboration Page",
+  "trackingPage": "Tracking Page",
+  "preferencesText": "偏好",
+  "mandatory": "Mandatory",
+  "accountable": "Accountable",
+  "saveButtonText": "儲存"
+}

--- a/packages/smooth_app/lib/main.dart
+++ b/packages/smooth_app/lib/main.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:smooth_app/bottom_sheet_views/user_preferences_view.dart';
-import 'package:smooth_app/pages/alternative_continuous_scan_page.dart';
 
+import 'package:smooth_app/bottom_sheet_views/user_preferences_view.dart';
+import 'package:smooth_app/generated/l10n.dart';
+import 'package:smooth_app/pages/alternative_continuous_scan_page.dart';
 import 'package:smooth_app/pages/choose_page.dart';
 import 'package:smooth_app/pages/collaboration_page.dart';
 import 'package:smooth_app/pages/continuous_scan_page.dart';
@@ -18,10 +20,19 @@ import 'package:smooth_ui_library/navigation/models/smooth_navigation_layout_mod
 import 'package:smooth_ui_library/navigation/models/smooth_navigation_screen_model.dart';
 import 'package:smooth_ui_library/navigation/smooth_navigation_layout.dart';
 
-void main() => runApp(MaterialApp(
-      home: SmoothApp(),
-      theme: SmoothThemes.getSmoothThemeData(),
-    ));
+void main() => runApp(
+      MaterialApp(
+        localizationsDelegates: const <LocalizationsDelegate<dynamic>>[
+          S.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: S.delegate.supportedLocales,
+        home: SmoothApp(),
+        theme: SmoothThemes.getSmoothThemeData(),
+      ),
+    );
 
 class SmoothApp extends StatelessWidget {
   final double _navigationIconSize = 24.0;
@@ -62,7 +73,7 @@ class SmoothApp extends StatelessWidget {
       ),
       page: ChoosePage(),
       action: SmoothNavigationActionModel(
-        title: 'Scan products',
+        title: S.of(context).scanProductTitle,
         icon: Container(
           padding: EdgeInsets.all(_navigationIconPadding),
           child: SvgPicture.asset(
@@ -72,8 +83,11 @@ class SmoothApp extends StatelessWidget {
           ),
         ),
         onTap: () async {
-          final SharedPreferences sharedPreferences = await SharedPreferences.getInstance();
-          final Widget newPage = sharedPreferences.getBool('useMlKit') ?? true ? ContinuousScanPage() : AlternativeContinuousScanPage();
+          final SharedPreferences sharedPreferences =
+              await SharedPreferences.getInstance();
+          final Widget newPage = sharedPreferences.getBool('useMlKit') ?? true
+              ? ContinuousScanPage()
+              : AlternativeContinuousScanPage();
           Navigator.push<Widget>(
             context,
             MaterialPageRoute<Widget>(
@@ -139,7 +153,7 @@ class SmoothApp extends StatelessWidget {
       ),
       page: ProfilePage(),
       action: SmoothNavigationActionModel(
-        title: 'My preferences',
+        title: S.of(context).preferencesText,
         icon: Container(
           padding: EdgeInsets.all(_navigationIconPadding),
           child: SvgPicture.asset(

--- a/packages/smooth_app/lib/pages/choose_page.dart
+++ b/packages/smooth_app/lib/pages/choose_page.dart
@@ -6,81 +6,86 @@ import 'package:smooth_app/cards/category_cards/category_chip.dart';
 import 'package:smooth_app/cards/category_cards/subcategory_card.dart';
 import 'package:smooth_app/data_models/choose_page_model.dart';
 import 'package:smooth_ui_library/widgets/smooth_search_bar.dart';
+import 'package:smooth_app/generated/l10n.dart';
 
 class ChoosePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        body: ChangeNotifierProvider<ChoosePageModel>(
-            create: (BuildContext context) => ChoosePageModel(),
-            child: Column(
-              children: <Widget>[
-                Padding(
-                  padding: const EdgeInsets.only(
-                      top: 46.0, right: 16.0, left: 16.0, bottom: 4.0),
-                  child: Row(
-                    children: <Widget>[
-                      Flexible(
+      body: ChangeNotifierProvider<ChoosePageModel>(
+        create: (BuildContext context) => ChoosePageModel(),
+        child: Column(
+          children: <Widget>[
+            Padding(
+              padding: const EdgeInsets.only(
+                  top: 46.0, right: 16.0, left: 16.0, bottom: 4.0),
+              child: Row(
+                children: <Widget>[
+                  Flexible(
+                    child: Text(
+                      S.of(context).searchTitle,
+                      style: Theme.of(context).textTheme.headline1,
+                    ),
+                  )
+                ],
+              ),
+            ),
+            Padding(
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 16.0, vertical: 12.0),
+              child: SmoothSearchBar(
+                hintText: S.of(context).searchHintText,
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.only(
+                left: 12.0,
+                right: 12.0,
+                top: 8.0,
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.max,
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: <Widget>[
+                  Flexible(
+                    child: Text(
+                      S.of(context).categories,
+                      style: Theme.of(context).textTheme.headline3,
+                    ),
+                  ),
+                  Consumer<ChoosePageModel>(
+                    builder: (BuildContext context,
+                        ChoosePageModel choosePageModel, Widget child) {
+                      return MaterialButton(
                         child: Text(
-                          'Search.\nFind the perfect product',
-                          style: Theme.of(context).textTheme.headline1,
+                          S.of(context).showAll,
+                          style: Theme.of(context)
+                              .textTheme
+                              .subtitle1
+                              .copyWith(color: Colors.black),
                         ),
-                      )
-                    ],
+                        onPressed: () {
+                          choosePageModel.unSelectCategory();
+                        },
+                      );
+                    },
                   ),
-                ),
-                const Padding(
-                  padding:
-                      EdgeInsets.symmetric(horizontal: 16.0, vertical: 12.0),
-                  child: SmoothSearchBar(
-                    hintText: 'Enter a barcode, category or product name',
-                  ),
-                ),
-                Padding(
-                  padding: const EdgeInsets.only(
-                    left: 12.0,
-                    right: 12.0,
-                    top: 8.0,
-                  ),
-                  child: Row(
-                    mainAxisSize: MainAxisSize.max,
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: <Widget>[
-                      Flexible(
-                        child: Text(
-                          'Categories',
-                          style: Theme.of(context).textTheme.headline3,
-                        ),
-                      ),
-                      Consumer<ChoosePageModel>(builder: (BuildContext context,
-                          ChoosePageModel choosePageModel, Widget child) {
-                        return MaterialButton(
-                          child: Text(
-                            'Show all',
-                            style: Theme.of(context)
-                                .textTheme
-                                .subtitle1
-                                .copyWith(color: Colors.black),
-                          ),
-                          onPressed: () {
-                            choosePageModel.unSelectCategory();
-                          },
-                        );
-                      }),
-                    ],
-                  ),
-                ),
-                Consumer<ChoosePageModel>(builder: (BuildContext context,
-                    ChoosePageModel choosePageModel, Widget child) {
-                  if (choosePageModel.selectedCategory != null) {
-                    return Container(
-                      padding: const EdgeInsets.only(bottom: 0.0),
-                      width: MediaQuery.of(context).size.width,
-                      height: 100.0,
-                      child: ListView(
-                        scrollDirection: Axis.horizontal,
-                        children: List<Widget>.generate(
-                            choosePageModel.categories.length, (int index) {
+                ],
+              ),
+            ),
+            Consumer<ChoosePageModel>(
+              builder: (BuildContext context, ChoosePageModel choosePageModel,
+                  Widget child) {
+                if (choosePageModel.selectedCategory != null) {
+                  return Container(
+                    padding: const EdgeInsets.only(bottom: 0.0),
+                    width: MediaQuery.of(context).size.width,
+                    height: 100.0,
+                    child: ListView(
+                      scrollDirection: Axis.horizontal,
+                      children: List<Widget>.generate(
+                        choosePageModel.categories.length,
+                        (int index) {
                           final String key =
                               choosePageModel.categories.keys.toList()[index];
                           return AnimationConfiguration.staggeredList(
@@ -89,83 +94,92 @@ class ChoosePage extends StatelessWidget {
                             child: SlideAnimation(
                               verticalOffset: 50.0,
                               child: FadeInAnimation(
-                                  child: CategoryChip(
-                                title: key,
-                                color: choosePageModel.categories[key],
-                                onTap: () {
-                                  choosePageModel.selectCategory(key);
-                                },
-                              )),
+                                child: CategoryChip(
+                                  title: key,
+                                  color: choosePageModel.categories[key],
+                                  onTap: () {
+                                    choosePageModel.selectCategory(key);
+                                  },
+                                ),
+                              ),
                             ),
                           );
-                        }),
+                        },
+                      ),
+                    ),
+                  );
+                }
+                return Container();
+              },
+            ),
+            Expanded(
+              child: Consumer<ChoosePageModel>(
+                builder: (BuildContext context, ChoosePageModel choosePageModel,
+                    Widget child) {
+                  if (choosePageModel.selectedCategory == null) {
+                    return GridView.count(
+                      crossAxisCount: 2,
+                      childAspectRatio: 3 / 2,
+                      padding: const EdgeInsets.only(
+                          top: 10.0, bottom: 120.0, right: 10.0, left: 10.0),
+                      mainAxisSpacing: 20.0,
+                      crossAxisSpacing: 10.0,
+                      children: List<Widget>.generate(
+                        choosePageModel.categories.length,
+                        (int index) {
+                          final String key =
+                              choosePageModel.categories.keys.toList()[index];
+                          return AnimationConfiguration.staggeredGrid(
+                            position: index,
+                            duration: const Duration(milliseconds: 400),
+                            columnCount: 2,
+                            child: ScaleAnimation(
+                              child: FadeInAnimation(
+                                child: CategoryCard(
+                                  title: key,
+                                  color: choosePageModel.categories[key],
+                                  onTap: () {
+                                    choosePageModel.selectCategory(key);
+                                  },
+                                ),
+                              ),
+                            ),
+                          );
+                        },
                       ),
                     );
                   }
-                  return Container();
-                }),
-                Expanded(
-                  child: Consumer<ChoosePageModel>(builder:
-                      (BuildContext context, ChoosePageModel choosePageModel,
-                          Widget child) {
-                    if (choosePageModel.selectedCategory == null) {
-                      return GridView.count(
-                        crossAxisCount: 2,
-                        childAspectRatio: 3 / 2,
-                        padding: const EdgeInsets.only(
-                            top: 10.0, bottom: 120.0, right: 10.0, left: 10.0),
-                        mainAxisSpacing: 20.0,
-                        crossAxisSpacing: 10.0,
-                        children: List<Widget>.generate(
-                          choosePageModel.categories.length,
-                          (int index) {
-                            final String key =
-                                choosePageModel.categories.keys.toList()[index];
-                            return AnimationConfiguration.staggeredGrid(
-                              position: index,
-                              duration: const Duration(milliseconds: 400),
-                              columnCount: 2,
-                              child: ScaleAnimation(
-                                child: FadeInAnimation(
-                                  child: CategoryCard(
-                                    title: key,
-                                    color: choosePageModel.categories[key],
-                                    onTap: () {
-                                      choosePageModel.selectCategory(key);
-                                    },
-                                  ),
-                                ),
-                              ),
-                            );
-                          },
-                        ),
-                      );
-                    }
-                    return ListView(
-                      padding: const EdgeInsets.only(top: 8.0, bottom: 100.0),
-                      children: List<Widget>.generate(
-                          choosePageModel
-                              .subCategories[choosePageModel.selectedCategory]
-                              .length, (int index) {
+                  return ListView(
+                    padding: const EdgeInsets.only(top: 8.0, bottom: 100.0),
+                    children: List<Widget>.generate(
+                      choosePageModel
+                          .subCategories[choosePageModel.selectedCategory]
+                          .length,
+                      (int index) {
                         return AnimationConfiguration.staggeredList(
                           position: index,
                           duration: const Duration(milliseconds: 250),
                           child: SlideAnimation(
                             horizontalOffset: 50.0,
                             child: FadeInAnimation(
-                                child: SubcategoryCard(
-                              title: choosePageModel.subCategories[
-                                  choosePageModel.selectedCategory][index],
-                              color: choosePageModel
-                                  .categories[choosePageModel.selectedCategory],
-                            )),
+                              child: SubcategoryCard(
+                                title: choosePageModel.subCategories[
+                                    choosePageModel.selectedCategory][index],
+                                color: choosePageModel.categories[
+                                    choosePageModel.selectedCategory],
+                              ),
+                            ),
                           ),
                         );
-                      }),
-                    );
-                  }),
-                )
-              ],
-            )));
+                      },
+                    ),
+                  );
+                },
+              ),
+            )
+          ],
+        ),
+      ),
+    );
   }
 }

--- a/packages/smooth_app/lib/pages/collaboration_page.dart
+++ b/packages/smooth_app/lib/pages/collaboration_page.dart
@@ -1,14 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:smooth_app/generated/l10n.dart';
 
 class CollaborationPage extends StatelessWidget {
-
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
+    return Scaffold(
       body: Center(
-        child: Text('Collaboration Page'),
-      )
+        child: Text(S.of(context).collaborationPage),
+      ),
     );
   }
-
 }

--- a/packages/smooth_app/lib/pages/organization_page.dart
+++ b/packages/smooth_app/lib/pages/organization_page.dart
@@ -1,14 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:smooth_app/generated/l10n.dart';
 
 class OrganizationPage extends StatelessWidget {
-
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
+    return Scaffold(
       body: Center(
-        child: Text('Organization Page'),
-      )
+        child: Text(S.of(context).organizationPage),
+      ),
     );
   }
-
 }

--- a/packages/smooth_app/lib/pages/profile_page.dart
+++ b/packages/smooth_app/lib/pages/profile_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/profile_page_model.dart';
+import 'package:smooth_app/generated/l10n.dart';
 import 'package:smooth_ui_library/widgets/smooth_toggle.dart';
 
 class ProfilePage extends StatelessWidget {
@@ -8,29 +9,33 @@ class ProfilePage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       body: ChangeNotifierProvider<ProfilePageModel>(
-          create: (BuildContext context) => ProfilePageModel(),
-          child: Column(
-            children: <Widget>[
-              const SizedBox(height: 50.0,),
-              Text(
-                'Testers settings',
-                style: Theme.of(context).textTheme.headline1,
-                textAlign: TextAlign.start,
-              ),
-              const SizedBox(height: 10.0,),
-              Container(
-                padding: const EdgeInsets.all(10.0),
-                margin: const EdgeInsets.all(10.0),
-                decoration: BoxDecoration(
-                    color: Colors.black.withAlpha(5),
-                    borderRadius:
-                        const BorderRadius.all(Radius.circular(20.0))),
-                child: Row(
-                  mainAxisSize: MainAxisSize.max,
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: <Widget>[
-                    const Text('Use ML Kit powered scanner'),
-                    Consumer<ProfilePageModel>(builder: (BuildContext context,
+        create: (BuildContext context) => ProfilePageModel(),
+        child: Column(
+          children: <Widget>[
+            const SizedBox(
+              height: 50.0,
+            ),
+            Text(
+              S.of(context).testerSettingTitle,
+              style: Theme.of(context).textTheme.headline1,
+              textAlign: TextAlign.start,
+            ),
+            const SizedBox(
+              height: 10.0,
+            ),
+            Container(
+              padding: const EdgeInsets.all(10.0),
+              margin: const EdgeInsets.all(10.0),
+              decoration: BoxDecoration(
+                  color: Colors.black.withAlpha(5),
+                  borderRadius: const BorderRadius.all(Radius.circular(20.0))),
+              child: Row(
+                mainAxisSize: MainAxisSize.max,
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: <Widget>[
+                  Text(S.of(context).useMLKitText),
+                  Consumer<ProfilePageModel>(
+                    builder: (BuildContext context,
                         ProfilePageModel profilePageModel, Widget child) {
                       return SmoothToggle(
                         value: profilePageModel.useMlKit,
@@ -38,12 +43,14 @@ class ProfilePage extends StatelessWidget {
                           profilePageModel.setMlKitState(newValue);
                         },
                       );
-                    }),
-                  ],
-                ),
+                    },
+                  ),
+                ],
               ),
-            ],
-          )),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/packages/smooth_app/lib/pages/tracking_page.dart
+++ b/packages/smooth_app/lib/pages/tracking_page.dart
@@ -1,14 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:smooth_app/generated/l10n.dart';
 
 class TrackingPage extends StatelessWidget {
-
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
+    return Scaffold(
       body: Center(
-        child: Text('Tracking Page'),
-      )
+        child: Text(S.of(context).trackingPage),
+      ),
     );
   }
-
 }

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -1,5 +1,7 @@
 name: smooth_app
-description: A new official Open Food Facts application build with great user experience in mind.
+description:
+  A new official Open Food Facts application build with great user experience in
+  mind.
 
 # The following defines the version and build number for your application.
 # A version number is three numbers separated by dots, like 1.2.43
@@ -19,6 +21,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
 
   flutter_svg: ^0.17.4
   modal_bottom_sheet: ^0.1.5
@@ -35,24 +39,20 @@ dependencies:
   image_picker: ^0.6.7+2
   image_cropper: ^1.2.3
   flutter_staggered_animations: ^0.1.2
+  intl: ^0.16.1
 
   smooth_ui_library:
     path: ../smooth_ui_library
-
   # openfoodfacts:
   #  path: ../../../openfoodfacts-dart
-
 dev_dependencies:
   flutter_test:
     sdk: flutter
 
-
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
-
 # The following section is specific to Flutter.
 flutter:
-
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
   # the material Icons class.
@@ -64,18 +64,14 @@ flutter:
     - assets/product/
     - assets/data/
     - assets/misc/
-
   # To add assets to your application, add an assets section, like this:
   # assets:
   #  - images/a_dot_burr.jpeg
   #  - images/a_dot_ham.jpeg
-
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/assets-and-images/#resolution-aware.
-
   # For details regarding adding assets from package dependencies, see
   # https://flutter.dev/assets-and-images/#from-packages
-
   # To add custom fonts to your application, add a fonts section here,
   # in this "flutter" section. Each entry in this list should have a
   # "family" key with the font family name, and a "fonts" key with a
@@ -95,3 +91,6 @@ flutter:
   #
   # For details regarding fonts from package dependencies,
   # see https://flutter.dev/custom-fonts/#from-packages
+
+flutter_intl:
+  enabled: true


### PR DESCRIPTION
This provides a bare bones implementation using [intl](https://pub.dev/packages/intl) package and [Flutter Intl](https://plugins.jetbrains.com/plugin/13666-flutter-intl) plugin to make it easier to localize the app down the road.

* use `intl` as suggested in the [offical docs](https://flutter.dev/docs/development/accessibility-and-localization/internationalization) to enable internationalization
* use [this IDE plugin](https://plugins.jetbrains.com/plugin/13666-flutter-intl) to generate boilerplate code for translations
* add translations for Japanese and Traditional Chinese (to check things work as expected)
* code formatting