### PR TITLE
fix/#427 - dialogs and context management with list items

### DIFF
--- a/packages/smooth_app/lib/pages/text_search_widget.dart
+++ b/packages/smooth_app/lib/pages/text_search_widget.dart
@@ -81,7 +81,7 @@ class _TextSearchWidgetState extends State<TextSearchWidget> {
                 label: const Text('Click here for server search'),
                 onPressed: () => ChoosePage.onSubmitted(
                   _searchController.text,
-                  context,
+                  this.context, // careful, here use the "main" context and not the transient item context
                   widget.daoProduct.localDatabase,
                 ),
               ),


### PR DESCRIPTION
Impacted file:
* `text_search_widget.dart`: now using the "main" context for the dialogs, instead of the transient single item context