### PR TITLE
feature/#32 - display only the preferences important attribute's svg of a product

### DIFF
--- a/packages/smooth_app/lib/cards/category_cards/attribute_card.dart
+++ b/packages/smooth_app/lib/cards/category_cards/attribute_card.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/material.dart';
+import 'package:openfoodfacts/model/Product.dart';
+import 'package:openfoodfacts/model/EnvironmentImpactLevels.dart';
+import 'package:openfoodfacts/model/NutrientLevels.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+class AttributeCard extends StatelessWidget {
+  const AttributeCard(
+    this.product,
+    this.variable,
+  );
+
+  final Product product;
+  final String variable;
+
+  static const double _HEIGHT = 40;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData themeData = Theme.of(context);
+    switch (variable) {
+      case 'nova':
+        return _getNova(themeData, product.nutriments.novaGroup);
+      case 'nutriscore':
+        return _getNutriscore(themeData, product.nutriscore);
+      case 'ecoscore':
+        return _getEcoscore(
+          themeData,
+          _getEnvironmentImpactColor(product.environmentImpactLevels),
+        );
+      // TODO(monsieurtanuki): put all the other possible variables, and use attributeGroups instead
+    }
+    return Container();
+  }
+
+  static Widget _getNutriscore(
+    final ThemeData themeData,
+    final String nutriscore,
+  ) =>
+      Container(
+        height: _HEIGHT,
+        child: nutriscore != null
+            ? Image.asset(
+                'assets/product/nutri_score_$nutriscore.png',
+                fit: BoxFit.fitHeight,
+              )
+            : Row(
+                children: <Widget>[
+                  Flexible(
+                    child: Text(
+                      'Nutri-score unavailable',
+                      style: themeData.textTheme.subtitle1
+                          .copyWith(color: Colors.black, fontSize: 12.0),
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                ],
+              ),
+      );
+
+  static Widget _getNova(
+    final ThemeData themeData,
+    final int novaGroup,
+  ) =>
+      Container(
+        width: _HEIGHT / 2,
+        height: _HEIGHT,
+        child: novaGroup != null
+            ? SvgPicture.asset(
+                'assets/product/nova_group_$novaGroup.svg',
+                fit: BoxFit.fitWidth,
+              )
+            : Container(),
+      );
+
+  static Widget _getEcoscore(
+    final ThemeData themeData,
+    final Color color,
+  ) =>
+      Container(
+        width: _HEIGHT,
+        height: _HEIGHT,
+        decoration: BoxDecoration(
+          color: color,
+          borderRadius: const BorderRadius.all(Radius.circular(30.0)),
+        ),
+        child: Center(
+          child: Stack(
+            children: <Widget>[
+              const Text(
+                'CO  ',
+                style: TextStyle(
+                    fontSize: 12.0,
+                    fontWeight: FontWeight.w900,
+                    color: Colors.white),
+              ),
+              Transform.translate(
+                offset: const Offset(16.0, 4.0),
+                child: const Text(
+                  '2',
+                  style: TextStyle(
+                      fontSize: 10.0,
+                      fontWeight: FontWeight.w900,
+                      color: Colors.white),
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+
+  static final Color _colorImpactDefault = Colors.black.withAlpha(15);
+
+  static final Map<Level, Color> _colorImpacts = <Level, Color>{
+    Level.LOW: Colors.green,
+    Level.MODERATE: Colors.orange,
+    Level.HIGH: Colors.red,
+    Level.UNDEFINED: _colorImpactDefault,
+  };
+
+  static Color _getEnvironmentImpactColor(
+          EnvironmentImpactLevels environmentImpactLevels) =>
+      environmentImpactLevels == null || environmentImpactLevels.levels.isEmpty
+          ? _colorImpactDefault
+          : _colorImpacts[environmentImpactLevels.levels.first] ??
+              _colorImpactDefault;
+}

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_edit.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_edit.dart
@@ -3,11 +3,13 @@ import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/model/Product.dart';
 import 'package:openfoodfacts/model/ProductImage.dart';
-import 'package:smooth_app/cards/product_cards/smooth_product_card_template.dart';
 import 'package:smooth_app/pages/product_page.dart';
 
-class SmoothProductCardEdit extends SmoothProductCardTemplate {
-  SmoothProductCardEdit({@required this.product, @required this.heroTag});
+class SmoothProductCardEdit extends StatelessWidget {
+  const SmoothProductCardEdit({
+    @required this.product,
+    @required this.heroTag,
+  });
 
   final Product product;
   final String heroTag;

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
@@ -1,16 +1,16 @@
 import 'dart:ui';
 
+import 'package:provider/provider.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/svg.dart';
-import 'package:openfoodfacts/model/EnvironmentImpactLevels.dart';
-import 'package:openfoodfacts/model/NutrientLevels.dart';
 import 'package:openfoodfacts/model/Product.dart';
-import 'package:smooth_app/cards/product_cards/smooth_product_card_template.dart';
 import 'package:smooth_app/pages/product_page.dart';
 import 'package:smooth_ui_library/widgets/smooth_product_image.dart';
+import 'package:smooth_app/cards/category_cards/attribute_card.dart';
+import 'package:smooth_app/temp/user_preferences.dart';
+import 'package:smooth_app/data_models/user_preferences_model.dart';
 
-class SmoothProductCardFound extends SmoothProductCardTemplate {
-  SmoothProductCardFound({
+class SmoothProductCardFound extends StatelessWidget {
+  const SmoothProductCardFound({
     @required this.product,
     @required this.heroTag,
     this.elevation = 0.0,
@@ -28,6 +28,20 @@ class SmoothProductCardFound extends SmoothProductCardTemplate {
   Widget build(BuildContext context) {
     if (!useNewStyle) {
       return _getOldStyle(context);
+    }
+
+    final UserPreferences userPreferences = context.watch<UserPreferences>();
+    final UserPreferencesModel userPreferencesModel =
+        context.watch<UserPreferencesModel>();
+
+    final List<String> orderedVariables =
+        userPreferencesModel.getOrderedVariables(userPreferences);
+    final List<Widget> scores = <Widget>[];
+    for (final String variable in orderedVariables) {
+      if (scores.isNotEmpty) {
+        scores.add(_getDivider());
+      }
+      scores.add(AttributeCard(product, variable));
     }
     return GestureDetector(
       onTap: () {
@@ -115,109 +129,7 @@ class SmoothProductCardFound extends SmoothProductCardTemplate {
                       child: Row(
                         mainAxisSize: MainAxisSize.max,
                         mainAxisAlignment: MainAxisAlignment.start,
-                        children: <Widget>[
-                          Container(
-                            width: MediaQuery.of(context).size.width * 0.225,
-                            child: product.nutriscore != null
-                                ? Image.asset(
-                                    'assets/product/nutri_score_${product.nutriscore}.png',
-                                    fit: BoxFit.fitWidth,
-                                  )
-                                : Row(
-                                    children: <Widget>[
-                                      Flexible(
-                                        child: Text(
-                                          'Nutri-score unavailable',
-                                          style: Theme.of(context)
-                                              .textTheme
-                                              .subtitle1
-                                              .copyWith(
-                                                  color: Colors.black,
-                                                  fontSize: 12.0),
-                                          textAlign: TextAlign.center,
-                                        ),
-                                      ),
-                                    ],
-                                  ),
-                          ),
-                          Container(
-                            height: 35.0,
-                            width: 1.0,
-                            margin: const EdgeInsets.symmetric(horizontal: 4.0),
-                            color: Colors.grey,
-                          ),
-                          Container(
-                            width: 20.0,
-                            height: 40.0,
-                            child: product.nutriments.novaGroup != null
-                                ? SvgPicture.asset(
-                                    'assets/product/nova_group_${product.nutriments.novaGroup}.svg',
-                                    fit: BoxFit.contain,
-                                  )
-                                : Container(),
-                          ),
-                          Container(
-                            width: MediaQuery.of(context).size.width * 0.225,
-                            margin: const EdgeInsets.only(left: 4.0),
-                            child: Row(
-                              children: <Widget>[
-                                Flexible(
-                                  child: Text(
-                                    product.nutriments.novaGroup != null
-                                        ? _getNovaText(
-                                            product.nutriments.novaGroup)
-                                        : 'NOVA group unavailable',
-                                    style: Theme.of(context)
-                                        .textTheme
-                                        .subtitle1
-                                        .copyWith(
-                                            color: Colors.black,
-                                            fontSize: 12.0),
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ),
-                          Container(
-                            height: 35.0,
-                            width: 1.0,
-                            margin: const EdgeInsets.symmetric(horizontal: 4.0),
-                            color: Colors.grey,
-                          ),
-                          Container(
-                            width: 30.0,
-                            height: 30.0,
-                            decoration: BoxDecoration(
-                              color: _getEnvironmentImpactColor(
-                                  product.environmentImpactLevels),
-                              borderRadius:
-                                  const BorderRadius.all(Radius.circular(30.0)),
-                            ),
-                            child: Center(
-                              child: Stack(
-                                children: <Widget>[
-                                  const Text(
-                                    'CO  ',
-                                    style: TextStyle(
-                                        fontSize: 12.0,
-                                        fontWeight: FontWeight.w900,
-                                        color: Colors.white),
-                                  ),
-                                  Transform.translate(
-                                    offset: const Offset(16.0, 4.0),
-                                    child: const Text(
-                                      '2',
-                                      style: TextStyle(
-                                          fontSize: 10.0,
-                                          fontWeight: FontWeight.w900,
-                                          color: Colors.white),
-                                    ),
-                                  ),
-                                ],
-                              ),
-                            ),
-                          ),
-                        ],
+                        children: scores,
                       ),
                     ),
                   ],
@@ -229,6 +141,13 @@ class SmoothProductCardFound extends SmoothProductCardTemplate {
       ),
     );
   }
+
+  Widget _getDivider() => Container(
+        height: 35.0,
+        width: 1.0,
+        margin: const EdgeInsets.symmetric(horizontal: 4.0),
+        color: Colors.grey,
+      );
 
   Widget _getOldStyle(final BuildContext context) => GestureDetector(
         onTap: () {
@@ -342,69 +261,4 @@ class SmoothProductCardFound extends SmoothProductCardTemplate {
           ),
         ),
       );
-
-  String _getNovaText(int novaGroup) {
-    switch (novaGroup) {
-      case 1:
-        return 'Un-processed product';
-        break;
-      case 2:
-        return 'Processed ingredient';
-        break;
-      case 3:
-        return 'Processed product';
-        break;
-      case 4:
-        return 'ultra-processed product';
-        break;
-      default:
-        return '';
-        break;
-    }
-  }
-
-  Color _getEnvironmentImpactColor(
-      EnvironmentImpactLevels environmentImpactLevels) {
-    if (environmentImpactLevels == null ||
-        environmentImpactLevels.levels.isEmpty) {
-      return Colors.black.withAlpha(15);
-    }
-
-    switch (environmentImpactLevels.levels.first) {
-      case Level.LOW:
-        return Colors.green;
-        break;
-      case Level.MODERATE:
-        return Colors.orange;
-        break;
-      case Level.HIGH:
-        return Colors.red;
-        break;
-      case Level.UNDEFINED:
-        return Colors.black.withAlpha(15);
-        break;
-      default:
-        return Colors.black.withAlpha(15);
-        break;
-    }
-  }
-
-  /*void _openSneakPeek(BuildContext context) {
-    Navigator.push<dynamic>(
-        context,
-        SmoothSneakPeekRoute<dynamic>(
-            builder: (BuildContext context) {
-              return Material(
-                color: Colors.transparent,
-                child: Center(
-                  child: SmoothProductSneakPeekView(
-                    product: product,
-                    context: context,
-                    heroTag: heroTag,
-                  ),
-                ),
-              );
-            },
-            duration: 250));
-  }*/
 }

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_loading.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_loading.dart
@@ -1,9 +1,8 @@
 import 'dart:ui';
 import 'package:flutter/material.dart';
-import 'package:smooth_app/cards/product_cards/smooth_product_card_template.dart';
 
-class SmoothProductCardLoading extends SmoothProductCardTemplate {
-  SmoothProductCardLoading({@required this.barcode});
+class SmoothProductCardLoading extends StatelessWidget {
+  const SmoothProductCardLoading({@required this.barcode});
 
   final String barcode;
 

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_not_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_not_found.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/material.dart';
-import 'package:smooth_app/cards/product_cards/smooth_product_card_template.dart';
 import 'package:smooth_app/pages/smooth_upload_page.dart';
 import 'package:smooth_ui_library/buttons/smooth_simple_button.dart';
 
-class SmoothProductCardNotFound extends SmoothProductCardTemplate {
-  SmoothProductCardNotFound(
-      {@required this.barcode, this.callback, this.elevation = 0.0});
+class SmoothProductCardNotFound extends StatelessWidget {
+  const SmoothProductCardNotFound({
+    @required this.barcode,
+    this.callback,
+    this.elevation = 0.0,
+  });
 
   final String barcode;
   final Function callback;

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_template.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_template.dart
@@ -1,5 +1,0 @@
-import 'package:flutter/widgets.dart';
-
-abstract class SmoothProductCardTemplate {
-  Widget build(BuildContext context);
-}

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_thanks.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_thanks.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:smooth_app/cards/product_cards/smooth_product_card_template.dart';
 
-class SmoothProductCardThanks extends SmoothProductCardTemplate {
+class SmoothProductCardThanks extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(

--- a/packages/smooth_app/lib/data_models/continuous_scan_model.dart
+++ b/packages/smooth_app/lib/data_models/continuous_scan_model.dart
@@ -6,7 +6,6 @@ import 'package:qr_code_scanner/qr_code_scanner.dart';
 import 'package:smooth_app/cards/product_cards/smooth_product_card_edit.dart';
 import 'package:smooth_app/cards/product_cards/smooth_product_card_found.dart';
 import 'package:smooth_app/cards/product_cards/smooth_product_card_not_found.dart';
-import 'package:smooth_app/cards/product_cards/smooth_product_card_template.dart';
 import 'package:smooth_app/cards/product_cards/smooth_product_card_loading.dart';
 import 'package:smooth_app/cards/product_cards/smooth_product_card_thanks.dart';
 import 'package:smooth_app/database/full_products_database.dart';
@@ -18,7 +17,7 @@ class ContinuousScanModel extends ChangeNotifier {
     carouselController = CarouselController();
 
     scannedBarcodes = <String, ScannedProductState>{};
-    cardTemplates = <String, SmoothProductCardTemplate>{};
+    cardTemplates = <String, Widget>{};
   }
 
   final GlobalKey scannerViewKey = GlobalKey(debugLabel: 'Barcode Scanner');
@@ -26,7 +25,7 @@ class ContinuousScanModel extends ChangeNotifier {
   CarouselController carouselController;
 
   Map<String, ScannedProductState> scannedBarcodes;
-  Map<String, SmoothProductCardTemplate> cardTemplates;
+  Map<String, Widget> cardTemplates;
 
   List<Product> foundProducts = <Product>[];
 
@@ -142,7 +141,7 @@ class ContinuousScanModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  void setCardTemplate(String barcode, SmoothProductCardTemplate cardTemplate) {
+  void setCardTemplate(String barcode, Widget cardTemplate) {
     cardTemplates[barcode] = cardTemplate;
     notifyListeners();
   }

--- a/packages/smooth_app/lib/data_models/user_preferences_model.dart
+++ b/packages/smooth_app/lib/data_models/user_preferences_model.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:smooth_app/temp/user_preferences.dart';
 import 'package:smooth_app/temp/attribute_group.dart';
+import 'package:smooth_app/temp/attribute.dart';
 
 class UserPreferencesModel extends ChangeNotifier {
   UserPreferencesModel._();
@@ -60,6 +61,38 @@ class UserPreferencesModel extends ChangeNotifier {
       print('An error occurred while loading user preferences : $e');
       return false;
     }
+  }
+
+  List<String> getOrderedVariables(final UserPreferences userPreferences) {
+    final Map<int, List<String>> map = <int, List<String>>{};
+    for (final AttributeGroup attributeGroup in preferenceVariableGroups) {
+      for (final Attribute attribute in attributeGroup.attributes) {
+        final String variable = attribute.id;
+        final int importance = getValueIndex(variable, userPreferences);
+        if (importance == null ||
+            importance == UserPreferences.INDEX_NOT_IMPORTANT) {
+          continue;
+        }
+        List<String> list = map[importance];
+        if (list == null) {
+          list = <String>[];
+          map[importance] = list;
+        }
+        list.add(variable);
+      }
+    }
+    final List<String> result = <String>[];
+    if (map.isEmpty) {
+      return result;
+    }
+    final List<int> decreasingImportances = <int>[];
+    decreasingImportances.addAll(map.keys);
+    decreasingImportances.sort((int a, int b) => b - a);
+    for (final int importance in decreasingImportances) {
+      final List<String> list = map[importance];
+      list.forEach(result.add);
+    }
+    return result;
   }
 
   int getValueIndex(

--- a/packages/smooth_app/lib/lists/smooth_product_carousel.dart
+++ b/packages/smooth_app/lib/lists/smooth_product_carousel.dart
@@ -1,12 +1,14 @@
 import 'package:carousel_slider/carousel_slider.dart';
 import 'package:flutter/widgets.dart';
-import 'package:smooth_app/cards/product_cards/smooth_product_card_template.dart';
 
 class SmoothProductCarousel extends StatelessWidget {
-  const SmoothProductCarousel(
-      {@required this.productCards, this.controller, this.height = 120.0});
+  const SmoothProductCarousel({
+    @required this.productCards,
+    this.controller,
+    this.height = 120.0,
+  });
 
-  final Map<String, SmoothProductCardTemplate> productCards;
+  final Map<String, Widget> productCards;
   final CarouselController controller;
   final double height;
 
@@ -17,8 +19,7 @@ class SmoothProductCarousel extends StatelessWidget {
       itemBuilder: (BuildContext context, int index) {
         return Padding(
           padding: const EdgeInsets.symmetric(horizontal: 4.0),
-          child:
-              productCards[productCards.keys.elementAt(index)].build(context),
+          child: productCards[productCards.keys.elementAt(index)],
         );
       },
       carouselController: controller,


### PR DESCRIPTION
… and in the correct order

New file:
* `attribute_card.dart`: displays the svg of the score of the product for the variable

Deleted file:
* `smooth_product_card_template.dart`: replaced implicitly with `Widget`

Impacted files:
* `continuous_scan_model.dart`: refactoring around the now deleted "template"
* `smooth_product_card_edit.dart`: refactoring around the now deleted "template"
* `smooth_product_card_found.dart`: display only the preferences important attribute's svg of a product, and in the correct order
* `smooth_product_card_loading.dart`: refactoring around the now deleted "template"
* `smooth_product_card_not_found.dart`: refactoring around the now deleted "template"
* `smooth_product_card_thanks.dart`: refactoring around the now deleted "template"
* `smooth_product_carousel.dart`: refactoring around the now deleted "template"
* `user_preferences_model.dart`: new `getOrderedVariables` method