### PR TITLE
feature/#37 - "details" button for ecoscore with html page display

### DIFF
--- a/packages/smooth_app/lib/cards/data_cards/attribute_card.dart
+++ b/packages/smooth_app/lib/cards/data_cards/attribute_card.dart
@@ -1,11 +1,20 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/model/Attribute.dart';
+import 'package:smooth_app/database/product_query.dart';
+import 'package:smooth_app/pages/html_page.dart';
 
 class AttributeCard extends StatelessWidget {
-  const AttributeCard(this.attribute, this.attributeChip);
+  const AttributeCard(
+    this.attribute,
+    this.attributeChip, {
+    this.barcode,
+  });
 
   final Attribute attribute;
   final Widget attributeChip;
+  final String? barcode;
 
   @override
   Widget build(BuildContext context) {
@@ -29,6 +38,8 @@ class AttributeCard extends StatelessWidget {
                   description,
                   style: Theme.of(context).textTheme.subtitle2,
                 ),
+              if (attribute.id == Attribute.ATTRIBUTE_ECOSCORE)
+                _getEcoscoreAddition(context),
             ],
           ),
         ),
@@ -36,4 +47,34 @@ class AttributeCard extends StatelessWidget {
       ],
     );
   }
+
+  Widget _getEcoscoreAddition(final BuildContext context) => ElevatedButton(
+        onPressed: () async {
+          final String language = ProductQuery.getCurrentLanguageCode(context);
+          const String FIELD = 'environment_infocard';
+          final String ecoscoreDetailsUrl =
+              'https://world-$language.openfoodfacts.org/api/v0/product/$barcode.json?fields=$FIELD';
+          http.Response response;
+          response = await http.get(Uri.parse(ecoscoreDetailsUrl));
+          if (response.statusCode != 200) {
+            return; // TODO(monsieurtanuki): display something nice in that case
+          }
+          // TODO(monsieurtanuki): check if the json is correct and successful
+          final Map<String, dynamic> json =
+              jsonDecode(response.body) as Map<String, dynamic>;
+          final Map<String, dynamic> product =
+              json['product'] as Map<String, dynamic>;
+          final String detailsHtmlString = product[FIELD] as String;
+          await Navigator.push<Widget>(
+            context,
+            MaterialPageRoute<Widget>(
+              builder: (BuildContext context) => HtmlPage(
+                htmlString: detailsHtmlString,
+                pageTitle: attribute.title!,
+              ),
+            ),
+          );
+        },
+        child: Text('Details...'),
+      );
 }

--- a/packages/smooth_app/lib/cards/data_cards/attribute_card.dart
+++ b/packages/smooth_app/lib/cards/data_cards/attribute_card.dart
@@ -75,6 +75,6 @@ class AttributeCard extends StatelessWidget {
             ),
           );
         },
-        child: Text('Details...'),
+        child: const Text('Details...'),
       );
 }

--- a/packages/smooth_app/lib/cards/expandables/attribute_list_expandable.dart
+++ b/packages/smooth_app/lib/cards/expandables/attribute_list_expandable.dart
@@ -113,7 +113,11 @@ class AttributeListExpandable extends StatelessWidget {
                 color: color,
                 borderRadius: const BorderRadius.all(Radius.circular(16)),
               ),
-              child: AttributeCard(attribute, chip),
+              child: AttributeCard(
+                attribute,
+                chip,
+                barcode: product.barcode,
+              ),
             ),
           ),
         ),

--- a/packages/smooth_app/lib/pages/html_page.dart
+++ b/packages/smooth_app/lib/pages/html_page.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_widget_from_html_core/flutter_widget_from_html_core.dart';
+
+/// Displays in widgets a HTML page
+class HtmlPage extends StatelessWidget {
+  const HtmlPage({
+    required this.pageTitle,
+    required this.htmlString,
+  });
+
+  final String pageTitle;
+  final String htmlString;
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+        appBar: AppBar(title: Text(pageTitle)),
+        body: SingleChildScrollView(child: HtmlWidget(htmlString)),
+      );
+}

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -33,6 +33,7 @@ dependencies:
   flutter_staggered_grid_view: ^0.4.0
   flutter_svg: ^0.22.0
   flutter_typeahead: ^3.1.3
+  flutter_widget_from_html_core: ^0.6.1+3
   image_cropper: ^1.4.1
   image_picker: ^0.8.1+3
   matomo: ^1.0.0


### PR DESCRIPTION
Based on https://world-$language.openfoodfacts.org/api/v0/product/$barcode.json?fields=environment_infocard

New file:
* `html_page.dart`: Displays as widgets a HTML page

Impacted files:
* `attribute_card.dart`: added a barcode parameter that is needed (only) for ecoscore details; added a "details" button for ecoscore with html page display
* `attribute_list_expandable.dart`: added a now relevant barcode parameter to `AttributeCard`
* `pubspec.yaml`: added `flutter_widget_from_html_core` for html page display

![Simulator Screen Shot - iPhone 8 Plus - 2021-07-07 at 09 06 13](https://user-images.githubusercontent.com/11576431/124714858-9654ca80-df02-11eb-958e-579c05750716.png)

![Simulator Screen Shot - iPhone 8 Plus - 2021-07-07 at 09 06 30](https://user-images.githubusercontent.com/11576431/124714889-9fde3280-df02-11eb-8b66-18599a7518fa.png)
