### PR TITLE
feature/#290 - Local search on pantry page, with product automatically added

### DIFF
--- a/packages/smooth_app/lib/data_models/pantry.dart
+++ b/packages/smooth_app/lib/data_models/pantry.dart
@@ -51,14 +51,29 @@ class Pantry {
   String get _defaultIconTag => pantryType == PantryType.PANTRY
       ? _ICON_DEFAULT_PANTRY
       : _ICON_DEFAULT_SHOPPING;
-  void add(final List<String> barcodes, final Map<String, Product> products) {
+
+  /// Returns the number of actually added barcodes (new barcodes, then)
+  int addAll(final List<String> barcodes, final Map<String, Product> products) {
+    int result = 0;
     for (final String barcode in barcodes) {
       if (!data.containsKey(barcode)) {
         data[barcode] = <String, int>{};
+        result++;
       }
     }
     this.products.addAll(products);
+    return result;
   }
+
+  /// Returns true if the product was actually added (= was not there before)
+  bool add(final Product product) =>
+      addAll(
+        <String>[product.barcode],
+        <String, Product>{
+          product.barcode: product,
+        },
+      ) ==
+      1;
 
   static const String _ICON_PAW = 'paw';
   static const String _ICON_FREEZER = 'heart';

--- a/packages/smooth_app/lib/pages/home_page.dart
+++ b/packages/smooth_app/lib/pages/home_page.dart
@@ -1,17 +1,9 @@
-// Flutter imports:
 import 'package:flutter/material.dart';
-
-// Package imports:
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:flutter_typeahead/flutter_typeahead.dart';
 import 'package:openfoodfacts/model/Attribute.dart';
-import 'package:openfoodfacts/model/Product.dart';
 import 'package:openfoodfacts/utils/PnnsGroups.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_ui_library/widgets/smooth_card.dart';
-import 'package:smooth_ui_library/widgets/smooth_product_image.dart';
-
-// Project imports:
 import 'package:smooth_app/bottom_sheet_views/user_preferences_view.dart';
 import 'package:smooth_app/cards/product_cards/product_list_preview.dart';
 import 'package:smooth_app/data_models/pantry.dart';
@@ -26,13 +18,13 @@ import 'package:smooth_app/pages/pantry/common/pantry_dialog_helper.dart';
 import 'package:smooth_app/pages/pantry/common/pantry_list_page.dart';
 import 'package:smooth_app/pages/product/common/product_list_button.dart';
 import 'package:smooth_app/pages/product/common/product_list_dialog_helper.dart';
-import 'package:smooth_app/pages/product/product_page.dart';
 import 'package:smooth_app/pages/settings_page.dart';
 import 'package:smooth_app/pages/scan/scan_page.dart';
 import 'package:smooth_app/temp/preference_importance.dart';
 import 'package:smooth_app/data_models/product_preferences.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
+import 'package:smooth_app/pages/text_search_widget.dart';
 
 class HomePage extends StatefulWidget {
   @override
@@ -50,25 +42,6 @@ class _HomePageState extends State<HomePage> {
 
   DaoProductList _daoProductList;
   DaoProduct _daoProduct;
-
-  final TextEditingController _searchController = TextEditingController();
-
-  bool _visibleCloseButton = false;
-
-  Future<List<Product>> _search(String pattern) async {
-    final bool _oldVisibleCloseButton = _visibleCloseButton;
-    if (pattern.isNotEmpty) {
-      _visibleCloseButton = true;
-    } else {
-      _visibleCloseButton = false;
-    }
-    if (_oldVisibleCloseButton != _visibleCloseButton) {
-      setState(() {});
-    }
-    final List<Product> _returnProducts =
-        await _daoProduct.getSuggestions(pattern, 3);
-    return _returnProducts;
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -111,79 +84,14 @@ class _HomePageState extends State<HomePage> {
 
       body: ListView(
         children: <Widget>[
-          //Search
-          StatefulBuilder(
-            builder: (BuildContext context, StateSetter setState) {
-              return SmoothCard(
-                padding: const EdgeInsets.only(
-                    right: 8.0, left: 8.0, top: 4.0, bottom: 4.0),
-                child: ListTile(
-                  leading: Icon(
-                    Icons.search,
-                    color: SmoothTheme.getColor(
-                      colorScheme,
-                      Colors.red,
-                      _COLOR_DESTINATION_FOR_ICON,
-                    ),
-                  ),
-                  trailing: AnimatedOpacity(
-                    opacity: _visibleCloseButton ? 1.0 : 0.0,
-                    duration: const Duration(milliseconds: 100),
-                    child: IgnorePointer(
-                      ignoring: !_visibleCloseButton,
-                      child: IconButton(
-                        icon: const Icon(Icons.close),
-                        onPressed: () {
-                          setState(() {
-                            FocusScope.of(context).unfocus();
-                            _searchController.text = '';
-                            _visibleCloseButton = false;
-                          });
-                        },
-                      ),
-                    ),
-                  ),
-                  title: TypeAheadFormField<Product>(
-                    textFieldConfiguration: TextFieldConfiguration(
-                      controller: _searchController,
-                      autofocus: false,
-                      decoration: const InputDecoration(
-                          border: InputBorder.none,
-                          hintText: 'What are you looking for?'),
-                    ),
-                    hideOnEmpty: true,
-                    hideOnLoading: true,
-                    suggestionsCallback: (String value) async => _search(value),
-                    transitionBuilder: (BuildContext context,
-                        Widget suggestionsBox, AnimationController controller) {
-                      return suggestionsBox;
-                    },
-                    itemBuilder: (BuildContext context, Product suggestion) {
-                      return ListTile(
-                        title: Text(suggestion.productName),
-                        leading: SmoothProductImage(
-                          product: suggestion,
-                        ),
-                      );
-                    },
-                    onSuggestionSelected: (Product suggestion) {
-                      Navigator.push<Widget>(
-                        context,
-                        MaterialPageRoute<Widget>(
-                          builder: (BuildContext context) => ProductPage(
-                            product: suggestion,
-                          ),
-                        ),
-                      );
-                    },
-                    // TODO(m123-dev): add fullscreen search page,
-                    //onSaved: (value) => ,
-                  ),
-                ),
-              );
-            },
+          TextSearchWidget(
+            color: SmoothTheme.getColor(
+              colorScheme,
+              Colors.red,
+              _COLOR_DESTINATION_FOR_ICON,
+            ),
+            daoProduct: _daoProduct,
           ),
-          //My lists
           _getProductListCard(
             <String>[ProductList.LIST_TYPE_USER_DEFINED],
             'My lists',

--- a/packages/smooth_app/lib/pages/text_search_widget.dart
+++ b/packages/smooth_app/lib/pages/text_search_widget.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_typeahead/flutter_typeahead.dart';
+import 'package:openfoodfacts/model/Product.dart';
+import 'package:smooth_ui_library/widgets/smooth_card.dart';
+import 'package:smooth_ui_library/widgets/smooth_product_image.dart';
+import 'package:smooth_app/database/dao_product.dart';
+import 'package:smooth_app/pages/product/product_page.dart';
+
+/// Local product search by text
+class TextSearchWidget extends StatefulWidget {
+  const TextSearchWidget({
+    @required this.color,
+    @required this.daoProduct,
+    this.addProductCallback,
+  });
+
+  /// Icon color
+  final Color color;
+  final DaoProduct daoProduct;
+
+  /// Callback after a product page is reached from the search, then pop'ed
+  final Future<void> Function(Product product) addProductCallback;
+
+  @override
+  _TextSearchWidgetState createState() => _TextSearchWidgetState();
+}
+
+class _TextSearchWidgetState extends State<TextSearchWidget> {
+  final TextEditingController _searchController = TextEditingController();
+
+  bool _visibleCloseButton = false;
+
+  @override
+  Widget build(BuildContext context) => SmoothCard(
+        child: ListTile(
+          leading: Icon(
+            Icons.search,
+            color: widget.color,
+          ),
+          trailing: AnimatedOpacity(
+            opacity: _visibleCloseButton ? 1.0 : 0.0,
+            duration: const Duration(milliseconds: 100),
+            child: IgnorePointer(
+              ignoring: !_visibleCloseButton,
+              child: IconButton(
+                icon: Icon(Icons.close, color: widget.color),
+                onPressed: () => setState(
+                  () {
+                    FocusScope.of(context).unfocus();
+                    _searchController.text = '';
+                    _visibleCloseButton = false;
+                  },
+                ),
+              ),
+            ),
+          ),
+          title: TypeAheadFormField<Product>(
+            textFieldConfiguration: TextFieldConfiguration(
+              controller: _searchController,
+              autofocus: false,
+              decoration: const InputDecoration(
+                border: InputBorder.none,
+                hintText: 'What are you looking for?',
+              ),
+            ),
+            hideOnEmpty: true,
+            hideOnLoading: true,
+            suggestionsCallback: (String value) async => _search(value),
+            transitionBuilder: (BuildContext context, Widget suggestionsBox,
+                    AnimationController controller) =>
+                suggestionsBox,
+            itemBuilder: (BuildContext context, Product suggestion) => ListTile(
+              title: Text(
+                suggestion.productName ??
+                    suggestion.productNameEN ??
+                    suggestion.productNameFR ??
+                    suggestion.productNameDE ??
+                    suggestion.barcode,
+              ),
+              leading: SmoothProductImage(
+                product: suggestion,
+                width: 40,
+                height: 40,
+              ),
+            ),
+            onSuggestionSelected: (Product suggestion) async {
+              await Navigator.push<Widget>(
+                context,
+                MaterialPageRoute<Widget>(
+                  builder: (BuildContext context) => ProductPage(
+                    product: suggestion,
+                  ),
+                ),
+              );
+              if (widget.addProductCallback != null) {
+                widget.addProductCallback(suggestion);
+              }
+            },
+          ),
+        ),
+      );
+
+  Future<List<Product>> _search(String pattern) async {
+    final bool _oldVisibleCloseButton = _visibleCloseButton;
+    _visibleCloseButton = pattern.isNotEmpty;
+    if (_oldVisibleCloseButton != _visibleCloseButton) {
+      setState(() {});
+    }
+    return await widget.daoProduct.getSuggestions(pattern, 3);
+  }
+}

--- a/packages/smooth_ui_library/lib/widgets/smooth_product_image.dart
+++ b/packages/smooth_ui_library/lib/widgets/smooth_product_image.dart
@@ -5,7 +5,11 @@ import 'package:flutter_svg/svg.dart';
 import 'package:openfoodfacts/model/Product.dart';
 
 class SmoothProductImage extends StatelessWidget {
-  const SmoothProductImage({@required this.product, this.width, this.height});
+  const SmoothProductImage({
+    @required this.product,
+    @required this.width,
+    @required this.height,
+  });
 
   final Product product;
   final double width;
@@ -13,9 +17,37 @@ class SmoothProductImage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (product.imageFrontSmallUrl != null &&
-        product.imageFrontSmallUrl != '') {
-      return ClipRRect(
+    Widget result;
+    result = _buildFromUrl(product.imageFrontSmallUrl);
+    if (result != null) {
+      return result;
+    }
+    result = _buildFromUrl(product.imageFrontUrl);
+    if (result != null) {
+      return result;
+    }
+    return ClipRRect(
+      borderRadius: const BorderRadius.all(Radius.circular(15.0)),
+      child: Container(
+        width: width,
+        height: height,
+        decoration: const BoxDecoration(
+          borderRadius: BorderRadius.all(Radius.circular(15.0)),
+        ),
+        child: Center(
+          child: SvgPicture.asset(
+            'assets/product/product_not_found.svg',
+            fit: BoxFit.cover,
+            height: height,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFromUrl(final String url) => url == null || url.isEmpty
+      ? null
+      : ClipRRect(
           borderRadius: const BorderRadius.all(Radius.circular(15.0)),
           child: Container(
             width: width,
@@ -24,52 +56,29 @@ class SmoothProductImage extends StatelessWidget {
               borderRadius: const BorderRadius.all(Radius.circular(15.0)),
               image: DecorationImage(
                 fit: BoxFit.cover,
-                image: NetworkImage(
-                  product.imageFrontSmallUrl,
-                  scale: 1.0,
-                ),
+                image: NetworkImage(url, scale: 1.0),
               ),
             ),
             child: BackdropFilter(
               filter: ImageFilter.blur(sigmaX: 12.0, sigmaY: 12.0),
               child: Image.network(
-                product.imageFrontSmallUrl,
+                url,
                 fit: BoxFit.contain,
                 loadingBuilder: (BuildContext context, Widget child,
-                    ImageChunkEvent progress) {
-                  if (progress == null) {
-                    return child;
-                  }
-                  return Center(
-                    child: CircularProgressIndicator(
-                      strokeWidth: 2.5,
-                      valueColor:
-                          const AlwaysStoppedAnimation<Color>(Colors.white),
-                      value: progress.cumulativeBytesLoaded /
-                          progress.expectedTotalBytes,
-                    ),
-                  );
-                },
+                        ImageChunkEvent progress) =>
+                    progress == null
+                        ? child
+                        : Center(
+                            child: CircularProgressIndicator(
+                              strokeWidth: 2.5,
+                              valueColor: const AlwaysStoppedAnimation<Color>(
+                                  Colors.white),
+                              value: progress.cumulativeBytesLoaded /
+                                  progress.expectedTotalBytes,
+                            ),
+                          ),
               ),
             ),
-          ));
-    } else {
-      return ClipRRect(
-        borderRadius: const BorderRadius.all(Radius.circular(15.0)),
-        child: Container(
-          width: width,
-          height: height,
-          decoration: const BoxDecoration(
-            borderRadius: BorderRadius.all(Radius.circular(15.0)),
           ),
-          child: Center(
-              child: SvgPicture.asset(
-            'assets/product/product_not_found.svg',
-            fit: BoxFit.cover,
-            height: height,
-          )),
-        ),
-      );
-    }
-  }
+        );
 }


### PR DESCRIPTION
New file:
* `text_search_widget.dart`: Local product search by text

Impacted files:
* `home_page.dart`: moved text search code to new `TextSearchWidget` class
* `pantry.dart`: renamed method `add` as `addAll`; added method `add` as an "add single item" method
* `pantry_page.dart`: added a `TextSearchWidget` on top of the screen; a product is automatically added after a product page is reached from the search and then pop'ed
* `smooth_product_image.dart`: unrelated fix where width and height are mandatory, and several image front urls are tried