### PR TITLE
fix: #794 - localized compatibility labels

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
@@ -108,20 +108,10 @@ class SmoothProductCardFound extends StatelessWidget {
                             const Padding(
                                 padding:
                                     EdgeInsets.only(left: VERY_SMALL_SPACE)),
-                            if (compatibility.productCompatibility !=
-                                ProductCompatibility.INCOMPATIBLE)
-                              Text(
-                                appLocalizations.pct_match(compatibility
-                                    .averageAttributeMatch
-                                    .toStringAsFixed(0)),
-                                style: Theme.of(context).textTheme.bodyText2,
-                              ),
-                            if (compatibility.productCompatibility ==
-                                ProductCompatibility.INCOMPATIBLE)
-                              Text(
-                                appLocalizations.incompatible,
-                                style: Theme.of(context).textTheme.bodyText2,
-                              ),
+                            Text(
+                              getSubtitle(compatibility, appLocalizations),
+                              style: Theme.of(context).textTheme.bodyText2,
+                            ),
                           ],
                         ),
                       ],

--- a/packages/smooth_app/lib/helpers/product_compatibility_helper.dart
+++ b/packages/smooth_app/lib/helpers/product_compatibility_helper.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/model/Attribute.dart';
 import 'package:openfoodfacts/model/AttributeGroup.dart';
 import 'package:openfoodfacts/model/Product.dart';
@@ -50,20 +51,20 @@ Color getProductCompatibilityHeaderBackgroundColor(
 }
 
 String getProductCompatibilityHeaderTextWidget(
-  ProductCompatibility compatibility,
+  final ProductCompatibility compatibility,
+  final AppLocalizations appLocalizations,
 ) {
-  // TODO(jasmeetsingh): This text should be internationalized.
   switch (compatibility) {
     case ProductCompatibility.UNKNOWN:
-      return 'Product Compatibility Unknown';
+      return appLocalizations.product_compatibility_unknown;
     case ProductCompatibility.INCOMPATIBLE:
-      return 'Very poor Match';
+      return appLocalizations.product_compatibility_incompatible;
     case ProductCompatibility.BAD_COMPATIBILITY:
-      return 'Poor Match';
+      return appLocalizations.product_compatibility_bad;
     case ProductCompatibility.NEUTRAL_COMPATIBILITY:
-      return 'Neutral Match';
+      return appLocalizations.product_compatibility_neutral;
     case ProductCompatibility.GOOD_COMPATIBILITY:
-      return 'Great Match';
+      return appLocalizations.product_compatibility_good;
   }
 }
 
@@ -109,4 +110,18 @@ ProductCompatibilityResult getProductCompatibility(
   }
   return ProductCompatibilityResult(
       averageAttributeMatch, ProductCompatibility.GOOD_COMPATIBILITY);
+}
+
+String getSubtitle(
+  final ProductCompatibilityResult compatibility,
+  final AppLocalizations appLocalizations,
+) {
+  if (compatibility.productCompatibility == ProductCompatibility.UNKNOWN) {
+    return appLocalizations.product_compatibility_unknown;
+  }
+  if (compatibility.productCompatibility == ProductCompatibility.INCOMPATIBLE) {
+    return appLocalizations.product_compatibility_incompatible;
+  }
+  return appLocalizations
+      .pct_match(compatibility.averageAttributeMatch.toStringAsFixed(0));
 }

--- a/packages/smooth_app/lib/helpers/product_compatibility_helper.dart
+++ b/packages/smooth_app/lib/helpers/product_compatibility_helper.dart
@@ -117,10 +117,10 @@ String getSubtitle(
   final AppLocalizations appLocalizations,
 ) {
   if (compatibility.productCompatibility == ProductCompatibility.UNKNOWN) {
-    return appLocalizations.product_compatibility_unknown;
+    return appLocalizations.unknown;
   }
   if (compatibility.productCompatibility == ProductCompatibility.INCOMPATIBLE) {
-    return appLocalizations.product_compatibility_incompatible;
+    return appLocalizations.incompatible;
   }
   return appLocalizations
       .pct_match(compatibility.averageAttributeMatch.toStringAsFixed(0));

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -311,6 +311,11 @@
             "pct": {}
         }
     },
+    "product_compatibility_unknown": "Product Compatibility Unknown",
+    "product_compatibility_incompatible": "Very poor Match",
+    "product_compatibility_bad": "Poor Match",
+    "product_compatibility_neutral": "Neutral Match",
+    "product_compatibility_good": "Great Match",
     "plural_ago_days": "{count,plural, =1{one day ago} other{{count} days ago}}",
     "@plural_ago_days": {
         "description": "Cached results from: x days ago",

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -33,6 +33,13 @@
     "learnMore": "Learn more",
     "@learnMore": {},
     "incompatible": "Incompatible",
+    "@incompatible": {
+        "description": "Short label for product list view: the product is incompatible with your preferences"
+    },
+    "unknown": "Unknown",
+    "@unknown": {
+        "description": "Short label for product list view: the compatibility of that product with your preferences is unknown"
+    },
     "licenses": "Licences",
     "@licenses": {},
     "looking_for": "Looking for",
@@ -312,10 +319,25 @@
         }
     },
     "product_compatibility_unknown": "Product Compatibility Unknown",
+    "@product_compatibility_unknown": {
+        "description": "Product compatibility summary title"
+    },
     "product_compatibility_incompatible": "Very poor Match",
+    "@product_compatibility_incompatible": {
+        "description": "Product compatibility summary title"
+    },
     "product_compatibility_bad": "Poor Match",
+    "@product_compatibility_bad": {
+        "description": "Product compatibility summary title"
+    },
     "product_compatibility_neutral": "Neutral Match",
+    "@product_compatibility_neutral": {
+        "description": "Product compatibility summary title"
+    },
     "product_compatibility_good": "Great Match",
+    "@product_compatibility_good": {
+        "description": "Product compatibility summary title"
+    },
     "plural_ago_days": "{count,plural, =1{one day ago} other{{count} days ago}}",
     "@plural_ago_days": {
         "description": "Cached results from: x days ago",

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -33,6 +33,13 @@
     "learnMore": "En savoir plus",
     "@learnMore": {},
     "incompatible": "Incompatible",
+    "@incompatible": {
+        "description": "Label court pour des listes de produits: ce produit est incompatible avec vos préférences"
+    },
+    "unknown": "Incalculable",
+    "@unknown": {
+        "description": "Label court pour des listes de produits: la compatibilité de ce produit avec vos préférences est incalculable"
+    },
     "licenses": "Licences",
     "@licenses": {},
     "looking_for": "À la recherche de",
@@ -308,10 +315,25 @@
         }
     },
     "product_compatibility_unknown": "Correspondance inconnue",
+    "@product_compatibility_unknown": {
+        "description": "Titre du sommaire de la compatibilité d'un produit"
+    },
     "product_compatibility_incompatible": "Très mauvaise correspondance",
+    "@product_compatibility_incompatible": {
+        "description": "Titre du sommaire de la compatibilité d'un produit"
+    },
     "product_compatibility_bad": "Mauvaise correspondance",
+    "@product_compatibility_bad": {
+        "description": "Titre du sommaire de la compatibilité d'un produit"
+    },
     "product_compatibility_neutral": "Correspondance neutre",
+    "@product_compatibility_neutral": {
+        "description": "Titre du sommaire de la compatibilité d'un produit"
+    },
     "product_compatibility_good": "Excellente correspondance",
+    "@product_compatibility_good": {
+        "description": "Titre du sommaire de la compatibilité d'un produit"
+    },
     "plural_ago_days": "{count,plural, =1{il y a un jour} other{il y a {count} jours}}",
     "@plural_ago_days": {
         "description": "Cached results from: x days ago",

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -307,6 +307,11 @@
             "pct": {}
         }
     },
+    "product_compatibility_unknown": "Correspondance inconnue",
+    "product_compatibility_incompatible": "Très mauvaise correspondance",
+    "product_compatibility_bad": "Mauvaise correspondance",
+    "product_compatibility_neutral": "Correspondance neutre",
+    "product_compatibility_good": "Excellente correspondance",
     "plural_ago_days": "{count,plural, =1{il y a un jour} other{il y a {count} jours}}",
     "@plural_ago_days": {
         "description": "Cached results from: x days ago",

--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -211,7 +211,10 @@ class _SummaryCardState extends State<SummaryCard> {
       padding: const EdgeInsets.symmetric(vertical: SMALL_SPACE),
       child: Center(
         child: Text(
-          getProductCompatibilityHeaderTextWidget(compatibility),
+          getProductCompatibilityHeaderTextWidget(
+            compatibility,
+            AppLocalizations.of(context)!,
+          ),
           style:
               Theme.of(context).textTheme.subtitle1!.apply(color: Colors.white),
         ),


### PR DESCRIPTION
Impacted files:
* `app_en.arb`: added 5 labels around "product_compatibility"
* `app_fr.arb`: added 5 labels around "product_compatibility"
* `product_compatibility_helper.dart`: added method `getSubtitle`; localized output of method `getProductCompatibilityHeaderTextWidget`
* `summary_card.dart`: now using localized compatibility labels
* `smooth_product_card_found.dart`: now displaying specific label for "unknown match"

The problem is that on product cards the label is too large:
![Simulator Screen Shot - iPhone 8 Plus - 2021-12-29 at 14 57 59](https://user-images.githubusercontent.com/11576431/147669655-36137c23-493d-4dc1-ac2b-654f30a0eaad.png)

