### PR TITLE
feature/#349 - history and scan lists now have displayed timestamps

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
@@ -20,6 +20,7 @@ class SmoothProductCardFound extends StatelessWidget {
     this.backgroundColor,
     this.handle,
     this.onLongPress,
+    this.refresh,
   });
 
   final Product product;
@@ -29,6 +30,7 @@ class SmoothProductCardFound extends StatelessWidget {
   final Color backgroundColor;
   final Widget handle;
   final Function onLongPress;
+  final Function refresh;
 
   @override
   Widget build(BuildContext context) {
@@ -63,12 +65,17 @@ class SmoothProductCardFound extends StatelessWidget {
       productTitle = product.barcode;
     }
     return GestureDetector(
-      onTap: () => Navigator.push<Widget>(
-        context,
-        MaterialPageRoute<Widget>(
-          builder: (BuildContext context) => ProductPage(product: product),
-        ),
-      ),
+      onTap: () async {
+        await Navigator.push<Widget>(
+          context,
+          MaterialPageRoute<Widget>(
+            builder: (BuildContext context) => ProductPage(product: product),
+          ),
+        );
+        if (refresh != null) {
+          await refresh();
+        }
+      },
       onLongPress: () => onLongPress == null ? null : onLongPress(),
       child: Hero(
         tag: heroTag,

--- a/packages/smooth_app/lib/data_models/continuous_scan_model.dart
+++ b/packages/smooth_app/lib/data_models/continuous_scan_model.dart
@@ -36,9 +36,9 @@ class ContinuousScanModel with ChangeNotifier {
       ProductList(listType: ProductList.LIST_TYPE_SCAN, parameters: '');
 
   bool _contributionMode;
-  String _barcodeLatestScan;
-  String _barcodeLatestSuccessfulScan;
-  String _barcodeTrustCheck;
+  String _latestScannedBarcode;
+  String _latestFoundBarcode;
+  String _barcodeTrustCheck; // TODO(monsieurtanuki): could probably be removed
   DaoProduct _daoProduct;
   DaoProductList _daoProductList;
   DaoProductExtra _daoProductExtra;
@@ -60,7 +60,7 @@ class ContinuousScanModel with ChangeNotifier {
       for (final String barcode in _productList.barcodes) {
         _barcodes.add(barcode);
         _states[barcode] = ScannedProductState.CACHED;
-        _barcodeLatestScan = barcode;
+        _latestScannedBarcode = barcode;
       }
       return this;
     } catch (e) {
@@ -92,10 +92,10 @@ class ContinuousScanModel with ChangeNotifier {
       _barcodeTrustCheck = code;
       return;
     }
-    if (_barcodeLatestScan == code) {
+    if (_latestScannedBarcode == code) {
       return;
     }
-    _barcodeLatestScan = code;
+    _latestScannedBarcode = code;
     _addBarcode(code);
   }
 
@@ -180,8 +180,8 @@ class ContinuousScanModel with ChangeNotifier {
     final ScannedProductState state,
   ) async {
     _productList.refresh(product);
-    if (_barcodeLatestSuccessfulScan != product.barcode) {
-      _barcodeLatestSuccessfulScan = product.barcode;
+    if (_latestFoundBarcode != product.barcode) {
+      _latestFoundBarcode = product.barcode;
       await _daoProductExtra.putLastScan(product);
     }
     setBarcodeState(product.barcode, state);

--- a/packages/smooth_app/lib/data_models/database_product_list_supplier.dart
+++ b/packages/smooth_app/lib/data_models/database_product_list_supplier.dart
@@ -1,4 +1,3 @@
-// Project imports:
 import 'package:smooth_app/data_models/product_list.dart';
 import 'package:smooth_app/data_models/product_list_supplier.dart';
 import 'package:smooth_app/data_models/query_product_list_supplier.dart';
@@ -6,25 +5,23 @@ import 'package:smooth_app/database/dao_product_list.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/database/product_query.dart';
 
-class DatabaseProductListSupplier implements ProductListSupplier {
-  DatabaseProductListSupplier(this.productQuery, this.localDatabase);
-
-  final ProductQuery productQuery;
-  final LocalDatabase localDatabase;
-  ProductList _productList;
-
-  @override
-  ProductList getProductList() => _productList;
+class DatabaseProductListSupplier extends ProductListSupplier {
+  DatabaseProductListSupplier(
+    final ProductQuery productQuery,
+    final LocalDatabase localDatabase,
+    final int timestamp,
+  ) : super(productQuery, localDatabase, timestamp: timestamp);
 
   @override
   Future<String> asyncLoad() async {
     try {
-      final ProductList productList = productQuery.getProductList();
-      final bool result = await DaoProductList(localDatabase).get(productList);
+      final ProductList loadedProductList = productQuery.getProductList();
+      final bool result =
+          await DaoProductList(localDatabase).get(loadedProductList);
       if (!result) {
         return 'unexpected empty record';
       }
-      _productList = productList;
+      productList = loadedProductList;
       return null;
     } catch (e) {
       return e.toString();
@@ -32,9 +29,6 @@ class DatabaseProductListSupplier implements ProductListSupplier {
   }
 
   @override
-  bool needsToBeSavedIntoDb() => false;
-
-  @override
   ProductListSupplier getRefreshSupplier() =>
-      QueryProductListSupplier(productQuery);
+      QueryProductListSupplier(productQuery, localDatabase);
 }

--- a/packages/smooth_app/lib/data_models/product_extra.dart
+++ b/packages/smooth_app/lib/data_models/product_extra.dart
@@ -1,0 +1,20 @@
+import 'dart:convert';
+
+/// Extra data attached to a Product when it belongs to a ProductList
+class ProductExtra {
+  ProductExtra(
+    this.intValue,
+    this.stringValue,
+  );
+
+  int intValue;
+  String stringValue;
+
+  /// Decode the string into a List<int>, when applicable
+  /// To be used for timestamps like history or scans
+  List<int> decodeStringAsIntList() =>
+      (jsonDecode(stringValue) as List<dynamic>).cast<int>();
+
+  @override
+  String toString() => '$intValue ; $stringValue';
+}

--- a/packages/smooth_app/lib/data_models/product_list.dart
+++ b/packages/smooth_app/lib/data_models/product_list.dart
@@ -2,6 +2,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/model/Product.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
+import 'package:smooth_app/data_models/product_extra.dart';
 
 class ProductList {
   ProductList({
@@ -94,7 +95,7 @@ class ProductList {
 
   final List<String> _barcodes = <String>[];
   final Map<String, Product> _products = <String, Product>{};
-  final Map<String, int> _productInts = <String, int>{};
+  final Map<String, ProductExtra> _productExtras = <String, ProductExtra>{};
 
   static const String LIST_TYPE_HTTP_SEARCH_GROUP = 'http/search/group';
   static const String LIST_TYPE_HTTP_SEARCH_KEYWORDS = 'http/search/keywords';
@@ -104,6 +105,7 @@ class ProductList {
   static const String LIST_TYPE_USER_DEFINED = 'user';
 
   List<String> get barcodes => _barcodes;
+  Map<String, ProductExtra> get productExtras => _productExtras;
 
   set colorTag(final String tag) => _setExtra(_EXTRA_COLOR, tag);
   set iconTag(final String tag) => _setExtra(_EXTRA_ICON, tag);
@@ -200,13 +202,13 @@ class ProductList {
   void set(
     final List<String> barcodes,
     final Map<String, Product> products, {
-    final Map<String, int> productInts,
+    final Map<String, ProductExtra> productExtras,
   }) {
     clear();
     _barcodes.addAll(barcodes);
     _products.addAll(products);
-    if (productInts != null) {
-      _productInts.addAll(productInts);
+    if (productExtras != null) {
+      _productExtras.addAll(productExtras);
     }
   }
 
@@ -231,18 +233,6 @@ class ProductList {
         throw Exception('no product for barcode $barcode');
       }
       result.add(product);
-    }
-    return result;
-  }
-
-  List<int> getTimestamps() {
-    final List<int> result = <int>[];
-    if (listType != LIST_TYPE_HISTORY && listType != LIST_TYPE_SCAN) {
-      return result;
-    }
-    final List<String> orderedBarcodes = getOrderedBarcodes();
-    for (final String barcode in orderedBarcodes) {
-      result.add(_productInts[barcode]);
     }
     return result;
   }

--- a/packages/smooth_app/lib/data_models/product_list.dart
+++ b/packages/smooth_app/lib/data_models/product_list.dart
@@ -1,11 +1,6 @@
-// Flutter imports:
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-
-// Package imports:
 import 'package:openfoodfacts/model/Product.dart';
-
-// Project imports:
 import 'package:smooth_app/themes/smooth_theme.dart';
 
 class ProductList {
@@ -99,6 +94,7 @@ class ProductList {
 
   final List<String> _barcodes = <String>[];
   final Map<String, Product> _products = <String, Product>{};
+  final Map<String, int> _productInts = <String, int>{};
 
   static const String LIST_TYPE_HTTP_SEARCH_GROUP = 'http/search/group';
   static const String LIST_TYPE_HTTP_SEARCH_KEYWORDS = 'http/search/keywords';
@@ -135,8 +131,8 @@ class ProductList {
 
   Product getProduct(final String barcode) => _products[barcode];
 
-  String get lousyKey =>
-      '$listType/$parameters'; // TODO(monsieurtanuki): does not work if you change the name
+  bool isSameAs(final ProductList other) =>
+      listType == other.listType && parameters == other.parameters;
 
   IconData get iconData => _ICON_DATA[_iconTag] ?? _ICON_DATA[_ICON_TAG];
 
@@ -203,11 +199,15 @@ class ProductList {
 
   void set(
     final List<String> barcodes,
-    final Map<String, Product> products,
-  ) {
+    final Map<String, Product> products, {
+    final Map<String, int> productInts,
+  }) {
     clear();
     _barcodes.addAll(barcodes);
     _products.addAll(products);
+    if (productInts != null) {
+      _productInts.addAll(productInts);
+    }
   }
 
   List<Product> getList() {
@@ -235,11 +235,21 @@ class ProductList {
     return result;
   }
 
+  List<int> getTimestamps() {
+    final List<int> result = <int>[];
+    if (listType != LIST_TYPE_HISTORY && listType != LIST_TYPE_SCAN) {
+      return result;
+    }
+    final List<String> orderedBarcodes = getOrderedBarcodes();
+    for (final String barcode in orderedBarcodes) {
+      result.add(_productInts[barcode]);
+    }
+    return result;
+  }
+
   List<String> getOrderedBarcodes() {
     final List<String> result = <String>[];
-    final Iterable<String> iterable =
-        _isReversed ? barcodes.reversed : barcodes;
-    for (final String barcode in iterable) {
+    for (final String barcode in barcodes) {
       if (result.contains(barcode)) {
         continue;
       }
@@ -247,8 +257,4 @@ class ProductList {
     }
     return result;
   }
-
-  bool get _isReversed =>
-      listType == ProductList.LIST_TYPE_HISTORY ||
-      listType == ProductList.LIST_TYPE_SCAN;
 }

--- a/packages/smooth_app/lib/data_models/product_list_supplier.dart
+++ b/packages/smooth_app/lib/data_models/product_list_supplier.dart
@@ -1,13 +1,43 @@
-// Project imports:
 import 'package:smooth_app/data_models/product_list.dart';
+import 'package:smooth_app/data_models/database_product_list_supplier.dart';
+import 'package:smooth_app/data_models/query_product_list_supplier.dart';
+import 'package:smooth_app/database/dao_product_list.dart';
+import 'package:flutter/material.dart';
+import 'package:smooth_app/database/local_database.dart';
+import 'package:smooth_app/database/product_query.dart';
 
+/// Asynchronously loads a [ProductList] with products
 abstract class ProductListSupplier {
-  /// returns null if OK, or the message error
+  ProductListSupplier(
+    this.productQuery,
+    this.localDatabase, {
+    this.timestamp,
+  });
+
+  final ProductQuery productQuery;
+  final LocalDatabase localDatabase;
+  final int timestamp;
+  @protected
+  ProductList productList;
+
+  /// Returns null if OK, or the message error
   Future<String> asyncLoad();
 
-  ProductList getProductList();
+  ProductList getProductList() => productList;
 
-  bool needsToBeSavedIntoDb();
-
+  /// Returns a helper supplier in order to refresh the data
   ProductListSupplier getRefreshSupplier();
+
+  /// Returns the fastest data supplier: database if possible, or server query
+  static Future<ProductListSupplier> getBestSupplier(
+    final ProductQuery productQuery,
+    final LocalDatabase localDatabase,
+  ) async {
+    final int timestamp = await DaoProductList(localDatabase).getTimestamp(
+      productQuery.getProductList(),
+    );
+    return timestamp == null
+        ? QueryProductListSupplier(productQuery, localDatabase)
+        : DatabaseProductListSupplier(productQuery, localDatabase, timestamp);
+  }
 }

--- a/packages/smooth_app/lib/data_models/product_query_model.dart
+++ b/packages/smooth_app/lib/data_models/product_query_model.dart
@@ -7,8 +7,6 @@ import 'package:openfoodfacts/model/Product.dart';
 // Project imports:
 import 'package:smooth_app/data_models/product_list.dart';
 import 'package:smooth_app/data_models/product_list_supplier.dart';
-import 'package:smooth_app/database/dao_product_list.dart';
-import 'package:smooth_app/database/local_database.dart';
 
 enum LoadingStatus {
   LOADING,
@@ -51,8 +49,7 @@ class ProductQueryModel with ChangeNotifier {
     notifyListeners();
   }
 
-  /// Processes the data: stores it in database if needed, and lists categories
-  void process(final LocalDatabase localDatabase) {
+  void process() {
     if (_loadingStatus != LoadingStatus.LOADED) {
       return;
     }
@@ -60,9 +57,6 @@ class ProductQueryModel with ChangeNotifier {
 
     final ProductList productList = supplier.getProductList();
     _products = productList.getList();
-    if (supplier.needsToBeSavedIntoDb()) {
-      DaoProductList(localDatabase).put(productList);
-    }
 
     displayProducts = _products;
 

--- a/packages/smooth_app/lib/data_models/query_product_list_supplier.dart
+++ b/packages/smooth_app/lib/data_models/query_product_list_supplier.dart
@@ -1,34 +1,30 @@
-// Package imports:
 import 'package:openfoodfacts/model/SearchResult.dart';
-
-// Project imports:
-import 'package:smooth_app/data_models/product_list.dart';
 import 'package:smooth_app/data_models/product_list_supplier.dart';
+import 'package:smooth_app/database/dao_product.dart';
+import 'package:smooth_app/database/local_database.dart';
+import 'package:smooth_app/database/dao_product_list.dart';
 import 'package:smooth_app/database/product_query.dart';
 
-class QueryProductListSupplier implements ProductListSupplier {
-  QueryProductListSupplier(this.productQuery);
-
-  final ProductQuery productQuery;
-  ProductList _productList;
-
-  @override
-  ProductList getProductList() => _productList;
+/// [ProductListSupplier] with a server query flavor
+class QueryProductListSupplier extends ProductListSupplier {
+  QueryProductListSupplier(
+    final ProductQuery productQuery,
+    final LocalDatabase localDatabase,
+  ) : super(productQuery, localDatabase);
 
   @override
   Future<String> asyncLoad() async {
     try {
       final SearchResult searchResult = await productQuery.getSearchResult();
-      _productList = productQuery.getProductList();
-      _productList.addAll(searchResult.products);
+      productList = productQuery.getProductList();
+      productList.addAll(searchResult.products);
+      await DaoProduct(localDatabase).put(productList.getList());
+      await DaoProductList(localDatabase).put(productList);
       return null;
     } catch (e) {
       return e.toString();
     }
   }
-
-  @override
-  bool needsToBeSavedIntoDb() => true;
 
   @override
   ProductListSupplier getRefreshSupplier() => null;

--- a/packages/smooth_app/lib/database/abstract_dao.dart
+++ b/packages/smooth_app/lib/database/abstract_dao.dart
@@ -1,0 +1,82 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:sqflite/sqflite.dart';
+import 'package:smooth_app/database/local_database.dart';
+
+/// DAO abstraction
+abstract class AbstractDao {
+  AbstractDao(this.localDatabase);
+
+  final LocalDatabase localDatabase;
+
+  /// Max number of parameters in a SQFlite query
+  ///
+  /// cf. SQLITE_MAX_VARIABLE_NUMBER, "which defaults to 999"
+  // TODO(monsieurtanuki): find a way to retrieve this number from SQFlite system tables, cf. https://github.com/tekartik/sqflite/issues/663
+  static const int SQLITE_MAX_VARIABLE_NUMBER = 999;
+
+  /// Optimized bulk insert
+  @protected
+  Future<void> bulkInsert(
+    final List<dynamic> parameters,
+    final DatabaseExecutor databaseExecutor,
+  ) async {
+    final String tableName = getTableName();
+    final List<String> columnNames = getBulkInsertColumns();
+    final int numCols = columnNames.length;
+    if (parameters.isEmpty) {
+      return;
+    }
+    if (columnNames.isEmpty) {
+      throw Exception('There must be at least one column!');
+    }
+    final String variables = '?${',?' * (columnNames.length - 1)}';
+    if (parameters.length % numCols != 0) {
+      throw Exception(
+          'Parameter list size (${parameters.length}) cannot be divided by $numCols');
+    }
+    final int additionalRecordsNumber = -1 + parameters.length ~/ numCols;
+    await databaseExecutor.rawInsert(
+        'insert into $tableName(${columnNames.join(',')}) '
+        'values($variables)${',($variables)' * additionalRecordsNumber}',
+        parameters);
+  }
+
+  /// Optimized bulk upsert
+  ///
+  /// In tests it looked 33% faster to use delete/insert rather than upsert
+  @protected
+  Future<void> bulkUpsert({
+    @required final List<dynamic> insertParameters,
+    @required final String deleteWhere,
+    @required final List<String> deleteParameters,
+    @required final DatabaseExecutor databaseExecutor,
+  }) async {
+    final String tableName = getTableName();
+    final List<String> insertColumns = getBulkInsertColumns();
+    if (insertParameters.isEmpty) {
+      return;
+    }
+    final int numCols = insertColumns.length;
+    if (insertParameters.length % numCols != 0) {
+      throw Exception(
+          'Parameter list size (${insertParameters.length}) cannot be divided by $numCols');
+    }
+    await databaseExecutor.delete(
+      tableName,
+      where: deleteWhere,
+      whereArgs: deleteParameters,
+    );
+    await bulkInsert(insertParameters, databaseExecutor);
+  }
+
+  /// Insert columns for bulk mode
+  List<String> getBulkInsertColumns();
+
+  /// Table name
+  String getTableName();
+
+  /// Max number of records to be inserted in bulk mode
+  int getBulkMaxRecordNumber() =>
+      SQLITE_MAX_VARIABLE_NUMBER ~/ getBulkInsertColumns().length;
+}

--- a/packages/smooth_app/lib/database/barcode_product_query.dart
+++ b/packages/smooth_app/lib/database/barcode_product_query.dart
@@ -1,25 +1,21 @@
-// Dart imports:
 import 'dart:async';
-
-// Flutter imports:
 import 'package:flutter/foundation.dart';
-
-// Package imports:
 import 'package:openfoodfacts/openfoodfacts.dart';
-
-// Project imports:
 import 'package:smooth_app/database/product_query.dart';
+import 'package:smooth_app/database/dao_product.dart';
 
 class BarcodeProductQuery {
   BarcodeProductQuery({
     @required this.barcode,
     @required this.languageCode,
     @required this.countryCode,
+    @required this.daoProduct,
   });
 
   final String barcode;
   final String languageCode;
   final String countryCode;
+  final DaoProduct daoProduct;
 
   Future<Product> getProduct() async {
     final ProductQueryConfiguration configuration = ProductQueryConfiguration(
@@ -33,7 +29,11 @@ class BarcodeProductQuery {
         await OpenFoodAPIClient.getProduct(configuration);
 
     if (result.status == 1) {
-      return result.product;
+      final Product product = result.product;
+      if (product != null) {
+        await daoProduct.put(<Product>[product]);
+      }
+      return product;
     }
     return null;
   }

--- a/packages/smooth_app/lib/database/dao_product.dart
+++ b/packages/smooth_app/lib/database/dao_product.dart
@@ -1,28 +1,17 @@
 import 'dart:async';
-import 'dart:collection';
 import 'dart:convert';
-import 'package:flutter/material.dart';
 import 'package:openfoodfacts/model/Product.dart';
+import 'package:smooth_app/database/abstract_dao.dart';
+import 'package:smooth_app/database/dao_product_extra.dart';
 import 'package:sqflite/sqflite.dart';
 import 'package:smooth_app/database/local_database.dart';
-import 'package:smooth_app/data_models/product_extra.dart';
-import 'package:diacritic/diacritic.dart';
 
-class DaoProduct {
-  DaoProduct(this.localDatabase);
-
-  final LocalDatabase localDatabase;
+class DaoProduct extends AbstractDao {
+  DaoProduct(final LocalDatabase localDatabase) : super(localDatabase);
 
   static const String TABLE_PRODUCT = 'product';
   static const String TABLE_PRODUCT_COLUMN_BARCODE = 'barcode';
   static const String _TABLE_PRODUCT_COLUMN_JSON = 'encoded_json';
-
-  static const String _TABLE_PRODUCT_EXTRA = 'product_extra';
-  static const String _TABLE_PRODUCT_EXTRA_COLUMN_KEY = 'extra_key';
-  static const String _TABLE_PRODUCT_EXTRA_COLUMN_VALUE = 'extra_value';
-  static const String _TABLE_PRODUCT_EXTRA_COLUMN_INT_VALUE = 'extra_int_value';
-
-  static const String _WHERE_PK = '$TABLE_PRODUCT_COLUMN_BARCODE = ?';
 
   static FutureOr<void> onUpgrade(
     final Database db,
@@ -36,49 +25,31 @@ class DaoProduct {
           '${LocalDatabase.COLUMN_TIMESTAMP} INT NOT NULL'
           ')');
     }
-    if (oldVersion < 4) {
-      await db.execute('create table $_TABLE_PRODUCT_EXTRA('
-          '$TABLE_PRODUCT_COLUMN_BARCODE TEXT NOT NULL,'
-          '$_TABLE_PRODUCT_EXTRA_COLUMN_KEY TEXT NOT NULL,'
-          '$_TABLE_PRODUCT_EXTRA_COLUMN_VALUE TEXT NOT NULL,'
-          '${LocalDatabase.COLUMN_TIMESTAMP} INT NOT NULL,'
-          'PRIMARY KEY ('
-          '$TABLE_PRODUCT_COLUMN_BARCODE,'
-          '$_TABLE_PRODUCT_EXTRA_COLUMN_KEY),'
-          'FOREIGN KEY ($TABLE_PRODUCT_COLUMN_BARCODE)'
-          ' REFERENCES $TABLE_PRODUCT'
-          '  ($TABLE_PRODUCT_COLUMN_BARCODE)'
-          '   ON DELETE CASCADE'
-          ')');
-    }
-    if (oldVersion < 6) {
-      await db.execute('alter table $_TABLE_PRODUCT_EXTRA '
-          'ADD COLUMN $_TABLE_PRODUCT_EXTRA_COLUMN_INT_VALUE INT DEFAULT 0 NOT NULL');
-    }
   }
 
-  Future<int> getLastUpdate(final String barcode) =>
-      _getLastUpdate(barcode, localDatabase.database);
-
-  Future<Product> get(final String barcode) async {
+  // TODO(monsieurtanuki): probably not relevant anymore; use product extra instead?
+  Future<int> getLastUpdate(final String barcode) async {
     final List<Map<String, dynamic>> queryResult =
         await localDatabase.database.query(
       TABLE_PRODUCT,
-      columns: <String>[_TABLE_PRODUCT_COLUMN_JSON],
-      where: _WHERE_PK,
+      columns: <String>[LocalDatabase.COLUMN_TIMESTAMP],
+      where: '$TABLE_PRODUCT_COLUMN_BARCODE = ?',
       whereArgs: <dynamic>[barcode],
     );
     if (queryResult.isEmpty) {
       // not found
       return null;
     }
-    if (queryResult.length > 1) {
-      // very very unlikely to happen
-      throw Exception('Several products with the same barcode $barcode');
-    }
-    return _getProductFromQueryResult(queryResult[0]);
+    // there's only one record expected, as barcode is the PK
+    return queryResult.first[LocalDatabase.COLUMN_TIMESTAMP] as int;
   }
 
+  Future<Product> get(final String barcode) async {
+    final Map<String, Product> map = await getAll(<String>[barcode]);
+    return map[barcode];
+  }
+
+  // TODO(monsieurtanuki): use the max variable threshold AbstractDao.SQLITE_MAX_VARIABLE_NUMBER
   Future<Map<String, Product>> getAll(final List<String> barcodes) async {
     final Map<String, Product> result = <String, Product>{};
     if (barcodes == null || barcodes.isEmpty) {
@@ -99,25 +70,17 @@ class DaoProduct {
   }
 
   Future<Map<String, Product>> getAllWithExtras(final String extraKey) async {
-    final List<
-        Map<String,
-            dynamic>> queryResults = await localDatabase.database.rawQuery(
-        'select '
-        '  a.$TABLE_PRODUCT_COLUMN_BARCODE '
-        ', a.$_TABLE_PRODUCT_COLUMN_JSON '
-        'from '
-        '  $TABLE_PRODUCT a '
-        'where '
-        '  exists( '
-        '    select '
-        '      null '
-        '    from '
-        '      $_TABLE_PRODUCT_EXTRA b '
-        '    where '
-        '      a.$TABLE_PRODUCT_COLUMN_BARCODE = b.$TABLE_PRODUCT_COLUMN_BARCODE '
-        '      and b.$_TABLE_PRODUCT_EXTRA_COLUMN_KEY = ? '
-        '  ) ',
-        <String>[extraKey]);
+    final List<Map<String, dynamic>> queryResults =
+        await localDatabase.database.rawQuery(
+      'select '
+      '  a.$TABLE_PRODUCT_COLUMN_BARCODE '
+      ', a.$_TABLE_PRODUCT_COLUMN_JSON '
+      'from '
+      '  $TABLE_PRODUCT a '
+      'where '
+      '  exists(${DaoProductExtra.getExistsSubQuery()})',
+      DaoProductExtra.getExistsSubQueryArgs(extraKey),
+    );
     return _getAll(queryResults);
   }
 
@@ -144,7 +107,6 @@ class DaoProduct {
     if (pattern == null || pattern.trim().length < minLength) {
       return result;
     }
-    await _initSimplifiedText();
     final List<Map<String, dynamic>> queryResults =
         await localDatabase.database.rawQuery(
       'select'
@@ -152,17 +114,11 @@ class DaoProduct {
       ', a.$_TABLE_PRODUCT_COLUMN_JSON '
       'from '
       '  $TABLE_PRODUCT a '
-      ', $_TABLE_PRODUCT_EXTRA b '
       'where '
-      '  a.$TABLE_PRODUCT_COLUMN_BARCODE = b.$TABLE_PRODUCT_COLUMN_BARCODE '
-      '  and b.$_TABLE_PRODUCT_EXTRA_COLUMN_KEY = ? '
-      '  and b.$_TABLE_PRODUCT_EXTRA_COLUMN_VALUE like ? '
+      '  exists(${DaoProductExtra.getExistsLikeSubQuery()}) '
       'order by '
       '  a.${LocalDatabase.COLUMN_TIMESTAMP} desc',
-      <String>[
-        _EXTRA_ID_SIMPLIFIED_TEXT,
-        '%${_getSimplifiedText(pattern)}%',
-      ],
+      DaoProductExtra.getExistsLikeSubQueryArgs(pattern),
     );
     for (final Map<String, dynamic> row in queryResults) {
       result.add(_getProductFromQueryResult(row));
@@ -170,292 +126,86 @@ class DaoProduct {
     return result;
   }
 
-  Future<void> put(final Product product) async =>
-      await _upsert(product, localDatabase.database);
+  Future<void> put(final List<Product> products) async =>
+      await localDatabase.database
+          .transaction((final Transaction transaction) async {
+        final int timestamp = LocalDatabase.nowInMillis();
+        final DaoProductExtra daoProductExtra = DaoProductExtra(localDatabase);
+        await bulkUpsertLoop(transaction, products, timestamp);
+        await daoProductExtra.bulkUpsertLoopSimplifiedText(
+          transaction,
+          products,
+          timestamp,
+        );
+        await daoProductExtra.bulkUpsertLoopLast(
+          transaction,
+          products,
+          timestamp,
+          DaoProductExtra.EXTRA_ID_LAST_REFRESH,
+        );
+      });
 
-  Future<void> putLastSeen(final Product product) async =>
-      await _putLast(product, EXTRA_ID_LAST_SEEN);
-
-  Future<void> putLastScan(final Product product) async =>
-      await _putLast(product, EXTRA_ID_LAST_SCAN);
-
-  Future<void> _putLast(final Product product, final String extraKey) async {
-    final int timestamp = LocalDatabase.nowInMillis();
-    final ProductExtra productExtra = await getProductExtra(
-      key: extraKey,
-      barcode: product.barcode,
-    );
-    List<int> timestamps;
-    if (productExtra == null) {
-      timestamps = <int>[];
-    } else {
-      timestamps = productExtra.decodeStringAsIntList();
-    }
-    timestamps.add(timestamp);
-    await _upsertExtra(
-      product.barcode,
-      extraKey,
-      jsonEncode(timestamps),
-      timestamp,
-      localDatabase.database,
-    );
-  }
-
-  Future<void> putProducts(final List<Product> products) async {
-    await localDatabase.database
-        .transaction((final Transaction transaction) async {
-      for (final Product product in products) {
-        await _upsert(product, transaction);
-      }
-    });
-  }
-
-  /// Upsert clumsy implementation due to poor SQLite support by sqlflite
-  /// (ConflictAlgorithm.replace is not an option because of FK cascade delete)
-  static Future<bool> _upsert(
-    final Product product,
+  Future<void> bulkUpsertLoop(
     final DatabaseExecutor databaseExecutor,
+    final List<Product> products,
+    final int timestamp,
   ) async {
-    try {
-      final int lastUpdate =
-          await _getLastUpdate(product.barcode, databaseExecutor);
-      if (lastUpdate != null) {
-        final int nbRows = await _update(product, databaseExecutor);
-        if (nbRows == 1) {
-          // very expected result
-          await _upsertSimplifiedText(product, databaseExecutor);
-          return true;
-        }
+    final int maxRecordNumber = getBulkMaxRecordNumber();
+    final List<dynamic> insertParameters = <dynamic>[];
+    final List<String> deleteParameters = <String>[];
+    int counter = 0;
+    for (final Product product in products) {
+      deleteParameters.add(product.barcode);
+      insertParameters.add(product.barcode);
+      insertParameters.add(json.encode(product.toJson()));
+      insertParameters.add(timestamp);
+      counter++;
+      if (counter == maxRecordNumber) {
+        await _bulkUpsert(
+          insertParameters,
+          deleteParameters,
+          databaseExecutor,
+        );
+        counter = 0;
+        deleteParameters.clear();
+        insertParameters.clear();
       }
-      final bool result = await _insert(product, databaseExecutor);
-      if (result) {
-        await _upsertSimplifiedText(product, databaseExecutor);
-      }
-      return result;
-    } catch (e) {
-      print('exception: $e');
     }
-    return false;
+    await _bulkUpsert(
+      insertParameters,
+      deleteParameters,
+      databaseExecutor,
+    );
   }
 
-  static Future<bool> _insert(
-    final Product product,
+  @override
+  List<String> getBulkInsertColumns() => <String>[
+        TABLE_PRODUCT_COLUMN_BARCODE,
+        _TABLE_PRODUCT_COLUMN_JSON,
+        LocalDatabase.COLUMN_TIMESTAMP,
+      ];
+
+  @override
+  String getTableName() => TABLE_PRODUCT;
+
+  /// Bulk upsert of products
+  Future<void> _bulkUpsert(
+    final List<dynamic> insertParameters,
+    final List<String> deleteParameters,
     final DatabaseExecutor databaseExecutor,
-  ) async {
-    try {
-      await databaseExecutor.insert(
-        TABLE_PRODUCT,
-        <String, dynamic>{
-          TABLE_PRODUCT_COLUMN_BARCODE: product.barcode,
-          _TABLE_PRODUCT_COLUMN_JSON: json.encode(product.toJson()),
-          LocalDatabase.COLUMN_TIMESTAMP: LocalDatabase.nowInMillis(),
-        },
+  ) async =>
+      await bulkUpsert(
+        insertParameters: insertParameters,
+        deleteParameters: deleteParameters,
+        deleteWhere:
+            '$TABLE_PRODUCT_COLUMN_BARCODE in (?${',?' * (deleteParameters.length - 1)})',
+        databaseExecutor: databaseExecutor,
       );
-      return true;
-    } catch (e) {
-      print('exception: $e');
-    }
-    return false;
-  }
-
-  static Future<int> _update(
-    final Product product,
-    final DatabaseExecutor databaseExecutor,
-  ) async {
-    try {
-      return await databaseExecutor.update(
-        TABLE_PRODUCT,
-        <String, dynamic>{
-          _TABLE_PRODUCT_COLUMN_JSON: json.encode(product.toJson()),
-          LocalDatabase.COLUMN_TIMESTAMP: LocalDatabase.nowInMillis(),
-        },
-        where: _WHERE_PK,
-        whereArgs: <dynamic>[product.barcode],
-      );
-    } catch (e) {
-      print('exception: $e');
-    }
-    return 0;
-  }
-
-  static Future<int> _getLastUpdate(
-    final String barcode,
-    final DatabaseExecutor databaseExecutor,
-  ) async {
-    final List<Map<String, dynamic>> queryResult = await databaseExecutor.query(
-      TABLE_PRODUCT,
-      columns: <String>[LocalDatabase.COLUMN_TIMESTAMP],
-      where: _WHERE_PK,
-      whereArgs: <dynamic>[barcode],
-    );
-    if (queryResult.isEmpty) {
-      // not found
-      return null;
-    }
-    if (queryResult.length > 1) {
-      // very very unlikely to happen
-      throw Exception('Several products with the same barcode $barcode');
-    }
-    return queryResult.first[LocalDatabase.COLUMN_TIMESTAMP] as int;
-  }
 
   Product _getProductFromQueryResult(final Map<String, dynamic> row) {
     final String encodedJson = row[_TABLE_PRODUCT_COLUMN_JSON] as String;
     final Map<String, dynamic> decodedJson =
         json.decode(encodedJson) as Map<String, dynamic>;
     return Product.fromJson(decodedJson);
-  }
-
-  /// Returns a lowercase not accented version of the text, for comparisons
-  static String _getSimplifiedText(final String text) {
-    if (text == null) {
-      return '';
-    }
-    return removeDiacritics(text).toLowerCase();
-  }
-
-  static const String _EXTRA_ID_SIMPLIFIED_TEXT = 'simplified_text';
-  static const String EXTRA_ID_LAST_SEEN = 'last_seen';
-  static const String EXTRA_ID_LAST_SCAN = 'last_scan';
-
-  /// Init, to be performed only during a transitional development phase
-  Future<void> _initSimplifiedText() async {
-    final List<Map<String, dynamic>> counting =
-        await localDatabase.database.query(
-      _TABLE_PRODUCT_EXTRA,
-      columns: <String>['count(*) as mycount'],
-      where: '$_TABLE_PRODUCT_EXTRA_COLUMN_KEY = ?',
-      whereArgs: <String>[_EXTRA_ID_SIMPLIFIED_TEXT],
-    );
-    final int count = counting[0]['mycount'] as int;
-    if (count > 0) {
-      return; // already done, nothing more to do
-    }
-    final List<Map<String, dynamic>> queryResults =
-        await localDatabase.database.query(
-      TABLE_PRODUCT,
-      columns: <String>[
-        TABLE_PRODUCT_COLUMN_BARCODE,
-        _TABLE_PRODUCT_COLUMN_JSON,
-      ],
-    );
-    if (queryResults.isEmpty) {
-      return; // empty database, nothing to do at all
-    }
-    for (final Map<String, dynamic> row in queryResults) {
-      final Product product = _getProductFromQueryResult(row);
-      await _upsertSimplifiedText(product, localDatabase.database);
-    }
-  }
-
-  /// Upserts the simplified text extra related to a product
-  static Future<void> _upsertSimplifiedText(
-    final Product product,
-    final DatabaseExecutor databaseExecutor,
-  ) async =>
-      await _upsertExtra(
-        product.barcode,
-        _EXTRA_ID_SIMPLIFIED_TEXT,
-        _getSimplifiedTextForProduct(product),
-        0,
-        databaseExecutor,
-      );
-
-  static String _getSimplifiedTextForProduct(final Product product) {
-    final List<String> labels = <String>[];
-    if (product.productName != null) {
-      labels.add(_getSimplifiedText(product.productName));
-    }
-    if (product.productNameFR != null) {
-      labels.add(_getSimplifiedText(product.productNameFR));
-    }
-    if (product.productNameDE != null) {
-      labels.add(_getSimplifiedText(product.productNameDE));
-    }
-    if (product.productNameEN != null) {
-      labels.add(_getSimplifiedText(product.productNameEN));
-    }
-    return labels.isEmpty ? '' : labels.join(', ');
-  }
-
-  /// Upserts the [ProductExtra] value for an extra [key] and a single [barcode]
-  static Future<void> _upsertExtra(
-    final String barcode,
-    final String extraKey,
-    final String extraValue,
-    final int extraIntValue,
-    final DatabaseExecutor databaseExecutor,
-  ) async =>
-      await databaseExecutor.insert(
-        _TABLE_PRODUCT_EXTRA,
-        <String, dynamic>{
-          TABLE_PRODUCT_COLUMN_BARCODE: barcode,
-          _TABLE_PRODUCT_EXTRA_COLUMN_KEY: extraKey,
-          _TABLE_PRODUCT_EXTRA_COLUMN_VALUE: extraValue,
-          _TABLE_PRODUCT_EXTRA_COLUMN_INT_VALUE: extraIntValue,
-          LocalDatabase.COLUMN_TIMESTAMP: LocalDatabase.nowInMillis(),
-        },
-        conflictAlgorithm: ConflictAlgorithm.replace,
-      );
-
-  /// Returns the [ProductExtra] values for all products with an extra [key]
-  Future<LinkedHashMap<String, ProductExtra>> getProductExtras({
-    @required final String key,
-    @required final bool reverse,
-    final int limit,
-  }) async {
-    final LinkedHashMap<String, ProductExtra> result =
-        LinkedHashMap<String, ProductExtra>();
-    final List<Map<String, dynamic>> queryResults =
-        await localDatabase.database.query(
-      DaoProduct._TABLE_PRODUCT_EXTRA,
-      columns: <String>[
-        TABLE_PRODUCT_COLUMN_BARCODE,
-        _TABLE_PRODUCT_EXTRA_COLUMN_VALUE,
-        _TABLE_PRODUCT_EXTRA_COLUMN_INT_VALUE,
-      ],
-      where: '$_TABLE_PRODUCT_EXTRA_COLUMN_KEY = ?',
-      whereArgs: <String>[key],
-      orderBy:
-          '$_TABLE_PRODUCT_EXTRA_COLUMN_INT_VALUE ${reverse ? 'DESC' : 'ASC'}',
-      limit: limit,
-    );
-    for (final Map<String, dynamic> row in queryResults) {
-      final String barcode =
-          row[DaoProduct.TABLE_PRODUCT_COLUMN_BARCODE] as String;
-      final String stringValue =
-          row[DaoProduct._TABLE_PRODUCT_EXTRA_COLUMN_VALUE] as String;
-      final int intValue =
-          row[DaoProduct._TABLE_PRODUCT_EXTRA_COLUMN_INT_VALUE] as int;
-      result[barcode] = ProductExtra(intValue, stringValue);
-    }
-    return result;
-  }
-
-  /// Returns the [ProductExtra] value for an extra [key] and a single [barcode]
-  Future<ProductExtra> getProductExtra({
-    @required final String key,
-    @required final String barcode,
-  }) async {
-    final List<Map<String, dynamic>> queryResults =
-        await localDatabase.database.query(
-      DaoProduct._TABLE_PRODUCT_EXTRA,
-      columns: <String>[
-        _TABLE_PRODUCT_EXTRA_COLUMN_VALUE,
-        _TABLE_PRODUCT_EXTRA_COLUMN_INT_VALUE,
-      ],
-      where: '$_TABLE_PRODUCT_EXTRA_COLUMN_KEY = ? '
-          'AND $TABLE_PRODUCT_COLUMN_BARCODE = ?',
-      whereArgs: <String>[key, barcode],
-    );
-    if (queryResults.isEmpty) {
-      return null;
-    }
-    final Map<String, dynamic> row = queryResults.first;
-    final String stringValue =
-        row[DaoProduct._TABLE_PRODUCT_EXTRA_COLUMN_VALUE] as String;
-    final int intValue =
-        row[DaoProduct._TABLE_PRODUCT_EXTRA_COLUMN_INT_VALUE] as int;
-    return ProductExtra(intValue, stringValue);
   }
 }

--- a/packages/smooth_app/lib/database/dao_product_extra.dart
+++ b/packages/smooth_app/lib/database/dao_product_extra.dart
@@ -1,0 +1,405 @@
+import 'dart:async';
+import 'dart:collection';
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:openfoodfacts/model/Product.dart';
+import 'package:smooth_app/database/abstract_dao.dart';
+import 'package:smooth_app/database/dao_product.dart';
+import 'package:sqflite/sqflite.dart';
+import 'package:smooth_app/database/local_database.dart';
+import 'package:smooth_app/data_models/product_extra.dart';
+import 'package:diacritic/diacritic.dart';
+import 'package:smooth_app/data_models/product_list.dart';
+
+/// DAO for Product Extra data
+///
+/// For a key and a barcode, we store a string value and an integer value.
+/// The whole idea is to store:
+/// - interesting data in the string value, e.g. in json,
+/// - and an integer value accessible in a SQL "order by" clause
+/// A typical use case is for timestamps history (e.g. scan, view or refresh).
+/// In that case the integer value contains the latest timestamp,
+/// and the string value contains a list of timestamps encoded as json.
+class DaoProductExtra extends AbstractDao {
+  DaoProductExtra(final LocalDatabase localDatabase) : super(localDatabase);
+
+  static const String _TABLE_PRODUCT_EXTRA = 'product_extra';
+  static const String _TABLE_PRODUCT_EXTRA_COLUMN_KEY = 'extra_key';
+  static const String _TABLE_PRODUCT_EXTRA_COLUMN_VALUE = 'extra_value';
+  static const String _TABLE_PRODUCT_EXTRA_COLUMN_INT_VALUE = 'extra_int_value';
+
+  static FutureOr<void> onUpgrade(
+    final Database db,
+    final int oldVersion,
+    final int newVersion,
+  ) async {
+    if (oldVersion < 4) {
+      await db.execute('create table $_TABLE_PRODUCT_EXTRA('
+          '${DaoProduct.TABLE_PRODUCT_COLUMN_BARCODE} TEXT NOT NULL,'
+          '$_TABLE_PRODUCT_EXTRA_COLUMN_KEY TEXT NOT NULL,'
+          '$_TABLE_PRODUCT_EXTRA_COLUMN_VALUE TEXT NOT NULL,'
+          '${LocalDatabase.COLUMN_TIMESTAMP} INT NOT NULL,'
+          'PRIMARY KEY ('
+          '${DaoProduct.TABLE_PRODUCT_COLUMN_BARCODE},'
+          '$_TABLE_PRODUCT_EXTRA_COLUMN_KEY),'
+          'FOREIGN KEY (${DaoProduct.TABLE_PRODUCT_COLUMN_BARCODE})' // FK dropped later
+          ' REFERENCES ${DaoProduct.TABLE_PRODUCT}'
+          '  (${DaoProduct.TABLE_PRODUCT_COLUMN_BARCODE})'
+          '   ON DELETE CASCADE'
+          ')');
+    }
+    if (oldVersion < 6) {
+      await db.execute('alter table $_TABLE_PRODUCT_EXTRA '
+          'ADD COLUMN $_TABLE_PRODUCT_EXTRA_COLUMN_INT_VALUE INT DEFAULT 0 NOT NULL');
+    }
+    if (oldVersion < 7) {
+      // dropping the FK of table product extra to table product
+      const String TMP_TABLE_NAME = 'ngjkdkjfesk';
+      await db.execute('create table $TMP_TABLE_NAME('
+          '${DaoProduct.TABLE_PRODUCT_COLUMN_BARCODE} TEXT NOT NULL,'
+          '$_TABLE_PRODUCT_EXTRA_COLUMN_KEY TEXT NOT NULL,'
+          '$_TABLE_PRODUCT_EXTRA_COLUMN_VALUE TEXT NOT NULL,'
+          '$_TABLE_PRODUCT_EXTRA_COLUMN_INT_VALUE INT DEFAULT 0 NOT NULL,'
+          '${LocalDatabase.COLUMN_TIMESTAMP} INT NOT NULL,'
+          'PRIMARY KEY ('
+          '${DaoProduct.TABLE_PRODUCT_COLUMN_BARCODE},'
+          '$_TABLE_PRODUCT_EXTRA_COLUMN_KEY)'
+          ')');
+      const String COLUMNS = '${DaoProduct.TABLE_PRODUCT_COLUMN_BARCODE},'
+          '$_TABLE_PRODUCT_EXTRA_COLUMN_KEY,'
+          '$_TABLE_PRODUCT_EXTRA_COLUMN_VALUE,'
+          '$_TABLE_PRODUCT_EXTRA_COLUMN_INT_VALUE,'
+          '${LocalDatabase.COLUMN_TIMESTAMP} ';
+      await db.execute(
+        'insert into $TMP_TABLE_NAME($COLUMNS) '
+        'select $COLUMNS from $_TABLE_PRODUCT_EXTRA',
+      );
+      await db.execute('drop table $_TABLE_PRODUCT_EXTRA');
+      await db.execute(
+          'alter table $TMP_TABLE_NAME rename to $_TABLE_PRODUCT_EXTRA');
+    }
+  }
+
+  /// Returns the sub-query for products that have a product extra
+  static String getExistsSubQuery() => ''
+      'select '
+      '  null '
+      'from '
+      '  $_TABLE_PRODUCT_EXTRA b '
+      'where '
+      '  a.${DaoProduct.TABLE_PRODUCT_COLUMN_BARCODE} = b.${DaoProduct.TABLE_PRODUCT_COLUMN_BARCODE} '
+      '  and b.$_TABLE_PRODUCT_EXTRA_COLUMN_KEY = ? ';
+
+  /// Returns the sub-query parameters for products that have a product extra
+  static List<String> getExistsSubQueryArgs(final String key) => <String>[key];
+
+  /// Returns the sub-query for products about the suggestion field
+  static String getExistsLikeSubQuery() =>
+      getExistsSubQuery() +
+      '  and b.$_TABLE_PRODUCT_EXTRA_COLUMN_VALUE like ? ';
+
+  /// Returns the sub-query parameters for products about the suggestion field
+  static List<String> getExistsLikeSubQueryArgs(final String pattern) =>
+      <String>[_EXTRA_ID_SIMPLIFIED_TEXT, '%${_getSimplifiedText(pattern)}%'];
+
+  /// Adds a "last time I saw this product" timestamp entry
+  Future<void> putLastSeen(final Product product) async =>
+      await _putLast(product, EXTRA_ID_LAST_SEEN);
+
+  /// Adds a "last time I scanned this product" timestamp entry
+  Future<void> putLastScan(final Product product) async =>
+      await _putLast(product, EXTRA_ID_LAST_SCAN);
+
+  /// Adds a "last time I did whatever with this product" timestamp entry
+  Future<void> _putLast(
+    final Product product,
+    final String extraKey, {
+    int timestamp,
+    DatabaseExecutor databaseExecutor,
+  }) async =>
+      await bulkUpsertLoopLast(
+        databaseExecutor ?? localDatabase.database,
+        <Product>[product],
+        timestamp ?? LocalDatabase.nowInMillis(),
+        extraKey,
+      );
+
+  /// Upserts the simplified text in bulk mode
+  Future<void> bulkUpsertLoopSimplifiedText(
+    final DatabaseExecutor databaseExecutor,
+    final List<Product> products,
+    final int timestamp,
+  ) async {
+    const String KEY = _EXTRA_ID_SIMPLIFIED_TEXT;
+    final int maxRecordNumber = getBulkMaxRecordNumber();
+    final List<dynamic> insertParameters = <dynamic>[];
+    final List<String> deleteParameters = <String>[KEY];
+
+    int counter = 0;
+    for (final Product product in products) {
+      deleteParameters.add(product.barcode);
+      insertParameters.add(product.barcode);
+      insertParameters.add(KEY);
+      insertParameters.add(_getSimplifiedTextForProduct(product));
+      insertParameters.add(0);
+      insertParameters.add(timestamp);
+      counter++;
+      if (counter == maxRecordNumber) {
+        await _bulkUpsert(insertParameters, deleteParameters, databaseExecutor);
+        counter = 0;
+        deleteParameters.clear();
+        deleteParameters.add(KEY);
+        insertParameters.clear();
+      }
+    }
+    await _bulkUpsert(insertParameters, deleteParameters, databaseExecutor);
+  }
+
+  /// Upserts the "last time I did whatever with this product" in bulk mode
+  Future<void> bulkUpsertLoopLast(
+    final DatabaseExecutor databaseExecutor,
+    final List<Product> products,
+    final int timestamp,
+    final String extraKey,
+  ) async {
+    final int maxRecordNumber = getBulkMaxRecordNumber();
+    final List<dynamic> insertParameters = <dynamic>[];
+    final List<String> deleteParameters = <String>[extraKey];
+
+    final List<String> barcodes = <String>[];
+    for (final Product product in products) {
+      barcodes.add(product.barcode);
+    }
+    final Map<String, ProductExtra> map = await getProductExtras(
+      key: extraKey,
+      barcodes: barcodes,
+      databaseExecutor: databaseExecutor,
+    );
+
+    int counter = 0;
+    for (final Product product in products) {
+      final ProductExtra productExtra = map[product.barcode];
+      List<int> timestamps;
+      if (productExtra == null) {
+        timestamps = <int>[];
+      } else {
+        timestamps = productExtra.decodeStringAsIntList();
+      }
+      timestamps.add(timestamp);
+
+      deleteParameters.add(product.barcode);
+      insertParameters.add(product.barcode);
+      insertParameters.add(extraKey);
+      insertParameters.add(jsonEncode(timestamps)); // string value
+      insertParameters.add(timestamp); // int value
+      insertParameters.add(timestamp);
+      counter++;
+      if (counter == maxRecordNumber) {
+        await _bulkUpsert(insertParameters, deleteParameters, databaseExecutor);
+        counter = 0;
+        deleteParameters.clear();
+        deleteParameters.add(extraKey);
+        insertParameters.clear();
+      }
+    }
+    await _bulkUpsert(insertParameters, deleteParameters, databaseExecutor);
+  }
+
+  @override
+  List<String> getBulkInsertColumns() => <String>[
+        DaoProduct.TABLE_PRODUCT_COLUMN_BARCODE,
+        _TABLE_PRODUCT_EXTRA_COLUMN_KEY,
+        _TABLE_PRODUCT_EXTRA_COLUMN_VALUE,
+        _TABLE_PRODUCT_EXTRA_COLUMN_INT_VALUE,
+        LocalDatabase.COLUMN_TIMESTAMP,
+      ];
+
+  @override
+  String getTableName() => _TABLE_PRODUCT_EXTRA;
+
+  /// Bulk upsert of product extra
+  Future<void> _bulkUpsert(
+    final List<dynamic> insertParameters,
+    final List<String> deleteParameters,
+    final DatabaseExecutor databaseExecutor,
+  ) async =>
+      await bulkUpsert(
+        insertParameters: insertParameters,
+        deleteParameters: deleteParameters,
+        deleteWhere: '$_TABLE_PRODUCT_EXTRA_COLUMN_KEY = ? '
+            'and ${DaoProduct.TABLE_PRODUCT_COLUMN_BARCODE} in (?${',?' * (deleteParameters.length - 2)})',
+        databaseExecutor: databaseExecutor,
+      );
+
+  /// Returns a lowercase not accented version of the text, for comparisons
+  static String _getSimplifiedText(final String text) {
+    if (text == null) {
+      return '';
+    }
+    return removeDiacritics(text).toLowerCase();
+  }
+
+  /// Extra id for a simplified version of the text, for search purposes
+  static const String _EXTRA_ID_SIMPLIFIED_TEXT = 'simplified_text';
+
+  /// Extra id for each time the user went to the product page
+  static const String EXTRA_ID_LAST_SEEN = 'last_seen';
+
+  /// Extra id for each time the user scanned a product
+  static const String EXTRA_ID_LAST_SCAN = 'last_scan';
+
+  /// Extra id for each time the product data was refreshed from the web
+  static const String EXTRA_ID_LAST_REFRESH = 'last_refresh';
+
+  static String _getSimplifiedTextForProduct(final Product product) {
+    final List<String> labels = <String>[];
+    if (product.productName != null) {
+      labels.add(_getSimplifiedText(product.productName));
+    }
+    if (product.productNameFR != null) {
+      labels.add(_getSimplifiedText(product.productNameFR));
+    }
+    if (product.productNameDE != null) {
+      labels.add(_getSimplifiedText(product.productNameDE));
+    }
+    if (product.productNameEN != null) {
+      labels.add(_getSimplifiedText(product.productNameEN));
+    }
+    return labels.isEmpty ? '' : labels.join(', ');
+  }
+
+  /// Returns the ordered [ProductExtra]s for all products with an extra [key]
+  Future<LinkedHashMap<String, ProductExtra>> getOrderedProductExtras({
+    @required final String key,
+    @required final bool reverse,
+    final int limit,
+  }) async {
+    final LinkedHashMap<String, ProductExtra> result =
+        LinkedHashMap<String, ProductExtra>();
+    final List<Map<String, dynamic>> queryResults =
+        await localDatabase.database.query(
+      _TABLE_PRODUCT_EXTRA,
+      columns: <String>[
+        DaoProduct.TABLE_PRODUCT_COLUMN_BARCODE,
+        _TABLE_PRODUCT_EXTRA_COLUMN_VALUE,
+        _TABLE_PRODUCT_EXTRA_COLUMN_INT_VALUE,
+      ],
+      where: '$_TABLE_PRODUCT_EXTRA_COLUMN_KEY = ?',
+      whereArgs: <String>[key],
+      orderBy:
+          '$_TABLE_PRODUCT_EXTRA_COLUMN_INT_VALUE ${reverse ? 'DESC' : 'ASC'}',
+      limit: limit,
+    );
+    for (final Map<String, dynamic> row in queryResults) {
+      final String barcode =
+          row[DaoProduct.TABLE_PRODUCT_COLUMN_BARCODE] as String;
+      final String stringValue =
+          row[_TABLE_PRODUCT_EXTRA_COLUMN_VALUE] as String;
+      final int intValue = row[_TABLE_PRODUCT_EXTRA_COLUMN_INT_VALUE] as int;
+      result[barcode] = ProductExtra(intValue, stringValue);
+    }
+    return result;
+  }
+
+  /// Returns the [ProductExtra] values for an extra [key] and several [barcode]s
+  Future<Map<String, ProductExtra>> getProductExtras({
+    @required final String key,
+    @required final Iterable<String> barcodes,
+    DatabaseExecutor databaseExecutor,
+  }) async {
+    final Map<String, ProductExtra> result = <String, ProductExtra>{};
+    if (barcodes.isEmpty) {
+      return result;
+    }
+    databaseExecutor ??= localDatabase.database;
+    final List<String> whereArgs = <String>[key];
+    whereArgs.addAll(barcodes);
+    final List<Map<String, dynamic>> queryResults =
+        await databaseExecutor.query(
+      _TABLE_PRODUCT_EXTRA,
+      columns: <String>[
+        DaoProduct.TABLE_PRODUCT_COLUMN_BARCODE,
+        _TABLE_PRODUCT_EXTRA_COLUMN_VALUE,
+        _TABLE_PRODUCT_EXTRA_COLUMN_INT_VALUE,
+      ],
+      where: '$_TABLE_PRODUCT_EXTRA_COLUMN_KEY = ? '
+          'AND ${DaoProduct.TABLE_PRODUCT_COLUMN_BARCODE} in (?${',?' * (barcodes.length - 1)})',
+      whereArgs: whereArgs,
+    );
+    for (final Map<String, dynamic> row in queryResults) {
+      final String barcode =
+          row[DaoProduct.TABLE_PRODUCT_COLUMN_BARCODE] as String;
+      final String stringValue =
+          row[_TABLE_PRODUCT_EXTRA_COLUMN_VALUE] as String;
+      final int intValue = row[_TABLE_PRODUCT_EXTRA_COLUMN_INT_VALUE] as int;
+      result[barcode] = ProductExtra(intValue, stringValue);
+    }
+    return result;
+  }
+
+  /// Returns the [ProductExtra] for an extra [key] and a [barcode]
+  Future<ProductExtra> getProductExtra({
+    @required final String key,
+    @required final String barcode,
+  }) async {
+    final Map<String, ProductExtra> map = await getProductExtras(
+      key: key,
+      barcodes: <String>[barcode],
+    );
+    return map[barcode];
+  }
+
+  String _getExtraKey(final ProductList productList) {
+    switch (productList.listType) {
+      case ProductList.LIST_TYPE_HISTORY:
+        return EXTRA_ID_LAST_SEEN;
+      case ProductList.LIST_TYPE_SCAN:
+        return EXTRA_ID_LAST_SCAN;
+    }
+    return null;
+  }
+
+  bool _getExtraReverse(final ProductList productList) {
+    switch (productList.listType) {
+      case ProductList.LIST_TYPE_HISTORY:
+        return true;
+      case ProductList.LIST_TYPE_SCAN:
+        return false;
+    }
+    return null;
+  }
+
+  Future<bool> getList(final ProductList productList) async {
+    final String extraKey = _getExtraKey(productList);
+    final bool extraReverse = _getExtraReverse(productList);
+    if (extraKey == null || extraReverse == null) {
+      return false;
+    }
+    final LinkedHashMap<String, ProductExtra> extras =
+        await getOrderedProductExtras(key: extraKey, reverse: extraReverse);
+    final List<String> barcodes = List<String>.from(extras.keys);
+    final Map<String, Product> products =
+        await DaoProduct(localDatabase).getAllWithExtras(extraKey);
+    productList.set(barcodes, products, productExtras: extras);
+    return true;
+  }
+
+  Future<List<String>> getFirstBarcodes(
+    final ProductList productList,
+    final int limit,
+  ) async {
+    final String extraKey = _getExtraKey(productList);
+    final bool extraReverse = _getExtraReverse(productList);
+    if (extraKey == null || extraReverse == null) {
+      return null;
+    }
+    final LinkedHashMap<String, ProductExtra> extras =
+        await getOrderedProductExtras(
+      key: extraKey,
+      reverse: extraReverse,
+      limit: limit,
+    );
+    final List<String> barcodes = List<String>.from(extras.keys);
+    return barcodes;
+  }
+}

--- a/packages/smooth_app/lib/database/dao_product_list.dart
+++ b/packages/smooth_app/lib/database/dao_product_list.dart
@@ -1,16 +1,14 @@
 import 'dart:async';
-import 'dart:collection';
 import 'package:openfoodfacts/model/Product.dart';
+import 'package:smooth_app/database/abstract_dao.dart';
+import 'package:smooth_app/database/dao_product_extra.dart';
 import 'package:sqflite/sqflite.dart';
 import 'package:smooth_app/data_models/product_list.dart';
 import 'package:smooth_app/database/dao_product.dart';
-import 'package:smooth_app/data_models/product_extra.dart';
 import 'package:smooth_app/database/local_database.dart';
 
-class DaoProductList {
-  DaoProductList(this.localDatabase);
-
-  final LocalDatabase localDatabase;
+class DaoProductList extends AbstractDao {
+  DaoProductList(final LocalDatabase localDatabase) : super(localDatabase);
 
   static const String _TABLE_PRODUCT_LIST = 'product_list';
   static const String _TABLE_PRODUCT_LIST_COLUMN_ID = '_id';
@@ -75,6 +73,29 @@ class DaoProductList {
           '  ($_TABLE_PRODUCT_LIST_COLUMN_ID)'
           '   ON DELETE CASCADE'
           ')');
+    }
+    if (oldVersion < 7) {
+      // removing the FK of table product list item to table product
+      const String TMP_TABLE_NAME = 'ngjkd';
+      await db.execute('create table $TMP_TABLE_NAME('
+          '$_TABLE_PRODUCT_LIST_ITEM_COLUMN_ID INTEGER PRIMARY KEY AUTOINCREMENT,'
+          '$_TABLE_PRODUCT_LIST_ITEM_COLUMN_LIST_ID INT NOT NULL,'
+          '$_TABLE_PRODUCT_LIST_ITEM_COLUMN_BARCODE TEXT NOT NULL,'
+          '${LocalDatabase.COLUMN_TIMESTAMP} INT NOT NULL,'
+          'FOREIGN KEY ($_TABLE_PRODUCT_LIST_ITEM_COLUMN_LIST_ID)'
+          ' REFERENCES $_TABLE_PRODUCT_LIST'
+          '  ($_TABLE_PRODUCT_LIST_COLUMN_ID)'
+          '   ON DELETE CASCADE '
+          ')');
+      const String COLUMNS = '$_TABLE_PRODUCT_LIST_ITEM_COLUMN_ID,'
+          '$_TABLE_PRODUCT_LIST_ITEM_COLUMN_LIST_ID,'
+          '$_TABLE_PRODUCT_LIST_ITEM_COLUMN_BARCODE,'
+          '${LocalDatabase.COLUMN_TIMESTAMP} ';
+      await db.execute('insert into $TMP_TABLE_NAME($COLUMNS) '
+          'select $COLUMNS from $_TABLE_PRODUCT_LIST_ITEM');
+      await db.execute('drop table $_TABLE_PRODUCT_LIST_ITEM');
+      await db.execute(
+          'alter table $TMP_TABLE_NAME rename to $_TABLE_PRODUCT_LIST_ITEM');
     }
   }
 
@@ -149,14 +170,14 @@ class DaoProductList {
     }
   }
 
-  Future<void> put(final ProductList productList) async {
-    final int productListId = await _upsertProductList(productList);
-    await DaoProduct(localDatabase).putProducts(productList.getList());
-    await _refreshListItems(productList, productListId);
-  }
+  Future<void> put(final ProductList productList) async =>
+      await _refreshListItems(
+        productList,
+        await _upsertProductList(productList),
+      );
 
   Future<bool> get(final ProductList productList) async {
-    if (await _getExtraList(productList)) {
+    if (await DaoProductExtra(localDatabase).getList(productList)) {
       return true;
     }
     final int id = await _getId(productList);
@@ -170,22 +191,6 @@ class DaoProductList {
     return true;
   }
 
-  Future<bool> _getExtraList(final ProductList productList) async {
-    final String extraKey = _getExtraKey(productList);
-    final bool extraReverse = _getExtraReverse(productList);
-    if (extraKey == null || extraReverse == null) {
-      return null;
-    }
-    final DaoProduct daoProduct = DaoProduct(localDatabase);
-    final LinkedHashMap<String, ProductExtra> extras =
-        await daoProduct.getProductExtras(key: extraKey, reverse: extraReverse);
-    final List<String> barcodes = List<String>.from(extras.keys);
-    final Map<String, Product> products =
-        await daoProduct.getAllWithExtras(extraKey);
-    productList.set(barcodes, products, productExtras: extras);
-    return true;
-  }
-
   Future<List<String>> getFirstBarcodes(
     final ProductList productList,
     final int limit,
@@ -193,7 +198,10 @@ class DaoProductList {
     final bool unique,
   ) async {
     final List<String> result =
-        await _getFirstBarcodesExtra(productList, limit);
+        await DaoProductExtra(localDatabase).getFirstBarcodes(
+      productList,
+      limit,
+    );
     if (result != null) {
       return result;
     }
@@ -208,46 +216,6 @@ class DaoProductList {
       reverse: reverse,
       unique: unique,
     );
-  }
-
-  Future<List<String>> _getFirstBarcodesExtra(
-    final ProductList productList,
-    final int limit,
-  ) async {
-    final String extraKey = _getExtraKey(productList);
-    final bool extraReverse = _getExtraReverse(productList);
-    if (extraKey == null || extraReverse == null) {
-      return null;
-    }
-    final DaoProduct daoProduct = DaoProduct(localDatabase);
-    final LinkedHashMap<String, ProductExtra> extras =
-        await daoProduct.getProductExtras(
-      key: extraKey,
-      reverse: extraReverse,
-      limit: limit,
-    );
-    final List<String> barcodes = List<String>.from(extras.keys);
-    return barcodes;
-  }
-
-  String _getExtraKey(final ProductList productList) {
-    switch (productList.listType) {
-      case ProductList.LIST_TYPE_HISTORY:
-        return DaoProduct.EXTRA_ID_LAST_SEEN;
-      case ProductList.LIST_TYPE_SCAN:
-        return DaoProduct.EXTRA_ID_LAST_SCAN;
-    }
-    return null;
-  }
-
-  bool _getExtraReverse(final ProductList productList) {
-    switch (productList.listType) {
-      case ProductList.LIST_TYPE_HISTORY:
-        return true;
-      case ProductList.LIST_TYPE_SCAN:
-        return false;
-    }
-    return null;
   }
 
   Future<List<Product>> getFirstProducts(
@@ -294,7 +262,7 @@ class DaoProductList {
     final int id = await _upsertProductList(productList);
     if (addOrRemove) {
       productList.barcodes.add(barcode);
-      await _insertListItem(id, barcode);
+      await _insertListItems(id, <String>[barcode]);
       return 1;
     }
     productList.barcodes.removeWhere((String element) => element == barcode);
@@ -532,23 +500,41 @@ class DaoProductList {
         whereArgs: <dynamic>[id],
       );
 
+  @override
+  List<String> getBulkInsertColumns() => <String>[
+        _TABLE_PRODUCT_LIST_ITEM_COLUMN_BARCODE,
+        _TABLE_PRODUCT_LIST_ITEM_COLUMN_LIST_ID,
+        LocalDatabase.COLUMN_TIMESTAMP
+      ];
+
+  @override
+  String getTableName() => _TABLE_PRODUCT_LIST_ITEM;
+
+  /// Optimized bulk insert of product list items
+  ///
+  /// Stats for 500 records on my smartphone:
+  /// - 7 seconds for MAX_RECORD_NUMBER = 1 (one by one)
+  /// - 150 milliseconds for MAX_RECORD_NUMBER = 300
   Future<int> _insertListItems(
-      final int id, final List<String> barcodes) async {
+    final int id,
+    final List<String> barcodes,
+  ) async {
+    final int maxRecordNumber = getBulkMaxRecordNumber();
+    final int timestamp = LocalDatabase.nowInMillis();
+    final List<dynamic> parameters = <dynamic>[];
+    int counter = 0;
     for (final String barcode in barcodes) {
-      await _insertListItem(id, barcode);
-      // TODO(monsieurtanuki): optim
+      parameters.add(barcode);
+      parameters.add(id);
+      parameters.add(timestamp);
+      counter++;
+      if (counter == maxRecordNumber) {
+        await bulkInsert(parameters, localDatabase.database);
+        counter = 0;
+        parameters.clear();
+      }
     }
+    await bulkInsert(parameters, localDatabase.database);
     return barcodes.length;
   }
-
-  Future<void> _insertListItem(final int id, final String barcode) async =>
-      await localDatabase.database.insert(
-        _TABLE_PRODUCT_LIST_ITEM,
-        <String, dynamic>{
-          _TABLE_PRODUCT_LIST_ITEM_COLUMN_BARCODE: barcode,
-          _TABLE_PRODUCT_LIST_ITEM_COLUMN_LIST_ID: id,
-          LocalDatabase.COLUMN_TIMESTAMP: LocalDatabase.nowInMillis(),
-        },
-        conflictAlgorithm: ConflictAlgorithm.rollback,
-      );
 }

--- a/packages/smooth_app/lib/database/local_database.dart
+++ b/packages/smooth_app/lib/database/local_database.dart
@@ -28,7 +28,7 @@ class LocalDatabase extends ChangeNotifier {
 
     final Database database = await openDatabase(
       databasePath,
-      version: 4,
+      version: 6,
       singleInstance: true,
       onUpgrade: _onUpgrade,
     );
@@ -50,6 +50,9 @@ class LocalDatabase extends ChangeNotifier {
   }
 
   static int nowInMillis() => DateTime.now().millisecondsSinceEpoch;
+
+  static DateTime timestampToDateTime(final int timestampInMillis) =>
+      DateTime.fromMillisecondsSinceEpoch(timestampInMillis);
 }
 
 class TableStats {

--- a/packages/smooth_app/lib/database/local_database.dart
+++ b/packages/smooth_app/lib/database/local_database.dart
@@ -11,6 +11,7 @@ import 'package:sqflite/sqflite.dart';
 // Project imports:
 import 'package:smooth_app/database/dao_product.dart';
 import 'package:smooth_app/database/dao_product_list.dart';
+import 'package:smooth_app/database/dao_product_extra.dart';
 
 class LocalDatabase extends ChangeNotifier {
   LocalDatabase._(final Database database) : _database = database;
@@ -28,7 +29,7 @@ class LocalDatabase extends ChangeNotifier {
 
     final Database database = await openDatabase(
       databasePath,
-      version: 6,
+      version: 7,
       singleInstance: true,
       onUpgrade: _onUpgrade,
     );
@@ -47,6 +48,7 @@ class LocalDatabase extends ChangeNotifier {
   ) async {
     await DaoProduct.onUpgrade(db, oldVersion, newVersion);
     await DaoProductList.onUpgrade(db, oldVersion, newVersion);
+    await DaoProductExtra.onUpgrade(db, oldVersion, newVersion);
   }
 
   static int nowInMillis() => DateTime.now().millisecondsSinceEpoch;

--- a/packages/smooth_app/lib/main.dart
+++ b/packages/smooth_app/lib/main.dart
@@ -74,7 +74,13 @@ class _MyAppState extends State<MyApp> {
       rethrow;
     }
     await _userPreferences.init(_productPreferences);
-    _localDatabase = await LocalDatabase.getLocalDatabase();
+    try {
+      _localDatabase = await LocalDatabase.getLocalDatabase();
+    } catch (e) {
+      // this is problematic - we should always be able to init the database
+      print('Cannot init database: $e');
+      rethrow;
+    }
     _themeProvider = ThemeProvider(_userPreferences);
   }
 

--- a/packages/smooth_app/lib/pages/product/common/product_dialog_helper.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_dialog_helper.dart
@@ -43,19 +43,17 @@ class ProductDialogHelper {
             barcode: barcode,
             languageCode: ProductQuery.getCurrentLanguageCode(context),
             countryCode: ProductQuery.getCurrentCountryCode(),
-          ).getProduct().then((Product value) async {
-            if (value != null) {
-              await DaoProduct(localDatabase).put(value);
-            }
-            _popSearchingDialog(value);
-            /* TODO(monsieurtanuki): better granularity - being able to say
+            daoProduct: DaoProduct(localDatabase),
+          ).getProduct().then(
+              (final Product value) => _popSearchingDialog(value)
+              /* TODO(monsieurtanuki): better granularity - being able to say...
              1. you clicked on 'stop'
              2. no internet connection
              3. no result at all
              4. time out
              5. of course, the product (when everything is fine)
              */
-          });
+              );
           return _getSearchingDialog();
         },
       );

--- a/packages/smooth_app/lib/pages/product/common/product_list_dialog_helper.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_dialog_helper.dart
@@ -69,7 +69,7 @@ class ProductListDialogHelper {
                     parameters: value,
                   );
                   for (final ProductList productList in list) {
-                    if (productList.lousyKey == newProductList.lousyKey) {
+                    if (productList.isSameAs(newProductList)) {
                       return appLocalizations.list_name_taken;
                     }
                   }
@@ -139,8 +139,8 @@ class ProductListDialogHelper {
                     parameters: value,
                   )..extraTags = productList.extraTags;
                   for (final ProductList item in list) {
-                    if (item.lousyKey == newProductList.lousyKey) {
-                      if (item.lousyKey == productList.lousyKey) {
+                    if (item.isSameAs(newProductList)) {
+                      if (item.isSameAs(productList)) {
                         return appLocalizations.already_same;
                       }
                       return appLocalizations.list_name_taken;

--- a/packages/smooth_app/lib/pages/product/common/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:openfoodfacts/model/Product.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/cards/product_cards/smooth_product_card_found.dart';
+import 'package:smooth_app/data_models/product_extra.dart';
 import 'package:smooth_app/data_models/product_list.dart';
 import 'package:smooth_app/database/dao_product_list.dart';
 import 'package:smooth_app/database/local_database.dart';
@@ -33,16 +34,15 @@ class _ProductListPageState extends State<ProductListPage> {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     productList ??= widget.productList;
     final List<Product> products = productList.getUniqueList();
-    final List<int> timestamps = productList.getTimestamps();
+    final Map<String, ProductExtra> productExtras = productList.productExtras;
     final List<_Meta> metas = <_Meta>[];
     if (productList.listType == ProductList.LIST_TYPE_HISTORY ||
         productList.listType == ProductList.LIST_TYPE_SCAN) {
       final int nowInMillis = LocalDatabase.nowInMillis();
       const int DAY_IN_MILLIS = 24 * 3600 * 1000;
       String daysAgoLabel;
-      int index = 0;
       for (final Product product in products) {
-        final int timestamp = timestamps[index++];
+        final int timestamp = productExtras[product.barcode].intValue;
         final int daysAgo = ((nowInMillis - timestamp) / DAY_IN_MILLIS).round();
         final String tmpDaysAgoLabel = _getDaysAgoLabel(daysAgo);
         if (daysAgoLabel != tmpDaysAgoLabel) {

--- a/packages/smooth_app/lib/pages/product/common/product_query_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_query_page.dart
@@ -16,7 +16,6 @@ import 'package:smooth_app/bottom_sheet_views/group_query_filter_view.dart';
 import 'package:smooth_app/cards/product_cards/smooth_product_card_found.dart';
 import 'package:smooth_app/data_models/product_list_supplier.dart';
 import 'package:smooth_app/data_models/product_query_model.dart';
-import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/pages/personalized_ranking_page.dart';
 import 'package:smooth_app/pages/product/common/product_query_page_helper.dart';
 import 'package:smooth_app/themes/constant_icons.dart';
@@ -79,8 +78,7 @@ class _ProductQueryPageState extends State<ProductQueryPage> {
         final Size screenSize = MediaQuery.of(context).size;
         final ThemeData themeData = Theme.of(context);
         if (_model.loadingStatus == LoadingStatus.LOADED) {
-          final LocalDatabase localDatabase = context.watch<LocalDatabase>();
-          _model.process(localDatabase);
+          _model.process();
         }
         switch (_model.loadingStatus) {
           case LoadingStatus.POST_LOAD_STARTED:

--- a/packages/smooth_app/lib/pages/product/common/product_query_page_helper.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_query_page_helper.dart
@@ -9,11 +9,8 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/utils/PnnsGroups.dart';
 
 // Project imports:
-import 'package:smooth_app/data_models/database_product_list_supplier.dart';
 import 'package:smooth_app/data_models/product_list.dart';
 import 'package:smooth_app/data_models/product_list_supplier.dart';
-import 'package:smooth_app/data_models/query_product_list_supplier.dart';
-import 'package:smooth_app/database/dao_product_list.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/database/product_query.dart';
 import 'package:smooth_app/pages/product/common/product_query_page.dart';
@@ -27,11 +24,11 @@ class ProductQueryPageHelper {
     @required final String name,
     @required final BuildContext context,
   }) async {
-    final int timestamp = await DaoProductList(localDatabase)
-        .getTimestamp(productQuery.getProductList());
-    final ProductListSupplier supplier = timestamp == null
-        ? QueryProductListSupplier(productQuery)
-        : DatabaseProductListSupplier(productQuery, localDatabase);
+    final ProductListSupplier supplier =
+        await ProductListSupplier.getBestSupplier(
+      productQuery,
+      localDatabase,
+    );
     Navigator.push<Widget>(
       context,
       MaterialPageRoute<Widget>(
@@ -40,7 +37,7 @@ class ProductQueryPageHelper {
           heroTag: heroTag,
           mainColor: color,
           name: name,
-          lastUpdate: timestamp,
+          lastUpdate: supplier.timestamp,
         ),
       ),
     );

--- a/packages/smooth_app/lib/pages/product/product_page.dart
+++ b/packages/smooth_app/lib/pages/product/product_page.dart
@@ -21,7 +21,6 @@ import 'package:smooth_ui_library/widgets/smooth_card.dart';
 import 'package:smooth_app/pages/user_preferences_page.dart';
 import 'package:smooth_app/cards/data_cards/image_upload_card.dart';
 import 'package:smooth_app/cards/expandables/attribute_list_expandable.dart';
-import 'package:smooth_app/data_models/product_list.dart';
 import 'package:smooth_app/database/category_product_query.dart';
 import 'package:smooth_app/database/dao_product_list.dart';
 import 'package:smooth_app/database/local_database.dart';
@@ -135,12 +134,7 @@ class _ProductPageState extends State<ProductPage> {
 
   Future<void> _updateHistory(final BuildContext context) async {
     final LocalDatabase localDatabase = context.read<LocalDatabase>();
-    final DaoProductList daoProductList = DaoProductList(localDatabase);
-    final ProductList productList =
-        ProductList(listType: ProductList.LIST_TYPE_HISTORY, parameters: '');
-    await daoProductList.get(productList);
-    productList.add(_product);
-    await daoProductList.put(productList);
+    await DaoProduct(localDatabase).putLastSeen(widget.product);
     localDatabase.notifyListeners();
   }
 

--- a/packages/smooth_app/lib/pages/product/product_page.dart
+++ b/packages/smooth_app/lib/pages/product/product_page.dart
@@ -16,6 +16,7 @@ import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:share/share.dart';
 import 'package:smooth_app/data_models/product_preferences.dart';
+import 'package:smooth_app/database/dao_product_extra.dart';
 import 'package:smooth_ui_library/widgets/smooth_card.dart';
 
 // Project imports:
@@ -118,9 +119,8 @@ class _ProductPageState extends State<ProductPage> {
                         duration: const Duration(seconds: 2),
                       ),
                     );
-                    setState(() {
-                      _product = product;
-                    });
+                    _product = product;
+                    await _updateHistory(context);
                     break;
                   default:
                     throw Exception('Unknown value: $value');
@@ -136,7 +136,7 @@ class _ProductPageState extends State<ProductPage> {
 
   Future<void> _updateHistory(final BuildContext context) async {
     final LocalDatabase localDatabase = context.read<LocalDatabase>();
-    await DaoProduct(localDatabase).putLastSeen(widget.product);
+    await DaoProductExtra(localDatabase).putLastSeen(widget.product);
     localDatabase.notifyListeners();
   }
 
@@ -237,6 +237,7 @@ class _ProductPageState extends State<ProductPage> {
     final UserPreferences userPreferences = context.watch<UserPreferences>();
     final DaoProductList daoProductList = DaoProductList(localDatabase);
     final DaoProduct daoProduct = DaoProduct(localDatabase);
+    final DaoProductExtra daoProductExtra = DaoProductExtra(localDatabase);
     final ProductPreferences productPreferences =
         context.watch<ProductPreferences>();
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
@@ -400,50 +401,40 @@ class _ProductPageState extends State<ProductPage> {
       }
     }
 
-    // TODO(monsieurtanuki): improve the display according to the feedbacks
-    listItems.add(
+    listItems.add(_getTemporaryButton(daoProductExtra));
+
+    return ListView(children: listItems);
+  }
+
+  // TODO(monsieurtanuki): remove / improve the display according to the feedbacks
+  Widget _getTemporaryButton(final DaoProductExtra daoProductExtra) =>
       ElevatedButton(
         onPressed: () async {
           final List<Widget> children = <Widget>[];
-          ProductExtra productExtra;
-          productExtra = await daoProduct.getProductExtra(
-            key: DaoProduct.EXTRA_ID_LAST_SEEN,
-            barcode: _product.barcode,
+          _temporary(
+            await daoProductExtra.getProductExtra(
+              key: DaoProductExtra.EXTRA_ID_LAST_SEEN,
+              barcode: _product.barcode,
+            ),
+            children,
+            'History of your access:',
           );
-          if (productExtra != null) {
-            final List<int> timestamps = productExtra.decodeStringAsIntList();
-            if (timestamps.isNotEmpty) {
-              children.add(
-                const Material(
-                  child: Text('History of your access to that product:'),
-                ),
-              );
-              for (final int timestamp in timestamps.reversed) {
-                final DateTime dateTime =
-                    LocalDatabase.timestampToDateTime(timestamp);
-                children.add(Material(child: Text('* $dateTime')));
-              }
-            }
-          }
-          productExtra = await daoProduct.getProductExtra(
-            key: DaoProduct.EXTRA_ID_LAST_SCAN,
-            barcode: _product.barcode,
+          _temporary(
+            await daoProductExtra.getProductExtra(
+              key: DaoProductExtra.EXTRA_ID_LAST_SCAN,
+              barcode: _product.barcode,
+            ),
+            children,
+            'History of your barcode scan:',
           );
-          if (productExtra != null) {
-            final List<int> timestamps = productExtra.decodeStringAsIntList();
-            if (timestamps.isNotEmpty) {
-              children.add(
-                const Material(
-                  child: Text('History of your barcode scan of that product:'),
-                ),
-              );
-              for (final int timestamp in timestamps.reversed) {
-                final DateTime dateTime =
-                    LocalDatabase.timestampToDateTime(timestamp);
-                children.add(Material(child: Text('* $dateTime')));
-              }
-            }
-          }
+          _temporary(
+            await daoProductExtra.getProductExtra(
+              key: DaoProductExtra.EXTRA_ID_LAST_REFRESH,
+              barcode: _product.barcode,
+            ),
+            children,
+            'History of your server refresh:',
+          );
           await showCupertinoModalBottomSheet<void>(
             context: context,
             builder: (final BuildContext context) => ListView(
@@ -452,10 +443,24 @@ class _ProductPageState extends State<ProductPage> {
           );
         },
         child: const Text('History (temporary button)'),
-      ),
-    );
+      );
 
-    return ListView(children: listItems);
+  void _temporary(
+    final ProductExtra productExtra,
+    final List<Widget> children,
+    final String title,
+  ) {
+    if (productExtra == null) {
+      return;
+    }
+    final List<int> timestamps = productExtra.decodeStringAsIntList();
+    if (timestamps.isNotEmpty) {
+      children.add(Material(child: Text(title)));
+      for (final int timestamp in timestamps.reversed) {
+        final DateTime dateTime = LocalDatabase.timestampToDateTime(timestamp);
+        children.add(Material(child: Text('* $dateTime')));
+      }
+    }
   }
 
   Widget _getAttributeGroupWidget(

--- a/packages/smooth_app/lib/pages/scan/continuous_scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/continuous_scan_page.dart
@@ -57,13 +57,16 @@ class ContinuousScanPage extends StatelessWidget {
                 style: const TextStyle(color: Colors.black),
               ),
               backgroundColor: Colors.white,
-              onPressed: () => Navigator.push<Widget>(
-                context,
-                MaterialPageRoute<Widget>(
-                  builder: (BuildContext context) =>
-                      PersonalizedRankingPage(_continuousScanModel.productList),
-                ),
-              ),
+              onPressed: () async {
+                await _continuousScanModel.refreshProductList();
+                await Navigator.push<Widget>(
+                  context,
+                  MaterialPageRoute<Widget>(
+                    builder: (BuildContext context) => PersonalizedRankingPage(
+                        _continuousScanModel.productList),
+                  ),
+                );
+              },
             ),
           ),
           body: Stack(
@@ -123,7 +126,8 @@ class ContinuousScanPage extends StatelessWidget {
                         padding: EdgeInsets.only(top: screenSize.height * 0.08),
                         child: Text(
                           appLocalizations.scannerProductsEmpty,
-                          style: themeData.textTheme.subtitle1,
+                          style: themeData.textTheme.subtitle1
+                              .copyWith(color: Colors.white),
                           textAlign: TextAlign.center,
                         ),
                       ),


### PR DESCRIPTION
History and Scan lists now behave differently from the other lists.
They use "extra data": a product is in the History (or the Scan) list
if it has as an "extra data" the "last seen timestamp" (or the last scan timestamp).

Bad news: as it's a new concept in the app, we'll start from scratch for both lists.

Impacted files:
* `continuous_scan_model.dart`: new way of adding a product to scanned products; refactoring
* `continuous_scan_page.dart`: unrelated color fix
* `dao_product.dart`: added "last seen" and "last scan" as extra data, with a direct access to products that have those extra data
* `dao_product_list.dart`: history and scan lists are now handled as "different" lists, computed from the "last seen" and "last scan" extra data; refactored
* `product_list.dart`: added extra `int` data; cleaner "same product list" test
* `product_list_dialog_helper.dart`: cleaner "same product list" test
* `product_list_page.dart`: added dates to the display
* `product_page.dart`: simplified history management
* `smooth_product_card_found.dart`: added an optional `refresh` parameter, after visiting the product page