### PR TITLE
bug/#27 - UserPreferencesView silent crash fix

### DIFF
--- a/packages/smooth_app/lib/bottom_sheet_views/user_preferences_view.dart
+++ b/packages/smooth_app/lib/bottom_sheet_views/user_preferences_view.dart
@@ -84,7 +84,9 @@ class UserPreferencesView extends StatelessWidget {
                               onPressed: () {
                                 userPreferencesModel.saveUserPreferences();
                                 Navigator.pop(context);
-                                callback();
+                                if (callback != null) {
+                                  callback();
+                                }
                               },
                             );
                           },


### PR DESCRIPTION
Impacted file:
* `user_preferences_view.dart`: now we don't call `this.callback` if it's `null`