### PR TITLE
feature/#148 - added editable icon and color to product lists

### DIFF
--- a/packages/smooth_app/lib/data_models/product_list.dart
+++ b/packages/smooth_app/lib/data_models/product_list.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/model/Product.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:smooth_app/themes/smooth_theme.dart';
 
 class ProductList {
   ProductList({
@@ -10,11 +12,80 @@ class ProductList {
     this.databaseCountDistinct,
   });
 
+  static const String _EXTRA_COLOR = 'color';
+  static const String _EXTRA_ICON = 'icon';
+
+  static const String _COLOR_RED = 'red';
+  static const String _COLOR_ORANGE = 'orange';
+  static const String _COLOR_GREEN = 'green';
+  static const String _COLOR_BLUE = 'blue';
+  static const String _COLOR_PURPLE = 'purple';
+
+  static const Map<String, MaterialColor> _COLORS = <String, MaterialColor>{
+    _COLOR_RED: Colors.red,
+    _COLOR_ORANGE: Colors.orange,
+    _COLOR_GREEN: Colors.green,
+    _COLOR_BLUE: Colors.blue,
+    _COLOR_PURPLE: Colors.purple,
+  };
+
+  static const List<String> ORDERED_COLORS = <String>[
+    _COLOR_RED,
+    _COLOR_ORANGE,
+    _COLOR_GREEN,
+    _COLOR_BLUE,
+    _COLOR_PURPLE,
+  ];
+
+  static const Map<String, String> _DEFAULT_COLOR_TAG_PER_TYPE =
+      <String, String>{
+    LIST_TYPE_HTTP_SEARCH_KEYWORDS: _COLOR_RED,
+    LIST_TYPE_HTTP_SEARCH_GROUP: _COLOR_ORANGE,
+    LIST_TYPE_SCAN: _COLOR_GREEN,
+    LIST_TYPE_HISTORY: _COLOR_BLUE,
+    LIST_TYPE_USER_DEFINED: _COLOR_PURPLE,
+  };
+
+  static const String _ICON_TAG = 'tag';
+  static const String _ICON_HEART = 'heart';
+  static const String _ICON_SEARCH = 'search';
+  static const String _ICON_GROUP = 'group';
+  static const String _ICON_SCAN = 'scan';
+  static const String _ICON_HISTORY = 'history';
+
+  static const Map<String, List<String>> _ORDERED_ICONS_PER_TYPE =
+      <String, List<String>>{
+    LIST_TYPE_HTTP_SEARCH_KEYWORDS: <String>[_ICON_SEARCH],
+    LIST_TYPE_HTTP_SEARCH_GROUP: <String>[_ICON_GROUP],
+    LIST_TYPE_SCAN: <String>[_ICON_SCAN],
+    LIST_TYPE_HISTORY: <String>[_ICON_HISTORY],
+    LIST_TYPE_USER_DEFINED: <String>[_ICON_TAG, _ICON_HEART]
+  };
+
+  static const Map<String, IconData> _ICON_DATA = <String, IconData>{
+    _ICON_TAG: CupertinoIcons.tag_fill,
+    _ICON_HEART: CupertinoIcons.heart_fill,
+    _ICON_SEARCH: Icons.search,
+    _ICON_GROUP: Icons.fastfood,
+    _ICON_SCAN: CupertinoIcons.barcode,
+    _ICON_HISTORY: Icons.history,
+  };
+
+  static const Map<String, String> _DEFAULT_ICON_TAG_PER_TYPE =
+      <String, String>{
+    LIST_TYPE_HTTP_SEARCH_KEYWORDS: _ICON_SEARCH,
+    LIST_TYPE_HTTP_SEARCH_GROUP: _ICON_GROUP,
+    LIST_TYPE_SCAN: _ICON_SCAN,
+    LIST_TYPE_HISTORY: _ICON_HISTORY,
+    LIST_TYPE_USER_DEFINED: _ICON_TAG,
+  };
+
   final String listType;
   final String parameters;
   final int databaseTimestamp;
   final int databaseCount;
   final int databaseCountDistinct;
+  Map<String, String> extraTags;
 
   final List<String> _barcodes = <String>[];
   final Map<String, Product> _products = <String, Product>{};
@@ -27,6 +98,23 @@ class ProductList {
 
   List<String> get barcodes => _barcodes;
 
+  set colorTag(final String tag) => _setExtra(_EXTRA_COLOR, tag);
+  set iconTag(final String tag) => _setExtra(_EXTRA_ICON, tag);
+
+  void _setExtra(final String key, final String value) {
+    extraTags ??= <String, String>{};
+    extraTags[key] = value;
+  }
+
+  String get _colorTag =>
+      (extraTags == null ? null : extraTags[_EXTRA_COLOR]) ??
+      _DEFAULT_COLOR_TAG_PER_TYPE[listType];
+  String get _iconTag =>
+      (extraTags == null ? null : extraTags[_EXTRA_ICON]) ??
+      _DEFAULT_ICON_TAG_PER_TYPE[listType];
+
+  List<String> getPossibleIcons() => _ORDERED_ICONS_PER_TYPE[listType];
+
   bool isEmpty() => _barcodes.isEmpty;
 
   void clear() {
@@ -37,6 +125,30 @@ class ProductList {
   Product getProduct(final String barcode) => _products[barcode];
 
   String get lousyKey => '$listType/$parameters';
+
+  static Widget getReferenceIcon({
+    final ColorScheme colorScheme,
+    final String colorTag,
+    final String iconTag,
+  }) =>
+      Icon(
+        _ICON_DATA[iconTag] ?? _ICON_DATA[_ICON_TAG],
+        color: SmoothTheme.getForegroundColor(
+          colorScheme,
+          _getReferenceMaterialColor(colorTag),
+        ),
+      );
+
+  static MaterialColor _getReferenceMaterialColor(final String colorTag) =>
+      _COLORS[colorTag] ?? _COLORS[_COLOR_RED];
+
+  Widget getIcon(final ColorScheme colorScheme) => getReferenceIcon(
+        colorScheme: colorScheme,
+        colorTag: _colorTag,
+        iconTag: _iconTag,
+      );
+
+  MaterialColor getMaterialColor() => _getReferenceMaterialColor(_colorTag);
 
   void add(final Product product) {
     if (product == null) {

--- a/packages/smooth_app/lib/database/local_database.dart
+++ b/packages/smooth_app/lib/database/local_database.dart
@@ -21,7 +21,7 @@ class LocalDatabase extends ChangeNotifier {
 
     final Database database = await openDatabase(
       databasePath,
-      version: 2,
+      version: 3,
       singleInstance: true,
       onUpgrade: _onUpgrade,
     );

--- a/packages/smooth_app/lib/pages/home_page.dart
+++ b/packages/smooth_app/lib/pages/home_page.dart
@@ -16,6 +16,7 @@ import 'package:smooth_app/bottom_sheet_views/user_preferences_view.dart';
 import 'package:openfoodfacts/model/Product.dart';
 import 'package:openfoodfacts/model/Attribute.dart';
 import 'package:smooth_app/data_models/user_preferences_model.dart';
+import 'package:smooth_app/themes/smooth_theme.dart';
 
 class HomePage extends StatefulWidget {
   @override
@@ -28,7 +29,6 @@ class _HomePageState extends State<HomePage> {
 
   DaoProductList _daoProductList;
   ProductList _productListHistory;
-  int _colorIntensity;
 
   @override
   Widget build(BuildContext context) {
@@ -42,17 +42,19 @@ class _HomePageState extends State<HomePage> {
       parameters: '',
     );
     final ThemeData themeData = Theme.of(context);
+    final ColorScheme colorScheme = themeData.colorScheme;
     final bool mlKitState = userPreferences.getMlKitState();
-    final bool dark = themeData.colorScheme.brightness != Brightness.light;
-    _colorIntensity = dark ? 200 : 800;
-    final Color notYetColor = dark ? Colors.grey[700] : Colors.grey[200];
+    final Color notYetColor = SmoothTheme.getBackgroundColor(
+      colorScheme,
+      Colors.grey,
+    );
     return Scaffold(
       appBar: AppBar(
         title: Text(
           'Smoothie',
-          style: TextStyle(color: themeData.colorScheme.onBackground),
+          style: TextStyle(color: colorScheme.onBackground),
         ),
-        iconTheme: IconThemeData(color: themeData.colorScheme.onBackground),
+        iconTheme: IconThemeData(color: colorScheme.onBackground),
         actions: <Widget>[
           IconButton(
             icon: const Icon(Icons.settings),
@@ -76,7 +78,10 @@ class _HomePageState extends State<HomePage> {
               child: ListTile(
                 leading: Icon(
                   Icons.search,
-                  color: Colors.red[_colorIntensity],
+                  color: SmoothTheme.getForegroundColor(
+                    colorScheme,
+                    Colors.red,
+                  ),
                 ),
                 title: TextField(
                   onSubmitted: (final String value) => ChoosePage.onSubmitted(
@@ -100,7 +105,10 @@ class _HomePageState extends State<HomePage> {
                 },
                 leading: Icon(
                   Icons.fastfood,
-                  color: Colors.orange[_colorIntensity],
+                  color: SmoothTheme.getForegroundColor(
+                    colorScheme,
+                    Colors.orange,
+                  ),
                 ),
                 subtitle: const Text('Food category search'),
                 title: Text(
@@ -122,7 +130,10 @@ class _HomePageState extends State<HomePage> {
               'Search history',
               Icon(
                 Icons.youtube_searched_for,
-                color: Colors.yellow[_colorIntensity],
+                color: SmoothTheme.getForegroundColor(
+                  colorScheme,
+                  Colors.yellow,
+                ),
               ),
             ),
             _getRankingPreferences(userPreferencesModel, userPreferences),
@@ -132,7 +143,10 @@ class _HomePageState extends State<HomePage> {
               'Your food lists',
               Icon(
                 Icons.list,
-                color: Colors.purple[_colorIntensity],
+                color: SmoothTheme.getForegroundColor(
+                  colorScheme,
+                  Colors.purple,
+                ),
               ),
             ),
             Card(
@@ -174,7 +188,7 @@ class _HomePageState extends State<HomePage> {
         child: SvgPicture.asset(
           'assets/actions/scanner_alt_2.svg',
           height: 25,
-          color: themeData.colorScheme.onSecondary,
+          color: colorScheme.onSecondary,
         ),
       ), // This trailing comma makes auto-formatting nicer for build methods.
     );
@@ -217,7 +231,10 @@ class _HomePageState extends State<HomePage> {
                 },
                 leading: Icon(
                   Icons.history,
-                  color: Colors.blue[_colorIntensity],
+                  color: SmoothTheme.getForegroundColor(
+                    Theme.of(context).colorScheme,
+                    Colors.blue,
+                  ),
                 ),
                 subtitle: const Text('Food history'),
                 title:
@@ -337,7 +354,10 @@ class _HomePageState extends State<HomePage> {
         onTap: () => UserPreferencesView.showModal(context),
         leading: Icon(
           Icons.bar_chart,
-          color: Colors.green[_colorIntensity],
+          color: SmoothTheme.getForegroundColor(
+            Theme.of(context).colorScheme,
+            Colors.green,
+          ),
         ),
         title: Text(
           attributes.isEmpty

--- a/packages/smooth_app/lib/pages/list_page.dart
+++ b/packages/smooth_app/lib/pages/list_page.dart
@@ -7,6 +7,7 @@ import 'package:smooth_app/data_models/product_list.dart';
 import 'package:smooth_app/pages/product_query_page_helper.dart';
 import 'package:smooth_app/pages/product_list_dialog_helper.dart';
 import 'package:smooth_app/pages/product_list_page.dart';
+import 'package:smooth_app/themes/smooth_theme.dart';
 
 class ListPage extends StatefulWidget {
   const ListPage({
@@ -66,7 +67,12 @@ class _ListPageState extends State<ListPage> {
                   itemBuilder: (final BuildContext context, final int index) {
                     final ProductList item = _list[index];
                     return Card(
+                      color: SmoothTheme.getBackgroundColor(
+                        colorScheme,
+                        item.getMaterialColor(),
+                      ),
                       child: ListTile(
+                        leading: item.getIcon(colorScheme),
                         title: Text(
                           ProductQueryPageHelper.getProductListLabel(
                             item,

--- a/packages/smooth_app/lib/pages/product_list_dialog_helper.dart
+++ b/packages/smooth_app/lib/pages/product_list_dialog_helper.dart
@@ -10,6 +10,7 @@ class ProductListDialogHelper {
       'Do you want to delete this product list?';
   static const String _TRANSLATE_ME_NEW_LIST = 'New list';
   static const String _TRANSLATE_ME_RENAME_LIST = 'Rename list';
+  static const String _TRANSLATE_ME_CHANGE_ICON = 'Change icon';
   static const String _TRANSLATE_ME_HINT = 'My custom list';
   static const String _TRANSLATE_ME_EMPTY = 'Please enter some text';
   static const String _TRANSLATE_ME_ALREADY_OTHER =
@@ -52,7 +53,7 @@ class ProductListDialogHelper {
   ) async {
     final GlobalKey<FormState> formKey = GlobalKey<FormState>();
     ProductList newProductList;
-    return showDialog<bool>(
+    return await showDialog<bool>(
       context: context,
       builder: (BuildContext context) => SmoothAlertDialog(
         close: false,
@@ -123,7 +124,7 @@ class ProductListDialogHelper {
     final List<ProductList> list =
         await daoProductList.getAll(withStats: false);
     ProductList newProductList;
-    return showDialog<ProductList>(
+    return await showDialog<ProductList>(
       context: context,
       builder: (BuildContext context) => SmoothAlertDialog(
         close: false,
@@ -181,6 +182,52 @@ class ProductListDialogHelper {
               Navigator.pop(context, newProductList);
             },
             important: true,
+          ),
+        ],
+      ),
+    );
+  }
+
+  static Future<bool> openChangeIcon(
+    final BuildContext context,
+    final DaoProductList daoProductList,
+    final ProductList productList,
+  ) async {
+    final List<String> orderedIcons = productList.getPossibleIcons();
+    return await showDialog<bool>(
+      context: context,
+      builder: (BuildContext context) => SmoothAlertDialog(
+        close: false,
+        title: _TRANSLATE_ME_CHANGE_ICON,
+        body: Wrap(
+          children: List<Widget>.generate(
+            ProductList.ORDERED_COLORS.length * orderedIcons.length,
+            (final int index) {
+              final String colorTag = ProductList
+                  .ORDERED_COLORS[index % ProductList.ORDERED_COLORS.length];
+              final String iconTag =
+                  orderedIcons[index ~/ ProductList.ORDERED_COLORS.length];
+              return IconButton(
+                icon: ProductList.getReferenceIcon(
+                  colorScheme: Theme.of(context).colorScheme,
+                  colorTag: colorTag,
+                  iconTag: iconTag,
+                ),
+                onPressed: () async {
+                  productList.colorTag = colorTag;
+                  productList.iconTag = iconTag;
+                  await daoProductList.put(productList);
+                  Navigator.pop(context, true);
+                },
+              );
+            },
+          ),
+        ),
+        actions: <SmoothSimpleButton>[
+          SmoothSimpleButton(
+            text: _TRANSLATE_ME_CANCEL,
+            onPressed: () => Navigator.pop(context, false),
+            important: false,
           ),
         ],
       ),

--- a/packages/smooth_app/lib/pages/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product_list_page.dart
@@ -13,6 +13,7 @@ import 'package:smooth_app/database/local_database.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/temp/user_preferences.dart';
 import 'package:wc_flutter_share/wc_flutter_share.dart';
+import 'package:smooth_app/themes/smooth_theme.dart';
 
 class ProductListPage extends StatefulWidget {
   const ProductListPage(
@@ -34,6 +35,7 @@ class _ProductListPageState extends State<ProductListPage> {
 
   static const String _TRANSLATE_ME_RENAME = 'Rename';
   static const String _TRANSLATE_ME_DELETE = 'Delete';
+  static const String _TRANSLATE_ME_CHANGE = 'Change icon';
   static const String _TRANSLATE_ME_COPY = 'copy';
   static const String _TRANSLATE_ME_PASTE = 'paste';
   static const String _TRANSLATE_ME_CLEAR = 'clear';
@@ -122,9 +124,20 @@ class _ProductListPageState extends State<ProductListPage> {
         ),
       ),
       appBar: AppBar(
-        title: Text(
-          ProductQueryPageHelper.getProductListLabel(productList),
-          style: TextStyle(color: colorScheme.onBackground),
+        backgroundColor: SmoothTheme.getBackgroundColor(
+          colorScheme,
+          productList.getMaterialColor(),
+        ),
+        title: Row(
+          children: <Widget>[
+            productList.getIcon(colorScheme),
+            const SizedBox(width: 8.0),
+            Text(
+              ProductQueryPageHelper.getProductListLabel(productList,
+                  verbose: false), // TODO(monsieurtanuki): handle the overflow
+              style: TextStyle(color: colorScheme.onBackground),
+            ),
+          ],
         ),
         iconTheme: IconThemeData(color: colorScheme.onBackground),
         actions: (!renamable) && (!deletable)
@@ -139,6 +152,11 @@ class _ProductListPageState extends State<ProductListPage> {
                         child: Text(_TRANSLATE_ME_RENAME),
                         enabled: true,
                       ),
+                    const PopupMenuItem<String>(
+                      value: 'change',
+                      child: Text(_TRANSLATE_ME_CHANGE),
+                      enabled: true,
+                    ),
                     if (deletable)
                       const PopupMenuItem<String>(
                         value: 'delete',
@@ -163,6 +181,14 @@ class _ProductListPageState extends State<ProductListPage> {
                             context, daoProductList, productList)) {
                           Navigator.pop(context);
                           localDatabase.notifyListeners();
+                        }
+                        break;
+                      case 'change':
+                        final bool changed =
+                            await ProductListDialogHelper.openChangeIcon(
+                                context, daoProductList, productList);
+                        if (changed) {
+                          setState(() {});
                         }
                         break;
                       default:

--- a/packages/smooth_app/lib/themes/smooth_theme.dart
+++ b/packages/smooth_app/lib/themes/smooth_theme.dart
@@ -1,6 +1,22 @@
 import 'package:flutter/material.dart';
 
 class SmoothTheme {
+  static Color getForegroundColor(
+    final ColorScheme colorScheme,
+    final MaterialColor materialColor,
+  ) =>
+      colorScheme.brightness == Brightness.light
+          ? materialColor[800]
+          : materialColor[200];
+
+  static Color getBackgroundColor(
+    final ColorScheme colorScheme,
+    final MaterialColor materialColor,
+  ) =>
+      colorScheme.brightness == Brightness.light
+          ? materialColor[200]
+          : materialColor[700].withOpacity(.3);
+
   static ThemeData getThemeData(final Brightness brightness) {
     final ColorScheme myColorScheme =
         brightness == Brightness.dark ? _COLOR_DARK : _COLOR_LIGHT;


### PR DESCRIPTION
Impacted files:
* `dao_product_list.dart`: created the new `product_list_extra` table and accessed it
* `home_page.dart`: not 100% unrelated - now using new method `SmoothTheme.getForegroundColor`
* `list_page.dart`: added the background color to the product list card
* `local_database.dart`: upgraded to version 3, in order to create the new `product_list_extra` table
* `product_list.dart`: added extraTags field (for the moment, icon and color)
* `product_list_dialog_helper.dart`: added method `openChange`; minor refactoring
* `product_list_page.dart`: added the background color and the icon to the app bar, added the change icon menu item
* `smooth_theme.dart`: not 100% related - added methods `getForegroundColor` and `getBackgroundColor` in order to get unified shades