### PR TITLE
feature/#21 - automatically storing keywords and group results into the database

### DIFF
--- a/packages/smooth_app/lib/data_models/continuous_scan_model.dart
+++ b/packages/smooth_app/lib/data_models/continuous_scan_model.dart
@@ -3,6 +3,7 @@ import 'package:flutter/widgets.dart';
 import 'package:openfoodfacts/model/Product.dart';
 import 'package:qr_code_scanner/qr_code_scanner.dart';
 import 'package:smooth_app/database/barcode_product_query.dart';
+import 'package:smooth_app/database/dao_product.dart';
 import 'package:smooth_app/database/local_database.dart';
 
 enum ScannedProductState {
@@ -96,7 +97,7 @@ class ContinuousScanModel {
   Future<void> _loadBarcode(final String barcode) async {
     final Product product = await BarcodeProductQuery(barcode).getProduct();
     if (product != null) {
-      _localDatabase.putProduct(product);
+      await DaoProduct(_localDatabase).put(product);
       _products[barcode] = product;
       setBarcodeState(barcode, ScannedProductState.FOUND);
     } else {

--- a/packages/smooth_app/lib/data_models/database_product_list_supplier.dart
+++ b/packages/smooth_app/lib/data_models/database_product_list_supplier.dart
@@ -1,0 +1,34 @@
+import 'package:smooth_app/data_models/product_list_supplier.dart';
+import 'package:smooth_app/database/dao_product_list.dart';
+import 'package:smooth_app/database/local_database.dart';
+import 'package:smooth_app/data_models/product_list.dart';
+import 'package:smooth_app/database/product_query.dart';
+
+class DatabaseProductListSupplier implements ProductListSupplier {
+  DatabaseProductListSupplier(this.productQuery, this.localDatabase);
+
+  final ProductQuery productQuery;
+  final LocalDatabase localDatabase;
+  ProductList _productList;
+
+  @override
+  ProductList getProductList() => _productList;
+
+  @override
+  Future<String> asyncLoad() async {
+    try {
+      final ProductList productList = productQuery.getProductList();
+      final bool result = await DaoProductList(localDatabase).get(productList);
+      if (!result) {
+        return 'unexpected empty record';
+      }
+      _productList = productList;
+      return null;
+    } catch (e) {
+      return e.toString();
+    }
+  }
+
+  @override
+  bool needsToBeSavedIntoDb() => false;
+}

--- a/packages/smooth_app/lib/data_models/product_list.dart
+++ b/packages/smooth_app/lib/data_models/product_list.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:openfoodfacts/model/Product.dart';
+
+class ProductList {
+  ProductList({
+    @required this.listType,
+    @required this.parameters,
+  });
+
+  final String listType;
+  final String parameters;
+
+  final List<String> _barcodes = <String>[];
+  final Map<String, Product> _products = <String, Product>{};
+
+  static const String LIST_TYPE_HTTP_SEARCH_GROUP = 'http/search/group';
+  static const String LIST_TYPE_HTTP_SEARCH_KEYWORDS = 'http/search/keywords';
+
+  List<String> get barcodes => _barcodes;
+
+  bool isEmpty() => _barcodes.isEmpty;
+
+  void clear() {
+    _barcodes.clear();
+    _products.clear();
+  }
+
+  void add(final Product product) {
+    if (product == null) {
+      throw Exception('null product');
+    }
+    final String barcode = product.barcode;
+    if (barcode == null) {
+      throw Exception('null barcode');
+    }
+    _barcodes.add(barcode);
+    _products[barcode] = product;
+  }
+
+  void addAll(final List<Product> products) => products.forEach(add);
+
+  void set(
+    final List<String> barcodes,
+    final Map<String, Product> products,
+  ) {
+    clear();
+    _barcodes.addAll(barcodes);
+    _products.addAll(products);
+  }
+
+  List<Product> getList() {
+    final List<Product> result = <Product>[];
+    for (final String barcode in _barcodes) {
+      final Product product = _products[barcode];
+      if (product == null) {
+        throw Exception('no product for barcode $barcode');
+      }
+      result.add(product);
+    }
+    return result;
+  }
+}

--- a/packages/smooth_app/lib/data_models/product_list_supplier.dart
+++ b/packages/smooth_app/lib/data_models/product_list_supplier.dart
@@ -1,0 +1,10 @@
+import 'package:smooth_app/data_models/product_list.dart';
+
+abstract class ProductListSupplier {
+  /// returns null if OK, or the message error
+  Future<String> asyncLoad();
+
+  ProductList getProductList();
+
+  bool needsToBeSavedIntoDb();
+}

--- a/packages/smooth_app/lib/data_models/query_product_list_supplier.dart
+++ b/packages/smooth_app/lib/data_models/query_product_list_supplier.dart
@@ -1,0 +1,29 @@
+import 'package:smooth_app/data_models/product_list_supplier.dart';
+import 'package:smooth_app/data_models/product_list.dart';
+import 'package:smooth_app/database/product_query.dart';
+import 'package:openfoodfacts/model/SearchResult.dart';
+
+class QueryProductListSupplier implements ProductListSupplier {
+  QueryProductListSupplier(this.productQuery);
+
+  final ProductQuery productQuery;
+  ProductList _productList;
+
+  @override
+  ProductList getProductList() => _productList;
+
+  @override
+  Future<String> asyncLoad() async {
+    try {
+      final SearchResult searchResult = await productQuery.getSearchResult();
+      _productList = productQuery.getProductList();
+      _productList.addAll(searchResult.products);
+      return null;
+    } catch (e) {
+      return e.toString();
+    }
+  }
+
+  @override
+  bool needsToBeSavedIntoDb() => true;
+}

--- a/packages/smooth_app/lib/database/dao_product.dart
+++ b/packages/smooth_app/lib/database/dao_product.dart
@@ -1,0 +1,112 @@
+import 'dart:async';
+import 'dart:convert';
+import 'package:smooth_app/database/local_database.dart';
+import 'package:sqflite/sqflite.dart';
+import 'package:openfoodfacts/model/Product.dart';
+
+class DaoProduct {
+  DaoProduct(this.localDatabase);
+
+  final LocalDatabase localDatabase;
+
+  static const String TABLE_PRODUCT = 'product';
+  static const String TABLE_PRODUCT_COLUMN_BARCODE = 'barcode';
+  static const String _TABLE_PRODUCT_COLUMN_JSON = 'encoded_json';
+
+  static FutureOr<void> onUpgrade(
+    final Database db,
+    final int oldVersion,
+    final int newVersion,
+  ) async {
+    if (oldVersion < 1) {
+      await db.execute('create table $TABLE_PRODUCT('
+          '$TABLE_PRODUCT_COLUMN_BARCODE TEXT PRIMARY KEY,'
+          '$_TABLE_PRODUCT_COLUMN_JSON TEXT NOT NULL,'
+          '${LocalDatabase.COLUMN_TIMESTAMP} INT NOT NULL'
+          ')');
+    }
+  }
+
+  Future<Product> get(final String barcode) async {
+    final List<Map<String, dynamic>> queryResult =
+        await localDatabase.database.query(
+      TABLE_PRODUCT,
+      columns: <String>[_TABLE_PRODUCT_COLUMN_JSON],
+      where: '$TABLE_PRODUCT_COLUMN_BARCODE = ?',
+      whereArgs: <String>[barcode],
+    );
+    if (queryResult.isEmpty) {
+      // not found
+      return null;
+    }
+    if (queryResult.length > 1) {
+      // very very unlikely to happen
+      throw Exception('Several products with the same barcode $barcode');
+    }
+    return _getProductFromQueryResult(queryResult[0]);
+  }
+
+  Future<Map<String, Product>> getAll(final List<String> barcodes) async {
+    final Map<String, Product> result = <String, Product>{};
+    if (barcodes == null || barcodes.isEmpty) {
+      return result;
+    }
+    final List<Map<String, dynamic>> queryResults =
+        await localDatabase.database.query(
+      TABLE_PRODUCT,
+      columns: <String>[
+        TABLE_PRODUCT_COLUMN_BARCODE,
+        _TABLE_PRODUCT_COLUMN_JSON,
+      ],
+      where:
+          '$TABLE_PRODUCT_COLUMN_BARCODE in(? ${',?' * (barcodes.length - 1)})',
+      whereArgs: barcodes,
+    );
+    if (queryResults.isEmpty) {
+      return result;
+    }
+    for (final Map<String, dynamic> row in queryResults) {
+      result[row[TABLE_PRODUCT_COLUMN_BARCODE] as String] =
+          _getProductFromQueryResult(row);
+    }
+    return result;
+  }
+
+  Future<void> put(final Product product) async =>
+      await _put(product, localDatabase.database);
+
+  Future<void> putProducts(final List<Product> products) async =>
+      await localDatabase.database
+          .transaction((final Transaction transaction) async {
+        for (final Product product in products) {
+          await _put(product, transaction);
+        }
+      });
+
+  static Future<void> _put(
+    final Product product,
+    final DatabaseExecutor databaseExecutor,
+  ) async {
+    await databaseExecutor.execute(
+        'insert into $TABLE_PRODUCT('
+        ' $TABLE_PRODUCT_COLUMN_BARCODE,'
+        ' $_TABLE_PRODUCT_COLUMN_JSON,'
+        ' ${LocalDatabase.COLUMN_TIMESTAMP}'
+        ')values(?, ?, ?)'
+        ' on conflict($TABLE_PRODUCT_COLUMN_BARCODE) DO UPDATE SET '
+        '  $_TABLE_PRODUCT_COLUMN_JSON=excluded.$_TABLE_PRODUCT_COLUMN_JSON,'
+        '  ${LocalDatabase.COLUMN_TIMESTAMP}=excluded.${LocalDatabase.COLUMN_TIMESTAMP}',
+        <dynamic>[
+          product.barcode,
+          json.encode(product.toJson()),
+          LocalDatabase.nowInMillis(),
+        ]); // TODO(monsieurtanuki): check if this upsert does not cause delete+insert, but just update
+  }
+
+  Product _getProductFromQueryResult(final Map<String, dynamic> row) {
+    final String encodedJson = row[_TABLE_PRODUCT_COLUMN_JSON] as String;
+    final Map<String, dynamic> decodedJson =
+        json.decode(encodedJson) as Map<String, dynamic>;
+    return Product.fromJson(decodedJson);
+  }
+}

--- a/packages/smooth_app/lib/database/dao_product_list.dart
+++ b/packages/smooth_app/lib/database/dao_product_list.dart
@@ -1,0 +1,180 @@
+import 'dart:async';
+import 'package:smooth_app/database/dao_product.dart';
+import 'package:sqflite/sqflite.dart';
+import 'package:smooth_app/data_models/product_list.dart';
+import 'package:smooth_app/database/local_database.dart';
+import 'package:openfoodfacts/model/Product.dart';
+
+class DaoProductList {
+  DaoProductList(this.localDatabase);
+
+  final LocalDatabase localDatabase;
+
+  static const String _TABLE_PRODUCT_LIST = 'product_list';
+  static const String _TABLE_PRODUCT_LIST_COLUMN_ID = '_id';
+  static const String _TABLE_PRODUCT_LIST_COLUMN_TYPE = 'list_type';
+  static const String _TABLE_PRODUCT_LIST_COLUMN_PARAMETERS = 'parameters';
+
+  static const String _TABLE_PRODUCT_LIST_ITEM = 'product_list_item';
+  static const String _TABLE_PRODUCT_LIST_ITEM_COLUMN_ID = '_id';
+  static const String _TABLE_PRODUCT_LIST_ITEM_COLUMN_LIST_ID = 'list_id';
+  static const String _TABLE_PRODUCT_LIST_ITEM_COLUMN_BARCODE = 'barcode';
+
+  static FutureOr<void> onUpgrade(
+    final Database db,
+    final int oldVersion,
+    final int newVersion,
+  ) async {
+    if (oldVersion < 2) {
+      await db.execute('create table $_TABLE_PRODUCT_LIST('
+          '$_TABLE_PRODUCT_LIST_COLUMN_ID INTEGER PRIMARY KEY AUTOINCREMENT,'
+          '$_TABLE_PRODUCT_LIST_COLUMN_TYPE TEXT NOT NULL,'
+          '$_TABLE_PRODUCT_LIST_COLUMN_PARAMETERS TEXT NOT NULL,'
+          '${LocalDatabase.COLUMN_TIMESTAMP} INT NOT NULL'
+          ')');
+
+      await db.execute('CREATE UNIQUE INDEX ${_TABLE_PRODUCT_LIST}_UK '
+          'ON $_TABLE_PRODUCT_LIST('
+          '$_TABLE_PRODUCT_LIST_COLUMN_TYPE,'
+          '$_TABLE_PRODUCT_LIST_COLUMN_PARAMETERS'
+          ')');
+
+      await db.execute('create table $_TABLE_PRODUCT_LIST_ITEM('
+          '$_TABLE_PRODUCT_LIST_ITEM_COLUMN_ID INTEGER PRIMARY KEY AUTOINCREMENT,'
+          '$_TABLE_PRODUCT_LIST_ITEM_COLUMN_LIST_ID INT NOT NULL,'
+          '$_TABLE_PRODUCT_LIST_ITEM_COLUMN_BARCODE TEXT NOT NULL,'
+          '${LocalDatabase.COLUMN_TIMESTAMP} INT NOT NULL,'
+          'FOREIGN KEY ($_TABLE_PRODUCT_LIST_ITEM_COLUMN_LIST_ID)'
+          ' REFERENCES $_TABLE_PRODUCT_LIST'
+          '  ($_TABLE_PRODUCT_LIST_COLUMN_ID)'
+          '   ON DELETE CASCADE,'
+          'FOREIGN KEY ($_TABLE_PRODUCT_LIST_ITEM_COLUMN_BARCODE)'
+          ' REFERENCES ${DaoProduct.TABLE_PRODUCT}'
+          '  (${DaoProduct.TABLE_PRODUCT_COLUMN_BARCODE})'
+          '   ON DELETE CASCADE'
+          ')');
+    }
+  }
+
+  Future<int> getTimestamp(final ProductList productList) async {
+    final Map<String, dynamic> record = await _getRecord(productList);
+    if (record == null) {
+      return null;
+    }
+    return record[LocalDatabase.COLUMN_TIMESTAMP] as int;
+  }
+
+  Future<Map<String, dynamic>> _getRecord(final ProductList productList) async {
+    final List<Map<String, dynamic>> queryResult =
+        await localDatabase.database.query(
+      _TABLE_PRODUCT_LIST,
+      columns: <String>[
+        _TABLE_PRODUCT_LIST_COLUMN_ID,
+        LocalDatabase.COLUMN_TIMESTAMP,
+      ],
+      where: '$_TABLE_PRODUCT_LIST_COLUMN_TYPE = ?'
+          ' AND $_TABLE_PRODUCT_LIST_COLUMN_PARAMETERS = ?',
+      whereArgs: <String>[productList.listType, productList.parameters],
+    );
+    if (queryResult.isEmpty) {
+      // not found
+      return null;
+    }
+    if (queryResult.length > 1) {
+      // very very unlikely to happen
+      throw Exception('Several product lists with the same PK');
+    }
+    return queryResult.first;
+  }
+
+  Future<void> put(final ProductList productList) async {
+    final int productListId = await _upsertProductList(productList);
+    await DaoProduct(localDatabase).putProducts(productList.getList());
+    await _refreshListItems(productList, productListId);
+  }
+
+  Future<bool> get(final ProductList productList) async {
+    final Map<String, dynamic> record = await _getRecord(productList);
+    if (record == null) {
+      return false;
+    }
+    final int id = record[_TABLE_PRODUCT_LIST_COLUMN_ID] as int;
+    final List<String> barcodes = await _getBarcodes(id);
+    final Map<String, Product> products =
+        await DaoProduct(localDatabase).getAll(barcodes);
+    productList.set(barcodes, products);
+    return true;
+  }
+
+  Future<List<String>> _getBarcodes(final int id) async {
+    const String BARCODE_COLUMN_NAME = _TABLE_PRODUCT_LIST_ITEM_COLUMN_BARCODE;
+    final List<Map<String, dynamic>> query = await localDatabase.database.query(
+        _TABLE_PRODUCT_LIST_ITEM,
+        where: '$_TABLE_PRODUCT_LIST_ITEM_COLUMN_LIST_ID = ?',
+        whereArgs: <dynamic>[id],
+        columns: <String>[BARCODE_COLUMN_NAME],
+        orderBy: '$_TABLE_PRODUCT_LIST_ITEM_COLUMN_ID ASC');
+    final List<String> result = <String>[];
+    for (final Map<String, dynamic> row in query) {
+      result.add(row[BARCODE_COLUMN_NAME] as String);
+    }
+    return result;
+  }
+
+  Future<int> _upsertProductList(final ProductList productList) async {
+    final Map<String, dynamic> record = await _getRecord(productList);
+    int id;
+    if (record == null) {
+      id = await localDatabase.database.insert(
+        _TABLE_PRODUCT_LIST,
+        <String, dynamic>{
+          _TABLE_PRODUCT_LIST_COLUMN_TYPE: productList.listType,
+          _TABLE_PRODUCT_LIST_COLUMN_PARAMETERS: productList.parameters,
+          LocalDatabase.COLUMN_TIMESTAMP: LocalDatabase.nowInMillis(),
+        },
+        conflictAlgorithm: ConflictAlgorithm.fail,
+      );
+    } else {
+      id = record[_TABLE_PRODUCT_LIST_COLUMN_ID] as int;
+      await localDatabase.database.update(
+        _TABLE_PRODUCT_LIST,
+        <String, dynamic>{
+          LocalDatabase.COLUMN_TIMESTAMP: LocalDatabase.nowInMillis(),
+        },
+        where: '$_TABLE_PRODUCT_LIST_COLUMN_ID = ?',
+        whereArgs: <dynamic>[id],
+        conflictAlgorithm: ConflictAlgorithm.fail,
+      );
+    }
+    return id;
+  }
+
+  Future<void> _refreshListItems(
+      final ProductList productList, final int id) async {
+    await _deleteListItems(id);
+    await _insertListItems(id, productList.barcodes);
+  }
+
+  Future<void> _deleteListItems(final int id) async =>
+      await localDatabase.database.delete(
+        _TABLE_PRODUCT_LIST_ITEM,
+        where: '$_TABLE_PRODUCT_LIST_ITEM_COLUMN_LIST_ID = ?',
+        whereArgs: <dynamic>[id],
+      );
+
+  Future<void> _insertListItems(
+      final int id, final List<String> barcodes) async {
+    for (final String barcode in barcodes) {
+      // TODO(monsieurtanuki): optim
+      await localDatabase.database.insert(
+        _TABLE_PRODUCT_LIST_ITEM,
+        <String, dynamic>{
+          _TABLE_PRODUCT_LIST_ITEM_COLUMN_BARCODE: barcode,
+          _TABLE_PRODUCT_LIST_ITEM_COLUMN_LIST_ID: id,
+          LocalDatabase.COLUMN_TIMESTAMP: LocalDatabase.nowInMillis(),
+        },
+        conflictAlgorithm: ConflictAlgorithm.rollback,
+      );
+    }
+  }
+}

--- a/packages/smooth_app/lib/database/group_product_query.dart
+++ b/packages/smooth_app/lib/database/group_product_query.dart
@@ -6,6 +6,7 @@ import 'package:openfoodfacts/utils/PnnsGroupQueryConfiguration.dart';
 import 'package:openfoodfacts/utils/PnnsGroups.dart';
 import 'package:smooth_app/database/product_query.dart';
 import 'package:openfoodfacts/utils/LanguageHelper.dart';
+import 'package:smooth_app/data_models/product_list.dart';
 
 class GroupProductQuery implements ProductQuery {
   GroupProductQuery(this.group);
@@ -23,5 +24,11 @@ class GroupProductQuery implements ProductQuery {
           page: page,
           language: OpenFoodFactsLanguage.ENGLISH,
         ),
+      );
+
+  @override
+  ProductList getProductList() => ProductList(
+        listType: ProductList.LIST_TYPE_HTTP_SEARCH_GROUP,
+        parameters: group.id,
       );
 }

--- a/packages/smooth_app/lib/database/keywords_product_query.dart
+++ b/packages/smooth_app/lib/database/keywords_product_query.dart
@@ -5,6 +5,7 @@ import 'package:openfoodfacts/model/parameter/TagFilter.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/model/SearchResult.dart';
 import 'package:openfoodfacts/utils/LanguageHelper.dart';
+import 'package:smooth_app/data_models/product_list.dart';
 
 class KeywordsProductQuery implements ProductQuery {
   KeywordsProductQuery(this.keywords);
@@ -27,5 +28,11 @@ class KeywordsProductQuery implements ProductQuery {
           ],
           language: OpenFoodFactsLanguage.ENGLISH,
         ),
+      );
+
+  @override
+  ProductList getProductList() => ProductList(
+        listType: ProductList.LIST_TYPE_HTTP_SEARCH_KEYWORDS,
+        parameters: keywords,
       );
 }

--- a/packages/smooth_app/lib/database/local_database.dart
+++ b/packages/smooth_app/lib/database/local_database.dart
@@ -1,19 +1,16 @@
 import 'dart:async';
-import 'dart:convert';
 import 'package:flutter/material.dart';
+import 'package:smooth_app/database/dao_product.dart';
+import 'package:smooth_app/database/dao_product_list.dart';
 import 'package:sqflite/sqflite.dart';
 import 'package:path/path.dart';
-import 'package:openfoodfacts/model/Product.dart';
 
 class LocalDatabase extends ChangeNotifier {
   LocalDatabase._(final Database database) : _database = database;
 
   final Database _database;
 
-  static const String _TABLE_PRODUCT = 'product';
-  static const String _TABLE_PRODUCT_COLUMN_BARCODE = 'barcode';
-  static const String _TABLE_PRODUCT_COLUMN_JSON = 'encoded_json';
-  static const String _TABLE_PRODUCT_COLUMN_TIMESTAMP = 'last_upsert';
+  Database get database => _database;
 
   static Future<LocalDatabase> getLocalDatabase() async {
     final String databasesRootPath = await getDatabasesPath();
@@ -21,151 +18,81 @@ class LocalDatabase extends ChangeNotifier {
 
     final Database database = await openDatabase(
       databasePath,
-      version: 1,
+      version: 2,
       singleInstance: true,
-      onCreate: _onCreate,
       onUpgrade: _onUpgrade,
     );
 
     return LocalDatabase._(database);
   }
 
-  static FutureOr<void> _onCreate(final Database db, final int version) async {
-    await db.execute('create table $_TABLE_PRODUCT('
-        '$_TABLE_PRODUCT_COLUMN_BARCODE TEXT PRIMARY KEY,'
-        '$_TABLE_PRODUCT_COLUMN_JSON TEXT NOT NULL,'
-        '$_TABLE_PRODUCT_COLUMN_TIMESTAMP INT NOT NULL'
-        ')');
-  }
+  static const String COLUMN_TIMESTAMP = 'last_upsert';
 
+  /// we don't use onCreate and onUpgrade, we use only onUpgrade instead
+  /// checked: from scratch, onUpgrade is called with oldVersion = 0
   static FutureOr<void> _onUpgrade(
     final Database db,
     final int oldVersion,
     final int newVersion,
   ) async {
-    // not relevant for the moment, we only have 1 version of the database
+    await DaoProduct.onUpgrade(db, oldVersion, newVersion);
+    await DaoProductList.onUpgrade(db, oldVersion, newVersion);
   }
 
-  static int _nowInMillis() => DateTime.now().millisecondsSinceEpoch;
+  static int nowInMillis() => DateTime.now().millisecondsSinceEpoch;
 
-  Future<TableStats> getTableStats() async {
+  void dummyNotifyListeners() {
+    notifyListeners(); // TODO(monsieurtanuki): create a ScanNotifier instead
+  }
+}
+
+class TableStats {
+  TableStats({
+    @required this.tableName,
+    @required this.count,
+    @required this.minTimestamp,
+    @required this.maxTimestamp,
+  });
+
+  final String tableName;
+  final int count;
+  final int minTimestamp;
+  final int maxTimestamp;
+
+  static Future<TableStats> getTableStats(
+    final LocalDatabase localDatabase,
+    final String tableName,
+  ) async {
     const String COLUMN_COUNT = 'mycount';
     const String COLUMN_MIN = 'mymin';
     const String COLUMN_MAX = 'mymax';
 
-    final List<Map<String, dynamic>> queryResult = await _database.query(
-      _TABLE_PRODUCT,
+    final List<Map<String, dynamic>> queryResult =
+        await localDatabase.database.query(
+      tableName,
       columns: <String>[
         'count(*) as $COLUMN_COUNT',
-        'max($_TABLE_PRODUCT_COLUMN_TIMESTAMP) as $COLUMN_MAX',
-        'min($_TABLE_PRODUCT_COLUMN_TIMESTAMP) as $COLUMN_MIN',
+        'max(${LocalDatabase.COLUMN_TIMESTAMP}) as $COLUMN_MAX',
+        'min(${LocalDatabase.COLUMN_TIMESTAMP}) as $COLUMN_MIN',
       ],
     );
     if (queryResult.isEmpty || queryResult.length > 1) {
       // very very unlikely to happen
-      throw Exception('No stats for table $_TABLE_PRODUCT');
+      throw Exception('No stats for table $tableName');
     }
     final Map<String, dynamic> uniqueRow = queryResult[0];
     return TableStats(
+      tableName: tableName,
       count: uniqueRow[COLUMN_COUNT] as int,
       minTimestamp: uniqueRow[COLUMN_MIN] as int,
       maxTimestamp: uniqueRow[COLUMN_MAX] as int,
     );
   }
 
-  void dummyNotifyListeners() {
-    print('localDatabase/notifyListeners');
-    notifyListeners();
-  }
-
-  Future<Product> getProduct(final String barcode) async {
-    final List<Map<String, dynamic>> queryResult = await _database.query(
-      _TABLE_PRODUCT,
-      columns: <String>[_TABLE_PRODUCT_COLUMN_JSON],
-      where: '$_TABLE_PRODUCT_COLUMN_BARCODE = ?',
-      whereArgs: <String>[barcode],
-    );
-    if (queryResult.isEmpty) {
-      // not found
-      return null;
-    }
-    if (queryResult.length > 1) {
-      // very very unlikely to happen
-      throw Exception('Several products with the same barcode $barcode');
-    }
-    return _getProductFromQueryResult(queryResult[0]);
-  }
-
-  Future<Map<String, Product>> getProducts(final List<String> barcodes) async {
-    final Map<String, Product> result = <String, Product>{};
-    if (barcodes == null || barcodes.isEmpty) {
-      return result;
-    }
-    final List<Map<String, dynamic>> queryResults = await _database.query(
-      _TABLE_PRODUCT,
-      columns: <String>[
-        _TABLE_PRODUCT_COLUMN_BARCODE,
-        _TABLE_PRODUCT_COLUMN_JSON,
-      ],
-      where:
-          '$_TABLE_PRODUCT_COLUMN_BARCODE in(? ${',?' * (barcodes.length - 1)})',
-      whereArgs: barcodes,
-    );
-    if (queryResults.isEmpty) {
-      return result;
-    }
-    for (final Map<String, dynamic> row in queryResults) {
-      result[row[_TABLE_PRODUCT_COLUMN_BARCODE] as String] =
-          _getProductFromQueryResult(row);
-    }
-    return result;
-  }
-
-  Future<void> putProduct(final Product product) async =>
-      await _putProduct(product, _database);
-
-  Future<void> putProducts(final List<Product> products) async =>
-      await _database.transaction((final Transaction transaction) async {
-        for (final Product product in products) {
-          await _putProduct(product, transaction);
-        }
-      });
-
-  static Future<void> _putProduct(
-    final Product product,
-    final DatabaseExecutor databaseExecutor,
-  ) async =>
-      await databaseExecutor.insert(
-        _TABLE_PRODUCT,
-        <String, dynamic>{
-          _TABLE_PRODUCT_COLUMN_BARCODE: product.barcode,
-          _TABLE_PRODUCT_COLUMN_JSON: json.encode(product.toJson()),
-          _TABLE_PRODUCT_COLUMN_TIMESTAMP: _nowInMillis(),
-        },
-        conflictAlgorithm: ConflictAlgorithm.replace,
-      );
-
-  Product _getProductFromQueryResult(final Map<String, dynamic> row) {
-    final String encodedJson = row[_TABLE_PRODUCT_COLUMN_JSON] as String;
-    final Map<String, dynamic> decodedJson =
-        json.decode(encodedJson) as Map<String, dynamic>;
-    return Product.fromJson(decodedJson);
-  }
-}
-
-class TableStats {
-  TableStats({
-    this.count,
-    this.minTimestamp,
-    this.maxTimestamp,
-  });
-
-  final int count;
-  final int minTimestamp;
-  final int maxTimestamp;
-
   @override
   String toString() => 'TableStats('
+      'tableName: $tableName'
+      ','
       'count: $count'
       ','
       'minTimestamp: ${DateTime.fromMillisecondsSinceEpoch(minTimestamp)}'

--- a/packages/smooth_app/lib/database/product_query.dart
+++ b/packages/smooth_app/lib/database/product_query.dart
@@ -1,5 +1,6 @@
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/model/SearchResult.dart';
+import 'package:smooth_app/data_models/product_list.dart';
 
 abstract class ProductQuery {
   static const User SMOOTH_USER = User(
@@ -31,4 +32,6 @@ abstract class ProductQuery {
   ];
 
   Future<SearchResult> getSearchResult();
+
+  ProductList getProductList();
 }

--- a/packages/smooth_app/lib/pages/product_query_page.dart
+++ b/packages/smooth_app/lib/pages/product_query_page.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/bottom_sheet_views/group_query_filter_view.dart';
+import 'package:smooth_app/data_models/product_list_supplier.dart';
 import 'package:smooth_app/database/local_database.dart';
-import 'package:smooth_app/database/product_query.dart';
 import 'package:smooth_app/temp/user_preferences.dart';
 import 'package:smooth_app/data_models/user_preferences_model.dart';
 import 'package:smooth_app/data_models/product_query_model.dart';
@@ -15,13 +15,13 @@ import 'package:smooth_app/themes/constant_icons.dart';
 
 class ProductQueryPage extends StatefulWidget {
   const ProductQueryPage({
-    @required this.productQuery,
+    @required this.productListSupplier,
     @required this.heroTag,
     @required this.mainColor,
     @required this.name,
   });
 
-  final ProductQuery productQuery;
+  final ProductListSupplier productListSupplier;
   final String heroTag;
   final Color mainColor;
   final String name;
@@ -38,7 +38,7 @@ class _ProductQueryPageState extends State<ProductQueryPage> {
   @override
   void initState() {
     super.initState();
-    _model = ProductQueryModel(widget.productQuery);
+    _model = ProductQueryModel(widget.productListSupplier);
     _scrollController.addListener(() {
       if (_scrollController.offset <=
               _scrollController.position.minScrollExtent &&

--- a/packages/smooth_app/lib/pages/product_query_page_helper.dart
+++ b/packages/smooth_app/lib/pages/product_query_page_helper.dart
@@ -1,0 +1,147 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:smooth_app/data_models/product_list_supplier.dart';
+import 'package:smooth_app/data_models/query_product_list_supplier.dart';
+import 'package:smooth_app/data_models/database_product_list_supplier.dart';
+import 'package:smooth_app/database/product_query.dart';
+import 'package:smooth_app/database/local_database.dart';
+import 'package:smooth_app/pages/product_query_page.dart';
+import 'package:smooth_app/database/dao_product_list.dart';
+import 'package:smooth_ui_library/buttons/smooth_simple_button.dart';
+import 'package:smooth_ui_library/dialogs/smooth_alert_dialog.dart';
+
+class ProductQueryPageHelper {
+  Future<void> openBestChoice({
+    @required final ProductQuery productQuery,
+    @required final LocalDatabase localDatabase,
+    @required final Color color,
+    @required final String heroTag,
+    @required final String name,
+    @required final BuildContext context,
+  }) async {
+    final int timestamp = await DaoProductList(localDatabase)
+        .getTimestamp(productQuery.getProductList());
+    if (timestamp == null) {
+      _openQueryPage(
+        color: color,
+        heroTag: heroTag,
+        name: name,
+        context: context,
+        popBefore: false,
+        supplier: QueryProductListSupplier(productQuery),
+      );
+      return;
+    }
+    final int now = LocalDatabase.nowInMillis();
+    final int seconds = ((now - timestamp) / 1000).floor();
+    final String lastTime = getDurationString(seconds);
+    showDialog<void>(
+      context: context,
+      builder: (BuildContext context) {
+        return SmoothAlertDialog(
+          title: 'Cached products',
+          body: Text(
+            'You already ran the same search $lastTime.\n'
+            'Do you want to reuse the cached results or to refresh them via internet?',
+          ),
+          actions: <SmoothSimpleButton>[
+            SmoothSimpleButton(
+              onPressed: () => _openQueryPage(
+                color: color,
+                heroTag: heroTag,
+                name: name,
+                context: context,
+                popBefore: true,
+                supplier:
+                    DatabaseProductListSupplier(productQuery, localDatabase),
+              ),
+              text: 'reuse',
+              width: 100,
+            ),
+            SmoothSimpleButton(
+              onPressed: () => _openQueryPage(
+                color: color,
+                heroTag: heroTag,
+                name: name,
+                context: context,
+                popBefore: true,
+                supplier: QueryProductListSupplier(productQuery),
+              ),
+              text: 'refresh',
+              width: 100,
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  void _openQueryPage({
+    @required final Color color,
+    @required final String heroTag,
+    @required final String name,
+    @required final ProductListSupplier supplier,
+    @required final BuildContext context,
+    @required final bool popBefore,
+  }) {
+    if (popBefore) {
+      Navigator.pop(context);
+    }
+    Navigator.push<dynamic>(
+      context,
+      MaterialPageRoute<dynamic>(
+        builder: (BuildContext context) => ProductQueryPage(
+          productListSupplier: supplier,
+          heroTag: heroTag,
+          mainColor: color,
+          name: name,
+        ),
+      ),
+    );
+  }
+
+  static String getDurationString(final int seconds) {
+    final double minutes = seconds / 60;
+    final int roundMinutes = minutes.round();
+    if (roundMinutes == 0) {
+      return 'less than one minute ago';
+    }
+    if (roundMinutes == 1) {
+      return 'about 1 minute ago';
+    }
+    if (roundMinutes < 60) {
+      return 'about $roundMinutes minutes ago';
+    }
+    final double hours = minutes / 60;
+    final int roundHours = hours.round();
+    if (roundHours == 1) {
+      return 'about 1 hour ago';
+    }
+    if (roundHours < 24) {
+      return 'about $roundHours hours ago';
+    }
+    final double days = hours / 24;
+    final int roundDays = days.round();
+    if (roundDays == 1) {
+      return 'about one day ago';
+    }
+    if (roundDays < 7) {
+      return 'about $roundDays days ago';
+    }
+    final double weeks = days / 7;
+    final int roundWeeks = weeks.round();
+    if (roundWeeks == 1) {
+      return 'about 1 week ago';
+    }
+    if (roundWeeks <= 4) {
+      return 'about $roundWeeks weeks ago';
+    }
+    final double months = days / (365 / 12);
+    final int roundMonths = months.round();
+    if (roundMonths == 1) {
+      return 'about 1 month ago';
+    }
+    return 'about $roundMonths months ago';
+  }
+}


### PR DESCRIPTION
... and automagically asking the end-user if they want to see the cache

New files:
* `dao_product.dart`
* `dao_product_list.dart`
* `database_product_list_supplier.dart`
* `product_list.dart`
* `product_list_supplier.dart`
* `product_query_page_helper.dart`
* `query_product_list_supplier.dart`

Impacted files:
* `choose_page.dart`: now uses `ProductQueryPageHelper` in order to get database or http results; refactored
* `continuous_scan_model.dart`: minor refactoring due to DAO
* `group_product_query.dart`: now implements new method `getProductList`
* `keywords_product_query.dart`: now implements new method `getProductList`
* `local_database.dart`: now it's version 2; refactored using the new DAO classes
* `product_query.dart`: new method `getProductList`
* `product_query_model.dart`: now we use a `ProductListSupplier` instead of a `ProductQuery`
* `product_query_page.dart`: now we use a `ProductListSupplier` instead of a `ProductQuery`

As mentioned, for the moment I've only implemented the list for keywords and group searches:
![Simulator Screen Shot - iPhone 8 Plus - 2021-01-10 at 16 38 51](https://user-images.githubusercontent.com/11576431/104127575-24d8fc80-5363-11eb-8af3-90fb9a813aee.png)
