### PR TITLE
upgrade openfoodfacts to 1.0.1-beta

### DIFF
--- a/packages/smooth_app/lib/data_models/user_preferences_model.dart
+++ b/packages/smooth_app/lib/data_models/user_preferences_model.dart
@@ -149,10 +149,10 @@ class UserPreferencesModel extends ChangeNotifier {
       final String importanceUrl = _getImportanceUrl(languageCode);
       final String attributeUrl = _getAttributeUrl(languageCode);
       http.Response response;
-      response = await http.get(importanceUrl);
+      response = await http.get(Uri.parse(importanceUrl));
       // TODO(monsieurtanuki): check response.statusCode
       final String importanceString = response.body;
-      response = await http.get(attributeUrl);
+      response = await http.get(Uri.parse(attributeUrl));
       // TODO(monsieurtanuki): check response.statusCode
       final String attributeGroupString = response.body;
       final UserPreferencesModel userPreferencesModel =

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -21,7 +21,7 @@ environment:
   sdk: ">=2.10.4 <3.0.0"
 
 dependencies:
-  basic_utils: ^2.7.1
+  basic_utils: ^3.0.0-nullsafety.0
   carousel_slider: ^3.0.0
   cupertino_icons: ^1.0.2
   flutter:
@@ -30,13 +30,13 @@ dependencies:
     sdk: flutter
   flutter_staggered_animations: ^0.1.3
   flutter_staggered_grid_view: ^0.3.4
-  flutter_svg: ^0.19.3
+  flutter_svg: ^0.21.0-nullsafety.0
   flutter_typeahead: ^2.0.0
   image_cropper: ^1.3.1
-  image_picker: ^0.6.7+17
+  image_picker: ^0.7.2
   intl: ^0.17.0
   modal_bottom_sheet: ^1.0.0+1
-  openfoodfacts: ^0.3.15+3
+  openfoodfacts: ^1.0.1-beta
   package_info: ^2.0.0
   path_provider: ^2.0.1
   provider: ^5.0.0
@@ -53,7 +53,7 @@ dependencies:
   url_launcher: ^5.7.10
 
 dev_dependencies:
-  flutter_native_splash: ^0.2.2
+  flutter_native_splash: ^1.0.3
   flutter_test:
     sdk: flutter
 

--- a/packages/smooth_ui_library/pubspec.yaml
+++ b/packages/smooth_ui_library/pubspec.yaml
@@ -12,8 +12,8 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_staggered_grid_view: ^0.3.4
-  flutter_svg: ^0.19.3
-  openfoodfacts: ^0.3.15+3
+  flutter_svg: ^0.21.0-nullsafety.0
+  openfoodfacts: ^1.0.1-beta
   percent_indicator: ^2.1.9+1
   provider: ^5.0.0
   rubber: ^0.4.0


### PR DESCRIPTION
fixes #246

I only upgraded the modules that flutter pub get was complaining about when doing dependency resolution.

Also changed: the new http module now expects an Uri instead of a String in http.get