### PR TITLE
Search panel UX follow-ups

### DIFF
--- a/packages/smooth_app/lib/pages/home_page.dart
+++ b/packages/smooth_app/lib/pages/home_page.dart
@@ -5,7 +5,6 @@ import 'package:openfoodfacts/utils/PnnsGroups.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/cards/product_cards/product_list_preview.dart';
 import 'package:smooth_app/data_models/product_list.dart';
-import 'package:smooth_app/database/dao_product.dart';
 import 'package:smooth_app/database/dao_product_list.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/pages/choose_page.dart';
@@ -18,7 +17,6 @@ import 'package:smooth_app/pages/scan/scan_page.dart';
 import 'package:smooth_app/pages/user_preferences_page.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
 import 'package:smooth_app/themes/theme_provider.dart';
-import 'package:smooth_app/widgets/text_search_widget.dart';
 import 'package:smooth_ui_library/widgets/smooth_card.dart';
 
 class HomePage extends StatefulWidget {
@@ -100,13 +98,11 @@ class _OldHomePageState extends State<OldHomePage> {
   static const Icon _ICON_ARROW_FORWARD = Icon(Icons.arrow_forward);
 
   late DaoProductList _daoProductList;
-  late DaoProduct _daoProduct;
 
   @override
   Widget build(BuildContext context) {
     final LocalDatabase localDatabase = context.watch<LocalDatabase>();
     _daoProductList = DaoProductList(localDatabase);
-    _daoProduct = DaoProduct(localDatabase);
     final ThemeData themeData = Theme.of(context);
     final ColorScheme colorScheme = themeData.colorScheme;
     final AppLocalizations appLocalizations = AppLocalizations.of(context)!;

--- a/packages/smooth_app/lib/pages/home_page.dart
+++ b/packages/smooth_app/lib/pages/home_page.dart
@@ -124,14 +124,7 @@ class _OldHomePageState extends State<OldHomePage> {
       ),
       body: ListView(
         children: <Widget>[
-          TextSearchWidget(
-            color: SmoothTheme.getColor(
-              colorScheme,
-              Colors.red,
-              _COLOR_DESTINATION_FOR_ICON,
-            ),
-            daoProduct: _daoProduct,
-          ),
+          const SizedBox(height: 6.0),
           _getProductListCard(
             <String>[ProductList.LIST_TYPE_USER_DEFINED],
             appLocalizations.my_lists,
@@ -220,23 +213,6 @@ class _OldHomePageState extends State<OldHomePage> {
                 ),
               );
             },
-          ),
-          _getProductListCard(
-            <String>[
-              ProductList.LIST_TYPE_HTTP_SEARCH_GROUP,
-              ProductList.LIST_TYPE_HTTP_SEARCH_KEYWORDS,
-              ProductList.LIST_TYPE_HTTP_SEARCH_CATEGORY,
-            ],
-            appLocalizations.search_history,
-            Icon(
-              Icons.youtube_searched_for,
-              color: SmoothTheme.getColor(
-                colorScheme,
-                Colors.yellow,
-                _COLOR_DESTINATION_FOR_ICON,
-              ),
-            ),
-            appLocalizations,
           ),
         ],
       ),

--- a/packages/smooth_app/lib/pages/scan/search_panel.dart
+++ b/packages/smooth_app/lib/pages/scan/search_panel.dart
@@ -13,6 +13,7 @@ class SearchPanel extends StatefulWidget {
 }
 
 class SearchPanelState extends State<SearchPanel> {
+  final TextEditingController _searchFieldController = TextEditingController();
   final FocusNode _searchFieldFocusNode = FocusNode();
   final PanelController _controller = PanelController();
   double _position = 0.0;
@@ -34,6 +35,7 @@ class SearchPanelState extends State<SearchPanel> {
 
   @override
   void dispose() {
+    _searchFieldController.dispose();
     _searchFieldFocusNode.dispose();
     super.dispose();
   }
@@ -102,6 +104,7 @@ class SearchPanelState extends State<SearchPanel> {
     final AppLocalizations localizations = AppLocalizations.of(context)!;
     return TextField(
       textInputAction: TextInputAction.search,
+      controller: _searchFieldController,
       focusNode: _searchFieldFocusNode,
       onSubmitted: _performSearch,
       decoration: InputDecoration(
@@ -113,6 +116,13 @@ class SearchPanelState extends State<SearchPanel> {
         ),
         contentPadding: const EdgeInsets.all(20.0),
         hintText: localizations.search,
+        suffixIcon: Padding(
+          padding: const EdgeInsets.only(right: 12.0),
+          child: IconButton(
+            onPressed: _searchFieldController.clear,
+            icon: const Icon(Icons.clear),
+          ),
+        ),
       ),
       style: const TextStyle(fontSize: 24.0),
     );

--- a/packages/smooth_app/lib/pages/scan/search_panel.dart
+++ b/packages/smooth_app/lib/pages/scan/search_panel.dart
@@ -128,8 +128,10 @@ class SearchPanelState extends State<SearchPanel> {
                 crossFadeState: _isEmpty
                     ? CrossFadeState.showFirst
                     : CrossFadeState.showSecond,
-                firstChild: const Icon(Icons.cancel), // Closes the panel.
-                secondChild: const Icon(Icons.clear), // Clears the text.
+                // Closes the panel.
+                firstChild: const Icon(Icons.close, color: Colors.black),
+                // Clears the text.
+                secondChild: const Icon(Icons.cancel, color: Colors.black),
               ),
             ),
           ),

--- a/packages/smooth_app/lib/pages/scan/search_panel.dart
+++ b/packages/smooth_app/lib/pages/scan/search_panel.dart
@@ -17,6 +17,7 @@ class SearchPanelState extends State<SearchPanel> {
   final FocusNode _searchFieldFocusNode = FocusNode();
   final PanelController _controller = PanelController();
   double _position = 0.0;
+  bool _isEmpty = true;
 
   bool get _isOpen => _position > _isOpenThreshold;
   static const double _isOpenThreshold = 0.5;
@@ -24,6 +25,12 @@ class SearchPanelState extends State<SearchPanel> {
   @override
   void initState() {
     super.initState();
+    _searchFieldController.addListener(() {
+      if (_searchFieldController.text.isEmpty && !_isEmpty) {
+        _controller.close();
+      }
+      _isEmpty = _searchFieldController.text.isEmpty;
+    });
     _searchFieldFocusNode.addListener(() {
       if (_searchFieldFocusNode.hasFocus) {
         _controller.open();

--- a/packages/smooth_app/lib/pages/scan/search_panel.dart
+++ b/packages/smooth_app/lib/pages/scan/search_panel.dart
@@ -17,15 +17,17 @@ class SearchPanelState extends State<SearchPanel> {
   final FocusNode _searchFieldFocusNode = FocusNode();
   final PanelController _panelController = PanelController();
   double _position = 0.0;
+  bool _isEmpty = true;
 
   bool get _isOpen => _position > _isOpenThreshold;
   static const double _isOpenThreshold = 0.5;
 
-  bool get _isEmpty => _searchFieldController.text.isEmpty;
+  static const Duration _animationDuration = Duration(milliseconds: 100);
 
   @override
   void initState() {
     super.initState();
+    _searchFieldController.addListener(_handleTextChange);
     _searchFieldFocusNode.addListener(_handleFocusChange);
   }
 
@@ -62,7 +64,7 @@ class SearchPanelState extends State<SearchPanel> {
           child: Column(children: <Widget>[
             const SizedBox(height: 25.0),
             AnimatedCrossFade(
-              duration: const Duration(milliseconds: 100),
+              duration: _animationDuration,
               crossFadeState: _isOpen
                   ? CrossFadeState.showFirst
                   : CrossFadeState.showSecond,
@@ -115,13 +117,20 @@ class SearchPanelState extends State<SearchPanel> {
         contentPadding: const EdgeInsets.all(20.0),
         hintText: localizations.search,
         suffixIcon: AnimatedOpacity(
+          duration: _animationDuration,
           opacity: !_isEmpty || _isOpen ? 1.0 : 0.0,
-          duration: const Duration(milliseconds: 100),
           child: Padding(
             padding: const EdgeInsets.only(right: 12.0),
             child: IconButton(
               onPressed: _handleClear,
-              icon: const Icon(Icons.clear),
+              icon: AnimatedCrossFade(
+                duration: _animationDuration,
+                crossFadeState: _isEmpty
+                    ? CrossFadeState.showFirst
+                    : CrossFadeState.showSecond,
+                firstChild: const Icon(Icons.cancel), // Closes the panel.
+                secondChild: const Icon(Icons.clear), // Clears the text.
+              ),
             ),
           ),
         ),
@@ -139,6 +148,12 @@ class SearchPanelState extends State<SearchPanel> {
     }
     setState(() {
       _position = newPosition;
+    });
+  }
+
+  void _handleTextChange() {
+    setState(() {
+      _isEmpty = _searchFieldController.text.isEmpty;
     });
   }
 

--- a/packages/smooth_app/lib/pages/scan/search_panel.dart
+++ b/packages/smooth_app/lib/pages/scan/search_panel.dart
@@ -53,28 +53,30 @@ class SearchPanelState extends State<SearchPanel> {
       margin: EdgeInsets.symmetric(horizontal: _isOpen ? 0.0 : 12.0),
       onPanelSlide: _handlePanelSlide,
       panelBuilder: (ScrollController scrollController) {
-        const double textBoxHeight = 44.0;
-        final Widget textBox = SizedBox(
-          height: textBoxHeight,
-          child: Container(
-            padding: const EdgeInsets.only(bottom: 22.0),
-            child: Text(
-              localizations.searchPanelHeader,
-              style: const TextStyle(fontSize: 18.0),
-            ),
-          ),
-        );
+        const double textBoxHeight = 40.0;
         final double searchBoxHeight =
             _isOpen ? minHeight - textBoxHeight : minHeight;
-        final Widget searchBox = SizedBox(
-          height: searchBoxHeight,
+        final Widget searchBox = SizedOverflowBox(
+          size: Size.fromHeight(searchBoxHeight),
+          alignment: Alignment.topCenter,
           child: Column(children: <Widget>[
             const SizedBox(height: 25.0),
-            if (!_isOpen) textBox,
-            Container(
-              // A key is required to preserve state when the above container
-              // disappears from the tree.
-              key: const Key('searchField'),
+            AnimatedCrossFade(
+              duration: const Duration(milliseconds: 100),
+              crossFadeState: _isOpen
+                  ? CrossFadeState.showFirst
+                  : CrossFadeState.showSecond,
+              firstChild: Container(),
+              secondChild: Container(
+                alignment: Alignment.topCenter,
+                height: textBoxHeight,
+                child: Text(
+                  localizations.searchPanelHeader,
+                  style: const TextStyle(fontSize: 18.0),
+                ),
+              ),
+            ),
+            Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: _buildSearchField(context),
             ),

--- a/packages/smooth_app/lib/pages/scan/search_panel.dart
+++ b/packages/smooth_app/lib/pages/scan/search_panel.dart
@@ -55,6 +55,14 @@ class SearchPanelState extends State<SearchPanel> {
       onPanelSlide: _handlePanelSlide,
       panelBuilder: (ScrollController scrollController) {
         const double textBoxHeight = 40.0;
+        final Widget textBox = Container(
+          alignment: Alignment.topCenter,
+          height: textBoxHeight,
+          child: Text(
+            localizations.searchPanelHeader,
+            style: const TextStyle(fontSize: 18.0),
+          ),
+        );
         final double searchBoxHeight =
             _panelIsOpen ? minHeight - textBoxHeight : minHeight;
         final Widget searchBox = SizedOverflowBox(
@@ -68,14 +76,7 @@ class SearchPanelState extends State<SearchPanel> {
                   ? CrossFadeState.showFirst
                   : CrossFadeState.showSecond,
               firstChild: Container(), // Hide the text when the panel is open.
-              secondChild: Container(
-                alignment: Alignment.topCenter,
-                height: textBoxHeight,
-                child: Text(
-                  localizations.searchPanelHeader,
-                  style: const TextStyle(fontSize: 18.0),
-                ),
-              ),
+              secondChild: textBox,
             ),
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),

--- a/packages/smooth_app/lib/pages/scan/search_panel.dart
+++ b/packages/smooth_app/lib/pages/scan/search_panel.dart
@@ -15,19 +15,18 @@ class SearchPanel extends StatefulWidget {
 class SearchPanelState extends State<SearchPanel> {
   final TextEditingController _searchFieldController = TextEditingController();
   final FocusNode _searchFieldFocusNode = FocusNode();
-  final PanelController _panelController = PanelController();
-  double _position = 0.0;
-  bool _isEmpty = true;
+  bool _searchFieldIsEmpty = true;
 
-  bool get _isOpen => _position > _isOpenThreshold;
-  static const double _isOpenThreshold = 0.5;
+  final PanelController _panelController = PanelController();
+  double _panelPosition = 0.0;
+  bool get _panelIsOpen => _panelPosition > 0.5;
 
   static const Duration _animationDuration = Duration(milliseconds: 100);
 
   @override
   void initState() {
     super.initState();
-    _searchFieldController.addListener(_handleTextChange);
+    _searchFieldController.addListener(_handleSearchFieldChange);
     _searchFieldFocusNode.addListener(_handleFocusChange);
   }
 
@@ -50,14 +49,14 @@ class SearchPanelState extends State<SearchPanel> {
     return SlidingUpPanel(
       controller: _panelController,
       borderRadius: BorderRadius.vertical(
-        top: _isOpen ? Radius.zero : const Radius.circular(20.0),
+        top: _panelIsOpen ? Radius.zero : const Radius.circular(20.0),
       ),
-      margin: EdgeInsets.symmetric(horizontal: _isOpen ? 0.0 : 12.0),
+      margin: EdgeInsets.symmetric(horizontal: _panelIsOpen ? 0.0 : 12.0),
       onPanelSlide: _handlePanelSlide,
       panelBuilder: (ScrollController scrollController) {
         const double textBoxHeight = 40.0;
         final double searchBoxHeight =
-            _isOpen ? minHeight - textBoxHeight : minHeight;
+            _panelIsOpen ? minHeight - textBoxHeight : minHeight;
         final Widget searchBox = SizedOverflowBox(
           size: Size.fromHeight(searchBoxHeight),
           alignment: Alignment.topCenter,
@@ -65,10 +64,10 @@ class SearchPanelState extends State<SearchPanel> {
             const SizedBox(height: 25.0),
             AnimatedCrossFade(
               duration: _animationDuration,
-              crossFadeState: _isOpen
+              crossFadeState: _panelIsOpen
                   ? CrossFadeState.showFirst
                   : CrossFadeState.showSecond,
-              firstChild: Container(),
+              firstChild: Container(), // Hide the text when the panel is open.
               secondChild: Container(
                 alignment: Alignment.topCenter,
                 height: textBoxHeight,
@@ -118,14 +117,14 @@ class SearchPanelState extends State<SearchPanel> {
         hintText: localizations.search,
         suffixIcon: AnimatedOpacity(
           duration: _animationDuration,
-          opacity: !_isEmpty || _isOpen ? 1.0 : 0.0,
+          opacity: !_searchFieldIsEmpty || _panelIsOpen ? 1.0 : 0.0,
           child: Padding(
             padding: const EdgeInsets.only(right: 12.0),
             child: IconButton(
               onPressed: _handleClear,
               icon: AnimatedCrossFade(
                 duration: _animationDuration,
-                crossFadeState: _isEmpty
+                crossFadeState: _searchFieldIsEmpty
                     ? CrossFadeState.showFirst
                     : CrossFadeState.showSecond,
                 // Closes the panel.
@@ -142,20 +141,20 @@ class SearchPanelState extends State<SearchPanel> {
   }
 
   void _handlePanelSlide(double newPosition) {
-    if (newPosition < _position && !_isOpen) {
+    if (newPosition < _panelPosition && !_panelIsOpen) {
       _searchFieldFocusNode.unfocus();
     }
-    if (newPosition > _position && _isOpen) {
+    if (newPosition > _panelPosition && _panelIsOpen) {
       _searchFieldFocusNode.requestFocus();
     }
     setState(() {
-      _position = newPosition;
+      _panelPosition = newPosition;
     });
   }
 
-  void _handleTextChange() {
+  void _handleSearchFieldChange() {
     setState(() {
-      _isEmpty = _searchFieldController.text.isEmpty;
+      _searchFieldIsEmpty = _searchFieldController.text.isEmpty;
     });
   }
 
@@ -168,7 +167,7 @@ class SearchPanelState extends State<SearchPanel> {
   }
 
   void _handleClear() {
-    if (_isEmpty) {
+    if (_searchFieldIsEmpty) {
       _panelController.close();
     } else {
       _searchFieldController.clear();

--- a/packages/smooth_app/lib/pages/scan/search_panel.dart
+++ b/packages/smooth_app/lib/pages/scan/search_panel.dart
@@ -25,19 +25,8 @@ class SearchPanelState extends State<SearchPanel> {
   @override
   void initState() {
     super.initState();
-    _searchFieldController.addListener(() {
-      if (_searchFieldController.text.isEmpty && !_isEmpty) {
-        _controller.close();
-      }
-      _isEmpty = _searchFieldController.text.isEmpty;
-    });
-    _searchFieldFocusNode.addListener(() {
-      if (_searchFieldFocusNode.hasFocus) {
-        _controller.open();
-      } else {
-        _controller.close();
-      }
-    });
+    _searchFieldController.addListener(_handleTextChange);
+    _searchFieldFocusNode.addListener(_handleFocusChange);
   }
 
   @override
@@ -126,7 +115,7 @@ class SearchPanelState extends State<SearchPanel> {
         suffixIcon: Padding(
           padding: const EdgeInsets.only(right: 12.0),
           child: IconButton(
-            onPressed: _searchFieldController.clear,
+            onPressed: _handleClear,
             icon: const Icon(Icons.clear),
           ),
         ),
@@ -145,6 +134,29 @@ class SearchPanelState extends State<SearchPanel> {
     setState(() {
       _position = newPosition;
     });
+  }
+
+  void _handleFocusChange() {
+    if (_searchFieldFocusNode.hasFocus) {
+      _controller.open();
+    } else {
+      _controller.close();
+    }
+  }
+
+  void _handleTextChange() {
+    if (_searchFieldController.text.isEmpty && !_isEmpty) {
+      _controller.close();
+    }
+    _isEmpty = _searchFieldController.text.isEmpty;
+  }
+
+  void _handleClear() {
+    if (_isEmpty) {
+      _controller.close();
+    } else {
+      _searchFieldController.clear();
+    }
   }
 
   void _performSearch(String query) {

--- a/packages/smooth_app/lib/pages/scan/search_panel.dart
+++ b/packages/smooth_app/lib/pages/scan/search_panel.dart
@@ -112,11 +112,15 @@ class SearchPanelState extends State<SearchPanel> {
         ),
         contentPadding: const EdgeInsets.all(20.0),
         hintText: localizations.search,
-        suffixIcon: Padding(
-          padding: const EdgeInsets.only(right: 12.0),
-          child: IconButton(
-            onPressed: _handleClear,
-            icon: const Icon(Icons.clear),
+        suffixIcon: AnimatedOpacity(
+          opacity: !_isEmpty || _isOpen ? 1.0 : 0.0,
+          duration: const Duration(milliseconds: 100),
+          child: Padding(
+            padding: const EdgeInsets.only(right: 12.0),
+            child: IconButton(
+              onPressed: _handleClear,
+              icon: const Icon(Icons.clear),
+            ),
           ),
         ),
       ),

--- a/packages/smooth_app/lib/pages/scan/search_panel.dart
+++ b/packages/smooth_app/lib/pages/scan/search_panel.dart
@@ -101,6 +101,7 @@ class SearchPanelState extends State<SearchPanel> {
   Widget _buildSearchField(BuildContext context) {
     final AppLocalizations localizations = AppLocalizations.of(context)!;
     return TextField(
+      textInputAction: TextInputAction.search,
       focusNode: _searchFieldFocusNode,
       onSubmitted: _performSearch,
       decoration: InputDecoration(

--- a/packages/smooth_app/lib/pages/scan/search_panel.dart
+++ b/packages/smooth_app/lib/pages/scan/search_panel.dart
@@ -17,15 +17,15 @@ class SearchPanelState extends State<SearchPanel> {
   final FocusNode _searchFieldFocusNode = FocusNode();
   final PanelController _controller = PanelController();
   double _position = 0.0;
-  bool _isEmpty = true;
 
   bool get _isOpen => _position > _isOpenThreshold;
   static const double _isOpenThreshold = 0.5;
 
+  bool get _isEmpty => _searchFieldController.text.isEmpty;
+
   @override
   void initState() {
     super.initState();
-    _searchFieldController.addListener(_handleTextChange);
     _searchFieldFocusNode.addListener(_handleFocusChange);
   }
 
@@ -142,13 +142,6 @@ class SearchPanelState extends State<SearchPanel> {
     } else {
       _controller.close();
     }
-  }
-
-  void _handleTextChange() {
-    if (_searchFieldController.text.isEmpty && !_isEmpty) {
-      _controller.close();
-    }
-    _isEmpty = _searchFieldController.text.isEmpty;
   }
 
   void _handleClear() {

--- a/packages/smooth_app/lib/pages/scan/search_panel.dart
+++ b/packages/smooth_app/lib/pages/scan/search_panel.dart
@@ -15,7 +15,7 @@ class SearchPanel extends StatefulWidget {
 class SearchPanelState extends State<SearchPanel> {
   final TextEditingController _searchFieldController = TextEditingController();
   final FocusNode _searchFieldFocusNode = FocusNode();
-  final PanelController _controller = PanelController();
+  final PanelController _panelController = PanelController();
   double _position = 0.0;
 
   bool get _isOpen => _position > _isOpenThreshold;
@@ -46,7 +46,7 @@ class SearchPanelState extends State<SearchPanel> {
     const double minHeight = 160.0;
     final double maxHeight = constraints.maxHeight;
     return SlidingUpPanel(
-      controller: _controller,
+      controller: _panelController,
       borderRadius: BorderRadius.vertical(
         top: _isOpen ? Radius.zero : const Radius.circular(20.0),
       ),
@@ -138,15 +138,15 @@ class SearchPanelState extends State<SearchPanel> {
 
   void _handleFocusChange() {
     if (_searchFieldFocusNode.hasFocus) {
-      _controller.open();
+      _panelController.open();
     } else {
-      _controller.close();
+      _panelController.close();
     }
   }
 
   void _handleClear() {
     if (_isEmpty) {
-      _controller.close();
+      _panelController.close();
     } else {
       _searchFieldController.clear();
     }


### PR DESCRIPTION
This PR:
1. Adds a "clear" button to the search field that also acts as a "close" button when the field is empty
2. Adds an animation to the disappearing text when the panel opens.
3. Changes the keyboard action key to "Search"
4. Removes the search field and search history card from the old home page (that sits in the "History" tab right now)

Screenshots:
![Screen Shot 2021-09-07 at 12 21 39 PM_small](https://user-images.githubusercontent.com/470136/132336841-18486b03-271f-46a0-95c8-5b2f46da402a.png) ![IMG_5688_small](https://user-images.githubusercontent.com/470136/132242546-6b914552-29d7-4e1b-bafc-828999f97558.png) ![Screen Shot 2021-09-07 at 12 21 44 PM_small](https://user-images.githubusercontent.com/470136/132336857-e2efb893-b10a-4672-89cc-a31b9ec8273b.png) ![Screen Shot 2021-09-07 at 12 21 48 PM_small](https://user-images.githubusercontent.com/470136/132336858-cdf3e21d-251e-4ea3-9477-aa52c2e544c1.png)
