### PR TITLE
feat: #1161 - created an "edit product" page

### DIFF
--- a/packages/smooth_app/ios/Podfile.lock
+++ b/packages/smooth_app/ios/Podfile.lock
@@ -1,8 +1,6 @@
 PODS:
   - camera (0.0.1):
     - Flutter
-  - fk_user_agent (2.0.0):
-    - Flutter
   - Flutter (1.0.0)
   - flutter_secure_storage (3.3.1):
     - Flutter
@@ -42,6 +40,8 @@ PODS:
   - image_picker (0.0.1):
     - Flutter
   - iso_countries (0.0.1):
+    - Flutter
+  - matomo_forever (0.0.1):
     - Flutter
   - MLImage (1.0.0-beta1)
   - MLKitBarcodeScanning (1.3.0):
@@ -94,12 +94,12 @@ PODS:
 
 DEPENDENCIES:
   - camera (from `.symlinks/plugins/camera/ios`)
-  - fk_user_agent (from `.symlinks/plugins/fk_user_agent/ios`)
   - Flutter (from `Flutter`)
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
   - google_ml_barcode_scanner (from `.symlinks/plugins/google_ml_barcode_scanner/ios`)
   - image_picker (from `.symlinks/plugins/image_picker/ios`)
   - iso_countries (from `.symlinks/plugins/iso_countries/ios`)
+  - matomo_forever (from `.symlinks/plugins/matomo_forever/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - path_provider_ios (from `.symlinks/plugins/path_provider_ios/ios`)
   - permission_handler (from `.symlinks/plugins/permission_handler/ios`)
@@ -129,8 +129,6 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   camera:
     :path: ".symlinks/plugins/camera/ios"
-  fk_user_agent:
-    :path: ".symlinks/plugins/fk_user_agent/ios"
   Flutter:
     :path: Flutter
   flutter_secure_storage:
@@ -141,6 +139,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/image_picker/ios"
   iso_countries:
     :path: ".symlinks/plugins/iso_countries/ios"
+  matomo_forever:
+    :path: ".symlinks/plugins/matomo_forever/ios"
   package_info_plus:
     :path: ".symlinks/plugins/package_info_plus/ios"
   path_provider_ios:
@@ -158,7 +158,6 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   camera: 9993f92f2c793e87b65e35f3a23c70582afb05b1
-  fk_user_agent: 1f47ec39291e8372b1d692b50084b0d54103c545
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
   flutter_secure_storage: 7953c38a04c3fdbb00571bcd87d8e3b5ceb9daec
   google_ml_barcode_scanner: 469be1279c5ab275846f0957c85015b7b30d0c16
@@ -170,6 +169,7 @@ SPEC CHECKSUMS:
   GTMSessionFetcher: 43748f93435c2aa068b1cbe39655aaf600652e91
   image_picker: 541dcbb3b9cf32d87eacbd957845d8651d6c62c3
   iso_countries: eb09d40f388e4c65e291e0bb36a701dfe7de6c74
+  matomo_forever: 7e5e5fd8f355f64979591282cad4e858fa4c9fae
   MLImage: 647f3d580c10b3c9a3f6154f5d7baead60c42a0c
   MLKitBarcodeScanning: 6b998bd1cfe471ae407a7f647d649494617787c0
   MLKitCommon: 6d6be0a2e9a6340aad1c1f2b9449c11dee8af70f

--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:openfoodfacts/model/Product.dart';
+
+/// Page where we can indirectly edit all data about a product.
+class EditProductPage extends StatelessWidget {
+  const EditProductPage(this.product);
+
+  final Product product;
+
+  // TODO(monsieurtanuki): translations
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(product.productName!)),
+      body: ListView(
+        children: <ListTile>[
+          ListTile(
+            title: const Text('Basic details'),
+            subtitle: const Text('Product name, brand, quantity'),
+            leading: _getLeadingWidget(),
+          ),
+          ListTile(
+            title: const Text('Photos'),
+            subtitle: const Text('Add or refresh photos'),
+            leading: _getLeadingWidget(),
+          ),
+          ListTile(
+            title: const Text('Labels & Certifications'),
+            subtitle: const Text('Environmental, Quality labels, ...'),
+            leading: _getLeadingWidget(),
+          ),
+          ListTile(
+            title: const Text('Ingredients & Origins'),
+            leading: _getLeadingWidget(),
+          ),
+          ListTile(
+            title: const Text('Packaging'),
+            leading: _getLeadingWidget(),
+          ),
+          ListTile(
+            title: const Text('Nutrition facts'),
+            subtitle: const Text('Nutrition, alcohol content, ...'),
+            leading: _getLeadingWidget(),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _getLeadingWidget() => ElevatedButton(
+        child: const Text('Edit'),
+        onPressed: () {},
+      );
+}

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -13,6 +13,7 @@ import 'package:smooth_app/database/dao_product_list.dart';
 import 'package:smooth_app/database/knowledge_panels_query.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/database/product_query.dart';
+import 'package:smooth_app/generic_lib/buttons/smooth_action_button.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/launch_url_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
@@ -20,6 +21,7 @@ import 'package:smooth_app/helpers/ui_helpers.dart';
 import 'package:smooth_app/pages/product/category_cache.dart';
 import 'package:smooth_app/pages/product/category_picker_page.dart';
 import 'package:smooth_app/pages/product/common/product_dialog_helper.dart';
+import 'package:smooth_app/pages/product/edit_product_page.dart';
 import 'package:smooth_app/pages/product/knowledge_panel_product_cards.dart';
 import 'package:smooth_app/pages/product/summary_card.dart';
 import 'package:smooth_app/pages/user_preferences_dev_mode.dart';
@@ -158,6 +160,20 @@ class _ProductPageState extends State<ProductPage> {
         ),
       ),
       _buildKnowledgePanelCards(),
+      Padding(
+        padding: const EdgeInsets.all(SMALL_SPACE),
+        child: SmoothActionButton(
+          text: 'Edit product', // TODO(monsieurtanuki): translations
+          onPressed: () async {
+            await Navigator.push<Widget>(
+              context,
+              MaterialPageRoute<Widget>(
+                builder: (BuildContext context) => EditProductPage(_product),
+              ),
+            );
+          },
+        ),
+      ),
       if (context.read<UserPreferences>().getFlag(
               UserPreferencesDevMode.userPreferencesFlagAdditionalButton) ??
           false)


### PR DESCRIPTION
New file:
* `edit_product_page.dart`: Page where we can indirectly edit all data about a product.

Impacted files:
* `new_product_page.dart`: added a button that calls the new `EditProductPage`
* `Podfile.lock`

<img src="https://user-images.githubusercontent.com/11576431/155892807-22ba50da-fcc8-470d-bfe5-05a3e5d4d881.png" width=250px>
<img src="https://user-images.githubusercontent.com/11576431/155892316-f7c6d0d2-e307-4c41-8602-ed0c2a77ae19.png" width=250px>

- #1161 