### PR TITLE
fix: null crash in new product page with knowledge panels builder

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panels_builder.dart
+++ b/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panels_builder.dart
@@ -9,6 +9,12 @@ class KnowledgePanelsBuilder {
 
   List<Widget> build(KnowledgePanels knowledgePanels) {
     final List<Widget> rootPanelWidgets = <Widget>[];
+    if (knowledgePanels.panelIdToPanelMap['root'] == null) {
+      return rootPanelWidgets;
+    }
+    if (knowledgePanels.panelIdToPanelMap['root']!.elements == null) {
+      return rootPanelWidgets;
+    }
     for (final KnowledgePanelElement panelElement
         in knowledgePanels.panelIdToPanelMap['root']!.elements!) {
       if (panelElement.elementType != KnowledgePanelElementType.PANEL) {


### PR DESCRIPTION
I've just found a null crash on the new product page with product 7300400481588, in the knowledge panel side.
I don't know how normal it is to have `null` values in that case, but at least there's no crash anymore with that fix.