### PR TITLE
attempt-fixing-ios

### DIFF
--- a/packages/smooth_app/ios/Runner/AppDelegate.swift
+++ b/packages/smooth_app/ios/Runner/AppDelegate.swift
@@ -3,6 +3,9 @@ import Flutter
 
 @UIApplicationMain
 @objc class AppDelegate: FlutterAppDelegate {
+  override func prefersStatusBarHidden() -> Bool {
+   return false
+  }
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
@@ -13,4 +16,7 @@ import Flutter
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
+  
+  
 }
+


### PR DESCRIPTION
Or run on an iOS simulator without code signing
════════════════════════════════════════════════════════════════════════════════
Encountered error while building for device.
Xcode's output:
↳
    /Users/runner/work/smooth-app/smooth-app/packages/smooth_app/ios/Runner/AppDelegate.swift:11:5: warning: setter for 'isStatusBarHidden' was deprecated in iOS 9.0: Use -[UIViewController prefersStatusBarHidden]
        UIApplication.shared.isStatusBarHidden = false
        ^
    /Users/runner/work/smooth-app/smooth-app/packages/smooth_app/ios/Runner/AppDelegate.swift:10:9: warning: initialization of variable 'flutter_native_splash' was never used; consider replacing with assignment to '_' or removing it
        var flutter_native_splash = 1
        ~~~~^~~~~~~~~~~~~~~~~~~~~
        _
    remark: Incremental compilation has been disabled: it is not compatible with whole module optimization
    remark: Incremental compilation has been disabled: it is not compatible with whole module optimization
    /Users/runner/work/smooth-app/smooth-app/packages/smooth_app/ios/Runner/AppDelegate.swift:11:5: warning: setter for 'isStatusBarHidden' was deprecated in iOS 9.0: Use -[UIViewController prefersStatusBarHidden]
        UIApplication.shared.isStatusBarHidden = false
        ^
    /Users/runner/work/smooth-app/smooth-app/packages/smooth_app/ios/Runner/AppDelegate.swift:10:9: warning: initialization of variable 'flutter_native_splash' was never used; consider replacing with assignment to '_' or removing it
        var flutter_native_splash = 1
        ~~~~^~~~~~~~~~~~~~~~~~~~~
        _
    /Users/runner/work/smooth-app/smooth-app/packages/smooth_app/ios/Runner/GeneratedPluginRegistrant.m:12:9: fatal error: module 'camera' not found
    @import camera;
     ~~~~~~~^~~~~~
    1 error generated.
    note: Using new build system
    note: Planning
    note: Build preparation complete
    note: Building targets in parallel

Error: Process completed with exit code 1.