### PR TITLE
bug/#616 - small layout fix for search panel

### DIFF
--- a/packages/smooth_app/lib/pages/scan/search_panel.dart
+++ b/packages/smooth_app/lib/pages/scan/search_panel.dart
@@ -6,6 +6,7 @@ import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/database/search_history.dart';
 import 'package:smooth_app/pages/choose_page.dart';
 import 'package:smooth_app/pages/scan/search_history_view.dart';
+import 'package:smooth_ui_library/util/ui_helpers.dart';
 
 class SearchPanel extends StatefulWidget {
   @override
@@ -57,6 +58,11 @@ class SearchPanelState extends State<SearchPanel> {
       panelBuilder: (ScrollController scrollController) {
         const double textBoxHeight = 40.0;
         final Widget textBox = Container(
+          margin: const EdgeInsets.only(
+            left: LARGE_SPACE,
+            right: LARGE_SPACE,
+            bottom: SMALL_SPACE,
+          ),
           alignment: Alignment.topCenter,
           height: textBoxHeight,
           child: Text(

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -16,21 +16,21 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   flutter_staggered_animations: ^1.0.0
-  flutter_staggered_grid_view: ^0.4.0
-  flutter_svg: ^0.22.0
+  flutter_staggered_grid_view: ^0.4.1
+  flutter_svg: ^0.23.0+1
   flutter_typeahead: ^3.2.0
-  flutter_widget_from_html_core: ^0.6.1+4
+  flutter_widget_from_html_core: ^0.8.1
   image_cropper: ^1.4.1
-  image_picker: ^0.8.2
+  image_picker: ^0.8.4+3
   matomo: ^1.0.0
   modal_bottom_sheet: ^2.0.0
-  openfoodfacts: ^1.3.7
+  openfoodfacts: ^1.3.8
   # Uncomment those lines if you want to use a local version of the openfoodfacts package
   #  openfoodfacts:
   #    path: ../../../openfoodfacts-dart
-  package_info_plus: ^1.0.6
-  photo_view: ^0.12.0
-  provider: ^5.0.0
+  package_info_plus: ^1.3.0
+  photo_view: ^0.13.0
+  provider: ^6.0.1
   qr_code_scanner: ^0.5.2
   rubber: ^1.0.1
   sentry_flutter: ^6.0.0
@@ -38,7 +38,7 @@ dependencies:
   smooth_ui_library:
     path: ../smooth_ui_library
   sqflite: ^2.0.0+3
-  url_launcher: ^6.0.3
+  url_launcher: ^6.0.12
   sliding_up_panel: ^2.0.0+1
   http: ^0.13.4
 

--- a/packages/smooth_ui_library/pubspec.yaml
+++ b/packages/smooth_ui_library/pubspec.yaml
@@ -9,12 +9,12 @@ dependencies:
   flutter_lints: ^1.0.4
   flutter:
     sdk: flutter
-  flutter_svg: ^0.22.0
-  openfoodfacts: ^1.1.0-beta
+  flutter_svg: ^0.23.0+1
+  openfoodfacts: ^1.3.8
   # Uncomment those lines if you want to use a local version of the openfoodfacts package
   #  openfoodfacts:
   #    path: ../../../openfoodfacts-dart
-  percent_indicator: ^3.0.1
+  percent_indicator: ^3.4.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Impacted files:
* `search_panel.dart`: added margin to title
* `smooth_app/pubspec.yaml`: unrelated library upgrades
* `smooth_ui_library/pubspec.yaml`: unrelated library upgrades

This is what it looks like in French:
![Screenshot_2021-10-26-10-16-14](https://user-images.githubusercontent.com/11576431/138837701-0fb5cbb3-eeef-4a80-b7bb-e8ea1ab45394.png)

This is what it looks like in debug phase:
![Screenshot_2021-10-26-10-15-19](https://user-images.githubusercontent.com/11576431/138837756-66bce1fe-9d12-4699-a241-a573bcd79bac.png)

