### PR TITLE
use openfoodfacts 1.3.2 to fix broken scan

### DIFF
--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   image_picker: ^0.8.1+3
   matomo: ^1.0.0
   modal_bottom_sheet: ^2.0.0
-  openfoodfacts: ^1.3.1
+  openfoodfacts: ^1.3.2
   # Uncomment those lines if you want to use a local version of the openfoodfacts package
   #openfoodfacts:
   #  path: ../../../openfoodfacts-dart


### PR DESCRIPTION
Scanning now works again on my device that had old JSON files saved in the database. Those JSONs can now be loaded properly.
Fixes #444 