### PR TITLE
Refactor ScanPage maintain a single ContinuousScanModel instance

### DIFF
--- a/packages/smooth_app/lib/pages/scan/continuous_scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/continuous_scan_page.dart
@@ -10,22 +10,11 @@ import 'package:smooth_app/widgets/smooth_product_carousel.dart';
 import 'package:smooth_ui_library/smooth_ui_library.dart';
 
 class ContinuousScanPage extends StatelessWidget {
-  ContinuousScanPage(this._continuousScanModel);
-
-  final ContinuousScanModel _continuousScanModel;
-
   final GlobalKey _scannerViewKey = GlobalKey(debugLabel: 'Barcode Scanner');
 
   @override
   Widget build(BuildContext context) {
-    return ChangeNotifierProvider<ContinuousScanModel>.value(
-      value: _continuousScanModel,
-      child: Consumer<ContinuousScanModel>(builder: _build),
-    );
-  }
-
-  Widget _build(
-      BuildContext context, ContinuousScanModel model, Widget? child) {
+    final ContinuousScanModel model = context.watch<ContinuousScanModel>();
     final AppLocalizations localizations = AppLocalizations.of(context)!;
     final Size screenSize = MediaQuery.of(context).size;
     return Scaffold(
@@ -48,7 +37,7 @@ class ContinuousScanPage extends StatelessWidget {
             animationCurve: Curves.easeInOutBack,
             child: QRView(
               key: _scannerViewKey,
-              onQRViewCreated: _continuousScanModel.setupScanner,
+              onQRViewCreated: model.setupScanner,
             ),
           ),
           SmoothRevealAnimation(
@@ -74,14 +63,14 @@ class ContinuousScanPage extends StatelessWidget {
             animationCurve: Curves.easeInOutBack,
             child: Column(
               children: <Widget>[
-                if (_continuousScanModel.isNotEmpty) ...<Widget>[
+                if (model.isNotEmpty) ...<Widget>[
                   const SizedBox(height: 10.0),
                   Row(
                     mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                     children: <Widget>[
                       ElevatedButton.icon(
                         icon: const Icon(Icons.cancel_outlined),
-                        onPressed: _continuousScanModel.clearScanSession,
+                        onPressed: model.clearScanSession,
                         label: const Text('Clear'),
                       ),
                       ElevatedButton.icon(
@@ -93,7 +82,7 @@ class ContinuousScanPage extends StatelessWidget {
                   ),
                   const SizedBox(height: 10.0),
                   SmoothProductCarousel(
-                    continuousScanModel: _continuousScanModel,
+                    continuousScanModel: model,
                   )
                 ],
               ],
@@ -106,15 +95,16 @@ class ContinuousScanPage extends StatelessWidget {
   }
 
   Future<void> _openPersonalizedRankingPage(BuildContext context) async {
-    await _continuousScanModel.refreshProductList();
+    final ContinuousScanModel model = context.read<ContinuousScanModel>();
+    await model.refreshProductList();
     await Navigator.push<Widget>(
       context,
       MaterialPageRoute<Widget>(
         builder: (BuildContext context) => PersonalizedRankingPage(
-          _continuousScanModel.productList,
+          model.productList,
         ),
       ),
     );
-    await _continuousScanModel.refresh();
+    await model.refresh();
   }
 }

--- a/packages/smooth_app/lib/pages/scan/continuous_scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/continuous_scan_page.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:provider/provider.dart';
 import 'package:qr_code_scanner/qr_code_scanner.dart';
 import 'package:smooth_app/data_models/continuous_scan_model.dart';
 import 'package:smooth_app/pages/personalized_ranking_page.dart';
-import 'package:smooth_app/pages/scan/scan_page.dart';
 import 'package:smooth_app/pages/scan/search_panel.dart';
 import 'package:smooth_app/widgets/smooth_product_carousel.dart';
 import 'package:smooth_ui_library/smooth_ui_library.dart';
@@ -32,7 +32,16 @@ class ContinuousScanPage extends StatelessWidget {
       appBar: AppBar(toolbarHeight: 0.0),
       body: Stack(
         children: <Widget>[
-          ScanPage.getHero(screenSize),
+          Container(
+            alignment: Alignment.center,
+            color: Colors.black,
+            child: SvgPicture.asset(
+              'assets/actions/scanner_alt_2.svg',
+              width: 60.0,
+              height: 60.0,
+              color: Colors.white,
+            ),
+          ),
           SmoothRevealAnimation(
             delay: 400,
             startOffset: Offset.zero,

--- a/packages/smooth_app/lib/pages/scan/continuous_scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/continuous_scan_page.dart
@@ -81,9 +81,7 @@ class ContinuousScanPage extends StatelessWidget {
                     ],
                   ),
                   const SizedBox(height: 10.0),
-                  SmoothProductCarousel(
-                    continuousScanModel: model,
-                  )
+                  const SmoothProductCarousel(),
                 ],
               ],
             ),

--- a/packages/smooth_app/lib/pages/scan/scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/scan_page.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/continuous_scan_model.dart';
 import 'package:smooth_app/database/local_database.dart';
@@ -29,20 +28,4 @@ class ScanPage extends StatelessWidget {
         });
   }
 
-  static Widget getHero(final Size screenSize) => Hero(
-        tag: 'action_button',
-        child: Container(
-          width: screenSize.width,
-          height: screenSize.height,
-          color: Colors.black,
-          child: Center(
-            child: SvgPicture.asset(
-              'assets/actions/scanner_alt_2.svg',
-              width: 60.0,
-              height: 60.0,
-              color: Colors.white,
-            ),
-          ),
-        ),
-      );
 }

--- a/packages/smooth_app/lib/pages/scan/scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/scan_page.dart
@@ -5,27 +5,43 @@ import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/database/product_query.dart';
 import 'package:smooth_app/pages/scan/continuous_scan_page.dart';
 
-class ScanPage extends StatelessWidget {
+class ScanPage extends StatefulWidget {
   const ScanPage();
 
   @override
-  Widget build(BuildContext context) {
-    final LocalDatabase localDatabase = context.watch<LocalDatabase>();
-    return FutureBuilder<ContinuousScanModel?>(
-        future: ContinuousScanModel(
-          languageCode: ProductQuery.getCurrentLanguageCode(context),
-          countryCode: ProductQuery.getCurrentCountryCode(),
-        ).load(localDatabase),
-        builder: (BuildContext context,
-            AsyncSnapshot<ContinuousScanModel?> snapshot) {
-          if (snapshot.connectionState == ConnectionState.done) {
-            final ContinuousScanModel? continuousScanModel = snapshot.data;
-            if (continuousScanModel != null) {
-              return ContinuousScanPage(continuousScanModel);
-            }
-          }
-          return const Center(child: CircularProgressIndicator());
-        });
+  State<ScanPage> createState() => _ScanPageState();
+}
+
+class _ScanPageState extends State<ScanPage> {
+  ContinuousScanModel? _model;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _updateModel();
   }
 
+  Future<void> _updateModel() async {
+    final LocalDatabase localDatabase = context.watch<LocalDatabase>();
+    if (_model == null) {
+      _model = await ContinuousScanModel(
+        languageCode: ProductQuery.getCurrentLanguageCode(context),
+        countryCode: ProductQuery.getCurrentCountryCode(),
+      ).load(localDatabase);
+    } else {
+      await _model?.refresh();
+    }
+    setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_model == null) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    return ChangeNotifierProvider<ContinuousScanModel>(
+      create: (BuildContext context) => _model!,
+      child: ContinuousScanPage(),
+    );
+  }
 }

--- a/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
+++ b/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
@@ -17,11 +17,9 @@ import 'package:smooth_app/themes/smooth_theme.dart';
 
 class SmoothProductCarousel extends StatefulWidget {
   const SmoothProductCarousel({
-    required this.continuousScanModel,
     this.height = 120.0,
   });
 
-  final ContinuousScanModel continuousScanModel;
   final double height;
 
   @override
@@ -36,7 +34,8 @@ class _SmoothProductCarouselState extends State<SmoothProductCarousel> {
   Widget build(BuildContext context) {
     final ProductPreferences productPreferences =
         context.watch<ProductPreferences>();
-    final List<String> barcodes = widget.continuousScanModel.getBarcodes();
+    final ContinuousScanModel model = context.watch<ContinuousScanModel>();
+    final List<String> barcodes = model.getBarcodes();
     final int barcodesLength = barcodes.length;
     if (_length != barcodesLength) {
       _length = barcodesLength;
@@ -78,11 +77,12 @@ class _SmoothProductCarouselState extends State<SmoothProductCarousel> {
     if (index >= barcodes.length) {
       return Container();
     }
+    final ContinuousScanModel model = context.watch<ContinuousScanModel>();
     final String barcode = barcodes[index];
-    switch (widget.continuousScanModel.getBarcodeState(barcode)!) {
+    switch (model.getBarcodeState(barcode)!) {
       case ScannedProductState.FOUND:
       case ScannedProductState.CACHED:
-        final Product product = widget.continuousScanModel.getProduct(barcode);
+        final Product product = model.getProduct(barcode);
         final MatchedProduct matchedProduct =
             MatchedProduct(product, productPreferences);
         return SmoothProductCardFound(
@@ -98,11 +98,9 @@ class _SmoothProductCarouselState extends State<SmoothProductCarousel> {
         return SmoothProductCardLoading(barcode: barcode);
       case ScannedProductState.NOT_FOUND:
         return SmoothProductCardNotFound(
-          product: Product(
-            barcode: barcode,
-          ),
-          callback: () => widget.continuousScanModel
-              .setBarcodeState(barcode, ScannedProductState.THANKS),
+          product: Product(barcode: barcode),
+          callback: () =>
+              model.setBarcodeState(barcode, ScannedProductState.THANKS),
         );
       case ScannedProductState.THANKS:
         return const SmoothProductCardThanks();


### PR DESCRIPTION
Before this change, `ScanPage` creates a new instance of `ContinuousScanModel` on every `build()` and passes to descendant components via parameters. After this change, `ScanPage` maintains a single `ContinuousScanModel` that descendants obtain from the context.

This change also removes `ScanPage.getHero()`.