### PR TITLE
feature/#164_2 - pantries are now available

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/pantry_preview.dart
+++ b/packages/smooth_app/lib/cards/product_cards/pantry_preview.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:openfoodfacts/model/Product.dart';
+import 'package:smooth_app/pages/pantry_page.dart';
+import 'package:smooth_app/data_models/pantry.dart';
+import 'package:smooth_app/themes/smooth_theme.dart';
+import 'package:smooth_app/cards/product_cards/product_list_preview_helper.dart';
+
+/// A preview button for a pantry, with its N first products
+class PantryPreview extends StatelessWidget {
+  const PantryPreview({
+    @required this.pantries,
+    @required this.index,
+    @required this.nbInPreview,
+  });
+
+  final List<Pantry> pantries;
+  final int index;
+  final int nbInPreview;
+
+  @override
+  Widget build(BuildContext context) {
+    final Pantry pantry = pantries[index];
+    final List<Product> list = pantry.getFirstProducts(nbInPreview);
+
+    String subtitle;
+    final double iconSize = MediaQuery.of(context).size.width / 6;
+    if (list == null || list.isEmpty) {
+      subtitle = 'Empty list';
+    }
+    return Card(
+      color: SmoothTheme.getBackgroundColor(
+          Theme.of(context).colorScheme, pantry.materialColor),
+      child: Column(
+        children: <Widget>[
+          ListTile(
+            onTap: () async => await Navigator.push<dynamic>(
+              context,
+              MaterialPageRoute<dynamic>(
+                builder: (BuildContext context) => PantryPage(pantries, index),
+              ),
+            ),
+            leading: pantry.getIcon(Theme.of(context).colorScheme),
+            trailing: const Icon(Icons.more_horiz),
+            subtitle: subtitle == null ? null : Text(subtitle),
+            title:
+                Text(pantry.name, style: Theme.of(context).textTheme.subtitle2),
+          ),
+          ProductListPreviewHelper(list: list, iconSize: iconSize),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/smooth_app/lib/cards/product_cards/product_list_preview.dart
+++ b/packages/smooth_app/lib/cards/product_cards/product_list_preview.dart
@@ -1,13 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/model/Product.dart';
 import 'package:smooth_app/database/dao_product_list.dart';
-import 'package:smooth_app/pages/product_page.dart';
-import 'package:smooth_ui_library/widgets/smooth_product_image.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:smooth_app/pages/product_list_page.dart';
 import 'package:smooth_app/data_models/product_list.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
 import 'package:smooth_app/pages/product_query_page_helper.dart';
+import 'package:smooth_app/cards/product_cards/product_list_preview_helper.dart';
 
 class ProductListPreview extends StatelessWidget {
   const ProductListPreview({
@@ -72,7 +70,7 @@ class ProductListPreview extends StatelessWidget {
                     title: Text(title,
                         style: Theme.of(context).textTheme.subtitle2),
                   ),
-                  _ProductListPreviewHelper(
+                  ProductListPreviewHelper(
                     list: list,
                     iconSize: iconSize,
                   ),
@@ -92,49 +90,4 @@ class ProductListPreview extends StatelessWidget {
           );
         },
       );
-}
-
-class _ProductListPreviewHelper extends StatelessWidget {
-  const _ProductListPreviewHelper({
-    @required this.list,
-    @required this.iconSize,
-  });
-
-  final List<Product> list;
-  final double iconSize;
-
-  static const double _PREVIEW_SPACING = 8.0;
-
-  @override
-  Widget build(BuildContext context) {
-    final List<Widget> previews = <Widget>[];
-    for (final Product product in list) {
-      previews.add(GestureDetector(
-        onTap: () async {
-          await Navigator.push<dynamic>(
-            context,
-            MaterialPageRoute<dynamic>(
-              builder: (BuildContext context) => ProductPage(
-                product: product,
-              ),
-            ),
-          );
-        },
-        child: SmoothProductImage(
-          product: product,
-          width: iconSize,
-          height: iconSize,
-        ),
-      ));
-    }
-    return Container(
-      child: Wrap(
-        direction: Axis.horizontal,
-        children: previews,
-        spacing: _PREVIEW_SPACING,
-        runSpacing: _PREVIEW_SPACING,
-      ),
-      padding: const EdgeInsets.only(bottom: _PREVIEW_SPACING),
-    );
-  }
 }

--- a/packages/smooth_app/lib/cards/product_cards/product_list_preview_helper.dart
+++ b/packages/smooth_app/lib/cards/product_cards/product_list_preview_helper.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:openfoodfacts/model/Product.dart';
+import 'package:smooth_app/pages/product_page.dart';
+import 'package:smooth_ui_library/widgets/smooth_product_image.dart';
+
+class ProductListPreviewHelper extends StatelessWidget {
+  const ProductListPreviewHelper({
+    @required this.list,
+    @required this.iconSize,
+  });
+
+  final List<Product> list;
+  final double iconSize;
+
+  static const double _PREVIEW_SPACING = 8.0;
+
+  @override
+  Widget build(BuildContext context) {
+    final List<Widget> previews = <Widget>[];
+    for (final Product product in list) {
+      previews.add(GestureDetector(
+        onTap: () async => await Navigator.push<dynamic>(
+          context,
+          MaterialPageRoute<dynamic>(
+            builder: (BuildContext context) => ProductPage(
+              product: product,
+            ),
+          ),
+        ),
+        child: SmoothProductImage(
+          product: product,
+          width: iconSize,
+          height: iconSize,
+        ),
+      ));
+    }
+    return Container(
+      child: Wrap(
+        direction: Axis.horizontal,
+        children: previews,
+        spacing: _PREVIEW_SPACING,
+        runSpacing: _PREVIEW_SPACING,
+      ),
+      padding: const EdgeInsets.only(bottom: _PREVIEW_SPACING),
+    );
+  }
+}

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
@@ -83,6 +83,7 @@ class SmoothProductCardFound extends StatelessWidget {
                 SmoothProductImage(
                   product: product,
                   width: screenSize.width * 0.20,
+                  height: screenSize.width * 0.20,
                 ),
                 const SizedBox(
                   width: 8.0,

--- a/packages/smooth_app/lib/data_models/pantry.dart
+++ b/packages/smooth_app/lib/data_models/pantry.dart
@@ -1,0 +1,216 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:openfoodfacts/model/Product.dart';
+import 'package:smooth_app/temp/user_preferences.dart';
+import 'package:smooth_app/database/dao_product.dart';
+import 'package:smooth_app/data_models/product_list.dart';
+
+/// A pantry, with a name, a color, an icon,
+/// and a list of barcodes with quantity and dates
+/// It's stored in the SharedPreferences
+/// The barcodes' Products are loaded from the local database
+class Pantry {
+  Pantry({
+    @required this.name,
+    this.data = const <String, Map<String, int>>{},
+    this.products = const <String, Product>{},
+    this.iconTag = _ICON_PAW,
+    this.colorTag = _COLOR_DEFAULT,
+  });
+
+  String name;
+  String colorTag;
+  String iconTag;
+  final Map<String, Map<String, int>> data;
+  final Map<String, Product> products;
+
+  static const String _ICON_DEFAULT = _ICON_PAW;
+  static const String _COLOR_DEFAULT = _COLOR_BLUE;
+
+  MaterialColor get materialColor =>
+      _COLORS[colorTag] ?? _COLORS[_COLOR_DEFAULT];
+  IconData get iconData => _ICON_DATA[iconTag] ?? _ICON_DATA[_ICON_DEFAULT];
+
+  void add(final List<String> barcodes, final Map<String, Product> products) {
+    for (final String barcode in barcodes) {
+      if (!data.containsKey(barcode)) {
+        data[barcode] = <String, int>{};
+      }
+    }
+    this.products.addAll(products);
+  }
+
+  static const String _ICON_PAW = 'paw';
+  static const String _ICON_FREEZER = 'heart';
+  static const String _ICON_HOME = 'home';
+
+  static const List<String> _ORDERED_ICONS = <String>[
+    _ICON_PAW,
+    _ICON_FREEZER,
+    _ICON_HOME,
+  ];
+
+  static const Map<String, IconData> _ICON_DATA = <String, IconData>{
+    _ICON_PAW: Icons.pets,
+    _ICON_FREEZER: Icons.ac_unit,
+    _ICON_HOME: Icons.home,
+  };
+
+  static const String _COLOR_RED = 'red';
+  static const String _COLOR_ORANGE = 'orange';
+  static const String _COLOR_GREEN = 'green';
+  static const String _COLOR_BLUE = 'blue';
+  static const String _COLOR_PURPLE = 'purple';
+
+  static const Map<String, MaterialColor> _COLORS = <String, MaterialColor>{
+    _COLOR_RED: Colors.red,
+    _COLOR_ORANGE: Colors.orange,
+    _COLOR_GREEN: Colors.green,
+    _COLOR_BLUE: Colors.blue,
+    _COLOR_PURPLE: Colors.purple,
+  };
+
+  static const List<String> ORDERED_COLORS = <String>[
+    _COLOR_RED,
+    _COLOR_ORANGE,
+    _COLOR_GREEN,
+    _COLOR_BLUE,
+    _COLOR_PURPLE,
+  ];
+
+  List<String> getPossibleIcons() => _ORDERED_ICONS;
+
+  static Widget getReferenceIcon({
+    final ColorScheme colorScheme,
+    final String colorTag,
+    final String iconTag,
+  }) =>
+      ProductList.getTintedIcon(
+        colorScheme: colorScheme,
+        materialColor: _COLORS[colorTag],
+        iconData: _ICON_DATA[iconTag] ?? _ICON_DATA[_ICON_DEFAULT],
+      );
+
+  Widget getIcon(final ColorScheme colorScheme) => ProductList.getTintedIcon(
+        colorScheme: colorScheme,
+        materialColor: materialColor,
+        iconData: iconData,
+      );
+
+  List<Product> getFirstProducts(final int nbInPreview) {
+    final List<Product> result = <Product>[];
+    for (final Product product in products.values) {
+      result.add(product);
+      if (result.length >= nbInPreview) {
+        break;
+      }
+    }
+    return result;
+  }
+
+  int increaseItem(
+    final String barcode,
+    final String date,
+    final int increment,
+  ) {
+    final int previous = data[barcode][date];
+    if (previous == null) {
+      data[barcode][date] = increment;
+    } else {
+      data[barcode][date] = previous + increment;
+    }
+    if (data[barcode][date] <= 0) {
+      data[barcode].remove(date);
+    }
+    return data[barcode][date];
+  }
+
+  void removeBarcode(final String barcode) {
+    data.remove(barcode);
+    products.remove(barcode);
+  }
+
+  void clear() {
+    data.clear();
+    products.clear();
+  }
+
+  static Future<void> putAll(
+    final UserPreferences userPreferences,
+    final List<Pantry> pantries,
+  ) async {
+    final List<String> encodedJsons = <String>[];
+    for (final Pantry pantry in pantries) {
+      encodedJsons.add(_put(pantry));
+    }
+    await userPreferences.setPantryRepository(encodedJsons);
+  }
+
+  static Future<List<Pantry>> getAll(
+    final UserPreferences userPreferences,
+    final DaoProduct daoProduct,
+  ) async {
+    final List<Pantry> result = <Pantry>[];
+    final List<String> pantryJsons = userPreferences.getPantryRepository();
+    for (final String pantryJson in pantryJsons) {
+      result.add(await _get(pantryJson, daoProduct));
+    }
+    return result;
+  }
+
+  static const String _JSON_TAG_NAME = 'name';
+  static const String _JSON_TAG_COLOR = 'color';
+  static const String _JSON_TAG_ICON = 'icon';
+  static const String _JSON_TAG_PRODUCTS = 'products';
+
+  static Future<Pantry> _get(
+    final String encodedJson,
+    final DaoProduct daoProduct,
+  ) async {
+    final Map<String, dynamic> decodedJsonAll =
+        json.decode(encodedJson) as Map<String, dynamic>;
+    final String name = decodedJsonAll[_JSON_TAG_NAME] as String;
+    final String colorTag = decodedJsonAll[_JSON_TAG_COLOR] as String;
+    final String iconTag = decodedJsonAll[_JSON_TAG_ICON] as String;
+    final Map<String, dynamic> decodedJson =
+        decodedJsonAll[_JSON_TAG_PRODUCTS] as Map<String, dynamic>;
+    final List<String> barcodes = decodedJson.keys.toList();
+    final Map<String, Product> products = await daoProduct.getAll(barcodes);
+    final Map<String, Map<String, int>> data = <String, Map<String, int>>{};
+    for (final String barcode in barcodes) {
+      final dynamic rawDataForBarcode = decodedJson[barcode];
+      if (rawDataForBarcode is! Map) {
+        // not expected
+        continue;
+      }
+      final Map<String, int> dataForBarcode = <String, int>{};
+      final Map<String, dynamic> rawMap =
+          rawDataForBarcode as Map<String, dynamic>;
+      for (final MapEntry<String, dynamic> entry in rawMap.entries) {
+        dataForBarcode[entry.key] = entry.value as int;
+      }
+      data[barcode] = dataForBarcode;
+    }
+    return Pantry(
+      data: data,
+      products: products,
+      name: name,
+      colorTag: colorTag,
+      iconTag: iconTag,
+    );
+  }
+
+  static String _put(final Pantry pantry) {
+    final Map<String, dynamic> result = <String, dynamic>{};
+    result[_JSON_TAG_NAME] = pantry.name;
+    result[_JSON_TAG_COLOR] = pantry.colorTag;
+    result[_JSON_TAG_ICON] = pantry.iconTag;
+    result[_JSON_TAG_PRODUCTS] = pantry.data;
+    final String encodedJson = json.encode(result);
+    return encodedJson;
+  }
+
+  @override
+  String toString() => 'Pantry(name: $name, data: $data)';
+}

--- a/packages/smooth_app/lib/data_models/product_list.dart
+++ b/packages/smooth_app/lib/data_models/product_list.dart
@@ -124,19 +124,28 @@ class ProductList {
 
   Product getProduct(final String barcode) => _products[barcode];
 
-  String get lousyKey => '$listType/$parameters';
+  String get lousyKey =>
+      '$listType/$parameters'; // TODO(monsieurtanuki): does not work if you change the name
 
   static Widget getReferenceIcon({
     final ColorScheme colorScheme,
     final String colorTag,
     final String iconTag,
   }) =>
+      getTintedIcon(
+        colorScheme: colorScheme,
+        materialColor: _getReferenceMaterialColor(colorTag),
+        iconData: _ICON_DATA[iconTag] ?? _ICON_DATA[_ICON_TAG],
+      );
+
+  static Widget getTintedIcon({
+    final ColorScheme colorScheme,
+    final MaterialColor materialColor,
+    final IconData iconData,
+  }) =>
       Icon(
-        _ICON_DATA[iconTag] ?? _ICON_DATA[_ICON_TAG],
-        color: SmoothTheme.getForegroundColor(
-          colorScheme,
-          _getReferenceMaterialColor(colorTag),
-        ),
+        iconData,
+        color: SmoothTheme.getForegroundColor(colorScheme, materialColor),
       );
 
   static MaterialColor _getReferenceMaterialColor(final String colorTag) =>

--- a/packages/smooth_app/lib/database/dao_product_list.dart
+++ b/packages/smooth_app/lib/database/dao_product_list.dart
@@ -249,11 +249,10 @@ class DaoProductList {
     final ProductList destination,
     final String sourceLousyKey,
   ) async {
-    final int sourceId = await _getProductListIdFromLousyKey(sourceLousyKey);
-    if (sourceId == null) {
+    final List<String> barcodes = await getBarcodes(sourceLousyKey);
+    if (barcodes == null) {
       return null;
     }
-    final List<String> barcodes = await _getBarcodes(sourceId);
     _upsertProductList(destination);
     final Map<String, dynamic> record = await _getRecord(destination);
     if (record == null) {
@@ -264,6 +263,14 @@ class DaoProductList {
     final int result = await _insertListItems(destinationId, barcodes);
     await get(destination);
     return result;
+  }
+
+  Future<List<String>> getBarcodes(final String lousyKey) async {
+    final int sourceId = await _getProductListIdFromLousyKey(lousyKey);
+    if (sourceId == null) {
+      return null;
+    }
+    return await _getBarcodes(sourceId);
   }
 
   Future<int> _getProductListIdFromLousyKey(final String lousyKey) async {

--- a/packages/smooth_app/lib/pages/pantry_button.dart
+++ b/packages/smooth_app/lib/pages/pantry_button.dart
@@ -11,13 +11,13 @@ class PantryButton extends StatelessWidget {
   final int index;
   final OutlinedBorder shape;
 
-  static const OutlinedBorder SHAPE_BEVELED = BeveledRectangleBorder(
-    borderRadius: BorderRadius.horizontal(
-        left: Radius.circular(16.0), right: Radius.circular(16.0)),
-  );
-  static final OutlinedBorder SHAPE_ROUNDED = RoundedRectangleBorder(
-    borderRadius: BorderRadius.circular(32.0),
-  );
+  static OutlinedBorder getShapeBeveled() => const BeveledRectangleBorder(
+        borderRadius: BorderRadius.horizontal(
+            left: Radius.circular(16.0), right: Radius.circular(16.0)),
+      );
+  static OutlinedBorder getShapeRounded() => RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(32.0),
+      );
 
   @override
   Widget build(BuildContext context) => ElevatedButton.icon(

--- a/packages/smooth_app/lib/pages/pantry_button.dart
+++ b/packages/smooth_app/lib/pages/pantry_button.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:smooth_app/data_models/pantry.dart';
+import 'package:smooth_app/pages/pantry_page.dart';
+import 'package:smooth_app/themes/smooth_theme.dart';
+
+/// A button for a pantry, with the corresponding color, icon, name and shape
+class PantryButton extends StatelessWidget {
+  const PantryButton(this.pantries, this.index, {this.shape});
+
+  final List<Pantry> pantries;
+  final int index;
+  final OutlinedBorder shape;
+
+  static const OutlinedBorder SHAPE_BEVELED = BeveledRectangleBorder(
+    borderRadius: BorderRadius.horizontal(
+        left: Radius.circular(16.0), right: Radius.circular(16.0)),
+  );
+  static final OutlinedBorder SHAPE_ROUNDED = RoundedRectangleBorder(
+    borderRadius: BorderRadius.circular(32.0),
+  );
+
+  @override
+  Widget build(BuildContext context) => ElevatedButton.icon(
+        icon: pantries[index].getIcon(Theme.of(context).colorScheme),
+        label: Text(pantries[index].name),
+        onPressed: () async {
+          await Navigator.push<dynamic>(
+            context,
+            MaterialPageRoute<dynamic>(
+              builder: (BuildContext context) => PantryPage(pantries, index),
+            ),
+          );
+        },
+        style: ElevatedButton.styleFrom(
+          primary: SmoothTheme.getBackgroundColor(
+            Theme.of(context).colorScheme,
+            pantries[index].materialColor,
+          ),
+          shape: shape,
+        ),
+      );
+}

--- a/packages/smooth_app/lib/pages/pantry_dialog_helper.dart
+++ b/packages/smooth_app/lib/pages/pantry_dialog_helper.dart
@@ -1,0 +1,225 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:smooth_app/data_models/pantry.dart';
+import 'package:smooth_ui_library/buttons/smooth_simple_button.dart';
+import 'package:smooth_ui_library/dialogs/smooth_alert_dialog.dart';
+
+/// A dialog helper for pantries
+class PantryDialogHelper {
+  static const String _TRANSLATE_ME_WANT_TO_DELETE =
+      'Do you want to delete this pantry?';
+  static const String _TRANSLATE_ME_NEW_LIST = 'New pantry';
+  static const String _TRANSLATE_ME_RENAME_LIST = 'Rename pantry';
+  static const String _TRANSLATE_ME_CHANGE_ICON = 'Change icon';
+  static const String _TRANSLATE_ME_HINT = 'My own pantry';
+  static const String _TRANSLATE_ME_EMPTY = 'Please enter some text';
+  static const String _TRANSLATE_ME_ALREADY_OTHER =
+      'There\'s already a pantry with that name';
+  static const String _TRANSLATE_ME_ALREADY_SAME = 'That\'s the same name!';
+  static const String _TRANSLATE_ME_CANCEL = 'Cancel';
+
+  static Future<bool> openDelete(
+    final BuildContext context,
+    final List<Pantry> pantries,
+    final int index,
+  ) async =>
+      await showDialog<bool>(
+        context: context,
+        builder: (BuildContext context) => SmoothAlertDialog(
+          close: false,
+          body: const Text(_TRANSLATE_ME_WANT_TO_DELETE),
+          actions: <SmoothSimpleButton>[
+            SmoothSimpleButton(
+              text: AppLocalizations.of(context).no,
+              important: false,
+              onPressed: () => Navigator.pop(context, false),
+            ),
+            SmoothSimpleButton(
+              text: AppLocalizations.of(context).yes,
+              important: true,
+              onPressed: () async {
+                pantries.removeAt(index);
+                Navigator.pop(context, true);
+              },
+            ),
+          ],
+        ),
+      );
+
+  static Future<bool> openNew(
+    final BuildContext context,
+    final List<Pantry> pantries,
+  ) async {
+    final GlobalKey<FormState> formKey = GlobalKey<FormState>();
+    return await showDialog<bool>(
+      context: context,
+      builder: (BuildContext context) => SmoothAlertDialog(
+        close: false,
+        title: _TRANSLATE_ME_NEW_LIST,
+        body: Form(
+          key: formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              TextFormField(
+                decoration: const InputDecoration(
+                  hintText: _TRANSLATE_ME_HINT,
+                ),
+                validator: (final String value) {
+                  if (value.isEmpty) {
+                    return _TRANSLATE_ME_EMPTY;
+                  }
+                  if (pantries == null) {
+                    return null;
+                  }
+                  for (int i = 0; i < pantries.length; i++) {
+                    if (value == pantries[i].name) {
+                      return _TRANSLATE_ME_ALREADY_OTHER;
+                    }
+                  }
+                  pantries.add(Pantry(name: value));
+                  return null;
+                },
+              ),
+            ],
+          ),
+        ),
+        actions: <SmoothSimpleButton>[
+          SmoothSimpleButton(
+            text: _TRANSLATE_ME_CANCEL,
+            onPressed: () => Navigator.pop(context, false),
+            important: false,
+          ),
+          SmoothSimpleButton(
+            text: AppLocalizations.of(context).okay,
+            onPressed: () async {
+              if (!formKey.currentState.validate()) {
+                return;
+              }
+              Navigator.pop(context, true);
+            },
+            important: true,
+          ),
+        ],
+      ),
+    );
+  }
+
+  static Future<bool> openRename(
+    final BuildContext context,
+    final List<Pantry> pantries,
+    final int index,
+  ) async {
+    final GlobalKey<FormState> formKey = GlobalKey<FormState>();
+    return await showDialog<bool>(
+      context: context,
+      builder: (BuildContext context) => SmoothAlertDialog(
+        close: false,
+        title: _TRANSLATE_ME_RENAME_LIST,
+        body: Form(
+          key: formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              TextFormField(
+                initialValue: pantries[index].name,
+                decoration: const InputDecoration(
+                  hintText: _TRANSLATE_ME_HINT,
+                ),
+                validator: (final String value) {
+                  if (value.isEmpty) {
+                    return _TRANSLATE_ME_EMPTY;
+                  }
+                  if (pantries == null) {
+                    return null;
+                  }
+                  for (int i = 0; i < pantries.length; i++) {
+                    if (value == pantries[i].name) {
+                      if (i == index) {
+                        return _TRANSLATE_ME_ALREADY_SAME;
+                      }
+                      return _TRANSLATE_ME_ALREADY_OTHER;
+                    }
+                  }
+                  pantries[index].name = value;
+                  return null;
+                },
+              ),
+            ],
+          ),
+        ),
+        actions: <SmoothSimpleButton>[
+          SmoothSimpleButton(
+            text: _TRANSLATE_ME_CANCEL,
+            onPressed: () => Navigator.pop(context, false),
+            important: false,
+          ),
+          SmoothSimpleButton(
+            text: AppLocalizations.of(context).okay,
+            onPressed: () async {
+              if (!formKey.currentState.validate()) {
+                return;
+              }
+              Navigator.pop(context, true);
+            },
+            important: true,
+          ),
+        ],
+      ),
+    );
+  }
+
+  static Future<bool> openChangeIcon(
+    final BuildContext context,
+    final List<Pantry> pantries,
+    final int index,
+  ) async {
+    final Pantry pantry = pantries[index];
+    final List<String> orderedIcons = pantries[index].getPossibleIcons();
+    final List<String> orderedColors = Pantry.ORDERED_COLORS;
+    final double size = MediaQuery.of(context).size.width / 8;
+    return await showDialog<bool>(
+      context: context,
+      builder: (BuildContext context) => SmoothAlertDialog(
+        close: false,
+        title: _TRANSLATE_ME_CHANGE_ICON,
+        body: Container(
+          width: orderedColors.length.toDouble() * size,
+          height: orderedIcons.length.toDouble() * size,
+          child: GridView.count(
+            crossAxisCount: 5,
+            childAspectRatio: 1,
+            children: List<Widget>.generate(
+              orderedColors.length * orderedIcons.length,
+              (final int index) {
+                final String colorTag =
+                    orderedColors[index % orderedColors.length];
+                final String iconTag =
+                    orderedIcons[index ~/ orderedColors.length];
+                return IconButton(
+                  icon: Pantry.getReferenceIcon(
+                    colorScheme: Theme.of(context).colorScheme,
+                    colorTag: colorTag,
+                    iconTag: iconTag,
+                  ),
+                  onPressed: () async {
+                    pantry.colorTag = colorTag;
+                    pantry.iconTag = iconTag;
+                    Navigator.pop(context, true);
+                  },
+                );
+              },
+            ),
+          ),
+        ),
+        actions: <SmoothSimpleButton>[
+          SmoothSimpleButton(
+            text: _TRANSLATE_ME_CANCEL,
+            onPressed: () => Navigator.pop(context, false),
+            important: false,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/smooth_app/lib/pages/pantry_dialog_helper.dart
+++ b/packages/smooth_app/lib/pages/pantry_dialog_helper.dart
@@ -176,7 +176,7 @@ class PantryDialogHelper {
   ) async {
     final Pantry pantry = pantries[index];
     final List<String> orderedIcons = pantries[index].getPossibleIcons();
-    final List<String> orderedColors = Pantry.ORDERED_COLORS;
+    const List<String> orderedColors = Pantry.ORDERED_COLORS;
     final double size = MediaQuery.of(context).size.width / 8;
     return await showDialog<bool>(
       context: context,

--- a/packages/smooth_app/lib/pages/pantry_list_page.dart
+++ b/packages/smooth_app/lib/pages/pantry_list_page.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:smooth_app/cards/product_cards/pantry_preview.dart';
+import 'package:smooth_app/data_models/pantry.dart';
+import 'package:smooth_app/pages/pantry_dialog_helper.dart';
+import 'package:smooth_app/temp/user_preferences.dart';
+import 'package:provider/provider.dart';
+
+/// A page where all the pantries are displayed as previews
+class PantryListPage extends StatefulWidget {
+  const PantryListPage(this.title, this.pantries);
+
+  final String title;
+  final List<Pantry> pantries;
+
+  @override
+  _PantryListPageState createState() => _PantryListPageState();
+}
+
+class _PantryListPageState extends State<PantryListPage> {
+  @override
+  Widget build(BuildContext context) {
+    final UserPreferences userPreferences = context.watch<UserPreferences>();
+    final ColorScheme colorScheme = Theme.of(context).colorScheme;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          widget.title,
+          style: TextStyle(color: colorScheme.onBackground),
+        ),
+        iconTheme: IconThemeData(color: colorScheme.onBackground),
+        actions: <Widget>[
+          IconButton(
+            icon: Icon(Icons.add, color: colorScheme.onBackground),
+            onPressed: () async {
+              if (await PantryDialogHelper.openNew(
+                context,
+                widget.pantries,
+              )) {
+                Pantry.putAll(userPreferences, widget.pantries);
+              }
+            },
+          )
+        ],
+      ),
+      body: (widget.pantries.isEmpty)
+          ? const Center(child: Text('Empty'))
+          : ListView.builder(
+              itemCount: widget.pantries.length,
+              itemBuilder: (final BuildContext context, final int index) =>
+                  PantryPreview(
+                pantries: widget.pantries,
+                index: index,
+                nbInPreview: 5,
+              ),
+            ),
+    );
+  }
+}

--- a/packages/smooth_app/lib/pages/pantry_page.dart
+++ b/packages/smooth_app/lib/pages/pantry_page.dart
@@ -1,0 +1,277 @@
+import 'package:flutter/material.dart';
+
+import 'package:smooth_app/cards/product_cards/smooth_product_card_found.dart';
+import 'package:smooth_app/data_models/pantry.dart';
+import 'package:openfoodfacts/model/Product.dart';
+
+import 'package:smooth_app/pages/pantry_dialog_helper.dart';
+import 'package:smooth_app/database/dao_product_list.dart';
+import 'package:smooth_app/database/dao_product.dart';
+import 'package:smooth_app/database/local_database.dart';
+import 'package:provider/provider.dart';
+import 'package:smooth_app/temp/user_preferences.dart';
+import 'package:smooth_app/themes/smooth_theme.dart';
+
+/// A page for one pantry where we can change all the data
+class PantryPage extends StatelessWidget {
+  const PantryPage(
+    this.pantries,
+    this.index,
+  );
+
+  final List<Pantry> pantries;
+  final int index;
+
+  static const String _TRANSLATE_ME_RENAME = 'Rename';
+  static const String _TRANSLATE_ME_DELETE = 'Delete';
+  static const String _TRANSLATE_ME_CHANGE = 'Change icon';
+  static const String _TRANSLATE_ME_PASTE = 'paste';
+  static const String _TRANSLATE_ME_CLEAR = 'clear';
+  static const String _TRANSLATE_ME_GROCERY = 'grocery';
+  static const String _TRANSLATE_ME_ANOTHER_DATE = 'Add another date';
+
+  @override
+  Widget build(BuildContext context) {
+    final LocalDatabase localDatabase = context.watch<LocalDatabase>();
+    final UserPreferences userPreferences = context.watch<UserPreferences>();
+    final DaoProduct daoProduct = DaoProduct(localDatabase);
+    final DaoProductList daoProductList = DaoProductList(localDatabase);
+    final ColorScheme colorScheme = Theme.of(context).colorScheme;
+    const TextStyle textStyle = TextStyle(fontSize: 16);
+    if (index >= pantries.length) {
+      return const CircularProgressIndicator();
+    }
+    final Pantry pantry = pantries[index];
+    final List<Product> products = pantry.products.values.toList();
+    return Scaffold(
+      bottomNavigationBar: Builder(
+        builder: (BuildContext context) => BottomNavigationBar(
+          type: BottomNavigationBarType.fixed,
+          items: const <BottomNavigationBarItem>[
+            BottomNavigationBarItem(
+                icon: Icon(Icons.paste), label: _TRANSLATE_ME_PASTE),
+            BottomNavigationBarItem(
+                icon: Icon(Icons.highlight_remove), label: _TRANSLATE_ME_CLEAR),
+            BottomNavigationBarItem(
+                icon: Icon(Icons.local_grocery_store),
+                label: _TRANSLATE_ME_GROCERY),
+          ],
+          onTap: (final int index) async {
+            if (index == 0) {
+              final List<String> barcodes = await daoProductList
+                  .getBarcodes(userPreferences.getProductListCopy());
+              final Map<String, Product> products =
+                  await daoProduct.getAll(barcodes);
+              pantry.add(barcodes, products);
+              await save(userPreferences);
+              return;
+            }
+            if (index == 1) {
+              pantry.clear();
+              await save(userPreferences);
+              return;
+            }
+          },
+        ),
+      ),
+      appBar: AppBar(
+        backgroundColor:
+            SmoothTheme.getBackgroundColor(colorScheme, pantry.materialColor),
+        title: Row(
+          children: <Widget>[
+            pantry.getIcon(colorScheme),
+            const SizedBox(width: 8.0),
+            Text(
+              pantry.name,
+              style: TextStyle(color: colorScheme.onBackground),
+            ),
+          ],
+        ),
+        iconTheme: IconThemeData(color: colorScheme.onBackground),
+        actions: <Widget>[
+          PopupMenuButton<String>(
+            itemBuilder: (final BuildContext context) =>
+                <PopupMenuEntry<String>>[
+              const PopupMenuItem<String>(
+                value: 'rename',
+                child: Text(_TRANSLATE_ME_RENAME),
+                enabled: true,
+              ),
+              const PopupMenuItem<String>(
+                value: 'change',
+                child: Text(_TRANSLATE_ME_CHANGE),
+                enabled: true,
+              ),
+              const PopupMenuItem<String>(
+                value: 'delete',
+                child: Text(_TRANSLATE_ME_DELETE),
+                enabled: true,
+              ),
+            ],
+            onSelected: (final String value) async {
+              switch (value) {
+                case 'rename':
+                  if (await PantryDialogHelper.openRename(
+                      context, pantries, index)) {
+                    await save(userPreferences);
+                  }
+                  break;
+                case 'delete':
+                  if (await PantryDialogHelper.openDelete(
+                      context, pantries, index)) {
+                    await save(userPreferences);
+                    Navigator.pop(context);
+                  }
+                  break;
+                case 'change':
+                  if (await PantryDialogHelper.openChangeIcon(
+                      context, pantries, index)) {
+                    await save(userPreferences);
+                  }
+                  break;
+                default:
+                  throw Exception('Unknown value: $value');
+              }
+            },
+          ),
+        ],
+      ),
+      body: products.isEmpty
+          ? Center(
+              child: Text('There is no product in this list',
+                  style: Theme.of(context).textTheme.subtitle1),
+            )
+          : ListView.builder(
+              itemCount: products.length,
+              itemBuilder: (BuildContext context, int index) {
+                final Product product = products[index];
+                final String barcode = product.barcode;
+                final List<Widget> children = <Widget>[
+                  SmoothProductCardFound(
+                    heroTag: barcode,
+                    product: product,
+                    backgroundColor: SmoothTheme.getBackgroundColor(
+                      colorScheme,
+                      Colors.grey,
+                    ),
+                  ),
+                  const Divider(
+                    color: Colors.grey,
+                  ),
+                ];
+                final Map<String, int> dates = pantry.data[barcode];
+                final String now = DateTime.now().toIso8601String();
+                final List<String> sortedDays = <String>[...dates.keys];
+                sortedDays.sort();
+                for (final String day in sortedDays) {
+                  children.add(
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: <Widget>[
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.start,
+                          children: <Widget>[
+                            IconButton(
+                              onPressed: () async {
+                                pantry.increaseItem(barcode, day, -1);
+                                await save(userPreferences);
+                              },
+                              icon: const Icon(Icons.remove_circle_outline),
+                            ),
+                            Text('${dates[day]}', style: textStyle),
+                            IconButton(
+                              onPressed: () async {
+                                pantry.increaseItem(barcode, day, 1);
+                                await save(userPreferences);
+                              },
+                              icon: const Icon(Icons.add_circle_outline),
+                            ),
+                          ],
+                        ),
+                        Text(day, style: textStyle),
+                        Container(
+                          width: 60,
+                          child: Center(
+                            child: Text(
+                              '(${_getDayDifference(now, day)}d)',
+                              style: textStyle,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  );
+                }
+                children.add(
+                  ListTile(
+                    title: ElevatedButton(
+                      onPressed: () async {
+                        final DateTime dateTime = await showDatePicker(
+                          context: context,
+                          initialDate: DateTime.now(),
+                          firstDate: DateTime.now(),
+                          lastDate: DateTime(2026),
+                          builder: (BuildContext context, Widget child) {
+                            final Color color = SmoothTheme.getForegroundColor(
+                                colorScheme, pantry.materialColor);
+                            return Theme(
+                              data: ThemeData.light().copyWith(
+                                primaryColor: color,
+                                accentColor: color,
+                                colorScheme: ColorScheme.light(primary: color),
+                                buttonTheme: const ButtonThemeData(
+                                    textTheme: ButtonTextTheme.primary),
+                              ),
+                              child: child,
+                            );
+                          },
+                        );
+                        if (dateTime == null) {
+                          return;
+                        }
+                        final String date =
+                            dateTime.toIso8601String().substring(0, 10);
+                        pantry.increaseItem(barcode, date, 1);
+                        await save(userPreferences);
+                      },
+                      child: const Text(
+                        _TRANSLATE_ME_ANOTHER_DATE,
+                        style: textStyle,
+                      ),
+                    ),
+                    trailing: sortedDays.isNotEmpty
+                        ? null
+                        : IconButton(
+                            onPressed: () async {
+                              pantry.removeBarcode(barcode);
+                              await save(userPreferences);
+                            },
+                            icon: Icon(Icons.delete, color: colorScheme.error)),
+                  ),
+                );
+                return Padding(
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: 12.0, vertical: 8.0),
+                  child: Card(
+                    color: SmoothTheme.getBackgroundColor(
+                      colorScheme,
+                      Colors.grey,
+                    ),
+                    child: Column(children: children),
+                  ),
+                );
+              },
+            ),
+    );
+  }
+
+  static int _getDayDifference(final String reference, final String value) {
+    final DateTime referenceDateTime = DateTime.parse(reference);
+    final DateTime valueDateTime = DateTime.parse(value);
+    final Duration difference = valueDateTime.difference(referenceDateTime);
+    return (difference.inHours / 24).round();
+  }
+
+  Future<void> save(final UserPreferences userPreferences) async =>
+      Pantry.putAll(userPreferences, pantries);
+}

--- a/packages/smooth_app/lib/temp/user_preferences.dart
+++ b/packages/smooth_app/lib/temp/user_preferences.dart
@@ -21,6 +21,7 @@ class UserPreferences extends ChangeNotifier {
   static const int INDEX_NOT_IMPORTANT = 0;
 
   static const String _TAG_PREFIX_IMPORTANCE = 'IMPORTANCE';
+  static const String _TAG_PANTRY_REPOSITORY = 'pantry_repository';
   static const String _TAG_VISIBLE_GROUPS = 'visible_groups';
   static const String _TAG_USE_ML_KIT = 'useMlKit';
   static const String _TAG_INIT = 'init';
@@ -78,7 +79,7 @@ class UserPreferences extends ChangeNotifier {
       await _setImportance(UserPreferencesModel.ATTRIBUTE_ECOSCORE, valueIndex,
           notify: false);
     }
-    _sharedPreferences.setStringList(_TAG_VISIBLE_GROUPS, null);
+    await _sharedPreferences.setStringList(_TAG_VISIBLE_GROUPS, null);
     notifyListeners();
   }
 
@@ -122,4 +123,13 @@ class UserPreferences extends ChangeNotifier {
   Future<void> setProductListCopy(final String productListLousyKey) async =>
       await _sharedPreferences.setString(
           _TAG_PRODUCT_LIST_COPY, productListLousyKey);
+
+  Future<void> setPantryRepository(final List<String> encodedJsons) async {
+    await _sharedPreferences.setStringList(
+        _TAG_PANTRY_REPOSITORY, encodedJsons);
+    notifyListeners();
+  }
+
+  List<String> getPantryRepository() =>
+      _sharedPreferences.getStringList(_TAG_PANTRY_REPOSITORY) ?? <String>[];
 }


### PR DESCRIPTION
For the moment, in order to copy products to a pantry:
* go to a product list
* click on the "copy" button (bottom bar)
* go to the pantry
* click on the "paste" button (bottom bar)

New files:
* `pantry.dart`: a pantry (name, color, icon, list of barcodes with quantity and dates)
* `pantry_button.dart`: a button for a pantry, with the corresponding color, icon, name and shape
* `pantry_dialog_helper.dart`: a dialog helper for pantries
* `pantry_list_page.dart`: a page where all the pantries are displayed as previews
* `pantry_page.dart`: a page for one pantry where we can change all the data
* `pantry_preview.dart`: a preview button for a pantry, with its N first products
* `product_list_view_helper.dart`: a preview button for a list of products; used to be private in ProductListPreview

Impacted files:
* `dao_product_list.dart`: new method `getBarcodes`
* `home_page.dart`: added a section for pantries; minor side effect fix
* `product_list.dart`: added generic method `getTintedIcon`
* `product_list_preview.dart`: moved code to new class `ProductListPreviewHelper`
* `smooth_product_card_found.dart`: square'd product thumbnail
* `user_preferences.dart`: rough management of pantries get/put