### PR TITLE
feature/#216_2 - "new pantry/product list" buttons visible at product copy time

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/pantry_preview.dart
+++ b/packages/smooth_app/lib/cards/product_cards/pantry_preview.dart
@@ -46,9 +46,8 @@ class PantryPreview extends StatelessWidget {
               context,
               MaterialPageRoute<Widget>(
                 builder: (BuildContext context) => PantryPage(
-                  pantries,
-                  index,
-                  pantries[index].pantryType,
+                  pantries: pantries,
+                  pantry: pantries[index],
                 ),
               ),
             ),

--- a/packages/smooth_app/lib/data_models/pantry.dart
+++ b/packages/smooth_app/lib/data_models/pantry.dart
@@ -28,11 +28,20 @@ class Pantry {
     @required this.name,
     @required this.pantryType,
     @required this.order,
-    this.data = const <String, Map<String, int>>{},
-    this.products = const <String, Product>{},
-    this.iconTag = '',
-    this.colorTag = _COLOR_DEFAULT,
+    @required this.data,
+    @required this.products,
+    @required this.iconTag,
+    @required this.colorTag,
   });
+
+  Pantry.empty({
+    @required this.name,
+    @required this.pantryType,
+  })  : order = <String>[],
+        data = <String, Map<String, int>>{},
+        products = <String, Product>{},
+        iconTag = '',
+        colorTag = _COLOR_DEFAULT;
 
   String name;
   String colorTag;

--- a/packages/smooth_app/lib/pages/list_page.dart
+++ b/packages/smooth_app/lib/pages/list_page.dart
@@ -1,22 +1,17 @@
-// Flutter imports:
 import 'package:flutter/material.dart';
-
-// Package imports:
 import 'package:provider/provider.dart';
-import 'package:smooth_ui_library/widgets/smooth_card.dart';
-
-// Project imports:
 import 'package:smooth_app/cards/product_cards/product_list_preview.dart';
 import 'package:smooth_app/data_models/product_list.dart';
 import 'package:smooth_app/database/dao_product_list.dart';
 import 'package:smooth_app/database/local_database.dart';
+import 'package:smooth_app/pages/product/common/product_list_page.dart';
+import 'package:smooth_app/pages/product/common/product_list_button.dart';
 import 'package:smooth_app/pages/product/common/product_list_dialog_helper.dart';
-import 'package:smooth_app/themes/smooth_theme.dart';
 
 class ListPage extends StatefulWidget {
   const ListPage({
-    this.title,
-    this.typeFilter,
+    @required this.title,
+    @required this.typeFilter,
   });
 
   final String title;
@@ -24,8 +19,6 @@ class ListPage extends StatefulWidget {
 
   @override
   _ListPageState createState() => _ListPageState();
-
-  static String getCreateListLabel() => 'Create a food list';
 }
 
 class _ListPageState extends State<ListPage> {
@@ -35,9 +28,6 @@ class _ListPageState extends State<ListPage> {
   Widget build(BuildContext context) {
     final LocalDatabase localDatabase = context.watch<LocalDatabase>();
     final DaoProductList daoProductList = DaoProductList(localDatabase);
-    final Size screenSize = MediaQuery.of(context).size;
-    final ThemeData themeData = Theme.of(context);
-    final double iconSize = screenSize.width / 10;
     final bool mayAddList =
         widget.typeFilter.contains(ProductList.LIST_TYPE_USER_DEFINED);
     return Scaffold(
@@ -63,10 +53,8 @@ class _ListPageState extends State<ListPage> {
                 if (_list.isEmpty) {
                   if (mayAddList) {
                     return Center(
-                      child: _addButtonWhenEmpty(
-                        iconSize,
-                        themeData,
-                        daoProductList,
+                      child: ProductListButton.add(
+                        onPressed: () async => await _add(daoProductList),
                       ),
                     );
                   }
@@ -99,27 +87,12 @@ class _ListPageState extends State<ListPage> {
     if (newProductList == null) {
       return;
     }
+    await Navigator.push<Widget>(
+      context,
+      MaterialPageRoute<Widget>(
+        builder: (BuildContext context) => ProductListPage(newProductList),
+      ),
+    );
     setState(() {});
   }
-
-  Widget _addButtonWhenEmpty(
-    final double iconSize,
-    final ThemeData themeData,
-    final DaoProductList daoProductList,
-  ) =>
-      SmoothCard(
-        color: SmoothTheme.getColor(
-          themeData.colorScheme,
-          Colors.blue,
-          ColorDestination.SURFACE_BACKGROUND,
-        ),
-        child: ListTile(
-          leading: Icon(Icons.add, size: iconSize),
-          onTap: () async => await _add(daoProductList),
-          title: Text(
-            ListPage.getCreateListLabel(),
-            style: themeData.textTheme.headline3,
-          ),
-        ),
-      );
 }

--- a/packages/smooth_app/lib/pages/multi_select_product_page.dart
+++ b/packages/smooth_app/lib/pages/multi_select_product_page.dart
@@ -133,6 +133,7 @@ class _MultiSelectProductPageState extends State<MultiSelectProductPage> {
                 daoProductList: daoProductList,
                 daoProduct: daoProduct,
                 allPantries: allPantries,
+                userPreferences: userPreferences,
                 ignoredProductList: widget.productList,
                 ignoredPantry: widget.pantry,
               );

--- a/packages/smooth_app/lib/pages/pantry/common/pantry_button.dart
+++ b/packages/smooth_app/lib/pages/pantry/common/pantry_button.dart
@@ -1,67 +1,101 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:smooth_app/data_models/pantry.dart';
-import 'package:smooth_app/pages/pantry/pantry_page.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
 
 /// A button for a pantry, with the corresponding color, icon, name and shape
 class PantryButton extends StatelessWidget {
-  const PantryButton(
-    this.pantries,
-    this.index, {
-    this.onPressed,
-  });
+  PantryButton({
+    @required this.pantries,
+    @required this.index,
+    @required this.onPressed,
+  }) : pantryType = pantries[index].pantryType;
+
+  const PantryButton.add({
+    @required this.pantries,
+    @required this.pantryType,
+    @required this.onPressed,
+  }) : index = null;
 
   final List<Pantry> pantries;
   final int index;
   final Function onPressed;
+  final PantryType pantryType;
 
   @override
-  Widget build(BuildContext context) => ElevatedButton.icon(
-        icon: pantries[index].getIcon(
-            Theme.of(context).colorScheme, ColorDestination.BUTTON_FOREGROUND),
-        label: Text(
-          pantries[index].name,
-          style: TextStyle(
-            color: SmoothTheme.getColor(
-              Theme.of(context).colorScheme,
-              pantries[index].materialColor,
-              ColorDestination.BUTTON_FOREGROUND,
-            ),
+  Widget build(BuildContext context) {
+    if (index == null) {
+      return _build(
+        const Icon(Icons.add),
+        Flexible(
+          child: Text(
+            _getCreateListLabel(AppLocalizations.of(context)),
+            overflow: TextOverflow.fade,
           ),
         ),
-        onPressed: () async {
-          if (onPressed != null) {
-            await onPressed();
-            return;
-          }
-          await Navigator.push<Widget>(
-            context,
-            MaterialPageRoute<Widget>(
-              builder: (BuildContext context) => PantryPage(
-                pantries,
-                index,
-                pantries[index].pantryType,
-              ),
-            ),
-          );
-        },
-        style: ElevatedButton.styleFrom(
-          primary: SmoothTheme.getColor(
-            Theme.of(context).colorScheme,
-            pantries[index].materialColor,
-            ColorDestination.BUTTON_BACKGROUND,
+        null,
+      );
+    }
+    final ColorScheme colorScheme = Theme.of(context).colorScheme;
+    final Pantry pantry = pantries[index];
+    final MaterialColor materialColor = pantry.materialColor;
+    return _build(
+      pantry.getIcon(colorScheme, ColorDestination.BUTTON_FOREGROUND),
+      Text(
+        pantry.name,
+        style: TextStyle(
+          color: SmoothTheme.getColor(
+            colorScheme,
+            materialColor,
+            ColorDestination.BUTTON_FOREGROUND,
           ),
-          shape: getShape(pantries[index].pantryType),
+        ),
+      ),
+      SmoothTheme.getColor(
+        colorScheme,
+        materialColor,
+        ColorDestination.BUTTON_BACKGROUND,
+      ),
+    );
+  }
+
+  Widget _build(
+    final Widget icon,
+    final Widget label,
+    final Color primary,
+  ) =>
+      ElevatedButton.icon(
+        icon: icon,
+        label: label,
+        onPressed: () async => await onPressed(),
+        style: ElevatedButton.styleFrom(
+          primary: primary,
+          shape: _getShape(),
         ),
       );
 
-  static OutlinedBorder getShape(final PantryType pantryType) =>
-      pantryType == PantryType.PANTRY
-          ? null
-          : const BeveledRectangleBorder(
-              borderRadius: BorderRadius.horizontal(
-                left: Radius.circular(16.0),
-                right: Radius.circular(16.0),
-              ),
-            );
+  String _getCreateListLabel(final AppLocalizations appLocalizations) {
+    switch (pantryType) {
+      case PantryType.PANTRY:
+        return appLocalizations.new_pantry;
+      case PantryType.SHOPPING:
+        return appLocalizations.new_shopping;
+    }
+    throw Exception('unknow pantry type $pantryType');
+  }
+
+  OutlinedBorder _getShape() {
+    switch (pantryType) {
+      case PantryType.PANTRY:
+        return null;
+      case PantryType.SHOPPING:
+        return const BeveledRectangleBorder(
+          borderRadius: BorderRadius.horizontal(
+            left: Radius.circular(16.0),
+            right: Radius.circular(16.0),
+          ),
+        );
+    }
+    throw Exception('unknow pantry type $pantryType');
+  }
 }

--- a/packages/smooth_app/lib/pages/pantry/common/pantry_dialog_helper.dart
+++ b/packages/smooth_app/lib/pages/pantry/common/pantry_dialog_helper.dart
@@ -1,15 +1,9 @@
-// Flutter imports:
 import 'package:flutter/material.dart';
-
-// Package imports:
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_ui_library/buttons/smooth_simple_button.dart';
 import 'package:smooth_ui_library/dialogs/smooth_alert_dialog.dart';
-
-// Project imports:
 import 'package:smooth_app/data_models/pantry.dart';
-import 'package:smooth_app/pages/pantry/pantry_page.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
 
 /// A dialog helper for pantries
@@ -46,21 +40,22 @@ class PantryDialogHelper {
         ),
       );
 
-  static Future<String> openNew(
+  static Future<Pantry> openNew(
     final BuildContext context,
     final List<Pantry> pantries,
     final PantryType pantryType,
     final UserPreferences userPreferences,
   ) async {
-    String newPantryName;
     final GlobalKey<FormState> formKey = GlobalKey<FormState>();
-    return await showDialog<String>(
+    Pantry newPantry;
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    return await showDialog<Pantry>(
       context: context,
       builder: (BuildContext context) => SmoothAlertDialog(
         close: false,
         title: pantryType == PantryType.PANTRY
-            ? AppLocalizations.of(context).new_pantry
-            : AppLocalizations.of(context).new_shopping,
+            ? appLocalizations.new_pantry
+            : appLocalizations.new_shopping,
         body: Form(
           key: formKey,
           child: Column(
@@ -69,12 +64,12 @@ class PantryDialogHelper {
               TextFormField(
                 decoration: InputDecoration(
                   hintText: pantryType == PantryType.PANTRY
-                      ? AppLocalizations.of(context).my_pantry_hint
-                      : AppLocalizations.of(context).my_shopping_hint,
+                      ? appLocalizations.my_pantry_hint
+                      : appLocalizations.my_shopping_hint,
                 ),
                 validator: (final String value) {
                   if (value.isEmpty) {
-                    return AppLocalizations.of(context).empty_list;
+                    return appLocalizations.empty_list;
                   }
                   if (pantries == null) {
                     return null;
@@ -82,21 +77,14 @@ class PantryDialogHelper {
                   for (int i = 0; i < pantries.length; i++) {
                     if (value == pantries[i].name) {
                       return pantryType == PantryType.PANTRY
-                          ? AppLocalizations.of(context).pantry_name_taken
-                          : AppLocalizations.of(context).shopping_name_taken;
+                          ? appLocalizations.pantry_name_taken
+                          : appLocalizations.shopping_name_taken;
                     }
                   }
-                  pantries.add(Pantry(
+                  newPantry = Pantry.empty(
                     name: value,
                     pantryType: pantryType,
-                    order: <String>[],
-                  ));
-                  Pantry.putAll(
-                    userPreferences,
-                    pantries,
-                    pantryType,
                   );
-                  newPantryName = value;
                   return null;
                 },
               ),
@@ -105,35 +93,23 @@ class PantryDialogHelper {
         ),
         actions: <SmoothSimpleButton>[
           SmoothSimpleButton(
-            text: AppLocalizations.of(context).cancel,
+            text: appLocalizations.cancel,
             onPressed: () => Navigator.pop(context, null),
             important: false,
           ),
           SmoothSimpleButton(
-            text: AppLocalizations.of(context).okay,
+            text: appLocalizations.okay,
             onPressed: () async {
               if (!formKey.currentState.validate()) {
                 return;
               }
-              Navigator.pop(context, newPantryName);
-
-              int index = 0;
-              for (final Pantry pantry in pantries) {
-                if (pantry.name == newPantryName) {
-                  await Navigator.push<Widget>(
-                    context,
-                    MaterialPageRoute<Widget>(
-                      builder: (BuildContext context) => PantryPage(
-                        pantries,
-                        index,
-                        pantryType,
-                      ),
-                    ),
-                  );
-                  return;
-                }
-                index++;
-              }
+              pantries.add(newPantry);
+              Pantry.putAll(
+                userPreferences,
+                pantries,
+                pantryType,
+              );
+              Navigator.pop<Pantry>(context, newPantry);
             },
             important: true,
           ),
@@ -148,13 +124,14 @@ class PantryDialogHelper {
     final int index,
   ) async {
     final GlobalKey<FormState> formKey = GlobalKey<FormState>();
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
     return await showDialog<bool>(
       context: context,
       builder: (BuildContext context) => SmoothAlertDialog(
         close: false,
         title: pantries[index].pantryType == PantryType.PANTRY
-            ? AppLocalizations.of(context).rename_pantry
-            : AppLocalizations.of(context).rename_shopping,
+            ? appLocalizations.rename_pantry
+            : appLocalizations.rename_shopping,
         body: Form(
           key: formKey,
           child: Column(
@@ -164,12 +141,12 @@ class PantryDialogHelper {
                 initialValue: pantries[index].name,
                 decoration: InputDecoration(
                   hintText: pantries[index].pantryType == PantryType.PANTRY
-                      ? AppLocalizations.of(context).my_pantry_hint
-                      : AppLocalizations.of(context).my_shopping_hint,
+                      ? appLocalizations.my_pantry_hint
+                      : appLocalizations.my_shopping_hint,
                 ),
                 validator: (final String value) {
                   if (value.isEmpty) {
-                    return AppLocalizations.of(context).empty_list;
+                    return appLocalizations.empty_list;
                   }
                   if (pantries == null) {
                     return null;
@@ -177,11 +154,11 @@ class PantryDialogHelper {
                   for (int i = 0; i < pantries.length; i++) {
                     if (value == pantries[i].name) {
                       if (i == index) {
-                        return AppLocalizations.of(context).already_same;
+                        return appLocalizations.already_same;
                       }
                       return pantries[index].pantryType == PantryType.PANTRY
-                          ? AppLocalizations.of(context).pantry_name_taken
-                          : AppLocalizations.of(context).shopping_name_taken;
+                          ? appLocalizations.pantry_name_taken
+                          : appLocalizations.shopping_name_taken;
                     }
                   }
                   pantries[index].name = value;
@@ -193,12 +170,12 @@ class PantryDialogHelper {
         ),
         actions: <SmoothSimpleButton>[
           SmoothSimpleButton(
-            text: AppLocalizations.of(context).cancel,
+            text: appLocalizations.cancel,
             onPressed: () => Navigator.pop(context, false),
             important: false,
           ),
           SmoothSimpleButton(
-            text: AppLocalizations.of(context).okay,
+            text: appLocalizations.okay,
             onPressed: () async {
               if (!formKey.currentState.validate()) {
                 return;

--- a/packages/smooth_app/lib/pages/product/common/product_list_button.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_button.dart
@@ -1,33 +1,43 @@
-// Flutter imports:
 import 'package:flutter/material.dart';
-
-// Project imports:
 import 'package:smooth_app/data_models/product_list.dart';
-import 'package:smooth_app/database/dao_product_list.dart';
-import 'package:smooth_app/pages/product/common/product_list_page.dart';
 import 'package:smooth_app/pages/product/common/product_query_page_helper.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
 
 class ProductListButton extends StatelessWidget {
-  const ProductListButton(
-    this.productList,
-    this.daoProductList, {
-    this.onPressed,
+  const ProductListButton({
+    @required this.productList,
+    @required this.onPressed,
   });
 
+  const ProductListButton.add({
+    @required this.onPressed,
+  }) : productList = null;
+
   final ProductList productList;
-  final DaoProductList daoProductList;
   final Function onPressed;
 
   @override
   Widget build(BuildContext context) {
+    if (productList == null) {
+      return _build(
+        const Icon(Icons.add),
+        Flexible(
+          child: Text(
+            AppLocalizations.of(context).new_list,
+            overflow: TextOverflow.fade,
+          ),
+        ),
+        null,
+      );
+    }
     final ColorScheme colorScheme = Theme.of(context).colorScheme;
-    return ElevatedButton.icon(
-      icon: productList.getIcon(
+    return _build(
+      productList.getIcon(
         colorScheme,
         ColorDestination.BUTTON_FOREGROUND,
       ),
-      label: Text(
+      Text(
         ProductQueryPageHelper.getProductListLabel(
           productList,
           context,
@@ -41,32 +51,28 @@ class ProductListButton extends StatelessWidget {
           ),
         ),
       ),
-      onPressed: () async {
-        if (onPressed != null) {
-          await onPressed();
-          return;
-        }
-        await daoProductList.get(productList);
-        await Navigator.push<Widget>(
-          context,
-          MaterialPageRoute<Widget>(
-            builder: (BuildContext context) => ProductListPage(productList),
-          ),
-        );
-        daoProductList.localDatabase.notifyListeners();
-      },
-      style: ElevatedButton.styleFrom(
-        primary: SmoothTheme.getColor(
-          colorScheme,
-          productList.getMaterialColor(),
-          ColorDestination.BUTTON_BACKGROUND,
-        ),
-        shape: getShape(),
+      SmoothTheme.getColor(
+        colorScheme,
+        productList.getMaterialColor(),
+        ColorDestination.BUTTON_BACKGROUND,
       ),
     );
   }
 
-  static OutlinedBorder getShape() => RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(32.0),
+  Widget _build(
+    final Widget icon,
+    final Widget label,
+    final Color primary,
+  ) =>
+      ElevatedButton.icon(
+        icon: icon,
+        label: label,
+        onPressed: () async => await onPressed(),
+        style: ElevatedButton.styleFrom(
+          primary: primary,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(32.0),
+          ),
+        ),
       );
 }

--- a/packages/smooth_app/lib/pages/product/common/product_list_dialog_helper.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_dialog_helper.dart
@@ -4,7 +4,6 @@ import 'package:smooth_ui_library/buttons/smooth_simple_button.dart';
 import 'package:smooth_ui_library/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/data_models/product_list.dart';
 import 'package:smooth_app/database/dao_product_list.dart';
-import 'package:smooth_app/pages/product/common/product_list_page.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
 
 class ProductListDialogHelper {
@@ -87,7 +86,7 @@ class ProductListDialogHelper {
             important: false,
           ),
           SmoothSimpleButton(
-            text: AppLocalizations.of(context).okay,
+            text: appLocalizations.okay,
             onPressed: () async {
               if (!formKey.currentState.validate()) {
                 return;
@@ -98,13 +97,6 @@ class ProductListDialogHelper {
               }
               await daoProductList.put(newProductList);
               Navigator.pop(context, newProductList);
-              await Navigator.push<Widget>(
-                context,
-                MaterialPageRoute<Widget>(
-                  builder: (BuildContext context) =>
-                      ProductListPage(newProductList),
-                ),
-              );
             },
             important: true,
           ),

--- a/packages/smooth_app/lib/pages/product/product_page.dart
+++ b/packages/smooth_app/lib/pages/product/product_page.dart
@@ -486,6 +486,7 @@ class _ProductPageState extends State<ProductPage> {
       daoProductList: daoProductList,
       daoProduct: daoProduct,
       allPantries: allPantries,
+      userPreferences: userPreferences,
     );
     if (children.isEmpty) {
       // no list to add to


### PR DESCRIPTION
Impacted files:
* `home_page.dart`: impact of `ProductListButton` and `PantryButton` refactoring; minor refactoring
* `list_page.dart`: impact of `ProductListButton` refactoring; minor refactoring
* `multi_select_product_page.dart`: minor refactoring
* `pantry.dart`: created a constructor for new empty instance
* `pantry_button.dart`: created a constructor for "add pantry"
* `pantry_dialog_helper.dart`: added flexibility to `openNew`; minor refactoring
* `pantry_list_page.dart`: impact of `PantryButton` refactoring; minor refactoring
* `pantry_page.dart`: replaced the `index` and `PantryType` constructor parameters with the more understandable `Pantry` parameter
* `pantry_preview.dart`: minor impact from `PantryPage` new constructor parameters
* `product_copy_helper.dart`: now we manage the "add product to new pantry/new shopping list/new product list" features
* `product_list_button.dart`: created a constructor for "add product list"
* `product_list_dialog_helper.dart`: added flexibility to `openNew`; minor refactoring
* `product_page.dart`: minor refactoring