### PR TITLE
Android APK build obsolete warning

### DIFF
--- a/packages/smooth_app/android/build.gradle
+++ b/packages/smooth_app/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.4.31'
     repositories {
         google()
         jcenter()
@@ -15,6 +15,9 @@ allprojects {
     repositories {
         google()
         jcenter()
+    }
+    tasks.withType(JavaCompile) {
+        options.compilerArgs << '-Xlint:-options'
     }
 }
 


### PR DESCRIPTION
```
3 warnings
warning: [options] source value 7 is obsolete and will be removed in a future release

warning: [options] target value 7 is obsolete and will be removed in a future release

warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
```