### PR TITLE
Smart camera activation

### DIFF
--- a/packages/smooth_app/lib/data_models/continuous_scan_model.dart
+++ b/packages/smooth_app/lib/data_models/continuous_scan_model.dart
@@ -100,7 +100,7 @@ class ContinuousScanModel with ChangeNotifier {
   }
 
   //Used when navigating away from the QRView itself
-  void stopQRView() => _qrViewController?.stopCamera();
+  void pauseQRView() => _qrViewController?.pauseCamera();
 
   //Used when navigating back to the QRView
   void restartQRView() => _qrViewController?.resumeCamera();

--- a/packages/smooth_app/lib/data_models/continuous_scan_model.dart
+++ b/packages/smooth_app/lib/data_models/continuous_scan_model.dart
@@ -102,6 +102,9 @@ class ContinuousScanModel with ChangeNotifier {
   //Used when navigating away from the QRView itself
   void stopQRView() => _qrViewController?.stopCamera();
 
+  //Used when navigating back to the QRView
+  void restartQRView() => _qrViewController?.resumeCamera();
+
   Future<void> onScan(final Barcode barcode) async {
     if (barcode.code == null) {
       return;

--- a/packages/smooth_app/lib/data_models/continuous_scan_model.dart
+++ b/packages/smooth_app/lib/data_models/continuous_scan_model.dart
@@ -103,7 +103,7 @@ class ContinuousScanModel with ChangeNotifier {
   void pauseQRView() => _qrViewController?.pauseCamera();
 
   //Used when navigating back to the QRView
-  void restartQRView() => _qrViewController?.resumeCamera();
+  void resumeQRView() => _qrViewController?.resumeCamera();
 
   Future<void> onScan(final Barcode barcode) async {
     if (barcode.code == null) {

--- a/packages/smooth_app/lib/pages/page_manager.dart
+++ b/packages/smooth_app/lib/pages/page_manager.dart
@@ -102,9 +102,9 @@ class PageManagerState extends State<PageManager> {
     //If is ScanTab check if it is currently offstage or not to decide whether the camera should be active or not
     if (tabItem == BottomNavigationTab.Scan) {
       if (offstage) {
-        ScanPageState.continuousScanModel?.pauseQRView();
+        ScanPageState.pauseCamera();
       } else {
-        ScanPageState.continuousScanModel?.restartQRView();
+        ScanPageState.resumeCamera();
       }
     }
     return Offstage(

--- a/packages/smooth_app/lib/pages/page_manager.dart
+++ b/packages/smooth_app/lib/pages/page_manager.dart
@@ -99,6 +99,7 @@ class PageManagerState extends State<PageManager> {
 
   Widget _buildOffstageNavigator(BottomNavigationTab tabItem) {
     final bool offstage = _currentPage != tabItem;
+    //If is ScanTab check if it is currently offstage or not to decide whether the camera should be active or not
     if (tabItem == BottomNavigationTab.Scan) {
       if (offstage) {
         ScanPageState.continuousScanModel?.pauseQRView();

--- a/packages/smooth_app/lib/pages/page_manager.dart
+++ b/packages/smooth_app/lib/pages/page_manager.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:smooth_app/pages/scan/scan_page.dart';
 import 'package:smooth_app/widgets/tab_navigator.dart';
 
 enum BottomNavigationTab {
@@ -98,6 +99,13 @@ class PageManagerState extends State<PageManager> {
 
   Widget _buildOffstageNavigator(BottomNavigationTab tabItem) {
     final bool offstage = _currentPage != tabItem;
+    if (tabItem == BottomNavigationTab.Scan) {
+      if (offstage) {
+        ScanPageState.continuousScanModel?.pauseQRView();
+      } else {
+        ScanPageState.continuousScanModel?.restartQRView();
+      }
+    }
     return Offstage(
       offstage: offstage,
       child: TabNavigator(

--- a/packages/smooth_app/lib/pages/scan/scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/scan_page.dart
@@ -43,30 +43,23 @@ class _ScanPageState extends State<ScanPage> {
       return const Center(child: CircularProgressIndicator());
     }
 
+    //Don't build Scanner (+activate camera) when not on the Scan Tab
+    if (widget.offstage) {
+      _model?.stopQRView();
+    } else {
+      _model?.restartQRView();
+    }
+
     return ChangeNotifierProvider<ContinuousScanModel>(
       create: (BuildContext context) => _model!,
       child: Navigator(
         key: widget.navigatorKey,
         onGenerateRoute: (RouteSettings routeSettings) {
           return MaterialPageRoute<dynamic>(
-            builder: (BuildContext context) => _buildChild(),
+            builder: (BuildContext context) => const ContinuousScanPage(),
           );
         },
       ),
     );
-  }
-
-  //This has to be build inside of the ChangeNotifierProvider to prevent the model to be disposed.
-  Widget _buildChild() {
-    //Don't build Scanner (+activate camera) when not on the Scan Tab
-    if (widget.offstage) {
-      _model?.stopQRView();
-      return const Center(
-          child: Text(
-        "This shouldn't be visible since only build when offstage, when you see this page send a email to contact@openfoodfacts.org",
-      ));
-    } else {
-      return const ContinuousScanPage();
-    }
   }
 }

--- a/packages/smooth_app/lib/pages/scan/scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/scan_page.dart
@@ -13,7 +13,7 @@ class ScanPage extends StatefulWidget {
 }
 
 class ScanPageState extends State<ScanPage> {
-  static ContinuousScanModel? continuousScanModel;
+  static ContinuousScanModel? _model;
 
   @override
   void didChangeDependencies() {
@@ -21,27 +21,35 @@ class ScanPageState extends State<ScanPage> {
     _updateModel();
   }
 
+  static void pauseCamera() {
+    _model?.pauseQRView();
+  }
+
+  static void resumeCamera() {
+    _model?.resumeQRView();
+  }
+
   Future<void> _updateModel() async {
     final LocalDatabase localDatabase = context.watch<LocalDatabase>();
-    if (continuousScanModel == null) {
-      continuousScanModel = await ContinuousScanModel(
+    if (_model == null) {
+      _model = await ContinuousScanModel(
         languageCode: ProductQuery.getCurrentLanguageCode(context),
         countryCode: ProductQuery.getCurrentCountryCode(),
       ).load(localDatabase);
     } else {
-      await continuousScanModel?.refresh();
+      await _model?.refresh();
     }
     setState(() {});
   }
 
   @override
   Widget build(BuildContext context) {
-    if (continuousScanModel == null) {
+    if (_model == null) {
       return const Center(child: CircularProgressIndicator());
     }
 
     return ChangeNotifierProvider<ContinuousScanModel>(
-      create: (BuildContext context) => continuousScanModel!,
+      create: (BuildContext context) => _model!,
       child: const ContinuousScanPage(),
     );
   }

--- a/packages/smooth_app/lib/pages/scan/scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/scan_page.dart
@@ -6,17 +6,14 @@ import 'package:smooth_app/database/product_query.dart';
 import 'package:smooth_app/pages/scan/continuous_scan_page.dart';
 
 class ScanPage extends StatefulWidget {
-  const ScanPage({required this.offstage, required this.navigatorKey});
-
-  final bool offstage;
-  final GlobalKey<NavigatorState> navigatorKey;
+  const ScanPage();
 
   @override
-  State<ScanPage> createState() => _ScanPageState();
+  State<ScanPage> createState() => ScanPageState();
 }
 
-class _ScanPageState extends State<ScanPage> {
-  ContinuousScanModel? _model;
+class ScanPageState extends State<ScanPage> {
+  static ContinuousScanModel? continuousScanModel;
 
   @override
   void didChangeDependencies() {
@@ -26,40 +23,26 @@ class _ScanPageState extends State<ScanPage> {
 
   Future<void> _updateModel() async {
     final LocalDatabase localDatabase = context.watch<LocalDatabase>();
-    if (_model == null) {
-      _model = await ContinuousScanModel(
+    if (continuousScanModel == null) {
+      continuousScanModel = await ContinuousScanModel(
         languageCode: ProductQuery.getCurrentLanguageCode(context),
         countryCode: ProductQuery.getCurrentCountryCode(),
       ).load(localDatabase);
     } else {
-      await _model?.refresh();
+      await continuousScanModel?.refresh();
     }
     setState(() {});
   }
 
   @override
   Widget build(BuildContext context) {
-    if (_model == null) {
+    if (continuousScanModel == null) {
       return const Center(child: CircularProgressIndicator());
     }
 
-    //Don't build Scanner (+activate camera) when not on the Scan Tab
-    if (widget.offstage) {
-      _model?.stopQRView();
-    } else {
-      _model?.restartQRView();
-    }
-
     return ChangeNotifierProvider<ContinuousScanModel>(
-      create: (BuildContext context) => _model!,
-      child: Navigator(
-        key: widget.navigatorKey,
-        onGenerateRoute: (RouteSettings routeSettings) {
-          return MaterialPageRoute<dynamic>(
-            builder: (BuildContext context) => const ContinuousScanPage(),
-          );
-        },
-      ),
+      create: (BuildContext context) => continuousScanModel!,
+      child: const ContinuousScanPage(),
     );
   }
 }

--- a/packages/smooth_app/lib/widgets/tab_navigator.dart
+++ b/packages/smooth_app/lib/widgets/tab_navigator.dart
@@ -16,14 +16,18 @@ class TabNavigator extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    late final Widget child;
+    final Widget child;
 
-    if (tabItem == BottomNavigationTab.Profile) {
-      child = const UserPreferencesPage();
-    } else if (tabItem == BottomNavigationTab.History) {
-      child = const HistoryPage();
-    } else if (tabItem == BottomNavigationTab.Scan) {
-      child = const ScanPage();
+    switch (tabItem) {
+      case BottomNavigationTab.Profile:
+        child = const UserPreferencesPage();
+        break;
+      case BottomNavigationTab.History:
+        child = const HistoryPage();
+        break;
+      case BottomNavigationTab.Scan:
+        child = const ScanPage();
+        break;
     }
 
     return Navigator(

--- a/packages/smooth_app/lib/widgets/tab_navigator.dart
+++ b/packages/smooth_app/lib/widgets/tab_navigator.dart
@@ -23,8 +23,7 @@ class TabNavigator extends StatelessWidget {
     } else if (tabItem == BottomNavigationTab.History) {
       child = const HistoryPage();
     } else if (tabItem == BottomNavigationTab.Scan) {
-      // The ScanPage doesn't use the here build Navigator, so that it can update when its offstage status changes
-      return ScanPage(offstage: offstage, navigatorKey: navigatorKey);
+      child = const ScanPage();
     }
 
     return Navigator(


### PR DESCRIPTION
Follow up PR for #703

With this PR, the ScanTab is now also kept stateful and not rebuild to an empty container every time you switch to another tab.
Additionally, the way the tabs are managed now is more consistent