### PR TITLE
bug/#136 - fixed info minor issues

### DIFF
--- a/packages/smooth_app/lib/data_models/match.dart
+++ b/packages/smooth_app/lib/data_models/match.dart
@@ -44,7 +44,7 @@ class Match {
   }
 
   static const String _UNKNOWN_STATUS = 'unknown';
-  static const String _KNOWN_STATUS = 'known';
+  static const String KNOWN_STATUS = 'known';
 
   double _score = 0;
   bool _status = true;

--- a/packages/smooth_app/lib/pages/product_page.dart
+++ b/packages/smooth_app/lib/pages/product_page.dart
@@ -375,7 +375,7 @@ class _ProductPageState extends State<ProductPage> {
   }
 
   Color _getBackgroundColor(final Attribute attribute) {
-    if (attribute.status == "known") {
+    if (attribute.status == Match.KNOWN_STATUS) {
       if (attribute.match <= 20) {
         return const HSLColor.fromAHSL(1, 0, 1, .9).toColor();
       }


### PR DESCRIPTION
info • The value of the field '_KNOWN_STATUS' isn't used •
       lib/data_models/match.dart:47:23 • unused_field
info • Only use double quotes for strings containing single quotes •
       lib/pages/product_page.dart:378:29 • prefer_single_quotes