### PR TITLE
feature/#146 - the product lists are now displayed with a preview of products

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/product_list_preview.dart
+++ b/packages/smooth_app/lib/cards/product_cards/product_list_preview.dart
@@ -1,0 +1,140 @@
+import 'package:flutter/material.dart';
+import 'package:openfoodfacts/model/Product.dart';
+import 'package:smooth_app/database/dao_product_list.dart';
+import 'package:smooth_app/pages/product_page.dart';
+import 'package:smooth_ui_library/widgets/smooth_product_image.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:smooth_app/pages/product_list_page.dart';
+import 'package:smooth_app/data_models/product_list.dart';
+import 'package:smooth_app/themes/smooth_theme.dart';
+import 'package:smooth_app/pages/product_query_page_helper.dart';
+
+class ProductListPreview extends StatelessWidget {
+  const ProductListPreview({
+    @required this.daoProductList,
+    @required this.productList,
+    @required this.nbInPreview,
+  });
+
+  final DaoProductList daoProductList;
+  final ProductList productList;
+  final int nbInPreview;
+
+  static const String _TRANSLATE_ME_SEARCHING = 'Searching...';
+
+  @override
+  Widget build(BuildContext context) => FutureBuilder<List<Product>>(
+        future: daoProductList.getFirstProducts(
+          productList,
+          nbInPreview,
+          true,
+          true,
+        ),
+        builder: (
+          final BuildContext context,
+          final AsyncSnapshot<List<Product>> snapshot,
+        ) {
+          final String title =
+              ProductQueryPageHelper.getProductListLabel(productList);
+          if (snapshot.connectionState == ConnectionState.done) {
+            final List<Product> list = snapshot.data;
+
+            String subtitle;
+            final double iconSize = MediaQuery.of(context).size.width / 6;
+            if (list == null || list.isEmpty) {
+              subtitle = 'Empty list';
+            }
+            return Card(
+              color: SmoothTheme.getBackgroundColor(
+                Theme.of(context).colorScheme,
+                productList.getMaterialColor(),
+              ),
+              child: Column(
+                children: <Widget>[
+                  ListTile(
+                    onTap: () async {
+                      await daoProductList.get(productList);
+                      await Navigator.push<dynamic>(
+                        context,
+                        MaterialPageRoute<dynamic>(
+                          builder: (BuildContext context) => ProductListPage(
+                            productList,
+                            reverse: ProductQueryPageHelper.isListReversed(
+                              productList,
+                            ),
+                          ),
+                        ),
+                      );
+                    },
+                    leading: productList.getIcon(Theme.of(context).colorScheme),
+                    trailing: const Icon(Icons.more_horiz),
+                    subtitle: subtitle == null ? null : Text(subtitle),
+                    title: Text(title,
+                        style: Theme.of(context).textTheme.subtitle2),
+                  ),
+                  _ProductListPreviewHelper(
+                    list: list,
+                    iconSize: iconSize,
+                  ),
+                ],
+              ),
+            );
+          }
+          return Card(
+            child: ListTile(
+              leading: const CircularProgressIndicator(),
+              subtitle: Text(title),
+              title: Text(
+                _TRANSLATE_ME_SEARCHING,
+                style: Theme.of(context).textTheme.subtitle2,
+              ),
+            ),
+          );
+        },
+      );
+}
+
+class _ProductListPreviewHelper extends StatelessWidget {
+  const _ProductListPreviewHelper({
+    @required this.list,
+    @required this.iconSize,
+  });
+
+  final List<Product> list;
+  final double iconSize;
+
+  static const double _PREVIEW_SPACING = 8.0;
+
+  @override
+  Widget build(BuildContext context) {
+    final List<Widget> previews = <Widget>[];
+    for (final Product product in list) {
+      previews.add(GestureDetector(
+        onTap: () async {
+          await Navigator.push<dynamic>(
+            context,
+            MaterialPageRoute<dynamic>(
+              builder: (BuildContext context) => ProductPage(
+                product: product,
+              ),
+            ),
+          );
+        },
+        child: SmoothProductImage(
+          product: product,
+          width: iconSize,
+          height: iconSize,
+        ),
+      ));
+    }
+    return Container(
+      child: Wrap(
+        direction: Axis.horizontal,
+        children: previews,
+        spacing: _PREVIEW_SPACING,
+        runSpacing: _PREVIEW_SPACING,
+      ),
+      padding: const EdgeInsets.only(bottom: _PREVIEW_SPACING),
+    );
+  }
+}

--- a/packages/smooth_app/lib/database/dao_product_list.dart
+++ b/packages/smooth_app/lib/database/dao_product_list.dart
@@ -157,24 +157,32 @@ class DaoProductList {
     final ProductList productList,
     final int limit,
     final bool reverse,
+    final bool unique,
   ) async {
     final Map<String, dynamic> record = await _getRecord(productList);
     if (record == null) {
       return null;
     }
     final int id = record[_TABLE_PRODUCT_LIST_COLUMN_ID] as int;
-    return await _getBarcodes(id, limit: limit, reverse: reverse);
+    return await _getBarcodes(
+      id,
+      limit: limit,
+      reverse: reverse,
+      unique: unique,
+    );
   }
 
   Future<List<Product>> getFirstProducts(
     final ProductList productList,
     final int limit,
     final bool reverse,
+    final bool unique,
   ) async {
     final List<String> barcodes = await getFirstBarcodes(
       productList,
       limit,
       reverse,
+      unique,
     );
     final Map<String, Product> products =
         await DaoProduct(localDatabase).getAll(barcodes);
@@ -393,6 +401,7 @@ class DaoProductList {
     final int id, {
     final int limit,
     final bool reverse = false,
+    final bool unique = false,
   }) async {
     const String BARCODE_COLUMN_NAME = _TABLE_PRODUCT_LIST_ITEM_COLUMN_BARCODE;
     final List<Map<String, dynamic>> query = await localDatabase.database.query(
@@ -402,11 +411,17 @@ class DaoProductList {
       columns: <String>[BARCODE_COLUMN_NAME],
       orderBy:
           '$_TABLE_PRODUCT_LIST_ITEM_COLUMN_ID ${reverse ? 'DESC' : 'ASC'}',
-      limit: limit,
+      limit: unique ? null : limit,
     );
     final List<String> result = <String>[];
     for (final Map<String, dynamic> row in query) {
-      result.add(row[BARCODE_COLUMN_NAME] as String);
+      final String barcode = row[BARCODE_COLUMN_NAME] as String;
+      if ((!unique) || !result.contains(barcode)) {
+        result.add(barcode);
+        if (limit != null && result.length >= limit) {
+          break;
+        }
+      }
     }
     return result;
   }

--- a/packages/smooth_app/lib/pages/list_page.dart
+++ b/packages/smooth_app/lib/pages/list_page.dart
@@ -1,13 +1,10 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:smooth_app/cards/product_cards/product_list_preview.dart';
 import 'package:smooth_app/database/dao_product_list.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/product_list.dart';
-import 'package:smooth_app/pages/product_query_page_helper.dart';
 import 'package:smooth_app/pages/product_list_dialog_helper.dart';
-import 'package:smooth_app/pages/product_list_page.dart';
-import 'package:smooth_app/themes/smooth_theme.dart';
 
 class ListPage extends StatefulWidget {
   const ListPage({
@@ -66,45 +63,10 @@ class _ListPageState extends State<ListPage> {
                   itemCount: _list.length,
                   itemBuilder: (final BuildContext context, final int index) {
                     final ProductList item = _list[index];
-                    return Card(
-                      color: SmoothTheme.getBackgroundColor(
-                        colorScheme,
-                        item.getMaterialColor(),
-                      ),
-                      child: ListTile(
-                        leading: item.getIcon(colorScheme),
-                        title: Text(
-                          ProductQueryPageHelper.getProductListLabel(
-                            item,
-                            verbose: false,
-                          ),
-                          style: Theme.of(context).textTheme.bodyText1,
-                        ),
-                        subtitle: Text(
-                          '${ProductQueryPageHelper.getDurationStringFromTimestamp(item.databaseTimestamp)}, '
-                          '${ProductQueryPageHelper.getProductCount(item)}',
-                        ),
-                        onTap: () async {
-                          await daoProductList.get(item);
-                          await Navigator.push<dynamic>(
-                            context,
-                            MaterialPageRoute<dynamic>(
-                              builder: (BuildContext context) =>
-                                  ProductListPage(
-                                item,
-                                reverse: _isListReversed(item),
-                              ),
-                            ),
-                          );
-                          localDatabase.notifyListeners();
-                        },
-                        onLongPress: () async {
-                          if (await ProductListDialogHelper.openDelete(
-                              context, daoProductList, item)) {
-                            setState(() {});
-                          }
-                        },
-                      ),
+                    return ProductListPreview(
+                      daoProductList: daoProductList,
+                      productList: item,
+                      nbInPreview: 5,
                     );
                   },
                 );
@@ -114,8 +76,4 @@ class _ListPageState extends State<ListPage> {
           }),
     );
   }
-
-  bool _isListReversed(final ProductList productList) =>
-      productList.listType == ProductList.LIST_TYPE_HISTORY ||
-      productList.listType == ProductList.LIST_TYPE_SCAN;
 }

--- a/packages/smooth_app/lib/pages/product_list_dialog_helper.dart
+++ b/packages/smooth_app/lib/pages/product_list_dialog_helper.dart
@@ -146,7 +146,7 @@ class ProductListDialogHelper {
                   newProductList = ProductList(
                     listType: ProductList.LIST_TYPE_USER_DEFINED,
                     parameters: value,
-                  );
+                  )..extraTags = productList.extraTags;
                   for (final ProductList item in list) {
                     if (item.lousyKey == newProductList.lousyKey) {
                       if (item.lousyKey == productList.lousyKey) {

--- a/packages/smooth_app/lib/pages/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product_list_page.dart
@@ -174,7 +174,7 @@ class _ProductListPageState extends State<ProductListPage> {
                           return;
                         }
                         productList = renamedProductList;
-                        setState(() {});
+                        localDatabase.notifyListeners();
                         break;
                       case 'delete':
                         if (await ProductListDialogHelper.openDelete(
@@ -188,7 +188,7 @@ class _ProductListPageState extends State<ProductListPage> {
                             await ProductListDialogHelper.openChangeIcon(
                                 context, daoProductList, productList);
                         if (changed) {
-                          setState(() {});
+                          localDatabase.notifyListeners();
                         }
                         break;
                       default:

--- a/packages/smooth_app/lib/pages/product_query_page_helper.dart
+++ b/packages/smooth_app/lib/pages/product_query_page_helper.dart
@@ -89,6 +89,10 @@ class ProductQueryPageHelper {
     return getDurationStringFromSeconds(seconds);
   }
 
+  static bool isListReversed(final ProductList productList) =>
+      productList.listType == ProductList.LIST_TYPE_HISTORY ||
+      productList.listType == ProductList.LIST_TYPE_SCAN;
+
   static String getProductListLabel(
     final ProductList productList, {
     final bool verbose = true,


### PR DESCRIPTION
New file:
* `product_list_preview.dart`: widget that computes and displays the first products of a list

Impacted files:
* `dao_product_list.dart`: added a 'bool unique' parameter to "first products" query
* `home_page.dart`: now using new widget `ProductListPreview` to display history
* `list_page.dart`: now using new widget `ProductListPreview` to display product lists
* `product_list_dialog_helper.dart`: unrelated minor bug fix
* `product_list_page.dart`: unrelated minor bug fix
* `product_query_page_helper.dart`: minor refactoring