### PR TITLE
Fix: Carousel _CastError: Null check operator used on a null value

### DIFF
--- a/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
+++ b/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
@@ -37,7 +37,9 @@ class _SmoothProductCarouselState extends State<SmoothProductCarousel> {
     setState(() {
       barcodes = model.getBarcodes();
     });
-    _controller.animateToPage(barcodes.length - 1 + _searchCardAdjustment);
+    if (_controller.ready) {
+      _controller.animateToPage(barcodes.length - 1 + _searchCardAdjustment);
+    }
   }
 
   @override


### PR DESCRIPTION
Co-Authored-By: monsieurtanuki <11576431+monsieurtanuki@users.noreply.github.com>
Fixes: #686
@monsieurtanuki tested, the animations still work and the errors stops to occur