### PR TITLE
fix: #684 - writing in white when in dark mode for score card

### DIFF
--- a/packages/smooth_app/lib/cards/data_cards/score_card.dart
+++ b/packages/smooth_app/lib/cards/data_cards/score_card.dart
@@ -33,7 +33,9 @@ class ScoreCard extends StatelessWidget {
         : SmoothTheme.ADDITIONAL_OPACITY_FOR_DARK;
     final Color backgroundColor =
         getBackgroundColor(cardEvaluation).withOpacity(opacity);
-    final Color textColor = getTextColor(cardEvaluation).withOpacity(opacity);
+    final Color textColor = themeData.brightness == Brightness.dark
+        ? Colors.white
+        : getTextColor(cardEvaluation).withOpacity(opacity);
     final SvgIconChip iconChip = SvgIconChip(iconUrl, height: iconHeight);
     return Container(
       margin: const EdgeInsets.symmetric(vertical: 8.0),


### PR DESCRIPTION
My assumption is that in dark mode we cannot really play with subtleties around colors, and writing in white on dark backgrounds should be at least the first choice, if not the only one.

Impacted file:
* `score_card.dart`

Night mode (did change):
![Simulator Screen Shot - iPhone 8 Plus - 2021-11-25 at 12 12 01](https://user-images.githubusercontent.com/11576431/143431313-28582dfd-9dfe-48d3-b0ef-f3564fb0236b.png)

Day mode (did not change): 
![Simulator Screen Shot - iPhone 8 Plus - 2021-11-25 at 12 06 09](https://user-images.githubusercontent.com/11576431/143431350-8c1fbea4-8fea-48a8-b2ed-1657ae56e5cb.png)
