### PR TITLE
feature/#336 - displaying attribute buttons as ListTiles

### DIFF
--- a/packages/smooth_app/assets/data/important.svg
+++ b/packages/smooth_app/assets/data/important.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000">
+    <g fill="red" stroke="none">
+        <circle cx="12" cy="19" r="2"/><path d="M10 3h4v12h-4z"/>
+    </g>
+</svg>

--- a/packages/smooth_app/assets/data/mandatory.svg
+++ b/packages/smooth_app/assets/data/mandatory.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000">
+    <g fill="red" stroke="none">
+        <circle cx="6" cy="19" r="2"/><path d="M4 3h4v12h-4z"/>
+        <circle cx="12" cy="19" r="2"/><path d="M10 3h4v12h-4z"/>
+        <circle cx="18" cy="19" r="2"/><path d="M16 3h4v12h-4z"/>
+    </g>
+</svg>

--- a/packages/smooth_app/assets/data/very_important.svg
+++ b/packages/smooth_app/assets/data/very_important.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000">
+    <g fill="red" stroke="none">
+        <circle cx="9" cy="19" r="2"/><path d="M7 3h4v12h-4z"/>
+        <circle cx="15" cy="19" r="2"/><path d="M13 3h4v12h-4z"/>
+    </g>
+</svg>

--- a/packages/smooth_app/lib/pages/attribute_button.dart
+++ b/packages/smooth_app/lib/pages/attribute_button.dart
@@ -8,8 +8,9 @@ import 'package:smooth_app/data_models/product_preferences.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
 import 'package:smooth_ui_library/buttons/smooth_simple_button.dart';
 import 'package:smooth_ui_library/dialogs/smooth_alert_dialog.dart';
-import 'package:smooth_app/pages/product/common/smooth_chip.dart';
 import 'package:openfoodfacts/personalized_search/preference_importance.dart';
+import 'package:smooth_app/themes/theme_provider.dart';
+import 'package:provider/provider.dart';
 
 /// Colored button for attribute importance, with corresponding action
 class AttributeButton extends StatelessWidget {
@@ -23,7 +24,7 @@ class AttributeButton extends StatelessWidget {
 
   static const MaterialColor WARNING_COLOR = Colors.deepOrange;
   static const Map<String, IconData> _IMPORTANCE_ICONS = <String, IconData>{
-    PreferenceImportance.ID_NOT_IMPORTANT: null,
+    PreferenceImportance.ID_NOT_IMPORTANT: Icons.remove,
     PreferenceImportance.ID_IMPORTANT: CupertinoIcons.star,
     PreferenceImportance.ID_VERY_IMPORTANT: CupertinoIcons.star_lefthalf_fill,
     PreferenceImportance.ID_MANDATORY: CupertinoIcons.star_fill,
@@ -35,10 +36,29 @@ class AttributeButton extends StatelessWidget {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final String importanceId =
         productPreferences.getImportanceIdForAttributeId(attribute.id);
-    return SmoothChip(
-      label: attribute.name,
-      iconData: _IMPORTANCE_ICONS[importanceId],
-      onPressed: () async {
+    final bool important =
+        importanceId != PreferenceImportance.ID_NOT_IMPORTANT;
+    final ThemeProvider themeProvider = context.watch<ThemeProvider>();
+    final MaterialColor materialColor =
+        SmoothTheme.getMaterialColor(themeProvider);
+    final Color strongBackgroundColor = SmoothTheme.getColor(
+      colorScheme,
+      materialColor,
+      ColorDestination.SURFACE_BACKGROUND,
+    );
+    final Color strongForegroundColor = SmoothTheme.getColor(
+      colorScheme,
+      materialColor,
+      ColorDestination.SURFACE_FOREGROUND,
+    );
+    final Color foregroundColor = !important ? null : strongForegroundColor;
+    final Color backgroundColor = !important ? null : strongBackgroundColor;
+    return ListTile(
+      tileColor: backgroundColor,
+      title: Text(attribute.name, style: TextStyle(color: foregroundColor)),
+      leading: SvgCache(attribute.iconUrl, width: 40),
+      trailing: Icon(_IMPORTANCE_ICONS[importanceId], color: foregroundColor),
+      onTap: () async {
         final List<Widget> children = <Widget>[
           ListTile(
             leading: SvgCache(attribute.iconUrl, width: 40),
@@ -71,16 +91,25 @@ class AttributeButton extends StatelessWidget {
           );
         }
         for (final String item in productPreferences.importanceIds) {
+          final bool important = item != PreferenceImportance.ID_NOT_IMPORTANT;
+          final Color foregroundColor =
+              !important ? null : strongForegroundColor;
+          final Color backgroundColor =
+              !important ? null : strongBackgroundColor;
           children.add(
             ListTile(
+              tileColor: backgroundColor,
               leading: importanceId == item
-                  ? const Icon(Icons.radio_button_checked)
-                  : const Icon(Icons.radio_button_unchecked),
-              title: Text(productPreferences
-                  .getPreferenceImportanceFromImportanceId(item)
-                  .name),
+                  ? Icon(Icons.radio_button_checked, color: foregroundColor)
+                  : Icon(Icons.radio_button_unchecked, color: foregroundColor),
+              title: Text(
+                productPreferences
+                    .getPreferenceImportanceFromImportanceId(item)
+                    .name,
+                style: TextStyle(color: foregroundColor),
+              ),
               onTap: () => Navigator.pop<String>(context, item),
-              trailing: Icon(_IMPORTANCE_ICONS[item]),
+              trailing: Icon(_IMPORTANCE_ICONS[item], color: foregroundColor),
             ),
           );
         }

--- a/packages/smooth_app/lib/pages/user_preferences_page.dart
+++ b/packages/smooth_app/lib/pages/user_preferences_page.dart
@@ -62,7 +62,12 @@ class UserPreferencesPage extends StatelessWidget {
         children: <Widget>[
           Padding(
             padding: const EdgeInsets.all(_TYPICAL_PADDING_OR_MARGIN),
-            child: ListTile(title: Text(group.name)),
+            child: ListTile(
+              title: Text(
+                group.name,
+                style: Theme.of(context).textTheme.headline3,
+              ),
+            ),
           ),
           if (group.warning != null)
             Container(


### PR DESCRIPTION
Now that we don't display attribute buttons in the home page, we have more liberty.

Impacted files:
* `attribute_button.dart`: now displaying `ListTile` instead of `SmoothChip`, with colors
* `user_preferences_pages.dart`: bigger text size for group names

This is what it looks like:

![Simulator Screen Shot - iPhone 8 Plus - 2021-05-02 at 18 21 36](https://user-images.githubusercontent.com/11576431/116820032-3c86fb80-ab73-11eb-82df-072d165dc8f7.png)

![Simulator Screen Shot - iPhone 8 Plus - 2021-05-02 at 18 22 04](https://user-images.githubusercontent.com/11576431/116820044-4d377180-ab73-11eb-9ab9-9f10e254d763.png)
