### PR TITLE
Return an empty widget in ProductListPreviewHelper's build function when the input list is null

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/product_list_preview_helper.dart
+++ b/packages/smooth_app/lib/cards/product_cards/product_list_preview_helper.dart
@@ -16,6 +16,11 @@ class ProductListPreviewHelper extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Return an empty widget if the list is null
+    if (list == null) {
+      return SizedBox.shrink();
+    }
+
     final List<Widget> previews = <Widget>[];
     for (final Product product in list) {
       previews.add(GestureDetector(


### PR DESCRIPTION
fixes #180