### PR TITLE
fix: iOS minimum deployment target

### DIFF
--- a/packages/smooth_app/ios/Podfile
+++ b/packages/smooth_app/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-platform :ios, '9.0'
+platform :ios, '10.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'
@@ -48,7 +48,6 @@ post_install do |installer|
     flutter_additional_ios_build_settings(target)
 
     target.build_configurations.each do |config|
-
       config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= [
         '$(inherited)',
         ## dart: PermissionGroup.camera


### PR DESCRIPTION
First merging in `release/0.0.2 `for testing if the changes resolve the error

Maybe closes #927