### PR TITLE
feat: #812 - additional optional button at the bottom of the product page

### DIFF
--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -8,6 +8,7 @@ import 'package:smooth_app/cards/product_cards/product_image_carousel.dart';
 import 'package:smooth_app/data_models/fetched_product.dart';
 import 'package:smooth_app/data_models/product_list.dart';
 import 'package:smooth_app/data_models/product_preferences.dart';
+import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/database/dao_product_list.dart';
 import 'package:smooth_app/database/knowledge_panels_query.dart';
 import 'package:smooth_app/database/local_database.dart';
@@ -17,6 +18,7 @@ import 'package:smooth_app/helpers/ui_helpers.dart';
 import 'package:smooth_app/pages/product/common/product_dialog_helper.dart';
 import 'package:smooth_app/pages/product/knowledge_panel_product_cards.dart';
 import 'package:smooth_app/pages/product/summary_card.dart';
+import 'package:smooth_app/pages/user_preferences_dev_mode.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
 import 'package:smooth_app/themes/theme_provider.dart';
 
@@ -149,6 +151,13 @@ class _ProductPageState extends State<ProductPage> {
         ),
       ),
       _buildKnowledgePanelCards(),
+      if (context.read<UserPreferences>().getFlag(
+              UserPreferencesDevMode.userPreferencesFlagAdditionalButton) ??
+          false)
+        ElevatedButton(
+          onPressed: () {},
+          child: const Text('Additional Button'),
+        ),
     ]);
   }
 

--- a/packages/smooth_app/lib/pages/user_preferences_dev_mode.dart
+++ b/packages/smooth_app/lib/pages/user_preferences_dev_mode.dart
@@ -36,6 +36,8 @@ class UserPreferencesDevMode extends AbstractUserPreferences {
 
   static const String userPreferencesFlagProd = '__devWorkingOnProd';
   static const String userPreferencesFlagUseMLKit = '__useMLKit';
+  static const String userPreferencesFlagAdditionalButton =
+      '__additionalButtonOnProductPage';
 
   @override
   bool isCollapsedByDefault() => true;
@@ -97,6 +99,17 @@ class UserPreferencesDevMode extends AbstractUserPreferences {
           value: userPreferences.getFlag(userPreferencesFlagUseMLKit) ?? true,
           onChanged: (bool value) async {
             await userPreferences.setFlag(userPreferencesFlagUseMLKit, value);
+            ScaffoldMessenger.of(context)
+                .showSnackBar(const SnackBar(content: Text('Ok')));
+          },
+        ),
+        SwitchListTile(
+          title: const Text('Additional button on product page'),
+          value: userPreferences.getFlag(userPreferencesFlagAdditionalButton) ??
+              false,
+          onChanged: (bool value) async {
+            await userPreferences.setFlag(
+                userPreferencesFlagAdditionalButton, value);
             ScaffoldMessenger.of(context)
                 .showSnackBar(const SnackBar(content: Text('Ok')));
           },


### PR DESCRIPTION
Impacted files:
* `new_product_page.dart`: added an optional button at the bottom of the product page
* `user_preferences_dev_mode.dart`: added an "optional button switch" in dev mode

### Screenshot
![Simulator Screen Shot - iPhone 8 Plus - 2022-02-12 at 16 03 20](https://user-images.githubusercontent.com/11576431/153716503-d5ff9ec7-668b-4f20-ab7f-0258066310f4.png)

