### PR TITLE
intl version fix

### DIFF
--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
   image_cropper: ^1.3.1
   url_launcher: ^5.7.10
   flutter_staggered_animations: ^0.1.2
-  intl: ^0.16.1
+  intl: ^0.17.0
   sentry: ^4.0.1
   sticky_grouped_list: ^1.3.0
   sticky_headers: ^0.1.8+1


### PR DESCRIPTION
> Because smooth_app depends on flutter_localizations any from sdk which depends on intl 0.17.0, intl 0.17.0 is required.
> So, because smooth_app depends on intl ^0.16.1, version solving failed.
> pub get failed (1; So, because smooth_app depends on intl ^0.16.1, version solving failed.)