### PR TITLE
feature/#214 - explicit "create a list" button instead of "empty" text

### DIFF
--- a/packages/smooth_app/lib/pages/list_page.dart
+++ b/packages/smooth_app/lib/pages/list_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 
 // Package imports:
 import 'package:provider/provider.dart';
+import 'package:smooth_ui_library/widgets/smooth_card.dart';
 
 // Project imports:
 import 'package:smooth_app/cards/product_cards/product_list_preview.dart';
@@ -10,6 +11,9 @@ import 'package:smooth_app/data_models/product_list.dart';
 import 'package:smooth_app/database/dao_product_list.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/pages/product_list_dialog_helper.dart';
+import 'package:smooth_app/pages/product_list_page.dart';
+import 'package:smooth_app/pages/product_query_page_helper.dart';
+import 'package:smooth_app/themes/smooth_theme.dart';
 
 class ListPage extends StatefulWidget {
   const ListPage({
@@ -31,19 +35,19 @@ class _ListPageState extends State<ListPage> {
   Widget build(BuildContext context) {
     final LocalDatabase localDatabase = context.watch<LocalDatabase>();
     final DaoProductList daoProductList = DaoProductList(localDatabase);
+    final Size screenSize = MediaQuery.of(context).size;
+    final ThemeData themeData = Theme.of(context);
+    final double iconSize = screenSize.width / 10;
+    final bool mayAddList =
+        widget.typeFilter.contains(ProductList.LIST_TYPE_USER_DEFINED);
     return Scaffold(
       appBar: AppBar(
         title: Text(widget.title),
         actions: <Widget>[
-          if (widget.typeFilter.contains(ProductList.LIST_TYPE_USER_DEFINED))
+          if (mayAddList)
             IconButton(
               icon: const Icon(Icons.add),
-              onPressed: () async {
-                if (await ProductListDialogHelper.openNew(
-                    context, daoProductList, _list)) {
-                  setState(() {});
-                }
-              },
+              onPressed: () async => await _add(daoProductList),
             )
         ],
       ),
@@ -57,6 +61,15 @@ class _ListPageState extends State<ListPage> {
               _list = snapshot.data;
               if (_list != null) {
                 if (_list.isEmpty) {
+                  if (mayAddList) {
+                    return Center(
+                      child: _addButtonWhenEmpty(
+                        iconSize,
+                        themeData,
+                        daoProductList,
+                      ),
+                    );
+                  }
                   return const Center(child: Text('No list so far'));
                 }
                 return ListView.builder(
@@ -76,4 +89,52 @@ class _ListPageState extends State<ListPage> {
           }),
     );
   }
+
+  Future<void> _add(final DaoProductList daoProductList) async {
+    final ProductList newProductList = await ProductListDialogHelper.openNew(
+      context,
+      daoProductList,
+      _list,
+    );
+    if (newProductList == null) {
+      return;
+    }
+    await Navigator.push<dynamic>(
+      context,
+      MaterialPageRoute<dynamic>(
+        builder: (BuildContext context) => ProductListPage(
+          newProductList,
+          reverse: ProductQueryPageHelper.isListReversed(
+            newProductList,
+          ),
+        ),
+      ),
+    );
+    setState(() {});
+  }
+
+  Widget _addButtonWhenEmpty(
+    final double iconSize,
+    final ThemeData themeData,
+    final DaoProductList daoProductList,
+  ) =>
+      SizedBox(
+        height: iconSize * 3,
+        child: SmoothCard(
+          background: SmoothTheme.getColor(
+            themeData.colorScheme,
+            Colors.blue,
+            ColorDestination.SURFACE_BACKGROUND,
+          ),
+          collapsed: null,
+          content: ListTile(
+            leading: Icon(Icons.add, size: iconSize),
+            onTap: () async => await _add(daoProductList),
+            title: Text(
+              'Create a food list',
+              style: themeData.textTheme.headline3,
+            ),
+          ),
+        ),
+      );
 }

--- a/packages/smooth_app/lib/pages/product_list_dialog_helper.dart
+++ b/packages/smooth_app/lib/pages/product_list_dialog_helper.dart
@@ -52,14 +52,14 @@ class ProductListDialogHelper {
         ),
       );
 
-  static Future<bool> openNew(
+  static Future<ProductList> openNew(
     final BuildContext context,
     final DaoProductList daoProductList,
     final List<ProductList> list,
   ) async {
     final GlobalKey<FormState> formKey = GlobalKey<FormState>();
     ProductList newProductList;
-    return await showDialog<bool>(
+    return await showDialog<ProductList>(
       context: context,
       builder: (BuildContext context) => SmoothAlertDialog(
         close: false,
@@ -98,7 +98,7 @@ class ProductListDialogHelper {
         actions: <SmoothSimpleButton>[
           SmoothSimpleButton(
             text: _TRANSLATE_ME_CANCEL,
-            onPressed: () => Navigator.pop(context, false),
+            onPressed: () => Navigator.pop(context, null),
             important: false,
           ),
           SmoothSimpleButton(
@@ -112,7 +112,7 @@ class ProductListDialogHelper {
                 return;
               }
               await daoProductList.put(newProductList);
-              Navigator.pop(context, true);
+              Navigator.pop(context, newProductList);
             },
             important: true,
           ),


### PR DESCRIPTION
For empty product lists only for the moment.

Impacted files:
* `list_page.dart`: replaced the "Empty" text with an explicit "create a food list" button, which eventually goes to the newly created product page
* `product_list_dialog_helper.dart`: method `openNew` now returns a `ProductList` instead of a simple `bool`