### PR TITLE
feature/#384 - collapsible version of attribute scores

### DIFF
--- a/packages/smooth_app/lib/cards/data_cards/attribute_card.dart
+++ b/packages/smooth_app/lib/cards/data_cards/attribute_card.dart
@@ -1,44 +1,39 @@
-// Flutter imports:
 import 'package:flutter/material.dart';
-
-// Package imports:
 import 'package:openfoodfacts/model/Attribute.dart';
 
-// Project imports:
-import 'package:smooth_app/cards/data_cards/attribute_chip.dart';
-
 class AttributeCard extends StatelessWidget {
-  const AttributeCard(this.attribute, this.iconWidth);
+  const AttributeCard(this.attribute, this.attributeChip);
 
   final Attribute attribute;
-  final double iconWidth;
+  final Widget attributeChip;
 
   @override
-  Widget build(BuildContext context) => Row(
-        mainAxisAlignment: MainAxisAlignment.start,
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: <Widget>[
-          AttributeChip(attribute, width: iconWidth),
-          Flexible(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
+  Widget build(BuildContext context) {
+    final String description =
+        attribute.descriptionShort ?? attribute.description ?? '';
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: <Widget>[
+        Flexible(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Text(
+                attribute.title,
+                style: Theme.of(context).textTheme.headline3,
+              ),
+              if (description != null && description != '')
                 Text(
-                  attribute.title,
-                  style: Theme.of(context).textTheme.headline3,
-                ),
-                Text(
-                  _getDescription(),
+                  description,
                   style: Theme.of(context).textTheme.subtitle2,
                 ),
-              ],
-            ),
+            ],
           ),
-        ],
-      );
-
-  String _getDescription() {
-    return attribute.descriptionShort ?? attribute.description ?? '';
+        ),
+        attributeChip,
+      ],
+    );
   }
 }

--- a/packages/smooth_app/lib/cards/data_cards/attribute_chip.dart
+++ b/packages/smooth_app/lib/cards/data_cards/attribute_chip.dart
@@ -1,27 +1,23 @@
-// Flutter imports:
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-
-// Package imports:
 import 'package:openfoodfacts/model/Attribute.dart';
-
-// Project imports:
 import 'package:smooth_app/cards/category_cards/svg_cache.dart';
 
 class AttributeChip extends StatelessWidget {
   const AttributeChip(
     this.attribute, {
-    this.width,
     this.height,
   });
 
   final Attribute attribute;
-  final double width;
   final double height;
 
   @override
   Widget build(BuildContext context) => Padding(
         padding: const EdgeInsets.all(8.0),
-        child: SvgCache(attribute?.iconUrl, width: width, height: height),
+        child: Container(
+          constraints: BoxConstraints(minWidth: height),
+          child: SvgCache(attribute?.iconUrl, height: height),
+        ),
       );
 }

--- a/packages/smooth_app/lib/cards/expandables/attribute_list_expandable.dart
+++ b/packages/smooth_app/lib/cards/expandables/attribute_list_expandable.dart
@@ -1,44 +1,46 @@
-// Flutter imports:
 import 'package:flutter/material.dart';
-
-// Package imports:
 import 'package:openfoodfacts/model/Attribute.dart';
 import 'package:openfoodfacts/model/Product.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_ui_library/widgets/smooth_card.dart';
 import 'package:smooth_ui_library/widgets/smooth_expandable_card.dart';
-
-// Project imports:
 import 'package:smooth_app/cards/data_cards/attribute_card.dart';
 import 'package:smooth_app/cards/data_cards/attribute_chip.dart';
 import 'package:smooth_app/data_models/product_preferences.dart';
+import 'package:smooth_app/themes/smooth_theme.dart';
 
 class AttributeListExpandable extends StatelessWidget {
   const AttributeListExpandable({
     @required this.product,
-    @required this.iconWidth,
+    @required this.iconHeight,
     @required this.attributeIds,
     this.title,
     this.collapsible = true,
     this.background,
     this.padding,
     this.insets,
+    this.initiallyCollapsed = true,
   });
 
   final Product product;
-  final double iconWidth;
+  final double iconHeight;
   final List<String> attributeIds;
   final String title;
   final bool collapsible;
   final Color background;
   final EdgeInsets padding;
   final EdgeInsets insets;
+  final bool initiallyCollapsed;
 
   @override
   Widget build(BuildContext context) {
     final ProductPreferences productPreferences =
         context.watch<ProductPreferences>();
     final Size screenSize = MediaQuery.of(context).size;
+    final ThemeData themeData = Theme.of(context);
+    final double opacity = themeData.brightness == Brightness.light
+        ? 1
+        : SmoothTheme.ADDITIONAL_OPACITY_FOR_DARK;
     final List<Widget> chips = <Widget>[];
     final List<Widget> cards = <Widget>[];
     final Map<String, Attribute> attributes = product.getAttributes(
@@ -66,8 +68,30 @@ class AttributeListExpandable extends StatelessWidget {
               additiveNames == null ? '' : additiveNames.join(', '),
         );
       }
-      chips.add(AttributeChip(attribute, width: iconWidth));
-      cards.add(AttributeCard(attribute, iconWidth));
+      final Color color = _getBackgroundColor(attribute).withOpacity(opacity);
+      final Widget chip = AttributeChip(attribute, height: iconHeight);
+      chips.add(
+        Container(
+          child: chip,
+          decoration: BoxDecoration(
+            color: color,
+            borderRadius: const BorderRadius.all(Radius.circular(16)),
+          ),
+        ),
+      );
+      cards.add(
+        Padding(
+          padding: const EdgeInsets.only(top: 8.0),
+          child: Container(
+            padding: const EdgeInsets.all(8.0),
+            decoration: BoxDecoration(
+              color: color,
+              borderRadius: const BorderRadius.all(Radius.circular(16)),
+            ),
+            child: AttributeCard(attribute, chip),
+          ),
+        ),
+      );
     }
     final Widget content = Column(
       mainAxisAlignment: MainAxisAlignment.start,
@@ -88,6 +112,7 @@ class AttributeListExpandable extends StatelessWidget {
     return SmoothExpandableCard(
       padding: padding,
       insets: insets,
+      initiallyCollapsed: initiallyCollapsed,
       collapsedHeader: Container(
         width: screenSize.width * 0.8,
         child: Column(
@@ -95,10 +120,15 @@ class AttributeListExpandable extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
             header,
-            Wrap(
-              direction: Axis.horizontal,
-              crossAxisAlignment: WrapCrossAlignment.center,
-              children: chips,
+            Padding(
+              padding: const EdgeInsets.only(top: 8.0),
+              child: Wrap(
+                direction: Axis.horizontal,
+                crossAxisAlignment: WrapCrossAlignment.center,
+                children: chips,
+                runSpacing: 8.0,
+                spacing: 8.0,
+              ),
             ),
           ],
         ),
@@ -106,5 +136,25 @@ class AttributeListExpandable extends StatelessWidget {
       child: content,
       expandedHeader: title == null ? null : header,
     );
+  }
+
+  static Color _getBackgroundColor(final Attribute attribute) {
+    if (attribute.status == Attribute.STATUS_KNOWN) {
+      if (attribute.match <= 20) {
+        return const HSLColor.fromAHSL(1, 0, 1, .9).toColor();
+      }
+      if (attribute.match <= 40) {
+        return const HSLColor.fromAHSL(1, 30, 1, .9).toColor();
+      }
+      if (attribute.match <= 60) {
+        return const HSLColor.fromAHSL(1, 60, 1, .9).toColor();
+      }
+      if (attribute.match <= 80) {
+        return const HSLColor.fromAHSL(1, 90, 1, .9).toColor();
+      }
+      return const HSLColor.fromAHSL(1, 120, 1, .9).toColor();
+    } else {
+      return const Color.fromARGB(0xff, 0xEE, 0xEE, 0xEE);
+    }
   }
 }

--- a/packages/smooth_app/lib/pages/product/product_page.dart
+++ b/packages/smooth_app/lib/pages/product/product_page.dart
@@ -246,7 +246,7 @@ class _ProductPageState extends State<ProductPage> {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final Size screenSize = MediaQuery.of(context).size;
     final ThemeData themeData = Theme.of(context);
-    final double iconWidth =
+    final double iconHeight =
         screenSize.width / 10; // TODO(monsieurtanuki): target size?
     final Map<String, String> attributeGroupLabels = <String, String>{};
     for (final AttributeGroup attributeGroup
@@ -326,32 +326,21 @@ class _ProductPageState extends State<ProductPage> {
       ),
     );
 
-    final Map<String, Attribute> attributes =
-        _product.getAttributes(attributeIds);
-    final double opacity = themeData.brightness == Brightness.light
-        ? 1
-        : SmoothTheme.ADDITIONAL_OPACITY_FOR_DARK;
-
-    for (final String attributeId in attributeIds) {
-      if (attributes[attributeId] != null) {
-        listItems.add(
-          AttributeListExpandable(
-            padding: padding,
-            insets: insets,
-            product: _product,
-            iconWidth: iconWidth,
-            attributeIds: <String>[attributeId],
-            collapsible: false,
-            background: _getBackgroundColor(attributes[attributeId])
-                .withOpacity(opacity),
-          ),
-        );
-      }
-    }
+    listItems.add(
+      AttributeListExpandable(
+        padding: padding,
+        insets: insets,
+        product: _product,
+        iconHeight: iconHeight,
+        attributeIds: attributeIds,
+        title: 'Scores',
+        initiallyCollapsed: false,
+      ),
+    );
 
     for (final AttributeGroup attributeGroup
         in _getOrderedAttributeGroups(productPreferences)) {
-      listItems.add(_getAttributeGroupWidget(attributeGroup, iconWidth));
+      listItems.add(_getAttributeGroupWidget(attributeGroup, iconHeight));
     }
 
     //Similar foods
@@ -373,7 +362,7 @@ class _ProductPageState extends State<ProductPage> {
             child: ListTile(
               leading: Icon(
                 Icons.search,
-                size: iconWidth,
+                size: iconHeight,
                 color: SmoothTheme.getColor(
                   themeData.colorScheme,
                   materialColor,
@@ -412,7 +401,7 @@ class _ProductPageState extends State<ProductPage> {
 
   Widget _getAttributeGroupWidget(
     final AttributeGroup attributeGroup,
-    final double iconWidth,
+    final double iconHeight,
   ) {
     final List<String> attributeIds = <String>[];
     for (final Attribute attribute in attributeGroup.attributes) {
@@ -422,7 +411,7 @@ class _ProductPageState extends State<ProductPage> {
       padding: padding,
       insets: insets,
       product: _product,
-      iconWidth: iconWidth,
+      iconHeight: iconHeight,
       attributeIds: attributeIds,
       title: attributeGroup.name,
     );
@@ -448,26 +437,6 @@ class _ProductPageState extends State<ProductPage> {
       }
     }
     return attributeGroups;
-  }
-
-  Color _getBackgroundColor(final Attribute attribute) {
-    if (attribute.status == Attribute.STATUS_KNOWN) {
-      if (attribute.match <= 20) {
-        return const HSLColor.fromAHSL(1, 0, 1, .9).toColor();
-      }
-      if (attribute.match <= 40) {
-        return const HSLColor.fromAHSL(1, 30, 1, .9).toColor();
-      }
-      if (attribute.match <= 60) {
-        return const HSLColor.fromAHSL(1, 60, 1, .9).toColor();
-      }
-      if (attribute.match <= 80) {
-        return const HSLColor.fromAHSL(1, 90, 1, .9).toColor();
-      }
-      return const HSLColor.fromAHSL(1, 120, 1, .9).toColor();
-    } else {
-      return const Color.fromARGB(0xff, 0xEE, 0xEE, 0xEE);
-    }
   }
 
   Future<void> _copy({

--- a/packages/smooth_app/lib/views/smooth_product_sneak_peek_view.dart
+++ b/packages/smooth_app/lib/views/smooth_product_sneak_peek_view.dart
@@ -144,7 +144,7 @@ class SmoothProductSneakPeekViewState extends State<SmoothProductSneakPeekView>
                       widget.product.getAttributes(
                         <String>[Attribute.ATTRIBUTE_NUTRISCORE],
                       )[Attribute.ATTRIBUTE_NUTRISCORE],
-                      width: 100.0,
+                      height: 100.0,
                     ),
                     Container(
                       width: 50.0,

--- a/packages/smooth_ui_library/lib/widgets/smooth_expandable_card.dart
+++ b/packages/smooth_ui_library/lib/widgets/smooth_expandable_card.dart
@@ -11,6 +11,7 @@ class SmoothExpandableCard extends StatefulWidget {
     this.padding =
         const EdgeInsets.only(right: 8.0, left: 8.0, top: 4.0, bottom: 20.0),
     this.insets = const EdgeInsets.all(12.0),
+    this.initiallyCollapsed = true,
   });
 
   final Widget collapsedHeader;
@@ -19,13 +20,21 @@ class SmoothExpandableCard extends StatefulWidget {
   final Widget child;
   final EdgeInsets padding;
   final EdgeInsets insets;
+  final bool initiallyCollapsed;
+
   @override
   _SmoothExpandableCardState createState() => _SmoothExpandableCardState();
 }
 
 class _SmoothExpandableCardState extends State<SmoothExpandableCard> {
-  bool collapsed = true;
+  bool collapsed = true; // to be overridden in initState
   static const Duration _ANIMATION_DURATION = Duration(milliseconds: 160);
+
+  @override
+  void initState() {
+    collapsed = widget.initiallyCollapsed;
+    super.initState();
+  }
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
Impacted files:
* `attribute_card.dart`: centered the text; refactored
* `attribute_chip.dart`: now using only height; added a min width for "tall" icons
* `attribute_list_expandable.dart`: now using height; added an `initiallyCollapsed` parameter; moved code from `ProductPage` regarding background colors
* `product_page.dart`: now using height; now using an `AttributeListExpandable` to display colored attribute scores
* `smooth_expandable_card.dart`: added an `initiallyCollapsed` parameter
* `smooth_product_sneek_peak_view.dart`: impacted deprecated code

![Simulator Screen Shot - iPhone 8 Plus - 2021-05-23 at 19 23 47](https://user-images.githubusercontent.com/11576431/119270314-670d2700-bbfc-11eb-809b-eeac83302623.png)
