### PR TITLE
Start of refactoring of new product page, with image upload

### DIFF
--- a/packages/smooth_app/lib/cards/data_cards/image_upload_card.dart
+++ b/packages/smooth_app/lib/cards/data_cards/image_upload_card.dart
@@ -1,0 +1,81 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:openfoodfacts/model/Product.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:image_cropper/image_cropper.dart';
+
+class ImageUploadCard extends StatefulWidget {
+  const ImageUploadCard({
+    Key key,
+    this.product,
+    this.imageField,
+    this.buttonText,
+  }) : super(key: key);
+
+  final Product product;
+  final ImageField imageField;
+  final String buttonText;
+
+  @override
+  _ImageUploadCardState createState() => _ImageUploadCardState();
+}
+
+class _ImageUploadCardState extends State<ImageUploadCard> {
+  File _image;
+  final picker = ImagePicker();
+
+  Future _getImage() async {
+    print("getImage");
+    final pickedFile = await picker.getImage(source: ImageSource.camera);
+    print("got image");
+
+    if (pickedFile != null) {
+      File croppedImage = await ImageCropper.cropImage(
+        sourcePath: pickedFile.path,
+        androidUiSettings: AndroidUiSettings(
+          lockAspectRatio: false,
+          hideBottomControls: true,
+        ),
+      );
+      print("cropping image - done");
+
+      if (croppedImage != null) {
+        setState(() {
+          _image = croppedImage;
+        });
+
+        SendImage image = new SendImage(
+          lang: OpenFoodFactsLanguage.ENGLISH,
+          barcode: widget.product.barcode,
+          imageField: widget.imageField,
+          imageUrl: _image.uri,
+        );
+
+        // a registered user login for https://world.openfoodfacts.org/ is required
+        User myUser =
+            new User(userId: "smoothie-app", password: "strawberrybanana");
+
+        // query the OpenFoodFacts API
+        Status result = await OpenFoodAPIClient.addProductImage(myUser, image);
+
+        if (result.status != "status ok") {
+          throw new Exception("image could not be uploaded: " +
+              result.error +
+              " " +
+              result.imageId.toString());
+        }
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton.icon(
+      onPressed: _getImage,
+      icon: Icon(Icons.add_a_photo),
+      label: Text(widget.buttonText),
+    );
+  }
+}

--- a/packages/smooth_app/lib/cards/data_cards/image_upload_card.dart
+++ b/packages/smooth_app/lib/cards/data_cards/image_upload_card.dart
@@ -24,29 +24,30 @@ class ImageUploadCard extends StatefulWidget {
 
 class _ImageUploadCardState extends State<ImageUploadCard> {
   File _image;
-  final picker = ImagePicker();
+  final ImagePicker picker = ImagePicker();
 
-  Future _getImage() async {
-    print("getImage");
-    final pickedFile = await picker.getImage(source: ImageSource.camera);
-    print("got image");
+  Future<void> _getImage() async {
+    print('getImage');
+    final PickedFile pickedFile =
+        await picker.getImage(source: ImageSource.camera);
+    print('got image');
 
     if (pickedFile != null) {
-      File croppedImage = await ImageCropper.cropImage(
+      final File croppedImage = await ImageCropper.cropImage(
         sourcePath: pickedFile.path,
-        androidUiSettings: AndroidUiSettings(
+        androidUiSettings: const AndroidUiSettings(
           lockAspectRatio: false,
           hideBottomControls: true,
         ),
       );
-      print("cropping image - done");
+      print('cropping image - done');
 
       if (croppedImage != null) {
         setState(() {
           _image = croppedImage;
         });
 
-        SendImage image = new SendImage(
+        final SendImage image = SendImage(
           lang: OpenFoodFactsLanguage.ENGLISH,
           barcode: widget.product.barcode,
           imageField: widget.imageField,
@@ -54,16 +55,17 @@ class _ImageUploadCardState extends State<ImageUploadCard> {
         );
 
         // a registered user login for https://world.openfoodfacts.org/ is required
-        User myUser =
-            new User(userId: "smoothie-app", password: "strawberrybanana");
+        const User myUser =
+            User(userId: 'smoothie-app', password: 'strawberrybanana');
 
         // query the OpenFoodFacts API
-        Status result = await OpenFoodAPIClient.addProductImage(myUser, image);
+        final Status result =
+            await OpenFoodAPIClient.addProductImage(myUser, image);
 
-        if (result.status != "status ok") {
-          throw new Exception("image could not be uploaded: " +
+        if (result.status != 'status ok') {
+          throw Exception('image could not be uploaded: ' +
               result.error +
-              " " +
+              ' ' +
               result.imageId.toString());
         }
       }
@@ -74,7 +76,7 @@ class _ImageUploadCardState extends State<ImageUploadCard> {
   Widget build(BuildContext context) {
     return ElevatedButton.icon(
       onPressed: _getImage,
-      icon: Icon(Icons.add_a_photo),
+      icon: const Icon(Icons.add_a_photo),
       label: Text(widget.buttonText),
     );
   }

--- a/packages/smooth_app/lib/cards/data_cards/image_upload_card.dart
+++ b/packages/smooth_app/lib/cards/data_cards/image_upload_card.dart
@@ -2,17 +2,17 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:openfoodfacts/utils/LanguageHelper.dart';
 import 'package:openfoodfacts/model/Product.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:image_cropper/image_cropper.dart';
 
 class ImageUploadCard extends StatefulWidget {
   const ImageUploadCard({
-    Key key,
     this.product,
     this.imageField,
     this.buttonText,
-  }) : super(key: key);
+  });
 
   final Product product;
   final ImageField imageField;
@@ -27,10 +27,8 @@ class _ImageUploadCardState extends State<ImageUploadCard> {
   final ImagePicker picker = ImagePicker();
 
   Future<void> _getImage() async {
-    print('getImage');
     final PickedFile pickedFile =
         await picker.getImage(source: ImageSource.camera);
-    print('got image');
 
     if (pickedFile != null) {
       final File croppedImage = await ImageCropper.cropImage(
@@ -40,7 +38,6 @@ class _ImageUploadCardState extends State<ImageUploadCard> {
           hideBottomControls: true,
         ),
       );
-      print('cropping image - done');
 
       if (croppedImage != null) {
         setState(() {
@@ -48,7 +45,8 @@ class _ImageUploadCardState extends State<ImageUploadCard> {
         });
 
         final SendImage image = SendImage(
-          lang: OpenFoodFactsLanguage.ENGLISH,
+          lang: LanguageHelper.fromJson(
+              Localizations.localeOf(context).languageCode),
           barcode: widget.product.barcode,
           imageField: widget.imageField,
           imageUrl: _image.uri,

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_not_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_not_found.dart
@@ -1,17 +1,25 @@
 import 'package:flutter/material.dart';
 import 'package:smooth_app/pages/smooth_upload_page.dart';
 import 'package:smooth_ui_library/buttons/smooth_simple_button.dart';
+import 'package:openfoodfacts/model/Product.dart';
+import 'package:smooth_app/pages/product_page.dart';
 
 class SmoothProductCardNotFound extends StatelessWidget {
-  const SmoothProductCardNotFound({
+  SmoothProductCardNotFound({
     @required this.barcode,
     this.callback,
     this.elevation = 0.0,
-  });
+  }) {
+    this.product = Product(
+      barcode: barcode,
+    );
+  }
 
   final String barcode;
   final Function callback;
   final double elevation;
+
+  Product product;
 
   @override
   Widget build(BuildContext context) {
@@ -44,12 +52,16 @@ class SmoothProductCardNotFound extends StatelessWidget {
                   width: 100.0,
                   onPressed: () {
                     Navigator.push<dynamic>(
-                        context,
-                        MaterialPageRoute<dynamic>(
-                            builder: (BuildContext context) =>
-                                SmoothUploadPage(barcode: barcode)));
+                      context,
+                      MaterialPageRoute<dynamic>(
+                          builder: (BuildContext context) => ProductPage(
+                                product: product,
+                                newProduct: true,
+                              )),
+                    );
                     callback();
                   },
+                  //onLongPress: () => ProductPage.showLists(product, context),
                 ),
               ],
             ),

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_not_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_not_found.dart
@@ -1,25 +1,18 @@
 import 'package:flutter/material.dart';
-import 'package:smooth_app/pages/smooth_upload_page.dart';
 import 'package:smooth_ui_library/buttons/smooth_simple_button.dart';
 import 'package:openfoodfacts/model/Product.dart';
 import 'package:smooth_app/pages/product_page.dart';
 
 class SmoothProductCardNotFound extends StatelessWidget {
-  SmoothProductCardNotFound({
-    @required this.barcode,
+  const SmoothProductCardNotFound({
+    @required this.product,
     this.callback,
     this.elevation = 0.0,
-  }) {
-    this.product = Product(
-      barcode: barcode,
-    );
-  }
+  });
 
-  final String barcode;
   final Function callback;
   final double elevation;
-
-  Product product;
+  final Product product;
 
   @override
   Widget build(BuildContext context) {
@@ -39,7 +32,7 @@ class SmoothProductCardNotFound extends StatelessWidget {
             const SizedBox(
               height: 12.0,
             ),
-            Text(barcode, style: Theme.of(context).textTheme.subtitle1),
+            Text(product.barcode, style: Theme.of(context).textTheme.subtitle1),
             const SizedBox(
               height: 12.0,
             ),

--- a/packages/smooth_app/lib/lists/smooth_product_carousel.dart
+++ b/packages/smooth_app/lib/lists/smooth_product_carousel.dart
@@ -70,7 +70,9 @@ class _SmoothProductCarouselState extends State<SmoothProductCarousel> {
         return SmoothProductCardLoading(barcode: barcode);
       case ScannedProductState.NOT_FOUND:
         return SmoothProductCardNotFound(
-          barcode: barcode,
+          product: Product(
+            barcode: barcode,
+          ),
           callback: () => widget.continuousScanModel
               .setBarcodeState(barcode, ScannedProductState.THANKS),
         );

--- a/packages/smooth_app/lib/pages/product_page.dart
+++ b/packages/smooth_app/lib/pages/product_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:openfoodfacts/model/Product.dart';
+import 'package:smooth_app/cards/data_cards/image_upload_card.dart';
 import 'package:smooth_app/cards/expandables/attribute_list_expandable.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:smooth_app/data_models/match.dart';
@@ -11,6 +12,7 @@ import 'package:smooth_app/data_models/user_preferences_model.dart';
 import 'package:provider/provider.dart';
 import 'package:openfoodfacts/model/AttributeGroup.dart';
 import 'package:openfoodfacts/model/Attribute.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/temp/user_preferences.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/data_models/product_list.dart';
@@ -23,8 +25,9 @@ import 'package:smooth_app/themes/constant_icons.dart';
 import 'package:wc_flutter_share/wc_flutter_share.dart';
 
 class ProductPage extends StatefulWidget {
-  const ProductPage({@required this.product});
+  const ProductPage({@required this.product, this.newProduct = false});
 
+  final bool newProduct;
   final Product product;
 
   @override
@@ -159,6 +162,118 @@ class _ProductPageState extends State<ProductPage> {
 
   @override
   Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+
+    return Scaffold(
+        appBar: AppBar(
+          title: ListTile(
+            title: Text(
+              widget.product.productName ?? appLocalizations.unknownProductName,
+              style: Theme.of(context)
+                  .textTheme
+                  .headline4
+                  .copyWith(color: Theme.of(context).colorScheme.onBackground),
+            ),
+          ),
+          iconTheme:
+              IconThemeData(color: Theme.of(context).colorScheme.onBackground),
+        ),
+        bottomNavigationBar: BottomNavigationBar(
+          type: BottomNavigationBarType.fixed,
+          items: <BottomNavigationBarItem>[
+            BottomNavigationBarItem(
+              icon: SvgPicture.asset('assets/actions/food-cog.svg'),
+              label: 'preferences',
+            ),
+            const BottomNavigationBarItem(
+              icon: Icon(Icons.playlist_add),
+              label: 'lists',
+            ),
+            const BottomNavigationBarItem(
+              icon: Icon(Icons.launch),
+              label: 'Web',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(ConstantIcons.getShareIcon()),
+              label: 'share',
+            ),
+          ],
+          onTap: (final int index) {
+            switch (index) {
+              case 0:
+                UserPreferencesView.showModal(context);
+                return;
+              case 1:
+                ProductPage.showLists(widget.product, context);
+                return;
+              case 2:
+                Launcher().launchURL(
+                    context,
+                    'https://openfoodfacts.org/product/${widget.product.barcode}/',
+                    false);
+                return;
+              case 3:
+                WcFlutterShare.share(
+                    sharePopupTitle: 'Share',
+                    subject:
+                        '${widget.product.productName} (by openfoodfacts.org)',
+                    text:
+                        'Try this food: https://openfoodfacts.org/product/${widget.product.barcode}/',
+                    mimeType: 'text/plain');
+                return;
+            }
+            throw 'Unexpected index $index';
+          },
+        ),
+        body: widget.newProduct
+            ? _buildNewProductBody(context)
+            : _buildProductBody(context));
+  }
+
+  Future<void> _updateHistory(final BuildContext context) async {
+    final LocalDatabase localDatabase = context.read<LocalDatabase>();
+    final DaoProductList daoProductList = DaoProductList(localDatabase);
+    final ProductList productList =
+        ProductList(listType: ProductList.LIST_TYPE_HISTORY, parameters: '');
+    await daoProductList.get(productList);
+    productList.add(widget.product);
+    await daoProductList.put(productList);
+    localDatabase.notifyListeners();
+  }
+
+  Widget _buildNewProductBody(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+
+    return ListView(children: <Widget>[
+      Container(
+        padding: const EdgeInsets.symmetric(horizontal: 20.0),
+        margin: const EdgeInsets.only(top: 20.0),
+        child: Text(
+          'Add a new product',
+          style: Theme.of(context).textTheme.headline1,
+        ),
+      ),
+      ImageUploadCard(
+          product: widget.product,
+          imageField: ImageField.FRONT,
+          buttonText: "Front photo"),
+      ImageUploadCard(
+          product: widget.product,
+          imageField: ImageField.INGREDIENTS,
+          buttonText: "Ingredients photo"),
+      ImageUploadCard(
+        product: widget.product,
+        imageField: ImageField.NUTRITION,
+        buttonText: "Nutrition facts photo",
+      ),
+      ImageUploadCard(
+          product: widget.product,
+          imageField: ImageField.OTHER,
+          buttonText: "More interesting photos"),
+    ]);
+  }
+
+  Widget _buildProductBody(BuildContext context) {
     final UserPreferences userPreferences = context.watch<UserPreferences>();
     final UserPreferencesModel userPreferencesModel =
         context.watch<UserPreferencesModel>();
@@ -174,6 +289,7 @@ class _ProductPageState extends State<ProductPage> {
     final List<String> mainAttributes =
         userPreferencesModel.getOrderedVariables(userPreferences);
     final List<Widget> listItems = <Widget>[];
+
     listItems.add(
       Padding(
         padding: const EdgeInsets.all(16.0),
@@ -221,119 +337,46 @@ class _ProductPageState extends State<ProductPage> {
         in _getOrderedAttributeGroups(userPreferencesModel)) {
       listItems.add(_getAttributeGroupWidget(attributeGroup, iconWidth));
     }
-    return Scaffold(
-      appBar: AppBar(
-        title: ListTile(
-          title: Text(
-            widget.product.productName ?? appLocalizations.unknownProductName,
-            style: Theme.of(context)
-                .textTheme
-                .headline4
-                .copyWith(color: Theme.of(context).colorScheme.onBackground),
+
+    return Stack(
+      children: <Widget>[
+        if (widget.product.imgSmallUrl != null)
+          Image.network(
+            widget.product.imgSmallUrl,
+            fit: BoxFit.cover,
+            height: double.infinity,
+            width: double.infinity,
+            alignment: Alignment.center,
+            loadingBuilder:
+                (BuildContext context, Widget child, ImageChunkEvent progress) {
+              if (progress == null) {
+                return child;
+              }
+              return Center(
+                child: CircularProgressIndicator(
+                  strokeWidth: 2.5,
+                  valueColor: const AlwaysStoppedAnimation<Color>(Colors.white),
+                  value: progress.cumulativeBytesLoaded /
+                      progress.expectedTotalBytes,
+                ),
+              );
+            },
+          )
+        else
+          Container(
+            width: screenSize.width,
+            height: screenSize.height,
+            color: Colors.black54,
+          ),
+        BackdropFilter(
+          filter: ImageFilter.blur(sigmaX: 18.0, sigmaY: 18.0),
+          child: Container(
+            color: Theme.of(context).colorScheme.surface.withAlpha(220),
+            child: ListView(children: listItems),
           ),
         ),
-        iconTheme:
-            IconThemeData(color: Theme.of(context).colorScheme.onBackground),
-      ),
-      bottomNavigationBar: BottomNavigationBar(
-        type: BottomNavigationBarType.fixed,
-        items: <BottomNavigationBarItem>[
-          BottomNavigationBarItem(
-            icon: SvgPicture.asset('assets/actions/food-cog.svg'),
-            label: 'preferences',
-          ),
-          const BottomNavigationBarItem(
-            icon: Icon(Icons.playlist_add),
-            label: 'lists',
-          ),
-          const BottomNavigationBarItem(
-            icon: Icon(Icons.launch),
-            label: 'Web',
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(ConstantIcons.getShareIcon()),
-            label: 'share',
-          ),
-        ],
-        onTap: (final int index) {
-          switch (index) {
-            case 0:
-              UserPreferencesView.showModal(context);
-              return;
-            case 1:
-              ProductPage.showLists(widget.product, context);
-              return;
-            case 2:
-              Launcher().launchURL(
-                  context,
-                  'https://openfoodfacts.org/product/${widget.product.barcode}/',
-                  false);
-              return;
-            case 3:
-              WcFlutterShare.share(
-                  sharePopupTitle: 'Share',
-                  subject:
-                      '${widget.product.productName} (by openfoodfacts.org)',
-                  text:
-                      'Try this food: https://openfoodfacts.org/product/${widget.product.barcode}/',
-                  mimeType: 'text/plain');
-              return;
-          }
-          throw 'Unexpected index $index';
-        },
-      ),
-      body: Stack(
-        children: <Widget>[
-          if (widget.product.imgSmallUrl != null)
-            Image.network(
-              widget.product.imgSmallUrl,
-              fit: BoxFit.cover,
-              height: double.infinity,
-              width: double.infinity,
-              alignment: Alignment.center,
-              loadingBuilder: (BuildContext context, Widget child,
-                  ImageChunkEvent progress) {
-                if (progress == null) {
-                  return child;
-                }
-                return Center(
-                  child: CircularProgressIndicator(
-                    strokeWidth: 2.5,
-                    valueColor:
-                        const AlwaysStoppedAnimation<Color>(Colors.white),
-                    value: progress.cumulativeBytesLoaded /
-                        progress.expectedTotalBytes,
-                  ),
-                );
-              },
-            )
-          else
-            Container(
-              width: screenSize.width,
-              height: screenSize.height,
-              color: Colors.black54,
-            ),
-          BackdropFilter(
-            filter: ImageFilter.blur(sigmaX: 18.0, sigmaY: 18.0),
-            child: Container(
-              color: Theme.of(context).colorScheme.surface.withAlpha(220),
-              child: ListView(children: listItems),
-            ),
-          ),
-        ],
-      ),
+      ],
     );
-  }
-
-  Future<void> _updateHistory(final BuildContext context) async {
-    final LocalDatabase localDatabase = context.read<LocalDatabase>();
-    final DaoProductList daoProductList = DaoProductList(localDatabase);
-    final ProductList productList =
-        ProductList(listType: ProductList.LIST_TYPE_HISTORY, parameters: '');
-    await daoProductList.get(productList);
-    productList.add(widget.product);
-    await daoProductList.put(productList);
-    localDatabase.notifyListeners();
   }
 
   Widget _getAttributeGroupWidget(

--- a/packages/smooth_app/lib/pages/product_page.dart
+++ b/packages/smooth_app/lib/pages/product_page.dart
@@ -242,7 +242,7 @@ class _ProductPageState extends State<ProductPage> {
   }
 
   Widget _buildNewProductBody(BuildContext context) {
-    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    //final AppLocalizations appLocalizations = AppLocalizations.of(context);
 
     return ListView(children: <Widget>[
       Container(
@@ -256,20 +256,20 @@ class _ProductPageState extends State<ProductPage> {
       ImageUploadCard(
           product: widget.product,
           imageField: ImageField.FRONT,
-          buttonText: "Front photo"),
+          buttonText: 'Front photo'),
       ImageUploadCard(
           product: widget.product,
           imageField: ImageField.INGREDIENTS,
-          buttonText: "Ingredients photo"),
+          buttonText: 'Ingredients photo'),
       ImageUploadCard(
         product: widget.product,
         imageField: ImageField.NUTRITION,
-        buttonText: "Nutrition facts photo",
+        buttonText: 'Nutrition facts photo',
       ),
       ImageUploadCard(
           product: widget.product,
           imageField: ImageField.OTHER,
-          buttonText: "More interesting photos"),
+          buttonText: 'More interesting photos'),
     ]);
   }
 


### PR DESCRIPTION
Related issue: #86 

When a product is not found in OFF, the app currently opens a SmoothUploadPage.

I think it would be best to do it differently, and to open a ProductPage (just like when we do find the product in OFF), so that we can benefit from all the features associated with it (e.g. the lists).

This is what this PR does:

- new image_upload_card.dart : currently just a button to take, crop, and upload a photo (front, ingredients etc.). Not beautiful, but working.
- smooth_product_card_not_found.dart : now creates a new Product instance, and open a ProductPage on it
- product_page.dart : separate the parts that are common to both existing products and new products (e.g. the navigation and bottom bars), and creates 2 methods _buildProductBody()  (with the existing code), and _buildNewProductBody (a special page where we invite users to upload photos).

Things I changed from the SmoothUploadPage: product pictures are uploaded right after they are cropped, there is no need to have a separate upload button.

It's only a start, but I'd like to get your feedback to see if I'm on the right track or not.

Things that would need to be changed at some point:
- better UI, better cards that say thank you, explain what do next etc.
- for existing products, use the ImageUploadCard when we are missing some of the photos, and to offer to take more ("other") photos
- we'll need a way to refresh product data, to try again to get the product from the API (it will be created after we receive the photos)
- it would be great to be able to keep a table of photos that need to be uploaded (e.g. the upload failed because we had no connection).
