### PR TITLE
Replace lc with language parameter, fixes #433

### DIFF
--- a/packages/smooth_app/lib/database/barcode_product_query.dart
+++ b/packages/smooth_app/lib/database/barcode_product_query.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:openfoodfacts/utils/LanguageHelper.dart';
 import 'package:smooth_app/database/product_query.dart';
 import 'package:smooth_app/database/dao_product.dart';
 
@@ -20,7 +21,7 @@ class BarcodeProductQuery {
     final ProductQueryConfiguration configuration = ProductQueryConfiguration(
       barcode,
       fields: ProductQuery.fields,
-      lc: languageCode,
+      language: LanguageHelper.fromJson(languageCode),
       cc: countryCode,
     );
 

--- a/packages/smooth_app/lib/database/category_product_query.dart
+++ b/packages/smooth_app/lib/database/category_product_query.dart
@@ -33,7 +33,7 @@ class CategoryProductQuery implements ProductQuery {
               tagName: category,
             ),
           ],
-          lc: languageCode,
+          language: LanguageHelper.fromJson(languageCode),
           cc: countryCode,
         ),
       );

--- a/packages/smooth_app/lib/database/group_product_query.dart
+++ b/packages/smooth_app/lib/database/group_product_query.dart
@@ -5,7 +5,7 @@ import 'dart:async';
 import 'package:openfoodfacts/model/SearchResult.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/utils/LanguageHelper.dart';
-import 'package:openfoodfacts/utils/PnnsGroupQueryConfiguration.dart';
+import 'package:openfoodfacts/model/parameter/PnnsGroup2Filter.dart';
 import 'package:openfoodfacts/utils/PnnsGroups.dart';
 
 // Project imports:
@@ -21,13 +21,15 @@ class GroupProductQuery implements ProductQuery {
 
   @override
   Future<SearchResult> getSearchResult() async =>
-      await OpenFoodAPIClient.queryPnnsGroup(
+      await OpenFoodAPIClient.searchProducts(
         ProductQuery.SMOOTH_USER,
-        PnnsGroupQueryConfiguration(
-          group,
+        ProductSearchQueryConfiguration(
           fields: ProductQuery.fields,
-          page: page,
           language: LanguageHelper.fromJson(languageCode),
+          parametersList: <Parameter>[
+            PnnsGroup2Filter(pnnsGroup2: group),
+            Page(page: page),
+          ],
         ),
       );
 

--- a/packages/smooth_app/lib/database/keywords_product_query.dart
+++ b/packages/smooth_app/lib/database/keywords_product_query.dart
@@ -28,7 +28,7 @@ class KeywordsProductQuery implements ProductQuery {
             PageSize(size: size),
             SearchTerms(terms: <String>[keywords]),
           ],
-          lc: languageCode,
+          language: LanguageHelper.fromJson(languageCode),
           cc: countryCode,
         ),
       );

--- a/packages/smooth_app/lib/database/product_query.dart
+++ b/packages/smooth_app/lib/database/product_query.dart
@@ -44,10 +44,10 @@ abstract class ProductQuery {
         ProductField.ADDITIVES,
         ProductField.INGREDIENTS_ANALYSIS_TAGS,
         ProductField.LABELS_TAGS,
-        ProductField.LABELS_TAGS_TRANSLATED,
+        ProductField.LABELS_TAGS_IN_LANGUAGES,
         ProductField.ENVIRONMENT_IMPACT_LEVELS,
         ProductField.CATEGORIES_TAGS,
-        ProductField.CATEGORIES_TAGS_TRANSLATED,
+        ProductField.CATEGORIES_TAGS_IN_LANGUAGES,
         ProductField.LANGUAGE,
         ProductField.ATTRIBUTE_GROUPS,
       ];

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
   image_picker: ^0.8.1+3
   matomo: ^1.0.0
   modal_bottom_sheet: ^2.0.0
-  openfoodfacts: ^1.1.0-beta
+  openfoodfacts: ^1.3.0
   # Uncomment those lines if you want to use a local version of the openfoodfacts package
   #openfoodfacts:
   #  path: ../../../openfoodfacts-dart


### PR DESCRIPTION
- Uses the new 1.3.0 openfoodfacts package, with @blazern's change for languages
- Replaces the lc param with language (fixes #433)
- Replaced the deprecated queryPnnsGroup by the new PnnsGroup2Filter from @monsieurtanuki 

(note: I mistakenly made those changes on top of my smoothie-icon branch, that's why this PR compares against it, so that  you can see only the related changes. If we don't merge the smoothie-icon branch first, I'll make the changes to a new branch)

fixes #433