### PR TITLE
product_improvement_translations - product improvement display

### DIFF
--- a/packages/smooth_app/lib/database/product_query.dart
+++ b/packages/smooth_app/lib/database/product_query.dart
@@ -43,6 +43,7 @@ abstract class ProductQuery {
         ProductField.CATEGORIES_TAGS_IN_LANGUAGES,
         ProductField.LANGUAGE,
         ProductField.ATTRIBUTE_GROUPS,
+        ProductField.STATES_TAGS,
       ];
 
   Future<SearchResult> getSearchResult();

--- a/packages/smooth_app/lib/helpers/product_translation_helper.dart
+++ b/packages/smooth_app/lib/helpers/product_translation_helper.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+
+/// Translations around products
+class ProductTranslationHelper {
+  ProductTranslationHelper(this.appLocalizations);
+
+  final AppLocalizations appLocalizations;
+
+  /// Translations for [ProductImprovement]s
+  String getImprovementTranslation(final ProductImprovement improvement) {
+    switch (improvement) {
+      case ProductImprovement.ORIGINS_TO_BE_COMPLETED:
+        return appLocalizations.product_improvement_origins_to_be_completed;
+      case ProductImprovement.CATEGORIES_BUT_NO_NUTRISCORE:
+        return appLocalizations
+            .product_improvement_categories_but_no_nutriscore;
+      case ProductImprovement.ADD_NUTRITION_FACTS:
+        return appLocalizations.product_improvement_add_nutrition_facts;
+      case ProductImprovement.ADD_CATEGORY:
+        return appLocalizations.product_improvement_add_category;
+      case ProductImprovement.ADD_NUTRITION_FACTS_AND_CATEGORY:
+        return appLocalizations
+            .product_improvement_add_nutrition_facts_and_category;
+      case ProductImprovement.OBSOLETE_NUTRITION_IMAGE:
+        return appLocalizations.product_improvement_obsolete_nutrition_image;
+    }
+  }
+}

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -242,6 +242,37 @@
     "@no_product_found": {},
     "product_internet_error": "Impossible to fetch information about this product due to a network error.",
     "product_internet_cancel": "Canceled by user.",
+    "product_improvement_origins_to_be_completed": "The Eco-Score takes into account the origins of the ingredients. Please take them into a photo (ingredient list and/or any geographic claim or edit the product so that they can be taken into account. If it is not clear, you can contact the food producer.",
+    "@product_improvement_origins_to_be_completed": {
+        "description": "Message for ProductImprovement.ORIGINS_TO_BE_COMPLETED"
+    },
+    "product_improvement_categories_but_no_nutriscore": "We could not compute an Nutri-Score for this product. It might be that the category is an exception. If you believe this is an error, contact us.",
+    "@product_improvement_categories_but_no_nutriscore": {
+        "description": "Message for ProductImprovement.CATEGORIES_BUT_NO_NUTRISCORE"
+    },
+    "product_improvement_add_nutrition_facts": "Add nutrition facts to compute the Nutri-Score.",
+    "@product_improvement_add_nutrition_facts": {
+        "description": "Message for ProductImprovement.ADD_NUTRITION_FACTS"
+    },
+    "product_improvement_add_category": "Add a category to compute the Nutri-Score.",
+    "@product_improvement_add_category": {
+        "description": "Message for ProductImprovement.ADD_CATEGORY"
+    },
+    "product_improvement_add_nutrition_facts_and_category": "Add nutrition facts and a category to compute the Nutri-Score.",
+    "@product_improvement_add_nutrition_facts_and_category": {
+        "description": "Message for ProductImprovement.ADD_NUTRITION_FACTS_AND_CATEGORY"
+    },
+    "product_improvement_obsolete_nutrition_image": "The nutrition image is obsolete: please refresh it.",
+    "@product_improvement_obsolete_nutrition_image": {
+        "description": "Message for ProductImprovement.OBSOLETE_NUTRITION_IMAGE"
+    },
+    "product_improvements_count": "{count,plural, =1{One possible improvement} other{{count} possible improvements}}",
+    "@product_improvements_count": {
+        "description": "x possible improvements",
+        "placeholders": {
+            "count": {}
+        }
+    },
     "products_pasted": "products pasted",
     "@products_pasted": {},
     "no_prodcut_in_list": "There is no product in this list",

--- a/packages/smooth_app/lib/pages/product/product_page.dart
+++ b/packages/smooth_app/lib/pages/product/product_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
 import 'package:openfoodfacts/model/Attribute.dart';
 import 'package:openfoodfacts/model/AttributeGroup.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
@@ -20,6 +21,7 @@ import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/database/product_query.dart';
 import 'package:smooth_app/helpers/launch_url_helper.dart';
 import 'package:smooth_app/helpers/product_copy_helper.dart';
+import 'package:smooth_app/helpers/product_translation_helper.dart';
 import 'package:smooth_app/pages/product/common/product_dialog_helper.dart';
 import 'package:smooth_app/pages/product/common/product_query_page_helper.dart';
 import 'package:smooth_app/pages/product/new_product_page.dart';
@@ -77,6 +79,31 @@ class _ProductPageState extends State<ProductPage> {
     if (_first) {
       _first = false;
       _product = widget.product;
+      final Set<ProductImprovement> improvements =
+          _product.getProductImprovements();
+      if (improvements.isNotEmpty) {
+        Future<void>.delayed(
+          Duration.zero,
+          () => ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(
+                appLocalizations
+                    .product_improvements_count(improvements.length),
+              ),
+              action: SnackBarAction(
+                label: appLocalizations.showAll.toUpperCase(),
+                onPressed: () async {
+                  // TODO(monsieurtanuki): do something with the result
+                  await _getSelectedImprovement(
+                    appLocalizations,
+                    improvements,
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+      }
     }
     return Scaffold(
       appBar: AppBar(
@@ -525,4 +552,46 @@ class _ProductPageState extends State<ProductPage> {
 
   static String _capitalize(final String input) =>
       '${input.substring(0, 1).toUpperCase()}${input.substring(1)}';
+
+  Future<ProductImprovement?> _getSelectedImprovement(
+    final AppLocalizations appLocalizations,
+    final Set<ProductImprovement> improvements,
+  ) async =>
+      showCupertinoModalBottomSheet<ProductImprovement>(
+        context: context,
+        builder: (final BuildContext context) {
+          final ProductTranslationHelper helper =
+              ProductTranslationHelper(appLocalizations);
+          final List<Widget> children = <Widget>[];
+          // vaguely ordered
+          for (final ProductImprovement improvement
+              in ProductImprovement.values) {
+            if (improvements.contains(improvement)) {
+              children.add(
+                ListTile(
+                  leading: const Icon(Icons.arrow_forward),
+                  title: Text(helper.getImprovementTranslation(improvement)),
+                  onTap: () => Navigator.pop(context, improvement),
+                ),
+              );
+            }
+          }
+          children.add(
+            ListTile(
+              trailing: const Icon(Icons.close),
+              onTap: () => Navigator.pop(context),
+            ),
+          );
+          return Material(
+            child: SingleChildScrollView(
+              scrollDirection: Axis.vertical,
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.start,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: children,
+              ),
+            ),
+          );
+        },
+      );
 }


### PR DESCRIPTION
New file:
* `product_translation_helper.dart`: Translations around products

Impacted files:
* `app_en.arb`: added translations for all product improvements and the product improvement snackbar
* `product_page.dart`: added an init snackbar with the number of possible improvements and the list of improvements as action
* `product_query.dart`: added "states" to fetched field list, in order to get relevant product improvements

Beyond the mere translations, I added a snackbar in the "old" product page. That could definitely be removed, it was just a test.

![Simulator Screen Shot - iPhone 8 Plus - 2021-11-03 at 14 05 05](https://user-images.githubusercontent.com/11576431/140065146-d6590cb0-d0e2-4971-ab40-d6b941ccd9c9.png)

![Simulator Screen Shot - iPhone 8 Plus - 2021-11-03 at 14 05 59](https://user-images.githubusercontent.com/11576431/140065280-8db0da46-119a-4948-a9fe-a950ffebe708.png)


