### PR TITLE
lock the orientation in portrait mode, fixes #153

### DIFF
--- a/packages/smooth_app/android/app/src/main/AndroidManifest.xml
+++ b/packages/smooth_app/android/app/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         <activity
             android:name=".MainActivity"
             android:launchMode="singleTop"
+            android:screenOrientation="portrait"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"

--- a/packages/smooth_app/ios/Runner/Info.plist
+++ b/packages/smooth_app/ios/Runner/Info.plist
@@ -29,8 +29,6 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   basic_utils: ^2.6.3
   modal_bottom_sheet: ^1.0.0+1
   provider: ^4.3.2+3
-  openfoodfacts: ^0.3.15
+  openfoodfacts: ^0.3.15+1
   flutter_qr_bar_scanner: ^1.0.2
   qr_code_scanner: ^0.3.0
   sqflite: ^1.3.2+1


### PR DESCRIPTION
fixes #153 

solution from https://greymag.medium.com/flutter-orientation-lock-portrait-only-c98910ebd769