### PR TITLE
ColorScheme refactoring: simplification by relying on the default colors

### DIFF
--- a/packages/smooth_app/lib/bottom_sheet_views/user_preferences_view.dart
+++ b/packages/smooth_app/lib/bottom_sheet_views/user_preferences_view.dart
@@ -86,9 +86,6 @@ class UserPreferencesView extends StatelessWidget {
                       sigmaY: 4.0,
                     ),
                     child: Container(
-                      color: Theme.of(context)
-                          .bottomNavigationBarTheme
-                          .backgroundColor,
                       padding: const EdgeInsets.symmetric(
                           horizontal: _TYPICAL_PADDING_OR_MARGIN,
                           vertical: 20.0),

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_loading.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_loading.dart
@@ -10,7 +10,7 @@ class SmoothProductCardLoading extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       decoration: BoxDecoration(
-        color: Theme.of(context).cardColor,
+        color: Theme.of(context).colorScheme.surface,
         borderRadius: const BorderRadius.all(Radius.circular(15.0)),
       ),
       child: Column(

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_not_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_not_found.dart
@@ -20,7 +20,7 @@ class SmoothProductCardNotFound extends StatelessWidget {
       borderRadius: const BorderRadius.all(Radius.circular(15.0)),
       child: Container(
         decoration: BoxDecoration(
-          color: Theme.of(context).cardColor,
+          color: Theme.of(context).colorScheme.surface,
           borderRadius: const BorderRadius.all(Radius.circular(15.0)),
         ),
         child: Column(

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_thanks.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_thanks.dart
@@ -6,7 +6,7 @@ class SmoothProductCardThanks extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       decoration: BoxDecoration(
-        color: Theme.of(context).cardColor,
+        color: Theme.of(context).colorScheme.surface,
         borderRadius: const BorderRadius.all(Radius.circular(15.0)),
       ),
       child: Column(

--- a/packages/smooth_app/lib/main.dart
+++ b/packages/smooth_app/lib/main.dart
@@ -99,8 +99,11 @@ class _MyAppState extends State<MyApp> {
                   localizationsDelegates:
                       AppLocalizations.localizationsDelegates,
                   supportedLocales: AppLocalizations.supportedLocales,
-                  theme: SmoothThemes.getSmoothThemeData(
-                      themeChangeProvider.darkTheme, context),
+                  theme: SmoothTheme.getThemeData(Brightness.light),
+                  darkTheme: SmoothTheme.getThemeData(Brightness.dark),
+                  themeMode: themeChangeProvider.darkTheme
+                      ? ThemeMode.dark
+                      : ThemeMode.light,
                   home: SmoothAppGetLanguage(),
                 );
               },
@@ -184,12 +187,10 @@ class SmoothApp extends StatelessWidget {
       animationDuration: 300,
       animationCurve: Curves.easeInOutBack,
       borderRadius: 20.0,
-      color: Theme.of(context).bottomNavigationBarTheme.backgroundColor,
-      scanButtonColor: Theme.of(context).colorScheme.onBackground,
-      scanShadowColor: context.watch<DarkThemeProvider>().darkTheme
-          ? Colors.white.withOpacity(0.0)
-          : Colors.deepPurple,
-      scanIconColor: Theme.of(context).colorScheme.primary,
+      color: Colors.transparent,
+      scanButtonColor: Theme.of(context).colorScheme.secondary,
+      scanShadowColor: Theme.of(context).colorScheme.secondary,
+      scanIconColor: Theme.of(context).colorScheme.onSecondary,
       classicMode: true,
     );
   }
@@ -208,10 +209,7 @@ class SmoothApp extends StatelessWidget {
             svg,
             width: _navigationIconSize,
             height: _navigationIconSize,
-            color: Theme.of(context)
-                .bottomNavigationBarTheme
-                .selectedIconTheme
-                .color,
+            color: Theme.of(context).bottomNavigationBarTheme.selectedItemColor,
           ),
         ),
         title: title,

--- a/packages/smooth_app/lib/pages/choose_page.dart
+++ b/packages/smooth_app/lib/pages/choose_page.dart
@@ -99,14 +99,9 @@ class _ChoosePageState extends State<ChoosePage> {
                   (BuildContext context, bool innerBoxIsScrolled) {
                 return <Widget>[
                   SliverAppBar(
-                    backgroundColor: Theme.of(context).colorScheme.background,
-                    expandedHeight: 248.0, //choosePageModel.appBarColor,
+                    expandedHeight: 248.0,
                     pinned: true,
                     elevation: 8.0,
-                    /*title: Padding(
-                        padding: const EdgeInsets.only(top: 8.0),
-                        child: Text('Smoothie', style: Theme.of(context).textTheme.headline2.copyWith(color: Colors.black.withOpacity(choosePageModel.opacity)),),
-                      ),*/
                     centerTitle: true,
                     flexibleSpace: FlexibleSpaceBar(
                       collapseMode: CollapseMode.parallax,
@@ -220,9 +215,6 @@ class _ChoosePageState extends State<ChoosePage> {
                       child: Container(
                         padding: const EdgeInsets.only(
                           left: 12.0,
-                        ),
-                        decoration: BoxDecoration(
-                          color: Theme.of(context).colorScheme.background,
                         ),
                         child: Row(
                           mainAxisSize: MainAxisSize.max,

--- a/packages/smooth_app/lib/pages/personalized_ranking_page.dart
+++ b/packages/smooth_app/lib/pages/personalized_ranking_page.dart
@@ -90,17 +90,8 @@ class _PersonalizedRankingPageState extends State<PersonalizedRankingPage> {
     return Scaffold(
       key: _scaffoldKey,
       bottomNavigationBar: BottomNavigationBar(
-        backgroundColor: Theme.of(context)
-            .bottomNavigationBarTheme
-            .backgroundColor
-            .withAlpha(255),
         type: BottomNavigationBarType.fixed,
         currentIndex: _currentTabIndex,
-        selectedItemColor: Theme.of(context).colorScheme.onSurface,
-        unselectedItemColor: Theme.of(context)
-            .bottomNavigationBarTheme
-            .unselectedIconTheme
-            .color,
         items: bottomNavigationBarItems,
         onTap: (int tapped) => setState(() {
           _currentTabIndex = tapped;

--- a/packages/smooth_app/lib/pages/product_page.dart
+++ b/packages/smooth_app/lib/pages/product_page.dart
@@ -52,7 +52,7 @@ class ProductPage extends StatelessWidget {
           BackdropFilter(
             filter: ImageFilter.blur(sigmaX: 18.0, sigmaY: 18.0),
             child: Container(
-              color: Theme.of(context).cardColor.withAlpha(220),
+              color: Theme.of(context).colorScheme.surface.withAlpha(220),
               child: ListView(
                 children: <Widget>[
                   Padding(

--- a/packages/smooth_app/lib/themes/smooth_theme.dart
+++ b/packages/smooth_app/lib/themes/smooth_theme.dart
@@ -15,6 +15,10 @@ class SmoothTheme {
         backgroundColor: myColorScheme.onSurface,
         actionTextColor: myColorScheme.surface,
       ),
+      appBarTheme: AppBarTheme(
+        color: myColorScheme.background,
+      ),
+      scaffoldBackgroundColor: myColorScheme.background,
     );
   }
 

--- a/packages/smooth_app/lib/themes/smooth_theme.dart
+++ b/packages/smooth_app/lib/themes/smooth_theme.dart
@@ -1,95 +1,68 @@
 import 'package:flutter/material.dart';
 
-class SmoothThemes {
-  static ThemeData getSmoothThemeData(
-    bool isDarkTheme,
-    BuildContext context,
-  ) {
-    // yellowAccent == null
-    const ColorScheme colorLight = ColorScheme(
-      primary: Colors.white,
-      primaryVariant: Colors.yellowAccent,
-      secondary: Color(0xFF696464),
-      secondaryVariant: Colors.yellowAccent,
-      surface: Colors.white,
-      background: Colors.white,
-      error: Color(0xFFf00a2c),
-      onPrimary: Colors.black,
-      onSecondary: Colors.white,
-      onSurface: Colors.black,
-      onBackground: Colors.black,
-      onError: Colors.white,
-      brightness: Brightness.light,
-    );
-    // yellowAccent == null
-    const ColorScheme colorDark = ColorScheme(
-      primary: Color(0xFF181818),
-      primaryVariant: Colors.yellowAccent,
-      secondary: Colors.black,
-      secondaryVariant: Colors.yellowAccent,
-      surface: Color(0xFF181818),
-      background: Colors.black,
-      error: Color(0xFFf00a2c),
-      onPrimary: Colors.white,
-      onSecondary: Colors.white,
-      onSurface: Colors.white,
-      onBackground: Colors.white,
-      onError: Colors.white,
-      brightness: Brightness.dark,
-    );
-
-    final ColorScheme myColorScheme = isDarkTheme ? colorDark : colorLight;
-
+class SmoothTheme {
+  static ThemeData getThemeData(final Brightness brightness) {
+    final ColorScheme myColorScheme =
+        brightness == Brightness.dark ? _COLOR_DARK : _COLOR_LIGHT;
     return ThemeData(
-      applyElevationOverlayColor: true,
       colorScheme: myColorScheme,
       bottomNavigationBarTheme: BottomNavigationBarThemeData(
-        backgroundColor: isDarkTheme ? const Color(0xB3181818) : Colors.white24,
-        selectedIconTheme: IconThemeData(
-          color: myColorScheme.onSurface,
-        ),
-        unselectedIconTheme: const IconThemeData(
-          color: Colors.blueGrey,
-        ),
+        selectedItemColor: myColorScheme.onSurface,
+        unselectedItemColor: myColorScheme.onSurface,
       ),
-      scaffoldBackgroundColor: myColorScheme.background,
-      cardColor: isDarkTheme ? myColorScheme.surface : const Color(0xFFF5F5F5),
-      buttonColor: myColorScheme.secondary,
-      textTheme: TextTheme(
-        headline1: TextStyle(
-          fontSize: 28.0,
-          fontWeight: FontWeight.bold,
-          color: myColorScheme.onBackground,
-        ),
-        headline2: TextStyle(
-          fontSize: 24.0,
-          fontWeight: FontWeight.bold,
-          color: myColorScheme.onSurface,
-        ),
-        headline3: TextStyle(
-          fontSize: 18.0,
-          fontWeight: FontWeight.bold,
-          color: myColorScheme.onSurface,
-        ),
-        headline4: TextStyle(
-          fontSize: 16.0,
-          fontWeight: FontWeight.bold,
-          color: myColorScheme.onSurface,
-        ),
-        bodyText2: TextStyle(
-          color: myColorScheme.onSurface,
-          fontSize: 14,
-          letterSpacing: 0.5,
-        ),
-        subtitle1: TextStyle(
-          fontSize: 14.0,
-          fontWeight: FontWeight.w200,
-          color: myColorScheme.onSurface,
-        ),
-        subtitle2: TextStyle(
-          color: myColorScheme.onSurface,
-        ),
+      textTheme: _TEXT_THEME,
+      snackBarTheme: SnackBarThemeData(
+        backgroundColor: myColorScheme.onSurface,
+        actionTextColor: myColorScheme.surface,
       ),
     );
   }
+
+  static const ColorScheme _COLOR_LIGHT = ColorScheme.light(
+    primary: Colors.white,
+    primaryVariant: Colors.white60,
+    secondary: Colors.black,
+    secondaryVariant: Colors.black,
+    onPrimary: Colors.black,
+    onSecondary: Colors.white,
+  );
+
+  static const ColorScheme _COLOR_DARK = ColorScheme.dark(
+    primary: Colors.black,
+    primaryVariant: Colors.black,
+    secondary: Colors.white,
+    secondaryVariant: Colors.white60,
+    onPrimary: Colors.white,
+    onSecondary: Colors.black,
+  );
+
+  static const TextTheme _TEXT_THEME = TextTheme(
+    headline1: TextStyle(
+      fontSize: 28.0,
+      fontWeight: FontWeight.bold,
+    ),
+    headline2: TextStyle(
+      fontSize: 24.0,
+      fontWeight: FontWeight.bold,
+    ),
+    headline3: TextStyle(
+      fontSize: 18.0,
+      fontWeight: FontWeight.bold,
+    ),
+    headline4: TextStyle(
+      fontSize: 16.0,
+      fontWeight: FontWeight.bold,
+    ),
+    bodyText2: TextStyle(
+      fontSize: 14,
+      letterSpacing: 0.5,
+    ),
+    subtitle1: TextStyle(
+      fontSize: 14.0,
+      fontWeight: FontWeight.w200,
+    ),
+    subtitle2: TextStyle(
+      fontSize: 12.0,
+    ),
+  );
 }

--- a/packages/smooth_ui_library/lib/widgets/smooth_expandable_card.dart
+++ b/packages/smooth_ui_library/lib/widgets/smooth_expandable_card.dart
@@ -52,7 +52,7 @@ class SmoothExpandableCard extends StatelessWidget {
           elevation: 8.0,
           shadowColor: Colors.black45,
           borderRadius: const BorderRadius.all(Radius.circular(10.0)),
-          color: themeData.cardColor,
+          color: themeData.colorScheme.surface,
           child: Container(
             padding: const EdgeInsets.all(12.0),
             child: Row(
@@ -82,7 +82,7 @@ class SmoothExpandableCard extends StatelessWidget {
         elevation: 8.0,
         shadowColor: Colors.black45,
         borderRadius: const BorderRadius.all(Radius.circular(10.0)),
-        color: themeData.cardColor,
+        color: themeData.colorScheme.surface,
         child: Container(
           padding: const EdgeInsets.all(12.0),
           child: Column(

--- a/packages/smooth_ui_library/lib/widgets/smooth_listTile.dart
+++ b/packages/smooth_ui_library/lib/widgets/smooth_listTile.dart
@@ -18,7 +18,7 @@ class SmoothListTile extends StatelessWidget {
         padding: const EdgeInsets.symmetric(vertical: 5.0, horizontal: 10.0),
         margin: const EdgeInsets.all(10.0),
         decoration: BoxDecoration(
-            color: Theme.of(context).cardColor,
+            color: Theme.of(context).colorScheme.surface,
             borderRadius: const BorderRadius.all(Radius.circular(20.0))),
         child: Row(
           mainAxisSize: MainAxisSize.max,

--- a/packages/smooth_ui_library/lib/widgets/smooth_search_bar.dart
+++ b/packages/smooth_ui_library/lib/widgets/smooth_search_bar.dart
@@ -19,8 +19,9 @@ class SmoothSearchBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final Color surface = Theme.of(context).colorScheme.surface;
     return Material(
-      color: Theme.of(context).cardColor,
+      color: surface,
       elevation: 24.0,
       borderRadius: BorderRadius.all(Radius.circular(borderRadius)),
       shadowColor: shadowColor.withAlpha(160),
@@ -40,7 +41,7 @@ class SmoothSearchBar extends StatelessWidget {
               color: Colors.grey,
             ),
           ),
-          focusColor: Theme.of(context).cardColor,
+          focusColor: surface,
         ),
         onSubmitted: onSubmitted,
       ),


### PR DESCRIPTION
Impacted files:
* `main.dart`: refactored
* `personalized_ranking_page.dart`: now transparently using the default values for `BottomNavigationBar`
* `product_page.dart`: replaced `themeData.cardColor` with `themeData.colorScheme.surface`
* `smooth_expandable_card.dart`: replaced `themeData.cardColor` with `themeData.colorScheme.surface`
* `smooth_listTile.dart`: replaced `themeData.cardColor` with `themeData.colorScheme.surface`
* `smooth_product_card_loading.dart`: replaced `themeData.cardColor` with `themeData.colorScheme.surface`
* `smooth_product_card_not_found.dart`: replaced `themeData.cardColor` with `themeData.colorScheme.surface`
* `smooth_product_card_thanks.dart`: replaced `themeData.cardColor` with `themeData.colorScheme.surface`
* `smooth_search_bar.dart`: replaced `themeData.cardColor` with `themeData.colorScheme.surface`
* `smooth_theme.dart`: simplified by relying on the default ColorScheme`s
* `user_preferences_view.dart`: removed useless color