### PR TITLE
Migrated to sentry_flutter

### DIFF
--- a/packages/smooth_app/lib/main.dart
+++ b/packages/smooth_app/lib/main.dart
@@ -6,8 +6,9 @@ import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/personalized_search/product_preferences_selection.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:provider/provider.dart';
-import 'package:sentry/sentry.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:smooth_app/data_models/product_preferences.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/database/local_database.dart';
@@ -18,26 +19,23 @@ import 'package:smooth_app/themes/theme_provider.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await Sentry.init(
-    (SentryOptions options) {
-      options.dsn =
-          'https://22ec5d0489534b91ba455462d3736680@o241488.ingest.sentry.io/5376745';
-    },
-  );
+  final PackageInfo packageInfo = await PackageInfo.fromPlatform();
+
   /* TODO: put back when we have clearer ideas about analytics
   await MatomoTracker().initialize(
     siteId: 2,
     url: 'https://analytics.openfoodfacts.org/',
   );
    */
-  try {
-    runApp(const SmoothApp());
-  } catch (exception, stackTrace) {
-    await Sentry.captureException(
-      exception,
-      stackTrace: stackTrace,
-    );
-  }
+
+  await SentryFlutter.init(
+    (SentryOptions options) {
+      options.dsn =
+          'https://22ec5d0489534b91ba455462d3736680@o241488.ingest.sentry.io/5376745';
+      options.sentryClientName = 'sentry.dart.smoothie/${packageInfo.version}';
+    },
+    appRunner: () => runApp(const SmoothApp()),
+  );
 }
 
 class SmoothApp extends StatefulWidget {

--- a/packages/smooth_app/lib/main.dart
+++ b/packages/smooth_app/lib/main.dart
@@ -120,7 +120,7 @@ class _SmoothAppState extends State<SmoothApp> {
     return MaterialApp(
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
-      navigatorObservers: [
+      navigatorObservers: <NavigatorObserver>[
         SentryNavigatorObserver(),
       ],
       theme: SmoothTheme.getThemeData(

--- a/packages/smooth_app/lib/main.dart
+++ b/packages/smooth_app/lib/main.dart
@@ -120,6 +120,9 @@ class _SmoothAppState extends State<SmoothApp> {
     return MaterialApp(
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
+      navigatorObservers: [
+        SentryNavigatorObserver(),
+      ],
       theme: SmoothTheme.getThemeData(
         Brightness.light,
         themeProvider.colorTag,

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
   provider: ^5.0.0
   qr_code_scanner: ^0.5.2
   rubber: ^1.0.1
-  sentry: ^5.1.0
+  sentry_flutter: ^6.0.0
   share: ^2.0.4
   smooth_ui_library:
     path: ../smooth_ui_library


### PR DESCRIPTION
Closes #480 

Migrated from sentry to sentry_flutter, I did not add anything special except for the `sentryClientName` since we probably do a large part of the tracking via Matomo.