### PR TITLE
Rework navigation

### DIFF
--- a/packages/smooth_app/lib/pages/home_page.dart
+++ b/packages/smooth_app/lib/pages/home_page.dart
@@ -28,39 +28,50 @@ class HomePage extends StatefulWidget {
   State<HomePage> createState() => _HomePageState();
 }
 
+class _Page {
+  const _Page({required this.name, required this.icon, required this.body});
+  final String name;
+  final IconData icon;
+  final Widget body;
+}
+
 class _HomePageState extends State<HomePage> {
-  final List<Widget> _pages = <Widget>[
-    const ProfilePage(),
-    const ScanPage(),
-    const OldHomePage(),
+  static const List<_Page> _pages = <_Page>[
+    _Page(
+      name: 'Profile',
+      icon: Icons.account_circle,
+      body: ProfilePage(),
+    ),
+    _Page(
+      name: 'Scan or Search',
+      icon: Icons.search,
+      body: ScanPage(),
+    ),
+    _Page(
+      name: 'History',
+      icon: Icons.history,
+      body: OldHomePage(),
+    ),
   ];
   int _currentPage = 1;
 
   @override
   Widget build(BuildContext context) {
-    // TODO(slava-sh): Add intro screen.
     return Scaffold(
-      body: _pages[_currentPage],
+      body: _pages[_currentPage].body,
       bottomNavigationBar: BottomNavigationBar(
         showSelectedLabels: false,
         showUnselectedLabels: false,
-        selectedItemColor: Colors.amber[800],
+        selectedItemColor: Colors.white,
+        backgroundColor: Theme.of(context).appBarTheme.backgroundColor,
         currentIndex: _currentPage,
         onTap: _onTap,
-        items: const <BottomNavigationBarItem>[
-          BottomNavigationBarItem(
-            icon: Icon(Icons.account_circle),
-            label: 'Profile',
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.search),
-            label: 'Scan or Search',
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.history),
-            label: 'History',
-          ),
-        ],
+        items: _pages
+            .map((_Page p) => BottomNavigationBarItem(
+                  icon: Icon(p.icon, size: 28),
+                  label: p.name,
+                ))
+            .toList(),
       ),
     );
   }

--- a/packages/smooth_app/lib/pages/home_page.dart
+++ b/packages/smooth_app/lib/pages/home_page.dart
@@ -1,10 +1,8 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:openfoodfacts/utils/PnnsGroups.dart';
 import 'package:provider/provider.dart';
-import 'package:smooth_app/cards/category_cards/svg_async_asset.dart';
 import 'package:smooth_app/cards/product_cards/product_list_preview.dart';
 import 'package:smooth_app/data_models/product_list.dart';
 import 'package:smooth_app/database/dao_product.dart';
@@ -17,12 +15,11 @@ import 'package:smooth_app/pages/product/common/product_list_button.dart';
 import 'package:smooth_app/pages/product/common/product_list_dialog_helper.dart';
 import 'package:smooth_app/pages/product/common/product_list_page.dart';
 import 'package:smooth_app/pages/scan/scan_page.dart';
-import 'package:smooth_app/pages/settings_page.dart';
-import 'package:smooth_app/widgets/text_search_widget.dart';
-import 'package:smooth_app/pages/user_preferences_page.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
 import 'package:smooth_app/themes/theme_provider.dart';
+import 'package:smooth_app/widgets/text_search_widget.dart';
 import 'package:smooth_ui_library/widgets/smooth_card.dart';
+import 'package:smooth_app/pages/settings_page.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage();
@@ -32,6 +29,61 @@ class HomePage extends StatefulWidget {
 }
 
 class _HomePageState extends State<HomePage> {
+  final List<Widget> _pages = <Widget>[
+    const ProfilePage(),
+    const ScanPage(),
+    const OldHomePage(),
+  ];
+  int _currentPage = 1;
+
+  @override
+  Widget build(BuildContext context) {
+    // TODO(slava-sh): Add intro screen.
+    return Scaffold(
+      body: _pages[_currentPage],
+      bottomNavigationBar: BottomNavigationBar(
+        showSelectedLabels: false,
+        showUnselectedLabels: false,
+        selectedItemColor: Colors.amber[800],
+        currentIndex: _currentPage,
+        onTap: _onTap,
+        items: const <BottomNavigationBarItem>[
+          BottomNavigationBarItem(
+            icon: Icon(Icons.account_circle),
+            label: 'Profile',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.search),
+            label: 'Scan or Search',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.history),
+            label: 'History',
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _onTap(int index) {
+    setState(() {
+      _currentPage = index;
+    });
+  }
+}
+
+// Note: In addition to the history of scanned products, this page currently
+// contains the user's lists and other stuff from the old Smoothie home page.
+// The intention is to move those features to other screens later or remove them
+// altogether.
+class OldHomePage extends StatefulWidget {
+  const OldHomePage();
+
+  @override
+  State<OldHomePage> createState() => _OldHomePageState();
+}
+
+class _OldHomePageState extends State<OldHomePage> {
   static const ColorDestination _COLOR_DESTINATION_FOR_ICON =
       ColorDestination.SURFACE_FOREGROUND;
   static const Icon _ICON_ARROW_FORWARD = Icon(Icons.arrow_forward);
@@ -47,7 +99,6 @@ class _HomePageState extends State<HomePage> {
     final ThemeData themeData = Theme.of(context);
     final ColorScheme colorScheme = themeData.colorScheme;
     final AppLocalizations appLocalizations = AppLocalizations.of(context)!;
-    final Size screenSize = MediaQuery.of(context).size;
     final ThemeProvider themeProvider = context.watch<ThemeProvider>();
     final MaterialColor materialColor =
         SmoothTheme.getMaterialColor(themeProvider);
@@ -58,37 +109,10 @@ class _HomePageState extends State<HomePage> {
         ColorDestination.SURFACE_BACKGROUND,
       ),
       appBar: AppBar(
-        title: Row(
-          children: const <Widget>[
-            Icon(Icons.pets),
-            SizedBox(width: 10.0),
-            Text('Smoothie'),
-          ],
-        ),
-        actions: <Widget>[
-          IconButton(
-            icon: const Icon(Icons.settings),
-            onPressed: () async {
-              await Navigator.push<Widget>(
-                context,
-                MaterialPageRoute<Widget>(
-                  builder: (BuildContext context) => const ProfilePage(),
-                ),
-              );
-            },
-          ),
-        ],
+        title: const Text('Smoothie'),
       ),
       body: ListView(
         children: <Widget>[
-          _getHeader(
-            themeData,
-            screenSize.width,
-            materialColor,
-            themeData.brightness == Brightness.light
-                ? 'assets/home/white.svg'
-                : 'assets/home/brown.svg',
-          ),
           TextSearchWidget(
             color: SmoothTheme.getColor(
               colorScheme,
@@ -97,7 +121,6 @@ class _HomePageState extends State<HomePage> {
             ),
             daoProduct: _daoProduct,
           ),
-          _getScanLargeButton(themeData, materialColor),
           _getProductListCard(
             <String>[ProductList.LIST_TYPE_USER_DEFINED],
             appLocalizations.my_lists,
@@ -349,115 +372,5 @@ class _HomePageState extends State<HomePage> {
                   //children: cards,
                 ),
               ),
-      );
-
-  Widget _getScanLargeButton(
-    final ThemeData themeData,
-    final MaterialColor materialColor,
-  ) =>
-      Padding(
-        padding: const EdgeInsets.all(8.0),
-        child: ElevatedButton.icon(
-          style: ElevatedButton.styleFrom(
-            primary: SmoothTheme.getColor(
-              themeData.colorScheme,
-              materialColor,
-              ColorDestination.BUTTON_BACKGROUND,
-            ),
-          ),
-          onPressed: () async => Navigator.push<Widget>(
-            context,
-            MaterialPageRoute<Widget>(
-              builder: (BuildContext context) => const ScanPage(),
-            ),
-          ),
-          icon: SvgPicture.asset(
-            'assets/actions/scanner_alt_2.svg',
-            height: 32,
-            color: SmoothTheme.getColor(
-              themeData.colorScheme,
-              materialColor,
-              ColorDestination.BUTTON_FOREGROUND,
-            ),
-          ),
-          label: Text(
-            'Scan and compare products',
-            style: themeData.textTheme.headline3!.copyWith(
-              color: SmoothTheme.getColor(
-                themeData.colorScheme,
-                materialColor,
-                ColorDestination.BUTTON_FOREGROUND,
-              ),
-            ),
-          ),
-        ),
-      );
-
-  Widget _getHeader(
-    final ThemeData themeData,
-    final double screenWidth,
-    final MaterialColor materialColor,
-    final String assetFilename,
-  ) =>
-      Row(
-        children: <Widget>[
-          SizedBox(
-            width: screenWidth / 2,
-            child: Padding(
-              padding: const EdgeInsets.only(left: 8.0, right: 8.0),
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.start,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: <Widget>[
-                  Text(
-                    'Find the best food for you!',
-                    style: themeData.textTheme.headline1,
-                    textAlign: TextAlign.center,
-                  ),
-                  ElevatedButton.icon(
-                    style: ElevatedButton.styleFrom(
-                      primary: SmoothTheme.getColor(
-                        themeData.colorScheme,
-                        materialColor,
-                        ColorDestination.BUTTON_BACKGROUND,
-                      ),
-                    ),
-                    onPressed: () async => Navigator.push<Widget>(
-                      context,
-                      MaterialPageRoute<Widget>(
-                        builder: (BuildContext context) =>
-                            const UserPreferencesPage(),
-                      ),
-                    ),
-                    icon: SvgPicture.asset(
-                      'assets/actions/food-cog.svg',
-                      color: SmoothTheme.getColor(
-                        themeData.colorScheme,
-                        materialColor,
-                        ColorDestination.BUTTON_FOREGROUND,
-                      ),
-                    ),
-                    label: Flexible(
-                      child: Text(
-                        AppLocalizations.of(context)!.myPreferences,
-                        style: TextStyle(
-                          color: SmoothTheme.getColor(
-                            themeData.colorScheme,
-                            materialColor,
-                            ColorDestination.BUTTON_FOREGROUND,
-                          ),
-                        ),
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ),
-          SvgAsyncAsset(
-            assetFilename,
-            width: screenWidth / 2,
-          ),
-        ],
       );
 }


### PR DESCRIPTION
This change adds a bottom navigation bar with three tabs intended to represent Profile, Search/Scan and History pages according to the [new design][1]. For now, existing Smoothie pages are used as stand-ins for those pages.

[1]: https://docs.google.com/presentation/d/1fVVAo888BM-rpOAdQvjFhrmWe7NeAdCO2ZRxMzkHEvg/edit?pli=1#slide=id.ge5853896dd_0_9

Screenshots:
![scan](https://user-images.githubusercontent.com/470136/129065080-19b0d09c-eac9-4be7-80e7-002956fb113a.jpg)
![profile](https://user-images.githubusercontent.com/470136/129065089-5db2a3cf-c732-4783-b0d2-02b762bfe6ad.jpg)
![history](https://user-images.githubusercontent.com/470136/129065096-eadd50f6-9840-49da-9d5f-11edcaa943af.jpg)

