### PR TITLE
bug/#232 - reinit of the Podfile after migration to Flutter 2.0.0

### DIFF
--- a/packages/smooth_app/ios/Podfile
+++ b/packages/smooth_app/ios/Podfile
@@ -1,55 +1,41 @@
 # Uncomment this line to define a global platform for your project
 platform :ios, '9.0'
-use_frameworks!
-use_modular_headers!
 
-def parse_KV_file(file,seperator='=')
-  file_abs_path = File.expand_path(file)
-  if !File.exists? file_abs_path
-    return [];
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
   end
-  pods_ary = []
-  skip_line_start_symbols = ["#", "/"]
-  File.foreach(file_abs_path) { |line|
-      next if skip_line_start_symbols.any? { |symbol| line =~ /^\s*#{symbol}/ }
-      plugin = line.split(pattern=seperator)
-      if plugin.length == 2
-        podname = plugin[0].strip()
-        path = plugin[1].strip()
-        podpath = File.expand_path("#{path}", file_abs_path)
-        pods_ary.push({:name => podname,:path=>podpath});
-      else
-        puts "Invalid plugin specification: #{line}"
-      end
-  }
-  return pods_ary
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
 end
 
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
 target 'Runner' do
-  # Flutter Pods
   use_frameworks!
   use_modular_headers!
-  generated_xcode_build_settings = parse_KV_file("./Flutter/Generated.xcconfig")
-  if generated_xcode_build_settings.empty?
-    puts "Generated.xcconfig must exist. If you're running pod install manually, make sure flutter build or flutter run is executed once first."
-  end
-  generated_xcode_build_settings.map{ |p|
-    if p[:name]=='FLUTTER_FRAMEWORK_DIR'
-      pod 'Flutter', :path => p[:path]
-    end
-  }
 
-  # Plugin Pods
-  plugin_pods = parse_KV_file("../.flutter-plugins")
-  plugin_pods.map{ |p|
-    pod p[:name], :path => File.expand_path("ios",p[:path])
-  }
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 end
 
 post_install do |installer|
   installer.pods_project.targets.each do |target|
-    target.build_configurations.each do |config|
-      config.build_settings['ENABLE_BITCODE'] = 'NO'
-    end
+    flutter_additional_ios_build_settings(target)
   end
 end


### PR DESCRIPTION
My assumption is that we used the default Podfile and that nobody ever edited it.

Impacted file:
* `Podfile`: deleted and automatically recreated