### PR TITLE
fix: #814 - no more constraints for the welcome title

### DIFF
--- a/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
+++ b/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
@@ -113,8 +113,6 @@ class SearchCard extends StatelessWidget {
             Text(
               localizations.welcomeToOpenFoodFacts,
               textAlign: TextAlign.center,
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
               style: const TextStyle(
                 fontSize: 36.0,
                 fontWeight: FontWeight.bold,


### PR DESCRIPTION
Impacted file:
* `smooth_product_carousel.dart`: removed constraints on welcome title

In first approach I don't think we need to shrink the font size:
![Simulator Screen Shot - iPhone 8 Plus - 2022-01-01 at 18 05 11](https://user-images.githubusercontent.com/11576431/147855903-2b5b1ad3-b248-4616-9785-882560f0f908.png)
