### PR TITLE
feature/#478 - clean fatal error management for end-users

### DIFF
--- a/packages/smooth_app/lib/main.dart
+++ b/packages/smooth_app/lib/main.dart
@@ -58,6 +58,7 @@ class _SmoothAppState extends State<SmoothApp> {
   // subsequent builds. This enables hot reloading. See
   // https://github.com/openfoodfacts/smooth-app/issues/473
   late Future<void> _initFuture;
+  String? _initFatalErrorMessage;
 
   @override
   void initState() {
@@ -66,29 +67,27 @@ class _SmoothAppState extends State<SmoothApp> {
   }
 
   Future<void> _init() async {
-    Function debugPrintAndRethrow(String message) => (dynamic error) {
-          debugPrint('$message: $error');
-          return error;
-        };
-    final Brightness brightness =
-        SchedulerBinding.instance?.window.platformBrightness ??
-            Brightness.light;
-    systemDarkmodeOn = brightness == Brightness.dark;
-    _userPreferences = await UserPreferences.getUserPreferences();
-    _productPreferences = ProductPreferences(ProductPreferencesSelection(
-      setImportance: _userPreferences.setImportance,
-      getImportance: _userPreferences.getImportance,
-      notify: () => _productPreferences.notifyListeners(),
-    ));
-    await _productPreferences
-        .loadReferenceFromAssets(DefaultAssetBundle.of(context))
-        // this is problematic - we should always be able to load the default
-        .catchError(debugPrintAndRethrow('Could not load reference files'));
-    await _userPreferences.init(_productPreferences);
-    _localDatabase = await LocalDatabase.getLocalDatabase()
-        // this is problematic - we should always be able to init the database
-        .catchError(debugPrintAndRethrow('Cannot init database'));
-    _themeProvider = ThemeProvider(_userPreferences);
+    try {
+      final Brightness brightness =
+          SchedulerBinding.instance?.window.platformBrightness ??
+              Brightness.light;
+      systemDarkmodeOn = brightness == Brightness.dark;
+      _userPreferences = await UserPreferences.getUserPreferences();
+      _productPreferences = ProductPreferences(ProductPreferencesSelection(
+        setImportance: _userPreferences.setImportance,
+        getImportance: _userPreferences.getImportance,
+        notify: () => _productPreferences.notifyListeners(),
+      ));
+      await _productPreferences
+          .loadReferenceFromAssets(DefaultAssetBundle.of(context));
+      // we should always be able to load the default
+      await _userPreferences.init(_productPreferences);
+      // we should always be able to init the database
+      _localDatabase = await LocalDatabase.getLocalDatabase();
+      _themeProvider = ThemeProvider(_userPreferences);
+    } catch (e) {
+      _initFatalErrorMessage = e.toString();
+    }
   }
 
   @override
@@ -96,6 +95,17 @@ class _SmoothAppState extends State<SmoothApp> {
     return FutureBuilder<void>(
       future: _initFuture,
       builder: (BuildContext context, AsyncSnapshot<void> snapshot) {
+        if (_initFatalErrorMessage != null) {
+          return MaterialApp(
+            home: Scaffold(
+              body: Center(
+                child: Text(
+                  'Fatal Error: $_initFatalErrorMessage',
+                ),
+              ),
+            ),
+          );
+        }
         if (snapshot.connectionState == ConnectionState.done) {
           return MultiProvider(
             providers: <ChangeNotifierProvider<dynamic>>[


### PR DESCRIPTION
Impacted file:
* `main.dart`: clearly displaying a fatal error message and that's the end of the app