### PR TITLE
fix: #788 - same ranking FAB for history and search

### DIFF
--- a/packages/smooth_app/lib/pages/product/common/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_page.dart
@@ -9,6 +9,7 @@ import 'package:smooth_app/pages/personalized_ranking_page.dart';
 import 'package:smooth_app/pages/product/common/product_list_dialog_helper.dart';
 import 'package:smooth_app/pages/product/common/product_list_item_simple.dart';
 import 'package:smooth_app/pages/product/common/product_query_page_helper.dart';
+import 'package:smooth_app/widgets/ranking_floating_action_button.dart';
 
 class ProductListPage extends StatefulWidget {
   const ProductListPage(this.productList);
@@ -90,8 +91,8 @@ class _ProductListPageState extends State<ProductListPage> {
       ),
       floatingActionButton: products.isEmpty
           ? null
-          : FloatingActionButton(
-              child: const Icon(Icons.emoji_events_outlined),
+          : RankingFloatingActionButton(
+              color: Colors.black,
               onPressed: () async {
                 await Navigator.push<Widget>(
                   context,

--- a/packages/smooth_app/lib/pages/product/common/product_query_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_query_page.dart
@@ -11,7 +11,7 @@ import 'package:smooth_app/pages/personalized_ranking_page.dart';
 import 'package:smooth_app/pages/product/common/product_query_page_helper.dart';
 import 'package:smooth_app/themes/constant_icons.dart';
 import 'package:smooth_app/views/bottom_sheet_views/group_query_filter_view.dart';
-import 'package:smooth_ui_library/animations/smooth_reveal_animation.dart';
+import 'package:smooth_app/widgets/ranking_floating_action_button.dart';
 
 class ProductQueryPage extends StatefulWidget {
   const ProductQueryPage({
@@ -146,38 +146,15 @@ class _ProductQueryPageState extends State<ProductQueryPage> {
   ) =>
       Scaffold(
           key: _scaffoldKeyNotEmpty,
-          floatingActionButton: SmoothRevealAnimation(
-            animationCurve: Curves.easeInOutBack,
-            startOffset: const Offset(0.0, 1.0),
-            child: Row(
-              mainAxisSize: MainAxisSize.max,
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: <Widget>[
-                SizedBox(width: screenSize.width * 0.09),
-                FloatingActionButton.extended(
-                  elevation: 12.0,
-                  icon: Icon(
-                    Icons.emoji_events_outlined,
-                    color: widget.mainColor,
-                  ),
-                  label: Text(
-                    AppLocalizations.of(context)!.myPersonalizedRanking,
-                    style: TextStyle(color: widget.mainColor),
-                  ),
-                  backgroundColor: Colors.white,
-                  onPressed: () {
-                    Navigator.push<Widget>(
-                      context,
-                      MaterialPageRoute<Widget>(
-                        builder: (BuildContext context) =>
-                            PersonalizedRankingPage(
-                          _model.supplier.getProductList(),
-                        ),
-                      ),
-                    );
-                  },
+          floatingActionButton: RankingFloatingActionButton(
+            color: widget.mainColor,
+            onPressed: () => Navigator.push<Widget>(
+              context,
+              MaterialPageRoute<Widget>(
+                builder: (BuildContext context) => PersonalizedRankingPage(
+                  _model.supplier.getProductList(),
                 ),
-              ],
+              ),
             ),
           ),
           body: Stack(

--- a/packages/smooth_app/lib/pages/scan/continuous_scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/continuous_scan_page.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import 'package:qr_code_scanner/qr_code_scanner.dart';
 import 'package:smooth_app/data_models/continuous_scan_model.dart';
 import 'package:smooth_app/pages/personalized_ranking_page.dart';
+import 'package:smooth_app/widgets/ranking_floating_action_button.dart';
 import 'package:smooth_app/widgets/smooth_product_carousel.dart';
 import 'package:smooth_ui_library/smooth_ui_library.dart';
 import 'package:smooth_ui_library/util/ui_helpers.dart';
@@ -149,7 +150,7 @@ class _ContinuousScanPageState extends State<ContinuousScanPage> {
             ),
             ElevatedButton.icon(
               style: buttonStyle,
-              icon: const Icon(Icons.emoji_events_outlined),
+              icon: const Icon(RankingFloatingActionButton.rankingIconData),
               onPressed: () => _openPersonalizedRankingPage(context),
               label: Text(
                 appLocalizations.plural_compare_x_products(

--- a/packages/smooth_app/lib/widgets/ranking_floating_action_button.dart
+++ b/packages/smooth_app/lib/widgets/ranking_floating_action_button.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:smooth_ui_library/animations/smooth_reveal_animation.dart';
+
+/// Floating Action Button dedicated to Personal Ranking
+class RankingFloatingActionButton extends StatelessWidget {
+  const RankingFloatingActionButton({
+    required this.color,
+    required this.onPressed,
+  });
+
+  final Color color;
+  final VoidCallback onPressed;
+
+  static const IconData rankingIconData = Icons.emoji_events_outlined;
+
+  @override
+  Widget build(BuildContext context) => SmoothRevealAnimation(
+        animationCurve: Curves.easeInOutBack,
+        startOffset: const Offset(0.0, 1.0),
+        child: Row(
+          mainAxisSize: MainAxisSize.max,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            SizedBox(width: MediaQuery.of(context).size.width * 0.09),
+            FloatingActionButton.extended(
+              elevation: 12.0,
+              icon: Icon(
+                rankingIconData,
+                color: color,
+              ),
+              label: Text(
+                AppLocalizations.of(context)!.myPersonalizedRanking,
+                style: TextStyle(color: color),
+              ),
+              backgroundColor: Colors.white,
+              onPressed: onPressed,
+            ),
+          ],
+        ),
+      );
+}


### PR DESCRIPTION
New file:
* `ranking_floating_action_button.dart`: Floating Action Button dedicated to Personal Ranking

Impacted files:
* `continuous_scan_page.dart`: minor refactoring
* `product_list_page.dart`: now using new Ranking FAB
* `product_query_page.dart`: now using new Ranking FAB