### PR TITLE
feature/#21 - scan now uses local database, for product look up and for its history

### DIFF
--- a/packages/smooth_app/lib/data_models/product_list.dart
+++ b/packages/smooth_app/lib/data_models/product_list.dart
@@ -15,6 +15,7 @@ class ProductList {
 
   static const String LIST_TYPE_HTTP_SEARCH_GROUP = 'http/search/group';
   static const String LIST_TYPE_HTTP_SEARCH_KEYWORDS = 'http/search/keywords';
+  static const String LIST_TYPE_SCAN = 'scan';
 
   List<String> get barcodes => _barcodes;
 
@@ -24,6 +25,8 @@ class ProductList {
     _barcodes.clear();
     _products.clear();
   }
+
+  Product getProduct(final String barcode) => _products[barcode];
 
   void add(final Product product) {
     if (product == null) {
@@ -51,6 +54,25 @@ class ProductList {
   List<Product> getList() {
     final List<Product> result = <Product>[];
     for (final String barcode in _barcodes) {
+      final Product product = _products[barcode];
+      if (product == null) {
+        throw Exception('no product for barcode $barcode');
+      }
+      result.add(product);
+    }
+    return result;
+  }
+
+  List<Product> getUniqueList({final bool ascending = true}) {
+    final List<Product> result = <Product>[];
+    final Set<String> done = <String>{};
+    final Iterable<String> orderedBarcodes =
+        ascending ? _barcodes : _barcodes.reversed;
+    for (final String barcode in orderedBarcodes) {
+      if (done.contains(barcode)) {
+        continue;
+      }
+      done.add(barcode);
       final Product product = _products[barcode];
       if (product == null) {
         throw Exception('no product for barcode $barcode');

--- a/packages/smooth_app/lib/data_models/smooth_it_model.dart
+++ b/packages/smooth_app/lib/data_models/smooth_it_model.dart
@@ -3,6 +3,7 @@ import 'package:smooth_app/structures/ranked_product.dart';
 import 'package:smooth_app/data_models/user_preferences_model.dart';
 import 'package:smooth_app/data_models/match.dart';
 import 'package:smooth_app/temp/user_preferences.dart';
+import 'package:smooth_app/data_models/product_list.dart';
 
 class SmoothItModel {
   static const int MATCH_INDEX_YES = 0;
@@ -16,7 +17,7 @@ class SmoothItModel {
   bool _nextRefreshIsJustChangingTabs = false;
 
   void refresh(
-    final List<Product> unprocessedProducts,
+    final ProductList productList,
     final UserPreferences userPreferences,
     final UserPreferencesModel userPreferencesModel,
   ) {
@@ -24,6 +25,7 @@ class SmoothItModel {
       _nextRefreshIsJustChangingTabs = false;
       return;
     }
+    final List<Product> unprocessedProducts = productList.getUniqueList();
     _allProducts =
         Match.sort(unprocessedProducts, userPreferences, userPreferencesModel);
     _categorizedProducts.clear();

--- a/packages/smooth_app/lib/database/local_database.dart
+++ b/packages/smooth_app/lib/database/local_database.dart
@@ -40,10 +40,6 @@ class LocalDatabase extends ChangeNotifier {
   }
 
   static int nowInMillis() => DateTime.now().millisecondsSinceEpoch;
-
-  void dummyNotifyListeners() {
-    notifyListeners(); // TODO(monsieurtanuki): create a ScanNotifier instead
-  }
 }
 
 class TableStats {

--- a/packages/smooth_app/lib/lists/smooth_product_carousel.dart
+++ b/packages/smooth_app/lib/lists/smooth_product_carousel.dart
@@ -32,7 +32,10 @@ class _SmoothProductCarouselState extends State<SmoothProductCarousel> {
     if (_length != barcodesLength) {
       _length = barcodesLength;
       if (_length > 1) {
-        _controller.animateToPage(_length - 1);
+        Future<void>.delayed(
+          const Duration(seconds: 0),
+          () => _controller.animateToPage(_length - 1),
+        );
       }
     }
     return CarouselSlider.builder(
@@ -55,6 +58,7 @@ class _SmoothProductCarouselState extends State<SmoothProductCarousel> {
     final Product product = widget.continuousScanModel.getProduct(barcode);
     switch (widget.continuousScanModel.getBarcodeState(barcode)) {
       case ScannedProductState.FOUND:
+      case ScannedProductState.CACHED:
         if (widget.continuousScanModel.contributionMode) {
           return SmoothProductCardEdit(heroTag: barcode, product: product);
         }

--- a/packages/smooth_app/lib/main.dart
+++ b/packages/smooth_app/lib/main.dart
@@ -10,10 +10,9 @@ import 'package:sentry/sentry.dart';
 import 'package:provider/provider.dart';
 
 import 'package:smooth_app/data_models/user_preferences_model.dart';
-import 'package:smooth_app/pages/alternative_continuous_scan_page.dart';
+import 'package:smooth_app/pages/scan_page.dart';
 import 'package:smooth_app/pages/choose_page.dart';
 import 'package:smooth_app/pages/contribution_page.dart';
-import 'package:smooth_app/pages/continuous_scan_page.dart';
 import 'package:smooth_app/pages/profile_page.dart';
 import 'package:smooth_app/pages/tracking_page.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
@@ -222,16 +221,15 @@ class SmoothApp extends StatelessWidget {
           icon: 'assets/actions/scanner_alt_2.svg',
           iconPadding: _navigationIconPadding,
           iconSize: _navigationIconSize,
-          onTap: () {
-            final Widget newPage = mlKitState
-                ? const ContinuousScanPage()
-                : const AlternativeContinuousScanPage();
-            Navigator.push<Widget>(
-              context,
-              MaterialPageRoute<Widget>(
-                  builder: (BuildContext context) => newPage),
-            );
-          },
+          onTap: () => Navigator.push<Widget>(
+            context,
+            MaterialPageRoute<Widget>(
+              builder: (BuildContext context) => ScanPage(
+                contributionMode: false,
+                mlKit: mlKitState,
+              ),
+            ),
+          ),
         ),
       );
 }

--- a/packages/smooth_app/lib/pages/alternative_continuous_scan_page.dart
+++ b/packages/smooth_app/lib/pages/alternative_continuous_scan_page.dart
@@ -4,132 +4,120 @@ import 'package:provider/provider.dart';
 import 'package:qr_code_scanner/qr_code_scanner.dart';
 import 'package:smooth_app/data_models/continuous_scan_model.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/lists/smooth_product_carousel.dart';
 import 'package:smooth_app/pages/personalized_ranking_page.dart';
 import 'package:smooth_ui_library/animations/smooth_reveal_animation.dart';
 import 'package:smooth_ui_library/widgets/smooth_view_finder.dart';
-import 'package:smooth_app/pages/continuous_scan_page.dart';
+import 'package:smooth_app/pages/scan_page.dart';
 
-class AlternativeContinuousScanPage extends StatefulWidget {
-  const AlternativeContinuousScanPage(
-      {this.initializeWithContributionMode = false});
+class AlternativeContinuousScanPage extends StatelessWidget {
+  AlternativeContinuousScanPage(this._continuousScanModel);
 
-  final bool initializeWithContributionMode;
+  final ContinuousScanModel _continuousScanModel;
 
-  @override
-  _AlternativeContinuousScanPageState createState() =>
-      _AlternativeContinuousScanPageState();
-}
-
-class _AlternativeContinuousScanPageState
-    extends State<AlternativeContinuousScanPage> {
-  ContinuousScanModel _continuousScanModel;
   final GlobalKey _scannerViewKey = GlobalKey(debugLabel: 'Barcode Scanner');
 
   @override
-  void initState() {
-    super.initState();
-    _continuousScanModel = ContinuousScanModel(
-        contributionMode: widget.initializeWithContributionMode);
-  }
-
-  @override
   Widget build(BuildContext context) {
-    final LocalDatabase localDatabase = context.watch<LocalDatabase>();
-    _continuousScanModel.setLocalDatabase(localDatabase);
     final Size screenSize = MediaQuery.of(context).size;
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final ThemeData themeData = Theme.of(context);
-    return Scaffold(
-      floatingActionButton: SmoothRevealAnimation(
-        delay: 400,
-        animationCurve: Curves.easeInOutBack,
-        child: FloatingActionButton.extended(
-          icon: SvgPicture.asset(
-            'assets/actions/smoothie.svg',
-            width: 24.0,
-            height: 24.0,
-            color: Colors.black,
-          ),
-          label: Text(
-            appLocalizations.myPersonalizedRanking,
-            style: const TextStyle(color: Colors.black),
-          ),
-          backgroundColor: Colors.white,
-          onPressed: () => Navigator.push<dynamic>(
-            context,
-            MaterialPageRoute<dynamic>(
-              builder: (BuildContext context) => PersonalizedRankingPage(
-                input: _continuousScanModel.getFoundProducts(),
+    return ChangeNotifierProvider<ContinuousScanModel>.value(
+      value: _continuousScanModel,
+      child: Consumer<ContinuousScanModel>(
+        builder:
+            (BuildContext context, ContinuousScanModel dummy, Widget child) =>
+                Scaffold(
+          floatingActionButton: SmoothRevealAnimation(
+            delay: 400,
+            animationCurve: Curves.easeInOutBack,
+            child: FloatingActionButton.extended(
+              icon: SvgPicture.asset(
+                'assets/actions/smoothie.svg',
+                width: 24.0,
+                height: 24.0,
+                color: Colors.black,
+              ),
+              label: Text(
+                appLocalizations.myPersonalizedRanking,
+                style: const TextStyle(color: Colors.black),
+              ),
+              backgroundColor: Colors.white,
+              onPressed: () => Navigator.push<dynamic>(
+                context,
+                MaterialPageRoute<dynamic>(
+                  builder: (BuildContext context) =>
+                      PersonalizedRankingPage(_continuousScanModel.productList),
+                ),
               ),
             ),
           ),
+          body: Stack(
+            children: <Widget>[
+              ScanPage.getHero(screenSize),
+              SmoothRevealAnimation(
+                delay: 400,
+                startOffset: const Offset(0.0, 0.0),
+                animationCurve: Curves.easeInOutBack,
+                child: QRView(
+                  key: _scannerViewKey,
+                  onQRViewCreated: (QRViewController controller) =>
+                      _continuousScanModel.setupScanner(controller),
+                ),
+              ),
+              SmoothRevealAnimation(
+                delay: 400,
+                startOffset: const Offset(0.0, 0.1),
+                animationCurve: Curves.easeInOutBack,
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  mainAxisSize: MainAxisSize.max,
+                  children: <Widget>[
+                    Container(
+                      height: screenSize.height * 0.3,
+                      padding: const EdgeInsets.only(top: 32.0),
+                      child: Column(
+                        children: <Widget>[
+                          ScanPage.getContributeChooseToggle(
+                              _continuousScanModel),
+                        ],
+                      ),
+                    ),
+                    Center(
+                      child: Container(
+                        child: SmoothViewFinder(
+                          width: screenSize.width * 0.8,
+                          height: screenSize.width * 0.4,
+                          animationDuration: 1500,
+                        ),
+                      ),
+                    ),
+                    if (_continuousScanModel.isNotEmpty)
+                      Container(
+                        height: screenSize.height * 0.35,
+                        padding:
+                            EdgeInsets.only(bottom: screenSize.height * 0.08),
+                        child: SmoothProductCarousel(
+                          continuousScanModel: _continuousScanModel,
+                        ),
+                      )
+                    else
+                      Container(
+                        width: screenSize.width,
+                        height: screenSize.height * 0.35,
+                        padding: EdgeInsets.only(top: screenSize.height * 0.08),
+                        child: Text(
+                          appLocalizations.scannerProductsEmpty,
+                          style: themeData.textTheme.subtitle1,
+                          textAlign: TextAlign.center,
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+            ],
+          ),
         ),
-      ),
-      body: Stack(
-        children: <Widget>[
-          ContinuousScanPage.getHero(screenSize),
-          SmoothRevealAnimation(
-            delay: 400,
-            startOffset: const Offset(0.0, 0.0),
-            animationCurve: Curves.easeInOutBack,
-            child: QRView(
-              key: _scannerViewKey,
-              onQRViewCreated: (QRViewController controller) =>
-                  _continuousScanModel.setupScanner(controller),
-            ),
-          ),
-          SmoothRevealAnimation(
-            delay: 400,
-            startOffset: const Offset(0.0, 0.1),
-            animationCurve: Curves.easeInOutBack,
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              mainAxisSize: MainAxisSize.max,
-              children: <Widget>[
-                Container(
-                  height: screenSize.height * 0.3,
-                  padding: const EdgeInsets.only(top: 32.0),
-                  child: Column(
-                    children: <Widget>[
-                      ContinuousScanPage.getContributeChooseToggle(
-                          _continuousScanModel),
-                    ],
-                  ),
-                ),
-                Center(
-                  child: Container(
-                    child: SmoothViewFinder(
-                      width: screenSize.width * 0.8,
-                      height: screenSize.width * 0.4,
-                      animationDuration: 1500,
-                    ),
-                  ),
-                ),
-                if (_continuousScanModel.isNotEmpty)
-                  Container(
-                    height: screenSize.height * 0.35,
-                    padding: EdgeInsets.only(bottom: screenSize.height * 0.08),
-                    child: SmoothProductCarousel(
-                      continuousScanModel: _continuousScanModel,
-                    ),
-                  )
-                else
-                  Container(
-                    width: screenSize.width,
-                    height: screenSize.height * 0.35,
-                    padding: EdgeInsets.only(top: screenSize.height * 0.08),
-                    child: Text(
-                      appLocalizations.scannerProductsEmpty,
-                      style: themeData.textTheme.subtitle1,
-                      textAlign: TextAlign.center,
-                    ),
-                  ),
-              ],
-            ),
-          ),
-        ],
       ),
     );
   }

--- a/packages/smooth_app/lib/pages/continuous_scan_page.dart
+++ b/packages/smooth_app/lib/pages/continuous_scan_page.dart
@@ -5,183 +5,138 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/continuous_scan_model.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/lists/smooth_product_carousel.dart';
 import 'package:smooth_app/pages/personalized_ranking_page.dart';
+import 'package:smooth_app/pages/scan_page.dart';
 import 'package:smooth_ui_library/animations/smooth_reveal_animation.dart';
-import 'package:smooth_ui_library/widgets/smooth_toggle.dart';
-
 import 'package:smooth_ui_library/widgets/smooth_view_finder.dart';
 
-class ContinuousScanPage extends StatefulWidget {
-  const ContinuousScanPage({this.initializeWithContributionMode = false});
+class ContinuousScanPage extends StatelessWidget {
+  const ContinuousScanPage(this._continuousScanModel);
 
-  final bool initializeWithContributionMode;
-
-  @override
-  _ContinuousScanPageState createState() => _ContinuousScanPageState();
-
-  static Widget getContributeChooseToggle(final ContinuousScanModel model) =>
-      SmoothToggle(
-        value: model.contributionMode,
-        textLeft: '  CONTRIBUTE',
-        textRight: 'CHOOSE      ',
-        colorLeft: Colors.black.withAlpha(160),
-        colorRight: Colors.black.withAlpha(160),
-        iconLeft: SvgPicture.asset('assets/ikonate_bold/add.svg'),
-        iconRight: SvgPicture.asset('assets/ikonate_bold/search.svg'),
-        textSize: 12.0,
-        animationDuration: const Duration(milliseconds: 320),
-        width: 150.0,
-        height: 50.0,
-        onChanged: (bool value) => model.contributionModeSwitch(value),
-      );
-
-  static Widget getHero(final Size screenSize) => Hero(
-        tag: 'action_button',
-        child: Container(
-          width: screenSize.width,
-          height: screenSize.height,
-          color: Colors.black,
-          child: Center(
-            child: SvgPicture.asset(
-              'assets/actions/scanner_alt_2.svg',
-              width: 60.0,
-              height: 60.0,
-              color: Colors.white,
-            ),
-          ),
-        ),
-      );
-}
-
-class _ContinuousScanPageState extends State<ContinuousScanPage> {
-  ContinuousScanModel _continuousScanModel;
-
-  @override
-  void initState() {
-    super.initState();
-    _continuousScanModel = ContinuousScanModel(
-        contributionMode: widget.initializeWithContributionMode);
-  }
+  final ContinuousScanModel _continuousScanModel;
 
   @override
   Widget build(BuildContext context) {
-    final LocalDatabase localDatabase = context.watch<LocalDatabase>();
-    _continuousScanModel.setLocalDatabase(localDatabase);
     final Size screenSize = MediaQuery.of(context).size;
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final ThemeData themeData = Theme.of(context);
-    return Scaffold(
-      floatingActionButton: SmoothRevealAnimation(
-        delay: 400,
-        animationCurve: Curves.easeInOutBack,
-        child: FloatingActionButton.extended(
-          icon: SvgPicture.asset(
-            'assets/actions/smoothie.svg',
-            width: 24.0,
-            height: 24.0,
-            color: Colors.black,
-          ),
-          label: Text(
-            appLocalizations.myPersonalizedRanking,
-            style: const TextStyle(color: Colors.black),
-          ),
-          backgroundColor: Colors.white,
-          onPressed: () => Navigator.push<dynamic>(
-            context,
-            MaterialPageRoute<dynamic>(
-              builder: (BuildContext context) => PersonalizedRankingPage(
-                input: _continuousScanModel.getFoundProducts(),
+    return ChangeNotifierProvider<ContinuousScanModel>.value(
+      value: _continuousScanModel,
+      child: Consumer<ContinuousScanModel>(
+        builder:
+            (BuildContext context, ContinuousScanModel dummy, Widget child) =>
+                Scaffold(
+          floatingActionButton: SmoothRevealAnimation(
+            delay: 400,
+            animationCurve: Curves.easeInOutBack,
+            child: FloatingActionButton.extended(
+              icon: SvgPicture.asset(
+                'assets/actions/smoothie.svg',
+                width: 24.0,
+                height: 24.0,
+                color: Colors.black,
+              ),
+              label: Text(
+                appLocalizations.myPersonalizedRanking,
+                style: const TextStyle(color: Colors.black),
+              ),
+              backgroundColor: Colors.white,
+              onPressed: () => Navigator.push<dynamic>(
+                context,
+                MaterialPageRoute<dynamic>(
+                  builder: (BuildContext context) =>
+                      PersonalizedRankingPage(_continuousScanModel.productList),
+                ),
               ),
             ),
           ),
-        ),
-      ),
-      body: Stack(
-        children: <Widget>[
-          ContinuousScanPage.getHero(screenSize),
-          SmoothRevealAnimation(
-            delay: 400,
-            startOffset: const Offset(0.0, 0.0),
-            animationCurve: Curves.easeInOutBack,
-            child: QRBarScannerCamera(
-              formats: const <BarcodeFormats>[
-                BarcodeFormats.EAN_8,
-                BarcodeFormats.EAN_13
-              ],
-              qrCodeCallback: (String code) =>
-                  _continuousScanModel.onScan(code),
-              notStartedBuilder: (BuildContext context) => Container(),
-            ),
-          ),
-          SmoothRevealAnimation(
-            delay: 400,
-            startOffset: const Offset(0.0, 0.1),
-            animationCurve: Curves.easeInOutBack,
-            child: Column(
-              mainAxisSize: MainAxisSize.max,
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: <Widget>[
-                Container(
-                  child: Column(
-                    children: <Widget>[
-                      Padding(
-                        padding: const EdgeInsets.only(top: 36.0),
-                        child: Row(
-                          mainAxisSize: MainAxisSize.max,
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: <Widget>[
-                            ContinuousScanPage.getContributeChooseToggle(
-                                _continuousScanModel),
-                          ],
-                        ),
-                      ),
-                      Padding(
-                        padding: const EdgeInsets.only(top: 14.0),
-                        child: Row(
-                          mainAxisSize: MainAxisSize.max,
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: <Widget>[
-                            SmoothViewFinder(
-                              width: screenSize.width * 0.8,
-                              height: screenSize.width * 0.45,
-                              animationDuration: 1500,
-                            )
-                          ],
-                        ),
-                      ),
-                    ],
-                  ),
+          body: Stack(
+            children: <Widget>[
+              ScanPage.getHero(screenSize),
+              SmoothRevealAnimation(
+                delay: 400,
+                startOffset: const Offset(0.0, 0.0),
+                animationCurve: Curves.easeInOutBack,
+                child: QRBarScannerCamera(
+                  formats: const <BarcodeFormats>[
+                    BarcodeFormats.EAN_8,
+                    BarcodeFormats.EAN_13
+                  ],
+                  qrCodeCallback: (String code) =>
+                      _continuousScanModel.onScan(code),
+                  notStartedBuilder: (BuildContext context) => Container(),
                 ),
-                Padding(
-                  padding: const EdgeInsets.only(bottom: 80.0),
-                  child: _continuousScanModel.isNotEmpty
-                      ? Container(
-                          width: screenSize.width,
-                          child: SmoothProductCarousel(
-                            continuousScanModel: _continuousScanModel,
-                            height: _continuousScanModel.contributionMode
-                                ? 160.0
-                                : 120.0,
-                          ),
-                        )
-                      : Container(
-                          width: screenSize.width,
-                          height: screenSize.height * 0.5,
-                          child: Center(
-                            child: Text(
-                              appLocalizations.scannerProductsEmpty,
-                              style: themeData.textTheme.subtitle1,
-                              textAlign: TextAlign.start,
+              ),
+              SmoothRevealAnimation(
+                delay: 400,
+                startOffset: const Offset(0.0, 0.1),
+                animationCurve: Curves.easeInOutBack,
+                child: Column(
+                  mainAxisSize: MainAxisSize.max,
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: <Widget>[
+                    Container(
+                      child: Column(
+                        children: <Widget>[
+                          Padding(
+                            padding: const EdgeInsets.only(top: 36.0),
+                            child: Row(
+                              mainAxisSize: MainAxisSize.max,
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: <Widget>[
+                                ScanPage.getContributeChooseToggle(
+                                    _continuousScanModel),
+                              ],
                             ),
                           ),
-                        ),
+                          Padding(
+                            padding: const EdgeInsets.only(top: 14.0),
+                            child: Row(
+                              mainAxisSize: MainAxisSize.max,
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: <Widget>[
+                                SmoothViewFinder(
+                                  width: screenSize.width * 0.8,
+                                  height: screenSize.width * 0.45,
+                                  animationDuration: 1500,
+                                )
+                              ],
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 80.0),
+                      child: _continuousScanModel.isNotEmpty
+                          ? Container(
+                              width: screenSize.width,
+                              child: SmoothProductCarousel(
+                                continuousScanModel: _continuousScanModel,
+                                height: _continuousScanModel.contributionMode
+                                    ? 160.0
+                                    : 120.0,
+                              ),
+                            )
+                          : Container(
+                              width: screenSize.width,
+                              height: screenSize.height * 0.5,
+                              child: Center(
+                                child: Text(
+                                  appLocalizations.scannerProductsEmpty,
+                                  style: themeData.textTheme.subtitle1,
+                                  textAlign: TextAlign.start,
+                                ),
+                              ),
+                            ),
+                    ),
+                  ],
                 ),
-              ],
-            ),
+              ),
+            ],
           ),
-        ],
+        ),
       ),
     );
   }

--- a/packages/smooth_app/lib/pages/contribution_page.dart
+++ b/packages/smooth_app/lib/pages/contribution_page.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:smooth_app/pages/alternative_continuous_scan_page.dart';
-import 'package:smooth_app/pages/continuous_scan_page.dart';
+import 'package:smooth_app/pages/scan_page.dart';
 import 'package:smooth_app/temp/user_preferences.dart';
 import 'package:smooth_ui_library/animations/smooth_reveal_animation.dart';
 import 'package:smooth_ui_library/buttons/smooth_simple_button.dart';
@@ -44,12 +43,10 @@ class CollaborationPage extends StatelessWidget {
                 onPressed: () => Navigator.push<Widget>(
                   context,
                   MaterialPageRoute<Widget>(
-                    builder: (BuildContext context) =>
-                        userPreferences.getMlKitState()
-                            ? const ContinuousScanPage(
-                                initializeWithContributionMode: true)
-                            : const AlternativeContinuousScanPage(
-                                initializeWithContributionMode: true),
+                    builder: (BuildContext context) => ScanPage(
+                      contributionMode: true,
+                      mlKit: userPreferences.getMlKitState(),
+                    ),
                   ),
                 ),
               ),

--- a/packages/smooth_app/lib/pages/personalized_ranking_page.dart
+++ b/packages/smooth_app/lib/pages/personalized_ranking_page.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:openfoodfacts/model/Product.dart';
+import 'package:smooth_app/data_models/product_list.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/bottom_sheet_views/user_preferences_view.dart';
 import 'package:smooth_app/cards/product_cards/smooth_product_card_found.dart';
@@ -13,9 +13,9 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:smooth_app/themes/constant_icons.dart';
 
 class PersonalizedRankingPage extends StatefulWidget {
-  const PersonalizedRankingPage({@required this.input});
+  const PersonalizedRankingPage(this.productList);
 
-  final List<Product> input;
+  final ProductList productList;
 
   @override
   _PersonalizedRankingPageState createState() =>
@@ -74,7 +74,7 @@ class _PersonalizedRankingPageState extends State<PersonalizedRankingPage> {
     final UserPreferences userPreferences = context.watch<UserPreferences>();
     final UserPreferencesModel userPreferencesModel =
         context.watch<UserPreferencesModel>();
-    _model.refresh(widget.input, userPreferences, userPreferencesModel);
+    _model.refresh(widget.productList, userPreferences, userPreferencesModel);
     final List<BottomNavigationBarItem> bottomNavigationBarItems =
         <BottomNavigationBarItem>[];
     for (final int matchIndex in _ORDERED_MATCH_INDEXES) {

--- a/packages/smooth_app/lib/pages/product_page.dart
+++ b/packages/smooth_app/lib/pages/product_page.dart
@@ -17,7 +17,6 @@ class ProductPage extends StatelessWidget {
     final Size screenSize = MediaQuery.of(context).size;
     final double iconWidth =
         screenSize.width / 10; // TODO(monsieurtanuki): target size?
-    final TextStyle dividerTextStyle = Theme.of(context).textTheme.headline2;
     return Scaffold(
       body: Stack(
         children: <Widget>[
@@ -98,9 +97,6 @@ class ProductPage extends StatelessWidget {
                       ],
                     ),
                   ),
-                  _getDivider(
-                    Text(appLocalizations.nutrition, style: dividerTextStyle),
-                  ),
                   AttributeListExpandable(
                     product: product,
                     iconWidth: iconWidth,
@@ -109,7 +105,7 @@ class ProductPage extends StatelessWidget {
                       UserPreferencesModel.ATTRIBUTE_VEGETARIAN,
                       UserPreferencesModel.ATTRIBUTE_PALM_OIL_FREE,
                     ],
-                    title: 'Nutrition levels',
+                    title: appLocalizations.nutrition,
                   ),
                   AttributeListExpandable(
                     product: product,
@@ -123,9 +119,6 @@ class ProductPage extends StatelessWidget {
                     ],
                     title: 'Nutrition levels',
                   ),
-                  _getDivider(
-                    Text(appLocalizations.ingredients, style: dividerTextStyle),
-                  ),
                   AttributeListExpandable(
                     product: product,
                     iconWidth: iconWidth,
@@ -133,10 +126,7 @@ class ProductPage extends StatelessWidget {
                       UserPreferencesModel.ATTRIBUTE_NOVA,
                       UserPreferencesModel.ATTRIBUTE_ADDITIVES,
                     ],
-                    title: 'Labels',
-                  ),
-                  _getDivider(
-                    Text(appLocalizations.ecology, style: dividerTextStyle),
+                    title: appLocalizations.ingredients,
                   ),
                   AttributeListExpandable(
                     product: product,
@@ -146,7 +136,7 @@ class ProductPage extends StatelessWidget {
                       UserPreferencesModel.ATTRIBUTE_ORGANIC,
                       UserPreferencesModel.ATTRIBUTE_FAIR_TRADE,
                     ],
-                    title: 'Labels',
+                    title: appLocalizations.ecology,
                   ),
                 ],
               ),
@@ -156,12 +146,4 @@ class ProductPage extends StatelessWidget {
       ),
     );
   }
-
-  Widget _getDivider(final Widget child) => Padding(
-        padding: const EdgeInsets.only(
-            top: 14.0, right: 16.0, left: 16.0, bottom: 8.0),
-        child: Row(
-          children: <Widget>[Flexible(child: child)],
-        ),
-      );
 }

--- a/packages/smooth_app/lib/pages/product_query_page.dart
+++ b/packages/smooth_app/lib/pages/product_query_page.dart
@@ -15,6 +15,7 @@ import 'package:smooth_app/pages/personalized_ranking_page.dart';
 import 'package:smooth_ui_library/animations/smooth_reveal_animation.dart';
 import 'package:smooth_app/themes/constant_icons.dart';
 import 'package:smooth_app/pages/product_query_page_helper.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class ProductQueryPage extends StatefulWidget {
   const ProductQueryPage({
@@ -170,7 +171,7 @@ class _ProductQueryPageState extends State<ProductQueryPage> {
                     color: widget.mainColor,
                   ),
                   label: Text(
-                    'My personalized ranking',
+                    AppLocalizations.of(context).myPersonalizedRanking,
                     style: TextStyle(color: widget.mainColor),
                   ),
                   backgroundColor: Colors.white,
@@ -178,9 +179,11 @@ class _ProductQueryPageState extends State<ProductQueryPage> {
                     Navigator.push<dynamic>(
                       context,
                       MaterialPageRoute<dynamic>(
-                          builder: (BuildContext context) =>
-                              PersonalizedRankingPage(
-                                  input: _model.displayProducts)),
+                        builder: (BuildContext context) =>
+                            PersonalizedRankingPage(
+                          _model.supplier.getProductList(),
+                        ),
+                      ),
                     );
                   },
                 ),

--- a/packages/smooth_app/lib/pages/scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan_page.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:smooth_app/data_models/continuous_scan_model.dart';
+import 'package:smooth_app/database/local_database.dart';
+import 'package:smooth_app/pages/alternative_continuous_scan_page.dart';
+import 'package:smooth_app/pages/continuous_scan_page.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:smooth_ui_library/widgets/smooth_toggle.dart';
+
+class ScanPage extends StatelessWidget {
+  const ScanPage({
+    @required this.contributionMode,
+    @required this.mlKit,
+  });
+
+  final bool contributionMode;
+  final bool mlKit;
+
+  @override
+  Widget build(BuildContext context) {
+    final LocalDatabase localDatabase = context.watch<LocalDatabase>();
+    return FutureBuilder<ContinuousScanModel>(
+        future: ContinuousScanModel(contributionMode: contributionMode)
+            .load(localDatabase),
+        builder: (BuildContext context,
+            AsyncSnapshot<ContinuousScanModel> snapshot) {
+          if (snapshot.connectionState == ConnectionState.done) {
+            final ContinuousScanModel continuousScanModel = snapshot.data;
+            if (continuousScanModel != null) {
+              return mlKit
+                  ? ContinuousScanPage(continuousScanModel)
+                  : AlternativeContinuousScanPage(continuousScanModel);
+            }
+          }
+          return const Center(child: CircularProgressIndicator());
+        });
+  }
+
+  static Widget getContributeChooseToggle(final ContinuousScanModel model) =>
+      SmoothToggle(
+        value: model.contributionMode,
+        textLeft: '  CONTRIBUTE',
+        textRight: 'CHOOSE      ',
+        colorLeft: Colors.black.withAlpha(160),
+        colorRight: Colors.black.withAlpha(160),
+        iconLeft: SvgPicture.asset('assets/ikonate_bold/add.svg'),
+        iconRight: SvgPicture.asset('assets/ikonate_bold/search.svg'),
+        textSize: 12.0,
+        animationDuration: const Duration(milliseconds: 320),
+        width: 150.0,
+        height: 50.0,
+        onChanged: (bool value) => model.contributionModeSwitch(value),
+      );
+
+  static Widget getHero(final Size screenSize) => Hero(
+        tag: 'action_button',
+        child: Container(
+          width: screenSize.width,
+          height: screenSize.height,
+          color: Colors.black,
+          child: Center(
+            child: SvgPicture.asset(
+              'assets/actions/scanner_alt_2.svg',
+              width: 60.0,
+              height: 60.0,
+              color: Colors.white,
+            ),
+          ),
+        ),
+      );
+}


### PR DESCRIPTION
New file:
* `scan_page.dart`: helper class to be used on top of `AlternativeContinuousScanPage` and `ContinuousScanPage`

Impacted files:
* `alternative_continuous_scan_page.dart`: `ContinuousScanModel` is now initialized upstream by `ScanPage`
* `continuous_scan_model.dart`: now a `ChangeNotifier`, uses a `ProductList` and database cache
* `continuous_scan_page.dart`: `ContinuousScanModel` is now initialized upstream by `ScanPage`
* `contribution_page.dart`: uses the new `ScanPage` widget instead of the 2 scan pages
* `local_database.dart`: removed the dummy notify listener method
* `main.dart`: uses the new `ScanPage` widget instead of the 2 scan pages
* `personalized_ranking_page.dart`: now we use a `ProductList` as input
* `product_list.dart`: added a `getProduct` method and a "scan list" identifier
* `product_page.dart`: unrelated UI fixes
* `product_query_page.dart`: slight refactoring
* `smooth_it_model.dart`: now we use `ProductList`
* `smooth_product_carousel.dart`: added the new "CACHED" product possibility; fixed an init bug