### PR TITLE
bug/#340 - scan: added the color to "found" card and removed the attributes

### DIFF
--- a/packages/smooth_app/lib/cards/data_cards/attribute_chip.dart
+++ b/packages/smooth_app/lib/cards/data_cards/attribute_chip.dart
@@ -13,11 +13,8 @@ class AttributeChip extends StatelessWidget {
   final double height;
 
   @override
-  Widget build(BuildContext context) => Padding(
-        padding: const EdgeInsets.all(8.0),
-        child: Container(
-          constraints: BoxConstraints(minWidth: height),
-          child: SvgCache(attribute?.iconUrl, height: height),
-        ),
+  Widget build(BuildContext context) => Container(
+        constraints: BoxConstraints(minWidth: height),
+        child: SvgCache(attribute?.iconUrl, height: height),
       );
 }

--- a/packages/smooth_app/lib/cards/expandables/attribute_list_expandable.dart
+++ b/packages/smooth_app/lib/cards/expandables/attribute_list_expandable.dart
@@ -72,7 +72,10 @@ class AttributeListExpandable extends StatelessWidget {
       final Widget chip = AttributeChip(attribute, height: iconHeight);
       chips.add(
         Container(
-          child: chip,
+          child: Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: chip,
+          ),
           decoration: BoxDecoration(
             color: color,
             borderRadius: const BorderRadius.all(Radius.circular(16)),

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
@@ -19,7 +19,6 @@ class SmoothProductCardFound extends StatelessWidget {
     this.backgroundColor,
     this.handle,
     this.onLongPress,
-    this.displayAttributes = true,
   });
 
   final Product product;
@@ -29,7 +28,6 @@ class SmoothProductCardFound extends StatelessWidget {
   final Color backgroundColor;
   final Widget handle;
   final Function onLongPress;
-  final bool displayAttributes;
 
   @override
   Widget build(BuildContext context) {
@@ -41,6 +39,7 @@ class SmoothProductCardFound extends StatelessWidget {
         context.watch<ProductPreferences>();
     final Size screenSize = MediaQuery.of(context).size;
     final ThemeData themeData = Theme.of(context);
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
 
     final List<String> attributeIds =
         productPreferences.getOrderedImportantAttributeIds();
@@ -104,67 +103,31 @@ class SmoothProductCardFound extends StatelessWidget {
                               children: <Widget>[
                                 Flexible(
                                   child: Text(
-                                    product.productName ??
-                                        AppLocalizations.of(context)
-                                            .unknownProductName,
+                                    (product.productName ??
+                                            appLocalizations
+                                                .unknownProductName) +
+                                        ' - ' +
+                                        (product.brands ??
+                                            appLocalizations.unknownBrand),
                                     maxLines: 2,
                                     overflow: TextOverflow.fade,
-                                    style: themeData.textTheme.headline4,
                                   ),
                                 ),
                                 if (handle != null) handle,
                               ],
                             ),
-                            const SizedBox(
-                              height: 2.0,
-                            ),
-                            Row(
-                              children: <Widget>[
-                                Flexible(
-                                  child: Text(
-                                    product.brands ??
-                                        AppLocalizations.of(context)
-                                            .unknownBrand,
-                                    maxLines: 1,
-                                    overflow: TextOverflow.fade,
-                                    style: themeData.textTheme.subtitle1,
-                                  ),
-                                ),
-                              ],
-                            ),
-                            const SizedBox(
-                              height: 2.0,
-                            ),
-                            Row(
-                              children: <Widget>[
-                                Flexible(
-                                  child: Text(
-                                    product.brands ??
-                                        AppLocalizations.of(context)
-                                            .unknownBrand,
-                                    maxLines: 1,
-                                    overflow: TextOverflow.fade,
-                                    style: themeData.textTheme.subtitle1,
-                                  ),
-                                )
-                              ],
+                            Container(
+                              width: screenSize.width * 0.65,
+                              child: Wrap(
+                                direction: Axis.horizontal,
+                                children: scores,
+                                spacing: 2.0,
+                                runSpacing: 2.0,
+                              ),
                             ),
                           ],
                         ),
                       ),
-                      if (displayAttributes)
-                        Container(
-                          decoration: const BoxDecoration(
-                            border: Border(
-                              top: BorderSide(color: Colors.grey, width: 1.0),
-                            ),
-                          ),
-                          width: screenSize.width * 0.65,
-                          child: Wrap(
-                            direction: Axis.horizontal,
-                            children: scores,
-                          ),
-                        ),
                     ],
                   ),
                 ),

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
@@ -19,6 +19,7 @@ class SmoothProductCardFound extends StatelessWidget {
     this.backgroundColor,
     this.handle,
     this.onLongPress,
+    this.displayAttributes = true,
   });
 
   final Product product;
@@ -28,6 +29,7 @@ class SmoothProductCardFound extends StatelessWidget {
   final Color backgroundColor;
   final Widget handle;
   final Function onLongPress;
+  final bool displayAttributes;
 
   @override
   Widget build(BuildContext context) {
@@ -150,17 +152,19 @@ class SmoothProductCardFound extends StatelessWidget {
                           ],
                         ),
                       ),
-                      Container(
-                        decoration: const BoxDecoration(
-                          border: Border(
-                              top: BorderSide(color: Colors.grey, width: 1.0)),
+                      if (displayAttributes)
+                        Container(
+                          decoration: const BoxDecoration(
+                            border: Border(
+                              top: BorderSide(color: Colors.grey, width: 1.0),
+                            ),
+                          ),
+                          width: screenSize.width * 0.65,
+                          child: Wrap(
+                            direction: Axis.horizontal,
+                            children: scores,
+                          ),
                         ),
-                        width: screenSize.width * 0.65,
-                        child: Wrap(
-                          direction: Axis.horizontal,
-                          children: scores,
-                        ),
-                      ),
                     ],
                   ),
                 ),

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
@@ -39,7 +39,6 @@ class SmoothProductCardFound extends StatelessWidget {
         context.watch<ProductPreferences>();
     final Size screenSize = MediaQuery.of(context).size;
     final ThemeData themeData = Theme.of(context);
-    final AppLocalizations appLocalizations = AppLocalizations.of(context);
 
     final List<String> attributeIds =
         productPreferences.getOrderedImportantAttributeIds();
@@ -52,6 +51,17 @@ class SmoothProductCardFound extends StatelessWidget {
     for (final String attributeId in attributeIds) {
       final Attribute attribute = attributes[attributeId];
       scores.add(AttributeChip(attribute, height: iconSize));
+    }
+    String productTitle;
+    if (product.productName != null) {
+      productTitle = product.productName;
+      if (product.brands != null) {
+        productTitle += ' - ' + product.brands;
+      }
+    } else if (product.brands != null) {
+      productTitle = product.brands;
+    } else {
+      productTitle = product.barcode;
     }
     return GestureDetector(
       onTap: () => Navigator.push<Widget>(
@@ -103,12 +113,7 @@ class SmoothProductCardFound extends StatelessWidget {
                               children: <Widget>[
                                 Flexible(
                                   child: Text(
-                                    (product.productName ??
-                                            appLocalizations
-                                                .unknownProductName) +
-                                        ' - ' +
-                                        (product.brands ??
-                                            appLocalizations.unknownBrand),
+                                    productTitle,
                                     maxLines: 2,
                                     overflow: TextOverflow.fade,
                                   ),

--- a/packages/smooth_app/lib/lists/smooth_product_carousel.dart
+++ b/packages/smooth_app/lib/lists/smooth_product_carousel.dart
@@ -81,7 +81,6 @@ class _SmoothProductCarouselState extends State<SmoothProductCarousel> {
         return SmoothProductCardFound(
           heroTag: barcode,
           product: product,
-          displayAttributes: false,
           backgroundColor: PersonalizedRankingPage.getColor(
             colorScheme: Theme.of(context).colorScheme,
             matchIndex: SmoothItModel.getMatchIndex(matchedProduct),

--- a/packages/smooth_app/lib/pages/personalized_ranking_page.dart
+++ b/packages/smooth_app/lib/pages/personalized_ranking_page.dart
@@ -24,6 +24,25 @@ class PersonalizedRankingPage extends StatefulWidget {
   @override
   _PersonalizedRankingPageState createState() =>
       _PersonalizedRankingPageState();
+
+  static const Map<int, MaterialColor> _COLORS = <int, MaterialColor>{
+    SmoothItModel.MATCH_INDEX_YES: Colors.green,
+    SmoothItModel.MATCH_INDEX_MAYBE: Colors.grey,
+    SmoothItModel.MATCH_INDEX_NO: Colors.red,
+  };
+
+  static Color getColor({
+    final ColorScheme colorScheme,
+    final int matchIndex,
+    final ColorDestination colorDestination,
+  }) =>
+      _COLORS[matchIndex] == null
+          ? null
+          : SmoothTheme.getColor(
+              colorScheme,
+              _COLORS[matchIndex],
+              colorDestination,
+            );
 }
 
 class _PersonalizedRankingPageState extends State<PersonalizedRankingPage> {
@@ -39,12 +58,6 @@ class _PersonalizedRankingPageState extends State<PersonalizedRankingPage> {
     SmoothItModel.MATCH_INDEX_YES: Icons.check_circle,
     SmoothItModel.MATCH_INDEX_MAYBE: CupertinoIcons.question_diamond,
     SmoothItModel.MATCH_INDEX_NO: Icons.cancel,
-  };
-
-  static const Map<int, MaterialColor> _COLORS = <int, MaterialColor>{
-    SmoothItModel.MATCH_INDEX_YES: Colors.green,
-    SmoothItModel.MATCH_INDEX_MAYBE: Colors.grey,
-    SmoothItModel.MATCH_INDEX_NO: Colors.red,
   };
 
   final SmoothItModel _model = SmoothItModel();
@@ -66,13 +79,11 @@ class _PersonalizedRankingPageState extends State<PersonalizedRankingPage> {
         BottomNavigationBarItem(
           icon: Icon(
             _ICONS[matchIndex],
-            color: _COLORS[matchIndex] == null
-                ? null
-                : SmoothTheme.getColor(
-                    colorScheme,
-                    _COLORS[matchIndex],
-                    ColorDestination.SURFACE_FOREGROUND,
-                  ),
+            color: PersonalizedRankingPage.getColor(
+              colorScheme: colorScheme,
+              matchIndex: matchIndex,
+              colorDestination: ColorDestination.SURFACE_FOREGROUND,
+            ),
           ),
           label: _model.getMatchedProducts(matchIndex).length.toString(),
         ),
@@ -143,10 +154,10 @@ class _PersonalizedRankingPageState extends State<PersonalizedRankingPage> {
           heroTag: matchedProduct.product.barcode,
           product: matchedProduct.product,
           elevation: 4.0,
-          backgroundColor: SmoothTheme.getColor(
-            colorScheme,
-            _COLORS[SmoothItModel.getMatchIndex(matchedProduct)],
-            ColorDestination.SURFACE_BACKGROUND,
+          backgroundColor: PersonalizedRankingPage.getColor(
+            colorScheme: colorScheme,
+            matchIndex: SmoothItModel.getMatchIndex(matchedProduct),
+            colorDestination: ColorDestination.SURFACE_BACKGROUND,
           ),
         ),
       );


### PR DESCRIPTION
Impacted files:
* `personalized_ranking_page.dart`: made public and reusable the code of `getColor`
* `smooth_product_card_found.dart`: added a `bool displayAttributes` parameter
* `smooth_product_carousel.dart`: added the color to "found" card and removed the attributes

![Screenshot_2021-05-25-12-54-11](https://user-images.githubusercontent.com/11576431/119488619-1102c580-bd5b-11eb-8ebd-9e2a4dc28db7.png)