### PR TITLE
refactored homepage to use SmoothCard instead of Card

### DIFF
--- a/packages/smooth_app/lib/cards/expandables/attribute_list_expandable.dart
+++ b/packages/smooth_app/lib/cards/expandables/attribute_list_expandable.dart
@@ -23,6 +23,8 @@ class AttributeListExpandable extends StatelessWidget {
     this.title,
     this.collapsible = true,
     this.background,
+    this.padding,
+    this.insets,
   });
 
   final Product product;
@@ -31,6 +33,8 @@ class AttributeListExpandable extends StatelessWidget {
   final String title;
   final bool collapsible;
   final Color background;
+  final EdgeInsets padding;
+  final EdgeInsets insets;
 
   @override
   Widget build(BuildContext context) {
@@ -75,14 +79,18 @@ class AttributeListExpandable extends StatelessWidget {
     );
     if (!collapsible) {
       return SmoothCard(
-        content: content,
-        background: background,
+        padding: padding,
+        insets: insets,
+        child: content,
+        color: background,
       );
     }
 
     final Widget header =
         Text(title, style: Theme.of(context).textTheme.headline3);
     return SmoothExpandableCard(
+      padding: padding,
+      insets: insets,
       collapsedHeader: Container(
         width: screenSize.width * 0.8,
         child: Column(
@@ -98,7 +106,7 @@ class AttributeListExpandable extends StatelessWidget {
           ],
         ),
       ),
-      content: content,
+      child: content,
       expandedHeader: title == null ? null : header,
     );
   }

--- a/packages/smooth_app/lib/cards/product_cards/product_list_preview.dart
+++ b/packages/smooth_app/lib/cards/product_cards/product_list_preview.dart
@@ -11,6 +11,7 @@ import 'package:smooth_app/database/dao_product_list.dart';
 import 'package:smooth_app/pages/product/common/product_list_page.dart';
 import 'package:smooth_app/pages/product/common/product_query_page_helper.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
+import 'package:smooth_ui_library/widgets/smooth_card.dart';
 
 class ProductListPreview extends StatelessWidget {
   const ProductListPreview({
@@ -47,7 +48,8 @@ class ProductListPreview extends StatelessWidget {
             if (list == null || list.isEmpty) {
               subtitle = 'Empty list';
             }
-            return Card(
+            return SmoothCard(
+              insets: const EdgeInsets.all(1.0),
               color: SmoothTheme.getColor(
                 Theme.of(context).colorScheme,
                 productList.getMaterialColor(),
@@ -89,7 +91,7 @@ class ProductListPreview extends StatelessWidget {
               ),
             );
           }
-          return Card(
+          return SmoothCard(
             child: ListTile(
               leading: const CircularProgressIndicator(),
               subtitle: Text(title),

--- a/packages/smooth_app/lib/pages/home_page.dart
+++ b/packages/smooth_app/lib/pages/home_page.dart
@@ -8,6 +8,7 @@ import 'package:openfoodfacts/model/Attribute.dart';
 import 'package:openfoodfacts/model/Product.dart';
 import 'package:openfoodfacts/utils/PnnsGroups.dart';
 import 'package:provider/provider.dart';
+import 'package:smooth_ui_library/widgets/smooth_card.dart';
 import 'package:smooth_ui_library/widgets/smooth_product_image.dart';
 
 // Project imports:
@@ -115,7 +116,9 @@ class _HomePageState extends State<HomePage> {
           //Search
           StatefulBuilder(
             builder: (BuildContext context, StateSetter setState) {
-              return Card(
+              return SmoothCard(
+                padding: const EdgeInsets.only(
+                    right: 8.0, left: 8.0, top: 4.0, bottom: 4.0),
                 child: ListTile(
                   leading: Icon(
                     Icons.search,
@@ -211,36 +214,37 @@ class _HomePageState extends State<HomePage> {
             nbInPreview: 5,
           ),
           //Food category's
-          Card(
-            child: ListTile(
-              onTap: () async {
-                await Navigator.push<dynamic>(
-                  context,
-                  MaterialPageRoute<dynamic>(
-                    builder: (BuildContext context) => ChoosePage(),
+          GestureDetector(
+            child: SmoothCard(
+              child: ListTile(
+                leading: Icon(
+                  Icons.fastfood,
+                  color: SmoothTheme.getColor(
+                    colorScheme,
+                    Colors.orange,
+                    _COLOR_DESTINATION_FOR_ICON,
                   ),
-                );
-                setState(() {});
-              },
-              leading: Icon(
-                Icons.fastfood,
-                color: SmoothTheme.getColor(
-                  colorScheme,
-                  Colors.orange,
-                  _COLOR_DESTINATION_FOR_ICON,
+                ),
+                title: Text('Food category search',
+                    style: Theme.of(context).textTheme.subtitle2),
+                subtitle: Text(
+                  '${PnnsGroup1.BEVERAGES.name}'
+                  ', ${PnnsGroup1.CEREALS_AND_POTATOES.name}'
+                  ', ${PnnsGroup1.COMPOSITE_FOODS.name}'
+                  ', ${PnnsGroup1.FAT_AND_SAUCES.name}'
+                  ', ${PnnsGroup1.FISH_MEAT_AND_EGGS.name}'
+                  ', ...',
                 ),
               ),
-              title: Text('Food category search',
-                  style: Theme.of(context).textTheme.subtitle2),
-              subtitle: Text(
-                '${PnnsGroup1.BEVERAGES.name}'
-                ', ${PnnsGroup1.CEREALS_AND_POTATOES.name}'
-                ', ${PnnsGroup1.COMPOSITE_FOODS.name}'
-                ', ${PnnsGroup1.FAT_AND_SAUCES.name}'
-                ', ${PnnsGroup1.FISH_MEAT_AND_EGGS.name}'
-                ', ...',
-              ),
             ),
+            onTap: () async {
+              await Navigator.push<dynamic>(
+                context,
+                MaterialPageRoute<dynamic>(
+                  builder: (BuildContext context) => ChoosePage(),
+                ),
+              );
+            },
           ),
           //Search history
           _getProductListCard(
@@ -260,7 +264,7 @@ class _HomePageState extends State<HomePage> {
             ),
           ),
           //Score
-          Card(
+          SmoothCard(
             color: notYetColor,
             child: const ListTile(
               leading: Icon(
@@ -271,7 +275,7 @@ class _HomePageState extends State<HomePage> {
             ),
           ),
           //Contribute
-          Card(
+          SmoothCard(
             color: notYetColor,
             child: const ListTile(
               leading: Icon(
@@ -280,9 +284,6 @@ class _HomePageState extends State<HomePage> {
               title: Text('Contribute'),
               subtitle: Text('Help us list more and more foods!'),
             ),
-          ),
-          const SizedBox(
-            height: 10,
           ),
         ],
       ),
@@ -357,7 +358,7 @@ class _HomePageState extends State<HomePage> {
                 cards.add(const Text(_TRANSLATE_ME_EMPTY));
               }
             }
-            return Card(
+            return SmoothCard(
               child: Column(
                 children: <Widget>[
                   ListTile(
@@ -386,7 +387,7 @@ class _HomePageState extends State<HomePage> {
               ),
             );
           }
-          return Card(
+          return SmoothCard(
             child: ListTile(
               leading: const CircularProgressIndicator(),
               title: Text(title),
@@ -445,7 +446,7 @@ class _HomePageState extends State<HomePage> {
     }
     return GestureDetector(
       onTap: () => onTap(),
-      child: Card(
+      child: SmoothCard(
         child: Column(
           children: <Widget>[
             ListTile(
@@ -519,7 +520,7 @@ class _HomePageState extends State<HomePage> {
                 },
               ),
             );
-            return Card(
+            return SmoothCard(
               child: Column(
                 children: <Widget>[
                   ListTile(
@@ -559,7 +560,7 @@ class _HomePageState extends State<HomePage> {
               ),
             );
           }
-          return Card(
+          return SmoothCard(
             child: ListTile(
               leading: const CircularProgressIndicator(),
               title: Text(title),

--- a/packages/smooth_app/lib/pages/home_page.dart
+++ b/packages/smooth_app/lib/pages/home_page.dart
@@ -276,6 +276,8 @@ class _HomePageState extends State<HomePage> {
           ),
           //Contribute
           SmoothCard(
+            padding: const EdgeInsets.only(
+                right: 8.0, left: 8.0, top: 4.0, bottom: 20.0),
             color: notYetColor,
             child: const ListTile(
               leading: Icon(

--- a/packages/smooth_app/lib/pages/list_page.dart
+++ b/packages/smooth_app/lib/pages/list_page.dart
@@ -110,12 +110,12 @@ class _ListPageState extends State<ListPage> {
       SizedBox(
         height: iconSize * 3,
         child: SmoothCard(
-          background: SmoothTheme.getColor(
+          color: SmoothTheme.getColor(
             themeData.colorScheme,
             Colors.blue,
             ColorDestination.SURFACE_BACKGROUND,
           ),
-          content: ListTile(
+          child: ListTile(
             leading: Icon(Icons.add, size: iconSize),
             onTap: () async => await _add(daoProductList),
             title: Text(

--- a/packages/smooth_app/lib/pages/pantry/common/pantry_list_page.dart
+++ b/packages/smooth_app/lib/pages/pantry/common/pantry_list_page.dart
@@ -92,12 +92,12 @@ class _PantryListPageState extends State<PantryListPage> {
       SizedBox(
         height: iconSize * 3,
         child: SmoothCard(
-          background: SmoothTheme.getColor(
+          color: SmoothTheme.getColor(
             themeData.colorScheme,
             Colors.blue,
             ColorDestination.SURFACE_BACKGROUND,
           ),
-          content: ListTile(
+          child: ListTile(
             leading: Icon(Icons.add, size: iconSize),
             onTap: () async => await _add(userPreferences),
             title: Text(

--- a/packages/smooth_app/lib/pages/product/product_page.dart
+++ b/packages/smooth_app/lib/pages/product/product_page.dart
@@ -159,6 +159,10 @@ class ProductPage extends StatefulWidget {
 class _ProductPageState extends State<ProductPage> {
   Product _product;
 
+  final EdgeInsets padding =
+      const EdgeInsets.only(right: 8.0, left: 8.0, top: 4.0, bottom: 20.0);
+  final EdgeInsets insets = const EdgeInsets.all(12.0);
+
   @override
   void initState() {
     super.initState();
@@ -419,6 +423,8 @@ class _ProductPageState extends State<ProductPage> {
       if (attributes[attributeId] != null) {
         listItems.add(
           AttributeListExpandable(
+            padding: padding,
+            insets: insets,
             product: _product,
             iconWidth: iconWidth,
             attributeIds: <String>[attributeId],
@@ -444,12 +450,14 @@ class _ProductPageState extends State<ProductPage> {
         const MaterialColor materialColor = Colors.blue;
         listItems.add(
           SmoothCard(
-            background: SmoothTheme.getColor(
+            padding: padding,
+            insets: insets,
+            color: SmoothTheme.getColor(
               themeData.colorScheme,
               materialColor,
               ColorDestination.SURFACE_BACKGROUND,
             ),
-            content: ListTile(
+            child: ListTile(
               leading: Icon(
                 Icons.search,
                 size: iconWidth,
@@ -498,6 +506,8 @@ class _ProductPageState extends State<ProductPage> {
       attributeIds.add(attribute.id);
     }
     return AttributeListExpandable(
+      padding: padding,
+      insets: insets,
       product: _product,
       iconWidth: iconWidth,
       attributeIds: attributeIds,

--- a/packages/smooth_ui_library/lib/widgets/smooth_card.dart
+++ b/packages/smooth_ui_library/lib/widgets/smooth_card.dart
@@ -3,30 +3,35 @@ import 'package:flutter/material.dart';
 
 class SmoothCard extends StatelessWidget {
   const SmoothCard({
-    @required this.content,
-    this.background,
+    @required this.child,
+    this.color,
     this.header,
+    this.padding = const EdgeInsets.only(
+        right: 8.0, left: 8.0, top: 4.0, bottom: 4.0),
+    this.insets = const  EdgeInsets.all(5.0),
+
   });
 
-  final Widget content;
-  final Color background;
+  final Widget child;
+  final Color color;
   final Widget header;
+  final EdgeInsets padding;
+  final EdgeInsets insets;
 
   @override
   Widget build(BuildContext context) => Padding(
-        padding: const EdgeInsets.only(
-            right: 8.0, left: 8.0, top: 4.0, bottom: 20.0),
+        padding: padding,
         child: Material(
           elevation: 8.0,
           shadowColor: Colors.black45,
           borderRadius: const BorderRadius.all(Radius.circular(10.0)),
-          color: background ?? Theme.of(context).colorScheme.surface,
+          color: color ?? Theme.of(context).colorScheme.surface,
           child: Container(
-            padding: const EdgeInsets.all(12.0),
+            padding: insets,
             child: Column(
               children: <Widget>[
                 header ?? Container(),
-                content,
+                child,
               ],
             ),
           ),

--- a/packages/smooth_ui_library/lib/widgets/smooth_expandable_card.dart
+++ b/packages/smooth_ui_library/lib/widgets/smooth_expandable_card.dart
@@ -6,15 +6,20 @@ import 'package:flutter/material.dart';
 class SmoothExpandableCard extends StatefulWidget {
   const SmoothExpandableCard({
     @required this.collapsedHeader,
-    @required this.content,
+    @required this.child,
     this.expandedHeader,
-    this.background,
+    this.color,
+    this.padding = const EdgeInsets.only(
+        right: 8.0, left: 8.0, top: 4.0, bottom: 20.0),
+    this.insets = const  EdgeInsets.all(12.0),
   });
 
   final Widget collapsedHeader;
   final Widget expandedHeader;
-  final Color background;
-  final Widget content;
+  final Color color;
+  final Widget child;
+  final EdgeInsets padding;
+  final EdgeInsets insets;
   @override
   _SmoothExpandableCardState createState() => _SmoothExpandableCardState();
 }
@@ -59,15 +64,14 @@ class _SmoothExpandableCardState extends State<SmoothExpandableCard>
         });
       },
       child: Padding(
-        padding: const EdgeInsets.only(
-            right: 8.0, left: 8.0, top: 4.0, bottom: 20.0),
+        padding: widget.padding,
         child: Material(
           elevation: 8.0,
           shadowColor: Colors.black45,
           borderRadius: const BorderRadius.all(Radius.circular(10.0)),
-          color: widget.background ?? Theme.of(context).colorScheme.surface,
+          color: widget.color ?? Theme.of(context).colorScheme.surface,
           child: Container(
-            padding: const EdgeInsets.all(12.0),
+            padding: widget.insets,
             child: Column(
               children: <Widget>[
                 Row(
@@ -92,7 +96,7 @@ class _SmoothExpandableCardState extends State<SmoothExpandableCard>
                     ),
                   ],
                 ),
-                if (collapsed != true) widget.content,
+                if (collapsed != true) widget.child,
               ],
             ),
           ),


### PR DESCRIPTION
Added padding + insets option to smooth_card and smooth_expandable_card.
The homepage and product_list_preview now use SmoothCard instead of Card.

Before and after comparison

Dark:
<details>

![Screenshot_1616592175](https://user-images.githubusercontent.com/39344769/112317864-bf7f8100-8cac-11eb-8083-88b0313082a0.png)

![Screenshot_1616592197](https://user-images.githubusercontent.com/39344769/112317870-c0b0ae00-8cac-11eb-9b8b-9d773fc134a8.png)




</details>

Light:

<details>

![Screenshot_1616592169](https://user-images.githubusercontent.com/39344769/112317936-cf976080-8cac-11eb-99e3-2500e5e2aa74.png)

![Screenshot_1616592192](https://user-images.githubusercontent.com/39344769/112317942-d1612400-8cac-11eb-91fd-6a6321478977.png)



</details>