### PR TITLE
Use low camera resolution while scanning

### DIFF
--- a/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
@@ -115,7 +115,7 @@ class MLKitScannerPageState extends State<MLKitScannerPage> {
 
     final CameraController cameraController = CameraController(
       camera,
-      ResolutionPreset.high,
+      ResolutionPreset.low,
       enableAudio: false,
     );
     cameraController.setFocusMode(FocusMode.auto);


### PR DESCRIPTION
### What

- Use low camera resolution while scanning
- Tested it out, seems to work fine. 

Here's documentation on `startImageStream`:

```
When running continuously with [CameraPreview] widget, this function runs best with [ResolutionPreset.low]. Running on [ResolutionPreset.high] can have significant frame rate drops for [CameraPreview] on lower end devices.
```