### PR TITLE
feature/#23 - added the "similar product" / category search

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/product_list_preview_helper.dart
+++ b/packages/smooth_app/lib/cards/product_cards/product_list_preview_helper.dart
@@ -18,7 +18,7 @@ class ProductListPreviewHelper extends StatelessWidget {
   Widget build(BuildContext context) {
     // Return an empty widget if the list is null
     if (list == null) {
-      return SizedBox.shrink();
+      return const SizedBox.shrink();
     }
 
     final List<Widget> previews = <Widget>[];

--- a/packages/smooth_app/lib/data_models/product_list.dart
+++ b/packages/smooth_app/lib/data_models/product_list.dart
@@ -40,6 +40,7 @@ class ProductList {
   static const Map<String, String> _DEFAULT_COLOR_TAG_PER_TYPE =
       <String, String>{
     LIST_TYPE_HTTP_SEARCH_KEYWORDS: _COLOR_RED,
+    LIST_TYPE_HTTP_SEARCH_CATEGORY: _COLOR_BLUE,
     LIST_TYPE_HTTP_SEARCH_GROUP: _COLOR_ORANGE,
     LIST_TYPE_SCAN: _COLOR_GREEN,
     LIST_TYPE_HISTORY: _COLOR_BLUE,
@@ -49,6 +50,7 @@ class ProductList {
   static const String _ICON_TAG = 'tag';
   static const String _ICON_HEART = 'heart';
   static const String _ICON_SEARCH = 'search';
+  static const String _ICON_CATEGORY = 'category';
   static const String _ICON_GROUP = 'group';
   static const String _ICON_SCAN = 'scan';
   static const String _ICON_HISTORY = 'history';
@@ -56,6 +58,7 @@ class ProductList {
   static const Map<String, List<String>> _ORDERED_ICONS_PER_TYPE =
       <String, List<String>>{
     LIST_TYPE_HTTP_SEARCH_KEYWORDS: <String>[_ICON_SEARCH],
+    LIST_TYPE_HTTP_SEARCH_CATEGORY: <String>[_ICON_CATEGORY],
     LIST_TYPE_HTTP_SEARCH_GROUP: <String>[_ICON_GROUP],
     LIST_TYPE_SCAN: <String>[_ICON_SCAN],
     LIST_TYPE_HISTORY: <String>[_ICON_HISTORY],
@@ -66,6 +69,7 @@ class ProductList {
     _ICON_TAG: CupertinoIcons.tag_fill,
     _ICON_HEART: CupertinoIcons.heart_fill,
     _ICON_SEARCH: Icons.search,
+    _ICON_CATEGORY: Icons.description,
     _ICON_GROUP: Icons.fastfood,
     _ICON_SCAN: CupertinoIcons.barcode,
     _ICON_HISTORY: Icons.history,
@@ -74,6 +78,7 @@ class ProductList {
   static const Map<String, String> _DEFAULT_ICON_TAG_PER_TYPE =
       <String, String>{
     LIST_TYPE_HTTP_SEARCH_KEYWORDS: _ICON_SEARCH,
+    LIST_TYPE_HTTP_SEARCH_CATEGORY: _ICON_CATEGORY,
     LIST_TYPE_HTTP_SEARCH_GROUP: _ICON_GROUP,
     LIST_TYPE_SCAN: _ICON_SCAN,
     LIST_TYPE_HISTORY: _ICON_HISTORY,
@@ -92,6 +97,7 @@ class ProductList {
 
   static const String LIST_TYPE_HTTP_SEARCH_GROUP = 'http/search/group';
   static const String LIST_TYPE_HTTP_SEARCH_KEYWORDS = 'http/search/keywords';
+  static const String LIST_TYPE_HTTP_SEARCH_CATEGORY = 'http/search/category';
   static const String LIST_TYPE_SCAN = 'scan';
   static const String LIST_TYPE_HISTORY = 'history';
   static const String LIST_TYPE_USER_DEFINED = 'user';

--- a/packages/smooth_app/lib/database/category_product_query.dart
+++ b/packages/smooth_app/lib/database/category_product_query.dart
@@ -1,0 +1,56 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:smooth_app/database/product_query.dart';
+import 'package:openfoodfacts/model/parameter/TagFilter.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:openfoodfacts/model/SearchResult.dart';
+import 'package:smooth_app/data_models/product_list.dart';
+
+/// Product query dedicated to category (e.g. 'en:mueslis-with-fruits')
+class CategoryProductQuery implements ProductQuery {
+  CategoryProductQuery({
+    @required this.category,
+    @required this.languageCode,
+    @required this.countryCode,
+    @required this.size,
+  });
+
+  final String category;
+  final String languageCode;
+  final String countryCode;
+  final int size;
+
+  @override
+  Future<SearchResult> getSearchResult() async =>
+      await OpenFoodAPIClient.searchProducts(
+        ProductQuery.SMOOTH_USER,
+        ProductSearchQueryConfiguration(
+          fields: ProductQuery.fields,
+          parametersList: <Parameter>[
+            PageSize(size: size),
+            TagFilter(
+              tagType: 'categories',
+              contains: true,
+              tagName: category,
+            ),
+          ],
+          lc: languageCode,
+          cc: countryCode,
+        ),
+      );
+
+  @override
+  ProductList getProductList() => ProductList(
+        listType: ProductList.LIST_TYPE_HTTP_SEARCH_CATEGORY,
+        parameters: category,
+      );
+
+  @override
+  String toString() => 'CategoryProductQuery('
+      '$category'
+      ', $languageCode'
+      ', $countryCode'
+      ', $size'
+      ')';
+}

--- a/packages/smooth_app/lib/pages/home_page.dart
+++ b/packages/smooth_app/lib/pages/home_page.dart
@@ -156,6 +156,7 @@ class _HomePageState extends State<HomePage> {
               <String>[
                 ProductList.LIST_TYPE_HTTP_SEARCH_GROUP,
                 ProductList.LIST_TYPE_HTTP_SEARCH_KEYWORDS,
+                ProductList.LIST_TYPE_HTTP_SEARCH_CATEGORY,
               ],
               'Search history',
               Icon(

--- a/packages/smooth_app/lib/pages/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product_list_page.dart
@@ -60,6 +60,7 @@ class _ProductListPageState extends State<ProductListPage> {
         renamable = true;
         break;
       case ProductList.LIST_TYPE_HTTP_SEARCH_KEYWORDS:
+      case ProductList.LIST_TYPE_HTTP_SEARCH_CATEGORY:
       case ProductList.LIST_TYPE_HTTP_SEARCH_GROUP:
         deletable = true;
         break;

--- a/packages/smooth_app/lib/pages/product_page.dart
+++ b/packages/smooth_app/lib/pages/product_page.dart
@@ -26,6 +26,8 @@ import 'package:wc_flutter_share/wc_flutter_share.dart';
 import 'package:smooth_app/pages/product_dialog_helper.dart';
 import 'package:smooth_app/database/category_product_query.dart';
 import 'package:smooth_app/database/product_query.dart';
+import 'package:smooth_ui_library/widgets/smooth_card.dart';
+import 'package:smooth_app/themes/smooth_theme.dart';
 
 class ProductPage extends StatefulWidget {
   const ProductPage({@required this.product, this.newProduct = false});
@@ -377,28 +379,49 @@ class _ProductPageState extends State<ProductPage> {
       listItems.add(_getAttributeGroupWidget(attributeGroup, iconWidth));
     }
 
-    if (_product.categoriesTags != null) {
-      for (int i = 0; i < _product.categoriesTags.length; i++) {
+    if (_product.categoriesTags != null && _product.categoriesTags.isNotEmpty) {
+      for (int i = _product.categoriesTags.length - 1;
+          i < _product.categoriesTags.length;
+          i++) {
         final String categoryTag = _product.categoriesTags[i];
+        final MaterialColor materialColor = Colors.blue;
         listItems.add(
-          Card(
-            child: ListTile(
-              onTap: () async {
-                await ProductQueryPageHelper().openBestChoice(
-                  color: Colors.deepPurple,
-                  heroTag: 'search_bar',
-                  name: categoryTag,
-                  localDatabase: localDatabase,
-                  productQuery: CategoryProductQuery(
-                    category: categoryTag,
-                    languageCode: ProductQuery.getCurrentLanguageCode(context),
-                    countryCode: ProductQuery.getCurrentCountryCode(),
-                    size: 500,
-                  ),
-                  context: context,
-                );
-              },
-              title: Text(categoryTag),
+          SmoothCard(
+            background: SmoothTheme.getBackgroundColor(
+              themeData.colorScheme,
+              materialColor,
+            ),
+            collapsed: null,
+            content: ListTile(
+              leading: Icon(
+                Icons.search,
+                size: iconWidth,
+                color: SmoothTheme.getForegroundColor(
+                  themeData.colorScheme,
+                  materialColor,
+                ),
+              ),
+              onTap: () async => await ProductQueryPageHelper().openBestChoice(
+                color: materialColor,
+                heroTag: 'search_bar',
+                name: categoryTag,
+                localDatabase: localDatabase,
+                productQuery: CategoryProductQuery(
+                  category: categoryTag,
+                  languageCode: ProductQuery.getCurrentLanguageCode(context),
+                  countryCode: ProductQuery.getCurrentCountryCode(),
+                  size: 500,
+                ),
+                context: context,
+              ),
+              title: Text(
+                categoryTag,
+                style: themeData.textTheme.headline3,
+              ),
+              subtitle: Text(
+                'Similar foods',
+                style: themeData.textTheme.subtitle2,
+              ),
             ),
           ),
         );

--- a/packages/smooth_app/lib/pages/product_page.dart
+++ b/packages/smooth_app/lib/pages/product_page.dart
@@ -24,6 +24,8 @@ import 'package:smooth_app/pages/product_query_page_helper.dart';
 import 'package:smooth_app/themes/constant_icons.dart';
 import 'package:wc_flutter_share/wc_flutter_share.dart';
 import 'package:smooth_app/pages/product_dialog_helper.dart';
+import 'package:smooth_app/database/category_product_query.dart';
+import 'package:smooth_app/database/product_query.dart';
 
 class ProductPage extends StatefulWidget {
   const ProductPage({@required this.product, this.newProduct = false});
@@ -310,6 +312,7 @@ class _ProductPageState extends State<ProductPage> {
   }
 
   Widget _buildProductBody(BuildContext context) {
+    final LocalDatabase localDatabase = context.watch<LocalDatabase>();
     final UserPreferences userPreferences = context.watch<UserPreferences>();
     final UserPreferencesModel userPreferencesModel =
         context.watch<UserPreferencesModel>();
@@ -372,6 +375,34 @@ class _ProductPageState extends State<ProductPage> {
     for (final AttributeGroup attributeGroup
         in _getOrderedAttributeGroups(userPreferencesModel)) {
       listItems.add(_getAttributeGroupWidget(attributeGroup, iconWidth));
+    }
+
+    if (_product.categoriesTags != null) {
+      for (int i = 0; i < _product.categoriesTags.length; i++) {
+        final String categoryTag = _product.categoriesTags[i];
+        listItems.add(
+          Card(
+            child: ListTile(
+              onTap: () async {
+                await ProductQueryPageHelper().openBestChoice(
+                  color: Colors.deepPurple,
+                  heroTag: 'search_bar',
+                  name: categoryTag,
+                  localDatabase: localDatabase,
+                  productQuery: CategoryProductQuery(
+                    category: categoryTag,
+                    languageCode: ProductQuery.getCurrentLanguageCode(context),
+                    countryCode: ProductQuery.getCurrentCountryCode(),
+                    size: 500,
+                  ),
+                  context: context,
+                );
+              },
+              title: Text(categoryTag),
+            ),
+          ),
+        );
+      }
     }
 
     return Stack(

--- a/packages/smooth_app/lib/pages/product_page.dart
+++ b/packages/smooth_app/lib/pages/product_page.dart
@@ -384,7 +384,7 @@ class _ProductPageState extends State<ProductPage> {
           i < _product.categoriesTags.length;
           i++) {
         final String categoryTag = _product.categoriesTags[i];
-        final MaterialColor materialColor = Colors.blue;
+        final MaterialColor materialColor = const Colors.blue;
         listItems.add(
           SmoothCard(
             background: SmoothTheme.getBackgroundColor(

--- a/packages/smooth_app/lib/pages/product_query_page_helper.dart
+++ b/packages/smooth_app/lib/pages/product_query_page_helper.dart
@@ -102,6 +102,8 @@ class ProductQueryPageHelper {
         return '${_getGroupName(productList.parameters)}${verbose ? ' (category search)' : ''}';
       case ProductList.LIST_TYPE_HTTP_SEARCH_KEYWORDS:
         return '${productList.parameters}${verbose ? ' (keyword search)' : ''}';
+      case ProductList.LIST_TYPE_HTTP_SEARCH_CATEGORY:
+        return '${productList.parameters}${verbose ? ' (category search)' : ''}';
       case ProductList.LIST_TYPE_SCAN:
         return 'Scan';
       case ProductList.LIST_TYPE_HISTORY:


### PR DESCRIPTION
From the bottom of the product page. It's ugly for the moment, it's just a feature suggestion. Any idea?

New file:
* `category_product_query.dart`: Product query dedicated to category (e.g. 'en:mueslis-with-fruits')

Impacted files:
* `home_page.dart`: added the category search to the search history
* `product_list.dart`: added the category search
* `product_list_page.dart`: added the category search
* `product_list_preview_helper.dart`: unrelated minor refactoring
* `product_page.dart`: added lousy clickable categories at the end of the product page, just to see
* `product_query_page_helper.dart`: added the category search