### PR TITLE
fix: #687 - safer product list load

### DIFF
--- a/packages/smooth_app/lib/data_models/product_list.dart
+++ b/packages/smooth_app/lib/data_models/product_list.dart
@@ -305,9 +305,10 @@ class ProductList {
     _barcodes.clear();
     _products.clear();
     _productExtras.clear();
-    _barcodes.addAll(barcodes);
     _products.addAll(products);
     _productExtras.addAll(productExtras);
+    // Last step, because they have no meaning without the others being loaded
+    _barcodes.addAll(barcodes);
   }
 
   /// The init string value to be used when you add a product to a list


### PR DESCRIPTION
Not sure if it solves #687, that I could not reproduce.

Impacted file:
* `product_list.dart`: reordering the load of fields