### PR TITLE
feature/#204 (2) - replaced the bottom navigation bar with a bar higher on screen

### DIFF
--- a/packages/smooth_app/lib/pages/product/product_page.dart
+++ b/packages/smooth_app/lib/pages/product/product_page.dart
@@ -277,9 +277,12 @@ class _ProductPageState extends State<ProductPage> {
       ),
     );
 
+    const int ITEM_COUNT = 3;
+    final double itemWidth = screenSize.width / ITEM_COUNT;
     listItems.add(
       Container(
         color: themeData.colorScheme.surface,
+        padding: const EdgeInsets.only(top: 8.0, bottom: 8.0),
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
           crossAxisAlignment: CrossAxisAlignment.center,
@@ -292,6 +295,7 @@ class _ProductPageState extends State<ProductPage> {
                 daoProductList: daoProductList,
                 daoProduct: daoProduct,
               ),
+              width: itemWidth,
             ),
             _getClickableIcon(
               label: appLocalizations.label_share,
@@ -300,6 +304,7 @@ class _ProductPageState extends State<ProductPage> {
                 'Try this food: https://openfoodfacts.org/product/${_product.barcode}/',
                 subject: '${_product.productName} (by openfoodfacts.org)',
               ),
+              width: itemWidth,
             ),
             _getClickableIcon(
               label: appLocalizations.label_preferences,
@@ -314,6 +319,7 @@ class _ProductPageState extends State<ProductPage> {
                       const UserPreferencesPage(),
                 ),
               ),
+              width: itemWidth,
             ),
           ],
         ),
@@ -527,20 +533,24 @@ class _ProductPageState extends State<ProductPage> {
       _product.productName ?? appLocalizations.unknownProductName;
 
   Widget _getClickableIcon({
-    final String label,
-    final Widget icon,
-    final Future<void> Function() onTap,
+    @required final String label,
+    @required final Widget icon,
+    @required final Future<void> Function() onTap,
+    @required final double width,
   }) =>
       InkWell(
         onTap: onTap,
-        child: Padding(
-          padding: const EdgeInsets.all(8.0),
+        child: SizedBox(
+          width: width,
           child: Column(
             children: <Widget>[
               icon,
-              Text(label),
+              Text(_capitalize(label)),
             ],
           ),
         ),
       );
+
+  static String _capitalize(final String input) =>
+      '${input.substring(0, 1).toUpperCase()}${input.substring(1)}';
 }

--- a/packages/smooth_app/lib/pages/product/product_page.dart
+++ b/packages/smooth_app/lib/pages/product/product_page.dart
@@ -72,10 +72,6 @@ class _ProductPageState extends State<ProductPage> {
   Widget build(BuildContext context) {
     final LocalDatabase localDatabase = context.watch<LocalDatabase>();
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    final ThemeData themeData = Theme.of(context);
-    final UserPreferences userPreferences = context.watch<UserPreferences>();
-    final DaoProductList daoProductList = DaoProductList(localDatabase);
-    final DaoProduct daoProduct = DaoProduct(localDatabase);
     _product ??= widget.product;
     return Scaffold(
         appBar: AppBar(
@@ -131,53 +127,6 @@ class _ProductPageState extends State<ProductPage> {
               },
             ),
           ],
-        ),
-        bottomNavigationBar: BottomNavigationBar(
-          type: BottomNavigationBarType.fixed,
-          items: <BottomNavigationBarItem>[
-            const BottomNavigationBarItem(
-              icon: Icon(Icons.copy),
-              label: 'Copy',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(ConstantIcons.getShareIcon()),
-              label: appLocalizations.label_share,
-            ),
-            BottomNavigationBarItem(
-              icon: SvgPicture.asset(
-                'assets/actions/food-cog.svg',
-                color: themeData.bottomNavigationBarTheme.selectedItemColor,
-              ),
-              label: appLocalizations.label_preferences,
-            ),
-          ],
-          onTap: (final int index) async {
-            switch (index) {
-              case 0:
-                await _copy(
-                  userPreferences: userPreferences,
-                  daoProductList: daoProductList,
-                  daoProduct: daoProduct,
-                );
-                return;
-              case 1:
-                Share.share(
-                  'Try this food: https://openfoodfacts.org/product/${_product.barcode}/',
-                  subject: '${_product.productName} (by openfoodfacts.org)',
-                );
-                return;
-              case 2:
-                await Navigator.push<Widget>(
-                  context,
-                  MaterialPageRoute<Widget>(
-                    builder: (BuildContext context) =>
-                        const UserPreferencesPage(),
-                  ),
-                );
-                return;
-            }
-            throw 'Unexpected index $index';
-          },
         ),
         body: widget.newProduct
             ? _buildNewProductBody(context)
@@ -289,6 +238,9 @@ class _ProductPageState extends State<ProductPage> {
 
   Widget _buildProductBody(BuildContext context) {
     final LocalDatabase localDatabase = context.watch<LocalDatabase>();
+    final UserPreferences userPreferences = context.watch<UserPreferences>();
+    final DaoProductList daoProductList = DaoProductList(localDatabase);
+    final DaoProduct daoProduct = DaoProduct(localDatabase);
     final ProductPreferences productPreferences =
         context.watch<ProductPreferences>();
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
@@ -321,6 +273,49 @@ class _ProductPageState extends State<ProductPage> {
             _product.quantity != null ? '${_product.quantity}' : '',
             style: themeData.textTheme.headline3,
           ),
+        ),
+      ),
+    );
+
+    listItems.add(
+      Container(
+        color: themeData.colorScheme.surface,
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: <Widget>[
+            _getClickableIcon(
+              label: 'lists',
+              icon: const Icon(Icons.playlist_add),
+              onTap: () async => await _copy(
+                userPreferences: userPreferences,
+                daoProductList: daoProductList,
+                daoProduct: daoProduct,
+              ),
+            ),
+            _getClickableIcon(
+              label: appLocalizations.label_share,
+              icon: Icon(ConstantIcons.getShareIcon()),
+              onTap: () async => await Share.share(
+                'Try this food: https://openfoodfacts.org/product/${_product.barcode}/',
+                subject: '${_product.productName} (by openfoodfacts.org)',
+              ),
+            ),
+            _getClickableIcon(
+              label: appLocalizations.label_preferences,
+              icon: SvgPicture.asset(
+                'assets/actions/food-cog.svg',
+                color: themeData.colorScheme.onSurface,
+              ),
+              onTap: () async => await Navigator.push<Widget>(
+                context,
+                MaterialPageRoute<Widget>(
+                  builder: (BuildContext context) =>
+                      const UserPreferencesPage(),
+                ),
+              ),
+            ),
+          ],
         ),
       ),
     );
@@ -530,4 +525,22 @@ class _ProductPageState extends State<ProductPage> {
 
   String _getProductName(final AppLocalizations appLocalizations) =>
       _product.productName ?? appLocalizations.unknownProductName;
+
+  Widget _getClickableIcon({
+    final String label,
+    final Widget icon,
+    final Future<void> Function() onTap,
+  }) =>
+      InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: Column(
+            children: <Widget>[
+              icon,
+              Text(label),
+            ],
+          ),
+        ),
+      );
 }


### PR DESCRIPTION
Done.
Still not convinced, @teolemon, as the top half of the screen is taken by things I can ignore (buttons) or already know (name, pictures) when I've seen the product before.
Assuming I'm interested in the scores (presumably the added value of the app), there could be at least a collapsed version of all the one-line scores. With a "display product scores as collapsed/expanded" to be stored in the preferences.

Anyway, this is what it looks like now:
 ![Simulator Screen Shot - iPhone 8 Plus - 2021-05-23 at 10 22 20](https://user-images.githubusercontent.com/11576431/119253280-c34a5980-bbb0-11eb-94a1-3c1226efed6d.png)
