### PR TITLE
feature/#31_2 - added "reset preferences" button and "init preferences"

### DIFF
--- a/packages/smooth_app/lib/bottom_sheet_views/user_preferences_view.dart
+++ b/packages/smooth_app/lib/bottom_sheet_views/user_preferences_view.dart
@@ -26,7 +26,7 @@ class UserPreferencesView extends StatelessWidget {
 
   static Color getColor(final int index) => _colors[index] ?? _COLOR_DEFAULT;
 
-  static const double _TYPICAL_PADDING_OR_MARGIN = 10;
+  static const double _TYPICAL_PADDING_OR_MARGIN = 12;
   static const double _PCT_ICON = .20;
 
   @override
@@ -35,6 +35,8 @@ class UserPreferencesView extends StatelessWidget {
     final UserPreferences userPreferences = context.watch<UserPreferences>();
     final UserPreferencesModel userPreferencesModel =
         context.watch<UserPreferencesModel>();
+    final double buttonWidth =
+        (screenSize.width - _TYPICAL_PADDING_OR_MARGIN * 3) / 2;
     return Material(
       child: Container(
         height: screenSize.height * 0.9,
@@ -85,15 +87,31 @@ class UserPreferencesView extends StatelessWidget {
                     child: Container(
                       color: Colors.black12,
                       padding: const EdgeInsets.symmetric(
-                          horizontal: 12.0, vertical: 20.0),
-                      child: SmoothMainButton(
-                        text: 'OK',
-                        onPressed: () {
-                          Navigator.pop(context);
-                          if (callback != null) {
-                            callback();
-                          }
-                        },
+                          horizontal: _TYPICAL_PADDING_OR_MARGIN,
+                          vertical: 20.0),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: <Widget>[
+                          SmoothMainButton(
+                            text: 'Reset',
+                            minWidth: buttonWidth,
+                            important: false,
+                            onPressed: () => userPreferences
+                                .resetImportances(userPreferencesModel),
+                          ),
+                          SmoothMainButton(
+                            text: 'OK',
+                            minWidth: buttonWidth,
+                            important: true,
+                            onPressed: () {
+                              Navigator.pop(context);
+                              if (callback != null) {
+                                callback();
+                              }
+                            },
+                          ),
+                        ],
                       ),
                     ),
                   ),
@@ -157,7 +175,7 @@ class UserPreferencesView extends StatelessWidget {
                     //thumbColor: Colors.black,
                     activeTrackColor: Colors.black54,
                     valueIndicatorColor: getColor(userPreferencesModel
-                        .getValueIndex(variable.id, userPreferences)),
+                        .getAttributeValueIndex(variable.id, userPreferences)),
                     trackHeight: 5.0,
                     inactiveTrackColor: Colors.black12,
                     showValueIndicator: ShowValueIndicator.always,
@@ -167,7 +185,7 @@ class UserPreferencesView extends StatelessWidget {
                     max: 3.0,
                     divisions: 3,
                     value: userPreferencesModel
-                        .getValueIndex(variable.id, userPreferences)
+                        .getAttributeValueIndex(variable.id, userPreferences)
                         .toDouble(),
                     onChanged: (double value) => userPreferences.setImportance(
                         variable.id, value.toInt()),

--- a/packages/smooth_app/lib/data_models/user_preferences_model.dart
+++ b/packages/smooth_app/lib/data_models/user_preferences_model.dart
@@ -62,13 +62,14 @@ class UserPreferencesModel extends ChangeNotifier {
     }
   }
 
-  int getValueIndex(
+  int getAttributeValueIndex(
     final String variable,
     final UserPreferences userPreferences,
   ) =>
-      _preferenceValuesReverse[
-          getPreferencesValue(variable, userPreferences).id] ??
-      UserPreferences.INDEX_NOT_IMPORTANT;
+      getValueIndex(getPreferencesValue(variable, userPreferences).id);
+
+  int getValueIndex(final String value) =>
+      _preferenceValuesReverse[value] ?? UserPreferences.INDEX_NOT_IMPORTANT;
 
   PreferencesValue getPreferencesValue(
     final String variable,

--- a/packages/smooth_app/lib/main.dart
+++ b/packages/smooth_app/lib/main.dart
@@ -50,6 +50,7 @@ class _MyAppState extends State<MyApp> {
     userPreferences = await UserPreferences.getUserPreferences();
     userPreferencesModel =
         await UserPreferencesModel.getUserPreferencesModel(context);
+    await userPreferences.init(userPreferencesModel);
   }
 
   @override

--- a/packages/smooth_app/lib/temp/user_preferences.dart
+++ b/packages/smooth_app/lib/temp/user_preferences.dart
@@ -2,7 +2,9 @@
 
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter/material.dart';
+import 'package:smooth_app/data_models/user_preferences_model.dart';
 import 'package:smooth_app/temp/attribute_group.dart';
+import 'package:smooth_app/temp/attribute.dart';
 
 class UserPreferences extends ChangeNotifier {
   UserPreferences._shared(final SharedPreferences sharedPreferences) {
@@ -21,18 +23,59 @@ class UserPreferences extends ChangeNotifier {
   static const String _TAG_PREFIX_IMPORTANCE = 'IMPORTANCE';
   static const String _TAG_HIDDEN_GROUPS = 'hidden_groups';
   static const String _TAG_USE_ML_KIT = 'useMlKit';
+  static const String _TAG_INIT = 'init';
+
+  Future<void> init(final UserPreferencesModel userPreferencesModel) async {
+    final bool alreadyDone = _sharedPreferences.getBool(_TAG_INIT);
+    if (alreadyDone != null) {
+      return;
+    }
+    await resetImportances(userPreferencesModel);
+    await _sharedPreferences.setBool(_TAG_INIT, true);
+  }
 
   String _getImportanceTag(final String variable) =>
       _TAG_PREFIX_IMPORTANCE + variable;
 
-  Future<void> setImportance(String variable, int value) async {
-    _sharedPreferences.setInt(_getImportanceTag(variable), value);
-    notifyListeners();
+  Future<void> setImportance(String variable, int value) async =>
+      _setImportance(variable, value, notify: true);
+
+  Future<void> _setImportance(
+    String variable,
+    int value, {
+    bool notify = true,
+  }) async {
+    await _sharedPreferences.setInt(_getImportanceTag(variable), value);
+    if (notify) {
+      notifyListeners();
+    }
   }
 
   int getImportance(String variable) =>
       _sharedPreferences.getInt(_getImportanceTag(variable)) ??
       INDEX_NOT_IMPORTANT;
+
+  Future<void> resetImportances(
+      final UserPreferencesModel userPreferencesModel) async {
+    for (final AttributeGroup attributeGroup
+        in userPreferencesModel.preferenceVariableGroups) {
+      for (final Attribute attribute in attributeGroup.attributes) {
+        await _setImportance(attribute.id, INDEX_NOT_IMPORTANT, notify: false);
+      }
+    }
+    int valueIndex;
+    valueIndex = userPreferencesModel.getValueIndex('very_important');
+    if (valueIndex != null) {
+      await _setImportance('nutriscore', valueIndex, notify: false);
+    }
+    valueIndex = userPreferencesModel.getValueIndex('important');
+    if (valueIndex != null) {
+      await _setImportance('nova', valueIndex, notify: false);
+      await _setImportance('ecoscore', valueIndex, notify: false);
+    }
+    _sharedPreferences.setStringList(_TAG_HIDDEN_GROUPS, null);
+    notifyListeners();
+  }
 
   bool isAttributeGroupVisible(final AttributeGroup group) {
     final List<String> hiddenList =

--- a/packages/smooth_ui_library/lib/buttons/smooth_main_button.dart
+++ b/packages/smooth_ui_library/lib/buttons/smooth_main_button.dart
@@ -1,25 +1,27 @@
-
 import 'package:flutter/material.dart';
 
 class SmoothMainButton extends StatelessWidget {
-
-  const SmoothMainButton({@required this.text, @required this.onPressed});
+  const SmoothMainButton({
+    @required this.text,
+    @required this.onPressed,
+    this.minWidth = double.infinity,
+    this.important = true,
+  });
 
   final String text;
   final Function onPressed;
+  final double minWidth;
+  final bool important;
 
   @override
-  Widget build(BuildContext context) {
-    return MaterialButton(
-      color: Colors.black,
-      textColor: Colors.white,
-      child: Text(text),
-      height: 56.0,
-      minWidth: double.infinity,
-      shape: const RoundedRectangleBorder(
-          borderRadius: BorderRadius.all(Radius.circular(15.0))
-      ),
-      onPressed: () => onPressed(),
-    );
-  }
+  Widget build(BuildContext context) => MaterialButton(
+        color: important ? Colors.black : Colors.white,
+        textColor: important ? Colors.white : Colors.black,
+        child: Text(text),
+        height: 56.0,
+        minWidth: minWidth,
+        shape: const RoundedRectangleBorder(
+            borderRadius: BorderRadius.all(Radius.circular(15.0))),
+        onPressed: () => onPressed(),
+      );
 }


### PR DESCRIPTION
Impacted files:
* `main.dart`: added an "init" of preferences
* `smooth_main_button.dart`: added parameters in order to add flexibility to color ("is it an important button?") and to width (e.g. 2 buttons on the same row)
* `user_preferences.dart`: added `init` and `resetImportances` methods
* `user_preferences_model.dart`: refactored
* `user_preferences_view.dart`: added a "reset preferences" button

![Simulator Screen Shot - iPhone 8 Plus - 2020-12-28 at 10 53 28](https://user-images.githubusercontent.com/11576431/103205995-246c4a80-48fb-11eb-9b0f-a406bd6d767b.png)
