### PR TITLE
fix: translated preferences from init

### DIFF
--- a/packages/smooth_app/lib/data_models/product_preferences.dart
+++ b/packages/smooth_app/lib/data_models/product_preferences.dart
@@ -75,6 +75,7 @@ class ProductPreferences extends ProductPreferencesManager with ChangeNotifier {
     availableProductPreferences = myAvailableProductPreferences;
     _isNetwork = false;
     _languageCode = languageCode;
+    notify();
   }
 
   /// Loads the references of importance and attribute groups from urls.
@@ -104,6 +105,7 @@ class ProductPreferences extends ProductPreferencesManager with ChangeNotifier {
     availableProductPreferences = myAvailableProductPreferences;
     _isNetwork = true;
     _languageCode = languageCode;
+    notify();
   }
 
   Future<void> resetImportances() async {


### PR DESCRIPTION
Before that fix, the preferences were in English from the start, and you had to change a preference in order to get the preferences translated...

Impacted file:
* `product_preferences.dart`: added a notification after reload in init