### PR TITLE
feat: Add SafeArea to ScannerOverlay page

### DIFF
--- a/packages/smooth_app/ios/Podfile.lock
+++ b/packages/smooth_app/ios/Podfile.lock
@@ -184,7 +184,7 @@ SPEC CHECKSUMS:
   qr_code_scanner: bb67d64904c3b9658ada8c402e8b4d406d5d796e
   Sentry: 2f7e91f247cfb05b05bd01e0b5d0692557a7687b
   sentry_flutter: 7c3cb050dc23563a4ea5db438c83afdb460a2ae6
-  shared_preferences_ios: aef470a42dc4675a1cdd50e3158b42e3d1232b32
+  shared_preferences_ios: 548a61f8053b9b8a49ac19c1ffbc8b92c50d68ad
   url_launcher_ios: 839c58cdb4279282219f5e248c3321761ff3c4de
 
 PODFILE CHECKSUM: e1ffd3daa5042cd516081f94f61b857c0deb822d

--- a/packages/smooth_app/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/smooth_app/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -121,7 +121,6 @@
 				4092D07C4F2C1D9CF03ED43B /* Pods-Runner.release.xcconfig */,
 				6A8EDBB414E6196187D21F38 /* Pods-Runner.profile.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -356,6 +355,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = X8NNQ9CYL2;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -484,6 +484,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = X8NNQ9CYL2;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -506,6 +507,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = X8NNQ9CYL2;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/packages/smooth_app/lib/pages/scan/scanner_overlay.dart
+++ b/packages/smooth_app/lib/pages/scan/scanner_overlay.dart
@@ -83,7 +83,7 @@ class ScannerOverlay extends StatelessWidget {
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.start,
                   children: <Widget>[
-                    buildButtonsRow(context, model),
+                    SafeArea(top: true, child: buildButtonsRow(context, model)),
                     const Spacer(),
                     SmoothProductCarousel(
                       showSearchCard: true,


### PR DESCRIPTION
### What
- This PR adds a SafeArea to the buttons on the ScannerOverlay page to prevent them from appearing under the status bar.

### Screenshot

| before | after | 
| -- | -- |
| ![photo_2022-02-12 11 06 18](https://user-images.githubusercontent.com/52815643/153712447-46a4964b-c617-467b-83ad-13a10eacc781.jpeg) | ![photo_2022-02-12 11 06 22](https://user-images.githubusercontent.com/52815643/153712444-ff52bc05-dc1d-4881-b6f9-81fcf2c68214.jpeg) |


### Fixes bug(s)
- #1099
### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/525
(please be as granular as possible)
