### PR TITLE
Issue 131/undefined attribute

### DIFF
--- a/packages/smooth_app/lib/cards/expandables/attribute_list_expandable.dart
+++ b/packages/smooth_app/lib/cards/expandables/attribute_list_expandable.dart
@@ -32,20 +32,23 @@ class AttributeListExpandable extends StatelessWidget {
     for (final String attributeTag in attributeTags) {
       Attribute attribute =
           UserPreferencesModel.getAttribute(product, attributeTag);
-      chips.add(AttributeChip(attribute, width: iconWidth));
-      if (attribute != null &&
-          attribute.id == UserPreferencesModel.ATTRIBUTE_ADDITIVES) {
-        // TODO(monsieurtanuki): remove that cheat when additives are more standard
-        final List<String> additiveNames = product.additives?.names;
-        attribute = Attribute(
-          id: attribute.id,
-          title: attribute.title,
-          iconUrl: attribute.iconUrl,
-          descriptionShort:
-              additiveNames == null ? '' : additiveNames.join(', '),
-        );
+
+      // Some attributes selected in the user preferences might be unavailable for some products
+      if (attribute != null) {
+        chips.add(AttributeChip(attribute, width: iconWidth));
+        if (attribute.id == UserPreferencesModel.ATTRIBUTE_ADDITIVES) {
+          // TODO(monsieurtanuki): remove that cheat when additives are more standard
+          final List<String> additiveNames = product.additives?.names;
+          attribute = Attribute(
+            id: attribute.id,
+            title: attribute.title,
+            iconUrl: attribute.iconUrl,
+            descriptionShort:
+                additiveNames == null ? '' : additiveNames.join(', '),
+          );
+        }
+        cards.add(AttributeCard(attribute, iconWidth));
       }
-      cards.add(AttributeCard(attribute, iconWidth));
     }
     final Widget content = Column(
       mainAxisAlignment: MainAxisAlignment.start,

--- a/packages/smooth_app/lib/data_models/match.dart
+++ b/packages/smooth_app/lib/data_models/match.dart
@@ -70,7 +70,7 @@ class Match {
   }
 
   // return a map of all existing product attributes matching a list of attribute ids
-  static Map<String, Attribute> getAttributeMatches(
+  static Map<String, Attribute> getMatchingAttributes(
     final Product product,
     final List<String> attributeIds,
   ) {

--- a/packages/smooth_app/lib/data_models/match.dart
+++ b/packages/smooth_app/lib/data_models/match.dart
@@ -69,11 +69,12 @@ class Match {
     return result;
   }
 
-  static Map<String, double> getAttributeMatches(
+  // return a map of all existing product attributes matching a list of attribute ids
+  static Map<String, Attribute> getAttributeMatches(
     final Product product,
     final List<String> attributeIds,
   ) {
-    final Map<String, double> result = <String, double>{};
+    final Map<String, Attribute> result = <String, Attribute>{};
     final List<AttributeGroup> attributeGroups = product.attributeGroups;
     if (attributeGroups == null) {
       return result;
@@ -81,9 +82,8 @@ class Match {
     for (final AttributeGroup group in attributeGroups) {
       for (final Attribute attribute in group.attributes) {
         final String attributeId = attribute.id;
-        if (attributeIds.contains(attributeId) &&
-            attribute.status == _KNOWN_STATUS) {
-          result[attributeId] = attribute.match;
+        if (attributeIds.contains(attributeId)) {
+          result[attributeId] = attribute;
         }
       }
     }

--- a/packages/smooth_app/lib/pages/product_page.dart
+++ b/packages/smooth_app/lib/pages/product_page.dart
@@ -92,18 +92,20 @@ class _ProductPageState extends State<ProductPage> {
         ),
       ),
     );
-    final Map<String, double> matches =
+    final Map<String, Attribute> matchingAttributes =
         Match.getAttributeMatches(widget.product, mainAttributes);
     for (final String attributeId in mainAttributes) {
-      listItems.add(
-        AttributeListExpandable(
-          product: widget.product,
-          iconWidth: iconWidth,
-          attributeTags: <String>[attributeId],
-          collapsible: false,
-          background: _getBackgroundColor(matches[attributeId]),
-        ),
-      );
+      if (matchingAttributes[attributeId] != null) {
+        listItems.add(
+          AttributeListExpandable(
+            product: widget.product,
+            iconWidth: iconWidth,
+            attributeTags: <String>[attributeId],
+            collapsible: false,
+            background: _getBackgroundColor(matchingAttributes[attributeId]),
+          ),
+        );
+      }
     }
     for (final AttributeGroup attributeGroup
         in _getOrderedAttributeGroups(userPreferencesModel)) {
@@ -262,23 +264,24 @@ class _ProductPageState extends State<ProductPage> {
     return attributeGroups;
   }
 
-  Color _getBackgroundColor(final double match) {
-    if (match == null) {
+  Color _getBackgroundColor(final Attribute attribute) {
+    if (attribute.status == "known") {
+      if (attribute.match <= 20) {
+        return const HSLColor.fromAHSL(1, 0, 1, .9).toColor();
+      }
+      if (attribute.match <= 40) {
+        return const HSLColor.fromAHSL(1, 30, 1, .9).toColor();
+      }
+      if (attribute.match <= 60) {
+        return const HSLColor.fromAHSL(1, 60, 1, .9).toColor();
+      }
+      if (attribute.match <= 80) {
+        return const HSLColor.fromAHSL(1, 90, 1, .9).toColor();
+      }
+      return const HSLColor.fromAHSL(1, 120, 1, .9).toColor();
+    } else {
       return const Color.fromARGB(0xff, 0xEE, 0xEE, 0xEE);
     }
-    if (match <= 20) {
-      return const HSLColor.fromAHSL(1, 0, 1, .9).toColor();
-    }
-    if (match <= 40) {
-      return const HSLColor.fromAHSL(1, 30, 1, .9).toColor();
-    }
-    if (match <= 60) {
-      return const HSLColor.fromAHSL(1, 60, 1, .9).toColor();
-    }
-    if (match <= 80) {
-      return const HSLColor.fromAHSL(1, 90, 1, .9).toColor();
-    }
-    return const HSLColor.fromAHSL(1, 120, 1, .9).toColor();
   }
 
   Future<void> _openLists(final String barcode) async {

--- a/packages/smooth_app/lib/pages/product_page.dart
+++ b/packages/smooth_app/lib/pages/product_page.dart
@@ -93,7 +93,7 @@ class _ProductPageState extends State<ProductPage> {
       ),
     );
     final Map<String, Attribute> matchingAttributes =
-        Match.getAttributeMatches(widget.product, mainAttributes);
+        Match.getMatchingAttributes(widget.product, mainAttributes);
     for (final String attributeId in mainAttributes) {
       if (matchingAttributes[attributeId] != null) {
         listItems.add(


### PR DESCRIPTION
This is a fix for #131, to handle the case where the user has selected some attributes in the preferences, and that some of those attributes are not available in some products. (e.g. if the Eco-Score is not available for a specific country).

Affected files:
- attribute_list_expandable.dart : do not add a card for the attribute if it is null
- match.dart : replaced getAttributeMatches with getMatchingAttributes to get a map of attributes instead of a map of match scores
- product_page.dart: as we have a separate AttributeList for each attribute, we now do not display the AttributeList if the only attribute it contains is null (otherwise we get an empty card).


