### PR TITLE
bug/#628 - special "internet error" case for scan carousel product card

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_error.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_error.dart
@@ -1,5 +1,6 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:smooth_app/pages/product/common/product_dialog_helper.dart';
 
 /// Product Card when an exception is caught
 class SmoothProductCardError extends StatelessWidget {
@@ -28,7 +29,9 @@ class SmoothProductCardError extends StatelessWidget {
           const SizedBox(
             height: 12.0,
           ),
-          const Icon(Icons.error_outline, color: Colors.red),
+          ProductDialogHelper.getErrorMessage(
+            AppLocalizations.of(context)!.product_internet_error,
+          ),
         ],
       ),
     );

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_error.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_error.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+/// Product Card when an exception is caught
+class SmoothProductCardError extends StatelessWidget {
+  const SmoothProductCardError({required this.barcode});
+
+  final String barcode;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        borderRadius: const BorderRadius.all(Radius.circular(15.0)),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.max,
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          Row(
+            mainAxisSize: MainAxisSize.max,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: <Widget>[
+              Text(barcode, style: Theme.of(context).textTheme.subtitle1),
+            ],
+          ),
+          const SizedBox(
+            height: 12.0,
+          ),
+          const Icon(Icons.error_outline, color: Colors.red),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/smooth_app/lib/data_models/continuous_scan_model.dart
+++ b/packages/smooth_app/lib/data_models/continuous_scan_model.dart
@@ -15,6 +15,7 @@ enum ScannedProductState {
   LOADING,
   THANKS,
   CACHED,
+  ERROR,
 }
 
 class ContinuousScanModel with ChangeNotifier {
@@ -162,20 +163,28 @@ class ContinuousScanModel with ChangeNotifier {
   Future<void> _loadBarcode(
     final String barcode,
   ) async {
-    final Product? product = await _queryBarcode(barcode);
-    if (product != null) {
-      _addProduct(product, ScannedProductState.FOUND);
-    } else {
-      setBarcodeState(barcode, ScannedProductState.NOT_FOUND);
+    try {
+      final Product? product = await _queryBarcode(barcode);
+      if (product != null) {
+        _addProduct(product, ScannedProductState.FOUND);
+      } else {
+        setBarcodeState(barcode, ScannedProductState.NOT_FOUND);
+      }
+    } catch (e) {
+      setBarcodeState(barcode, ScannedProductState.ERROR);
     }
   }
 
   Future<void> _updateBarcode(
     final String barcode,
   ) async {
-    final Product? product = await _queryBarcode(barcode);
-    if (product != null) {
-      _addProduct(product, ScannedProductState.FOUND);
+    try {
+      final Product? product = await _queryBarcode(barcode);
+      if (product != null) {
+        _addProduct(product, ScannedProductState.FOUND);
+      }
+    } catch (e) {
+      setBarcodeState(barcode, ScannedProductState.ERROR);
     }
   }
 

--- a/packages/smooth_app/lib/data_models/continuous_scan_model.dart
+++ b/packages/smooth_app/lib/data_models/continuous_scan_model.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:openfoodfacts/model/Product.dart';
 import 'package:qr_code_scanner/qr_code_scanner.dart';
+import 'package:smooth_app/data_models/fetched_product.dart';
 import 'package:smooth_app/data_models/product_list.dart';
 import 'package:smooth_app/database/barcode_product_query.dart';
 import 'package:smooth_app/database/dao_product.dart';
@@ -150,7 +151,7 @@ class ContinuousScanModel with ChangeNotifier {
     return false;
   }
 
-  Future<Product?> _queryBarcode(
+  Future<FetchedProduct> _queryBarcode(
     final String barcode,
   ) async =>
       BarcodeProductQuery(
@@ -158,33 +159,45 @@ class ContinuousScanModel with ChangeNotifier {
         languageCode: languageCode,
         countryCode: countryCode,
         daoProduct: _daoProduct,
-      ).getProduct();
+      ).getFetchedProduct();
 
   Future<void> _loadBarcode(
     final String barcode,
   ) async {
-    try {
-      final Product? product = await _queryBarcode(barcode);
-      if (product != null) {
-        _addProduct(product, ScannedProductState.FOUND);
-      } else {
+    final FetchedProduct fetchedProduct = await _queryBarcode(barcode);
+    switch (fetchedProduct.status) {
+      case FetchedProductStatus.ok:
+        _addProduct(fetchedProduct.product!, ScannedProductState.FOUND);
+        return;
+      case FetchedProductStatus.internetNotFound:
         setBarcodeState(barcode, ScannedProductState.NOT_FOUND);
-      }
-    } catch (e) {
-      setBarcodeState(barcode, ScannedProductState.ERROR);
+        return;
+      case FetchedProductStatus.internetError:
+        setBarcodeState(barcode, ScannedProductState.ERROR);
+        return;
+      case FetchedProductStatus.userCancelled:
+        // we do nothing
+        return;
     }
   }
 
   Future<void> _updateBarcode(
     final String barcode,
   ) async {
-    try {
-      final Product? product = await _queryBarcode(barcode);
-      if (product != null) {
-        _addProduct(product, ScannedProductState.FOUND);
-      }
-    } catch (e) {
-      setBarcodeState(barcode, ScannedProductState.ERROR);
+    final FetchedProduct fetchedProduct = await _queryBarcode(barcode);
+    switch (fetchedProduct.status) {
+      case FetchedProductStatus.ok:
+        _addProduct(fetchedProduct.product!, ScannedProductState.FOUND);
+        return;
+      case FetchedProductStatus.internetNotFound:
+        setBarcodeState(barcode, ScannedProductState.NOT_FOUND);
+        return;
+      case FetchedProductStatus.internetError:
+        setBarcodeState(barcode, ScannedProductState.ERROR);
+        return;
+      case FetchedProductStatus.userCancelled:
+        // we do nothing
+        return;
     }
   }
 

--- a/packages/smooth_app/lib/data_models/fetched_product.dart
+++ b/packages/smooth_app/lib/data_models/fetched_product.dart
@@ -1,0 +1,27 @@
+import 'package:openfoodfacts/model/Product.dart';
+
+/// Status of a "fetch [Product]" operation
+enum FetchedProductStatus {
+  ok,
+  internetNotFound,
+  internetError,
+  userCancelled,
+  // TODO(monsieurtanuki): time-out
+}
+
+/// A [Product] that we tried to fetch, but was it successful?..
+class FetchedProduct {
+  // The reason behind the "ignore": I want to force "product" to be not null
+  FetchedProduct(final Product product)
+      // ignore: prefer_initializing_formals
+      : product = product,
+        status = FetchedProductStatus.ok;
+
+  /// When the "fetch product" operation didn't go well (no status "ok" here)
+  FetchedProduct.error(this.status)
+      : product = null,
+        assert(status != FetchedProductStatus.ok);
+
+  final Product? product;
+  final FetchedProductStatus status;
+}

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -238,6 +238,8 @@
     "@could_not_refresh": {},
     "no_product_found": "No product found",
     "@no_product_found": {},
+    "product_internet_error": "Impossible to fetch information about this product due to a network error.",
+    "product_internet_cancel": "Canceled by user.",
     "products_pasted": "products pasted",
     "@products_pasted": {},
     "no_prodcut_in_list": "There is no product in this list",

--- a/packages/smooth_app/lib/pages/choose_page.dart
+++ b/packages/smooth_app/lib/pages/choose_page.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_staggered_animations/flutter_staggered_animations.dart';
-import 'package:openfoodfacts/model/Product.dart';
 import 'package:openfoodfacts/utils/PnnsGroups.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/cards/category_cards/category_card.dart';
 import 'package:smooth_app/cards/category_cards/category_chip.dart';
 import 'package:smooth_app/cards/category_cards/subcategory_card.dart';
+import 'package:smooth_app/data_models/fetched_product.dart';
 import 'package:smooth_app/database/group_product_query.dart';
 import 'package:smooth_app/database/keywords_product_query.dart';
 import 'package:smooth_app/database/local_database.dart';
@@ -33,19 +33,20 @@ class ChoosePage extends StatefulWidget {
         localDatabase: localDatabase,
         refresh: false,
       );
-      final Product? product = await productDialogHelper.openBestChoice();
-      if (product == null) {
-        productDialogHelper.openProductNotFoundDialog();
-        return;
-      }
-      Navigator.push<Widget>(
-        context,
-        MaterialPageRoute<Widget>(
-          builder: (BuildContext context) => ProductPage(
-            product: product,
+      final FetchedProduct fetchedProduct =
+          await productDialogHelper.openBestChoice();
+      if (fetchedProduct.status == FetchedProductStatus.ok) {
+        Navigator.push<Widget>(
+          context,
+          MaterialPageRoute<Widget>(
+            builder: (BuildContext context) => ProductPage(
+              product: fetchedProduct.product!,
+            ),
           ),
-        ),
-      );
+        );
+      } else {
+        productDialogHelper.openError(fetchedProduct);
+      }
       return;
     }
     await ProductQueryPageHelper().openBestChoice(

--- a/packages/smooth_app/lib/pages/product/common/product_dialog_helper.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_dialog_helper.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/model/Product.dart';
+import 'package:smooth_app/data_models/fetched_product.dart';
 import 'package:smooth_app/database/barcode_product_query.dart';
 import 'package:smooth_app/database/dao_product.dart';
 import 'package:smooth_app/database/local_database.dart';
@@ -23,42 +24,38 @@ class ProductDialogHelper {
   final bool refresh;
   bool _popEd = false;
 
-  Future<Product?> openBestChoice() async {
+  Future<FetchedProduct> openBestChoice() async {
     final Product? product = await DaoProduct(localDatabase).get(barcode);
     if (product != null) {
-      return product;
+      return FetchedProduct(product);
     }
     return openUniqueProductSearch();
   }
 
-  Future<Product?> openUniqueProductSearch() => showDialog<Product>(
-        context: context,
-        builder: (BuildContext context) {
-          BarcodeProductQuery(
-            barcode: barcode,
-            languageCode: ProductQuery.getCurrentLanguageCode(context),
-            countryCode: ProductQuery.getCurrentCountryCode(),
-            daoProduct: DaoProduct(localDatabase),
-          ).getProduct().then<void>(
-              (final Product? value) => _popSearchingDialog(value)
-              /* TODO(monsieurtanuki): better granularity - being able to say...
-             1. you clicked on 'stop'
-             2. no internet connection
-             3. no result at all
-             4. time out
-             5. of course, the product (when everything is fine)
-             */
-              );
-          return _getSearchingDialog();
-        },
-      );
+  Future<FetchedProduct> openUniqueProductSearch() async {
+    final FetchedProduct? result = await showDialog<FetchedProduct>(
+      context: context,
+      builder: (BuildContext context) {
+        BarcodeProductQuery(
+          barcode: barcode,
+          languageCode: ProductQuery.getCurrentLanguageCode(context),
+          countryCode: ProductQuery.getCurrentCountryCode(),
+          daoProduct: DaoProduct(localDatabase),
+        ).getFetchedProduct().then<void>(
+              (final FetchedProduct value) => _popSearchingDialog(value),
+            );
+        return _getSearchingDialog();
+      },
+    );
+    return result ?? FetchedProduct.error(FetchedProductStatus.userCancelled);
+  }
 
-  void _popSearchingDialog(final Product? product) {
+  void _popSearchingDialog(final FetchedProduct fetchedProduct) {
     if (_popEd) {
       return;
     }
     _popEd = true;
-    Navigator.pop(context, product);
+    Navigator.pop(context, fetchedProduct);
   }
 
   Widget _getSearchingDialog() => SmoothAlertDialog(
@@ -74,12 +71,14 @@ class ProductDialogHelper {
         actions: <SmoothSimpleButton>[
           SmoothSimpleButton(
             text: AppLocalizations.of(context)!.stop,
-            onPressed: () => _popSearchingDialog(null),
+            onPressed: () => _popSearchingDialog(
+              FetchedProduct.error(FetchedProductStatus.userCancelled),
+            ),
           ),
         ],
       );
 
-  void openProductNotFoundDialog() => showDialog<Widget>(
+  void _openProductNotFoundDialog() => showDialog<Widget>(
         context: context,
         builder: (BuildContext context) {
           return SmoothAlertDialog(
@@ -104,4 +103,41 @@ class ProductDialogHelper {
           );
         },
       );
+
+  static Widget getErrorMessage(final String message) => ListTile(
+        leading: const Icon(Icons.error_outline, color: Colors.red),
+        title: Text(message),
+      );
+
+  void _openErrorMessage(final String message) => showDialog<void>(
+        context: context,
+        builder: (BuildContext context) => SmoothAlertDialog(
+          close: false,
+          body: getErrorMessage(message),
+          actions: <SmoothSimpleButton>[
+            SmoothSimpleButton(
+              text: AppLocalizations.of(context)!.close,
+              onPressed: () => Navigator.pop(context),
+            ),
+          ],
+        ),
+      );
+
+  /// Opens an error dialog; to be used only if the status is not ok.
+  void openError(final FetchedProduct fetchedProduct) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context)!;
+    switch (fetchedProduct.status) {
+      case FetchedProductStatus.ok:
+        throw Exception("You're not supposed to call this if the status is ok");
+      case FetchedProductStatus.userCancelled:
+        _openErrorMessage(appLocalizations.product_internet_cancel);
+        return;
+      case FetchedProductStatus.internetError:
+        _openErrorMessage(appLocalizations.product_internet_error);
+        return;
+      case FetchedProductStatus.internetNotFound:
+        _openProductNotFoundDialog();
+        return;
+    }
+  }
 }

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -10,6 +10,7 @@ import 'package:smooth_app/cards/data_cards/image_upload_card.dart';
 import 'package:smooth_app/cards/data_cards/score_card.dart';
 import 'package:smooth_app/cards/expandables/attribute_list_expandable.dart';
 import 'package:smooth_app/cards/product_cards/knowledge_panels/knowledge_panels_builder.dart';
+import 'package:smooth_app/data_models/fetched_product.dart';
 import 'package:smooth_app/data_models/product_preferences.dart';
 import 'package:smooth_app/database/dao_product_extra.dart';
 import 'package:smooth_app/database/knowledge_panels_query.dart';
@@ -122,22 +123,20 @@ class _ProductPageState extends State<NewProductPage> {
       localDatabase: localDatabase,
       refresh: true,
     );
-    final Product? product =
+    final FetchedProduct fetchedProduct =
         await productDialogHelper.openUniqueProductSearch();
-    if (product == null) {
-      productDialogHelper.openProductNotFoundDialog();
-      return;
+    if (fetchedProduct.status == FetchedProductStatus.ok) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(appLocalizations.product_refreshed),
+          duration: const Duration(seconds: 2),
+        ),
+      );
+      setState(() => _product = fetchedProduct.product!);
+      await _updateLocalDatabaseWithProductHistory(context, _product);
+    } else {
+      productDialogHelper.openError(fetchedProduct);
     }
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(appLocalizations.product_refreshed),
-        duration: const Duration(seconds: 2),
-      ),
-    );
-    setState(() {
-      _product = product;
-    });
-    await _updateLocalDatabaseWithProductHistory(context, _product);
   }
 
   Future<void> _updateLocalDatabaseWithProductHistory(

--- a/packages/smooth_app/lib/pages/product/product_page.dart
+++ b/packages/smooth_app/lib/pages/product/product_page.dart
@@ -8,6 +8,7 @@ import 'package:provider/provider.dart';
 import 'package:share/share.dart';
 import 'package:smooth_app/cards/data_cards/image_upload_card.dart';
 import 'package:smooth_app/cards/expandables/attribute_list_expandable.dart';
+import 'package:smooth_app/data_models/fetched_product.dart';
 import 'package:smooth_app/data_models/product_list.dart';
 import 'package:smooth_app/data_models/product_preferences.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
@@ -112,20 +113,20 @@ class _ProductPageState extends State<ProductPage> {
                     localDatabase: localDatabase,
                     refresh: true,
                   );
-                  final Product? product =
+                  final FetchedProduct fetchedProduct =
                       await productDialogHelper.openUniqueProductSearch();
-                  if (product == null) {
-                    productDialogHelper.openProductNotFoundDialog();
-                    return;
+                  if (fetchedProduct.status == FetchedProductStatus.ok) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        content: Text(appLocalizations.product_refreshed),
+                        duration: const Duration(seconds: 2),
+                      ),
+                    );
+                    _product = fetchedProduct.product!;
+                    await _updateHistory(context);
+                  } else {
+                    productDialogHelper.openError(fetchedProduct);
                   }
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(
-                      content: Text(appLocalizations.product_refreshed),
-                      duration: const Duration(seconds: 2),
-                    ),
-                  );
-                  _product = product;
-                  await _updateHistory(context);
                   break;
                 case 'new_product_page':
                   Navigator.push<Widget>(

--- a/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
+++ b/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:openfoodfacts/model/Product.dart';
 import 'package:openfoodfacts/personalized_search/matched_product.dart';
 import 'package:provider/provider.dart';
+import 'package:smooth_app/cards/product_cards/smooth_product_card_error.dart';
 import 'package:smooth_app/cards/product_cards/smooth_product_card_found.dart';
 import 'package:smooth_app/cards/product_cards/smooth_product_card_loading.dart';
 import 'package:smooth_app/cards/product_cards/smooth_product_card_not_found.dart';
@@ -102,6 +103,8 @@ class _SmoothProductCarouselState extends State<SmoothProductCarousel> {
         );
       case ScannedProductState.THANKS:
         return const SmoothProductCardThanks();
+      case ScannedProductState.ERROR:
+        return SmoothProductCardError(barcode: barcode);
     }
   }
 }


### PR DESCRIPTION
New file:
* `smooth_product_card_error.dart`: Product Card when an exception is caught

Impacted files:
* `continuous_scan_model.dart`: new value `ScannedProductState.ERROR`, used when an exception is caught during API call
* `smooth_product_carousel.dart`: handling the `ScannedProductState.ERROR` case

Currently this is what an internet error looks like:
![Screenshot_2021-10-21-12-28-02](https://user-images.githubusercontent.com/11576431/138261473-7505ff87-6cdd-4af8-9836-26c4acdae716.png)
I won't get the Nobel Prize for Design with that, but it's still better than a misleading `CircularProgressIndicator`.