### PR TITLE
Fix lint warnings

### DIFF
--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -35,7 +35,7 @@ jobs:
       
       # analyze Dart for errors
       - name: "Analyze code"
-        run: flutter analyze .
+        run: flutter analyze --fatal-infos --fatal-warnings .
       
       # Run tests
       - name: "Run Tests"

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -28,7 +28,7 @@ jobs:
       
       # analyze Dart for errors
       - name: "Analyze code"
-        run: flutter analyze .
+        run: flutter analyze --fatal-infos --fatal-warnings .
       
       # Run tests
       - name: "Run Tests"

--- a/.github/workflows/web-release.yml
+++ b/.github/workflows/web-release.yml
@@ -36,7 +36,7 @@ jobs:
 #        run: flutter pub get
 #
 #      - name: Analyze code
-#        run: flutter analyze .
+#        run: flutter analyze --fatal-infos --fatal-warnings .
 #
 #      - name: Set version
 #        run:  pub global activate cider && export PATH="$PATH":"$HOME/.pub-cache/bin" && newVersion=$(echo ${GITHUB_REF##*/} | cut -d/ -f2) &&  cider version $newVersion && cider version 

--- a/packages/smooth_app/lib/cards/data_cards/image_upload_card.dart
+++ b/packages/smooth_app/lib/cards/data_cards/image_upload_card.dart
@@ -3,9 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:image_cropper/image_cropper.dart';
 import 'package:image_picker/image_picker.dart';
-import 'package:openfoodfacts/model/Product.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
-import 'package:openfoodfacts/utils/LanguageHelper.dart';
 import 'package:smooth_app/pages/product/product_image_page.dart';
 
 class ImageUploadCard extends StatefulWidget {

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_svg/flutter_svg.dart';

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_loading.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_loading.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:flutter/material.dart';
 
 class SmoothProductCardLoading extends StatelessWidget {

--- a/packages/smooth_app/lib/data_models/product_preferences.dart
+++ b/packages/smooth_app/lib/data_models/product_preferences.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
 import 'package:openfoodfacts/model/Attribute.dart';
 import 'package:openfoodfacts/model/AttributeGroup.dart';

--- a/packages/smooth_app/lib/database/barcode_product_query.dart
+++ b/packages/smooth_app/lib/database/barcode_product_query.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:openfoodfacts/openfoodfacts.dart';
-import 'package:openfoodfacts/utils/LanguageHelper.dart';
 import 'package:smooth_app/database/dao_product.dart';
 import 'package:smooth_app/database/product_query.dart';
 

--- a/packages/smooth_app/lib/database/category_product_query.dart
+++ b/packages/smooth_app/lib/database/category_product_query.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'package:openfoodfacts/model/SearchResult.dart';
 import 'package:openfoodfacts/model/parameter/TagFilter.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/data_models/product_list.dart';

--- a/packages/smooth_app/lib/database/group_product_query.dart
+++ b/packages/smooth_app/lib/database/group_product_query.dart
@@ -1,9 +1,7 @@
 import 'dart:async';
 
-import 'package:openfoodfacts/model/SearchResult.dart';
 import 'package:openfoodfacts/model/parameter/PnnsGroup2Filter.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
-import 'package:openfoodfacts/utils/LanguageHelper.dart';
 import 'package:openfoodfacts/utils/PnnsGroups.dart';
 import 'package:smooth_app/data_models/product_list.dart';
 import 'package:smooth_app/database/product_query.dart';

--- a/packages/smooth_app/lib/database/keywords_product_query.dart
+++ b/packages/smooth_app/lib/database/keywords_product_query.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'package:openfoodfacts/model/SearchResult.dart';
 import 'package:openfoodfacts/model/parameter/SearchTerms.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/data_models/product_list.dart';

--- a/packages/smooth_app/lib/database/product_query.dart
+++ b/packages/smooth_app/lib/database/product_query.dart
@@ -1,7 +1,6 @@
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
-import 'package:openfoodfacts/model/SearchResult.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/data_models/product_list.dart';
 

--- a/packages/smooth_app/lib/main.dart
+++ b/packages/smooth_app/lib/main.dart
@@ -1,9 +1,7 @@
 import 'dart:async';
 
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/personalized_search/product_preferences_selection.dart';
 import 'package:package_info_plus/package_info_plus.dart';

--- a/packages/smooth_app/lib/pages/choose_page.dart
+++ b/packages/smooth_app/lib/pages/choose_page.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_staggered_animations/flutter_staggered_animations.dart';

--- a/packages/smooth_app/lib/pages/home_page.dart
+++ b/packages/smooth_app/lib/pages/home_page.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/utils/PnnsGroups.dart';

--- a/packages/smooth_app/lib/pages/product/common/product_query_page_helper.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_query_page_helper.dart
@@ -1,14 +1,6 @@
-// Dart imports:
-import 'dart:ui';
-
-// Flutter imports:
 import 'package:flutter/material.dart';
-
-// Package imports:
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/utils/PnnsGroups.dart';
-
-// Project imports:
 import 'package:smooth_app/data_models/product_list.dart';
 import 'package:smooth_app/data_models/product_list_supplier.dart';
 import 'package:smooth_app/database/local_database.dart';

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -1,10 +1,6 @@
-import 'dart:ui';
-
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/model/Attribute.dart';
-import 'package:openfoodfacts/model/Product.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/cards/data_cards/image_upload_card.dart';

--- a/packages/smooth_app/lib/pages/product/product_image_page.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_page.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:openfoodfacts/model/Product.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:photo_view/photo_view.dart';
 

--- a/packages/smooth_app/lib/pages/product/product_page.dart
+++ b/packages/smooth_app/lib/pages/product/product_page.dart
@@ -1,13 +1,9 @@
-import 'dart:ui';
-
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
 import 'package:openfoodfacts/model/Attribute.dart';
 import 'package:openfoodfacts/model/AttributeGroup.dart';
-import 'package:openfoodfacts/model/Product.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:share/share.dart';

--- a/packages/smooth_app/lib/widgets/attribute_button.dart
+++ b/packages/smooth_app/lib/widgets/attribute_button.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_svg/flutter_svg.dart';

--- a/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
+++ b/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
@@ -1,7 +1,5 @@
 import 'package:carousel_slider/carousel_slider.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:openfoodfacts/model/Product.dart';
 import 'package:openfoodfacts/personalized_search/matched_product.dart';
 import 'package:provider/provider.dart';

--- a/packages/smooth_app/lib/widgets/text_search_widget.dart
+++ b/packages/smooth_app/lib/widgets/text_search_widget.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_typeahead/flutter_typeahead.dart';

--- a/packages/smooth_ui_library/lib/widgets/smooth_card.dart
+++ b/packages/smooth_ui_library/lib/widgets/smooth_card.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 class SmoothCard extends StatelessWidget {

--- a/packages/smooth_ui_library/lib/widgets/smooth_expandable_card.dart
+++ b/packages/smooth_ui_library/lib/widgets/smooth_expandable_card.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:smooth_ui_library/animations/smooth_animated_collapse_arrow.dart';
 


### PR DESCRIPTION
This fixes a number of lint warnings by removing redundant imports.
No changes in functionality or logic, just removing redundant imports.

Bumped up the analysis checks by making infos and warnings fatal.