### PR TITLE
bug/#297_2 - case and accent independent local database suggestion lookup

### DIFF
--- a/packages/smooth_app/lib/database/local_database.dart
+++ b/packages/smooth_app/lib/database/local_database.dart
@@ -28,7 +28,7 @@ class LocalDatabase extends ChangeNotifier {
 
     final Database database = await openDatabase(
       databasePath,
-      version: 3,
+      version: 4,
       singleInstance: true,
       onUpgrade: _onUpgrade,
     );

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   carousel_slider: ^4.0.0-nullsafety.0
   cupertino_icons: ^1.0.2
   device_preview: 0.7.1
+  diacritic: ^0.1.3
   flutter:
     sdk: flutter
   flutter_localizations:


### PR DESCRIPTION
Now works only on the product name(s), too.

Impacted classes:
* `dao_product.dart`: added table `product_extra` for accented character management
* `local_database.dart`: incremented the database version from 3 to 4
* `pubspec.yaml`: added library `diacritic` for accented characters management