### PR TITLE
Fix "already disposed" error

### DIFF
--- a/packages/smooth_ui_library/lib/animations/smooth_reveal_animation.dart
+++ b/packages/smooth_ui_library/lib/animations/smooth_reveal_animation.dart
@@ -22,7 +22,7 @@ class SmoothRevealAnimation extends StatefulWidget {
 
 class _SmoothRevealAnimationState extends State<SmoothRevealAnimation>
     with SingleTickerProviderStateMixin {
-  late AnimationController _animationController;
+  AnimationController? _animationController;
   late Animation<Offset> _animationOffset;
 
   @override
@@ -32,19 +32,24 @@ class _SmoothRevealAnimationState extends State<SmoothRevealAnimation>
         vsync: this,
         duration: Duration(milliseconds: widget.animationDuration));
     final CurvedAnimation curve = CurvedAnimation(
-        curve: widget.animationCurve, parent: _animationController);
+        curve: widget.animationCurve, parent: _animationController!);
     _animationOffset =
         Tween<Offset>(begin: widget.startOffset, end: Offset.zero)
             .animate(curve);
 
     Timer(Duration(milliseconds: widget.delay), () {
-      _animationController.forward();
+      if (_animationController != null) {
+        _animationController!.forward();
+      }
     });
   }
 
   @override
   void dispose() {
-    _animationController.dispose();
+    if (_animationController != null) {
+      _animationController!.dispose();
+      _animationController = null;
+    }
     super.dispose();
   }
 
@@ -55,7 +60,7 @@ class _SmoothRevealAnimationState extends State<SmoothRevealAnimation>
         position: _animationOffset,
         child: widget.child,
       ),
-      opacity: _animationController,
+      opacity: _animationController!,
     );
   }
 }

--- a/packages/smooth_ui_library/lib/animations/smooth_reveal_animation.dart
+++ b/packages/smooth_ui_library/lib/animations/smooth_reveal_animation.dart
@@ -22,8 +22,9 @@ class SmoothRevealAnimation extends StatefulWidget {
 
 class _SmoothRevealAnimationState extends State<SmoothRevealAnimation>
     with SingleTickerProviderStateMixin {
-  AnimationController? _animationController;
-  late Animation<Offset> _animationOffset;
+  late final AnimationController _animationController;
+  late final Animation<Offset> _animationOffset;
+  late final Timer _animationTimer;
 
   @override
   void initState() {
@@ -32,24 +33,20 @@ class _SmoothRevealAnimationState extends State<SmoothRevealAnimation>
         vsync: this,
         duration: Duration(milliseconds: widget.animationDuration));
     final CurvedAnimation curve = CurvedAnimation(
-        curve: widget.animationCurve, parent: _animationController!);
+        curve: widget.animationCurve, parent: _animationController);
     _animationOffset =
         Tween<Offset>(begin: widget.startOffset, end: Offset.zero)
             .animate(curve);
 
-    Timer(Duration(milliseconds: widget.delay), () {
-      if (_animationController != null) {
-        _animationController!.forward();
-      }
+    _animationTimer = Timer(Duration(milliseconds: widget.delay), () {
+      _animationController.forward();
     });
   }
 
   @override
   void dispose() {
-    if (_animationController != null) {
-      _animationController!.dispose();
-      _animationController = null;
-    }
+    _animationController.dispose();
+    _animationTimer.cancel();
     super.dispose();
   }
 
@@ -60,7 +57,7 @@ class _SmoothRevealAnimationState extends State<SmoothRevealAnimation>
         position: _animationOffset,
         child: widget.child,
       ),
-      opacity: _animationController!,
+      opacity: _animationController,
     );
   }
 }

--- a/packages/smooth_ui_library/test/animations/smooth_reveal_animation_test.dart
+++ b/packages/smooth_ui_library/test/animations/smooth_reveal_animation_test.dart
@@ -76,7 +76,9 @@ class _SwitchablePageState extends State<_SwitchablePage> {
 
 void main() {
   // Regression test for https://github.com/openfoodfacts/smooth-app/issues/483
-  testWidgets("SmoothRevealAnimation doesn't use AnimationController after dispose", (WidgetTester tester) async {
+  testWidgets(
+      "SmoothRevealAnimation doesn't use AnimationController after dispose",
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       const MaterialApp(
         home: _SwitchablePage(

--- a/packages/smooth_ui_library/test/animations/smooth_reveal_animation_test.dart
+++ b/packages/smooth_ui_library/test/animations/smooth_reveal_animation_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:smooth_ui_library/smooth_ui_library.dart';
+
+class _SwitchablePage extends StatefulWidget {
+  const _SwitchablePage({
+    Key? key,
+    this.delay = 0,
+  }) : super(key: key);
+
+  final int delay;
+
+  @override
+  State<_SwitchablePage> createState() => _SwitchablePageState();
+}
+
+class _SwitchablePageState extends State<_SwitchablePage> {
+  int _selectedIndex = 0;
+
+  static const TextStyle optionStyle =
+      TextStyle(fontSize: 30, fontWeight: FontWeight.bold);
+
+  late final List<Widget> _widgetOptions;
+
+  void _onItemTapped(int index) {
+    setState(() {
+      _selectedIndex = index;
+    });
+  }
+
+  @override
+  void initState() {
+    _widgetOptions = <Widget>[
+      SmoothRevealAnimation(
+        delay: widget.delay,
+        child: const Text(
+          'Index 0: Home, which has SmoothRevealAnimation',
+          style: optionStyle,
+        ),
+      ),
+      const Text(
+        'Index 1: Business, which does not have SmoothRevealAnimation',
+        style: optionStyle,
+      ),
+    ];
+    return super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Test App'),
+      ),
+      body: Center(
+        child: _widgetOptions.elementAt(_selectedIndex),
+      ),
+      bottomNavigationBar: BottomNavigationBar(
+        items: const <BottomNavigationBarItem>[
+          BottomNavigationBarItem(
+            icon: Icon(Icons.home),
+            label: 'Home',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.business),
+            label: 'Business',
+          ),
+        ],
+        currentIndex: _selectedIndex,
+        selectedItemColor: Colors.amber[800],
+        onTap: _onItemTapped,
+      ),
+    );
+  }
+}
+
+void main() {
+  // Regression test for https://github.com/openfoodfacts/smooth-app/issues/483
+  testWidgets("SmoothRevealAnimation doesn't use AnimationController after dispose", (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: _SwitchablePage(
+          // Set a large delay so that the AnimationController has time to be
+          // disposed.
+          delay: 1000,
+        ),
+      ),
+    );
+
+    expect(find.byType(SmoothRevealAnimation), findsOneWidget);
+
+    // Move to the page that doesn't have SmoothRevealAnimation.
+    await tester.tap(find.text('Business'));
+    await tester.pumpAndSettle();
+    expect(find.byType(SmoothRevealAnimation), findsNothing);
+
+    // Wait 1 second so the SmoothRevealAnimation delay expires on the previous
+    // page.
+    await tester.pump(const Duration(seconds: 1));
+    expect(tester.takeException(), isNull);
+  });
+}


### PR DESCRIPTION
This prevents an error where the AnimationController in SmoothRevealAnimation is used after it has already been disposed.

Partial fix for https://github.com/openfoodfacts/smooth-app/issues/483.  This error appears when the freeze happens, but I'm still able to reproduce the freeze after making this fix 😞 .

<details>

<summary>Error</summary>

```
AnimationController methods should not be used after calling dispose.
#0      _AssertionError._doThrowNew (dart:core-patch/errors_patch.dart:47:61)
#1      _AssertionError._throwNew (dart:core-patch/errors_patch.dart:36:5)
#2      AnimationController.forward (package:flutter/src/animation/animation_controller.dart:455:7)
#3      _SmoothRevealAnimationState.initState.<anonymous closure> (package:smooth_ui_library/animations/smooth_reveal_animation.dart:41:28)
#4      _rootRun (dart:async/zone.dart:1420:47)
#5      _CustomZone.run (dart:async/zone.dart:1328:19)
#6      _CustomZone.runGuarded (dart:async/zone.dart:1236:7)
#7      _CustomZone.bindCallbackGuarded.<anonymous closure> (dart:async/zone.dart:1276:23)
#8      _rootRun (dart:async/zone.dart:1428:13)
#9      _CustomZone.run (dart:async/zone.dart:1328:19)
#10     _CustomZone.bindCallback.<anonymous closure> (dart:async/zone.dart:1260:23)
#11     Timer._createTimer.<anonymous closure> (dart:async-patch/timer_patch.dart:18:15)
#12     _Timer._runTimers (dart:isolate-patch/timer_impl.dart:395:19)
#13     _Timer._handleMessage (dart:isolate-patch/timer_impl.dart:426:5)
#14     _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:192:12)
```

</details>