### PR TITLE
feature/#243 - at least we see the product image on top of product page

### DIFF
--- a/packages/smooth_app/lib/pages/product_page.dart
+++ b/packages/smooth_app/lib/pages/product_page.dart
@@ -16,6 +16,7 @@ import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:share/share.dart';
 import 'package:smooth_ui_library/widgets/smooth_card.dart';
+import 'package:smooth_ui_library/widgets/smooth_product_image.dart';
 
 // Project imports:
 import 'package:smooth_app/bottom_sheet_views/user_preferences_view.dart';
@@ -328,6 +329,16 @@ class _ProductPageState extends State<ProductPage> {
         userPreferencesModel.getOrderedVariables(userPreferences);
     final List<Widget> listItems = <Widget>[];
 
+    if (_product.imgSmallUrl != null) {
+      listItems.add(
+        SmoothProductImage(
+          product: _product,
+          width: screenSize.width,
+          height: screenSize.height / 4,
+        ),
+      );
+    }
+
     listItems.add(
       Padding(
         padding: const EdgeInsets.all(16.0),
@@ -427,45 +438,7 @@ class _ProductPageState extends State<ProductPage> {
       }
     }
 
-    return Stack(
-      children: <Widget>[
-        if (_product.imgSmallUrl != null)
-          Image.network(
-            _product.imgSmallUrl,
-            fit: BoxFit.cover,
-            height: double.infinity,
-            width: double.infinity,
-            alignment: Alignment.center,
-            loadingBuilder:
-                (BuildContext context, Widget child, ImageChunkEvent progress) {
-              if (progress == null) {
-                return child;
-              }
-              return Center(
-                child: CircularProgressIndicator(
-                  strokeWidth: 2.5,
-                  valueColor: const AlwaysStoppedAnimation<Color>(Colors.white),
-                  value: progress.cumulativeBytesLoaded /
-                      progress.expectedTotalBytes,
-                ),
-              );
-            },
-          )
-        else
-          Container(
-            width: screenSize.width,
-            height: screenSize.height,
-            color: Colors.black54,
-          ),
-        BackdropFilter(
-          filter: ImageFilter.blur(sigmaX: 18.0, sigmaY: 18.0),
-          child: Container(
-            color: themeData.colorScheme.surface.withAlpha(220),
-            child: ListView(children: listItems),
-          ),
-        ),
-      ],
-    );
+    return ListView(children: listItems);
   }
 
   Widget _getAttributeGroupWidget(


### PR DESCRIPTION
Impacted file:
* `product_page.dart`: display the product image on top of product page; removed the not effective stack

![Simulator Screen Shot - iPhone 8 Plus - 2021-03-09 at 19 20 04](https://user-images.githubusercontent.com/11576431/110518502-75bf6400-810c-11eb-8118-c8d5a5c56bde.png)
