### PR TITLE
fix: #790 - "unknown product" and "unknown brand" instead of "???"

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
@@ -87,12 +87,13 @@ class SmoothProductCardFound extends StatelessWidget {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: <Widget>[
                         Text(
-                          product.productName ?? '???',
+                          product.productName ??
+                              appLocalizations.unknownProductName,
                           overflow: TextOverflow.ellipsis,
                           style: Theme.of(context).textTheme.headline4,
                         ),
                         Text(
-                          product.brands ?? '???',
+                          product.brands ?? appLocalizations.unknownBrand,
                           overflow: TextOverflow.ellipsis,
                           style: Theme.of(context).textTheme.subtitle1,
                         ),


### PR DESCRIPTION
Impacted file:
* `smooth_product_card_found.dart`