### PR TITLE
Fix lint errors, add testability to static classes

### DIFF
--- a/packages/smooth_app/lib/cards/expandables/attribute_list_expandable.dart
+++ b/packages/smooth_app/lib/cards/expandables/attribute_list_expandable.dart
@@ -5,9 +5,9 @@ import 'package:provider/provider.dart';
 import 'package:smooth_app/cards/data_cards/attribute_card.dart';
 import 'package:smooth_app/cards/data_cards/attribute_chip.dart';
 import 'package:smooth_app/data_models/product_preferences.dart';
-import 'package:smooth_app/widgets/attribute_button.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
 import 'package:smooth_app/themes/theme_provider.dart';
+import 'package:smooth_app/widgets/attribute_button.dart';
 import 'package:smooth_ui_library/widgets/smooth_card.dart';
 import 'package:smooth_ui_library/widgets/smooth_expandable_card.dart';
 

--- a/packages/smooth_app/lib/helpers/product_copy_helper.dart
+++ b/packages/smooth_app/lib/helpers/product_copy_helper.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
 import 'package:openfoodfacts/model/Product.dart';
-import 'package:smooth_app/views/bottom_sheet_views/product_copy_view.dart';
 import 'package:smooth_app/data_models/product_list.dart';
 import 'package:smooth_app/database/dao_product.dart';
 import 'package:smooth_app/database/dao_product_list.dart';
@@ -9,9 +8,22 @@ import 'package:smooth_app/pages/product/common/product_list_add_button.dart';
 import 'package:smooth_app/pages/product/common/product_list_button.dart';
 import 'package:smooth_app/pages/product/common/product_list_dialog_helper.dart';
 import 'package:smooth_app/pages/product/common/product_list_page.dart';
+import 'package:smooth_app/views/bottom_sheet_views/product_copy_view.dart';
 
 /// Helper for product copy as multi selected
 class ProductCopyHelper {
+  @visibleForTesting
+  const ProductCopyHelper();
+
+  static ProductCopyHelper get instance =>
+      _instance ??= const ProductCopyHelper();
+  static ProductCopyHelper? _instance;
+
+  /// Setter that allows tests to override the singleton instance.
+  @visibleForTesting
+  static set instance(ProductCopyHelper testInstance) =>
+      _instance = testInstance;
+
   /// Returns a user [ProductList] selected among the existing ones, or created
   Future<ProductList?> showProductListDialog({
     required final BuildContext context,
@@ -52,7 +64,7 @@ class ProductCopyHelper {
           productListType: productListType,
           onPressed: () async {
             final ProductList? newProductList =
-                await ProductListDialogHelper.openNew(
+                await ProductListDialogHelper.instance.openNew(
               context,
               daoProductList,
               productLists,

--- a/packages/smooth_app/lib/pages/home_page.dart
+++ b/packages/smooth_app/lib/pages/home_page.dart
@@ -281,7 +281,7 @@ class _OldHomePageState extends State<OldHomePage> {
                 productListType: userProductListType,
                 onPressed: () async {
                   final ProductList? newProductList =
-                      await ProductListDialogHelper.openNew(
+                      await ProductListDialogHelper.instance.openNew(
                     context,
                     _daoProductList,
                     list,

--- a/packages/smooth_app/lib/pages/list_page.dart
+++ b/packages/smooth_app/lib/pages/list_page.dart
@@ -91,7 +91,8 @@ class _ListPageState extends State<ListPage> {
     final DaoProductList daoProductList,
     final String userProductListType,
   ) async {
-    final ProductList? newProductList = await ProductListDialogHelper.openNew(
+    final ProductList? newProductList =
+        await ProductListDialogHelper.instance.openNew(
       context,
       daoProductList,
       _list!,

--- a/packages/smooth_app/lib/pages/multi_select_product_page.dart
+++ b/packages/smooth_app/lib/pages/multi_select_product_page.dart
@@ -74,9 +74,8 @@ class _MultiSelectProductPageState extends State<MultiSelectProductPage> {
                 // nothing selected
                 return;
               }
-              final ProductCopyHelper productCopyHelper = ProductCopyHelper();
               final ProductList? productList =
-                  await productCopyHelper.showProductListDialog(
+                  await ProductCopyHelper.instance.showProductListDialog(
                 context: context,
                 daoProductList: daoProductList,
                 daoProduct: daoProduct,
@@ -90,7 +89,7 @@ class _MultiSelectProductPageState extends State<MultiSelectProductPage> {
               for (final String barcode in barcodes) {
                 products.add(_getProduct(barcode));
               }
-              await productCopyHelper.copy(
+              await ProductCopyHelper.instance.copy(
                 context: context,
                 productList: productList,
                 daoProductList: daoProductList,

--- a/packages/smooth_app/lib/pages/product/common/product_list_dialog_helper.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_dialog_helper.dart
@@ -7,7 +7,19 @@ import 'package:smooth_ui_library/buttons/smooth_simple_button.dart';
 import 'package:smooth_ui_library/dialogs/smooth_alert_dialog.dart';
 
 class ProductListDialogHelper {
-  static Future<bool> openDelete(
+  @visibleForTesting
+  const ProductListDialogHelper();
+
+  static ProductListDialogHelper get instance =>
+      _instance ??= const ProductListDialogHelper();
+  static ProductListDialogHelper? _instance;
+
+  /// Setter that allows tests to override the singleton instance.
+  @visibleForTesting
+  static set instance(ProductListDialogHelper testInstance) =>
+      _instance = testInstance;
+
+  Future<bool> openDelete(
     final BuildContext context,
     final DaoProductList daoProductList,
     final ProductList productList,
@@ -36,7 +48,7 @@ class ProductListDialogHelper {
       ) ??
       false;
 
-  static Future<ProductList?> openNew(
+  Future<ProductList?> openNew(
     final BuildContext context,
     final DaoProductList daoProductList,
     final List<ProductList> list,
@@ -103,7 +115,7 @@ class ProductListDialogHelper {
     );
   }
 
-  static Future<ProductList?> openRename(
+  Future<ProductList?> openRename(
     final BuildContext context,
     final DaoProductList daoProductList,
     final ProductList productList,
@@ -179,7 +191,7 @@ class ProductListDialogHelper {
     );
   }
 
-  static Future<bool> openChangeIcon(
+  Future<bool> openChangeIcon(
     final BuildContext context,
     final DaoProductList daoProductList,
     final ProductList productList,

--- a/packages/smooth_app/lib/pages/product/common/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_page.dart
@@ -140,7 +140,7 @@ class _ProductListPageState extends State<ProductListPage> {
                     switch (value) {
                       case 'rename':
                         final ProductList? renamedProductList =
-                            await ProductListDialogHelper.openRename(
+                            await ProductListDialogHelper.instance.openRename(
                                 context, daoProductList, productList);
                         if (renamedProductList == null) {
                           return;
@@ -149,15 +149,16 @@ class _ProductListPageState extends State<ProductListPage> {
                         localDatabase.notifyListeners();
                         break;
                       case 'delete':
-                        if (await ProductListDialogHelper.openDelete(
-                            context, daoProductList, productList)) {
+                        if (await ProductListDialogHelper.instance
+                            .openDelete(context, daoProductList, productList)) {
                           Navigator.pop(context);
                           localDatabase.notifyListeners();
                         }
                         break;
                       case 'change':
-                        final bool changed =
-                            await ProductListDialogHelper.openChangeIcon(
+                        final bool changed = await ProductListDialogHelper
+                            .instance
+                            .openChangeIcon(
                                 context, daoProductList, productList);
                         if (changed) {
                           localDatabase.notifyListeners();

--- a/packages/smooth_app/lib/pages/product/common/product_query_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_query_page.dart
@@ -4,13 +4,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
 import 'package:provider/provider.dart';
-import 'package:smooth_app/views/bottom_sheet_views/group_query_filter_view.dart';
 import 'package:smooth_app/cards/product_cards/smooth_product_card_found.dart';
 import 'package:smooth_app/data_models/product_list_supplier.dart';
 import 'package:smooth_app/data_models/product_query_model.dart';
 import 'package:smooth_app/pages/personalized_ranking_page.dart';
 import 'package:smooth_app/pages/product/common/product_query_page_helper.dart';
 import 'package:smooth_app/themes/constant_icons.dart';
+import 'package:smooth_app/views/bottom_sheet_views/group_query_filter_view.dart';
 import 'package:smooth_ui_library/animations/smooth_reveal_animation.dart';
 
 class ProductQueryPage extends StatefulWidget {
@@ -344,7 +344,7 @@ class _ProductQueryPageState extends State<ProductQueryPage> {
         padding: const EdgeInsets.only(top: 28.0),
         child: IconButton(
           icon: Icon(
-            ConstantIcons.getBackIcon(),
+            ConstantIcons.instance.getBackIcon(),
             color: color,
           ),
           onPressed: () => Navigator.pop(context),

--- a/packages/smooth_app/lib/pages/product/product_page.dart
+++ b/packages/smooth_app/lib/pages/product/product_page.dart
@@ -24,9 +24,9 @@ import 'package:smooth_app/database/dao_product_list.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/database/product_query.dart';
 import 'package:smooth_app/helpers/launch_url_helper.dart';
+import 'package:smooth_app/helpers/product_copy_helper.dart';
 import 'package:smooth_app/pages/product/common/product_dialog_helper.dart';
 import 'package:smooth_app/pages/product/common/product_query_page_helper.dart';
-import 'package:smooth_app/helpers/product_copy_helper.dart';
 import 'package:smooth_app/pages/user_preferences_page.dart';
 import 'package:smooth_app/themes/constant_icons.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
@@ -306,7 +306,7 @@ class _ProductPageState extends State<ProductPage> {
             ),
             _getClickableIcon(
               label: appLocalizations.label_share,
-              icon: Icon(ConstantIcons.getShareIcon()),
+              icon: Icon(ConstantIcons.instance.getShareIcon()),
               onTap: () async => Share.share(
                 'Try this food: https://openfoodfacts.org/product/${_product.barcode}/',
                 subject: '${_product.productName} (by openfoodfacts.org)',
@@ -524,9 +524,8 @@ class _ProductPageState extends State<ProductPage> {
     required final DaoProductList daoProductList,
     required final DaoProduct daoProduct,
   }) async {
-    final ProductCopyHelper productCopyHelper = ProductCopyHelper();
     final ProductList? productList =
-        await productCopyHelper.showProductListDialog(
+        await ProductCopyHelper.instance.showProductListDialog(
       context: context,
       daoProductList: daoProductList,
       daoProduct: daoProduct,
@@ -536,7 +535,7 @@ class _ProductPageState extends State<ProductPage> {
       return;
     }
     final List<Product> products = <Product>[widget.product];
-    await productCopyHelper.copy(
+    await ProductCopyHelper.instance.copy(
       context: context,
       productList: productList,
       daoProductList: daoProductList,

--- a/packages/smooth_app/lib/themes/constant_icons.dart
+++ b/packages/smooth_app/lib/themes/constant_icons.dart
@@ -4,13 +4,22 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 class ConstantIcons {
+  @visibleForTesting
+  const ConstantIcons();
+
+  static ConstantIcons get instance => _instance ??= const ConstantIcons();
+  static ConstantIcons? _instance;
+
+  /// Setter that allows tests to override the singleton instance.
+  @visibleForTesting
+  static set instance(ConstantIcons testInstance) => _instance = testInstance;
+
   static bool _isApple() =>
       defaultTargetPlatform == TargetPlatform.iOS ||
       defaultTargetPlatform == TargetPlatform.macOS;
 
-  static IconData getShareIcon() =>
+  IconData getShareIcon() =>
       _isApple() ? CupertinoIcons.square_arrow_up : Icons.share;
 
-  static IconData getBackIcon() =>
-      _isApple() ? CupertinoIcons.back : Icons.arrow_back;
+  IconData getBackIcon() => _isApple() ? CupertinoIcons.back : Icons.arrow_back;
 }

--- a/packages/smooth_app/lib/themes/smooth_theme.dart
+++ b/packages/smooth_app/lib/themes/smooth_theme.dart
@@ -12,6 +12,17 @@ enum ColorDestination {
 }
 
 class SmoothTheme {
+  @visibleForTesting
+  const SmoothTheme();
+
+  /// The singleton for the theme.
+  static SmoothTheme get instance => _instance ??= const SmoothTheme();
+  static SmoothTheme? _instance;
+
+  /// Setter that allows tests to override the singleton instance.
+  @visibleForTesting
+  static set instance(SmoothTheme testInstance) => _instance = testInstance;
+
   static const double ADDITIONAL_OPACITY_FOR_DARK = .3;
 
   /// Theme color tags
@@ -27,6 +38,18 @@ class SmoothTheme {
     COLOR_TAG_BROWN: Colors.brown,
   };
 
+  static Color? getColor(
+    final ColorScheme colorScheme,
+    final MaterialColor materialColor,
+    final ColorDestination colorDestination,
+  ) =>
+      instance.getColorImpl(colorScheme, materialColor, colorDestination);
+
+  static MaterialColor getMaterialColor(
+    final ThemeProvider themeProvider,
+  ) =>
+      instance.getMaterialColorImpl(themeProvider);
+
   /// Returns a shade of a [materialColor]
   ///
   /// For instance, if you want to display a red button,
@@ -34,7 +57,8 @@ class SmoothTheme {
   /// the destination will be ColorDestination.BUTTON_BACKGROUND,
   /// and you'll specify the current ColorScheme.
   /// For the moment, the ColorScheme matters only for the light/dark switch.
-  static Color? getColor(
+  @protected
+  Color? getColorImpl(
     final ColorScheme colorScheme,
     final MaterialColor materialColor,
     final ColorDestination colorDestination,
@@ -64,7 +88,8 @@ class SmoothTheme {
     }
   }
 
-  static MaterialColor getMaterialColor(final ThemeProvider themeProvider) {
+  @protected
+  MaterialColor getMaterialColorImpl(final ThemeProvider themeProvider) {
     if (themeProvider.darkTheme) {
       return Colors.grey;
     }


### PR DESCRIPTION
This fixes a number of lint errors that were somehow committed, and updates a few of the "static-only" classes so that they are instead singletons that can have their contents mocked/faked by tests. Static only classes have a tendency to discourage testing by making it difficult to test because they can't be overridden.