### PR TITLE
feature/#290_2 - product search with local and API lookup

### DIFF
--- a/packages/smooth_app/lib/pages/choose_page.dart
+++ b/packages/smooth_app/lib/pages/choose_page.dart
@@ -31,7 +31,7 @@ class ChoosePage extends StatefulWidget {
     final BuildContext context,
     final LocalDatabase localDatabase,
   ) async {
-    if (int.parse(value) != null) {
+    if (int.tryParse(value) != null) {
       final ProductDialogHelper productDialogHelper = ProductDialogHelper(
         barcode: value,
         context: context,

--- a/packages/smooth_app/lib/pages/text_search_widget.dart
+++ b/packages/smooth_app/lib/pages/text_search_widget.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter_typeahead/flutter_typeahead.dart';
 import 'package:openfoodfacts/model/Product.dart';
 import 'package:smooth_ui_library/widgets/smooth_card.dart';
 import 'package:smooth_ui_library/widgets/smooth_product_image.dart';
 import 'package:smooth_app/database/dao_product.dart';
 import 'package:smooth_app/pages/product/product_page.dart';
+import 'package:smooth_app/pages/choose_page.dart';
 
 /// Local product search by text
 class TextSearchWidget extends StatefulWidget {
@@ -33,18 +35,23 @@ class _TextSearchWidgetState extends State<TextSearchWidget> {
   @override
   Widget build(BuildContext context) => SmoothCard(
         child: ListTile(
-          leading: Icon(
-            Icons.search,
-            color: widget.color,
-          ),
-          trailing: AnimatedOpacity(
-            opacity: _visibleCloseButton ? 1.0 : 0.0,
-            duration: const Duration(milliseconds: 100),
-            child: IgnorePointer(
-              ignoring: !_visibleCloseButton,
-              child: IconButton(
-                icon: Icon(Icons.close, color: widget.color),
-                onPressed: () => setState(
+          leading: _getIcon(Icons.search),
+          title: Row(
+            mainAxisAlignment: MainAxisAlignment.start,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: <Widget>[
+              Expanded(child: _getTextField()),
+              _getInvisibleIconButton(
+                CupertinoIcons.arrow_up_right,
+                () => ChoosePage.onSubmitted(
+                  _searchController.text,
+                  context,
+                  widget.daoProduct.localDatabase,
+                ),
+              ),
+              _getInvisibleIconButton(
+                Icons.close,
+                () => setState(
                   () {
                     FocusScope.of(context).unfocus();
                     _searchController.text = '';
@@ -52,53 +59,69 @@ class _TextSearchWidgetState extends State<TextSearchWidget> {
                   },
                 ),
               ),
-            ),
-          ),
-          title: TypeAheadFormField<Product>(
-            textFieldConfiguration: TextFieldConfiguration(
-              controller: _searchController,
-              autofocus: false,
-              decoration: const InputDecoration(
-                border: InputBorder.none,
-                hintText: 'What are you looking for?',
-              ),
-            ),
-            hideOnEmpty: true,
-            hideOnLoading: true,
-            suggestionsCallback: (String value) async => _search(value),
-            transitionBuilder: (BuildContext context, Widget suggestionsBox,
-                    AnimationController controller) =>
-                suggestionsBox,
-            itemBuilder: (BuildContext context, Product suggestion) => ListTile(
-              title: Text(
-                suggestion.productName ??
-                    suggestion.productNameEN ??
-                    suggestion.productNameFR ??
-                    suggestion.productNameDE ??
-                    suggestion.barcode,
-              ),
-              leading: SmoothProductImage(
-                product: suggestion,
-                width: 40,
-                height: 40,
-              ),
-            ),
-            onSuggestionSelected: (Product suggestion) async {
-              await Navigator.push<Widget>(
-                context,
-                MaterialPageRoute<Widget>(
-                  builder: (BuildContext context) => ProductPage(
-                    product: suggestion,
-                  ),
-                ),
-              );
-              if (widget.addProductCallback != null) {
-                widget.addProductCallback(suggestion);
-              }
-            },
+            ],
           ),
         ),
       );
+
+  Widget _getTextField() => TypeAheadFormField<Product>(
+        textFieldConfiguration: TextFieldConfiguration(
+          controller: _searchController,
+          autofocus: false,
+          decoration: const InputDecoration(
+            border: InputBorder.none,
+            hintText: 'What are you looking for?',
+          ),
+        ),
+        hideOnEmpty: true,
+        hideOnLoading: true,
+        suggestionsCallback: (String value) async => _search(value),
+        transitionBuilder: (BuildContext context, Widget suggestionsBox,
+                AnimationController controller) =>
+            suggestionsBox,
+        itemBuilder: (BuildContext context, Product suggestion) => ListTile(
+          title: Text(
+            suggestion.productName ??
+                suggestion.productNameEN ??
+                suggestion.productNameFR ??
+                suggestion.productNameDE ??
+                suggestion.barcode,
+          ),
+          leading: SmoothProductImage(
+            product: suggestion,
+            width: 40,
+            height: 40,
+          ),
+        ),
+        onSuggestionSelected: (Product suggestion) async {
+          await Navigator.push<Widget>(
+            context,
+            MaterialPageRoute<Widget>(
+              builder: (BuildContext context) => ProductPage(
+                product: suggestion,
+              ),
+            ),
+          );
+          if (widget.addProductCallback != null) {
+            widget.addProductCallback(suggestion);
+          }
+        },
+      );
+
+  Widget _getInvisibleIconButton(
+    final IconData iconData,
+    final void Function() onPressed,
+  ) =>
+      AnimatedOpacity(
+        opacity: _visibleCloseButton ? 1.0 : 0.0,
+        duration: const Duration(milliseconds: 100),
+        child: IgnorePointer(
+          ignoring: !_visibleCloseButton,
+          child: IconButton(icon: _getIcon(iconData), onPressed: onPressed),
+        ),
+      );
+
+  Icon _getIcon(final IconData iconData) => Icon(iconData, color: widget.color);
 
   Future<List<Product>> _search(String pattern) async {
     final bool _oldVisibleCloseButton = _visibleCloseButton;


### PR DESCRIPTION
For some reason the internet lookup was not called anymore.
Now when you type in the product name:
* there's a local lookup
* NEW: there's an additional icon button that launches the API lookup

Impacted files:
* `choose_page.dart`: minor fix probably needed from flutter 2.0
* `text_search_widget.dart`: added an "internet search button"