### PR TITLE
feature/#216 - multi select product copy from lists + single product copy

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/product_list_preview.dart
+++ b/packages/smooth_app/lib/cards/product_cards/product_list_preview.dart
@@ -62,12 +62,8 @@ class ProductListPreview extends StatelessWidget {
                       await Navigator.push<Widget>(
                         context,
                         MaterialPageRoute<Widget>(
-                          builder: (BuildContext context) => ProductListPage(
-                            productList,
-                            reverse: ProductQueryPageHelper.isListReversed(
-                              productList,
-                            ),
-                          ),
+                          builder: (BuildContext context) =>
+                              ProductListPage(productList),
                         ),
                       );
                     },

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
@@ -1,18 +1,11 @@
-// Dart imports:
 import 'dart:ui';
-
-// Flutter imports:
 import 'package:flutter/material.dart';
-
-// Package imports:
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:openfoodfacts/model/Attribute.dart';
 import 'package:openfoodfacts/model/Product.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_ui_library/widgets/smooth_product_image.dart';
-
-// Project imports:
 import 'package:smooth_app/cards/data_cards/attribute_chip.dart';
 import 'package:smooth_app/pages/product/product_page.dart';
 import 'package:smooth_app/data_models/product_preferences.dart';
@@ -25,6 +18,7 @@ class SmoothProductCardFound extends StatelessWidget {
     this.useNewStyle = true,
     this.backgroundColor,
     this.handle,
+    this.onLongPress,
   });
 
   final Product product;
@@ -33,6 +27,7 @@ class SmoothProductCardFound extends StatelessWidget {
   final bool useNewStyle;
   final Color backgroundColor;
   final Widget handle;
+  final Function onLongPress;
 
   @override
   Widget build(BuildContext context) {
@@ -58,17 +53,13 @@ class SmoothProductCardFound extends StatelessWidget {
       scores.add(AttributeChip(attribute, height: iconSize));
     }
     return GestureDetector(
-      onTap: () {
-        //_openSneakPeek(context);
-        Navigator.push<Widget>(
-          context,
-          MaterialPageRoute<Widget>(
-              builder: (BuildContext context) => ProductPage(
-                    product: product,
-                  )),
-        );
-      },
-      onLongPress: () => ProductPage.showLists(product, context),
+      onTap: () => Navigator.push<Widget>(
+        context,
+        MaterialPageRoute<Widget>(
+          builder: (BuildContext context) => ProductPage(product: product),
+        ),
+      ),
+      onLongPress: () => onLongPress == null ? null : onLongPress(),
       child: Hero(
         tag: heroTag,
         child: Material(

--- a/packages/smooth_app/lib/data_models/product_list.dart
+++ b/packages/smooth_app/lib/data_models/product_list.dart
@@ -220,16 +220,10 @@ class ProductList {
     return result;
   }
 
-  List<Product> getUniqueList({final bool ascending = true}) {
+  List<Product> getUniqueList() {
     final List<Product> result = <Product>[];
-    final Set<String> done = <String>{};
-    final Iterable<String> orderedBarcodes =
-        ascending ? _barcodes : _barcodes.reversed;
+    final List<String> orderedBarcodes = getOrderedBarcodes();
     for (final String barcode in orderedBarcodes) {
-      if (done.contains(barcode)) {
-        continue;
-      }
-      done.add(barcode);
       final Product product = _products[barcode];
       if (product == null) {
         throw Exception('no product for barcode $barcode');
@@ -238,4 +232,21 @@ class ProductList {
     }
     return result;
   }
+
+  List<String> getOrderedBarcodes() {
+    final List<String> result = <String>[];
+    final Iterable<String> iterable =
+        _isReversed ? barcodes.reversed : barcodes;
+    for (final String barcode in iterable) {
+      if (result.contains(barcode)) {
+        continue;
+      }
+      result.add(barcode);
+    }
+    return result;
+  }
+
+  bool get _isReversed =>
+      listType == ProductList.LIST_TYPE_HISTORY ||
+      listType == ProductList.LIST_TYPE_SCAN;
 }

--- a/packages/smooth_app/lib/data_models/user_preferences.dart
+++ b/packages/smooth_app/lib/data_models/user_preferences.dart
@@ -29,7 +29,6 @@ class UserPreferences extends ChangeNotifier {
   static const String _TAG_SHOPPING_REPOSITORY = 'shopping_repository';
   static const String _TAG_VISIBLE_GROUPS = 'visible_groups';
   static const String _TAG_INIT = 'init';
-  static const String _TAG_PRODUCT_LIST_COPY = 'productListCopy';
   static const String _TAG_THEME_DARK = 'themeDark';
   static const String _TAG_THEME_COLOR_TAG = 'themeColorTag';
 
@@ -94,13 +93,6 @@ class UserPreferences extends ChangeNotifier {
     await _sharedPreferences.setStringList(_TAG_VISIBLE_GROUPS, visibleList);
     notifyListeners();
   }
-
-  String getProductListCopy() =>
-      _sharedPreferences.getString(_TAG_PRODUCT_LIST_COPY);
-
-  Future<void> setProductListCopy(final String productListLousyKey) async =>
-      await _sharedPreferences.setString(
-          _TAG_PRODUCT_LIST_COPY, productListLousyKey);
 
   Future<void> setPantryRepository(
     final List<String> encodedJsons,

--- a/packages/smooth_app/lib/pages/home_page.dart
+++ b/packages/smooth_app/lib/pages/home_page.dart
@@ -262,6 +262,9 @@ class _HomePageState extends State<HomePage> {
                       overflow: TextOverflow.fade,
                     ),
                   ),
+                  style: ElevatedButton.styleFrom(
+                    shape: ProductListButton.getShape(),
+                  ),
                   onPressed: () async {
                     final ProductList newProductList =
                         await ProductListDialogHelper.openNew(
@@ -460,6 +463,9 @@ class _HomePageState extends State<HomePage> {
                     PantryListPage.getCreateListLabel(pantryType, context),
                     overflow: TextOverflow.fade,
                   ),
+                ),
+                style: ElevatedButton.styleFrom(
+                  shape: PantryButton.getShape(pantryType),
                 ),
                 onPressed: () async {
                   final String newPantryName = await PantryDialogHelper.openNew(

--- a/packages/smooth_app/lib/pages/multi_select_product_page.dart
+++ b/packages/smooth_app/lib/pages/multi_select_product_page.dart
@@ -1,0 +1,245 @@
+import 'package:flutter/material.dart';
+import 'package:openfoodfacts/model/Product.dart';
+import 'package:provider/provider.dart';
+import 'package:smooth_app/pages/product_copy_helper.dart';
+import 'package:smooth_ui_library/widgets/smooth_product_image.dart';
+import 'package:smooth_app/data_models/pantry.dart';
+import 'package:smooth_app/database/dao_product.dart';
+import 'package:smooth_app/database/dao_product_list.dart';
+import 'package:smooth_app/database/local_database.dart';
+import 'package:smooth_app/data_models/product_list.dart';
+import 'package:smooth_app/data_models/user_preferences.dart';
+import 'package:smooth_app/themes/smooth_theme.dart';
+
+/// Page where products can be selected for copy or removal
+///
+/// The list of products come from
+/// a pantry, a shopping list or a product list.
+class MultiSelectProductPage extends StatefulWidget {
+  const MultiSelectProductPage.pantry({
+    @required this.barcode,
+    @required this.pantries,
+    this.index,
+    this.pantryType,
+  }) : productList = null;
+
+  const MultiSelectProductPage.productList({
+    @required this.barcode,
+    this.productList,
+  })  : pantries = null,
+        pantryType = null,
+        index = null;
+
+  /// Initial selected barcode
+  final String barcode;
+
+  final List<Pantry> pantries;
+  final int index;
+  final PantryType pantryType;
+  Pantry get pantry => pantries == null ? null : pantries[index];
+
+  final ProductList productList;
+
+  @override
+  _MultiSelectProductPageState createState() => _MultiSelectProductPageState();
+}
+
+class _MultiSelectProductPageState extends State<MultiSelectProductPage> {
+  final Set<String> _selectedBarcodes = <String>{};
+  List<String> _orderedBarcodes; // late final
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedBarcodes.add(widget.barcode);
+    if (widget.productList != null) {
+      _orderedBarcodes = widget.productList.getOrderedBarcodes();
+    } else {
+      _orderedBarcodes = widget.pantry.getOrderedBarcodes();
+    }
+  }
+
+  void _removeBarcode(final String barcode) => widget.productList != null
+      ? widget.productList.barcodes.remove(barcode)
+      : widget.pantry.removeBarcode(barcode);
+
+  Product _getProduct(final String barcode) => widget.productList != null
+      ? widget.productList.getProduct(barcode)
+      : widget.pantry.products[barcode];
+
+  Future<void> _commit(
+    final UserPreferences userPreferences,
+    final DaoProductList daoProductList,
+  ) async =>
+      widget.productList != null
+          ? await daoProductList.put(widget.productList)
+          : await Pantry.putAll(
+              userPreferences,
+              widget.pantries,
+              widget.pantryType,
+            );
+
+  @override
+  Widget build(BuildContext context) {
+    final LocalDatabase localDatabase = context.watch<LocalDatabase>();
+    final UserPreferences userPreferences = context.watch<UserPreferences>();
+    final DaoProductList daoProductList = DaoProductList(localDatabase);
+    final DaoProduct daoProduct = DaoProduct(localDatabase);
+    final ColorScheme colorScheme = Theme.of(context).colorScheme;
+    final ThemeData themeData = Theme.of(context);
+    final Size screenSize = MediaQuery.of(context).size;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('${_selectedBarcodes.length} selected'),
+        actions: <Widget>[
+          IconButton(
+            icon: const Icon(Icons.select_all),
+            onPressed: () => setState(
+              () => _selectedBarcodes.length == _orderedBarcodes.length
+                  ? _selectedBarcodes.clear()
+                  : _selectedBarcodes.addAll(_orderedBarcodes),
+            ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.copy),
+            onPressed: () async {
+              final List<String> barcodes = _getSelectedBarcodes();
+              if (barcodes.isEmpty) {
+                // nothing selected
+                return;
+              }
+              final List<PantryType> pantryTypes = <PantryType>[
+                PantryType.PANTRY,
+                PantryType.SHOPPING,
+              ];
+              final Map<PantryType, List<Pantry>> allPantries =
+                  <PantryType, List<Pantry>>{};
+              for (final PantryType pantryType in pantryTypes) {
+                final List<Pantry> pantries = await Pantry.getAll(
+                  userPreferences,
+                  daoProduct,
+                  pantryType,
+                );
+                allPantries[pantryType] = pantries;
+              }
+              final ProductCopyHelper productCopyHelper = ProductCopyHelper();
+              final List<Widget> children = await productCopyHelper.getButtons(
+                context: context,
+                daoProductList: daoProductList,
+                daoProduct: daoProduct,
+                allPantries: allPantries,
+                ignoredProductList: widget.productList,
+                ignoredPantry: widget.pantry,
+              );
+              if (children.isEmpty) {
+                // no list to add to
+                return;
+              }
+              final dynamic target = await showModalBottomSheet<dynamic>(
+                context: context,
+                builder: (final BuildContext context) => Column(
+                  children: <Widget>[
+                    const Text('Select the destination:'),
+                    Wrap(
+                      direction: Axis.horizontal,
+                      children: children,
+                      spacing: 8.0,
+                    ),
+                  ],
+                ),
+              );
+              if (target == null) {
+                // nothing selected
+                return;
+              }
+              final List<Product> products = <Product>[];
+              for (final String barcode in barcodes) {
+                products.add(_getProduct(barcode));
+              }
+              productCopyHelper.copy(
+                context: context,
+                target: target,
+                allPantries: allPantries,
+                daoProductList: daoProductList,
+                products: products,
+                userPreferences: userPreferences,
+              );
+            },
+          ),
+          IconButton(
+            icon: const Icon(Icons.delete),
+            onPressed: () {
+              if (_selectedBarcodes.isEmpty) {
+                return;
+              }
+              _selectedBarcodes.forEach(_removeBarcode);
+              _commit(userPreferences, daoProductList);
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text('${_selectedBarcodes.length} products removed'),
+                  duration: const Duration(seconds: 3),
+                ),
+              );
+              setState(() => _selectedBarcodes.clear());
+            },
+          ),
+        ],
+      ),
+      body: ListView.builder(
+        itemCount: _orderedBarcodes.length,
+        itemBuilder: (BuildContext context, int index) {
+          final Product product = _getProduct(_orderedBarcodes[index]);
+          final String barcode = product.barcode;
+          final bool selected = _selectedBarcodes.contains(barcode);
+          return Card(
+            color: SmoothTheme.getColor(
+              colorScheme,
+              Colors.grey,
+              ColorDestination.SURFACE_BACKGROUND,
+            ),
+            child: Container(
+              height: screenSize.height / 10,
+              child: ListTile(
+                onTap: () => setState(
+                  () => selected
+                      ? _selectedBarcodes.remove(barcode)
+                      : _selectedBarcodes.add(barcode),
+                ),
+                leading: SmoothProductImage(
+                  product: product,
+                  width: screenSize.height / 10,
+                  height: screenSize.height / 10,
+                ),
+                title: Text(
+                  product.productName ??
+                      product.productNameEN ??
+                      product.productNameFR ??
+                      product.productNameDE ??
+                      product.barcode,
+                  style: themeData.textTheme.headline4,
+                ),
+                trailing: Icon(
+                  _selectedBarcodes.contains(product.barcode)
+                      ? Icons.check_box
+                      : Icons.check_box_outline_blank,
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  List<String> _getSelectedBarcodes() {
+    final List<String> result = <String>[];
+    if (_selectedBarcodes.isNotEmpty) {
+      for (final String barcode in _orderedBarcodes) {
+        if (_selectedBarcodes.contains(barcode)) {
+          result.add(barcode);
+        }
+      }
+    }
+    return result;
+  }
+}

--- a/packages/smooth_app/lib/pages/multi_select_product_page.dart
+++ b/packages/smooth_app/lib/pages/multi_select_product_page.dart
@@ -59,9 +59,14 @@ class _MultiSelectProductPageState extends State<MultiSelectProductPage> {
     }
   }
 
-  void _removeBarcode(final String barcode) => widget.productList != null
-      ? widget.productList.barcodes.remove(barcode)
-      : widget.pantry.removeBarcode(barcode);
+  void _removeBarcode(final String barcode) {
+    _orderedBarcodes.remove(barcode);
+    if (widget.productList != null) {
+      widget.productList.barcodes.remove(barcode);
+    } else {
+      widget.pantry.removeBarcode(barcode);
+    }
+  }
 
   Product _getProduct(final String barcode) => widget.productList != null
       ? widget.productList.getProduct(barcode)

--- a/packages/smooth_app/lib/pages/pantry/common/pantry_button.dart
+++ b/packages/smooth_app/lib/pages/pantry/common/pantry_button.dart
@@ -1,26 +1,19 @@
-// Flutter imports:
 import 'package:flutter/material.dart';
-
-// Project imports:
 import 'package:smooth_app/data_models/pantry.dart';
 import 'package:smooth_app/pages/pantry/pantry_page.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
 
 /// A button for a pantry, with the corresponding color, icon, name and shape
 class PantryButton extends StatelessWidget {
-  const PantryButton(this.pantries, this.index, {this.shape});
+  const PantryButton(
+    this.pantries,
+    this.index, {
+    this.onPressed,
+  });
 
   final List<Pantry> pantries;
   final int index;
-  final OutlinedBorder shape;
-
-  static OutlinedBorder getShapeBeveled() => const BeveledRectangleBorder(
-        borderRadius: BorderRadius.horizontal(
-            left: Radius.circular(16.0), right: Radius.circular(16.0)),
-      );
-  static OutlinedBorder getShapeRounded() => RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(32.0),
-      );
+  final Function onPressed;
 
   @override
   Widget build(BuildContext context) => ElevatedButton.icon(
@@ -37,6 +30,10 @@ class PantryButton extends StatelessWidget {
           ),
         ),
         onPressed: () async {
+          if (onPressed != null) {
+            await onPressed();
+            return;
+          }
           await Navigator.push<Widget>(
             context,
             MaterialPageRoute<Widget>(
@@ -54,9 +51,17 @@ class PantryButton extends StatelessWidget {
             pantries[index].materialColor,
             ColorDestination.BUTTON_BACKGROUND,
           ),
-          shape: pantries[index].pantryType == PantryType.PANTRY
-              ? null
-              : getShapeBeveled(),
+          shape: getShape(pantries[index].pantryType),
         ),
       );
+
+  static OutlinedBorder getShape(final PantryType pantryType) =>
+      pantryType == PantryType.PANTRY
+          ? null
+          : const BeveledRectangleBorder(
+              borderRadius: BorderRadius.horizontal(
+                left: Radius.circular(16.0),
+                right: Radius.circular(16.0),
+              ),
+            );
 }

--- a/packages/smooth_app/lib/pages/pantry/pantry_page.dart
+++ b/packages/smooth_app/lib/pages/pantry/pantry_page.dart
@@ -1,20 +1,15 @@
-// Flutter imports:
 import 'package:flutter/material.dart';
-
-// Package imports:
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/model/Product.dart';
 import 'package:provider/provider.dart';
-
-// Project imports:
 import 'package:smooth_app/cards/product_cards/smooth_product_card_found.dart';
 import 'package:smooth_app/data_models/pantry.dart';
 import 'package:smooth_app/database/dao_product.dart';
-import 'package:smooth_app/database/dao_product_list.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/pages/pantry/common/pantry_dialog_helper.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/pages/text_search_widget.dart';
+import 'package:smooth_app/pages/multi_select_product_page.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
 
 /// A page for one pantry where we can change all the data
@@ -36,7 +31,6 @@ class PantryPage extends StatelessWidget {
     final LocalDatabase localDatabase = context.watch<LocalDatabase>();
     final UserPreferences userPreferences = context.watch<UserPreferences>();
     final DaoProduct daoProduct = DaoProduct(localDatabase);
-    final DaoProductList daoProductList = DaoProductList(localDatabase);
     final ColorScheme colorScheme = Theme.of(context).colorScheme;
     const TextStyle textStyle = TextStyle(fontSize: 16);
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
@@ -46,37 +40,6 @@ class PantryPage extends StatelessWidget {
     final Pantry pantry = pantries[index];
     final List<String> orderedBarcodes = pantry.getOrderedBarcodes();
     return Scaffold(
-      bottomNavigationBar: Builder(
-        builder: (BuildContext context) => BottomNavigationBar(
-          type: BottomNavigationBarType.fixed,
-          items: <BottomNavigationBarItem>[
-            BottomNavigationBarItem(
-                icon: const Icon(Icons.paste), label: appLocalizations.paste),
-            BottomNavigationBarItem(
-                icon: const Icon(Icons.highlight_remove),
-                label: appLocalizations.clear),
-            BottomNavigationBarItem(
-                icon: const Icon(Icons.local_grocery_store),
-                label: appLocalizations.grocery),
-          ],
-          onTap: (final int index) async {
-            if (index == 0) {
-              final List<String> barcodes = await daoProductList
-                  .getBarcodes(userPreferences.getProductListCopy());
-              final Map<String, Product> products =
-                  await daoProduct.getAll(barcodes);
-              pantry.addAll(barcodes, products);
-              await _save(userPreferences);
-              return;
-            }
-            if (index == 1) {
-              pantry.clear();
-              await _save(userPreferences);
-              return;
-            }
-          },
-        ),
-      ),
       appBar: AppBar(
         backgroundColor: SmoothTheme.getColor(
           colorScheme,
@@ -191,6 +154,18 @@ class PantryPage extends StatelessWidget {
                 index: index,
                 child: const Icon(Icons.drag_handle),
               ),
+              onLongPress: () => Navigator.push<Widget>(
+                context,
+                MaterialPageRoute<Widget>(
+                  builder: (BuildContext context) =>
+                      MultiSelectProductPage.pantry(
+                    barcode: product.barcode,
+                    pantries: pantries,
+                    index: this.index,
+                    pantryType: pantryType,
+                  ),
+                ),
+              ),
             ),
             const Divider(
               color: Colors.grey,
@@ -219,17 +194,25 @@ class PantryPage extends StatelessWidget {
               context: context,
             );
           }
-          return Padding(
-            key: ValueKey<String>(product.barcode),
-            padding:
-                const EdgeInsets.symmetric(horizontal: 12.0, vertical: 8.0),
-            child: Card(
-              color: SmoothTheme.getColor(
-                colorScheme,
-                Colors.grey,
-                ColorDestination.SURFACE_BACKGROUND,
+          return Dismissible(
+            background: Container(color: colorScheme.background),
+            key: Key(barcode),
+            onDismissed: (final DismissDirection direction) async {
+              pantry.removeBarcode(barcode);
+              await _save(userPreferences);
+            },
+            child: Padding(
+              key: ValueKey<String>(product.barcode),
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 12.0, vertical: 8.0),
+              child: Card(
+                color: SmoothTheme.getColor(
+                  colorScheme,
+                  Colors.grey,
+                  ColorDestination.SURFACE_BACKGROUND,
+                ),
+                child: Column(children: children),
               ),
-              child: Column(children: children),
             ),
           );
         },
@@ -360,17 +343,6 @@ class PantryPage extends StatelessWidget {
                   noDateButton,
                 ],
               ),
-        trailing: Container(
-          width: 60,
-          child: sortedDays.isNotEmpty
-              ? null
-              : _getDeleteButton(
-                  pantry,
-                  barcode,
-                  userPreferences,
-                  colorScheme,
-                ),
-        ),
       ),
     );
   }
@@ -408,28 +380,7 @@ class PantryPage extends StatelessWidget {
                 ),
               ],
             ),
-            if (count == 0)
-              _getDeleteButton(
-                pantry,
-                barcode,
-                userPreferences,
-                colorScheme,
-              ),
           ],
         ),
-      );
-
-  Widget _getDeleteButton(
-    final Pantry pantry,
-    final String barcode,
-    final UserPreferences userPreferences,
-    final ColorScheme colorScheme,
-  ) =>
-      IconButton(
-        onPressed: () async {
-          pantry.removeBarcode(barcode);
-          await _save(userPreferences);
-        },
-        icon: Icon(Icons.delete, color: colorScheme.error),
       );
 }

--- a/packages/smooth_app/lib/pages/pantry/pantry_page.dart
+++ b/packages/smooth_app/lib/pages/pantry/pantry_page.dart
@@ -11,6 +11,7 @@ import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/pages/text_search_widget.dart';
 import 'package:smooth_app/pages/multi_select_product_page.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
+import 'package:smooth_ui_library/widgets/smooth_card.dart';
 
 /// A page for one pantry where we can change all the data
 class PantryPage extends StatelessWidget {
@@ -205,7 +206,7 @@ class PantryPage extends StatelessWidget {
               key: ValueKey<String>(product.barcode),
               padding:
                   const EdgeInsets.symmetric(horizontal: 12.0, vertical: 8.0),
-              child: Card(
+              child: SmoothCard(
                 color: SmoothTheme.getColor(
                   colorScheme,
                   Colors.grey,

--- a/packages/smooth_app/lib/pages/product/common/product_list_button.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_button.dart
@@ -9,10 +9,15 @@ import 'package:smooth_app/pages/product/common/product_query_page_helper.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
 
 class ProductListButton extends StatelessWidget {
-  const ProductListButton(this.productList, this.daoProductList);
+  const ProductListButton(
+    this.productList,
+    this.daoProductList, {
+    this.onPressed,
+  });
 
   final ProductList productList;
   final DaoProductList daoProductList;
+  final Function onPressed;
 
   @override
   Widget build(BuildContext context) {
@@ -37,6 +42,10 @@ class ProductListButton extends StatelessWidget {
         ),
       ),
       onPressed: () async {
+        if (onPressed != null) {
+          await onPressed();
+          return;
+        }
         await daoProductList.get(productList);
         await Navigator.push<Widget>(
           context,
@@ -52,10 +61,12 @@ class ProductListButton extends StatelessWidget {
           productList.getMaterialColor(),
           ColorDestination.BUTTON_BACKGROUND,
         ),
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(32.0),
-        ),
+        shape: getShape(),
       ),
     );
   }
+
+  static OutlinedBorder getShape() => RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(32.0),
+      );
 }

--- a/packages/smooth_app/lib/pages/product/common/product_list_dialog_helper.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_dialog_helper.dart
@@ -1,16 +1,10 @@
-// Flutter imports:
 import 'package:flutter/material.dart';
-
-// Package imports:
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:smooth_ui_library/buttons/smooth_simple_button.dart';
 import 'package:smooth_ui_library/dialogs/smooth_alert_dialog.dart';
-
-// Project imports:
 import 'package:smooth_app/data_models/product_list.dart';
 import 'package:smooth_app/database/dao_product_list.dart';
 import 'package:smooth_app/pages/product/common/product_list_page.dart';
-import 'package:smooth_app/pages/product/common/product_query_page_helper.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
 
 class ProductListDialogHelper {
@@ -107,12 +101,8 @@ class ProductListDialogHelper {
               await Navigator.push<Widget>(
                 context,
                 MaterialPageRoute<Widget>(
-                  builder: (BuildContext context) => ProductListPage(
-                    newProductList,
-                    reverse: ProductQueryPageHelper.isListReversed(
-                      newProductList,
-                    ),
-                  ),
+                  builder: (BuildContext context) =>
+                      ProductListPage(newProductList),
                 ),
               );
             },

--- a/packages/smooth_app/lib/pages/product/common/product_query_page_helper.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_query_page_helper.dart
@@ -83,10 +83,6 @@ class ProductQueryPageHelper {
     return getDurationStringFromSeconds(seconds, AppLocalizations.of(context));
   }
 
-  static bool isListReversed(final ProductList productList) =>
-      productList.listType == ProductList.LIST_TYPE_HISTORY ||
-      productList.listType == ProductList.LIST_TYPE_SCAN;
-
   static String getProductListLabel(
       final ProductList productList, final BuildContext context,
       {final bool verbose = true}) {

--- a/packages/smooth_app/lib/pages/product_copy_helper.dart
+++ b/packages/smooth_app/lib/pages/product_copy_helper.dart
@@ -1,0 +1,172 @@
+import 'package:flutter/material.dart';
+import 'package:openfoodfacts/model/Product.dart';
+import 'package:smooth_app/pages/pantry/common/pantry_button.dart';
+import 'package:smooth_app/pages/pantry/pantry_page.dart';
+import 'package:smooth_app/pages/product/common/product_list_button.dart';
+import 'package:smooth_app/pages/product/common/product_list_page.dart';
+import 'package:smooth_app/data_models/pantry.dart';
+import 'package:smooth_app/database/dao_product.dart';
+import 'package:smooth_app/database/dao_product_list.dart';
+import 'package:smooth_app/data_models/product_list.dart';
+import 'package:smooth_app/data_models/user_preferences.dart';
+
+/// Helper for product copy as multi selected
+class ProductCopyHelper {
+  Future<List<Widget>> getButtons({
+    @required final BuildContext context,
+    @required final DaoProductList daoProductList,
+    @required final DaoProduct daoProduct,
+    @required final Map<PantryType, List<Pantry>> allPantries,
+    final ProductList ignoredProductList,
+    final Pantry ignoredPantry,
+  }) async {
+    final List<Widget> children = <Widget>[];
+    final List<ProductList> productLists = await daoProductList.getAll(
+      typeFilter: <String>[ProductList.LIST_TYPE_USER_DEFINED],
+    );
+    for (final ProductList productList in productLists) {
+      if (ignoredProductList != null &&
+          productList.parameters == ignoredProductList.parameters) {
+        // skipped, it's the same product list
+      } else {
+        children.add(
+          ProductListButton(
+            productList,
+            daoProductList,
+            onPressed: () => Navigator.pop<ProductList>(context, productList),
+          ),
+        );
+      }
+    }
+    // TODO(monsieurtanuki): add "add product list / pantry / shopping list" buttons
+    final List<PantryType> pantryTypes = <PantryType>[
+      PantryType.PANTRY,
+      PantryType.SHOPPING,
+    ];
+    for (final PantryType pantryType in pantryTypes) {
+      final List<Pantry> pantries = allPantries[pantryType];
+      int index = 0;
+      for (final Pantry pantry in pantries) {
+        if (ignoredPantry != null &&
+            ignoredPantry.name == pantry.name &&
+            ignoredPantry.pantryType == pantry.pantryType) {
+          // skip
+        } else {
+          children.add(
+            PantryButton(
+              pantries,
+              index,
+              onPressed: () => Navigator.pop<Pantry>(context, pantry),
+            ),
+          );
+        }
+        index++;
+      }
+    }
+    return children;
+  }
+
+  Future<void> copy({
+    @required final BuildContext context,
+    @required dynamic target,
+    @required final Map<PantryType, List<Pantry>> allPantries,
+    @required final DaoProductList daoProductList,
+    @required final List<Product> products,
+    @required final UserPreferences userPreferences,
+  }) async {
+    int count; // late
+    Widget Function(BuildContext) go; // late
+    if (target is ProductList) {
+      count = await _addToProductList(
+        daoProductList,
+        target,
+        products,
+      );
+      go = (BuildContext context) => ProductListPage(target);
+    } else if (target is Pantry) {
+      final List<Pantry> pantries = allPantries[target.pantryType];
+      int index = 0;
+      for (final Pantry pantry in pantries) {
+        if (pantry.name == target.name) {
+          final int value = index;
+          count = await _addToPantry(
+            pantries,
+            value,
+            target.pantryType,
+            products,
+            userPreferences,
+          );
+          go = (BuildContext context) => PantryPage(
+                pantries,
+                value,
+                target.pantryType,
+              );
+        }
+        index++;
+      }
+    } else {
+      throw Exception('unknown type $target');
+    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text('$count products actually added'),
+        duration: const Duration(seconds: 5),
+        action: SnackBarAction(
+          label: 'GO',
+          onPressed: () {
+            Navigator.pop(context);
+            Navigator.push<Widget>(
+              context,
+              MaterialPageRoute<Widget>(builder: go),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  Future<int> _addToProductList(
+    final DaoProductList daoProductList,
+    final ProductList target,
+    final List<Product> products,
+  ) async {
+    await daoProductList.get(target);
+    int count = 0;
+    for (final Product product in products) {
+      if (target.barcodes.contains(product.barcode)) {
+        // do nothing?
+      } else {
+        target.add(product);
+        count++;
+      }
+    }
+    if (count > 0) {
+      await daoProductList.put(target);
+    }
+    return count;
+  }
+
+  Future<int> _addToPantry(
+    final List<Pantry> pantries,
+    final int index,
+    final PantryType pantryType,
+    final List<Product> products,
+    final UserPreferences userPreferences,
+  ) async {
+    int count = 0;
+    final Pantry pantry = pantries[index];
+    final List<String> currentBarcodes = pantry.getOrderedBarcodes();
+    for (final Product product in products) {
+      if (currentBarcodes.contains(product.barcode)) {
+        // do nothing?
+      } else {
+        pantry.add(product);
+        count++;
+      }
+    }
+    if (count > 0) {
+      await Pantry.putAll(userPreferences, pantries, pantryType);
+    }
+    return count;
+  }
+}


### PR DESCRIPTION
New files:
* `multi_select_product_page.dart`: Page where products can be selected for copy or removal
* `product_copy_helper.dart`: Helper for product copy as multi selected

Impacted files:
* `home_page.dart`: minor refactoring
* `pantry_button.dart`: added optional `onPressed` constructor parameter
* `pantry_page.dart`: removed bottom navigation bar; long press on a product opens new multi select product page; products are now dismissible
* `product_list.dart`: added method `getOrderedBarcodes`
* `product_list_button.dart`: added optional `onPressed` constructor parameter
* `product_list_dialog_helper.dart`: simplified call to `ProductListPage`
* `product_list_page.dart`: simplified constructor parameters; removed bottom navigation bar; long press on a product opens new multi select product page; products are now always dismissible
* `product_list_preview.dart`: simplified call to `ProductListPage`
* `product_page.dart`: replaced a clumsy "list" button with a "copy" button
* `product_query_page_helper.dart`: minor refactoring
* `smooth_product_card_found.dart`: added optional `onPressed` constructor parameter
* `user_preferences.dart`: removed the "to-be-pasted products" list