### PR TITLE
Fix: Refresh product on image upload from new product page

### DIFF
--- a/packages/smooth_app/lib/cards/data_cards/image_upload_card.dart
+++ b/packages/smooth_app/lib/cards/data_cards/image_upload_card.dart
@@ -15,6 +15,7 @@ class ImageUploadCard extends StatefulWidget {
     this.imageUrl,
     this.title,
     required this.buttonText,
+    required this.onUpload,
   });
 
   final Product product;
@@ -22,6 +23,7 @@ class ImageUploadCard extends StatefulWidget {
   final String? imageUrl;
   final String? title;
   final String buttonText;
+  final Function(BuildContext) onUpload;
 
   @override
   State<ImageUploadCard> createState() => _ImageUploadCardState();
@@ -73,6 +75,7 @@ class _ImageUploadCardState extends State<ImageUploadCard> {
           throw Exception(
               'image could not be uploaded: ${result.error} ${result.imageId.toString()}');
         }
+        widget.onUpload(context);
       }
     }
   }

--- a/packages/smooth_app/lib/cards/product_cards/product_image_carousel.dart
+++ b/packages/smooth_app/lib/cards/product_cards/product_image_carousel.dart
@@ -5,10 +5,15 @@ import 'package:openfoodfacts/model/ProductImage.dart';
 import 'package:smooth_app/cards/data_cards/image_upload_card.dart';
 
 class ProductImageCarousel extends StatelessWidget {
-  const ProductImageCarousel(this.product, {required this.height});
+  const ProductImageCarousel(
+    this.product, {
+    required this.height,
+    required this.onUpload,
+  });
 
   final Product product;
   final double height;
+  final Function(BuildContext) onUpload;
 
   @override
   Widget build(BuildContext context) {
@@ -20,6 +25,7 @@ class ProductImageCarousel extends StatelessWidget {
         imageUrl: product.imageFrontUrl,
         title: appLocalizations.product,
         buttonText: appLocalizations.front_photo,
+        onUpload: onUpload,
       ),
       ImageUploadCard(
         product: product,
@@ -27,6 +33,7 @@ class ProductImageCarousel extends StatelessWidget {
         imageUrl: product.imageIngredientsUrl,
         title: appLocalizations.ingredients,
         buttonText: appLocalizations.ingredients_photo,
+        onUpload: onUpload,
       ),
       ImageUploadCard(
         product: product,
@@ -34,6 +41,7 @@ class ProductImageCarousel extends StatelessWidget {
         imageUrl: product.imageNutritionUrl,
         title: appLocalizations.nutrition,
         buttonText: appLocalizations.nutrition_facts_photo,
+        onUpload: onUpload,
       ),
       ImageUploadCard(
         product: product,
@@ -41,6 +49,7 @@ class ProductImageCarousel extends StatelessWidget {
         imageUrl: product.imagePackagingUrl,
         title: appLocalizations.packaging_information,
         buttonText: appLocalizations.packaging_information_photo,
+        onUpload: onUpload,
       ),
       ImageUploadCard(
         product: product,
@@ -48,6 +57,7 @@ class ProductImageCarousel extends StatelessWidget {
         imageUrl: null,
         title: appLocalizations.more_photos,
         buttonText: appLocalizations.more_photos,
+        onUpload: onUpload,
       ),
     ];
 

--- a/packages/smooth_app/lib/cards/product_cards/question_card.dart
+++ b/packages/smooth_app/lib/cards/product_cards/question_card.dart
@@ -148,7 +148,11 @@ class _QuestionCardState extends State<QuestionCard>
       ),
       child: Column(
         children: <Widget>[
-          ProductImageCarousel(widget.product, height: screenSize.height / 6),
+          ProductImageCarousel(
+            widget.product,
+            height: screenSize.height / 6,
+            onUpload: (_) {},
+          ),
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
             child: Column(

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -130,7 +130,11 @@ class _ProductPageState extends State<ProductPage> {
       Align(
         heightFactor: 0.7,
         alignment: Alignment.topLeft,
-        child: ProductImageCarousel(_product, height: 200),
+        child: ProductImageCarousel(
+          _product,
+          height: 200,
+          onUpload: _refreshProduct,
+        ),
       ),
       Padding(
         padding: const EdgeInsets.symmetric(


### PR DESCRIPTION
Currently we have a bug:

- Open Product page
- Add a new picture
- Product page shows the new picture (because ImageUploadCard's state is updated)
- Navigate out of product page
- Go back to the product.
- The image is not there anymore
- refreshing the product brings the image back

Since the product is "dirty" after uploading the image, we should update it from the server. 