### PR TITLE
feature/#147 - local look-up - first step towards autocomplete text field

### DIFF
--- a/packages/smooth_app/lib/pages/home_page.dart
+++ b/packages/smooth_app/lib/pages/home_page.dart
@@ -20,6 +20,7 @@ import 'package:openfoodfacts/model/Attribute.dart';
 import 'package:smooth_app/data_models/user_preferences_model.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
 import 'package:smooth_app/cards/product_cards/product_list_preview.dart';
+import 'package:openfoodfacts/model/Product.dart';
 
 class HomePage extends StatefulWidget {
   @override
@@ -93,6 +94,16 @@ class _HomePageState extends State<HomePage> {
                   ),
                 ),
                 title: TextField(
+                  onChanged: (final String value) =>
+                      _daoProduct.getSuggestions(value, 3).then(
+                    (List<Product> list) {
+                      print(
+                          '${list.length} products locally found with $value:');
+                      for (final Product item in list) {
+                        print('${item.barcode}: ${item.productName}');
+                      }
+                    },
+                  ),
                   onSubmitted: (final String value) => ChoosePage.onSubmitted(
                     value,
                     context,


### PR DESCRIPTION
Implemented a look-up on the local database, and linked it to the text field.
For the moment, the matching products are only printed in the console.
The next step would be to display the results with an autocomplete text field.

Impacted files:
* `dao_product.dart`: new method `List<Product> getSuggestions(String)`
* `home_page.dart`: added an `onUpdate` method on the text field to print the products that match locally