### PR TITLE
feature/#214_2 - for pantry/shopping list, "create a list" button instead of "empty" text

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/pantry_preview.dart
+++ b/packages/smooth_app/lib/cards/product_cards/pantry_preview.dart
@@ -44,7 +44,11 @@ class PantryPreview extends StatelessWidget {
             onTap: () async => await Navigator.push<dynamic>(
               context,
               MaterialPageRoute<dynamic>(
-                builder: (BuildContext context) => PantryPage(pantries, index),
+                builder: (BuildContext context) => PantryPage(
+                  pantries,
+                  index,
+                  pantries[index].pantryType,
+                ),
               ),
             ),
             leading: pantry.getIcon(

--- a/packages/smooth_app/lib/pages/home_page.dart
+++ b/packages/smooth_app/lib/pages/home_page.dart
@@ -22,8 +22,10 @@ import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/pages/choose_page.dart';
 import 'package:smooth_app/pages/list_page.dart';
 import 'package:smooth_app/pages/pantry_button.dart';
+import 'package:smooth_app/pages/pantry_dialog_helper.dart';
 import 'package:smooth_app/pages/pantry_list_page.dart';
 import 'package:smooth_app/pages/product_list_button.dart';
+import 'package:smooth_app/pages/product_list_dialog_helper.dart';
 import 'package:smooth_app/pages/product_page.dart';
 import 'package:smooth_app/pages/profile_page.dart';
 import 'package:smooth_app/pages/scan_page.dart';
@@ -318,16 +320,30 @@ class _HomePageState extends State<HomePage> {
         ) {
           if (snapshot.connectionState == ConnectionState.done) {
             final List<ProductList> list = snapshot.data;
-            List<Widget> cards;
-            final bool empty = list == null || list.isEmpty;
-            if (empty) {
-              cards = null;
-            } else {
-              cards = <Widget>[];
+            final List<Widget> cards = <Widget>[];
+            if (list != null) {
               for (final ProductList item in list) {
                 cards.add(ProductListButton(item, _daoProductList));
               }
             }
+            cards.add(
+              ElevatedButton.icon(
+                icon: const Icon(Icons.add),
+                label: Text(ListPage.getCreateListLabel()),
+                onPressed: () async {
+                  final ProductList newProductList =
+                      await ProductListDialogHelper.openNew(
+                    context,
+                    _daoProductList,
+                    list,
+                  );
+                  if (newProductList == null) {
+                    return;
+                  }
+                  setState(() {});
+                },
+              ),
+            );
             return Card(
               child: Column(
                 children: <Widget>[
@@ -345,16 +361,14 @@ class _HomePageState extends State<HomePage> {
                       setState(() {});
                     },
                     leading: leadingIcon,
-                    subtitle: empty ? const Text(_TRANSLATE_ME_EMPTY) : null,
                     title: Text(title,
                         style: Theme.of(context).textTheme.subtitle2),
                   ),
-                  if (!empty)
-                    Wrap(
-                      direction: Axis.horizontal,
-                      children: cards,
-                      spacing: 8.0,
-                    ),
+                  Wrap(
+                    direction: Axis.horizontal,
+                    children: cards,
+                    spacing: 8.0,
+                  )
                 ],
               ),
             );
@@ -478,6 +492,24 @@ class _HomePageState extends State<HomePage> {
             for (int index = 0; index < pantries.length; index++) {
               cards.add(PantryButton(pantries, index));
             }
+            cards.add(
+              ElevatedButton.icon(
+                icon: const Icon(Icons.add),
+                label: Text(PantryListPage.getCreateListLabel(pantryType)),
+                onPressed: () async {
+                  final String newPantryName = await PantryDialogHelper.openNew(
+                    context,
+                    pantries,
+                    pantryType,
+                    userPreferences,
+                  );
+                  if (newPantryName == null) {
+                    return;
+                  }
+                  setState(() {});
+                },
+              ),
+            );
             return Card(
               child: Column(
                 children: <Widget>[

--- a/packages/smooth_app/lib/pages/list_page.dart
+++ b/packages/smooth_app/lib/pages/list_page.dart
@@ -11,8 +11,6 @@ import 'package:smooth_app/data_models/product_list.dart';
 import 'package:smooth_app/database/dao_product_list.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/pages/product_list_dialog_helper.dart';
-import 'package:smooth_app/pages/product_list_page.dart';
-import 'package:smooth_app/pages/product_query_page_helper.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
 
 class ListPage extends StatefulWidget {
@@ -26,6 +24,8 @@ class ListPage extends StatefulWidget {
 
   @override
   _ListPageState createState() => _ListPageState();
+
+  static String getCreateListLabel() => 'Create a food list';
 }
 
 class _ListPageState extends State<ListPage> {
@@ -99,17 +99,6 @@ class _ListPageState extends State<ListPage> {
     if (newProductList == null) {
       return;
     }
-    await Navigator.push<dynamic>(
-      context,
-      MaterialPageRoute<dynamic>(
-        builder: (BuildContext context) => ProductListPage(
-          newProductList,
-          reverse: ProductQueryPageHelper.isListReversed(
-            newProductList,
-          ),
-        ),
-      ),
-    );
     setState(() {});
   }
 
@@ -131,7 +120,7 @@ class _ListPageState extends State<ListPage> {
             leading: Icon(Icons.add, size: iconSize),
             onTap: () async => await _add(daoProductList),
             title: Text(
-              'Create a food list',
+              ListPage.getCreateListLabel(),
               style: themeData.textTheme.headline3,
             ),
           ),

--- a/packages/smooth_app/lib/pages/pantry_button.dart
+++ b/packages/smooth_app/lib/pages/pantry_button.dart
@@ -40,7 +40,11 @@ class PantryButton extends StatelessWidget {
           await Navigator.push<dynamic>(
             context,
             MaterialPageRoute<dynamic>(
-              builder: (BuildContext context) => PantryPage(pantries, index),
+              builder: (BuildContext context) => PantryPage(
+                pantries,
+                index,
+                pantries[index].pantryType,
+              ),
             ),
           );
         },

--- a/packages/smooth_app/lib/pages/pantry_dialog_helper.dart
+++ b/packages/smooth_app/lib/pages/pantry_dialog_helper.dart
@@ -3,11 +3,13 @@ import 'package:flutter/material.dart';
 
 // Package imports:
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:smooth_app/temp/user_preferences.dart';
 import 'package:smooth_ui_library/buttons/smooth_simple_button.dart';
 import 'package:smooth_ui_library/dialogs/smooth_alert_dialog.dart';
 
 // Project imports:
 import 'package:smooth_app/data_models/pantry.dart';
+import 'package:smooth_app/pages/pantry_page.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
 
 /// A dialog helper for pantries
@@ -64,13 +66,15 @@ class PantryDialogHelper {
         ),
       );
 
-  static Future<bool> openNew(
+  static Future<String> openNew(
     final BuildContext context,
     final List<Pantry> pantries,
     final PantryType pantryType,
+    final UserPreferences userPreferences,
   ) async {
+    String newPantryName;
     final GlobalKey<FormState> formKey = GlobalKey<FormState>();
-    return await showDialog<bool>(
+    return await showDialog<String>(
       context: context,
       builder: (BuildContext context) => SmoothAlertDialog(
         close: false,
@@ -103,6 +107,12 @@ class PantryDialogHelper {
                     }
                   }
                   pantries.add(Pantry(name: value, pantryType: pantryType));
+                  Pantry.putAll(
+                    userPreferences,
+                    pantries,
+                    pantryType,
+                  );
+                  newPantryName = value;
                   return null;
                 },
               ),
@@ -112,7 +122,7 @@ class PantryDialogHelper {
         actions: <SmoothSimpleButton>[
           SmoothSimpleButton(
             text: _TRANSLATE_ME_CANCEL,
-            onPressed: () => Navigator.pop(context, false),
+            onPressed: () => Navigator.pop(context, null),
             important: false,
           ),
           SmoothSimpleButton(
@@ -121,7 +131,25 @@ class PantryDialogHelper {
               if (!formKey.currentState.validate()) {
                 return;
               }
-              Navigator.pop(context, true);
+              Navigator.pop(context, newPantryName);
+
+              int index = 0;
+              for (final Pantry pantry in pantries) {
+                if (pantry.name == newPantryName) {
+                  await Navigator.push<dynamic>(
+                    context,
+                    MaterialPageRoute<dynamic>(
+                      builder: (BuildContext context) => PantryPage(
+                        pantries,
+                        index,
+                        pantryType,
+                      ),
+                    ),
+                  );
+                  return;
+                }
+                index++;
+              }
             },
             important: true,
           ),

--- a/packages/smooth_app/lib/pages/pantry_list_page.dart
+++ b/packages/smooth_app/lib/pages/pantry_list_page.dart
@@ -3,12 +3,14 @@ import 'package:flutter/material.dart';
 
 // Package imports:
 import 'package:provider/provider.dart';
+import 'package:smooth_ui_library/widgets/smooth_card.dart';
 
 // Project imports:
 import 'package:smooth_app/cards/product_cards/pantry_preview.dart';
 import 'package:smooth_app/data_models/pantry.dart';
 import 'package:smooth_app/pages/pantry_dialog_helper.dart';
 import 'package:smooth_app/temp/user_preferences.dart';
+import 'package:smooth_app/themes/smooth_theme.dart';
 
 /// A page where all the pantries are displayed as previews
 class PantryListPage extends StatefulWidget {
@@ -20,36 +22,43 @@ class PantryListPage extends StatefulWidget {
 
   @override
   _PantryListPageState createState() => _PantryListPageState();
+
+  static String getCreateListLabel(final PantryType pantryType) {
+    switch (pantryType) {
+      case PantryType.PANTRY:
+        return 'Create a pantry';
+      case PantryType.SHOPPING:
+        return 'Create a shopping list';
+    }
+    throw Exception('unknow pantry type $pantryType');
+  }
 }
 
 class _PantryListPageState extends State<PantryListPage> {
   @override
   Widget build(BuildContext context) {
     final UserPreferences userPreferences = context.watch<UserPreferences>();
+    final Size screenSize = MediaQuery.of(context).size;
+    final ThemeData themeData = Theme.of(context);
+    final double iconSize = screenSize.width / 10;
     return Scaffold(
       appBar: AppBar(
         title: Text(widget.title),
         actions: <Widget>[
           IconButton(
             icon: const Icon(Icons.add),
-            onPressed: () async {
-              if (await PantryDialogHelper.openNew(
-                context,
-                widget.pantries,
-                widget.pantryType,
-              )) {
-                Pantry.putAll(
-                  userPreferences,
-                  widget.pantries,
-                  widget.pantryType,
-                );
-              }
-            },
+            onPressed: () async => await _add(userPreferences),
           )
         ],
       ),
       body: (widget.pantries.isEmpty)
-          ? const Center(child: Text('Empty'))
+          ? Center(
+              child: _addButtonWhenEmpty(
+                iconSize,
+                themeData,
+                userPreferences,
+              ),
+            )
           : ListView.builder(
               itemCount: widget.pantries.length,
               itemBuilder: (final BuildContext context, final int index) =>
@@ -61,4 +70,42 @@ class _PantryListPageState extends State<PantryListPage> {
             ),
     );
   }
+
+  Future<void> _add(final UserPreferences userPreferences) async {
+    final String newPantryName = await PantryDialogHelper.openNew(
+      context,
+      widget.pantries,
+      widget.pantryType,
+      userPreferences,
+    );
+    if (newPantryName == null) {
+      return;
+    }
+    setState(() {});
+  }
+
+  Widget _addButtonWhenEmpty(
+    final double iconSize,
+    final ThemeData themeData,
+    final UserPreferences userPreferences,
+  ) =>
+      SizedBox(
+        height: iconSize * 3,
+        child: SmoothCard(
+          background: SmoothTheme.getColor(
+            themeData.colorScheme,
+            Colors.blue,
+            ColorDestination.SURFACE_BACKGROUND,
+          ),
+          collapsed: null,
+          content: ListTile(
+            leading: Icon(Icons.add, size: iconSize),
+            onTap: () async => await _add(userPreferences),
+            title: Text(
+              PantryListPage.getCreateListLabel(widget.pantryType),
+              style: themeData.textTheme.headline3,
+            ),
+          ),
+        ),
+      );
 }

--- a/packages/smooth_app/lib/pages/pantry_page.dart
+++ b/packages/smooth_app/lib/pages/pantry_page.dart
@@ -20,10 +20,12 @@ class PantryPage extends StatelessWidget {
   const PantryPage(
     this.pantries,
     this.index,
+    this.pantryType,
   );
 
   final List<Pantry> pantries;
   final int index;
+  final PantryType pantryType;
 
   static const String _EMPTY_DATE = '';
   static const String _TRANSLATE_ME_RENAME = 'Rename';
@@ -212,7 +214,7 @@ class PantryPage extends StatelessWidget {
   }
 
   Future<void> _save(final UserPreferences userPreferences) async =>
-      Pantry.putAll(userPreferences, pantries, pantries[index].pantryType);
+      Pantry.putAll(userPreferences, pantries, pantryType);
 
   Widget _getPantryDayLine({
     @required final Pantry pantry,

--- a/packages/smooth_app/lib/pages/product_list_dialog_helper.dart
+++ b/packages/smooth_app/lib/pages/product_list_dialog_helper.dart
@@ -9,6 +9,8 @@ import 'package:smooth_ui_library/dialogs/smooth_alert_dialog.dart';
 // Project imports:
 import 'package:smooth_app/data_models/product_list.dart';
 import 'package:smooth_app/database/dao_product_list.dart';
+import 'package:smooth_app/pages/product_list_page.dart';
+import 'package:smooth_app/pages/product_query_page_helper.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
 
 class ProductListDialogHelper {
@@ -113,6 +115,17 @@ class ProductListDialogHelper {
               }
               await daoProductList.put(newProductList);
               Navigator.pop(context, newProductList);
+              await Navigator.push<dynamic>(
+                context,
+                MaterialPageRoute<dynamic>(
+                  builder: (BuildContext context) => ProductListPage(
+                    newProductList,
+                    reverse: ProductQueryPageHelper.isListReversed(
+                      newProductList,
+                    ),
+                  ),
+                ),
+              );
             },
             important: true,
           ),


### PR DESCRIPTION
Now available for home page too.

Impacted files:
* `home_page.dart`: instead of an "empty" text, always added a "create a list/pantry" from the home page
* `list_page.dart`: minor refactoring
* `pantry_button.dart`: minor refactoring
* `pantry_dialog_helper.dart`: now actually opening the pantry page at the end of `openNew`
* `pantry_list_page.dart`: added a "create list" button instead of "empty" text
* `pantry_page.dart`: minor refactoring
* `pantry_preview.dart`: minor refactoring
* `product_list_dialog_helper.dart`: now actually opening the product page at the end of `openNew`