### PR TITLE
Add a new product page that follows the new design. 

### DIFF
--- a/packages/smooth_app/lib/cards/data_cards/score_attribute_card.dart
+++ b/packages/smooth_app/lib/cards/data_cards/score_attribute_card.dart
@@ -27,23 +27,20 @@ class ScoreAttributeCard extends StatelessWidget {
     final String? description =
         attribute.descriptionShort ?? attribute.description;
     return Container(
-      margin: const EdgeInsets.fromLTRB(0, 8, 0, 8),
-      child: Padding(
-        padding: const EdgeInsets.all(8.0),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: <Widget>[
-            attributeChip,
-            if (description != null)
-              Expanded(
-                  child: Center(
-                      child: Text(
-                description,
-                style: themeData.textTheme.headline4!.apply(color: textColor),
-              ))),
-          ],
-        ),
+      margin: const EdgeInsets.symmetric(vertical: 8.0),
+      padding: const EdgeInsets.all(8.0),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: <Widget>[
+          attributeChip,
+          if (description != null)
+            Expanded(
+                child: Center(
+                    child: Text(
+              description,
+              style: themeData.textTheme.headline4!.apply(color: textColor),
+            ))),
+        ],
       ),
       decoration: BoxDecoration(
         color: backgroundColor,

--- a/packages/smooth_app/lib/cards/data_cards/score_attribute_card.dart
+++ b/packages/smooth_app/lib/cards/data_cards/score_attribute_card.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:openfoodfacts/model/Attribute.dart';
+import 'package:smooth_app/cards/data_cards/attribute_chip.dart';
+import 'package:smooth_app/helpers/attributes_card_helper.dart';
+import 'package:smooth_app/themes/smooth_theme.dart';
+
+class ScoreAttributeCard extends StatelessWidget {
+  const ScoreAttributeCard({
+    required this.attribute,
+    required this.iconHeight,
+    this.barcode,
+  });
+
+  final Attribute attribute;
+  final double iconHeight;
+  final String? barcode;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData themeData = Theme.of(context);
+    final double opacity = themeData.brightness == Brightness.light
+        ? 1
+        : SmoothTheme.ADDITIONAL_OPACITY_FOR_DARK;
+    final Color backgroundColor =
+        getBackgroundColor(attribute).withOpacity(opacity);
+    final Color textColor = getTextColor(attribute).withOpacity(1);
+    final AttributeChip attributeChip =
+        AttributeChip(attribute, height: iconHeight);
+    final String? description =
+        attribute.descriptionShort ?? attribute.description;
+    return Container(
+      margin: const EdgeInsets.fromLTRB(0, 8, 0, 8),
+      child: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: <Widget>[
+            attributeChip,
+            if (description != null)
+              Expanded(
+                  child: Center(
+                      child: Text(
+                description,
+                style: TextStyle(
+                    fontFamily: 'Open Sans',
+                    fontWeight: FontWeight.bold,
+                    color: textColor),
+              ))),
+          ],
+        ),
+      ),
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: const BorderRadius.all(Radius.circular(16)),
+      ),
+    );
+  }
+}

--- a/packages/smooth_app/lib/cards/data_cards/score_attribute_card.dart
+++ b/packages/smooth_app/lib/cards/data_cards/score_attribute_card.dart
@@ -23,7 +23,7 @@ class ScoreAttributeCard extends StatelessWidget {
         : SmoothTheme.ADDITIONAL_OPACITY_FOR_DARK;
     final Color backgroundColor =
         getBackgroundColor(attribute).withOpacity(opacity);
-    final Color textColor = getTextColor(attribute).withOpacity(1);
+    final Color textColor = getTextColor(attribute).withOpacity(opacity);
     final AttributeChip attributeChip =
         AttributeChip(attribute, height: iconHeight);
     final String? description =

--- a/packages/smooth_app/lib/cards/data_cards/score_attribute_card.dart
+++ b/packages/smooth_app/lib/cards/data_cards/score_attribute_card.dart
@@ -8,12 +8,10 @@ class ScoreAttributeCard extends StatelessWidget {
   const ScoreAttributeCard({
     required this.attribute,
     required this.iconHeight,
-    this.barcode,
   });
 
   final Attribute attribute;
   final double iconHeight;
-  final String? barcode;
 
   @override
   Widget build(BuildContext context) {
@@ -42,10 +40,7 @@ class ScoreAttributeCard extends StatelessWidget {
                   child: Center(
                       child: Text(
                 description,
-                style: TextStyle(
-                    fontFamily: 'Open Sans',
-                    fontWeight: FontWeight.bold,
-                    color: textColor),
+                style: themeData.textTheme.headline4!.apply(color: textColor),
               ))),
           ],
         ),

--- a/packages/smooth_app/lib/cards/expandables/attribute_list_expandable.dart
+++ b/packages/smooth_app/lib/cards/expandables/attribute_list_expandable.dart
@@ -5,9 +5,10 @@ import 'package:provider/provider.dart';
 import 'package:smooth_app/cards/data_cards/attribute_card.dart';
 import 'package:smooth_app/cards/data_cards/attribute_chip.dart';
 import 'package:smooth_app/data_models/product_preferences.dart';
+import 'package:smooth_app/helpers/attributes_card_helper.dart';
+import 'package:smooth_app/widgets/attribute_button.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
 import 'package:smooth_app/themes/theme_provider.dart';
-import 'package:smooth_app/widgets/attribute_button.dart';
 import 'package:smooth_ui_library/widgets/smooth_card.dart';
 import 'package:smooth_ui_library/widgets/smooth_expandable_card.dart';
 
@@ -75,7 +76,7 @@ class AttributeListExpandable extends StatelessWidget {
     final List<Widget> chips = <Widget>[];
     final List<Widget> cards = <Widget>[];
     for (final Attribute attribute in attributes) {
-      final Color color = _getBackgroundColor(attribute).withOpacity(opacity);
+      final Color color = getBackgroundColor(attribute).withOpacity(opacity);
       final Widget chip = AttributeChip(attribute, height: iconHeight);
       chips.add(
         InkWell(
@@ -166,25 +167,5 @@ class AttributeListExpandable extends StatelessWidget {
       child: content,
       expandedHeader: header,
     );
-  }
-
-  static Color _getBackgroundColor(final Attribute attribute) {
-    if (attribute.status == Attribute.STATUS_KNOWN && attribute.match != null) {
-      if (attribute.match! <= 20) {
-        return const HSLColor.fromAHSL(1, 0, 1, .9).toColor();
-      }
-      if (attribute.match! <= 40) {
-        return const HSLColor.fromAHSL(1, 30, 1, .9).toColor();
-      }
-      if (attribute.match! <= 60) {
-        return const HSLColor.fromAHSL(1, 60, 1, .9).toColor();
-      }
-      if (attribute.match! <= 80) {
-        return const HSLColor.fromAHSL(1, 90, 1, .9).toColor();
-      }
-      return const HSLColor.fromAHSL(1, 120, 1, .9).toColor();
-    } else {
-      return const Color.fromARGB(0xff, 0xEE, 0xEE, 0xEE);
-    }
   }
 }

--- a/packages/smooth_app/lib/cards/expandables/attribute_list_expandable.dart
+++ b/packages/smooth_app/lib/cards/expandables/attribute_list_expandable.dart
@@ -6,9 +6,9 @@ import 'package:smooth_app/cards/data_cards/attribute_card.dart';
 import 'package:smooth_app/cards/data_cards/attribute_chip.dart';
 import 'package:smooth_app/data_models/product_preferences.dart';
 import 'package:smooth_app/helpers/attributes_card_helper.dart';
-import 'package:smooth_app/widgets/attribute_button.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
 import 'package:smooth_app/themes/theme_provider.dart';
+import 'package:smooth_app/widgets/attribute_button.dart';
 import 'package:smooth_ui_library/widgets/smooth_card.dart';
 import 'package:smooth_ui_library/widgets/smooth_expandable_card.dart';
 
@@ -71,7 +71,7 @@ class AttributeListExpandable extends StatelessWidget {
     final ThemeData themeData = Theme.of(context);
     final ThemeProvider themeProvider = context.watch<ThemeProvider>();
     final double opacity = themeData.brightness == Brightness.light
-        ? 1
+        ? 1.0
         : SmoothTheme.ADDITIONAL_OPACITY_FOR_DARK;
     final List<Widget> chips = <Widget>[];
     final List<Widget> cards = <Widget>[];

--- a/packages/smooth_app/lib/cards/product_cards/product_list_preview_helper.dart
+++ b/packages/smooth_app/lib/cards/product_cards/product_list_preview_helper.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/model/Product.dart';
+import 'package:smooth_app/pages/product/new_product_page.dart';
 import 'package:smooth_app/pages/product/product_page.dart';
 import 'package:smooth_ui_library/widgets/smooth_product_image.dart';
 
@@ -22,8 +23,8 @@ class ProductListPreviewHelper extends StatelessWidget {
         onTap: () async => Navigator.push<Widget>(
           context,
           MaterialPageRoute<Widget>(
-            builder: (BuildContext context) => ProductPage(
-              product: product,
+            builder: (BuildContext context) => NewProductPage(
+              product,
             ),
           ),
         ),

--- a/packages/smooth_app/lib/cards/product_cards/product_list_preview_helper.dart
+++ b/packages/smooth_app/lib/cards/product_cards/product_list_preview_helper.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/model/Product.dart';
-import 'package:smooth_app/pages/product/new_product_page.dart';
 import 'package:smooth_app/pages/product/product_page.dart';
 import 'package:smooth_ui_library/widgets/smooth_product_image.dart';
 
@@ -23,8 +22,8 @@ class ProductListPreviewHelper extends StatelessWidget {
         onTap: () async => Navigator.push<Widget>(
           context,
           MaterialPageRoute<Widget>(
-            builder: (BuildContext context) => NewProductPage(
-              product,
+            builder: (BuildContext context) => ProductPage(
+              product: product,
             ),
           ),
         ),

--- a/packages/smooth_app/lib/helpers/attributes_card_helper.dart
+++ b/packages/smooth_app/lib/helpers/attributes_card_helper.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:openfoodfacts/model/Attribute.dart';
+
+Color getBackgroundColor(final Attribute attribute) {
+  if (attribute.status != Attribute.STATUS_KNOWN || attribute.match == null) {
+    return const Color.fromARGB(0xff, 0xEE, 0xEE, 0xEE);
+  }
+  if (attribute.match! <= 20) {
+    return const HSLColor.fromAHSL(1, 0, 1, .9).toColor();
+  }
+  if (attribute.match! <= 40) {
+    return const HSLColor.fromAHSL(1, 30, 1, .9).toColor();
+  }
+  if (attribute.match! <= 60) {
+    return const HSLColor.fromAHSL(1, 60, 1, .9).toColor();
+  }
+  if (attribute.match! <= 80) {
+    return const HSLColor.fromAHSL(1, 90, 1, .9).toColor();
+  }
+  return const HSLColor.fromAHSL(1, 120, 1, .9).toColor();
+}
+
+Color getTextColor(final Attribute attribute) {
+  if (attribute.status == Attribute.STATUS_KNOWN && attribute.match != null) {
+    if (attribute.match! <= 20) {
+      return const Color.fromARGB(1, 235, 87, 87);
+    }
+    if (attribute.match! <= 40) {
+      return const Color.fromARGB(1, 242, 153, 74);
+    }
+    if (attribute.match! <= 60) {
+      return const Color.fromARGB(255, 149, 116, 0);
+    }
+    if (attribute.match! <= 80) {
+      return const Color.fromARGB(1, 133, 187, 47);
+    }
+    return const Color.fromARGB(1, 3, 129, 65);
+  } else {
+    return Color.fromARGB(1, 75, 75, 75);
+  }
+}
+
+Widget getAttributeDisplayIcon(final Attribute attribute) {
+  if (attribute.status != Attribute.STATUS_KNOWN || attribute.match == null) {
+    // Default emoji.
+    return Text("ℹ️  ");
+  }
+  if (attribute.match! < 20) {
+    return Text("💔  ");
+  }
+  if (attribute.match! < 40) {
+    return Text("🍂  ");
+  }
+  if (attribute.match! < 60) {
+    return Text("🌻  ");
+  }
+  if (attribute.match! < 80) {
+    return Text("🌱  ");
+  }
+  return Text("💚  ");
+}
+
+String? getDisplayTitle(final Attribute attribute) {
+  if (attribute.id != Attribute.ATTRIBUTE_NOVA) {
+    return attribute.title;
+  }
+  return _getNovaDisplayTitle(attribute);
+}
+
+String? _getNovaDisplayTitle(final Attribute attribute) {
+  if (attribute.status != Attribute.STATUS_KNOWN ||
+      attribute.match == null ||
+      attribute.title == null) {
+    return null;
+  }
+  if (attribute.match! <= 20) {
+    return "Ultra processed";
+  }
+  if (attribute.match! <= 40) {
+    return "Extremely processed";
+  }
+  if (attribute.match! <= 60) {
+    return "Processed";
+  }
+  if (attribute.match! <= 80) {
+    return "Slightly processed";
+  }
+  return "Unprocessed";
+}

--- a/packages/smooth_app/lib/helpers/attributes_card_helper.dart
+++ b/packages/smooth_app/lib/helpers/attributes_card_helper.dart
@@ -49,7 +49,8 @@ String? getDisplayTitle(final Attribute attribute) {
 
 String? _getNovaDisplayTitle(final Attribute attribute) {
   // Note: This method is temporary, this field will come from Backend and it will be internationalized.
-  return _attributeMatchComparison(attribute,
+  return _attributeMatchComparison(
+      attribute,
       null,
       'Ultra processed',
       'Highly processed',
@@ -67,8 +68,7 @@ dynamic _attributeMatchComparison(
     dynamic midMatchResult,
     dynamic highMatchResult,
     dynamic highestMatchResult) {
-  if (attribute.status != Attribute.STATUS_KNOWN ||
-      attribute.match == null) {
+  if (attribute.status != Attribute.STATUS_KNOWN || attribute.match == null) {
     return invalidAttributeResult;
   }
   if (attribute.match! <= _LOWEST_MATCH_SCORE_THRESHOLD) {

--- a/packages/smooth_app/lib/helpers/attributes_card_helper.dart
+++ b/packages/smooth_app/lib/helpers/attributes_card_helper.dart
@@ -2,63 +2,42 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/model/Attribute.dart';
 
+const int _LOWEST_MATCH_SCORE_THRESHOLD = 20;
+const int _LOW_MATCH_SCORE_THRESHOLD = 40;
+const int _MID_MATCH_SCORE_THRESHOLD = 60;
+const int _HIGH_MATCH_SCORE_THRESHOLD = 80;
+
 Color getBackgroundColor(final Attribute attribute) {
-  if (attribute.status != Attribute.STATUS_KNOWN || attribute.match == null) {
-    return const Color.fromARGB(0xff, 0xEE, 0xEE, 0xEE);
-  }
-  if (attribute.match! <= 20) {
-    return const HSLColor.fromAHSL(1, 0, 1, .9).toColor();
-  }
-  if (attribute.match! <= 40) {
-    return const HSLColor.fromAHSL(1, 30, 1, .9).toColor();
-  }
-  if (attribute.match! <= 60) {
-    return const HSLColor.fromAHSL(1, 60, 1, .9).toColor();
-  }
-  if (attribute.match! <= 80) {
-    return const HSLColor.fromAHSL(1, 90, 1, .9).toColor();
-  }
-  return const HSLColor.fromAHSL(1, 120, 1, .9).toColor();
+  return _attributeMatchComparison(
+      attribute,
+      const Color.fromARGB(0xff, 0xEE, 0xEE, 0xEE),
+      const HSLColor.fromAHSL(1, 0, 1, .9).toColor(),
+      const HSLColor.fromAHSL(1, 30, 1, .9).toColor(),
+      const HSLColor.fromAHSL(1, 60, 1, .9).toColor(),
+      const HSLColor.fromAHSL(1, 90, 1, .9).toColor(),
+      const HSLColor.fromAHSL(1, 120, 1, .9).toColor()) as Color;
 }
 
 Color getTextColor(final Attribute attribute) {
-  if (attribute.status == Attribute.STATUS_KNOWN && attribute.match != null) {
-    if (attribute.match! <= 20) {
-      return const Color.fromARGB(1, 235, 87, 87);
-    }
-    if (attribute.match! <= 40) {
-      return const Color.fromARGB(1, 242, 153, 74);
-    }
-    if (attribute.match! <= 60) {
-      return const Color.fromARGB(255, 149, 116, 0);
-    }
-    if (attribute.match! <= 80) {
-      return const Color.fromARGB(1, 133, 187, 47);
-    }
-    return const Color.fromARGB(1, 3, 129, 65);
-  } else {
-    return const Color.fromARGB(1, 75, 75, 75);
-  }
+  return _attributeMatchComparison(
+      attribute,
+      const Color.fromARGB(1, 75, 75, 75),
+      const Color.fromARGB(1, 235, 87, 87),
+      const Color.fromARGB(1, 242, 153, 74),
+      const Color.fromARGB(255, 149, 116, 0),
+      const Color.fromARGB(1, 133, 187, 47),
+      const Color.fromARGB(1, 3, 129, 65)) as Color;
 }
 
 Widget getAttributeDisplayIcon(final Attribute attribute) {
-  if (attribute.status != Attribute.STATUS_KNOWN || attribute.match == null) {
-    // Default emoji.
-    return const Text('ℹ️  ');
-  }
-  if (attribute.match! < 20) {
-    return const Text('💔  ');
-  }
-  if (attribute.match! < 40) {
-    return const Text('🍂  ');
-  }
-  if (attribute.match! < 60) {
-    return const Text('🌻  ');
-  }
-  if (attribute.match! < 80) {
-    return const Text('🌱  ');
-  }
-  return const Text('💚  ');
+  return _attributeMatchComparison(
+      attribute,
+      const Text('ℹ️  '),
+      const Text('💔  '),
+      const Text('🍂  '),
+      const Text('🌻  '),
+      const Text('🌱  '),
+      const Text('💚  ')) as Widget;
 }
 
 String? getDisplayTitle(final Attribute attribute) {
@@ -70,22 +49,39 @@ String? getDisplayTitle(final Attribute attribute) {
 
 String? _getNovaDisplayTitle(final Attribute attribute) {
   // Note: This method is temporary, this field will come from Backend and it will be internationalized.
+  return _attributeMatchComparison(attribute,
+      null,
+      'Ultra processed',
+      'Highly processed',
+      'Processed',
+      'Slightly processed',
+      'Unprocessed') as String?;
+}
+
+/// Compares the match score from [attribute] with various thresholds and returns appropriate result.
+dynamic _attributeMatchComparison(
+    final Attribute attribute,
+    dynamic invalidAttributeResult,
+    dynamic lowestMatchResult,
+    dynamic lowMatchResult,
+    dynamic midMatchResult,
+    dynamic highMatchResult,
+    dynamic highestMatchResult) {
   if (attribute.status != Attribute.STATUS_KNOWN ||
-      attribute.match == null ||
-      attribute.title == null) {
-    return null;
+      attribute.match == null) {
+    return invalidAttributeResult;
   }
-  if (attribute.match! <= 20) {
-    return 'Ultra processed';
+  if (attribute.match! <= _LOWEST_MATCH_SCORE_THRESHOLD) {
+    return lowestMatchResult;
   }
-  if (attribute.match! <= 40) {
-    return 'Highly processed';
+  if (attribute.match! <= _LOW_MATCH_SCORE_THRESHOLD) {
+    return lowMatchResult;
   }
-  if (attribute.match! <= 60) {
-    return 'Processed';
+  if (attribute.match! <= _MID_MATCH_SCORE_THRESHOLD) {
+    return midMatchResult;
   }
-  if (attribute.match! <= 80) {
-    return 'Slightly processed';
+  if (attribute.match! <= _HIGH_MATCH_SCORE_THRESHOLD) {
+    return highMatchResult;
   }
-  return 'Unprocessed';
+  return highestMatchResult;
 }

--- a/packages/smooth_app/lib/helpers/attributes_card_helper.dart
+++ b/packages/smooth_app/lib/helpers/attributes_card_helper.dart
@@ -15,7 +15,7 @@ Color getBackgroundColor(final Attribute attribute) {
       const HSLColor.fromAHSL(1, 30, 1, .9).toColor(),
       const HSLColor.fromAHSL(1, 60, 1, .9).toColor(),
       const HSLColor.fromAHSL(1, 90, 1, .9).toColor(),
-      const HSLColor.fromAHSL(1, 120, 1, .9).toColor()) as Color;
+      const HSLColor.fromAHSL(1, 120, 1, .9).toColor());
 }
 
 Color getTextColor(final Attribute attribute) {
@@ -26,7 +26,7 @@ Color getTextColor(final Attribute attribute) {
       const Color.fromARGB(1, 242, 153, 74),
       const Color.fromARGB(255, 149, 116, 0),
       const Color.fromARGB(1, 133, 187, 47),
-      const Color.fromARGB(1, 3, 129, 65)) as Color;
+      const Color.fromARGB(1, 3, 129, 65));
 }
 
 Widget getAttributeDisplayIcon(final Attribute attribute) {
@@ -37,7 +37,7 @@ Widget getAttributeDisplayIcon(final Attribute attribute) {
       const Text('🍂  '),
       const Text('🌻  '),
       const Text('🌱  '),
-      const Text('💚  ')) as Widget;
+      const Text('💚  '));
 }
 
 String? getDisplayTitle(final Attribute attribute) {
@@ -49,25 +49,19 @@ String? getDisplayTitle(final Attribute attribute) {
 
 String? _getNovaDisplayTitle(final Attribute attribute) {
   // Note: This method is temporary, this field will come from Backend and it will be internationalized.
-  return _attributeMatchComparison(
-      attribute,
-      null,
-      'Ultra processed',
-      'Highly processed',
-      'Processed',
-      'Slightly processed',
-      'Unprocessed') as String?;
+  return _attributeMatchComparison(attribute, null, 'Ultra processed',
+      'Highly processed', 'Processed', 'Slightly processed', 'Unprocessed');
 }
 
 /// Compares the match score from [attribute] with various thresholds and returns appropriate result.
-dynamic _attributeMatchComparison(
+T _attributeMatchComparison<T>(
     final Attribute attribute,
-    dynamic invalidAttributeResult,
-    dynamic lowestMatchResult,
-    dynamic lowMatchResult,
-    dynamic midMatchResult,
-    dynamic highMatchResult,
-    dynamic highestMatchResult) {
+    T invalidAttributeResult,
+    T lowestMatchResult,
+    T lowMatchResult,
+    T midMatchResult,
+    T highMatchResult,
+    T highestMatchResult) {
   if (attribute.status != Attribute.STATUS_KNOWN || attribute.match == null) {
     return invalidAttributeResult;
   }

--- a/packages/smooth_app/lib/helpers/attributes_card_helper.dart
+++ b/packages/smooth_app/lib/helpers/attributes_card_helper.dart
@@ -37,28 +37,28 @@ Color getTextColor(final Attribute attribute) {
     }
     return const Color.fromARGB(1, 3, 129, 65);
   } else {
-    return Color.fromARGB(1, 75, 75, 75);
+    return const Color.fromARGB(1, 75, 75, 75);
   }
 }
 
 Widget getAttributeDisplayIcon(final Attribute attribute) {
   if (attribute.status != Attribute.STATUS_KNOWN || attribute.match == null) {
     // Default emoji.
-    return Text("ℹ️  ");
+    return const Text('ℹ️  ');
   }
   if (attribute.match! < 20) {
-    return Text("💔  ");
+    return const Text('💔  ');
   }
   if (attribute.match! < 40) {
-    return Text("🍂  ");
+    return const Text('🍂  ');
   }
   if (attribute.match! < 60) {
-    return Text("🌻  ");
+    return const Text('🌻  ');
   }
   if (attribute.match! < 80) {
-    return Text("🌱  ");
+    return const Text('🌱  ');
   }
-  return Text("💚  ");
+  return const Text('💚  ');
 }
 
 String? getDisplayTitle(final Attribute attribute) {
@@ -69,22 +69,23 @@ String? getDisplayTitle(final Attribute attribute) {
 }
 
 String? _getNovaDisplayTitle(final Attribute attribute) {
+  // Note: This method is temporary, this field will come from Backend and it will be internationalized.
   if (attribute.status != Attribute.STATUS_KNOWN ||
       attribute.match == null ||
       attribute.title == null) {
     return null;
   }
   if (attribute.match! <= 20) {
-    return "Ultra processed";
+    return 'Ultra processed';
   }
   if (attribute.match! <= 40) {
-    return "Extremely processed";
+    return 'Highly processed';
   }
   if (attribute.match! <= 60) {
-    return "Processed";
+    return 'Processed';
   }
   if (attribute.match! <= 80) {
-    return "Slightly processed";
+    return 'Slightly processed';
   }
-  return "Unprocessed";
+  return 'Unprocessed';
 }

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -16,6 +16,7 @@ import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/helpers/attributes_card_helper.dart';
 import 'package:smooth_app/helpers/launch_url_helper.dart';
 import 'package:smooth_app/pages/product/common/product_dialog_helper.dart';
+import 'package:smooth_app/themes/smooth_theme.dart';
 import 'package:smooth_ui_library/widgets/smooth_card.dart';
 
 class NewProductPage extends StatefulWidget {
@@ -50,7 +51,7 @@ class _ProductPageState extends State<NewProductPage> {
       _product = widget.product;
     }
     return Scaffold(
-      backgroundColor: _BACKGROUND_COLOR,
+      backgroundColor: SmoothTheme.COLOR_PRODUCT_PAGE_BACKGROUND,
       appBar: AppBar(
         title: Text(_getProductName(appLocalizations)),
         actions: <Widget>[

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -37,7 +37,7 @@ class _ProductPageState extends State<NewProductPage> {
   void initState() {
     super.initState();
     _product = widget.product;
-    _updateLastSeenProduct(context, _product);
+    _updateLocalDatabaseWithProductHistory(context, _product);
   }
 
   @override
@@ -103,10 +103,10 @@ class _ProductPageState extends State<NewProductPage> {
     setState(() {
       _product = product;
     });
-    await _updateLastSeenProduct(context, _product);
+    await _updateLocalDatabaseWithProductHistory(context, _product);
   }
 
-  Future<void> _updateLastSeenProduct(
+  Future<void> _updateLocalDatabaseWithProductHistory(
       BuildContext context, Product product) async {
     final LocalDatabase localDatabase = context.read<LocalDatabase>();
     await DaoProductExtra(localDatabase).putLastSeen(product);

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -236,9 +236,7 @@ class _ProductPageState extends State<NewProductPage> {
                 ),
               )),
           for (final Attribute attribute in scoreAttributes)
-            ScoreAttributeCard(
-                attribute: attribute,
-                iconHeight: iconHeight),
+            ScoreAttributeCard(attribute: attribute, iconHeight: iconHeight),
           attributesContainer
         ]),
       ),

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -227,7 +227,7 @@ class _ProductPageState extends State<NewProductPage> {
                 subtitle:
                     Text(_product.brands ?? appLocalizations.unknownBrand),
                 trailing: Text(
-                  _product.quantity != null ? _product.quantity! : '',
+                  _product.quantity?? '',
                   style: themeData.textTheme.headline3,
                 ),
               )),

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -178,7 +178,7 @@ class _ProductPageState extends State<NewProductPage> {
     final ThemeData themeData = Theme.of(context);
     final double iconHeight =
         screenSize.width / 10; // TODO(monsieurtanuki): target size?
-    final List<String> scoreAttributeIds = [
+    final List<String> scoreAttributeIds = <String>[
       Attribute.ATTRIBUTE_NUTRISCORE,
       Attribute.ATTRIBUTE_ECOSCORE
     ];
@@ -186,8 +186,11 @@ class _ProductPageState extends State<NewProductPage> {
         AttributeListExpandable.getPopulatedAttributes(
             _product, scoreAttributeIds);
 
-    final List<String> importantAttributeIds = productPreferences
-        .getOrderedImportantAttributeIds(filter_ids: scoreAttributeIds);
+    List<String> importantAttributeIds =
+        productPreferences.getOrderedImportantAttributeIds();
+    importantAttributeIds = importantAttributeIds
+        .where((String attributeId) => scoreAttributeIds.contains(attributeId))
+        .toList();
     final List<Attribute> importantAttributes =
         AttributeListExpandable.getPopulatedAttributes(
             _product, importantAttributeIds);
@@ -201,7 +204,7 @@ class _ProductPageState extends State<NewProductPage> {
           ])
         ]));
 
-    final List<Widget> listItems = [];
+    final List<Widget> listItems = <Widget>[];
     listItems.add(Align(
         heightFactor: 0.7,
         alignment: Alignment.topLeft,
@@ -215,7 +218,7 @@ class _ProductPageState extends State<NewProductPage> {
           bottom: 20.0,
         ),
         insets: const EdgeInsets.all(12.0),
-        child: Column(children: [
+        child: Column(children: <Widget>[
           Align(
               alignment: Alignment.topLeft,
               child: ListTile(
@@ -227,7 +230,7 @@ class _ProductPageState extends State<NewProductPage> {
                 subtitle:
                     Text(_product.brands ?? appLocalizations.unknownBrand),
                 trailing: Text(
-                  _product.quantity?? '',
+                  _product.quantity ?? '',
                   style: themeData.textTheme.headline3,
                 ),
               )),

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -110,7 +110,7 @@ class _ProductPageState extends State<NewProductPage> {
     await _updateHistory(context);
   }
 
-  Future<void> _updateHistory(final BuildContext context) async {
+  Future<void> _updateHistory(BuildContext context) async {
     final LocalDatabase localDatabase = context.read<LocalDatabase>();
     await DaoProductExtra(localDatabase).putLastSeen(widget.product);
     localDatabase.notifyListeners();

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -104,7 +104,9 @@ class _ProductPageState extends State<NewProductPage> {
         duration: const Duration(seconds: 2),
       ),
     );
-    setState(() => _product = product);
+    setState(() {
+      _product = product;
+    });
     await _updateHistory(context);
   }
 

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -33,6 +33,8 @@ class _ProductPageState extends State<NewProductPage> {
   late Product _product;
   bool _first = true;
 
+  static const Color _BACKGROUND_COLOR = Color.fromARGB(255, 234, 244, 234);
+
   @override
   void initState() {
     super.initState();
@@ -47,9 +49,8 @@ class _ProductPageState extends State<NewProductPage> {
       _first = false;
       _product = widget.product;
     }
-    const Color backgroundColor = Color.fromARGB(255, 234, 244, 234);
     return Scaffold(
-      backgroundColor: backgroundColor,
+      backgroundColor: _BACKGROUND_COLOR,
       appBar: AppBar(
         title: Text(_getProductName(appLocalizations)),
         actions: <Widget>[
@@ -189,7 +190,7 @@ class _ProductPageState extends State<NewProductPage> {
     List<String> importantAttributeIds =
         productPreferences.getOrderedImportantAttributeIds();
     importantAttributeIds = importantAttributeIds
-        .where((String attributeId) => scoreAttributeIds.contains(attributeId))
+        .where((String attributeId) => !scoreAttributeIds.contains(attributeId))
         .toList();
     final List<Attribute> importantAttributes =
         AttributeListExpandable.getPopulatedAttributes(
@@ -237,8 +238,7 @@ class _ProductPageState extends State<NewProductPage> {
           for (final Attribute attribute in scoreAttributes)
             ScoreAttributeCard(
                 attribute: attribute,
-                iconHeight: iconHeight,
-                barcode: _product.barcode),
+                iconHeight: iconHeight),
           attributesContainer
         ]),
       ),

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -69,7 +69,7 @@ class _ProductPageState extends State<NewProductPage> {
                       false);
                   break;
                 case ProductPageMenuItem.REFRESH:
-                  _refreshProduct(localDatabase, context);
+                  _refreshProduct(localDatabase, appLocalizations);
                   break;
                 default:
                   throw UnimplementedError(
@@ -84,8 +84,7 @@ class _ProductPageState extends State<NewProductPage> {
   }
 
   Future<void> _refreshProduct(
-      LocalDatabase localDatabase, BuildContext context) async {
-    final AppLocalizations appLocalizations = AppLocalizations.of(context)!;
+      LocalDatabase localDatabase, AppLocalizations appLocalizations) async {
     final ProductDialogHelper productDialogHelper = ProductDialogHelper(
       barcode: _product.barcode!,
       context: context,

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -1,0 +1,271 @@
+import 'dart:ui';
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:openfoodfacts/model/Attribute.dart';
+import 'package:openfoodfacts/model/Product.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:provider/provider.dart';
+import 'package:smooth_app/cards/data_cards/image_upload_card.dart';
+import 'package:smooth_app/cards/data_cards/score_attribute_card.dart';
+import 'package:smooth_app/cards/expandables/attribute_list_expandable.dart';
+import 'package:smooth_app/data_models/product_preferences.dart';
+import 'package:smooth_app/database/dao_product_extra.dart';
+import 'package:smooth_app/database/local_database.dart';
+import 'package:smooth_app/helpers/attributes_card_helper.dart';
+import 'package:smooth_app/helpers/launch_url_helper.dart';
+import 'package:smooth_app/pages/product/common/product_dialog_helper.dart';
+import 'package:smooth_ui_library/widgets/smooth_card.dart';
+
+class NewProductPage extends StatefulWidget {
+  const NewProductPage({
+    required this.product,
+  });
+
+  final Product product;
+
+  @override
+  State<NewProductPage> createState() => _ProductPageState();
+}
+
+class _ProductPageState extends State<NewProductPage> {
+  late Product _product;
+  bool _first = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _updateHistory(context);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final LocalDatabase localDatabase = context.watch<LocalDatabase>();
+    final AppLocalizations appLocalizations = AppLocalizations.of(context)!;
+    if (_first) {
+      _first = false;
+      _product = widget.product;
+    }
+    const Color backgroundColor = Color.fromARGB(255, 234, 244, 234);
+    return Scaffold(
+      backgroundColor: backgroundColor,
+      appBar: AppBar(
+        title: Text(_getProductName(appLocalizations)),
+        actions: <Widget>[
+          PopupMenuButton<String>(
+            itemBuilder: (final BuildContext context) =>
+                <PopupMenuEntry<String>>[
+              PopupMenuItem<String>(
+                value: 'web',
+                child: Text(appLocalizations.label_web),
+              ),
+              PopupMenuItem<String>(
+                value: 'refresh',
+                child: Text(appLocalizations.label_refresh),
+              ),
+            ],
+            onSelected: (final String value) async {
+              switch (value) {
+                case 'web':
+                  LaunchUrlHelper.launchURL(
+                      'https://openfoodfacts.org/product/${_product.barcode}/',
+                      false);
+                  break;
+                case 'refresh':
+                  final ProductDialogHelper productDialogHelper =
+                      ProductDialogHelper(
+                    barcode: _product.barcode!,
+                    context: context,
+                    localDatabase: localDatabase,
+                    refresh: true,
+                  );
+                  final Product? product =
+                      await productDialogHelper.openUniqueProductSearch();
+                  if (product == null) {
+                    productDialogHelper.openProductNotFoundDialog();
+                    return;
+                  }
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(
+                      content: Text(appLocalizations.product_refreshed),
+                      duration: const Duration(seconds: 2),
+                    ),
+                  );
+                  _product = product;
+                  await _updateHistory(context);
+                  break;
+                default:
+                  throw Exception('Unknown value: $value');
+              }
+            },
+          ),
+        ],
+      ),
+      body: _buildProductBody(context),
+    );
+  }
+
+  Future<void> _updateHistory(final BuildContext context) async {
+    final LocalDatabase localDatabase = context.read<LocalDatabase>();
+    await DaoProductExtra(localDatabase).putLastSeen(widget.product);
+    localDatabase.notifyListeners();
+  }
+
+  Widget _buildProductImagesCarousel(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context)!;
+    final List<ImageUploadCard> carouselItems = <ImageUploadCard>[
+      ImageUploadCard(
+        product: _product,
+        imageField: ImageField.FRONT,
+        imageUrl: _product.imageFrontUrl,
+        title: appLocalizations.product,
+        buttonText: appLocalizations.front_photo,
+      ),
+      ImageUploadCard(
+        product: _product,
+        imageField: ImageField.INGREDIENTS,
+        imageUrl: _product.imageIngredientsUrl,
+        title: appLocalizations.ingredients,
+        buttonText: appLocalizations.ingredients_photo,
+      ),
+      ImageUploadCard(
+        product: _product,
+        imageField: ImageField.NUTRITION,
+        imageUrl: _product.imageNutritionUrl,
+        title: appLocalizations.nutrition,
+        buttonText: appLocalizations.nutrition_facts_photo,
+      ),
+      ImageUploadCard(
+        product: _product,
+        imageField: ImageField.PACKAGING,
+        imageUrl: _product.imagePackagingUrl,
+        title: appLocalizations.packaging_information,
+        buttonText: appLocalizations.packaging_information_photo,
+      ),
+      ImageUploadCard(
+        product: _product,
+        imageField: ImageField.OTHER,
+        imageUrl: null,
+        title: appLocalizations.more_photos,
+        buttonText: appLocalizations.more_photos,
+      ),
+    ];
+
+    return SizedBox(
+      height: 200,
+      child: ListView(
+        // This next line does the trick.
+        scrollDirection: Axis.horizontal,
+        children: carouselItems
+            .map(
+              (ImageUploadCard item) => Container(
+                margin: const EdgeInsets.fromLTRB(0, 0, 5, 0),
+                decoration: const BoxDecoration(color: Colors.black12),
+                child: item,
+              ),
+            )
+            .toList(),
+      ),
+    );
+  }
+
+  Widget _buildProductBody(BuildContext context) {
+    final ProductPreferences productPreferences =
+        context.watch<ProductPreferences>();
+    final AppLocalizations appLocalizations = AppLocalizations.of(context)!;
+    final Size screenSize = MediaQuery.of(context).size;
+    final ThemeData themeData = Theme.of(context);
+    final double iconHeight =
+        screenSize.width / 10; // TODO(monsieurtanuki): target size?
+    final List<String> scoreAttributeIds = [
+      Attribute.ATTRIBUTE_NUTRISCORE,
+      Attribute.ATTRIBUTE_ECOSCORE
+    ];
+    final List<Attribute> scoreAttributes =
+        AttributeListExpandable.getPopulatedAttributes(
+            _product, scoreAttributeIds);
+
+    final List<String> importantAttributeIds = productPreferences
+        .getOrderedImportantAttributeIds(filter_ids: scoreAttributeIds);
+    final List<Attribute> importantAttributes =
+        AttributeListExpandable.getPopulatedAttributes(
+            _product, importantAttributeIds);
+    final Widget attributesContainer = Container(
+        alignment: Alignment.topLeft,
+        margin: const EdgeInsets.fromLTRB(0, 16, 0, 16),
+        child: Column(children: <Widget>[
+          Wrap(runSpacing: 16, children: <Widget>[
+            for (final Attribute attribute in importantAttributes)
+              getAttributeChip(attribute, screenSize) ?? Container(),
+          ])
+        ]));
+
+    final List<Widget> listItems = [];
+    listItems.add(Align(
+        heightFactor: 0.7,
+        alignment: Alignment.topLeft,
+        child: _buildProductImagesCarousel(context)));
+    listItems.add(
+      SmoothCard(
+        padding: const EdgeInsets.only(
+          right: 8.0,
+          left: 8.0,
+          top: 4.0,
+          bottom: 20.0,
+        ),
+        insets: const EdgeInsets.all(12.0),
+        child: Column(children: [
+          Align(
+              alignment: Alignment.topLeft,
+              child: ListTile(
+                contentPadding: EdgeInsets.zero,
+                title: Text(
+                  _getProductName(appLocalizations),
+                  style: themeData.textTheme.headline4,
+                ),
+                subtitle:
+                    Text(_product.brands ?? appLocalizations.unknownBrand),
+                trailing: Text(
+                  _product.quantity != null ? _product.quantity! : '',
+                  style: themeData.textTheme.headline3,
+                ),
+              )),
+          for (final Attribute attribute in scoreAttributes)
+            ScoreAttributeCard(
+                attribute: attribute,
+                iconHeight: iconHeight,
+                barcode: _product.barcode),
+          attributesContainer
+        ]),
+      ),
+    );
+    return ListView(children: listItems);
+  }
+
+  Widget? getAttributeChip(Attribute attribute, Size screenSize) {
+    final String? attributeDisplayTitle = getDisplayTitle(attribute);
+    final Widget attributeIcon = getAttributeDisplayIcon(attribute);
+    if (attributeDisplayTitle == null) {
+      return null;
+    }
+    return LayoutBuilder(
+        builder: (BuildContext context, BoxConstraints constraints) {
+      return SizedBox(
+          width: constraints.maxWidth / 2,
+          child: Row(
+              mainAxisAlignment: MainAxisAlignment.start,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                attributeIcon,
+                Expanded(
+                    child: Text(
+                  attributeDisplayTitle,
+                ))
+              ]));
+    });
+  }
+
+  String _getProductName(final AppLocalizations appLocalizations) =>
+      _product.productName ?? appLocalizations.unknownProductName;
+}

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -34,8 +34,6 @@ class _ProductPageState extends State<NewProductPage> {
   late Product _product;
   bool _first = true;
 
-  static const Color _BACKGROUND_COLOR = Color.fromARGB(255, 234, 244, 234);
-
   @override
   void initState() {
     super.initState();

--- a/packages/smooth_app/lib/themes/smooth_theme.dart
+++ b/packages/smooth_app/lib/themes/smooth_theme.dart
@@ -30,6 +30,10 @@ class SmoothTheme {
   static const String COLOR_TAG_GREEN = 'green';
   static const String COLOR_TAG_BROWN = 'brown';
 
+  /// Product page color
+  static const Color COLOR_PRODUCT_PAGE_BACKGROUND =
+      Color.fromARGB(255, 234, 244, 234);
+
   /// Theme material colors
   static const Map<String, MaterialColor> MATERIAL_COLORS =
       <String, MaterialColor>{


### PR DESCRIPTION
Add a new product page that follows the new design. 

- Reuses as much code as possible from product_page.dart.
- This product page is not patched in the main user flow, it will be patched once it's made pitch perfect as per the new mocks.
- Please ignore attribute_cards_helper._getNovaDisplayTitle() method, it's only temporary, this field will be coming form the Backend in the future.
- Also please ignore the emojis used in attribute_cards_helper.dart, these are temporary.

How it looks now: 

![image](https://user-images.githubusercontent.com/7541730/132898582-3b96713d-85b3-4f06-b8ad-ab4380f7ae0e.png)
![image](https://user-images.githubusercontent.com/7541730/132898667-bff587e5-1487-42fb-8851-982b17201f9f.png)
