### PR TITLE
Switch preferences and settings pages around

### DIFF
--- a/packages/smooth_app/lib/pages/home_page.dart
+++ b/packages/smooth_app/lib/pages/home_page.dart
@@ -15,11 +15,11 @@ import 'package:smooth_app/pages/product/common/product_list_button.dart';
 import 'package:smooth_app/pages/product/common/product_list_dialog_helper.dart';
 import 'package:smooth_app/pages/product/common/product_list_page.dart';
 import 'package:smooth_app/pages/scan/scan_page.dart';
+import 'package:smooth_app/pages/user_preferences_page.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
 import 'package:smooth_app/themes/theme_provider.dart';
 import 'package:smooth_app/widgets/text_search_widget.dart';
 import 'package:smooth_ui_library/widgets/smooth_card.dart';
-import 'package:smooth_app/pages/settings_page.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage();
@@ -40,7 +40,7 @@ class _HomePageState extends State<HomePage> {
     _Page(
       name: 'Profile',
       icon: Icons.account_circle,
-      body: ProfilePage(),
+      body: UserPreferencesPage(),
     ),
     _Page(
       name: 'Scan or Search',

--- a/packages/smooth_app/lib/pages/settings_page.dart
+++ b/packages/smooth_app/lib/pages/settings_page.dart
@@ -1,15 +1,12 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
 import 'package:package_info/package_info.dart';
 import 'package:provider/provider.dart';
-import 'package:smooth_app/views/bottom_sheet_views/user_contribution_view.dart';
 import 'package:smooth_app/helpers/launch_url_helper.dart';
-import 'package:smooth_app/pages/user_preferences_page.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
 import 'package:smooth_app/themes/theme_provider.dart';
+import 'package:smooth_app/views/bottom_sheet_views/user_contribution_view.dart';
 import 'package:smooth_ui_library/buttons/smooth_simple_button.dart';
 import 'package:smooth_ui_library/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_ui_library/widgets/smooth_list_tile.dart';
@@ -52,17 +49,6 @@ class ProfilePage extends StatelessWidget {
               ),
               onChanged: (bool newValue) async =>
                   themeProvider.setDarkTheme(newValue),
-            ),
-          ),
-
-          //Configure Preferences
-          SmoothListTile(
-            text: appLocalizations.configurePreferences,
-            onPressed: () async => Navigator.push<Widget>(
-              context,
-              MaterialPageRoute<Widget>(
-                builder: (BuildContext context) => const UserPreferencesPage(),
-              ),
             ),
           ),
 

--- a/packages/smooth_app/lib/pages/user_preferences_page.dart
+++ b/packages/smooth_app/lib/pages/user_preferences_page.dart
@@ -5,8 +5,9 @@ import 'package:openfoodfacts/model/AttributeGroup.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/product_preferences.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
-import 'package:smooth_app/widgets/attribute_button.dart';
+import 'package:smooth_app/pages/settings_page.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
+import 'package:smooth_app/widgets/attribute_button.dart';
 
 /// Preferences page for attribute importances
 class UserPreferencesPage extends StatelessWidget {
@@ -19,17 +20,29 @@ class UserPreferencesPage extends StatelessWidget {
     final UserPreferences userPreferences = context.watch<UserPreferences>();
     final ProductPreferences productPreferences =
         context.watch<ProductPreferences>();
+    final AppLocalizations appLocalizations = AppLocalizations.of(context)!;
     final List<AttributeGroup>? groups = productPreferences.attributeGroups;
     final List<String> orderedImportantAttributeIds =
         productPreferences.getOrderedImportantAttributeIds();
     return Scaffold(
       appBar: AppBar(
-        title: Text(AppLocalizations.of(context)!.myPreferences),
+        title: Text(appLocalizations.myPreferences),
         actions: <Widget>[
           IconButton(
-            icon: const Icon(Icons.refresh),
+            icon: const Icon(Icons.rotate_left),
+            tooltip: appLocalizations.reset,
             onPressed: () => userPreferences.resetImportances(
               productPreferences,
+            ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.settings),
+            tooltip: appLocalizations.settingsTitle,
+            onPressed: () => Navigator.push<Widget>(
+              context,
+              MaterialPageRoute<Widget>(
+                builder: (BuildContext context) => const ProfilePage(),
+              ),
             ),
           ),
         ],


### PR DESCRIPTION
This change makes the leftmost button of the bottom navbar open the user preferences page and puts the settings page behind a "settings" button on that page according to the following mockup:

![Screen Shot 2021-08-12 at 11 56 41 AM](https://user-images.githubusercontent.com/470136/129185627-368fe578-1aa3-49c1-b421-1bcf8672d020.png)

Screenshots:
![Simulator Screen Shot - iPhone 8 - 2021-08-16 at 17 59 21](https://user-images.githubusercontent.com/470136/129601289-059ba5c4-b8ca-4132-ac1e-e265dd769ba9.png)
![Simulator Screen Shot - iPhone 8 - 2021-08-16 at 17 59 24](https://user-images.githubusercontent.com/470136/129601292-ce3adca7-b0ba-44a0-ad21-bfcb85a42fc2.png)
