### PR TITLE
feature/#461 - added preview of scanned product list on home page

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/product_list_preview.dart
+++ b/packages/smooth_app/lib/cards/product_cards/product_list_preview.dart
@@ -36,9 +36,7 @@ class ProductListPreview extends StatelessWidget {
               snapshot.data != null) {
             final List<Product> list = snapshot.data!;
 
-            String subtitle;
             final double iconSize = MediaQuery.of(context).size.width / 6;
-            subtitle = AppLocalizations.of(context)!.empty_list;
             return SmoothCard(
               child: Column(
                 children: <Widget>[
@@ -61,7 +59,9 @@ class ProductListPreview extends StatelessWidget {
                       ColorDestination.SURFACE_FOREGROUND,
                     ),
                     trailing: const Icon(Icons.arrow_forward),
-                    subtitle: Text(subtitle),
+                    subtitle: list.isEmpty
+                        ? Text(AppLocalizations.of(context)!.empty_list)
+                        : null,
                     title: Text(
                       title,
                       style: Theme.of(context).textTheme.subtitle2,

--- a/packages/smooth_app/lib/pages/home_page.dart
+++ b/packages/smooth_app/lib/pages/home_page.dart
@@ -146,6 +146,15 @@ class _HomePageState extends State<HomePage> {
             nbInPreview: 5,
             andThen: () => setState(() {}),
           ),
+          ProductListPreview(
+            daoProductList: _daoProductList,
+            productList: ProductList(
+              listType: ProductList.LIST_TYPE_SCAN,
+              parameters: '',
+            ),
+            nbInPreview: 5,
+            andThen: () => setState(() {}),
+          ),
           GestureDetector(
             child: SmoothCard(
               child: ListTile(


### PR DESCRIPTION
Impacted files:
* `home_page.dart`: added a product list preview for scanned products
* `product_list_preview.dart`: unrelated bug fix (always printed "Empty list" before)