### PR TITLE
Added backbutton to scanner

### DIFF
--- a/packages/smooth_app/lib/pages/alternative_continuous_scan_page.dart
+++ b/packages/smooth_app/lib/pages/alternative_continuous_scan_page.dart
@@ -28,6 +28,15 @@ class AlternativeContinuousScanPage extends StatelessWidget {
         builder:
             (BuildContext context, ContinuousScanModel dummy, Widget child) =>
                 Scaffold(
+          extendBodyBehindAppBar: true,
+          appBar: AppBar(
+            elevation: 0,
+            backgroundColor: Colors.transparent,
+            leading: IconButton(
+              icon: const Icon(Icons.arrow_back),
+              onPressed: () => Navigator.pop(context),
+            ),
+          ),
           floatingActionButton: SmoothRevealAnimation(
             delay: 400,
             animationCurve: Curves.easeInOutBack,

--- a/packages/smooth_app/lib/pages/continuous_scan_page.dart
+++ b/packages/smooth_app/lib/pages/continuous_scan_page.dart
@@ -27,6 +27,15 @@ class ContinuousScanPage extends StatelessWidget {
         builder:
             (BuildContext context, ContinuousScanModel dummy, Widget child) =>
                 Scaffold(
+          extendBodyBehindAppBar: true,
+          appBar: AppBar(
+            elevation: 0,
+            backgroundColor: Colors.transparent,
+            leading: IconButton(
+              icon: const Icon(Icons.arrow_back),
+              onPressed: () => Navigator.pop(context),
+            ),
+          ),
           floatingActionButton: SmoothRevealAnimation(
             delay: 400,
             animationCurve: Curves.easeInOutBack,


### PR DESCRIPTION
Added a backbutton to a transparent `appBar` to the `continuous_scan_page` and `alternative_continuous_scan_page`, for navigation on Iphone #17.