### PR TITLE
feature/#21_6 - user product lists can now be renamed and exported as grocery lists

### DIFF
--- a/packages/smooth_app/lib/database/dao_product_list.dart
+++ b/packages/smooth_app/lib/database/dao_product_list.dart
@@ -94,6 +94,26 @@ class DaoProductList {
     return queryResult.first;
   }
 
+  Future<bool> rename(
+    final ProductList productList,
+    final String newName,
+  ) async {
+    try {
+      final int nbUpdated = await localDatabase.database.update(
+        _TABLE_PRODUCT_LIST,
+        <String, dynamic>{
+          _TABLE_PRODUCT_LIST_COLUMN_PARAMETERS: newName,
+          LocalDatabase.COLUMN_TIMESTAMP: LocalDatabase.nowInMillis(),
+        },
+        where: _getProductListUKWhere(),
+        whereArgs: _getProductListUKWhereArgs(productList),
+      );
+      return nbUpdated == 1;
+    } catch (e) {
+      return false;
+    }
+  }
+
   Future<void> put(final ProductList productList) async {
     final int productListId = await _upsertProductList(productList);
     await DaoProduct(localDatabase).putProducts(productList.getList());

--- a/packages/smooth_app/lib/pages/list_page.dart
+++ b/packages/smooth_app/lib/pages/list_page.dart
@@ -5,10 +5,8 @@ import 'package:smooth_app/database/local_database.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/product_list.dart';
 import 'package:smooth_app/pages/product_query_page_helper.dart';
+import 'package:smooth_app/pages/product_list_dialog_helper.dart';
 import 'package:smooth_app/pages/product_list_page.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:smooth_ui_library/buttons/smooth_simple_button.dart';
-import 'package:smooth_ui_library/dialogs/smooth_alert_dialog.dart';
 
 class ListPage extends StatefulWidget {
   const ListPage({
@@ -24,9 +22,7 @@ class ListPage extends StatefulWidget {
 }
 
 class _ListPageState extends State<ListPage> {
-  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
   List<ProductList> _list;
-  ProductList _newProductList;
 
   @override
   Widget build(BuildContext context) {
@@ -44,67 +40,12 @@ class _ListPageState extends State<ListPage> {
           if (widget.typeFilter.contains(ProductList.LIST_TYPE_USER_DEFINED))
             IconButton(
               icon: Icon(Icons.add, color: colorScheme.onBackground),
-              onPressed: () => showDialog<void>(
-                context: context,
-                // TODO(monsieurtanuki): rename list, delete list
-                builder: (BuildContext context) => SmoothAlertDialog(
-                  title: 'New list',
-                  body: Form(
-                    key: _formKey,
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: <Widget>[
-                        TextFormField(
-                            decoration: const InputDecoration(
-                              hintText: 'My new custom list',
-                            ),
-                            validator: (final String value) {
-                              if (value.isEmpty) {
-                                return 'Please enter some text';
-                              }
-                              if (_list == null) {
-                                return null;
-                              }
-                              _newProductList = ProductList(
-                                listType: ProductList.LIST_TYPE_USER_DEFINED,
-                                parameters: value,
-                              );
-                              for (final ProductList productList in _list) {
-                                if (productList.lousyKey ==
-                                    _newProductList.lousyKey) {
-                                  return 'There\'s already a list with that name';
-                                }
-                              }
-                              return null;
-                            }),
-                      ],
-                    ),
-                  ),
-                  actions: <SmoothSimpleButton>[
-                    SmoothSimpleButton(
-                      text: 'Cancel',
-                      onPressed: () => Navigator.pop(context),
-                      important: false,
-                    ),
-                    SmoothSimpleButton(
-                      text: 'OK',
-                      onPressed: () async {
-                        if (!_formKey.currentState.validate()) {
-                          return;
-                        }
-                        if (await daoProductList.get(_newProductList)) {
-                          // TODO(monsieurtanuki): unexpected, but do something!
-                          return;
-                        }
-                        await daoProductList.put(_newProductList);
-                        Navigator.pop(context);
-                        setState(() {});
-                      },
-                      important: true,
-                    ),
-                  ],
-                ),
-              ),
+              onPressed: () async {
+                if (await ProductListDialogHelper.openNew(
+                    context, daoProductList, _list)) {
+                  setState(() {});
+                }
+              },
             )
         ],
       ),
@@ -127,7 +68,10 @@ class _ListPageState extends State<ListPage> {
                     return Card(
                       child: ListTile(
                         title: Text(
-                          ProductQueryPageHelper.getProductListLabel(item),
+                          ProductQueryPageHelper.getProductListLabel(
+                            item,
+                            verbose: false,
+                          ),
                           style: Theme.of(context).textTheme.bodyText1,
                         ),
                         subtitle: Text(
@@ -148,33 +92,11 @@ class _ListPageState extends State<ListPage> {
                           );
                           localDatabase.notifyListeners();
                         },
-                        onLongPress: () {
-                          showDialog<bool>(
-                            context: context,
-                            builder: (BuildContext context) {
-                              return SmoothAlertDialog(
-                                //title: AppLocalizations.of(context).contribute_translate_header,
-                                body: const Text(
-                                    'Do you want to delete this product list?'),
-                                actions: <SmoothSimpleButton>[
-                                  SmoothSimpleButton(
-                                    onPressed: () => Navigator.pop(context),
-                                    text: AppLocalizations.of(context).no,
-                                    important: false,
-                                  ),
-                                  SmoothSimpleButton(
-                                    onPressed: () async {
-                                      await daoProductList.delete(item);
-                                      Navigator.pop(context);
-                                      setState(() {});
-                                    },
-                                    text: AppLocalizations.of(context).yes,
-                                    important: true,
-                                  ),
-                                ],
-                              );
-                            },
-                          );
+                        onLongPress: () async {
+                          if (await ProductListDialogHelper.openDelete(
+                              context, daoProductList, item)) {
+                            setState(() {});
+                          }
                         },
                       ),
                     );

--- a/packages/smooth_app/lib/pages/product_list_dialog_helper.dart
+++ b/packages/smooth_app/lib/pages/product_list_dialog_helper.dart
@@ -1,0 +1,189 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:smooth_app/database/dao_product_list.dart';
+import 'package:smooth_app/data_models/product_list.dart';
+import 'package:smooth_ui_library/buttons/smooth_simple_button.dart';
+import 'package:smooth_ui_library/dialogs/smooth_alert_dialog.dart';
+
+class ProductListDialogHelper {
+  static const String _TRANSLATE_ME_WANT_TO_DELETE =
+      'Do you want to delete this product list?';
+  static const String _TRANSLATE_ME_NEW_LIST = 'New list';
+  static const String _TRANSLATE_ME_RENAME_LIST = 'Rename list';
+  static const String _TRANSLATE_ME_HINT = 'My custom list';
+  static const String _TRANSLATE_ME_EMPTY = 'Please enter some text';
+  static const String _TRANSLATE_ME_ALREADY_OTHER =
+      'There\'s already a list with that name';
+  static const String _TRANSLATE_ME_ALREADY_SAME = 'That\'s the same name!';
+  static const String _TRANSLATE_ME_CANCEL = 'Cancel';
+
+  static Future<bool> openDelete(
+    final BuildContext context,
+    final DaoProductList daoProductList,
+    final ProductList productList,
+  ) async =>
+      await showDialog<bool>(
+        context: context,
+        builder: (BuildContext context) => SmoothAlertDialog(
+          close: false,
+          body: const Text(_TRANSLATE_ME_WANT_TO_DELETE),
+          actions: <SmoothSimpleButton>[
+            SmoothSimpleButton(
+              text: AppLocalizations.of(context).no,
+              important: false,
+              onPressed: () => Navigator.pop(context, false),
+            ),
+            SmoothSimpleButton(
+              text: AppLocalizations.of(context).yes,
+              important: true,
+              onPressed: () async {
+                await daoProductList.delete(productList);
+                Navigator.pop(context, true);
+              },
+            ),
+          ],
+        ),
+      );
+
+  static Future<bool> openNew(
+    final BuildContext context,
+    final DaoProductList daoProductList,
+    final List<ProductList> list,
+  ) async {
+    final GlobalKey<FormState> formKey = GlobalKey<FormState>();
+    ProductList newProductList;
+    return showDialog<bool>(
+      context: context,
+      builder: (BuildContext context) => SmoothAlertDialog(
+        close: false,
+        title: _TRANSLATE_ME_NEW_LIST,
+        body: Form(
+          key: formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              TextFormField(
+                decoration: const InputDecoration(
+                  hintText: _TRANSLATE_ME_HINT,
+                ),
+                validator: (final String value) {
+                  if (value.isEmpty) {
+                    return _TRANSLATE_ME_EMPTY;
+                  }
+                  if (list == null) {
+                    return null;
+                  }
+                  newProductList = ProductList(
+                    listType: ProductList.LIST_TYPE_USER_DEFINED,
+                    parameters: value,
+                  );
+                  for (final ProductList productList in list) {
+                    if (productList.lousyKey == newProductList.lousyKey) {
+                      return _TRANSLATE_ME_ALREADY_OTHER;
+                    }
+                  }
+                  return null;
+                },
+              ),
+            ],
+          ),
+        ),
+        actions: <SmoothSimpleButton>[
+          SmoothSimpleButton(
+            text: _TRANSLATE_ME_CANCEL,
+            onPressed: () => Navigator.pop(context, false),
+            important: false,
+          ),
+          SmoothSimpleButton(
+            text: AppLocalizations.of(context).okay,
+            onPressed: () async {
+              if (!formKey.currentState.validate()) {
+                return;
+              }
+              if (await daoProductList.get(newProductList)) {
+                // TODO(monsieurtanuki): unexpected, but do something!
+                return;
+              }
+              await daoProductList.put(newProductList);
+              Navigator.pop(context, true);
+            },
+            important: true,
+          ),
+        ],
+      ),
+    );
+  }
+
+  static Future<ProductList> openRename(
+    final BuildContext context,
+    final DaoProductList daoProductList,
+    final ProductList productList,
+  ) async {
+    final GlobalKey<FormState> formKey = GlobalKey<FormState>();
+    final List<ProductList> list =
+        await daoProductList.getAll(withStats: false);
+    ProductList newProductList;
+    return showDialog<ProductList>(
+      context: context,
+      builder: (BuildContext context) => SmoothAlertDialog(
+        close: false,
+        title: _TRANSLATE_ME_RENAME_LIST,
+        body: Form(
+          key: formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              TextFormField(
+                initialValue: productList.parameters,
+                decoration: const InputDecoration(
+                  hintText: _TRANSLATE_ME_HINT,
+                ),
+                validator: (final String value) {
+                  if (value.isEmpty) {
+                    return _TRANSLATE_ME_EMPTY;
+                  }
+                  newProductList = ProductList(
+                    listType: ProductList.LIST_TYPE_USER_DEFINED,
+                    parameters: value,
+                  );
+                  for (final ProductList item in list) {
+                    if (item.lousyKey == newProductList.lousyKey) {
+                      if (item.lousyKey == productList.lousyKey) {
+                        return _TRANSLATE_ME_ALREADY_SAME;
+                      }
+                      return _TRANSLATE_ME_ALREADY_OTHER;
+                    }
+                  }
+                  return null;
+                },
+              ),
+            ],
+          ),
+        ),
+        actions: <SmoothSimpleButton>[
+          SmoothSimpleButton(
+            text: _TRANSLATE_ME_CANCEL,
+            onPressed: () => Navigator.pop(context, null),
+            important: false,
+          ),
+          SmoothSimpleButton(
+            text: AppLocalizations.of(context).okay,
+            onPressed: () async {
+              if (!formKey.currentState.validate()) {
+                return;
+              }
+              if (!await daoProductList.rename(
+                  productList, newProductList.parameters)) {
+                // TODO(monsieurtanuki): unexpected, but do something!
+                return;
+              }
+              await daoProductList.get(newProductList);
+              Navigator.pop(context, newProductList);
+            },
+            important: true,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/smooth_app/lib/pages/product_query_page_helper.dart
+++ b/packages/smooth_app/lib/pages/product_query_page_helper.dart
@@ -89,18 +89,21 @@ class ProductQueryPageHelper {
     return getDurationStringFromSeconds(seconds);
   }
 
-  static String getProductListLabel(final ProductList productList) {
+  static String getProductListLabel(
+    final ProductList productList, {
+    final bool verbose = true,
+  }) {
     switch (productList.listType) {
       case ProductList.LIST_TYPE_HTTP_SEARCH_GROUP:
-        return '${_getGroupName(productList.parameters)} (category search)';
+        return '${_getGroupName(productList.parameters)}${verbose ? ' (category search)' : ''}';
       case ProductList.LIST_TYPE_HTTP_SEARCH_KEYWORDS:
-        return '${productList.parameters} (keyword search)';
+        return '${productList.parameters}${verbose ? ' (keyword search)' : ''}';
       case ProductList.LIST_TYPE_SCAN:
         return 'Scan';
       case ProductList.LIST_TYPE_HISTORY:
         return 'History';
       case ProductList.LIST_TYPE_USER_DEFINED:
-        return '${productList.parameters} (my list)';
+        return '${productList.parameters}${verbose ? ' (my list)' : ''}';
     }
     return 'Unknown product list: ${productList.listType} / ${productList.parameters}';
   }


### PR DESCRIPTION
New file:
* `product_list_dialog_helper.dart`: centralizing the dialogs for product lists

Impacted files:
* `dao_product_list.dart`: added method `rename`
* `list_page.dart`: now using the new ProductListDialogHelper class; minor refactoring
* `product_list_page.dart`: added a "rename" top action; moved "delete" to top; added a "grocery" bottom action; now using the new ProductListDialogHelper class
* `product_query_page_helper.dart`: minor presentation refactoring