### PR TITLE
Remove working directory from post-submit script

### DIFF
--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -4,12 +4,11 @@ on: push
     
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: ./packages/smooth_app
+        shell: bash
     steps:
-    
       - name: "Checkout code"
         uses: actions/checkout@v1
 
@@ -44,6 +43,7 @@ jobs:
       # Build apk.
       - name: "Build apk"
         run: flutter build apk --debug
+        working-directory: ./packages/smooth_app
       
       # Upload generated apk to the artifacts.
       - name: "Upload APK"


### PR DESCRIPTION
I introduced a failure in the post-submit script because I forgot to remove the working directory that was set. This fixed that.

While the patient was open, I switched the post-submit host to `ubuntu-latest` to get better build scheduling latency.

## Related Issues

 - Fixes https://github.com/openfoodfacts/smooth-app/issues/456