### PR TITLE
feature/#782 - now using the onboarding's country for searches

### DIFF
--- a/packages/smooth_app/lib/cards/data_cards/image_upload_card.dart
+++ b/packages/smooth_app/lib/cards/data_cards/image_upload_card.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:image_cropper/image_cropper.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/database/product_query.dart';
 import 'package:smooth_app/pages/product/product_image_page.dart';
 
 class ImageUploadCard extends StatefulWidget {
@@ -54,8 +55,7 @@ class _ImageUploadCardState extends State<ImageUploadCard> {
         });
 
         final SendImage image = SendImage(
-          lang: LanguageHelper.fromJson(
-              Localizations.localeOf(context).languageCode),
+          lang: ProductQuery.getLanguage(),
           barcode: widget.product
               .barcode!, //Probably throws an error, but this is not a big problem when we got a product without a barcode
           imageField: widget.imageField,

--- a/packages/smooth_app/lib/data_models/continuous_scan_model.dart
+++ b/packages/smooth_app/lib/data_models/continuous_scan_model.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:openfoodfacts/model/Product.dart';
-import 'package:openfoodfacts/utils/CountryHelper.dart';
-import 'package:openfoodfacts/utils/LanguageHelper.dart';
 import 'package:qr_code_scanner/qr_code_scanner.dart';
 import 'package:smooth_app/data_models/fetched_product.dart';
 import 'package:smooth_app/data_models/product_list.dart';
@@ -21,10 +19,7 @@ enum ScannedProductState {
 }
 
 class ContinuousScanModel with ChangeNotifier {
-  ContinuousScanModel({
-    required this.country,
-    required this.language,
-  });
+  ContinuousScanModel();
 
   final Map<String, ScannedProductState> _states =
       <String, ScannedProductState>{};
@@ -36,8 +31,6 @@ class ContinuousScanModel with ChangeNotifier {
   String? _barcodeTrustCheck; // TODO(monsieurtanuki): could probably be removed
   late DaoProduct _daoProduct;
   late DaoProductList _daoProductList;
-  final OpenFoodFactsLanguage? language;
-  final OpenFoodFactsCountry? country;
 
   QRViewController? _qrViewController;
 
@@ -167,8 +160,6 @@ class ContinuousScanModel with ChangeNotifier {
   ) async =>
       BarcodeProductQuery(
         barcode: barcode,
-        language: language,
-        country: country,
         daoProduct: _daoProduct,
       ).getFetchedProduct();
 

--- a/packages/smooth_app/lib/data_models/user_preferences.dart
+++ b/packages/smooth_app/lib/data_models/user_preferences.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/personalized_search/preference_importance.dart';
+import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:smooth_app/data_models/product_preferences.dart';
+import 'package:smooth_app/database/product_query.dart';
 import 'package:smooth_app/pages/onboarding/onboarding_flow_navigator.dart';
 
 class UserPreferences extends ChangeNotifier {
@@ -64,8 +66,9 @@ class UserPreferences extends ChangeNotifier {
   Future<void> setUserCountry(final String countryCode) async =>
       _sharedPreferences.setString(_TAG_USER_COUNTRY_CODE, countryCode);
 
-  String? get userCountry =>
-      _sharedPreferences.getString(_TAG_USER_COUNTRY_CODE);
+  OpenFoodFactsCountry? get userCountry => ProductQuery.getCountry(
+        _sharedPreferences.getString(_TAG_USER_COUNTRY_CODE),
+      );
 
   Future<void> setLastVisitedOnboardingPage(final OnboardingPage page) async =>
       _sharedPreferences.setInt(_TAG_LAST_VISITED_ONBOARDING_PAGE, page.index);

--- a/packages/smooth_app/lib/data_models/user_preferences.dart
+++ b/packages/smooth_app/lib/data_models/user_preferences.dart
@@ -1,9 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/personalized_search/preference_importance.dart';
-import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:smooth_app/data_models/product_preferences.dart';
-import 'package:smooth_app/database/product_query.dart';
 import 'package:smooth_app/pages/onboarding/onboarding_flow_navigator.dart';
 
 class UserPreferences extends ChangeNotifier {
@@ -66,9 +64,8 @@ class UserPreferences extends ChangeNotifier {
   Future<void> setUserCountry(final String countryCode) async =>
       _sharedPreferences.setString(_TAG_USER_COUNTRY_CODE, countryCode);
 
-  OpenFoodFactsCountry? get userCountry => ProductQuery.getCountry(
-        _sharedPreferences.getString(_TAG_USER_COUNTRY_CODE),
-      );
+  String? get userCountryCode =>
+      _sharedPreferences.getString(_TAG_USER_COUNTRY_CODE);
 
   Future<void> setLastVisitedOnboardingPage(final OnboardingPage page) async =>
       _sharedPreferences.setInt(_TAG_LAST_VISITED_ONBOARDING_PAGE, page.index);

--- a/packages/smooth_app/lib/database/barcode_product_query.dart
+++ b/packages/smooth_app/lib/database/barcode_product_query.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:openfoodfacts/openfoodfacts.dart';
-import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:smooth_app/data_models/fetched_product.dart';
 import 'package:smooth_app/database/dao_product.dart';
 import 'package:smooth_app/database/product_query.dart';
@@ -9,22 +8,18 @@ import 'package:smooth_app/database/product_query.dart';
 class BarcodeProductQuery {
   BarcodeProductQuery({
     required this.barcode,
-    required this.language,
-    required this.country,
     required this.daoProduct,
   });
 
   final String barcode;
-  final OpenFoodFactsLanguage? language;
-  final OpenFoodFactsCountry? country;
   final DaoProduct daoProduct;
 
   Future<FetchedProduct> getFetchedProduct() async {
     final ProductQueryConfiguration configuration = ProductQueryConfiguration(
       barcode,
       fields: ProductQuery.fields,
-      language: language,
-      country: country,
+      language: ProductQuery.getLanguage(),
+      country: ProductQuery.getCountry(),
     );
 
     final ProductResult result;

--- a/packages/smooth_app/lib/database/keywords_product_query.dart
+++ b/packages/smooth_app/lib/database/keywords_product_query.dart
@@ -1,21 +1,16 @@
 import 'dart:async';
 import 'package:openfoodfacts/model/parameter/SearchTerms.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
-import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:smooth_app/data_models/product_list.dart';
 import 'package:smooth_app/database/product_query.dart';
 
 class KeywordsProductQuery implements ProductQuery {
   KeywordsProductQuery({
     required this.keywords,
-    required this.language,
-    required this.country,
     required this.size,
   });
 
   final String keywords;
-  final OpenFoodFactsLanguage? language;
-  final OpenFoodFactsCountry? country;
   final int size;
 
   @override
@@ -28,8 +23,8 @@ class KeywordsProductQuery implements ProductQuery {
             PageSize(size: size),
             SearchTerms(terms: <String>[keywords]),
           ],
-          language: language,
-          country: country,
+          language: ProductQuery.getLanguage(),
+          country: ProductQuery.getCountry(),
         ),
       );
 
@@ -37,10 +32,5 @@ class KeywordsProductQuery implements ProductQuery {
   ProductList getProductList() => ProductList.keywordSearch(keywords);
 
   @override
-  String toString() => 'KeywordsProductQuery('
-      '"$keywords"'
-      ', $language'
-      ', $country'
-      ', $size'
-      ')';
+  String toString() => 'KeywordsProductQuery("$keywords", $size)';
 }

--- a/packages/smooth_app/lib/database/knowledge_panels_query.dart
+++ b/packages/smooth_app/lib/database/knowledge_panels_query.dart
@@ -2,25 +2,21 @@ import 'dart:async';
 
 import 'package:openfoodfacts/model/KnowledgePanels.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
-import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:openfoodfacts/utils/QueryType.dart';
+import 'package:smooth_app/database/product_query.dart';
 
 class KnowledgePanelsQuery {
   KnowledgePanelsQuery({
     required this.barcode,
-    required this.country,
-    required this.language,
   });
 
   final String barcode;
-  final OpenFoodFactsCountry? country;
-  final OpenFoodFactsLanguage? language;
 
   Future<KnowledgePanels> getKnowledgePanels() async {
     final ProductQueryConfiguration configuration = ProductQueryConfiguration(
       barcode,
-      language: language,
-      country: country,
+      language: ProductQuery.getLanguage(),
+      country: ProductQuery.getCountry(),
     );
     return OpenFoodAPIClient.getKnowledgePanels(configuration, QueryType.PROD);
   }

--- a/packages/smooth_app/lib/database/knowledge_panels_query.dart
+++ b/packages/smooth_app/lib/database/knowledge_panels_query.dart
@@ -1,23 +1,26 @@
 import 'dart:async';
 
-import 'package:flutter/cupertino.dart';
 import 'package:openfoodfacts/model/KnowledgePanels.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:openfoodfacts/utils/QueryType.dart';
-import 'package:smooth_app/database/product_query.dart';
 
 class KnowledgePanelsQuery {
   KnowledgePanelsQuery({
     required this.barcode,
+    required this.country,
+    required this.language,
   });
 
   final String barcode;
+  final OpenFoodFactsCountry? country;
+  final OpenFoodFactsLanguage? language;
 
-  Future<KnowledgePanels> getKnowledgePanels(BuildContext context) async {
+  Future<KnowledgePanels> getKnowledgePanels() async {
     final ProductQueryConfiguration configuration = ProductQueryConfiguration(
       barcode,
-      language: ProductQuery.getCurrentLanguage(context),
-      country: ProductQuery.getCurrentCountry(),
+      language: language,
+      country: country,
     );
     return OpenFoodAPIClient.getKnowledgePanels(configuration, QueryType.PROD);
   }

--- a/packages/smooth_app/lib/database/product_query.dart
+++ b/packages/smooth_app/lib/database/product_query.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/utils/CountryHelper.dart';
@@ -13,11 +11,8 @@ abstract class ProductQuery {
           final BuildContext context) =>
       LanguageHelper.fromJson(_getCurrentLanguageCode(context));
 
-  /// Returns the country code from the environment - uppercase or empty string
-  static String _getCurrentCountryCode() => window.locale.countryCode ?? '';
-
-  static OpenFoodFactsCountry? getCurrentCountry() =>
-      CountryHelper.fromJson(_getCurrentCountryCode().toLowerCase());
+  static OpenFoodFactsCountry? getCountry(final String? isoCode) =>
+      CountryHelper.fromJson(isoCode?.toLowerCase());
 
   static const User SMOOTH_USER = User(
     userId: 'project-smoothie',

--- a/packages/smooth_app/lib/database/product_query.dart
+++ b/packages/smooth_app/lib/database/product_query.dart
@@ -1,18 +1,35 @@
-import 'package:flutter/material.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/utils/CountryHelper.dart';
+import 'package:openfoodfacts/utils/OpenFoodAPIConfiguration.dart';
 import 'package:smooth_app/data_models/product_list.dart';
 
 abstract class ProductQuery {
-  static String _getCurrentLanguageCode(final BuildContext context) =>
-      Localizations.localeOf(context).languageCode;
+  /// Returns the global language for API queries.
+  static OpenFoodFactsLanguage? getLanguage() {
+    final List<OpenFoodFactsLanguage> languages =
+        OpenFoodAPIConfiguration.globalLanguages ?? <OpenFoodFactsLanguage>[];
+    if (languages.isEmpty) {
+      return null;
+    }
+    return languages[0];
+  }
 
-  static OpenFoodFactsLanguage? getCurrentLanguage(
-          final BuildContext context) =>
-      LanguageHelper.fromJson(_getCurrentLanguageCode(context));
+  /// Sets the global language for API queries.
+  static void setLanguage(final String languageCode) {
+    final OpenFoodFactsLanguage language =
+        LanguageHelper.fromJson(languageCode);
+    OpenFoodAPIConfiguration.globalLanguages = <OpenFoodFactsLanguage>[
+      language,
+    ];
+  }
 
-  static OpenFoodFactsCountry? getCountry(final String? isoCode) =>
-      CountryHelper.fromJson(isoCode);
+  /// Returns the global country for API queries?
+  static OpenFoodFactsCountry? getCountry() =>
+      OpenFoodAPIConfiguration.globalCountry;
+
+  /// Sets the global country for API queries.
+  static void setCountry(final String? isoCode) =>
+      OpenFoodAPIConfiguration.globalCountry = CountryHelper.fromJson(isoCode);
 
   static const User SMOOTH_USER = User(
     userId: 'project-smoothie',

--- a/packages/smooth_app/lib/database/product_query.dart
+++ b/packages/smooth_app/lib/database/product_query.dart
@@ -12,7 +12,7 @@ abstract class ProductQuery {
       LanguageHelper.fromJson(_getCurrentLanguageCode(context));
 
   static OpenFoodFactsCountry? getCountry(final String? isoCode) =>
-      CountryHelper.fromJson(isoCode?.toLowerCase());
+      CountryHelper.fromJson(isoCode);
 
   static const User SMOOTH_USER = User(
     userId: 'project-smoothie',

--- a/packages/smooth_app/lib/main.dart
+++ b/packages/smooth_app/lib/main.dart
@@ -11,6 +11,7 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:smooth_app/data_models/product_preferences.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/database/local_database.dart';
+import 'package:smooth_app/database/product_query.dart';
 import 'package:smooth_app/pages/onboarding/onboarding_flow_navigator.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
 import 'package:smooth_app/themes/theme_provider.dart';
@@ -81,6 +82,7 @@ class _SmoothAppState extends State<SmoothApp> {
     await _productPreferences
         .loadReferenceFromAssets(DefaultAssetBundle.of(context));
     await _userPreferences.init(_productPreferences);
+    ProductQuery.setCountry(_userPreferences.userCountryCode);
     _localDatabase = await LocalDatabase.getLocalDatabase();
     _themeProvider = ThemeProvider(_userPreferences);
   }
@@ -173,6 +175,7 @@ class SmoothAppGetLanguage extends StatelessWidget {
         context.watch<ProductPreferences>();
     final Locale myLocale = Localizations.localeOf(context);
     final String languageCode = myLocale.languageCode;
+    ProductQuery.setLanguage(languageCode);
     _refresh(
       productPreferences,
       DefaultAssetBundle.of(context),

--- a/packages/smooth_app/lib/pages/onboarding/country_selector.dart
+++ b/packages/smooth_app/lib/pages/onboarding/country_selector.dart
@@ -133,7 +133,7 @@ class _CountrySelectorState extends State<CountrySelector> {
     countries
         .sort((final Country a, final Country b) => a.name.compareTo(b.name));
     final String? mostLikelyUserCountryCode =
-        WidgetsBinding.instance?.window.locale.countryCode;
+        WidgetsBinding.instance?.window.locale.countryCode?.toLowerCase();
     if (mostLikelyUserCountryCode == null) {
       return countries;
     }

--- a/packages/smooth_app/lib/pages/onboarding/country_selector.dart
+++ b/packages/smooth_app/lib/pages/onboarding/country_selector.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:iso_countries/iso_countries.dart';
 import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
+import 'package:smooth_app/database/product_query.dart';
 import 'package:smooth_ui_library/util/ui_helpers.dart';
 
 /// A selector for selecting user's country.
@@ -31,7 +32,12 @@ class _CountrySelectorState extends State<CountrySelector> {
     _userPreferences = await UserPreferences.getUserPreferences();
     _countryList = _sanitizeCountriesList(localizedCountries);
     _chosenValue = _countryList[0];
-    _userPreferences.setUserCountry(_chosenValue.countryCode);
+    _setUserCountry(_chosenValue.countryCode);
+  }
+
+  Future<void> _setUserCountry(final String countryCode) async {
+    await _userPreferences.setUserCountry(_chosenValue.countryCode);
+    ProductQuery.setCountry(_userPreferences.userCountryCode);
   }
 
   @override
@@ -68,10 +74,10 @@ class _CountrySelectorState extends State<CountrySelector> {
                 );
               }).toList(),
               onChanged: (Country? value) {
-                setState(() {
+                setState(() async {
                   if (value != null) {
                     _chosenValue = value;
-                    _userPreferences.setUserCountry(_chosenValue.countryCode);
+                    await _setUserCountry(_chosenValue.countryCode);
                   }
                 });
               },

--- a/packages/smooth_app/lib/pages/product/common/product_dialog_helper.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_dialog_helper.dart
@@ -1,11 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/model/Product.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:smooth_app/data_models/fetched_product.dart';
 import 'package:smooth_app/database/barcode_product_query.dart';
 import 'package:smooth_app/database/dao_product.dart';
 import 'package:smooth_app/database/local_database.dart';
-import 'package:smooth_app/database/product_query.dart';
 import 'package:smooth_ui_library/buttons/smooth_simple_button.dart';
 import 'package:smooth_ui_library/dialogs/smooth_alert_dialog.dart';
 
@@ -16,12 +17,16 @@ class ProductDialogHelper {
     required this.context,
     required this.localDatabase,
     required this.refresh,
+    required this.country,
+    required this.language,
   });
 
   final String barcode;
   final BuildContext context;
   final LocalDatabase localDatabase;
   final bool refresh;
+  final OpenFoodFactsCountry? country;
+  final OpenFoodFactsLanguage? language;
   bool _popEd = false;
 
   Future<FetchedProduct> openBestChoice() async {
@@ -38,8 +43,8 @@ class ProductDialogHelper {
       builder: (BuildContext context) {
         BarcodeProductQuery(
           barcode: barcode,
-          language: ProductQuery.getCurrentLanguage(context),
-          country: ProductQuery.getCurrentCountry(),
+          language: language,
+          country: country,
           daoProduct: DaoProduct(localDatabase),
         ).getFetchedProduct().then<void>(
               (final FetchedProduct value) => _popSearchingDialog(value),

--- a/packages/smooth_app/lib/pages/product/common/product_dialog_helper.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_dialog_helper.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:openfoodfacts/model/Product.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:smooth_app/data_models/fetched_product.dart';

--- a/packages/smooth_app/lib/pages/product/common/product_dialog_helper.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_dialog_helper.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
-import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:smooth_app/data_models/fetched_product.dart';
 import 'package:smooth_app/database/barcode_product_query.dart';
 import 'package:smooth_app/database/dao_product.dart';
@@ -16,16 +15,12 @@ class ProductDialogHelper {
     required this.context,
     required this.localDatabase,
     required this.refresh,
-    required this.country,
-    required this.language,
   });
 
   final String barcode;
   final BuildContext context;
   final LocalDatabase localDatabase;
   final bool refresh;
-  final OpenFoodFactsCountry? country;
-  final OpenFoodFactsLanguage? language;
   bool _popEd = false;
 
   Future<FetchedProduct> openBestChoice() async {
@@ -42,8 +37,6 @@ class ProductDialogHelper {
       builder: (BuildContext context) {
         BarcodeProductQuery(
           barcode: barcode,
-          language: language,
-          country: country,
           daoProduct: DaoProduct(localDatabase),
         ).getFetchedProduct().then<void>(
               (final FetchedProduct value) => _popSearchingDialog(value),

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -2,18 +2,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/model/KnowledgePanels.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
-import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/cards/data_cards/image_upload_card.dart';
 import 'package:smooth_app/cards/product_cards/knowledge_panels/knowledge_panels_builder.dart';
 import 'package:smooth_app/data_models/fetched_product.dart';
 import 'package:smooth_app/data_models/product_list.dart';
 import 'package:smooth_app/data_models/product_preferences.dart';
-import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/database/dao_product_list.dart';
 import 'package:smooth_app/database/knowledge_panels_query.dart';
 import 'package:smooth_app/database/local_database.dart';
-import 'package:smooth_app/database/product_query.dart';
 import 'package:smooth_app/helpers/launch_url_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/pages/product/common/product_dialog_helper.dart';
@@ -36,8 +33,6 @@ enum ProductPageMenuItem { WEB, REFRESH }
 class _ProductPageState extends State<ProductPage> {
   late Product _product;
   late ProductPreferences _productPreferences;
-  late OpenFoodFactsCountry? _country;
-  late OpenFoodFactsLanguage? _language;
 
   @override
   void initState() {
@@ -51,9 +46,6 @@ class _ProductPageState extends State<ProductPage> {
     // All watchers defined here:
     _productPreferences = context.watch<ProductPreferences>();
     final ThemeProvider themeProvider = context.watch<ThemeProvider>();
-    final UserPreferences userPreferences = context.watch<UserPreferences>();
-    _country = userPreferences.userCountry;
-    _language = ProductQuery.getCurrentLanguage(context);
     final AppLocalizations appLocalizations = AppLocalizations.of(context)!;
     final ThemeData themeData = Theme.of(context);
     final ColorScheme colorScheme = themeData.colorScheme;
@@ -107,8 +99,6 @@ class _ProductPageState extends State<ProductPage> {
       context: context,
       localDatabase: localDatabase,
       refresh: true,
-      language: _language,
-      country: _country,
     );
     final FetchedProduct fetchedProduct =
         await productDialogHelper.openUniqueProductSearch();
@@ -209,8 +199,6 @@ class _ProductPageState extends State<ProductPage> {
     // TODO(jasmeet): Avoid additional requests on rebuilds.
     final Future<KnowledgePanels> knowledgePanels = KnowledgePanelsQuery(
       barcode: _product.barcode!,
-      country: _country,
-      language: _language,
     ).getKnowledgePanels();
     return FutureBuilder<KnowledgePanels>(
         future: knowledgePanels,

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -2,15 +2,18 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/model/KnowledgePanels.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/cards/data_cards/image_upload_card.dart';
 import 'package:smooth_app/cards/product_cards/knowledge_panels/knowledge_panels_builder.dart';
 import 'package:smooth_app/data_models/fetched_product.dart';
 import 'package:smooth_app/data_models/product_list.dart';
 import 'package:smooth_app/data_models/product_preferences.dart';
+import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/database/dao_product_list.dart';
 import 'package:smooth_app/database/knowledge_panels_query.dart';
 import 'package:smooth_app/database/local_database.dart';
+import 'package:smooth_app/database/product_query.dart';
 import 'package:smooth_app/helpers/launch_url_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/pages/product/common/product_dialog_helper.dart';
@@ -33,6 +36,8 @@ enum ProductPageMenuItem { WEB, REFRESH }
 class _ProductPageState extends State<ProductPage> {
   late Product _product;
   late ProductPreferences _productPreferences;
+  late OpenFoodFactsCountry? _country;
+  late OpenFoodFactsLanguage? _language;
 
   @override
   void initState() {
@@ -46,7 +51,9 @@ class _ProductPageState extends State<ProductPage> {
     // All watchers defined here:
     _productPreferences = context.watch<ProductPreferences>();
     final ThemeProvider themeProvider = context.watch<ThemeProvider>();
-
+    final UserPreferences userPreferences = context.watch<UserPreferences>();
+    _country = userPreferences.userCountry;
+    _language = ProductQuery.getCurrentLanguage(context);
     final AppLocalizations appLocalizations = AppLocalizations.of(context)!;
     final ThemeData themeData = Theme.of(context);
     final ColorScheme colorScheme = themeData.colorScheme;
@@ -100,6 +107,8 @@ class _ProductPageState extends State<ProductPage> {
       context: context,
       localDatabase: localDatabase,
       refresh: true,
+      language: _language,
+      country: _country,
     );
     final FetchedProduct fetchedProduct =
         await productDialogHelper.openUniqueProductSearch();
@@ -198,9 +207,11 @@ class _ProductPageState extends State<ProductPage> {
   FutureBuilder<KnowledgePanels> _buildKnowledgePanelCards() {
     // Note that this will make a new request on every rebuild.
     // TODO(jasmeet): Avoid additional requests on rebuilds.
-    final Future<KnowledgePanels> knowledgePanels =
-        KnowledgePanelsQuery(barcode: _product.barcode!)
-            .getKnowledgePanels(context);
+    final Future<KnowledgePanels> knowledgePanels = KnowledgePanelsQuery(
+      barcode: _product.barcode!,
+      country: _country,
+      language: _language,
+    ).getKnowledgePanels();
     return FutureBuilder<KnowledgePanels>(
         future: knowledgePanels,
         builder:

--- a/packages/smooth_app/lib/pages/scan/scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/scan_page.dart
@@ -1,9 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/continuous_scan_model.dart';
-import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/database/local_database.dart';
-import 'package:smooth_app/database/product_query.dart';
 import 'package:smooth_app/pages/scan/continuous_scan_page.dart';
 
 class ScanPage extends StatefulWidget {
@@ -24,12 +22,8 @@ class _ScanPageState extends State<ScanPage> {
 
   Future<void> _updateModel() async {
     final LocalDatabase localDatabase = context.watch<LocalDatabase>();
-    final UserPreferences userPreferences = context.watch<UserPreferences>();
     if (_model == null) {
-      _model = await ContinuousScanModel(
-        language: ProductQuery.getCurrentLanguage(context),
-        country: userPreferences.userCountry,
-      ).load(localDatabase);
+      _model = await ContinuousScanModel().load(localDatabase);
     } else {
       await _model?.refresh();
     }

--- a/packages/smooth_app/lib/pages/scan/scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/scan_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/continuous_scan_model.dart';
+import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/database/product_query.dart';
 import 'package:smooth_app/pages/scan/continuous_scan_page.dart';
@@ -23,10 +24,11 @@ class _ScanPageState extends State<ScanPage> {
 
   Future<void> _updateModel() async {
     final LocalDatabase localDatabase = context.watch<LocalDatabase>();
+    final UserPreferences userPreferences = context.watch<UserPreferences>();
     if (_model == null) {
       _model = await ContinuousScanModel(
         language: ProductQuery.getCurrentLanguage(context),
-        country: ProductQuery.getCurrentCountry(),
+        country: userPreferences.userCountry,
       ).load(localDatabase);
     } else {
       await _model?.refresh();

--- a/packages/smooth_app/lib/pages/scan/search_page.dart
+++ b/packages/smooth_app/lib/pages/scan/search_page.dart
@@ -1,25 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:openfoodfacts/openfoodfacts.dart';
-import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/fetched_product.dart';
-import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/database/dao_string_list.dart';
 import 'package:smooth_app/database/keywords_product_query.dart';
 import 'package:smooth_app/database/local_database.dart';
-import 'package:smooth_app/database/product_query.dart';
 import 'package:smooth_app/pages/product/common/product_dialog_helper.dart';
 import 'package:smooth_app/pages/product/common/product_query_page_helper.dart';
 import 'package:smooth_app/pages/product/new_product_page.dart';
 import 'package:smooth_app/pages/scan/search_history_view.dart';
 
-void _performSearch(
-  BuildContext context,
-  String query,
-  final OpenFoodFactsCountry? country,
-  final OpenFoodFactsLanguage? language,
-) {
+void _performSearch(BuildContext context, String query) {
   if (query.trim().isEmpty) {
     return;
   }
@@ -30,16 +21,12 @@ void _performSearch(
       query,
       context,
       localDatabase,
-      country,
-      language,
     );
   } else {
     _onSubmittedText(
       query,
       context,
       localDatabase,
-      country,
-      language,
     );
   }
 }
@@ -49,16 +36,12 @@ Future<void> _onSubmittedBarcode(
   final String value,
   final BuildContext context,
   final LocalDatabase localDatabase,
-  final OpenFoodFactsCountry? country,
-  final OpenFoodFactsLanguage? language,
 ) async {
   final ProductDialogHelper productDialogHelper = ProductDialogHelper(
     barcode: value,
     context: context,
     localDatabase: localDatabase,
     refresh: false,
-    country: country,
-    language: language,
   );
   final FetchedProduct fetchedProduct =
       await productDialogHelper.openBestChoice();
@@ -79,27 +62,19 @@ Future<void> _onSubmittedText(
   final String value,
   final BuildContext context,
   final LocalDatabase localDatabase,
-  final OpenFoodFactsCountry? country,
-  final OpenFoodFactsLanguage? language,
 ) async =>
     ProductQueryPageHelper().openBestChoice(
       color: Colors.deepPurple,
       heroTag: 'search_bar',
       name: value,
       localDatabase: localDatabase,
-      productQuery: KeywordsProductQuery(
-        keywords: value,
-        language: language,
-        country: country,
-        size: 500,
-      ),
+      productQuery: KeywordsProductQuery(keywords: value, size: 500),
       context: context,
     );
 
 class SearchPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    final UserPreferences userPreferences = context.read<UserPreferences>();
     return Scaffold(
       appBar: AppBar(toolbarHeight: 0.0),
       body: Column(
@@ -110,12 +85,7 @@ class SearchPage extends StatelessWidget {
           ),
           Expanded(
             child: SearchHistoryView(
-              onTap: (String query) => _performSearch(
-                context,
-                query,
-                userPreferences.userCountry,
-                ProductQuery.getCurrentLanguage(context),
-              ),
+              onTap: (String query) => _performSearch(context, query),
             ),
           ),
         ],
@@ -165,18 +135,12 @@ class _SearchFieldState extends State<SearchField> {
     if (widget.autofocus) {
       _focusNode.requestFocus();
     }
-    final UserPreferences userPreferences = context.read<UserPreferences>();
     final AppLocalizations localizations = AppLocalizations.of(context)!;
     return TextField(
       textInputAction: TextInputAction.search,
       controller: _textController,
       focusNode: _focusNode,
-      onSubmitted: (String query) => _performSearch(
-        context,
-        query,
-        userPreferences.userCountry,
-        ProductQuery.getCurrentLanguage(context),
-      ),
+      onSubmitted: (String query) => _performSearch(context, query),
       decoration: InputDecoration(
         filled: true,
         border: OutlineInputBorder(

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -510,7 +510,7 @@ packages:
       name: openfoodfacts
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   package_config:
     dependency: transitive
     description:

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -314,7 +314,7 @@ packages:
       name: flutter_widget_from_html_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.3+1"
+    version: "0.8.4"
   fwfh_text_style:
     dependency: transitive
     description:
@@ -335,7 +335,7 @@ packages:
       name: hive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.4"
+    version: "2.0.5"
   hive_flutter:
     dependency: "direct main"
     description:
@@ -489,7 +489,7 @@ packages:
       name: mockito
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.16"
+    version: "5.0.17"
   modal_bottom_sheet:
     dependency: "direct main"
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   latlong2: ^0.8.1
   matomo: ^1.1.0
   modal_bottom_sheet: ^2.0.0
-  openfoodfacts: ^1.8.0
+  openfoodfacts: ^1.8.1
   # Uncomment those lines if you want to use a local version of the openfoodfacts package
 #  openfoodfacts:
 #    path: ../../../openfoodfacts-dart
@@ -52,9 +52,6 @@ dev_dependencies:
     sdk: flutter
   mockito: ^5.0.17
   path: ^1.8.0 # careful with 1.8.1 because of https://github.com/flutter/flutter/issues/95478
-
-dependency_overrides:
-  path: ^1.8.0
 
 # 'flutter pub run flutter_launcher_icons:main' to update
 flutter_icons:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -17,9 +17,9 @@ dependencies:
     sdk: flutter
   flutter_svg: ^1.0.0
   flutter_map: ^0.14.0
-  flutter_widget_from_html_core: ^0.8.3+1
+  flutter_widget_from_html_core: ^0.8.4
   flutter_secure_storage: ^5.0.2
-  hive: ^2.0.4
+  hive: ^2.0.5
   hive_flutter: ^1.1.0
   http: ^0.13.4
   image_cropper: ^1.4.1
@@ -50,8 +50,8 @@ dev_dependencies:
   flutter_native_splash: ^1.3.2
   flutter_test:
     sdk: flutter
-  mockito: ^5.0.16
-  path: ^1.8.0
+  mockito: ^5.0.17
+  path: ^1.8.0 # careful with 1.8.1 because of https://github.com/flutter/flutter/issues/95478
 
 dependency_overrides:
   path: ^1.8.0

--- a/packages/smooth_ui_library/example/pubspec.lock
+++ b/packages/smooth_ui_library/example/pubspec.lock
@@ -63,7 +63,7 @@ packages:
       name: cupertino_icons
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   fake_async:
     dependency: transitive
     description:

--- a/packages/smooth_ui_library/example/pubspec.lock
+++ b/packages/smooth_ui_library/example/pubspec.lock
@@ -115,14 +115,14 @@ packages:
       name: image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.8"
+    version: "3.1.0"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.3.0"
+    version: "4.4.0"
   lints:
     dependency: transitive
     description:
@@ -157,7 +157,7 @@ packages:
       name: openfoodfacts
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.1"
   path:
     dependency: transitive
     description:

--- a/packages/smooth_ui_library/example/pubspec.yaml
+++ b/packages/smooth_ui_library/example/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.12.2 <3.0.0"
 
 dependencies:
-  cupertino_icons: ^1.0.2
+  cupertino_icons: ^1.0.4
   flutter:
     sdk: flutter
   nested: ^1.0.0

--- a/packages/smooth_ui_library/pubspec.lock
+++ b/packages/smooth_ui_library/pubspec.lock
@@ -108,14 +108,14 @@ packages:
       name: image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.8"
+    version: "3.1.0"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.3.0"
+    version: "4.4.0"
   lints:
     dependency: transitive
     description:
@@ -143,7 +143,7 @@ packages:
       name: openfoodfacts
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.1"
   path:
     dependency: transitive
     description:

--- a/packages/smooth_ui_library/pubspec.yaml
+++ b/packages/smooth_ui_library/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_svg: ^1.0.0
-  openfoodfacts: ^1.7.0
+  openfoodfacts: ^1.8.1
   # Uncomment those lines if you want to use a local version of the openfoodfacts package
 #  openfoodfacts:
 #    path: ../../../openfoodfacts-dart


### PR DESCRIPTION
Impacted files:
* `country_selector.dart`: fixed the initial country search (lowercase)
* `knowledge_panels_query.dart`: added language and country as parameters
* `new_product_page.dart`: now computing here language and country
* `product_dialog_helper.dart`: added language and country as parameters
* `product_query.dart`: removed the environment country code
* `smooth_app/pubspec.yaml`: unrelated minor upgrades
* `smooth_app/pubspec.lock`: unrelated minor upgrades
* `example/pubspec.yaml`: unrelated minor upgrades
* `example/pubspec.lock`: unrelated minor upgrades
* `scan_page.dart`: now using the preferences' country
* `search_page.dart`: now computing here language and country
* `user_preferences.dart`: replaced getter `userCountryCode` with `userCountry`