### PR TITLE
feature/#158 - removes null attributes from product display

### DIFF
--- a/packages/smooth_app/lib/cards/expandables/attribute_list_expandable.dart
+++ b/packages/smooth_app/lib/cards/expandables/attribute_list_expandable.dart
@@ -8,8 +8,8 @@ import 'package:smooth_app/cards/data_cards/attribute_card.dart';
 import 'package:smooth_app/cards/data_cards/attribute_chip.dart';
 import 'package:smooth_app/data_models/product_preferences.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
-import 'package:smooth_app/pages/attribute_button.dart';
 import 'package:smooth_app/themes/theme_provider.dart';
+import 'package:smooth_app/pages/attribute_button.dart';
 
 class AttributeListExpandable extends StatelessWidget {
   const AttributeListExpandable({

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
@@ -8,8 +8,8 @@ import 'package:provider/provider.dart';
 import 'package:smooth_app/cards/expandables/attribute_list_expandable.dart';
 import 'package:smooth_ui_library/widgets/smooth_product_image.dart';
 import 'package:smooth_app/cards/data_cards/attribute_chip.dart';
-import 'package:smooth_app/pages/product/product_page.dart';
 import 'package:smooth_app/data_models/product_preferences.dart';
+import 'package:smooth_app/pages/product/product_page.dart';
 
 class SmoothProductCardFound extends StatelessWidget {
   const SmoothProductCardFound({

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
@@ -5,6 +5,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:openfoodfacts/model/Attribute.dart';
 import 'package:openfoodfacts/model/Product.dart';
 import 'package:provider/provider.dart';
+import 'package:smooth_app/cards/expandables/attribute_list_expandable.dart';
 import 'package:smooth_ui_library/widgets/smooth_product_image.dart';
 import 'package:smooth_app/cards/data_cards/attribute_chip.dart';
 import 'package:smooth_app/pages/product/product_page.dart';
@@ -45,11 +46,9 @@ class SmoothProductCardFound extends StatelessWidget {
     final List<Widget> scores = <Widget>[];
     final double iconSize =
         screenSize.width / 10; // TODO(monsieurtanuki): target size?
-    final Map<String, Attribute> attributes = product.getAttributes(
-      attributeIds,
-    );
-    for (final String attributeId in attributeIds) {
-      final Attribute attribute = attributes[attributeId];
+    final List<Attribute> attributes =
+        AttributeListExpandable.getPopulatedAttributes(product, attributeIds);
+    for (final Attribute attribute in attributes) {
       scores.add(AttributeChip(attribute, height: iconSize));
     }
     String productTitle;

--- a/packages/smooth_app/lib/pages/product/product_page.dart
+++ b/packages/smooth_app/lib/pages/product/product_page.dart
@@ -33,8 +33,8 @@ import 'package:smooth_app/themes/constant_icons.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
 import 'package:smooth_app/pages/product_copy_helper.dart';
 import 'package:smooth_app/data_models/pantry.dart';
-import 'package:smooth_app/database/dao_product.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
+import 'package:smooth_app/database/dao_product.dart';
 
 class ProductPage extends StatefulWidget {
   const ProductPage({@required this.product, this.newProduct = false});

--- a/packages/smooth_app/lib/pages/product/product_page.dart
+++ b/packages/smooth_app/lib/pages/product/product_page.dart
@@ -326,21 +326,29 @@ class _ProductPageState extends State<ProductPage> {
       ),
     );
 
-    listItems.add(
-      AttributeListExpandable(
-        padding: padding,
-        insets: insets,
-        product: _product,
-        iconHeight: iconHeight,
-        attributeIds: attributeIds,
-        title: 'Scores',
-        initiallyCollapsed: false,
-      ),
-    );
+    final List<Attribute> attributes =
+        AttributeListExpandable.getPopulatedAttributes(_product, attributeIds);
+    if (attributes.isNotEmpty) {
+      listItems.add(
+        AttributeListExpandable(
+          padding: padding,
+          insets: insets,
+          product: _product,
+          iconHeight: iconHeight,
+          attributes: attributes,
+          title: 'Scores',
+          initiallyCollapsed: false,
+        ),
+      );
+    }
 
     for (final AttributeGroup attributeGroup
         in _getOrderedAttributeGroups(productPreferences)) {
-      listItems.add(_getAttributeGroupWidget(attributeGroup, iconHeight));
+      final Widget grouped =
+          _getAttributeGroupWidget(attributeGroup, iconHeight);
+      if (grouped != null) {
+        listItems.add(grouped);
+      }
     }
 
     //Similar foods
@@ -407,12 +415,17 @@ class _ProductPageState extends State<ProductPage> {
     for (final Attribute attribute in attributeGroup.attributes) {
       attributeIds.add(attribute.id);
     }
+    final List<Attribute> attributes =
+        AttributeListExpandable.getPopulatedAttributes(_product, attributeIds);
+    if (attributes.isEmpty) {
+      return null;
+    }
     return AttributeListExpandable(
       padding: padding,
       insets: insets,
       product: _product,
       iconHeight: iconHeight,
-      attributeIds: attributeIds,
+      attributes: attributes,
       title: attributeGroup.name,
     );
   }


### PR DESCRIPTION
Impacted files:
* `attribute_list_expandable.dart`: new static method `getPopulatedAttributes` that removes null attributes (code moved from `build`)
* `product_page.dart`: now using new method `AttributeListExpandable.getPopulatedAttributes` in order to display only populated attributes
* `smooth_product_card_found.dart`: now using new method `AttributeListExpandable.getPopulatedAttributes` in order to display only populated attributes