### PR TITLE
feat: #954 - back to product after saving nutrition facts

### DIFF
--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -508,5 +508,6 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
         ],
       ),
     );
+    Navigator.of(context).pop();
   }
 }


### PR DESCRIPTION
Impacted file:
* `nutrition_page_loaded.dart`: back after saving nutrition facts

Still missing, the actual saving: should we save just the nutrition facts instead of the whole product? And if so, is it feasible now with the current status of the server or of off-dart?