### PR TITLE
feature/#551 - towards a refresh of stale data on the Product page

### DIFF
--- a/packages/smooth_app/lib/data_models/product_database_timestamp.dart
+++ b/packages/smooth_app/lib/data_models/product_database_timestamp.dart
@@ -1,0 +1,20 @@
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/database/dao_product.dart';
+import 'package:smooth_app/database/local_database.dart';
+import 'product_timestamp.dart';
+
+/// Product timestamp taken from the local database upsert timestamp.
+class ProductDatabaseTimestamp implements ProductTimestamp {
+  ProductDatabaseTimestamp(final LocalDatabase localDatabase)
+      : _daoProduct = DaoProduct(localDatabase);
+
+  final DaoProduct _daoProduct;
+
+  @override
+  Future<int?> getTimestamp(final Product product) async {
+    if (product.barcode == null) {
+      return null;
+    }
+    return _daoProduct.getLastUpdate(product.barcode!);
+  }
+}

--- a/packages/smooth_app/lib/data_models/product_off_timestamp.dart
+++ b/packages/smooth_app/lib/data_models/product_off_timestamp.dart
@@ -1,0 +1,13 @@
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'product_timestamp.dart';
+
+/// Product timestamp taken from the "last modified" OFF field.
+class ProductOffTimestamp implements ProductTimestamp {
+  @override
+  Future<int?> getTimestamp(final Product product) async {
+    if (product.lastModified == null) {
+      return null;
+    }
+    return product.lastModified!.millisecondsSinceEpoch;
+  }
+}

--- a/packages/smooth_app/lib/data_models/product_timestamp.dart
+++ b/packages/smooth_app/lib/data_models/product_timestamp.dart
@@ -1,0 +1,7 @@
+import 'package:openfoodfacts/openfoodfacts.dart';
+
+/// Abstract timestamp getter for [Product].
+abstract class ProductTimestamp {
+  /// Returns a timestamp as number of millis in UTC since Epoch
+  Future<int?> getTimestamp(final Product product);
+}

--- a/packages/smooth_app/lib/data_models/product_timestamp_list.dart
+++ b/packages/smooth_app/lib/data_models/product_timestamp_list.dart
@@ -1,0 +1,24 @@
+import 'package:openfoodfacts/model/Product.dart';
+import 'package:smooth_app/data_models/product_timestamp.dart';
+
+/// List of [ProductTimestamp]s.
+class ProductTimestampList implements ProductTimestamp {
+  ProductTimestampList(this.list);
+
+  final List<ProductTimestamp> list;
+
+  @override
+  Future<int?> getTimestamp(final Product product) async {
+    int? maxTimestamp;
+    for (final ProductTimestamp productTimestamp in list) {
+      final int? tmp = await productTimestamp.getTimestamp(product);
+      if (tmp == null) {
+        continue;
+      }
+      if (maxTimestamp == null || maxTimestamp < tmp) {
+        maxTimestamp = tmp;
+      }
+    }
+    return maxTimestamp;
+  }
+}


### PR DESCRIPTION
New files:
* `product_timestamp.dart`: Abstract timestamp getter for Product.
* `product_timestamp_list.dart`: List of ProductTimestamps.
* `product_database_timestamp.dart`: Product timestamp taken from the local database upsert timestamp.
* `product_off_timestamp.dart`: Product timestamp taken from the "last modified" OFF field.

Impacted file:
* `product_page.dart`: added a check on the product timestamp, with the goal of stale data refresh