### PR TITLE
feature/#87 - immediate access to database data, with a snackbar for http refresh

### DIFF
--- a/packages/smooth_app/lib/data_models/database_product_list_supplier.dart
+++ b/packages/smooth_app/lib/data_models/database_product_list_supplier.dart
@@ -1,4 +1,5 @@
 import 'package:smooth_app/data_models/product_list_supplier.dart';
+import 'package:smooth_app/data_models/query_product_list_supplier.dart';
 import 'package:smooth_app/database/dao_product_list.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/data_models/product_list.dart';
@@ -31,4 +32,8 @@ class DatabaseProductListSupplier implements ProductListSupplier {
 
   @override
   bool needsToBeSavedIntoDb() => false;
+
+  @override
+  ProductListSupplier getRefreshSupplier() =>
+      QueryProductListSupplier(productQuery);
 }

--- a/packages/smooth_app/lib/data_models/product_list_supplier.dart
+++ b/packages/smooth_app/lib/data_models/product_list_supplier.dart
@@ -7,4 +7,6 @@ abstract class ProductListSupplier {
   ProductList getProductList();
 
   bool needsToBeSavedIntoDb();
+
+  ProductListSupplier getRefreshSupplier();
 }

--- a/packages/smooth_app/lib/data_models/query_product_list_supplier.dart
+++ b/packages/smooth_app/lib/data_models/query_product_list_supplier.dart
@@ -26,4 +26,7 @@ class QueryProductListSupplier implements ProductListSupplier {
 
   @override
   bool needsToBeSavedIntoDb() => true;
+
+  @override
+  ProductListSupplier getRefreshSupplier() => null;
 }

--- a/packages/smooth_app/lib/pages/product_query_page_helper.dart
+++ b/packages/smooth_app/lib/pages/product_query_page_helper.dart
@@ -8,8 +8,6 @@ import 'package:smooth_app/database/product_query.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/pages/product_query_page.dart';
 import 'package:smooth_app/database/dao_product_list.dart';
-import 'package:smooth_ui_library/buttons/smooth_simple_button.dart';
-import 'package:smooth_ui_library/dialogs/smooth_alert_dialog.dart';
 
 class ProductQueryPageHelper {
   Future<void> openBestChoice({
@@ -22,72 +20,9 @@ class ProductQueryPageHelper {
   }) async {
     final int timestamp = await DaoProductList(localDatabase)
         .getTimestamp(productQuery.getProductList());
-    if (timestamp == null) {
-      _openQueryPage(
-        color: color,
-        heroTag: heroTag,
-        name: name,
-        context: context,
-        popBefore: false,
-        supplier: QueryProductListSupplier(productQuery),
-      );
-      return;
-    }
-    final int now = LocalDatabase.nowInMillis();
-    final int seconds = ((now - timestamp) / 1000).floor();
-    final String lastTime = getDurationString(seconds);
-    showDialog<void>(
-      context: context,
-      builder: (BuildContext context) {
-        return SmoothAlertDialog(
-          title: 'Cached products',
-          body: Text(
-            'You already ran the same search $lastTime.\n'
-            'Do you want to reuse the cached results or to refresh them via internet?',
-          ),
-          actions: <SmoothSimpleButton>[
-            SmoothSimpleButton(
-              onPressed: () => _openQueryPage(
-                color: color,
-                heroTag: heroTag,
-                name: name,
-                context: context,
-                popBefore: true,
-                supplier:
-                    DatabaseProductListSupplier(productQuery, localDatabase),
-              ),
-              text: 'reuse',
-              width: 100,
-            ),
-            SmoothSimpleButton(
-              onPressed: () => _openQueryPage(
-                color: color,
-                heroTag: heroTag,
-                name: name,
-                context: context,
-                popBefore: true,
-                supplier: QueryProductListSupplier(productQuery),
-              ),
-              text: 'refresh',
-              width: 100,
-            ),
-          ],
-        );
-      },
-    );
-  }
-
-  void _openQueryPage({
-    @required final Color color,
-    @required final String heroTag,
-    @required final String name,
-    @required final ProductListSupplier supplier,
-    @required final BuildContext context,
-    @required final bool popBefore,
-  }) {
-    if (popBefore) {
-      Navigator.pop(context);
-    }
+    final ProductListSupplier supplier = timestamp == null
+        ? QueryProductListSupplier(productQuery)
+        : DatabaseProductListSupplier(productQuery, localDatabase);
     Navigator.push<dynamic>(
       context,
       MaterialPageRoute<dynamic>(
@@ -96,6 +31,7 @@ class ProductQueryPageHelper {
           heroTag: heroTag,
           mainColor: color,
           name: name,
+          lastUpdate: timestamp,
         ),
       ),
     );


### PR DESCRIPTION
Impacted files:
* `database_product_list_supplier.dart`: implemented new method `getRefreshSupplier()`
* `product_list_supplier.dart`: added method `getRefreshSupplier()`
* `product_query_page.dart`: added a snack bar - for refreshment
* `product_query_page_helper.dart`: remove the alert dialog and moved the logic to `ProductQueryPage`
* `query_product_list_supplier.dart`: implemented new method `getRefreshSupplier()`