### PR TITLE
Display category name in local language for similar foods

### DIFF
--- a/packages/smooth_app/lib/pages/product/product_page.dart
+++ b/packages/smooth_app/lib/pages/product/product_page.dart
@@ -379,11 +379,9 @@ class _ProductPageState extends State<ProductPage> {
             ProductQuery.getCurrentLanguageCode(context);
         final OpenFoodFactsLanguage currentLanguage =
             LanguageHelper.fromJson(currentLanguageCode);
-        String categoryTagInLocalLanguage = categoryTag;
-        if (_product.categoriesTagsInLanguages!.containsKey(currentLanguage)) {
-          categoryTagInLocalLanguage =
-              _product.categoriesTagsInLanguages![currentLanguage]![i];
-        }
+        final String categoryTagInLocalLanguage =
+            _product.categoriesTagsInLanguages?[currentLanguage]?[i] ??
+                categoryTag;
 
         const MaterialColor materialColor = Colors.blue;
         listItems.add(

--- a/packages/smooth_app/lib/pages/product/product_page.dart
+++ b/packages/smooth_app/lib/pages/product/product_page.dart
@@ -375,6 +375,16 @@ class _ProductPageState extends State<ProductPage> {
           i < _product.categoriesTags!.length;
           i++) {
         final String categoryTag = _product.categoriesTags![i];
+        final String currentLanguageCode =
+            ProductQuery.getCurrentLanguageCode(context);
+        final OpenFoodFactsLanguage currentLanguage =
+            LanguageHelper.fromJson(currentLanguageCode);
+        String categoryTagInLocalLanguage = categoryTag;
+        if (_product.categoriesTagsInLanguages!.containsKey(currentLanguage)) {
+          categoryTagInLocalLanguage =
+              _product.categoriesTagsInLanguages![currentLanguage]![i];
+        }
+
         const MaterialColor materialColor = Colors.blue;
         listItems.add(
           SmoothCard(
@@ -409,7 +419,7 @@ class _ProductPageState extends State<ProductPage> {
                 context: context,
               ),
               title: Text(
-                categoryTag,
+                categoryTagInLocalLanguage,
                 style: themeData.textTheme.headline3,
               ),
               subtitle: Text(

--- a/packages/smooth_app/lib/pages/product/product_page.dart
+++ b/packages/smooth_app/lib/pages/product/product_page.dart
@@ -371,14 +371,15 @@ class _ProductPageState extends State<ProductPage> {
     //Similar foods
     if (_product.categoriesTags != null &&
         _product.categoriesTags!.isNotEmpty) {
+      final String currentLanguageCode =
+          ProductQuery.getCurrentLanguageCode(context);
+      final OpenFoodFactsLanguage currentLanguage =
+          LanguageHelper.fromJson(currentLanguageCode);
+
       for (int i = _product.categoriesTags!.length - 1;
           i < _product.categoriesTags!.length;
           i++) {
         final String categoryTag = _product.categoriesTags![i];
-        final String currentLanguageCode =
-            ProductQuery.getCurrentLanguageCode(context);
-        final OpenFoodFactsLanguage currentLanguage =
-            LanguageHelper.fromJson(currentLanguageCode);
         final String categoryTagInLocalLanguage =
             _product.categoriesTagsInLanguages?[currentLanguage]?[i] ??
                 categoryTag;
@@ -410,7 +411,7 @@ class _ProductPageState extends State<ProductPage> {
                 localDatabase: localDatabase,
                 productQuery: CategoryProductQuery(
                   category: categoryTag,
-                  languageCode: ProductQuery.getCurrentLanguageCode(context),
+                  languageCode: currentLanguageCode,
                   countryCode: ProductQuery.getCurrentCountryCode(),
                   size: 500,
                 ),

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   image_picker: ^0.8.2
   matomo: ^1.0.0
   modal_bottom_sheet: ^2.0.0
-  openfoodfacts: ^1.3.2
+  openfoodfacts: ^1.3.4
   # Uncomment those lines if you want to use a local version of the openfoodfacts package
   #openfoodfacts:
   #  path: ../../../openfoodfacts-dart


### PR DESCRIPTION
Use categoriesTagsInLanguages to display the name of the category in the local language.

Fixes #592 

![image](https://user-images.githubusercontent.com/8158668/135073359-4722f870-0146-4099-b050-c593052cd6b2.png)
