### PR TITLE
Fix: Unnecessary keyboard openings when not on the page anymore

### DIFF
--- a/packages/smooth_app/lib/pages/scan/search_page.dart
+++ b/packages/smooth_app/lib/pages/scan/search_page.dart
@@ -174,6 +174,8 @@ class _SearchFieldState extends State<SearchField> {
   }
 
   void _handleTextChange() {
+    //Only rebuild the widget if the text length is 0 or 1 as we only check if
+    //the text length is empty or not
     if (_textController.text.isEmpty || _textController.text.length == 1) {
       setState(() {
         _isEmpty = _textController.text.isEmpty;

--- a/packages/smooth_app/lib/pages/scan/search_page.dart
+++ b/packages/smooth_app/lib/pages/scan/search_page.dart
@@ -174,9 +174,11 @@ class _SearchFieldState extends State<SearchField> {
   }
 
   void _handleTextChange() {
-    setState(() {
-      _isEmpty = _textController.text.isEmpty;
-    });
+    if (_textController.text.isEmpty || _textController.text.length == 1) {
+      setState(() {
+        _isEmpty = _textController.text.isEmpty;
+      });
+    }
   }
 
   void _handleFocusChange() {


### PR DESCRIPTION
- For: #800

I wasn't able to reproduce this issue but this change prevents unnecessary rebuilds, so the code still has a purpose