### PR TITLE
fix: #754 - display localized description for nova score

### DIFF
--- a/packages/smooth_app/lib/helpers/attributes_card_helper.dart
+++ b/packages/smooth_app/lib/helpers/attributes_card_helper.dart
@@ -65,11 +65,8 @@ String? getDisplayTitle(final Attribute attribute) {
   return _getNovaDisplayTitle(attribute);
 }
 
-String? _getNovaDisplayTitle(final Attribute attribute) {
-  // Note: This method is temporary, this field will come from Backend and it will be internationalized.
-  return _attributeMatchComparison(attribute, null, 'Ultra processed',
-      'Highly processed', 'Processed', 'Slightly processed', 'Unprocessed');
-}
+String? _getNovaDisplayTitle(final Attribute attribute) =>
+    attribute.descriptionShort;
 
 /// Compares the match score from [attribute] with various thresholds and returns appropriate result.
 T _attributeMatchComparison<T>(


### PR DESCRIPTION
Impacted file:
* `attributes_card_helper.dart` - for nova, now using an attribute field instead of a list of terms in English

![Simulator Screen Shot - iPhone 8 Plus - 2021-12-26 at 18 54 12](https://user-images.githubusercontent.com/11576431/147416260-18e09405-23ff-414c-8ca9-a354c5d74cc4.png)

