### PR TITLE
fix: #773 - fixed width for title; default white color for svg in dark mode

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panel_title_card.dart
+++ b/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panel_title_card.dart
@@ -14,10 +14,15 @@ class KnowledgePanelTitleCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final ThemeData themeData = Theme.of(context);
     Color? colorFromEvaluation;
     if (evaluation != null &&
         (knowledgePanelTitleElement.iconColorFromEvaluation ?? false)) {
       colorFromEvaluation = _getColorFromEvaluation(evaluation!);
+    }
+    if (colorFromEvaluation == null &&
+        themeData.brightness == Brightness.dark) {
+      colorFromEvaluation = Colors.white;
     }
     return Padding(
       padding: const EdgeInsets.only(top: SMALL_SPACE),
@@ -42,11 +47,14 @@ class KnowledgePanelTitleCard extends StatelessWidget {
                 return Wrap(
                   direction: Axis.vertical,
                   children: <Widget>[
-                    Text(
-                      knowledgePanelTitleElement.title,
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
-                      style: TextStyle(color: colorFromEvaluation),
+                    SizedBox(
+                      width: constraints.maxWidth,
+                      child: Text(
+                        knowledgePanelTitleElement.title,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(color: colorFromEvaluation),
+                      ),
                     ),
                     if (knowledgePanelTitleElement.subtitle != null)
                       SizedBox(


### PR DESCRIPTION
Impacted file:
* `knowledge_panel_title_card.dart`

Used to be:
![Simulator Screen Shot - iPhone 8 Plus - 2021-12-29 at 09 17 08](https://user-images.githubusercontent.com/11576431/147641394-3a369816-5425-4c5c-8551-281fe6c41960.png)

Now:
![Simulator Screen Shot - iPhone 8 Plus - 2021-12-29 at 09 16 14](https://user-images.githubusercontent.com/11576431/147641339-28e35982-ada4-4cee-b8d1-a65f38c7bac9.png)

