### PR TITLE
feat: #682 - add a "Clear all" menu item in the product history page

### DIFF
--- a/packages/smooth_app/lib/database/dao_product_list.dart
+++ b/packages/smooth_app/lib/database/dao_product_list.dart
@@ -352,6 +352,7 @@ class DaoProductList extends AbstractDao {
     return result;
   }
 
+  /// Removes a product list (it won't exist anymore) and unlinks all its items
   Future<void> delete(final ProductList productList) async {
     await localDatabase.database.transaction(
       (final Transaction transaction) async {
@@ -371,6 +372,19 @@ class DaoProductList extends AbstractDao {
       },
     );
   }
+
+  /// Clears a product list: unlinks all its items
+  Future<void> clear(final ProductList productList) async =>
+      localDatabase.database.transaction(
+        (final Transaction transaction) async {
+          final int? id = await _getId(productList, transaction);
+          await DaoProductExtra(localDatabase).clearList(
+            productList,
+            id,
+            transaction,
+          );
+        },
+      );
 
   Future<Map<int, Map<String, String>>> _getExtras({final int? listId}) async {
     final Map<int, Map<String, String>> result = <int, Map<String, String>>{};

--- a/packages/smooth_app/lib/pages/product/common/product_list_dialog_helper.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_dialog_helper.dart
@@ -46,6 +46,34 @@ class ProductListDialogHelper {
       ) ??
       false;
 
+  Future<bool> openClear(
+    final BuildContext context,
+    final DaoProductList daoProductList,
+    final ProductList productList,
+  ) async =>
+      await showDialog<bool>(
+        context: context,
+        builder: (BuildContext context) => SmoothAlertDialog(
+          close: false,
+          body: const Text(
+              'Do you really want to clear this list?'), // TODO(monsieurtanuki): translate
+          actions: <SmoothSimpleButton>[
+            SmoothSimpleButton(
+              text: AppLocalizations.of(context)!.no,
+              onPressed: () => Navigator.pop(context, false),
+            ),
+            SmoothSimpleButton(
+              text: AppLocalizations.of(context)!.yes,
+              onPressed: () async {
+                await daoProductList.clear(productList);
+                Navigator.pop(context, true);
+              },
+            ),
+          ],
+        ),
+      ) ??
+      false;
+
   Future<ProductList?> openNew(
     final BuildContext context,
     final DaoProductList daoProductList,

--- a/packages/smooth_app/lib/pages/product/common/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_page.dart
@@ -72,7 +72,7 @@ class _ProductListPageState extends State<ProductListPage> {
         deletable = true;
         renamable = true;
         reorderable = true;
-        dismissible = true;
+        dismissible = productList.barcodes.isNotEmpty;
         break;
       case ProductList.LIST_TYPE_HTTP_SEARCH_KEYWORDS:
       case ProductList.LIST_TYPE_HTTP_SEARCH_CATEGORY:
@@ -82,7 +82,7 @@ class _ProductListPageState extends State<ProductListPage> {
       case ProductList.LIST_TYPE_SCAN_HISTORY:
       case ProductList.LIST_TYPE_SCAN_SESSION:
       case ProductList.LIST_TYPE_HISTORY:
-        dismissible = true;
+        dismissible = productList.barcodes.isNotEmpty;
         break;
       default:
         throw Exception('unknown list type ${productList.listType}');
@@ -116,7 +116,7 @@ class _ProductListPageState extends State<ProductListPage> {
             ),
           ],
         ),
-        actions: (!renamable) && (!deletable)
+        actions: (!renamable) && (!deletable) && (!dismissible)
             ? null
             : <Widget>[
                 PopupMenuButton<String>(
@@ -128,11 +128,18 @@ class _ProductListPageState extends State<ProductListPage> {
                         child: Text(appLocalizations.rename),
                         enabled: true,
                       ),
-                    PopupMenuItem<String>(
-                      value: 'change',
-                      child: Text(appLocalizations.change_icon),
-                      enabled: true,
-                    ),
+                    if (renamable)
+                      PopupMenuItem<String>(
+                        value: 'change',
+                        child: Text(appLocalizations.change_icon),
+                        enabled: true,
+                      ),
+                    if (dismissible)
+                      const PopupMenuItem<String>(
+                        value: 'clear',
+                        child: Text('Clear'), // TODO(monsieurtanuki): translate
+                        enabled: true,
+                      ),
                     if (deletable)
                       PopupMenuItem<String>(
                         value: 'delete',
@@ -156,6 +163,12 @@ class _ProductListPageState extends State<ProductListPage> {
                         if (await ProductListDialogHelper.instance
                             .openDelete(context, daoProductList, productList)) {
                           Navigator.pop(context);
+                          localDatabase.notifyListeners();
+                        }
+                        break;
+                      case 'clear':
+                        if (await ProductListDialogHelper.instance
+                            .openClear(context, daoProductList, productList)) {
                           localDatabase.notifyListeners();
                         }
                         break;


### PR DESCRIPTION
Impacted files:
* `dao_product_list.dart`: added `clear` method
* `product_list_dialog_helper.dart`: added `openClear` method
* `product_list_page.dart`: added a "clear" menu item whenever relevant