### PR TITLE
feature/#198 - switched to a simpler (and closer to defaults) color management

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/pantry_preview.dart
+++ b/packages/smooth_app/lib/cards/product_cards/pantry_preview.dart
@@ -28,8 +28,11 @@ class PantryPreview extends StatelessWidget {
       subtitle = 'Empty list';
     }
     return Card(
-      color: SmoothTheme.getBackgroundColor(
-          Theme.of(context).colorScheme, pantry.materialColor),
+      color: SmoothTheme.getColor(
+        Theme.of(context).colorScheme,
+        pantry.materialColor,
+        ColorDestination.SURFACE_BACKGROUND,
+      ),
       child: Column(
         children: <Widget>[
           ListTile(
@@ -39,7 +42,10 @@ class PantryPreview extends StatelessWidget {
                 builder: (BuildContext context) => PantryPage(pantries, index),
               ),
             ),
-            leading: pantry.getIcon(Theme.of(context).colorScheme),
+            leading: pantry.getIcon(
+              Theme.of(context).colorScheme,
+              ColorDestination.SURFACE_FOREGROUND,
+            ),
             trailing: const Icon(Icons.more_horiz),
             subtitle: subtitle == null ? null : Text(subtitle),
             title:

--- a/packages/smooth_app/lib/cards/product_cards/product_list_preview.dart
+++ b/packages/smooth_app/lib/cards/product_cards/product_list_preview.dart
@@ -43,9 +43,10 @@ class ProductListPreview extends StatelessWidget {
               subtitle = 'Empty list';
             }
             return Card(
-              color: SmoothTheme.getBackgroundColor(
+              color: SmoothTheme.getColor(
                 Theme.of(context).colorScheme,
                 productList.getMaterialColor(),
+                ColorDestination.SURFACE_BACKGROUND,
               ),
               child: Column(
                 children: <Widget>[
@@ -64,11 +65,16 @@ class ProductListPreview extends StatelessWidget {
                         ),
                       );
                     },
-                    leading: productList.getIcon(Theme.of(context).colorScheme),
+                    leading: productList.getIcon(
+                      Theme.of(context).colorScheme,
+                      ColorDestination.SURFACE_FOREGROUND,
+                    ),
                     trailing: const Icon(Icons.more_horiz),
                     subtitle: subtitle == null ? null : Text(subtitle),
-                    title: Text(title,
-                        style: Theme.of(context).textTheme.subtitle2),
+                    title: Text(
+                      title,
+                      style: Theme.of(context).textTheme.subtitle2,
+                    ),
                   ),
                   ProductListPreviewHelper(
                     list: list,

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
@@ -17,15 +17,13 @@ class SmoothProductCardFound extends StatelessWidget {
     @required this.heroTag,
     this.elevation = 0.0,
     this.useNewStyle = true,
-    this.translucentBackground = false,
-    this.backgroundColor = Colors.white,
+    this.backgroundColor,
   });
 
   final Product product;
   final String heroTag;
   final double elevation;
   final bool useNewStyle;
-  final bool translucentBackground;
   final Color backgroundColor;
 
   @override
@@ -70,9 +68,7 @@ class SmoothProductCardFound extends StatelessWidget {
           color: Colors.transparent,
           child: Container(
             decoration: BoxDecoration(
-              color: translucentBackground
-                  ? backgroundColor.withOpacity(0.25)
-                  : backgroundColor,
+              color: backgroundColor,
               borderRadius: const BorderRadius.all(Radius.circular(15.0)),
             ),
             padding: const EdgeInsets.all(5.0),
@@ -104,8 +100,7 @@ class SmoothProductCardFound extends StatelessWidget {
                                   product.productName ?? 'Unknown product name',
                                   maxLines: 2,
                                   overflow: TextOverflow.fade,
-                                  style: themeData.textTheme.headline4
-                                      .copyWith(color: Colors.black),
+                                  style: themeData.textTheme.headline4,
                                 ),
                               ),
                             ],
@@ -167,7 +162,6 @@ class SmoothProductCardFound extends StatelessWidget {
             borderRadius: const BorderRadius.all(Radius.circular(15.0)),
             child: Container(
               decoration: const BoxDecoration(
-                color: Colors.white,
                 borderRadius: BorderRadius.all(Radius.circular(15.0)),
               ),
               padding: const EdgeInsets.all(10.0),
@@ -201,8 +195,8 @@ class SmoothProductCardFound extends StatelessWidget {
                                         maxLines: 3,
                                         overflow: TextOverflow.fade,
                                         style: const TextStyle(
-                                            color: Colors.black,
-                                            fontWeight: FontWeight.bold),
+                                          fontWeight: FontWeight.bold,
+                                        ),
                                       ),
                                     ),
                                   ],
@@ -218,7 +212,6 @@ class SmoothProductCardFound extends StatelessWidget {
                                         maxLines: 1,
                                         overflow: TextOverflow.fade,
                                         style: const TextStyle(
-                                            color: Colors.black,
                                             fontWeight: FontWeight.w300,
                                             fontStyle: FontStyle.italic),
                                       ),

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
@@ -68,7 +68,7 @@ class SmoothProductCardFound extends StatelessWidget {
           color: Colors.transparent,
           child: Container(
             decoration: BoxDecoration(
-              color: backgroundColor,
+              color: backgroundColor ?? themeData.colorScheme.surface,
               borderRadius: const BorderRadius.all(Radius.circular(15.0)),
             ),
             padding: const EdgeInsets.all(5.0),

--- a/packages/smooth_app/lib/data_models/pantry.dart
+++ b/packages/smooth_app/lib/data_models/pantry.dart
@@ -5,6 +5,7 @@ import 'package:openfoodfacts/model/Product.dart';
 import 'package:smooth_app/temp/user_preferences.dart';
 import 'package:smooth_app/database/dao_product.dart';
 import 'package:smooth_app/data_models/product_list.dart';
+import 'package:smooth_app/themes/smooth_theme.dart';
 
 enum PantryType {
   PANTRY,
@@ -110,17 +111,24 @@ class Pantry {
     final ColorScheme colorScheme,
     final String colorTag,
     final String iconTag,
+    final ColorDestination colorDestination,
   }) =>
       ProductList.getTintedIcon(
         colorScheme: colorScheme,
         materialColor: _COLORS[colorTag],
         iconData: _ICON_DATA[iconTag] ?? _ICON_DATA[_defaultIconTag],
+        colorDestination: colorDestination,
       );
 
-  Widget getIcon(final ColorScheme colorScheme) => ProductList.getTintedIcon(
+  Widget getIcon(
+    final ColorScheme colorScheme,
+    final ColorDestination colorDestination,
+  ) =>
+      ProductList.getTintedIcon(
         colorScheme: colorScheme,
         materialColor: materialColor,
         iconData: iconData,
+        colorDestination: colorDestination,
       );
 
   List<Product> getFirstProducts(final int nbInPreview) {

--- a/packages/smooth_app/lib/data_models/product_list.dart
+++ b/packages/smooth_app/lib/data_models/product_list.dart
@@ -134,33 +134,44 @@ class ProductList {
       '$listType/$parameters'; // TODO(monsieurtanuki): does not work if you change the name
 
   static Widget getReferenceIcon({
-    final ColorScheme colorScheme,
-    final String colorTag,
-    final String iconTag,
+    @required final ColorScheme colorScheme,
+    @required final String colorTag,
+    @required final String iconTag,
+    @required final ColorDestination colorDestination,
   }) =>
       getTintedIcon(
         colorScheme: colorScheme,
         materialColor: _getReferenceMaterialColor(colorTag),
         iconData: _ICON_DATA[iconTag] ?? _ICON_DATA[_ICON_TAG],
+        colorDestination: colorDestination,
       );
 
   static Widget getTintedIcon({
-    final ColorScheme colorScheme,
-    final MaterialColor materialColor,
-    final IconData iconData,
+    @required final ColorScheme colorScheme,
+    @required final MaterialColor materialColor,
+    @required final IconData iconData,
+    @required final ColorDestination colorDestination,
   }) =>
       Icon(
         iconData,
-        color: SmoothTheme.getForegroundColor(colorScheme, materialColor),
+        color: colorDestination == null
+            ? null
+            : SmoothTheme.getColor(
+                colorScheme, materialColor, colorDestination),
       );
 
   static MaterialColor _getReferenceMaterialColor(final String colorTag) =>
       _COLORS[colorTag] ?? _COLORS[_COLOR_RED];
 
-  Widget getIcon(final ColorScheme colorScheme) => getReferenceIcon(
+  Widget getIcon(
+    final ColorScheme colorScheme,
+    final ColorDestination colorDestination,
+  ) =>
+      getReferenceIcon(
         colorScheme: colorScheme,
         colorTag: _colorTag,
         iconTag: _iconTag,
+        colorDestination: colorDestination,
       );
 
   MaterialColor getMaterialColor() => _getReferenceMaterialColor(_colorTag);

--- a/packages/smooth_app/lib/pages/choose_page.dart
+++ b/packages/smooth_app/lib/pages/choose_page.dart
@@ -106,18 +106,13 @@ class _ChoosePageState extends State<ChoosePage> {
   @override
   Widget build(BuildContext context) {
     final LocalDatabase localDatabase = context.watch<LocalDatabase>();
-    final ColorScheme colorScheme = Theme.of(context).colorScheme;
     return WillPopScope(
       onWillPop: _onWillPop,
       child: Scaffold(
         appBar: AppBar(
-          title: Text(
-            _selectedCategory == null
-                ? 'Food Categories'
-                : _selectedCategory.name,
-            style: TextStyle(color: colorScheme.onBackground),
-          ),
-          iconTheme: IconThemeData(color: colorScheme.onBackground),
+          title: Text(_selectedCategory == null
+              ? 'Food Categories'
+              : _selectedCategory.name),
         ),
         body: Column(
           children: <Widget>[

--- a/packages/smooth_app/lib/pages/home_page.dart
+++ b/packages/smooth_app/lib/pages/home_page.dart
@@ -32,6 +32,9 @@ class _HomePageState extends State<HomePage> {
   static const String _TRANSLATE_ME_SHOPPINGS = 'My shopping lists';
   static const String _TRANSLATE_ME_EMPTY = 'Empty!';
 
+  static const ColorDestination _COLOR_DESTINATION_FOR_ICON =
+      ColorDestination.SURFACE_FOREGROUND;
+
   DaoProductList _daoProductList;
   DaoProduct _daoProduct;
 
@@ -46,23 +49,20 @@ class _HomePageState extends State<HomePage> {
     final ThemeData themeData = Theme.of(context);
     final ColorScheme colorScheme = themeData.colorScheme;
     final bool mlKitState = userPreferences.getMlKitState();
-    final Color notYetColor = SmoothTheme.getBackgroundColor(
+    final Color notYetColor = SmoothTheme.getColor(
       colorScheme,
       Colors.grey,
+      ColorDestination.SURFACE_BACKGROUND,
     );
     return Scaffold(
       appBar: AppBar(
         title: Row(
-          children: <Widget>[
-            const Icon(Icons.pets),
-            const SizedBox(width: 8.0),
-            Text(
-              'Smoothie',
-              style: TextStyle(color: colorScheme.onBackground),
-            )
+          children: const <Widget>[
+            Icon(Icons.pets),
+            SizedBox(width: 8.0),
+            Text('Smoothie'),
           ],
         ),
-        iconTheme: IconThemeData(color: colorScheme.onBackground),
         actions: <Widget>[
           IconButton(
             icon: const Icon(Icons.settings),
@@ -86,9 +86,10 @@ class _HomePageState extends State<HomePage> {
               child: ListTile(
                 leading: Icon(
                   Icons.search,
-                  color: SmoothTheme.getForegroundColor(
+                  color: SmoothTheme.getColor(
                     colorScheme,
                     Colors.red,
+                    _COLOR_DESTINATION_FOR_ICON,
                   ),
                 ),
                 title: TextField(
@@ -105,9 +106,10 @@ class _HomePageState extends State<HomePage> {
               'My lists',
               Icon(
                 Icons.list,
-                color: SmoothTheme.getForegroundColor(
+                color: SmoothTheme.getColor(
                   colorScheme,
                   Colors.purple,
+                  _COLOR_DESTINATION_FOR_ICON,
                 ),
               ),
             ),
@@ -135,9 +137,10 @@ class _HomePageState extends State<HomePage> {
                 },
                 leading: Icon(
                   Icons.fastfood,
-                  color: SmoothTheme.getForegroundColor(
+                  color: SmoothTheme.getColor(
                     colorScheme,
                     Colors.orange,
+                    _COLOR_DESTINATION_FOR_ICON,
                   ),
                 ),
                 subtitle: const Text('Food category search'),
@@ -161,9 +164,10 @@ class _HomePageState extends State<HomePage> {
               'Search history',
               Icon(
                 Icons.youtube_searched_for,
-                color: SmoothTheme.getForegroundColor(
+                color: SmoothTheme.getColor(
                   colorScheme,
                   Colors.yellow,
+                  _COLOR_DESTINATION_FOR_ICON,
                 ),
               ),
             ),
@@ -309,11 +313,21 @@ class _HomePageState extends State<HomePage> {
       attributes.add(
         ElevatedButton(
           onPressed: () => onTap(),
-          child: Text('${attribute.name}'),
+          child: Text(
+            '${attribute.name}',
+            style: TextStyle(
+              color: SmoothTheme.getColor(
+                Theme.of(context).colorScheme,
+                colors[importance.id],
+                ColorDestination.BUTTON_FOREGROUND,
+              ),
+            ),
+          ),
           style: ElevatedButton.styleFrom(
-            primary: SmoothTheme.getBackgroundColor(
+            primary: SmoothTheme.getColor(
               Theme.of(context).colorScheme,
               colors[importance.id],
+              ColorDestination.BUTTON_BACKGROUND,
             ),
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(32.0),
@@ -330,9 +344,10 @@ class _HomePageState extends State<HomePage> {
             ListTile(
               leading: Icon(
                 Icons.bar_chart,
-                color: SmoothTheme.getForegroundColor(
+                color: SmoothTheme.getColor(
                   Theme.of(context).colorScheme,
                   Colors.green,
+                  _COLOR_DESTINATION_FOR_ICON,
                 ),
               ),
               subtitle: attributes.isEmpty
@@ -398,9 +413,10 @@ class _HomePageState extends State<HomePage> {
                     },
                     leading: Icon(
                       iconData,
-                      color: SmoothTheme.getForegroundColor(
+                      color: SmoothTheme.getColor(
                         Theme.of(context).colorScheme,
                         materialColor,
+                        _COLOR_DESTINATION_FOR_ICON,
                       ),
                     ),
                     subtitle:

--- a/packages/smooth_app/lib/pages/list_page.dart
+++ b/packages/smooth_app/lib/pages/list_page.dart
@@ -26,18 +26,13 @@ class _ListPageState extends State<ListPage> {
   Widget build(BuildContext context) {
     final LocalDatabase localDatabase = context.watch<LocalDatabase>();
     final DaoProductList daoProductList = DaoProductList(localDatabase);
-    final ColorScheme colorScheme = Theme.of(context).colorScheme;
     return Scaffold(
       appBar: AppBar(
-        title: Text(
-          widget.title,
-          style: TextStyle(color: colorScheme.onBackground),
-        ),
-        iconTheme: IconThemeData(color: colorScheme.onBackground),
+        title: Text(widget.title),
         actions: <Widget>[
           if (widget.typeFilter.contains(ProductList.LIST_TYPE_USER_DEFINED))
             IconButton(
-              icon: Icon(Icons.add, color: colorScheme.onBackground),
+              icon: const Icon(Icons.add),
               onPressed: () async {
                 if (await ProductListDialogHelper.openNew(
                     context, daoProductList, _list)) {

--- a/packages/smooth_app/lib/pages/pantry_button.dart
+++ b/packages/smooth_app/lib/pages/pantry_button.dart
@@ -21,8 +21,18 @@ class PantryButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => ElevatedButton.icon(
-        icon: pantries[index].getIcon(Theme.of(context).colorScheme),
-        label: Text(pantries[index].name),
+        icon: pantries[index].getIcon(
+            Theme.of(context).colorScheme, ColorDestination.BUTTON_FOREGROUND),
+        label: Text(
+          pantries[index].name,
+          style: TextStyle(
+            color: SmoothTheme.getColor(
+              Theme.of(context).colorScheme,
+              pantries[index].materialColor,
+              ColorDestination.BUTTON_FOREGROUND,
+            ),
+          ),
+        ),
         onPressed: () async {
           await Navigator.push<dynamic>(
             context,
@@ -32,9 +42,10 @@ class PantryButton extends StatelessWidget {
           );
         },
         style: ElevatedButton.styleFrom(
-          primary: SmoothTheme.getBackgroundColor(
+          primary: SmoothTheme.getColor(
             Theme.of(context).colorScheme,
             pantries[index].materialColor,
+            ColorDestination.BUTTON_BACKGROUND,
           ),
           shape: pantries[index].pantryType == PantryType.PANTRY
               ? null

--- a/packages/smooth_app/lib/pages/pantry_dialog_helper.dart
+++ b/packages/smooth_app/lib/pages/pantry_dialog_helper.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:smooth_app/data_models/pantry.dart';
+import 'package:smooth_app/themes/smooth_theme.dart';
 import 'package:smooth_ui_library/buttons/smooth_simple_button.dart';
 import 'package:smooth_ui_library/dialogs/smooth_alert_dialog.dart';
 
@@ -226,6 +227,7 @@ class PantryDialogHelper {
                     colorScheme: Theme.of(context).colorScheme,
                     colorTag: colorTag,
                     iconTag: iconTag,
+                    colorDestination: ColorDestination.SURFACE_FOREGROUND,
                   ),
                   onPressed: () async {
                     pantry.colorTag = colorTag;

--- a/packages/smooth_app/lib/pages/pantry_list_page.dart
+++ b/packages/smooth_app/lib/pages/pantry_list_page.dart
@@ -21,17 +21,12 @@ class _PantryListPageState extends State<PantryListPage> {
   @override
   Widget build(BuildContext context) {
     final UserPreferences userPreferences = context.watch<UserPreferences>();
-    final ColorScheme colorScheme = Theme.of(context).colorScheme;
     return Scaffold(
       appBar: AppBar(
-        title: Text(
-          widget.title,
-          style: TextStyle(color: colorScheme.onBackground),
-        ),
-        iconTheme: IconThemeData(color: colorScheme.onBackground),
+        title: Text(widget.title),
         actions: <Widget>[
           IconButton(
-            icon: Icon(Icons.add, color: colorScheme.onBackground),
+            icon: const Icon(Icons.add),
             onPressed: () async {
               if (await PantryDialogHelper.openNew(
                 context,

--- a/packages/smooth_app/lib/pages/pantry_page.dart
+++ b/packages/smooth_app/lib/pages/pantry_page.dart
@@ -77,19 +77,18 @@ class PantryPage extends StatelessWidget {
         ),
       ),
       appBar: AppBar(
-        backgroundColor:
-            SmoothTheme.getBackgroundColor(colorScheme, pantry.materialColor),
+        backgroundColor: SmoothTheme.getColor(
+          colorScheme,
+          pantry.materialColor,
+          ColorDestination.APP_BAR_BACKGROUND,
+        ),
         title: Row(
           children: <Widget>[
-            pantry.getIcon(colorScheme),
+            pantry.getIcon(colorScheme, ColorDestination.APP_BAR_FOREGROUND),
             const SizedBox(width: 8.0),
-            Text(
-              pantry.name,
-              style: TextStyle(color: colorScheme.onBackground),
-            ),
+            Text(pantry.name),
           ],
         ),
-        iconTheme: IconThemeData(color: colorScheme.onBackground),
         actions: <Widget>[
           PopupMenuButton<String>(
             itemBuilder: (final BuildContext context) =>
@@ -152,9 +151,10 @@ class PantryPage extends StatelessWidget {
                   SmoothProductCardFound(
                     heroTag: barcode,
                     product: product,
-                    backgroundColor: SmoothTheme.getBackgroundColor(
+                    backgroundColor: SmoothTheme.getColor(
                       colorScheme,
                       Colors.grey,
+                      ColorDestination.SURFACE_BACKGROUND,
                     ),
                   ),
                   const Divider(
@@ -188,9 +188,10 @@ class PantryPage extends StatelessWidget {
                   padding: const EdgeInsets.symmetric(
                       horizontal: 12.0, vertical: 8.0),
                   child: Card(
-                    color: SmoothTheme.getBackgroundColor(
+                    color: SmoothTheme.getColor(
                       colorScheme,
                       Colors.grey,
+                      ColorDestination.SURFACE_BACKGROUND,
                     ),
                     child: Column(children: children),
                   ),
@@ -293,8 +294,11 @@ class PantryPage extends StatelessWidget {
           firstDate: DateTime.now(),
           lastDate: DateTime(2026),
           builder: (BuildContext context, Widget child) {
-            final Color color = SmoothTheme.getForegroundColor(
-                colorScheme, pantry.materialColor);
+            final Color color = SmoothTheme.getColor(
+              colorScheme,
+              pantry.materialColor,
+              ColorDestination.BUTTON_FOREGROUND,
+            );
             return Theme(
               data: ThemeData.light().copyWith(
                 primaryColor: color,

--- a/packages/smooth_app/lib/pages/pantry_page.dart
+++ b/packages/smooth_app/lib/pages/pantry_page.dart
@@ -205,7 +205,7 @@ class PantryPage extends StatelessWidget {
     final DateTime referenceDateTime = DateTime.parse(reference);
     final DateTime valueDateTime = DateTime.parse(value);
     final Duration difference = valueDateTime.difference(referenceDateTime);
-    return (difference.inHours / 24).round();
+    return (difference.inHours / 24).ceil();
   }
 
   Future<void> _save(final UserPreferences userPreferences) async =>
@@ -293,23 +293,7 @@ class PantryPage extends StatelessWidget {
           initialDate: DateTime.now(),
           firstDate: DateTime.now(),
           lastDate: DateTime(2026),
-          builder: (BuildContext context, Widget child) {
-            final Color color = SmoothTheme.getColor(
-              colorScheme,
-              pantry.materialColor,
-              ColorDestination.BUTTON_FOREGROUND,
-            );
-            return Theme(
-              data: ThemeData.light().copyWith(
-                primaryColor: color,
-                accentColor: color,
-                colorScheme: ColorScheme.light(primary: color),
-                buttonTheme:
-                    const ButtonThemeData(textTheme: ButtonTextTheme.primary),
-              ),
-              child: child,
-            );
-          },
+          builder: (BuildContext context, Widget child) => child,
         );
         if (dateTime == null) {
           return;

--- a/packages/smooth_app/lib/pages/personalized_ranking_page.dart
+++ b/packages/smooth_app/lib/pages/personalized_ranking_page.dart
@@ -9,6 +9,7 @@ import 'package:smooth_app/structures/ranked_product.dart';
 import 'package:smooth_app/temp/user_preferences.dart';
 import 'package:smooth_app/pages/product_query_page_helper.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:smooth_app/themes/smooth_theme.dart';
 
 class PersonalizedRankingPage extends StatefulWidget {
   const PersonalizedRankingPage(this.productList);
@@ -35,10 +36,10 @@ class _PersonalizedRankingPageState extends State<PersonalizedRankingPage> {
     SmoothItModel.MATCH_INDEX_NO: Icons.cancel,
   };
 
-  static final Map<int, Color> _colors = <int, Color>{
-    SmoothItModel.MATCH_INDEX_YES: Colors.green[300],
-    SmoothItModel.MATCH_INDEX_MAYBE: Colors.grey[300],
-    SmoothItModel.MATCH_INDEX_NO: Colors.red[300],
+  static const Map<int, MaterialColor> _COLORS = <int, MaterialColor>{
+    SmoothItModel.MATCH_INDEX_YES: Colors.green,
+    SmoothItModel.MATCH_INDEX_MAYBE: Colors.grey,
+    SmoothItModel.MATCH_INDEX_NO: Colors.red,
   };
 
   final SmoothItModel _model = SmoothItModel();
@@ -51,34 +52,36 @@ class _PersonalizedRankingPageState extends State<PersonalizedRankingPage> {
     final UserPreferences userPreferences = context.watch<UserPreferences>();
     final UserPreferencesModel userPreferencesModel =
         context.watch<UserPreferencesModel>();
+    final ColorScheme colorScheme = Theme.of(context).colorScheme;
     _model.refresh(widget.productList, userPreferences, userPreferencesModel);
     final List<BottomNavigationBarItem> bottomNavigationBarItems =
         <BottomNavigationBarItem>[];
     for (final int matchIndex in _ORDERED_MATCH_INDEXES) {
       bottomNavigationBarItems.add(
         BottomNavigationBarItem(
-          icon: Icon(_ICONS[matchIndex],
-              color: _colors[matchIndex] ??
-                  Theme.of(context).colorScheme.onSurface),
+          icon: Icon(
+            _ICONS[matchIndex],
+            color: _COLORS[matchIndex] == null
+                ? null
+                : SmoothTheme.getColor(
+                    colorScheme,
+                    _COLORS[matchIndex],
+                    ColorDestination.SURFACE_FOREGROUND,
+                  ),
+          ),
           label: _model.getRankedProducts(matchIndex).length.toString(),
         ),
       );
     }
-    final ColorScheme colorScheme = Theme.of(context).colorScheme;
     return Scaffold(
       key: _scaffoldKey,
       appBar: AppBar(
         title: Text(
           ProductQueryPageHelper.getProductListLabel(widget.productList),
-          style: TextStyle(color: colorScheme.onBackground),
         ),
-        iconTheme: IconThemeData(color: colorScheme.onBackground),
         actions: <Widget>[
           IconButton(
-            icon: Icon(
-              Icons.settings,
-              color: colorScheme.onBackground,
-            ),
+            icon: const Icon(Icons.settings),
             onPressed: () => UserPreferencesView.showModal(
               context,
               callback: () {
@@ -103,21 +106,34 @@ class _PersonalizedRankingPageState extends State<PersonalizedRankingPage> {
         }),
       ),
       body: _getStickyHeader(
-          _model.getRankedProducts(_ORDERED_MATCH_INDEXES[_currentTabIndex])),
+        _model.getRankedProducts(_ORDERED_MATCH_INDEXES[_currentTabIndex]),
+        colorScheme,
+      ),
     );
   }
 
-  Widget _buildSmoothProductCard(final RankedProduct rankedProduct) => Padding(
+  Widget _buildSmoothProductCard(
+    final RankedProduct rankedProduct,
+    final ColorScheme colorScheme,
+  ) =>
+      Padding(
         padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 8.0),
         child: SmoothProductCardFound(
           heroTag: rankedProduct.product.barcode,
           product: rankedProduct.product,
           elevation: 4.0,
-          backgroundColor: _colors[SmoothItModel.getMatchIndex(rankedProduct)],
+          backgroundColor: SmoothTheme.getColor(
+            colorScheme,
+            _COLORS[SmoothItModel.getMatchIndex(rankedProduct)],
+            ColorDestination.SURFACE_BACKGROUND,
+          ),
         ),
       );
 
-  Widget _getStickyHeader(final List<RankedProduct> products) =>
+  Widget _getStickyHeader(
+    final List<RankedProduct> products,
+    final ColorScheme colorScheme,
+  ) =>
       products.isEmpty
           ? Center(
               child: Text('There is no product in this section',
@@ -126,6 +142,6 @@ class _PersonalizedRankingPageState extends State<PersonalizedRankingPage> {
           : ListView.builder(
               itemCount: products.length,
               itemBuilder: (BuildContext context, int index) =>
-                  _buildSmoothProductCard(products[index]),
+                  _buildSmoothProductCard(products[index], colorScheme),
             );
 }

--- a/packages/smooth_app/lib/pages/product_list_button.dart
+++ b/packages/smooth_app/lib/pages/product_list_button.dart
@@ -15,11 +15,21 @@ class ProductListButton extends StatelessWidget {
   Widget build(BuildContext context) {
     final ColorScheme colorScheme = Theme.of(context).colorScheme;
     return ElevatedButton.icon(
-      icon: productList.getIcon(colorScheme),
+      icon: productList.getIcon(
+        colorScheme,
+        ColorDestination.BUTTON_FOREGROUND,
+      ),
       label: Text(
         ProductQueryPageHelper.getProductListLabel(
           productList,
           verbose: false,
+        ),
+        style: TextStyle(
+          color: SmoothTheme.getColor(
+            colorScheme,
+            productList.getMaterialColor(),
+            ColorDestination.BUTTON_FOREGROUND,
+          ),
         ),
       ),
       onPressed: () async {
@@ -33,9 +43,10 @@ class ProductListButton extends StatelessWidget {
         daoProductList.localDatabase.notifyListeners();
       },
       style: ElevatedButton.styleFrom(
-        primary: SmoothTheme.getBackgroundColor(
+        primary: SmoothTheme.getColor(
           colorScheme,
           productList.getMaterialColor(),
+          ColorDestination.BUTTON_BACKGROUND,
         ),
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(32.0),

--- a/packages/smooth_app/lib/pages/product_list_dialog_helper.dart
+++ b/packages/smooth_app/lib/pages/product_list_dialog_helper.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:smooth_app/database/dao_product_list.dart';
 import 'package:smooth_app/data_models/product_list.dart';
+import 'package:smooth_app/themes/smooth_theme.dart';
 import 'package:smooth_ui_library/buttons/smooth_simple_button.dart';
 import 'package:smooth_ui_library/dialogs/smooth_alert_dialog.dart';
 
@@ -194,33 +195,41 @@ class ProductListDialogHelper {
     final ProductList productList,
   ) async {
     final List<String> orderedIcons = productList.getPossibleIcons();
+    final double size = MediaQuery.of(context).size.width / 8;
     return await showDialog<bool>(
       context: context,
       builder: (BuildContext context) => SmoothAlertDialog(
         close: false,
         title: _TRANSLATE_ME_CHANGE_ICON,
-        body: Wrap(
-          children: List<Widget>.generate(
-            ProductList.ORDERED_COLORS.length * orderedIcons.length,
-            (final int index) {
-              final String colorTag = ProductList
-                  .ORDERED_COLORS[index % ProductList.ORDERED_COLORS.length];
-              final String iconTag =
-                  orderedIcons[index ~/ ProductList.ORDERED_COLORS.length];
-              return IconButton(
-                icon: ProductList.getReferenceIcon(
-                  colorScheme: Theme.of(context).colorScheme,
-                  colorTag: colorTag,
-                  iconTag: iconTag,
-                ),
-                onPressed: () async {
-                  productList.colorTag = colorTag;
-                  productList.iconTag = iconTag;
-                  await daoProductList.put(productList);
-                  Navigator.pop(context, true);
-                },
-              );
-            },
+        body: Container(
+          width: ProductList.ORDERED_COLORS.length.toDouble() * size,
+          height: orderedIcons.length.toDouble() * size,
+          child: GridView.count(
+            crossAxisCount: 5,
+            childAspectRatio: 1,
+            children: List<Widget>.generate(
+              ProductList.ORDERED_COLORS.length * orderedIcons.length,
+              (final int index) {
+                final String colorTag = ProductList
+                    .ORDERED_COLORS[index % ProductList.ORDERED_COLORS.length];
+                final String iconTag =
+                    orderedIcons[index ~/ ProductList.ORDERED_COLORS.length];
+                return IconButton(
+                  icon: ProductList.getReferenceIcon(
+                    colorScheme: Theme.of(context).colorScheme,
+                    colorTag: colorTag,
+                    iconTag: iconTag,
+                    colorDestination: ColorDestination.SURFACE_FOREGROUND,
+                  ),
+                  onPressed: () async {
+                    productList.colorTag = colorTag;
+                    productList.iconTag = iconTag;
+                    await daoProductList.put(productList);
+                    Navigator.pop(context, true);
+                  },
+                );
+              },
+            ),
           ),
         ),
         actions: <SmoothSimpleButton>[

--- a/packages/smooth_app/lib/pages/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product_list_page.dart
@@ -125,22 +125,24 @@ class _ProductListPageState extends State<ProductListPage> {
         ),
       ),
       appBar: AppBar(
-        backgroundColor: SmoothTheme.getBackgroundColor(
+        backgroundColor: SmoothTheme.getColor(
           colorScheme,
           productList.getMaterialColor(),
+          ColorDestination.APP_BAR_BACKGROUND,
         ),
         title: Row(
           children: <Widget>[
-            productList.getIcon(colorScheme),
+            productList.getIcon(
+              colorScheme,
+              ColorDestination.APP_BAR_FOREGROUND,
+            ),
             const SizedBox(width: 8.0),
             Text(
               ProductQueryPageHelper.getProductListLabel(productList,
                   verbose: false), // TODO(monsieurtanuki): handle the overflow
-              style: TextStyle(color: colorScheme.onBackground),
             ),
           ],
         ),
-        iconTheme: IconThemeData(color: colorScheme.onBackground),
         actions: (!renamable) && (!deletable)
             ? null
             : <Widget>[

--- a/packages/smooth_app/lib/pages/product_page.dart
+++ b/packages/smooth_app/lib/pages/product_page.dart
@@ -168,27 +168,19 @@ class _ProductPageState extends State<ProductPage> {
     UserPreferencesModel.ATTRIBUTE_GROUP_ALLERGENS,
   ];
 
-  static const double _OPACITY_FOR_DARK =
-      .3; // TODO(monsieurtanuki): make it more public?
-
   @override
   Widget build(BuildContext context) {
     final LocalDatabase localDatabase = context.watch<LocalDatabase>();
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final ThemeData themeData = Theme.of(context);
-    final ColorScheme colorScheme = themeData.colorScheme;
     _product ??= widget.product;
     return Scaffold(
         key: _scaffoldKey,
         appBar: AppBar(
-          title: ListTile(
-            title: Text(
-              _product.productName ?? appLocalizations.unknownProductName,
-              style: themeData.textTheme.headline4
-                  .copyWith(color: colorScheme.onBackground),
-            ),
+          title: Text(
+            _product.productName ?? appLocalizations.unknownProductName,
+            //style: themeData.textTheme.headline4,
           ),
-          iconTheme: IconThemeData(color: colorScheme.onBackground),
         ),
         bottomNavigationBar: BottomNavigationBar(
           type: BottomNavigationBarType.fixed,
@@ -358,8 +350,9 @@ class _ProductPageState extends State<ProductPage> {
     );
     final Map<String, Attribute> matchingAttributes =
         Match.getMatchingAttributes(_product, mainAttributes);
-    final double opacity =
-        themeData.brightness == Brightness.light ? 1 : _OPACITY_FOR_DARK;
+    final double opacity = themeData.brightness == Brightness.light
+        ? 1
+        : SmoothTheme.ADDITIONAL_OPACITY_FOR_DARK;
     for (final String attributeId in mainAttributes) {
       if (matchingAttributes[attributeId] != null) {
         listItems.add(
@@ -384,21 +377,23 @@ class _ProductPageState extends State<ProductPage> {
           i < _product.categoriesTags.length;
           i++) {
         final String categoryTag = _product.categoriesTags[i];
-        final MaterialColor materialColor = Colors.blue;
+        const MaterialColor materialColor = Colors.blue;
         listItems.add(
           SmoothCard(
-            background: SmoothTheme.getBackgroundColor(
+            background: SmoothTheme.getColor(
               themeData.colorScheme,
               materialColor,
+              ColorDestination.SURFACE_BACKGROUND,
             ),
             collapsed: null,
             content: ListTile(
               leading: Icon(
                 Icons.search,
                 size: iconWidth,
-                color: SmoothTheme.getForegroundColor(
+                color: SmoothTheme.getColor(
                   themeData.colorScheme,
                   materialColor,
+                  ColorDestination.SURFACE_FOREGROUND,
                 ),
               ),
               onTap: () async => await ProductQueryPageHelper().openBestChoice(

--- a/packages/smooth_app/lib/pages/product_query_page.dart
+++ b/packages/smooth_app/lib/pages/product_query_page.dart
@@ -200,7 +200,6 @@ class _ProductQueryPageState extends State<ProductQueryPage> {
                     padding: const EdgeInsets.symmetric(
                         horizontal: 12.0, vertical: 8.0),
                     child: SmoothProductCardFound(
-                      backgroundColor: Colors.white,
                       heroTag: _model.displayProducts[index].barcode,
                       product: _model.displayProducts[index],
                       elevation:

--- a/packages/smooth_app/lib/pages/profile_page.dart
+++ b/packages/smooth_app/lib/pages/profile_page.dart
@@ -23,11 +23,7 @@ class ProfilePage extends StatelessWidget {
     final Launcher launcher = Launcher();
     return Scaffold(
       appBar: AppBar(
-        title: Text(
-          AppLocalizations.of(context).testerSettingTitle,
-          style: TextStyle(color: themeData.colorScheme.onBackground),
-        ),
-        iconTheme: IconThemeData(color: themeData.colorScheme.onBackground),
+        title: Text(AppLocalizations.of(context).testerSettingTitle),
       ),
       body: Column(
         children: <Widget>[

--- a/packages/smooth_app/lib/themes/smooth_theme.dart
+++ b/packages/smooth_app/lib/themes/smooth_theme.dart
@@ -13,6 +13,13 @@ enum ColorDestination {
 class SmoothTheme {
   static const double ADDITIONAL_OPACITY_FOR_DARK = .3;
 
+  /// Returns a shade of a [materialColor]
+  ///
+  /// For instance, if you want to display a red button,
+  /// you'll use Colors.red as root color,
+  /// the destination will be ColorDestination.BUTTON_BACKGROUND,
+  /// and you'll specify the current ColorScheme.
+  /// For the moment, the ColorScheme matters only for the light/dark switch.
   static Color getColor(
     final ColorScheme colorScheme,
     final MaterialColor materialColor,

--- a/packages/smooth_app/lib/themes/smooth_theme.dart
+++ b/packages/smooth_app/lib/themes/smooth_theme.dart
@@ -1,25 +1,56 @@
 import 'package:flutter/material.dart';
 
-class SmoothTheme {
-  static Color getForegroundColor(
-    final ColorScheme colorScheme,
-    final MaterialColor materialColor,
-  ) =>
-      colorScheme.brightness == Brightness.light
-          ? materialColor[800]
-          : materialColor[200];
+/// Color destination
+enum ColorDestination {
+  APP_BAR_FOREGROUND,
+  APP_BAR_BACKGROUND,
+  SURFACE_FOREGROUND,
+  SURFACE_BACKGROUND,
+  BUTTON_FOREGROUND,
+  BUTTON_BACKGROUND,
+}
 
-  static Color getBackgroundColor(
+class SmoothTheme {
+  static const double ADDITIONAL_OPACITY_FOR_DARK = .3;
+
+  static Color getColor(
     final ColorScheme colorScheme,
     final MaterialColor materialColor,
-  ) =>
-      colorScheme.brightness == Brightness.light
-          ? materialColor[200]
-          : materialColor[700].withOpacity(.3);
+    final ColorDestination colorDestination,
+  ) {
+    if (colorScheme.brightness == Brightness.light) {
+      switch (colorDestination) {
+        case ColorDestination.APP_BAR_BACKGROUND:
+        case ColorDestination.SURFACE_FOREGROUND:
+        case ColorDestination.BUTTON_BACKGROUND:
+          return materialColor[800];
+        case ColorDestination.APP_BAR_FOREGROUND:
+        case ColorDestination.SURFACE_BACKGROUND:
+        case ColorDestination.BUTTON_FOREGROUND:
+          return materialColor[100];
+      }
+    }
+    switch (colorDestination) {
+      case ColorDestination.APP_BAR_BACKGROUND:
+        return null;
+      case ColorDestination.SURFACE_BACKGROUND:
+      case ColorDestination.BUTTON_BACKGROUND:
+        return materialColor[900].withOpacity(ADDITIONAL_OPACITY_FOR_DARK);
+      case ColorDestination.APP_BAR_FOREGROUND:
+      case ColorDestination.SURFACE_FOREGROUND:
+      case ColorDestination.BUTTON_FOREGROUND:
+        return materialColor[100];
+    }
+    throw Exception(
+      'unknown brightness / destination:'
+      ' ${colorScheme.brightness} / $colorDestination',
+    );
+  }
 
   static ThemeData getThemeData(final Brightness brightness) {
-    final ColorScheme myColorScheme =
-        brightness == Brightness.dark ? _COLOR_DARK : _COLOR_LIGHT;
+    final ColorScheme myColorScheme = brightness == Brightness.dark
+        ? const ColorScheme.dark()
+        : const ColorScheme.light();
     return ThemeData(
       colorScheme: myColorScheme,
       bottomNavigationBarTheme: BottomNavigationBarThemeData(
@@ -27,36 +58,12 @@ class SmoothTheme {
         unselectedItemColor: myColorScheme.onSurface,
       ),
       textTheme: _TEXT_THEME,
-      snackBarTheme: SnackBarThemeData(
-        backgroundColor: myColorScheme.onSurface,
-        actionTextColor: myColorScheme.surface,
+      floatingActionButtonTheme: FloatingActionButtonThemeData(
+        backgroundColor: myColorScheme.secondary,
+        foregroundColor: myColorScheme.onSecondary,
       ),
-      appBarTheme: AppBarTheme(
-        color: myColorScheme.background,
-      ),
-      scaffoldBackgroundColor: myColorScheme.background,
     );
   }
-
-  static const ColorScheme _COLOR_LIGHT = ColorScheme.light(
-    primary: Colors.white,
-    primaryVariant: Colors.white60,
-    secondary: Colors.black,
-    secondaryVariant: Colors.black,
-    onPrimary: Colors.black,
-    onSecondary: Colors.white,
-    background: Colors.white,
-  );
-
-  static const ColorScheme _COLOR_DARK = ColorScheme.dark(
-    primary: Colors.black,
-    primaryVariant: Colors.black,
-    secondary: Colors.white,
-    secondaryVariant: Colors.white60,
-    onPrimary: Colors.white,
-    onSecondary: Colors.black,
-    background: Colors.black,
-  );
 
   static const TextTheme _TEXT_THEME = TextTheme(
     headline1: TextStyle(


### PR DESCRIPTION
The main change is in `smooth_theme.dart`. Everything comes from there.

Impacted files:
* `choose_page.dart`: simplified
* `home_page.dart`: simplified; used the new method `SmoothTheme.getColor`
* `list_page.dart`: simplified
* `pantry.dart`: used the new method `SmoothTheme.getColor`
* `pantry_button.dart`: used the new method `SmoothTheme.getColor`
* `pantry_dialog_helper.dart`: used the new method `SmoothTheme.getColor`
* `pantry_list_page.dart`
* `pantry_page.dart`: simplified; used the new method `SmoothTheme.getColor`
* `pantry_preview.dart`: used the new method `SmoothTheme.getColor`
* `personalized_ranking_page.dart`: simplified; used the new method `SmoothTheme.getColor`
* `product_list.dart`: used the new method `SmoothTheme.getColor`
* `product_list_button.dart`: used the new method `SmoothTheme.getColor`
* `product_list_dialog_helper.dart`: used the new method `SmoothTheme.getColor`; unrelated uniformisation with pantry list when displaying tinted icons
* `product_list_page.dart`: simplified; used the new method `SmoothTheme.getColor`
* `product_list_preview.dart`: used the new method `SmoothTheme.getColor`
* `product_page.dart`: simplified; used the new method `SmoothTheme.getColor`
* `product_query_page.dart`: no more "white" as default background color
* `profile_page.dart`: simplified
* `smooth_product_card_found.dart`: simplified; no more "white/black" as default (for dark theme reasons)
* `smooth_theme.dart`: create enum `ColorDestination` and a powerful `static Color getColor` method; simplified the colorSchemes to the defaults