### PR TITLE
feature/#166_3 - user product lists are now reorderable

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/product_list_preview.dart
+++ b/packages/smooth_app/lib/cards/product_cards/product_list_preview.dart
@@ -19,20 +19,17 @@ class ProductListPreview extends StatelessWidget {
     @required this.daoProductList,
     @required this.productList,
     @required this.nbInPreview,
+    this.andThen,
   });
 
   final DaoProductList daoProductList;
   final ProductList productList;
   final int nbInPreview;
+  final Function andThen;
 
   @override
   Widget build(BuildContext context) => FutureBuilder<List<Product>>(
-        future: daoProductList.getFirstProducts(
-          productList,
-          nbInPreview,
-          true,
-          true,
-        ),
+        future: daoProductList.getFirstProducts(productList, nbInPreview),
         builder: (
           final BuildContext context,
           final AsyncSnapshot<List<Product>> snapshot,
@@ -60,6 +57,9 @@ class ProductListPreview extends StatelessWidget {
                               ProductListPage(productList),
                         ),
                       );
+                      if (andThen != null) {
+                        andThen();
+                      }
                     },
                     leading: productList.getIcon(
                       Theme.of(context).colorScheme,

--- a/packages/smooth_app/lib/data_models/query_product_list_supplier.dart
+++ b/packages/smooth_app/lib/data_models/query_product_list_supplier.dart
@@ -17,7 +17,7 @@ class QueryProductListSupplier extends ProductListSupplier {
     try {
       final SearchResult searchResult = await productQuery.getSearchResult();
       productList = productQuery.getProductList();
-      productList.addAll(searchResult.products);
+      productList.setAll(searchResult.products);
       await DaoProduct(localDatabase).put(productList.getList());
       await DaoProductList(localDatabase).put(productList);
       return null;

--- a/packages/smooth_app/lib/data_models/smooth_it_model.dart
+++ b/packages/smooth_app/lib/data_models/smooth_it_model.dart
@@ -25,7 +25,7 @@ class SmoothItModel {
       _nextRefreshIsJustChangingTabs = false;
       return;
     }
-    final List<Product> unprocessedProducts = productList.getUniqueList();
+    final List<Product> unprocessedProducts = productList.getList();
     _allProducts = MatchedProduct.sort(unprocessedProducts, productPreferences);
     _categorizedProducts.clear();
     for (final MatchedProduct matchededProduct in _allProducts) {

--- a/packages/smooth_app/lib/database/abstract_dao.dart
+++ b/packages/smooth_app/lib/database/abstract_dao.dart
@@ -1,6 +1,3 @@
-import 'dart:async';
-import 'package:flutter/material.dart';
-import 'package:sqflite/sqflite.dart';
 import 'package:smooth_app/database/local_database.dart';
 
 /// DAO abstraction
@@ -8,75 +5,4 @@ abstract class AbstractDao {
   AbstractDao(this.localDatabase);
 
   final LocalDatabase localDatabase;
-
-  /// Max number of parameters in a SQFlite query
-  ///
-  /// cf. SQLITE_MAX_VARIABLE_NUMBER, "which defaults to 999"
-  // TODO(monsieurtanuki): find a way to retrieve this number from SQFlite system tables, cf. https://github.com/tekartik/sqflite/issues/663
-  static const int SQLITE_MAX_VARIABLE_NUMBER = 999;
-
-  /// Optimized bulk insert
-  @protected
-  Future<void> bulkInsert(
-    final List<dynamic> parameters,
-    final DatabaseExecutor databaseExecutor,
-  ) async {
-    final String tableName = getTableName();
-    final List<String> columnNames = getBulkInsertColumns();
-    final int numCols = columnNames.length;
-    if (parameters.isEmpty) {
-      return;
-    }
-    if (columnNames.isEmpty) {
-      throw Exception('There must be at least one column!');
-    }
-    final String variables = '?${',?' * (columnNames.length - 1)}';
-    if (parameters.length % numCols != 0) {
-      throw Exception(
-          'Parameter list size (${parameters.length}) cannot be divided by $numCols');
-    }
-    final int additionalRecordsNumber = -1 + parameters.length ~/ numCols;
-    await databaseExecutor.rawInsert(
-        'insert into $tableName(${columnNames.join(',')}) '
-        'values($variables)${',($variables)' * additionalRecordsNumber}',
-        parameters);
-  }
-
-  /// Optimized bulk upsert
-  ///
-  /// In tests it looked 33% faster to use delete/insert rather than upsert
-  @protected
-  Future<void> bulkUpsert({
-    @required final List<dynamic> insertParameters,
-    @required final String deleteWhere,
-    @required final List<String> deleteParameters,
-    @required final DatabaseExecutor databaseExecutor,
-  }) async {
-    final String tableName = getTableName();
-    final List<String> insertColumns = getBulkInsertColumns();
-    if (insertParameters.isEmpty) {
-      return;
-    }
-    final int numCols = insertColumns.length;
-    if (insertParameters.length % numCols != 0) {
-      throw Exception(
-          'Parameter list size (${insertParameters.length}) cannot be divided by $numCols');
-    }
-    await databaseExecutor.delete(
-      tableName,
-      where: deleteWhere,
-      whereArgs: deleteParameters,
-    );
-    await bulkInsert(insertParameters, databaseExecutor);
-  }
-
-  /// Insert columns for bulk mode
-  List<String> getBulkInsertColumns();
-
-  /// Table name
-  String getTableName();
-
-  /// Max number of records to be inserted in bulk mode
-  int getBulkMaxRecordNumber() =>
-      SQLITE_MAX_VARIABLE_NUMBER ~/ getBulkInsertColumns().length;
 }

--- a/packages/smooth_app/lib/database/bulk_deletable.dart
+++ b/packages/smooth_app/lib/database/bulk_deletable.dart
@@ -1,0 +1,9 @@
+import 'package:smooth_app/database/bulk_insertable.dart';
+
+/// Interface for bulk database deletes
+///
+/// cf. [BulkManager], [BulkInsertable]
+abstract class BulkDeletable implements BulkInsertable {
+  /// "where" clause for delete in bulk mode
+  String getDeleteWhere(final List<dynamic> deleteWhereArgs);
+}

--- a/packages/smooth_app/lib/database/bulk_insertable.dart
+++ b/packages/smooth_app/lib/database/bulk_insertable.dart
@@ -1,0 +1,12 @@
+import 'package:smooth_app/database/bulk_manager.dart';
+
+/// Interface for bulk database inserts
+///
+/// cf. [BulkManager]
+abstract class BulkInsertable {
+  /// Insert columns for bulk mode
+  List<String> getInsertColumns();
+
+  /// Table name
+  String getTableName();
+}

--- a/packages/smooth_app/lib/database/bulk_manager.dart
+++ b/packages/smooth_app/lib/database/bulk_manager.dart
@@ -1,0 +1,80 @@
+import 'dart:async';
+import 'dart:math';
+import 'package:flutter/material.dart';
+import 'package:smooth_app/database/bulk_insertable.dart';
+import 'package:smooth_app/database/bulk_deletable.dart';
+import 'package:sqflite/sqflite.dart';
+
+/// Manager for bulk database inserts and deletes
+///
+/// In tests it looked 33% faster to use delete/insert rather than upsert
+/// And of course it's much faster to perform bulk actions
+/// rather than numerous single actions
+/// cf. [BulkInsertable], [BulkDeletable]
+class BulkManager {
+  /// Max number of parameters in a SQFlite query
+  ///
+  /// cf. SQLITE_MAX_VARIABLE_NUMBER, "which defaults to 999"
+  // TODO(monsieurtanuki): find a way to retrieve this number from SQFlite system tables, cf. https://github.com/tekartik/sqflite/issues/663
+  static const int _SQLITE_MAX_VARIABLE_NUMBER = 999;
+
+  /// Optimized bulk insert
+  Future<void> insert({
+    @required final BulkInsertable bulkInsertable,
+    @required final List<dynamic> parameters,
+    @required final DatabaseExecutor databaseExecutor,
+  }) async {
+    final String tableName = bulkInsertable.getTableName();
+    final List<String> columnNames = bulkInsertable.getInsertColumns();
+    final int numCols = columnNames.length;
+    if (parameters.isEmpty) {
+      return;
+    }
+    if (columnNames.isEmpty) {
+      throw Exception('There must be at least one column!');
+    }
+    if (parameters.length % numCols != 0) {
+      throw Exception(
+          'Parameter list size (${parameters.length}) cannot be divided by $numCols');
+    }
+    final String variables = '?${',?' * (columnNames.length - 1)}';
+    final int maxSlice = _SQLITE_MAX_VARIABLE_NUMBER ~/ numCols;
+    for (int start = 0; start < parameters.length; start += maxSlice) {
+      final int size = min(parameters.length - start, maxSlice);
+      final int additionalRecordsNumber = -1 + size ~/ numCols;
+      await databaseExecutor.rawInsert(
+        'insert into $tableName(${columnNames.join(',')}) '
+        'values($variables)${',($variables)' * additionalRecordsNumber}',
+        parameters.sublist(start, start + size),
+      );
+    }
+  }
+
+  /// Optimized bulk delete
+  Future<void> delete({
+    @required final BulkDeletable bulkDeletable,
+    @required final List<dynamic> parameters,
+    @required final DatabaseExecutor databaseExecutor,
+    final List<dynamic> additionalParameters,
+  }) async {
+    final String tableName = bulkDeletable.getTableName();
+    if (parameters.isEmpty) {
+      return;
+    }
+    final int maxSlice =
+        _SQLITE_MAX_VARIABLE_NUMBER - (additionalParameters?.length ?? 0);
+    for (int start = 0; start < parameters.length; start += maxSlice) {
+      final int size = min(parameters.length - start, maxSlice);
+      final List<dynamic> currentParameters = <dynamic>[];
+      if (additionalParameters != null && additionalParameters.isNotEmpty) {
+        currentParameters.addAll(additionalParameters);
+      }
+      currentParameters.addAll(parameters.sublist(start, start + size));
+      await databaseExecutor.delete(
+        tableName,
+        where: bulkDeletable.getDeleteWhere(currentParameters),
+        whereArgs: currentParameters,
+      );
+    }
+  }
+}

--- a/packages/smooth_app/lib/database/dao_product_extra.dart
+++ b/packages/smooth_app/lib/database/dao_product_extra.dart
@@ -4,6 +4,8 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/model/Product.dart';
 import 'package:smooth_app/database/abstract_dao.dart';
+import 'package:smooth_app/database/bulk_manager.dart';
+import 'package:smooth_app/database/bulk_deletable.dart';
 import 'package:smooth_app/database/dao_product.dart';
 import 'package:sqflite/sqflite.dart';
 import 'package:smooth_app/database/local_database.dart';
@@ -20,7 +22,7 @@ import 'package:smooth_app/data_models/product_list.dart';
 /// A typical use case is for timestamps history (e.g. scan, view or refresh).
 /// In that case the integer value contains the latest timestamp,
 /// and the string value contains a list of timestamps encoded as json.
-class DaoProductExtra extends AbstractDao {
+class DaoProductExtra extends AbstractDao implements BulkDeletable {
   DaoProductExtra(final LocalDatabase localDatabase) : super(localDatabase);
 
   static const String _TABLE_PRODUCT_EXTRA = 'product_extra';
@@ -131,11 +133,10 @@ class DaoProductExtra extends AbstractDao {
     final int timestamp,
   ) async {
     const String KEY = _EXTRA_ID_SIMPLIFIED_TEXT;
-    final int maxRecordNumber = getBulkMaxRecordNumber();
+    final BulkManager bulkManager = BulkManager();
     final List<dynamic> insertParameters = <dynamic>[];
-    final List<String> deleteParameters = <String>[KEY];
+    final List<dynamic> deleteParameters = <dynamic>[];
 
-    int counter = 0;
     for (final Product product in products) {
       deleteParameters.add(product.barcode);
       insertParameters.add(product.barcode);
@@ -143,28 +144,30 @@ class DaoProductExtra extends AbstractDao {
       insertParameters.add(_getSimplifiedTextForProduct(product));
       insertParameters.add(0);
       insertParameters.add(timestamp);
-      counter++;
-      if (counter == maxRecordNumber) {
-        await _bulkUpsert(insertParameters, deleteParameters, databaseExecutor);
-        counter = 0;
-        deleteParameters.clear();
-        deleteParameters.add(KEY);
-        insertParameters.clear();
-      }
     }
-    await _bulkUpsert(insertParameters, deleteParameters, databaseExecutor);
+    await bulkManager.delete(
+      bulkDeletable: this,
+      parameters: deleteParameters,
+      databaseExecutor: databaseExecutor,
+      additionalParameters: <dynamic>[KEY],
+    );
+    await bulkManager.insert(
+      bulkInsertable: this,
+      parameters: insertParameters,
+      databaseExecutor: databaseExecutor,
+    );
   }
 
-  /// Upserts the "last time I did whatever with this product" in bulk mode
+  /// Upserts the "last time I did whatever with those products" in bulk mode
   Future<void> bulkUpsertLoopLast(
     final DatabaseExecutor databaseExecutor,
     final List<Product> products,
     final int timestamp,
     final String extraKey,
   ) async {
-    final int maxRecordNumber = getBulkMaxRecordNumber();
+    final BulkManager bulkManager = BulkManager();
     final List<dynamic> insertParameters = <dynamic>[];
-    final List<String> deleteParameters = <String>[extraKey];
+    final List<dynamic> deleteParameters = <dynamic>[];
 
     final List<String> barcodes = <String>[];
     for (final Product product in products) {
@@ -176,7 +179,6 @@ class DaoProductExtra extends AbstractDao {
       databaseExecutor: databaseExecutor,
     );
 
-    int counter = 0;
     for (final Product product in products) {
       final ProductExtra productExtra = map[product.barcode];
       List<int> timestamps;
@@ -193,20 +195,49 @@ class DaoProductExtra extends AbstractDao {
       insertParameters.add(jsonEncode(timestamps)); // string value
       insertParameters.add(timestamp); // int value
       insertParameters.add(timestamp);
-      counter++;
-      if (counter == maxRecordNumber) {
-        await _bulkUpsert(insertParameters, deleteParameters, databaseExecutor);
-        counter = 0;
-        deleteParameters.clear();
-        deleteParameters.add(extraKey);
-        insertParameters.clear();
-      }
     }
-    await _bulkUpsert(insertParameters, deleteParameters, databaseExecutor);
+    await bulkManager.delete(
+      bulkDeletable: this,
+      parameters: deleteParameters,
+      databaseExecutor: databaseExecutor,
+      additionalParameters: <dynamic>[extraKey],
+    );
+    await bulkManager.insert(
+      bulkInsertable: this,
+      parameters: insertParameters,
+      databaseExecutor: databaseExecutor,
+    );
+  }
+
+  /// Deletes all then inserts a simple product list in bulk mode
+  Future<void> bulkInsertExtra({
+    @required final DatabaseExecutor databaseExecutor,
+    @required final ProductList productList,
+    @required final int productListId,
+  }) async {
+    final BulkManager bulkManager = BulkManager();
+    final int timestamp = LocalDatabase.nowInMillis();
+    final List<dynamic> insertParameters = <dynamic>[];
+    final String extraKey = _getExtraKey(productList, productListId);
+
+    for (final String barcode in productList.barcodes) {
+      final ProductExtra productExtra = productList.productExtras[barcode];
+      insertParameters.add(barcode);
+      insertParameters.add(extraKey);
+      insertParameters.add(productExtra.stringValue);
+      insertParameters.add(productExtra.intValue);
+      insertParameters.add(timestamp);
+    }
+    await clearList(productList, productListId, databaseExecutor);
+    await bulkManager.insert(
+      bulkInsertable: this,
+      parameters: insertParameters,
+      databaseExecutor: databaseExecutor,
+    );
   }
 
   @override
-  List<String> getBulkInsertColumns() => <String>[
+  List<String> getInsertColumns() => <String>[
         DaoProduct.TABLE_PRODUCT_COLUMN_BARCODE,
         _TABLE_PRODUCT_EXTRA_COLUMN_KEY,
         _TABLE_PRODUCT_EXTRA_COLUMN_VALUE,
@@ -215,21 +246,13 @@ class DaoProductExtra extends AbstractDao {
       ];
 
   @override
-  String getTableName() => _TABLE_PRODUCT_EXTRA;
+  String getDeleteWhere(final List<dynamic> deleteWhereArgs) =>
+      '$_TABLE_PRODUCT_EXTRA_COLUMN_KEY = ? '
+      'and ${DaoProduct.TABLE_PRODUCT_COLUMN_BARCODE} '
+      '  in (?${',?' * (deleteWhereArgs.length - 2)})';
 
-  /// Bulk upsert of product extra
-  Future<void> _bulkUpsert(
-    final List<dynamic> insertParameters,
-    final List<String> deleteParameters,
-    final DatabaseExecutor databaseExecutor,
-  ) async =>
-      await bulkUpsert(
-        insertParameters: insertParameters,
-        deleteParameters: deleteParameters,
-        deleteWhere: '$_TABLE_PRODUCT_EXTRA_COLUMN_KEY = ? '
-            'and ${DaoProduct.TABLE_PRODUCT_COLUMN_BARCODE} in (?${',?' * (deleteParameters.length - 2)})',
-        databaseExecutor: databaseExecutor,
-      );
+  @override
+  String getTableName() => _TABLE_PRODUCT_EXTRA;
 
   /// Returns a lowercase not accented version of the text, for comparisons
   static String _getSimplifiedText(final String text) {
@@ -349,50 +372,54 @@ class DaoProductExtra extends AbstractDao {
     return map[barcode];
   }
 
-  String _getExtraKey(final ProductList productList) {
+  String _getExtraKey(final ProductList productList, final int id) {
     switch (productList.listType) {
       case ProductList.LIST_TYPE_HISTORY:
         return EXTRA_ID_LAST_SEEN;
       case ProductList.LIST_TYPE_SCAN:
         return EXTRA_ID_LAST_SCAN;
     }
-    return null;
+    if (id == null) {
+      throw Exception('Unknown product list of type ${productList.listType}');
+    }
+    return 'list/$id';
   }
 
-  bool _getExtraReverse(final ProductList productList) {
+  bool _getExtraReverse(final ProductList productList, final int id) {
     switch (productList.listType) {
       case ProductList.LIST_TYPE_HISTORY:
         return true;
       case ProductList.LIST_TYPE_SCAN:
         return false;
     }
-    return null;
+    if (id == null) {
+      throw Exception('Unknown product list of type ${productList.listType}');
+    }
+    return false;
   }
 
-  Future<bool> getList(final ProductList productList) async {
-    final String extraKey = _getExtraKey(productList);
-    final bool extraReverse = _getExtraReverse(productList);
-    if (extraKey == null || extraReverse == null) {
-      return false;
-    }
+  Future<bool> getList(final ProductList productList, final int id) async {
+    final String extraKey = _getExtraKey(productList, id);
+    final bool extraReverse = _getExtraReverse(productList, id);
     final LinkedHashMap<String, ProductExtra> extras =
-        await getOrderedProductExtras(key: extraKey, reverse: extraReverse);
+        await getOrderedProductExtras(
+      key: extraKey,
+      reverse: extraReverse,
+    );
     final List<String> barcodes = List<String>.from(extras.keys);
     final Map<String, Product> products =
         await DaoProduct(localDatabase).getAllWithExtras(extraKey);
-    productList.set(barcodes, products, productExtras: extras);
+    productList.set(barcodes, products, extras);
     return true;
   }
 
   Future<List<String>> getFirstBarcodes(
     final ProductList productList,
+    final int id,
     final int limit,
   ) async {
-    final String extraKey = _getExtraKey(productList);
-    final bool extraReverse = _getExtraReverse(productList);
-    if (extraKey == null || extraReverse == null) {
-      return null;
-    }
+    final String extraKey = _getExtraKey(productList, id);
+    final bool extraReverse = _getExtraReverse(productList, id);
     final LinkedHashMap<String, ProductExtra> extras =
         await getOrderedProductExtras(
       key: extraKey,
@@ -401,5 +428,38 @@ class DaoProductExtra extends AbstractDao {
     );
     final List<String> barcodes = List<String>.from(extras.keys);
     return barcodes;
+  }
+
+  Future<void> clearList(
+    final ProductList productList,
+    final int id,
+    final DatabaseExecutor databaseExecutor,
+  ) async =>
+      await databaseExecutor.delete(
+        _TABLE_PRODUCT_EXTRA,
+        where: '$_TABLE_PRODUCT_EXTRA_COLUMN_KEY = ?',
+        whereArgs: <String>[_getExtraKey(productList, id)],
+      );
+
+  /// Returns the number of products of each product list
+  Future<Map<String, int>> getStats() async {
+    final Map<String, int> result = <String, int>{};
+    const String COLUMN_NAME_COUNT = 'my_count';
+    final List<Map<String, dynamic>> countResult =
+        await localDatabase.database.rawQuery(
+      'select '
+      '  $_TABLE_PRODUCT_EXTRA_COLUMN_KEY '
+      ', count(1) as $COLUMN_NAME_COUNT '
+      'from'
+      '  $_TABLE_PRODUCT_EXTRA '
+      'group by '
+      '  $_TABLE_PRODUCT_EXTRA_COLUMN_KEY',
+    );
+    for (final Map<String, dynamic> row in countResult) {
+      final String extraKey = row[_TABLE_PRODUCT_EXTRA_COLUMN_KEY] as String;
+      final int count = row[COLUMN_NAME_COUNT] as int;
+      result[extraKey] = count;
+    }
+    return result;
   }
 }

--- a/packages/smooth_app/lib/database/local_database.dart
+++ b/packages/smooth_app/lib/database/local_database.dart
@@ -29,7 +29,7 @@ class LocalDatabase extends ChangeNotifier {
 
     final Database database = await openDatabase(
       databasePath,
-      version: 7,
+      version: 8,
       singleInstance: true,
       onUpgrade: _onUpgrade,
     );

--- a/packages/smooth_app/lib/pages/home_page.dart
+++ b/packages/smooth_app/lib/pages/home_page.dart
@@ -145,6 +145,7 @@ class _HomePageState extends State<HomePage> {
               parameters: '',
             ),
             nbInPreview: 5,
+            andThen: () => setState(() {}),
           ),
           GestureDetector(
             child: SmoothCard(

--- a/packages/smooth_app/lib/pages/list_page.dart
+++ b/packages/smooth_app/lib/pages/list_page.dart
@@ -69,6 +69,7 @@ class _ListPageState extends State<ListPage> {
                       daoProductList: daoProductList,
                       productList: item,
                       nbInPreview: 5,
+                      andThen: () => setState(() {}),
                     );
                   },
                 );

--- a/packages/smooth_app/lib/pages/multi_select_product_page.dart
+++ b/packages/smooth_app/lib/pages/multi_select_product_page.dart
@@ -54,7 +54,7 @@ class _MultiSelectProductPageState extends State<MultiSelectProductPage> {
     super.initState();
     _selectedBarcodes.add(widget.barcode);
     if (widget.productList != null) {
-      _orderedBarcodes = widget.productList.getOrderedBarcodes();
+      _orderedBarcodes = widget.productList.barcodes;
     } else {
       _orderedBarcodes = widget.pantry.getOrderedBarcodes();
     }
@@ -63,7 +63,7 @@ class _MultiSelectProductPageState extends State<MultiSelectProductPage> {
   void _removeBarcode(final String barcode) {
     _orderedBarcodes.remove(barcode);
     if (widget.productList != null) {
-      widget.productList.barcodes.remove(barcode);
+      widget.productList.remove(barcode);
     } else {
       widget.pantry.removeBarcode(barcode);
     }

--- a/packages/smooth_app/lib/pages/product/common/product_list_dialog_helper.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_dialog_helper.dart
@@ -91,10 +91,7 @@ class ProductListDialogHelper {
               if (!formKey.currentState.validate()) {
                 return;
               }
-              if (await daoProductList.get(newProductList)) {
-                // TODO(monsieurtanuki): unexpected, but do something!
-                return;
-              }
+              await daoProductList.create(newProductList);
               await daoProductList.put(newProductList);
               Navigator.pop(context, newProductList);
             },

--- a/packages/smooth_app/lib/pages/product/product_page.dart
+++ b/packages/smooth_app/lib/pages/product/product_page.dart
@@ -557,7 +557,7 @@ class _ProductPageState extends State<ProductPage> {
       return;
     }
     final List<Product> products = <Product>[widget.product];
-    productCopyHelper.copy(
+    await productCopyHelper.copy(
       context: context,
       target: target,
       allPantries: allPantries,

--- a/packages/smooth_app/lib/pages/product_copy_helper.dart
+++ b/packages/smooth_app/lib/pages/product_copy_helper.dart
@@ -170,10 +170,7 @@ class ProductCopyHelper {
     await daoProductList.get(target);
     int count = 0;
     for (final Product product in products) {
-      if (target.barcodes.contains(product.barcode)) {
-        // do nothing?
-      } else {
-        target.add(product);
+      if (target.add(product)) {
         count++;
       }
     }


### PR DESCRIPTION
As you can see in the screenshot below, there's a new drag handle for reordering.
The point was not specifically to make user product lists reorderable, but to refactor in the same pattern product lists, shopping lists and pantries. Which gave the flexibility to add the "reorder" feature in the meanwhile.
The next step is to actually include shopping lists and pantries inside the same pattern, in table `product_extra`. Which should be rather easy (I hope).
Database table `product_extra` replaces now dropped `product_list_item`.

New files:
* `bulk_deletable.dart`: Interface for bulk database deletes
* `bulk_insertable.dart`: Interface for bulk database inserts
* `bulk_manager.dart`: Manager for bulk database inserts and deletes

Impacted files:
* `abstract_dao.dart`: moved specific code to new classes `Bulk...`
* `dao_product.dart`: refactored
* `dao_product_extra.dart`: now manages the product list as "product extra"; now implements new interface `BulkDeletable`
* `dao_product_list.dart`: moved the data from table `product_list_item` to table `product_extra`; dropped table `product_list_item`; refactored
* `home_page.dart`: refresh after product list preview
* `list_page.dart`: refresh after product list preview
* `local_database.dart`: new database version
* `multi_select_product_page.dart`: refactored
* `product_copy_helper.dart`: refactored
* `product_list.dart`: added the list reordering feature; refactored
* `product_list_dialog_helper.dart`: refactored
* `product_list_page.dart`: some product lists are now reorderable and with dismissible items
* `product_list_preview.dart`: added the `andThen` parameter for a refresh afterwards
* `product_page.dart`: minor fix
* `query_product_list_supplier.dart`: refactored
* `smooth_it_model.dart`: refactored

![Simulator Screen Shot - iPhone 8 Plus - 2021-06-27 at 21 19 16](https://user-images.githubusercontent.com/11576431/123556768-5583e580-d78d-11eb-80ba-e66b4e94aa94.png)
