### PR TITLE
Revert Key constructor argument additions, turn off use_key_in_widget_constructors

### DIFF
--- a/packages/smooth_app/lib/bottom_sheet_views/group_query_filter_view.dart
+++ b/packages/smooth_app/lib/bottom_sheet_views/group_query_filter_view.dart
@@ -14,8 +14,7 @@ class GroupQueryFilterView extends StatelessWidget {
     required this.categories,
     required this.categoriesList,
     required this.callback,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final Map<String, String> categories;
   final List<String> categoriesList;

--- a/packages/smooth_app/lib/bottom_sheet_views/product_copy_view.dart
+++ b/packages/smooth_app/lib/bottom_sheet_views/product_copy_view.dart
@@ -3,7 +3,7 @@ import 'package:smooth_app/data_models/product_list.dart';
 
 ///The ModalBottomSheet to choose where to copy/add products to
 class ProductCopyView extends StatelessWidget {
-  const ProductCopyView(this.children, {Key? key}) : super(key: key);
+  const ProductCopyView(this.children);
 
   final Map<String, List<Widget>> children;
 

--- a/packages/smooth_app/lib/bottom_sheet_views/user_contribution_view.dart
+++ b/packages/smooth_app/lib/bottom_sheet_views/user_contribution_view.dart
@@ -6,8 +6,6 @@ import 'package:smooth_ui_library/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_ui_library/widgets/smooth_list_tile.dart';
 
 class UserContributionView extends StatelessWidget {
-  UserContributionView({Key? key}) : super(key: key);
-
   final Launcher launcher = Launcher();
 
   @override

--- a/packages/smooth_app/lib/cards/category_cards/category_card.dart
+++ b/packages/smooth_app/lib/cards/category_cards/category_card.dart
@@ -7,8 +7,7 @@ class CategoryCard extends StatelessWidget {
     required this.color,
     required this.onTap,
     this.iconName = 'smoothie.svg',
-    Key? key,
-  }) : super(key: key);
+  });
 
   final String title;
   final Color color;

--- a/packages/smooth_app/lib/cards/category_cards/category_chip.dart
+++ b/packages/smooth_app/lib/cards/category_cards/category_chip.dart
@@ -1,3 +1,4 @@
+// Flutter imports:
 import 'package:flutter/material.dart';
 
 class CategoryChip extends StatelessWidget {
@@ -5,8 +6,7 @@ class CategoryChip extends StatelessWidget {
     required this.title,
     required this.color,
     required this.onTap,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final String title;
   final Color color;

--- a/packages/smooth_app/lib/cards/category_cards/subcategory_card.dart
+++ b/packages/smooth_app/lib/cards/category_cards/subcategory_card.dart
@@ -7,8 +7,7 @@ class SubcategoryCard extends StatelessWidget {
     required this.color,
     required this.onTap,
     required this.heroTag,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final String title;
   final Color color;

--- a/packages/smooth_app/lib/cards/category_cards/svg_async_asset.dart
+++ b/packages/smooth_app/lib/cards/category_cards/svg_async_asset.dart
@@ -8,8 +8,7 @@ class SvgAsyncAsset extends StatelessWidget {
     this.fullFilename, {
     this.width,
     this.height,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final String fullFilename;
   final double? width;

--- a/packages/smooth_app/lib/cards/category_cards/svg_cache.dart
+++ b/packages/smooth_app/lib/cards/category_cards/svg_cache.dart
@@ -9,8 +9,7 @@ class SvgCache extends StatelessWidget {
     this.width,
     this.height,
     this.displayAssetWhileWaiting = true,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final String? iconUrl;
   final double? width;

--- a/packages/smooth_app/lib/cards/data_cards/attribute_card.dart
+++ b/packages/smooth_app/lib/cards/data_cards/attribute_card.dart
@@ -12,8 +12,7 @@ class AttributeCard extends StatelessWidget {
     this.attribute,
     this.attributeChip, {
     this.barcode,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final Attribute attribute;
   final Widget attributeChip;

--- a/packages/smooth_app/lib/cards/data_cards/attribute_chip.dart
+++ b/packages/smooth_app/lib/cards/data_cards/attribute_chip.dart
@@ -7,8 +7,7 @@ class AttributeChip extends StatelessWidget {
   const AttributeChip(
     this.attribute, {
     required this.height,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final Attribute attribute;
   final double height;

--- a/packages/smooth_app/lib/cards/data_cards/image_upload_card.dart
+++ b/packages/smooth_app/lib/cards/data_cards/image_upload_card.dart
@@ -15,8 +15,7 @@ class ImageUploadCard extends StatefulWidget {
     this.imageUrl,
     this.title,
     required this.buttonText,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final Product product;
   final ImageField imageField;

--- a/packages/smooth_app/lib/cards/data_cards/smooth_data_card.dart
+++ b/packages/smooth_app/lib/cards/data_cards/smooth_data_card.dart
@@ -11,8 +11,7 @@ class SmoothDataCard extends StatelessWidget {
     this.width,
     this.height,
     this.color = Colors.white,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final Widget content;
   final double? width;

--- a/packages/smooth_app/lib/cards/expandables/attribute_list_expandable.dart
+++ b/packages/smooth_app/lib/cards/expandables/attribute_list_expandable.dart
@@ -22,8 +22,7 @@ class AttributeListExpandable extends StatelessWidget {
     this.padding,
     this.insets,
     this.initiallyCollapsed = true,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final Product product;
   final double iconHeight;

--- a/packages/smooth_app/lib/cards/product_cards/product_list_preview.dart
+++ b/packages/smooth_app/lib/cards/product_cards/product_list_preview.dart
@@ -16,8 +16,7 @@ class ProductListPreview extends StatelessWidget {
     required this.productList,
     required this.nbInPreview,
     this.andThen,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final DaoProductList daoProductList;
   final ProductList productList;

--- a/packages/smooth_app/lib/cards/product_cards/product_list_preview_helper.dart
+++ b/packages/smooth_app/lib/cards/product_cards/product_list_preview_helper.dart
@@ -7,8 +7,7 @@ class ProductListPreviewHelper extends StatelessWidget {
   const ProductListPreviewHelper({
     required this.list,
     required this.iconSize,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final List<Product> list;
   final double iconSize;

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_edit.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_edit.dart
@@ -10,8 +10,7 @@ class SmoothProductCardEdit extends StatelessWidget {
   const SmoothProductCardEdit({
     required this.product,
     required this.heroTag,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final Product product;
   final String heroTag;

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
@@ -22,8 +22,7 @@ class SmoothProductCardFound extends StatelessWidget {
     this.handle,
     this.onLongPress,
     this.refresh,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final Product product;
   final String heroTag;

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_loading.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_loading.dart
@@ -3,10 +3,7 @@ import 'dart:ui';
 import 'package:flutter/material.dart';
 
 class SmoothProductCardLoading extends StatelessWidget {
-  const SmoothProductCardLoading({
-    required this.barcode,
-    Key? key,
-  }) : super(key: key);
+  const SmoothProductCardLoading({required this.barcode});
 
   final String barcode;
 

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_not_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_not_found.dart
@@ -9,8 +9,7 @@ class SmoothProductCardNotFound extends StatelessWidget {
     required this.product,
     this.callback,
     this.elevation = 0.0,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final VoidCallback? callback;
   final double elevation;

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_thanks.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_thanks.dart
@@ -4,7 +4,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 
 class SmoothProductCardThanks extends StatelessWidget {
-  const SmoothProductCardThanks({Key? key}) : super(key: key);
+  const SmoothProductCardThanks();
 
   @override
   Widget build(BuildContext context) {

--- a/packages/smooth_app/lib/lists/smooth_product_carousel.dart
+++ b/packages/smooth_app/lib/lists/smooth_product_carousel.dart
@@ -20,8 +20,7 @@ class SmoothProductCarousel extends StatefulWidget {
   const SmoothProductCarousel({
     required this.continuousScanModel,
     this.height = 120.0,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final ContinuousScanModel continuousScanModel;
   final double height;

--- a/packages/smooth_app/lib/main.dart
+++ b/packages/smooth_app/lib/main.dart
@@ -39,7 +39,7 @@ Future<void> main() async {
 }
 
 class SmoothApp extends StatefulWidget {
-  const SmoothApp({Key? key}) : super(key: key);
+  const SmoothApp();
 
   // This widget is the root of your application.
   @override
@@ -153,7 +153,7 @@ class _SmoothAppState extends State<SmoothApp> {
 
 /// Layer needed because we need to know the language
 class SmoothAppGetLanguage extends StatelessWidget {
-  const SmoothAppGetLanguage({Key? key}) : super(key: key);
+  const SmoothAppGetLanguage();
 
   @override
   Widget build(BuildContext context) {

--- a/packages/smooth_app/lib/pages/attribute_button.dart
+++ b/packages/smooth_app/lib/pages/attribute_button.dart
@@ -17,9 +17,8 @@ import 'package:smooth_ui_library/dialogs/smooth_alert_dialog.dart';
 class AttributeButton extends StatelessWidget {
   const AttributeButton(
     this.attribute,
-    this.productPreferences, {
-    Key? key,
-  }) : super(key: key);
+    this.productPreferences,
+  );
 
   final Attribute attribute;
   final ProductPreferences productPreferences;

--- a/packages/smooth_app/lib/pages/choose_page.dart
+++ b/packages/smooth_app/lib/pages/choose_page.dart
@@ -18,7 +18,7 @@ import 'package:smooth_app/pages/product/common/product_query_page_helper.dart';
 import 'package:smooth_app/pages/product/product_page.dart';
 
 class ChoosePage extends StatefulWidget {
-  const ChoosePage({Key? key}) : super(key: key);
+  const ChoosePage();
 
   @override
   State<ChoosePage> createState() => _ChoosePageState();

--- a/packages/smooth_app/lib/pages/contribution_page.dart
+++ b/packages/smooth_app/lib/pages/contribution_page.dart
@@ -7,8 +7,6 @@ import 'package:smooth_ui_library/buttons/smooth_simple_button.dart';
 
 // TODO(stephanegigandet): not used, to be deleted?
 class CollaborationPage extends StatelessWidget {
-  const CollaborationPage({Key? key}) : super(key: key);
-
   @override
   Widget build(BuildContext context) {
     return Scaffold(

--- a/packages/smooth_app/lib/pages/home_page.dart
+++ b/packages/smooth_app/lib/pages/home_page.dart
@@ -25,7 +25,7 @@ import 'package:smooth_app/themes/theme_provider.dart';
 import 'package:smooth_ui_library/widgets/smooth_card.dart';
 
 class HomePage extends StatefulWidget {
-  const HomePage({Key? key}) : super(key: key);
+  const HomePage();
 
   @override
   State<HomePage> createState() => _HomePageState();

--- a/packages/smooth_app/lib/pages/html_page.dart
+++ b/packages/smooth_app/lib/pages/html_page.dart
@@ -6,8 +6,7 @@ class HtmlPage extends StatelessWidget {
   const HtmlPage({
     required this.pageTitle,
     required this.htmlString,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final String pageTitle;
   final String htmlString;

--- a/packages/smooth_app/lib/pages/list_page.dart
+++ b/packages/smooth_app/lib/pages/list_page.dart
@@ -12,8 +12,7 @@ class ListPage extends StatefulWidget {
   const ListPage({
     required this.title,
     required this.typeFilter,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final String title;
   final List<String> typeFilter;

--- a/packages/smooth_app/lib/pages/multi_select_product_page.dart
+++ b/packages/smooth_app/lib/pages/multi_select_product_page.dart
@@ -17,8 +17,7 @@ class MultiSelectProductPage extends StatefulWidget {
   const MultiSelectProductPage({
     required this.barcode,
     required this.productList,
-    Key? key,
-  }) : super(key: key);
+  });
 
   /// Initial selected barcode
   final String barcode;

--- a/packages/smooth_app/lib/pages/organization_page.dart
+++ b/packages/smooth_app/lib/pages/organization_page.dart
@@ -5,8 +5,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class OrganizationPage extends StatelessWidget {
-  const OrganizationPage({Key? key}) : super(key: key);
-
   @override
   Widget build(BuildContext context) {
     return Scaffold(

--- a/packages/smooth_app/lib/pages/personalized_ranking_page.dart
+++ b/packages/smooth_app/lib/pages/personalized_ranking_page.dart
@@ -13,10 +13,7 @@ import 'package:smooth_app/pages/user_preferences_page.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
 
 class PersonalizedRankingPage extends StatefulWidget {
-  const PersonalizedRankingPage(
-    this.productList, {
-    Key? key,
-  }) : super(key: key);
+  const PersonalizedRankingPage(this.productList);
 
   final ProductList productList;
 

--- a/packages/smooth_app/lib/pages/product/common/product_list_add_button.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_add_button.dart
@@ -9,8 +9,7 @@ class ProductListAddButton extends StatelessWidget {
     required this.onPressed,
     required this.onlyIcon,
     required this.productListType,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final VoidCallback onPressed;
   final bool onlyIcon;

--- a/packages/smooth_app/lib/pages/product/common/product_list_button.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_button.dart
@@ -8,8 +8,7 @@ class ProductListButton extends StatelessWidget {
   const ProductListButton({
     required this.productList,
     required this.onPressed,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final ProductList productList;
   final VoidCallback onPressed;

--- a/packages/smooth_app/lib/pages/product/common/product_list_item.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_item.dart
@@ -14,8 +14,7 @@ class ProductListItem extends StatelessWidget {
     required this.listRefresher,
     required this.daoProductList,
     this.reorderIndex,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final Product product;
   final ProductList productList;

--- a/packages/smooth_app/lib/pages/product/common/product_list_item_pantry.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_item_pantry.dart
@@ -16,10 +16,8 @@ class ProductListItemPantry extends StatelessWidget {
     required this.listRefresher,
     required this.daoProductList,
     required this.reorderIndex,
-    Key? key,
   })  : _productExtra = productList.getProductExtra(product.barcode!),
-        _counts = _getCounts(productList.getProductExtra(product.barcode!)),
-        super(key: key);
+        _counts = _getCounts(productList.getProductExtra(product.barcode!));
   // TODO(monsieurtanuki): do it with more elegance, but without a StatefulWidget
 
   static const String _EMPTY_DATE = '';

--- a/packages/smooth_app/lib/pages/product/common/product_list_item_simple.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_item_simple.dart
@@ -13,8 +13,7 @@ class ProductListItemSimple extends StatelessWidget {
     required this.listRefresher,
     required this.daoProductList,
     this.reorderIndex,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final Product product;
   final ProductList productList;

--- a/packages/smooth_app/lib/pages/product/common/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_page.dart
@@ -14,10 +14,7 @@ import 'package:smooth_app/pages/product/common/product_query_page_helper.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
 
 class ProductListPage extends StatefulWidget {
-  const ProductListPage(
-    this.productList, {
-    Key? key,
-  }) : super(key: key);
+  const ProductListPage(this.productList);
 
   final ProductList productList;
 

--- a/packages/smooth_app/lib/pages/product/common/product_query_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_query_page.dart
@@ -21,8 +21,7 @@ class ProductQueryPage extends StatefulWidget {
     required this.mainColor,
     required this.name,
     this.lastUpdate,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final ProductListSupplier productListSupplier;
   final String heroTag;

--- a/packages/smooth_app/lib/pages/product/common/smooth_chip.dart
+++ b/packages/smooth_app/lib/pages/product/common/smooth_chip.dart
@@ -9,8 +9,7 @@ class SmoothChip extends StatelessWidget {
     this.label,
     this.materialColor,
     this.shape,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final VoidCallback onPressed;
   final IconData? iconData;

--- a/packages/smooth_app/lib/pages/product/product_image_page.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_page.dart
@@ -10,8 +10,7 @@ class ProductImagePage extends StatelessWidget {
     required this.imageProvider,
     required this.title,
     required this.buttonText,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final Product product;
   final ImageField imageField;

--- a/packages/smooth_app/lib/pages/product/product_page.dart
+++ b/packages/smooth_app/lib/pages/product/product_page.dart
@@ -36,8 +36,7 @@ class ProductPage extends StatefulWidget {
   const ProductPage({
     required this.product,
     this.newProduct = false,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final bool newProduct;
   final Product product;

--- a/packages/smooth_app/lib/pages/scan/continuous_scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/continuous_scan_page.dart
@@ -11,10 +11,7 @@ import 'package:smooth_ui_library/animations/smooth_reveal_animation.dart';
 import 'package:smooth_ui_library/widgets/smooth_view_finder.dart';
 
 class ContinuousScanPage extends StatelessWidget {
-  ContinuousScanPage(
-    this._continuousScanModel, {
-    Key? key,
-  }) : super(key: key);
+  ContinuousScanPage(this._continuousScanModel);
 
   final ContinuousScanModel _continuousScanModel;
 

--- a/packages/smooth_app/lib/pages/scan/scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/scan_page.dart
@@ -11,8 +11,7 @@ import 'package:smooth_ui_library/widgets/smooth_toggle.dart';
 class ScanPage extends StatelessWidget {
   const ScanPage({
     required this.contributionMode,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final bool contributionMode;
 

--- a/packages/smooth_app/lib/pages/settings_page.dart
+++ b/packages/smooth_app/lib/pages/settings_page.dart
@@ -16,7 +16,7 @@ import 'package:smooth_ui_library/widgets/smooth_list_tile.dart';
 import 'package:smooth_ui_library/widgets/smooth_toggle.dart';
 
 class ProfilePage extends StatelessWidget {
-  const ProfilePage({Key? key}) : super(key: key);
+  const ProfilePage();
 
   static const List<String> _ORDERED_COLOR_TAGS = <String>[
     SmoothTheme.COLOR_TAG_BLUE,

--- a/packages/smooth_app/lib/pages/text_search_widget.dart
+++ b/packages/smooth_app/lib/pages/text_search_widget.dart
@@ -15,8 +15,7 @@ class TextSearchWidget extends StatefulWidget {
     this.color,
     required this.daoProduct,
     this.addProductCallback,
-    Key? key,
-  }) : super(key: key);
+  });
 
   /// Icon color
   final Color? color;

--- a/packages/smooth_app/lib/pages/tracking_page.dart
+++ b/packages/smooth_app/lib/pages/tracking_page.dart
@@ -1,14 +1,9 @@
-// Flutter imports:
 import 'package:flutter/material.dart';
-
-// Package imports:
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:smooth_ui_library/animations/smooth_reveal_animation.dart';
 
 class TrackingPage extends StatelessWidget {
-  const TrackingPage({Key? key}) : super(key: key);
-
   @override
   Widget build(BuildContext context) {
     return Scaffold(

--- a/packages/smooth_app/lib/pages/user_preferences_page.dart
+++ b/packages/smooth_app/lib/pages/user_preferences_page.dart
@@ -10,7 +10,7 @@ import 'package:smooth_app/themes/smooth_theme.dart';
 
 /// Preferences page for attribute importances
 class UserPreferencesPage extends StatelessWidget {
-  const UserPreferencesPage({Key? key}) : super(key: key);
+  const UserPreferencesPage();
 
   static const double _TYPICAL_PADDING_OR_MARGIN = 12;
 

--- a/packages/smooth_app/lib/views/label_sneak_peek_view.dart
+++ b/packages/smooth_app/lib/views/label_sneak_peek_view.dart
@@ -4,8 +4,6 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:smooth_ui_library/animations/smooth_reveal_animation.dart';
 
 class LabelSneakPeekView extends StatelessWidget {
-  const LabelSneakPeekView({Key? key}) : super(key: key);
-
   @override
   Widget build(BuildContext context) {
     return Column(

--- a/packages/smooth_ui_library/analysis_options.yaml
+++ b/packages/smooth_ui_library/analysis_options.yaml
@@ -146,7 +146,7 @@ linter:
     use_full_hex_values_for_flutter_colors: true
     use_function_type_syntax_for_parameters: true
     use_is_even_rather_than_modulo: true
-    use_key_in_widget_constructors: true
+    use_key_in_widget_constructors: false
     use_late_for_private_fields_and_variables: true
     use_named_constants: true
     use_raw_strings: true

--- a/packages/smooth_ui_library/lib/animations/smooth_animated_collapse_arrow.dart
+++ b/packages/smooth_ui_library/lib/animations/smooth_animated_collapse_arrow.dart
@@ -7,8 +7,7 @@ class SmoothAnimatedCollapseArrow extends StatefulWidget {
     required this.collapsed,
     this.duration = const Duration(milliseconds: 160),
     this.curve = Curves.ease,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final bool collapsed;
   final Duration duration;

--- a/packages/smooth_ui_library/lib/animations/smooth_reveal_animation.dart
+++ b/packages/smooth_ui_library/lib/animations/smooth_reveal_animation.dart
@@ -3,14 +3,12 @@ import 'dart:async';
 import 'package:flutter/cupertino.dart';
 
 class SmoothRevealAnimation extends StatefulWidget {
-  const SmoothRevealAnimation({
-    required this.child,
-    this.delay = 0,
-    this.animationCurve = Curves.ease,
-    this.animationDuration = 400,
-    this.startOffset = const Offset(1.0, 0.0),
-    Key? key,
-  }) : super(key: key);
+  const SmoothRevealAnimation(
+      {required this.child,
+      this.delay = 0,
+      this.animationCurve = Curves.ease,
+      this.animationDuration = 400,
+      this.startOffset = const Offset(1.0, 0.0)});
 
   final Widget child;
   final int delay;

--- a/packages/smooth_ui_library/lib/buttons/smooth_main_button.dart
+++ b/packages/smooth_ui_library/lib/buttons/smooth_main_button.dart
@@ -7,8 +7,7 @@ class SmoothMainButton extends StatelessWidget {
     this.width = double.infinity,
     this.important = true,
     this.height = 56.0,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final String text;
   final VoidCallback onPressed;

--- a/packages/smooth_ui_library/lib/buttons/smooth_simple_button.dart
+++ b/packages/smooth_ui_library/lib/buttons/smooth_simple_button.dart
@@ -7,8 +7,7 @@ class SmoothSimpleButton extends StatelessWidget {
     this.minWidth = 15,
     this.height = 20,
     this.important = true,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final String text;
   final VoidCallback onPressed;

--- a/packages/smooth_ui_library/lib/dialogs/smooth_alert_dialog.dart
+++ b/packages/smooth_ui_library/lib/dialogs/smooth_alert_dialog.dart
@@ -19,8 +19,7 @@ class SmoothAlertDialog extends StatelessWidget {
     this.height,
     required this.body,
     this.actions,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final String? title;
   final bool close;

--- a/packages/smooth_ui_library/lib/navigation/smooth_bottom_navigation_bar.dart
+++ b/packages/smooth_ui_library/lib/navigation/smooth_bottom_navigation_bar.dart
@@ -5,12 +5,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:smooth_ui_library/navigation/models/smooth_bottom_navigation_bar_item.dart';
 
 class SmoothBottomNavigationBar extends StatefulWidget {
-  const SmoothBottomNavigationBar(
-    this.items, {
-    required this.fabAction,
-    Key? key,
-  }) : super(key: key);
-
+  const SmoothBottomNavigationBar(this.items, {required this.fabAction});
   final List<SmoothBottomNavigationBarItem> items;
   final VoidCallback fabAction;
 

--- a/packages/smooth_ui_library/lib/widgets/smooth_card.dart
+++ b/packages/smooth_ui_library/lib/widgets/smooth_card.dart
@@ -9,8 +9,7 @@ class SmoothCard extends StatelessWidget {
     this.padding =
         const EdgeInsets.only(right: 8.0, left: 8.0, top: 4.0, bottom: 4.0),
     this.insets = const EdgeInsets.all(5.0),
-    Key? key,
-  }) : super(key: key);
+  });
 
   final Widget child;
   final Color? color;

--- a/packages/smooth_ui_library/lib/widgets/smooth_expandable_card.dart
+++ b/packages/smooth_ui_library/lib/widgets/smooth_expandable_card.dart
@@ -12,8 +12,7 @@ class SmoothExpandableCard extends StatefulWidget {
         const EdgeInsets.only(right: 8.0, left: 8.0, top: 4.0, bottom: 20.0),
     this.insets = const EdgeInsets.all(12.0),
     this.initiallyCollapsed = true,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final Widget collapsedHeader;
   final Widget? expandedHeader;

--- a/packages/smooth_ui_library/lib/widgets/smooth_gauge.dart
+++ b/packages/smooth_ui_library/lib/widgets/smooth_gauge.dart
@@ -9,8 +9,7 @@ class SmoothGauge extends StatelessWidget {
     this.backgroundColor,
     this.circular = true,
     this.width = 100.0,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final double value;
   final double size;

--- a/packages/smooth_ui_library/lib/widgets/smooth_product_image.dart
+++ b/packages/smooth_ui_library/lib/widgets/smooth_product_image.dart
@@ -9,8 +9,7 @@ class SmoothProductImage extends StatelessWidget {
     required this.product,
     required this.height,
     required this.width,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final Product product;
   final double height;

--- a/packages/smooth_ui_library/lib/widgets/smooth_search_bar.dart
+++ b/packages/smooth_ui_library/lib/widgets/smooth_search_bar.dart
@@ -9,8 +9,7 @@ class SmoothSearchBar extends StatelessWidget {
     this.textColor = Colors.black,
     this.borderRadius = 20.0,
     this.onSubmitted,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final TextEditingController? controller;
   final String? hintText;

--- a/packages/smooth_ui_library/lib/widgets/smooth_toggle.dart
+++ b/packages/smooth_ui_library/lib/widgets/smooth_toggle.dart
@@ -20,8 +20,7 @@ class SmoothToggle extends StatefulWidget {
     required this.onChanged,
     this.width = 150.0,
     this.height = 50.0,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final bool value;
   final Function(bool) onChanged;

--- a/packages/smooth_ui_library/lib/widgets/smooth_view_finder.dart
+++ b/packages/smooth_ui_library/lib/widgets/smooth_view_finder.dart
@@ -7,8 +7,7 @@ class SmoothViewFinder extends StatefulWidget {
     required this.width,
     required this.height,
     required this.animationDuration,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final double width;
   final double height;


### PR DESCRIPTION
In https://github.com/openfoodfacts/smooth-app/pull/445, I added the lint use_key_in_widget_constructors and added the missing parameters, but it's not really necessary, so I'm reverting that portion of that change.