### PR TITLE
feat: Add retry button in case of Internet Error

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_error.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_error.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:provider/provider.dart';
+
+import 'package:smooth_app/data_models/continuous_scan_model.dart';
 import 'package:smooth_app/pages/product/common/product_dialog_helper.dart';
 
 /// Product Card when an exception is caught
@@ -10,6 +13,8 @@ class SmoothProductCardError extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context)!;
+
     return Container(
       decoration: BoxDecoration(
         color: Theme.of(context).colorScheme.surface,
@@ -30,7 +35,18 @@ class SmoothProductCardError extends StatelessWidget {
             height: 12.0,
           ),
           ProductDialogHelper.getErrorMessage(
-            AppLocalizations.of(context)!.product_internet_error,
+            appLocalizations.product_internet_error,
+          ),
+          const SizedBox(
+            height: 12.0,
+          ),
+          ElevatedButton(
+            onPressed: () async {
+              await context
+                  .read<ContinuousScanModel>()
+                  .retryBarcodeFetch(barcode);
+            },
+            child: Text(appLocalizations.retry_button_label),
           ),
         ],
       ),

--- a/packages/smooth_app/lib/data_models/continuous_scan_model.dart
+++ b/packages/smooth_app/lib/data_models/continuous_scan_model.dart
@@ -103,6 +103,11 @@ class ContinuousScanModel with ChangeNotifier {
     _addBarcode(code);
   }
 
+  Future<void> retryBarcodeFetch(String barcode) async {
+    setBarcodeState(barcode, ScannedProductState.LOADING);
+    await _updateBarcode(barcode);
+  }
+
   Future<bool> _addBarcode(final String barcode) async {
     final ScannedProductState? state = getBarcodeState(barcode);
     if (state == null) {

--- a/packages/smooth_app/lib/data_models/continuous_scan_model.dart
+++ b/packages/smooth_app/lib/data_models/continuous_scan_model.dart
@@ -74,7 +74,7 @@ class ContinuousScanModel with ChangeNotifier {
 
   Future<void> refreshProductList() async => _daoProductList.get(_productList);
 
-  void setBarcodeState(
+  void _setBarcodeState(
     final String barcode,
     final ScannedProductState state,
   ) {
@@ -104,7 +104,7 @@ class ContinuousScanModel with ChangeNotifier {
   }
 
   Future<void> retryBarcodeFetch(String barcode) async {
-    setBarcodeState(barcode, ScannedProductState.LOADING);
+    _setBarcodeState(barcode, ScannedProductState.LOADING);
     await _updateBarcode(barcode);
   }
 
@@ -112,7 +112,7 @@ class ContinuousScanModel with ChangeNotifier {
     final ScannedProductState? state = getBarcodeState(barcode);
     if (state == null) {
       _barcodes.add(barcode);
-      setBarcodeState(barcode, ScannedProductState.LOADING);
+      _setBarcodeState(barcode, ScannedProductState.LOADING);
       _cacheOrLoadBarcode(barcode);
       return true;
     }
@@ -164,10 +164,10 @@ class ContinuousScanModel with ChangeNotifier {
         _addProduct(fetchedProduct.product!, ScannedProductState.FOUND);
         return;
       case FetchedProductStatus.internetNotFound:
-        setBarcodeState(barcode, ScannedProductState.NOT_FOUND);
+        _setBarcodeState(barcode, ScannedProductState.NOT_FOUND);
         return;
       case FetchedProductStatus.internetError:
-        setBarcodeState(barcode, ScannedProductState.ERROR);
+        _setBarcodeState(barcode, ScannedProductState.ERROR);
         return;
       case FetchedProductStatus.userCancelled:
         // we do nothing
@@ -184,10 +184,10 @@ class ContinuousScanModel with ChangeNotifier {
         _addProduct(fetchedProduct.product!, ScannedProductState.FOUND);
         return;
       case FetchedProductStatus.internetNotFound:
-        setBarcodeState(barcode, ScannedProductState.NOT_FOUND);
+        _setBarcodeState(barcode, ScannedProductState.NOT_FOUND);
         return;
       case FetchedProductStatus.internetError:
-        setBarcodeState(barcode, ScannedProductState.ERROR);
+        _setBarcodeState(barcode, ScannedProductState.ERROR);
         return;
       case FetchedProductStatus.userCancelled:
         // we do nothing
@@ -205,7 +205,7 @@ class ContinuousScanModel with ChangeNotifier {
       await _daoProductList.push(productList, _latestFoundBarcode!);
       await _daoProductList.push(_history, _latestFoundBarcode!);
     }
-    setBarcodeState(product.barcode!, state);
+    _setBarcodeState(product.barcode!, state);
   }
 
   Future<void> clearScanSession() async {

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -572,5 +572,6 @@
     "compare_products_mode": "Compare Mode",
     "@compare_products_mode": {
         "description": "Button to switch to 'compare products mode'"
-    }
+    },
+    "retry_button_label": "Retry"
 }


### PR DESCRIPTION
### What
- This PR adds a retry button to the SmoothProductCardError widget. 

### Video

https://user-images.githubusercontent.com/52815643/153628151-ce5e3df4-8988-48a6-afe7-952006b682f1.mp4

### Fixes bug(s)
- #891
### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/525
(please be as granular as possible)
