### PR TITLE
fix: #1013 - "knowledge images" don't crash anymore with null width and height

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panel_element_card.dart
+++ b/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panel_element_card.dart
@@ -27,8 +27,8 @@ class KnowledgePanelElementCard extends StatelessWidget {
       case KnowledgePanelElementType.IMAGE:
         return Image.network(
           knowledgePanelElement.imageElement!.url,
-          width: knowledgePanelElement.imageElement!.width!.toDouble(),
-          height: knowledgePanelElement.imageElement!.height!.toDouble(),
+          width: knowledgePanelElement.imageElement!.width?.toDouble(),
+          height: knowledgePanelElement.imageElement!.height?.toDouble(),
         );
       case KnowledgePanelElementType.PANEL:
         return KnowledgePanelCard(


### PR DESCRIPTION
Impacted file:
* `knowledge_panel_element_card.dart`: `null` width and height are tolerated

For the record beers are not strong enough for that bug; whiskey is.

### Screenshot
![Simulator Screen Shot - iPhone 8 Plus - 2022-02-12 at 14 45 13](https://user-images.githubusercontent.com/11576431/153713839-26f3b261-a337-48cd-a04e-8b3f90c86187.png)

