### PR TITLE
feature_2/#461 - fixed product order for scanned products in dedicated page

### DIFF
--- a/packages/smooth_app/lib/data_models/continuous_scan_model.dart
+++ b/packages/smooth_app/lib/data_models/continuous_scan_model.dart
@@ -52,7 +52,7 @@ class ContinuousScanModel with ChangeNotifier {
       _daoProductList = DaoProductList(localDatabase);
       _daoProductExtra = DaoProductExtra(localDatabase);
       await _daoProductList.get(_productList);
-      for (final String barcode in _productList.barcodes) {
+      for (final String barcode in _productList.barcodes.reversed) {
         _barcodes.add(barcode);
         _states[barcode] = ScannedProductState.CACHED;
         _latestScannedBarcode = barcode;

--- a/packages/smooth_app/lib/database/dao_product_extra.dart
+++ b/packages/smooth_app/lib/database/dao_product_extra.dart
@@ -378,9 +378,8 @@ class DaoProductExtra extends AbstractDao implements BulkDeletable {
   bool _getExtraReverse(final ProductList productList, final int? id) {
     switch (productList.listType) {
       case ProductList.LIST_TYPE_HISTORY:
-        return true;
       case ProductList.LIST_TYPE_SCAN:
-        return false;
+        return true;
     }
     if (id == null) {
       throw Exception('Unknown product list of type ${productList.listType}');


### PR DESCRIPTION
Impacted files:
* `continuous_scan_model.dart`: reversing the order (= no change in display)
* `dao_product_extra.dart`: reversing the order of scanned products - the order is now from newer to older