### PR TITLE
feature/#166_2 - products in pantries are now reorderable, with a drag handle

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
@@ -23,6 +23,7 @@ class SmoothProductCardFound extends StatelessWidget {
     this.elevation = 0.0,
     this.useNewStyle = true,
     this.backgroundColor,
+    this.handle,
   });
 
   final Product product;
@@ -30,6 +31,7 @@ class SmoothProductCardFound extends StatelessWidget {
   final double elevation;
   final bool useNewStyle;
   final Color backgroundColor;
+  final Widget handle;
 
   @override
   Widget build(BuildContext context) {
@@ -100,6 +102,7 @@ class SmoothProductCardFound extends StatelessWidget {
                       child: Column(
                         children: <Widget>[
                           Row(
+                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
                             children: <Widget>[
                               Flexible(
                                 child: Text(
@@ -109,6 +112,7 @@ class SmoothProductCardFound extends StatelessWidget {
                                   style: themeData.textTheme.headline4,
                                 ),
                               ),
+                              if (handle != null) handle,
                             ],
                           ),
                           const SizedBox(

--- a/packages/smooth_app/lib/data_models/pantry.dart
+++ b/packages/smooth_app/lib/data_models/pantry.dart
@@ -29,6 +29,7 @@ class Pantry {
     @required this.pantryType,
     this.data = const <String, Map<String, int>>{},
     this.products = const <String, Product>{},
+    this.order = const <String>[],
     this.iconTag = '',
     this.colorTag = _COLOR_DEFAULT,
   });
@@ -37,8 +38,15 @@ class Pantry {
   String colorTag;
   String iconTag;
   final PantryType pantryType;
+
+  /// Pantry data for each barcode
   final Map<String, Map<String, int>> data;
+
+  /// Product for each barcode
   final Map<String, Product> products;
+
+  /// Order of the barcodes
+  final List<String> order;
 
   static const String _ICON_DEFAULT_PANTRY = _ICON_PAW;
   static const String _ICON_DEFAULT_SHOPPING = _ICON_CART;
@@ -58,6 +66,7 @@ class Pantry {
     for (final String barcode in barcodes) {
       if (!data.containsKey(barcode)) {
         data[barcode] = <String, int>{};
+        order.add(barcode);
         result++;
       }
     }
@@ -155,8 +164,10 @@ class Pantry {
 
   List<Product> getFirstProducts(final int nbInPreview) {
     final List<Product> result = <Product>[];
-    for (final Product product in products.values) {
-      result.add(product);
+    final List<String> order =
+        getOrderedBarcodes(); // in the old version case only
+    for (final String barcode in order) {
+      result.add(products[barcode]);
       if (result.length >= nbInPreview) {
         break;
       }
@@ -187,11 +198,13 @@ class Pantry {
 
   void removeBarcode(final String barcode) {
     data.remove(barcode);
+    order.remove(barcode);
     products.remove(barcode);
   }
 
   void clear() {
     data.clear();
+    order.clear();
     products.clear();
   }
 
@@ -225,6 +238,7 @@ class Pantry {
   static const String _JSON_TAG_COLOR = 'color';
   static const String _JSON_TAG_ICON = 'icon';
   static const String _JSON_TAG_PRODUCTS = 'products';
+  static const String _JSON_TAG_ORDER = 'order';
 
   static Future<Pantry> _get(
     final String encodedJson,
@@ -236,6 +250,14 @@ class Pantry {
     final String name = decodedJsonAll[_JSON_TAG_NAME] as String;
     final String colorTag = decodedJsonAll[_JSON_TAG_COLOR] as String;
     final String iconTag = decodedJsonAll[_JSON_TAG_ICON] as String;
+    final List<String> order = <String>[];
+    final List<dynamic> tmpOrder =
+        decodedJsonAll[_JSON_TAG_ORDER] as List<dynamic>;
+    if (tmpOrder != null) {
+      for (final dynamic item in tmpOrder) {
+        order.add(item as String);
+      }
+    }
     final Map<String, dynamic> decodedJson =
         decodedJsonAll[_JSON_TAG_PRODUCTS] as Map<String, dynamic>;
     final List<String> barcodes = decodedJson.keys.toList();
@@ -260,6 +282,7 @@ class Pantry {
       data: data,
       products: products,
       name: name,
+      order: order,
       colorTag: colorTag,
       iconTag: iconTag,
     );
@@ -271,8 +294,26 @@ class Pantry {
     result[_JSON_TAG_COLOR] = pantry.colorTag;
     result[_JSON_TAG_ICON] = pantry.iconTag;
     result[_JSON_TAG_PRODUCTS] = pantry.data;
+    result[_JSON_TAG_ORDER] = pantry.order;
     final String encodedJson = json.encode(result);
     return encodedJson;
+  }
+
+  List<String> getOrderedBarcodes() {
+    if (order.isEmpty) {
+      // fix for old versions
+      order.addAll(products.keys);
+    }
+    return order;
+  }
+
+  void reorder(final int oldIndex, int newIndex) {
+    final List<String> order = getOrderedBarcodes();
+    if (oldIndex < newIndex) {
+      newIndex -= 1;
+    }
+    final String item = order.removeAt(oldIndex);
+    order.insert(newIndex, item);
   }
 
   @override


### PR DESCRIPTION
Impacted files:
* `pantry.dart`: added the notion of ordered barcodes and the related methods
* `pantry_page.dart`: used a `ReorderableListView` instead of a `ListView`
* `smooth_product_card_found.dart`: added an optional handle `Widget` at the level of the product title