### PR TITLE
feat: #1161 - the edit product page now calls the edit nutrition page

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panels_builder.dart
+++ b/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panels_builder.dart
@@ -3,15 +3,11 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/model/KnowledgePanel.dart';
 import 'package:openfoodfacts/model/KnowledgePanelElement.dart';
 import 'package:openfoodfacts/model/KnowledgePanels.dart';
-import 'package:openfoodfacts/model/OrderedNutrients.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
-import 'package:provider/provider.dart';
 import 'package:smooth_app/cards/product_cards/knowledge_panels/knowledge_panel_element_card.dart';
-import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/pages/product/nutrition_page_loaded.dart';
 import 'package:smooth_app/pages/product/ordered_nutrients_cache.dart';
-import 'package:smooth_app/widgets/loading_dialog.dart';
 
 /// Builds "knowledge panels" panels.
 ///
@@ -111,16 +107,9 @@ class KnowledgePanelsBuilder {
                 : appLocalizations.score_update_nutrition_facts,
             iconData: nutritionAddOrUpdate ? Icons.add : Icons.edit,
             onPressed: () async {
-              final LocalDatabase localDatabase = context.read<LocalDatabase>();
-              final OrderedNutrientsCache cache =
-                  OrderedNutrientsCache(localDatabase);
-              final OrderedNutrients? orderedNutrients = await cache.get() ??
-                  await LoadingDialog.run<OrderedNutrients>(
-                    context: context,
-                    future: cache.download(),
-                  );
-              if (orderedNutrients == null) {
-                await LoadingDialog.error(context: context);
+              final OrderedNutrientsCache? cache =
+                  await OrderedNutrientsCache.getCache(context);
+              if (cache == null) {
                 return;
               }
               final bool? refreshed = await Navigator.push<bool>(
@@ -128,7 +117,7 @@ class KnowledgePanelsBuilder {
                 MaterialPageRoute<bool>(
                   builder: (BuildContext context) => NutritionPageLoaded(
                     product,
-                    orderedNutrients,
+                    cache.orderedNutrients,
                   ),
                 ),
               );

--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -1,55 +1,101 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/model/Product.dart';
+import 'package:smooth_app/pages/product/nutrition_page_loaded.dart';
+import 'package:smooth_app/pages/product/ordered_nutrients_cache.dart';
 
 /// Page where we can indirectly edit all data about a product.
-class EditProductPage extends StatelessWidget {
+class EditProductPage extends StatefulWidget {
   const EditProductPage(this.product);
 
   final Product product;
 
+  @override
+  State<EditProductPage> createState() => _EditProductPageState();
+}
+
+class _EditProductPageState extends State<EditProductPage> {
   // TODO(monsieurtanuki): translations
+  int _changes = 0;
 
   @override
   Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context)!;
     return Scaffold(
-      appBar: AppBar(title: Text(product.productName!)),
-      body: ListView(
-        children: <ListTile>[
-          ListTile(
-            title: const Text('Basic details'),
-            subtitle: const Text('Product name, brand, quantity'),
-            leading: _getLeadingWidget(),
-          ),
-          ListTile(
-            title: const Text('Photos'),
-            subtitle: const Text('Add or refresh photos'),
-            leading: _getLeadingWidget(),
-          ),
-          ListTile(
-            title: const Text('Labels & Certifications'),
-            subtitle: const Text('Environmental, Quality labels, ...'),
-            leading: _getLeadingWidget(),
-          ),
-          ListTile(
-            title: const Text('Ingredients & Origins'),
-            leading: _getLeadingWidget(),
-          ),
-          ListTile(
-            title: const Text('Packaging'),
-            leading: _getLeadingWidget(),
-          ),
-          ListTile(
-            title: const Text('Nutrition facts'),
-            subtitle: const Text('Nutrition, alcohol content, ...'),
-            leading: _getLeadingWidget(),
-          ),
-        ],
+      appBar: AppBar(
+        title: Text(
+          widget.product.productName ?? appLocalizations.unknownProductName,
+        ),
+      ),
+      body: WillPopScope(
+        onWillPop: () async {
+          // cf. https://stackoverflow.com/questions/51927885/flutter-back-button-with-return-data
+          // we want the same returned value for the app back button and the android back button
+          final bool result = _changes > 0;
+          Navigator.pop(context, result);
+          return result;
+        },
+        child: ListView(
+          children: <ListTile>[
+            _getListTile(
+              title: 'Basic details',
+              subtitle: 'Product name, brand, quantity',
+            ),
+            _getListTile(
+              title: 'Photos',
+              subtitle: 'Add or refresh photos',
+            ),
+            _getListTile(
+              title: 'Labels & Certifications',
+              subtitle: 'Environmental, Quality labels, ...',
+            ),
+            _getListTile(
+              title: 'Ingredients & Origins',
+            ),
+            _getListTile(
+              title: 'Packaging',
+            ),
+            _getListTile(
+              title: 'Nutrition facts',
+              subtitle: 'Nutrition, alcohol content, ...',
+              onTap: () async {
+                final OrderedNutrientsCache? cache =
+                    await OrderedNutrientsCache.getCache(context);
+                if (cache == null) {
+                  return;
+                }
+                final bool? refreshed = await Navigator.push<bool>(
+                  context,
+                  MaterialPageRoute<bool>(
+                    builder: (BuildContext context) => NutritionPageLoaded(
+                      widget.product,
+                      cache.orderedNutrients,
+                    ),
+                  ),
+                );
+                if (refreshed ?? false) {
+                  _changes++;
+                }
+              },
+            )
+          ],
+        ),
       ),
     );
   }
 
-  Widget _getLeadingWidget() => ElevatedButton(
-        child: const Text('Edit'),
-        onPressed: () {},
+  ListTile _getListTile({
+    required final String title,
+    final String? subtitle,
+    final VoidCallback? onTap,
+  }) =>
+      ListTile(
+        onTap: onTap,
+        title: Text(title),
+        subtitle: subtitle == null ? null : Text(subtitle),
+        leading: ElevatedButton(
+          child: const Text('Edit'),
+          onPressed: onTap,
+        ),
       );
 }

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -165,12 +165,15 @@ class _ProductPageState extends State<ProductPage> {
         child: SmoothActionButton(
           text: 'Edit product', // TODO(monsieurtanuki): translations
           onPressed: () async {
-            await Navigator.push<Widget>(
+            final bool? refreshed = await Navigator.push<bool>(
               context,
-              MaterialPageRoute<Widget>(
+              MaterialPageRoute<bool>(
                 builder: (BuildContext context) => EditProductPage(_product),
               ),
             );
+            if (refreshed ?? false) {
+              setState(() {});
+            }
           },
         ),
       ),

--- a/packages/smooth_app/lib/pages/product/ordered_nutrients_cache.dart
+++ b/packages/smooth_app/lib/pages/product/ordered_nutrients_cache.dart
@@ -1,36 +1,61 @@
 import 'dart:convert';
+
+import 'package:flutter/material.dart';
 import 'package:openfoodfacts/model/OrderedNutrients.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:openfoodfacts/utils/OpenFoodAPIConfiguration.dart';
+import 'package:provider/provider.dart';
 import 'package:smooth_app/database/dao_string.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/database/product_query.dart';
+import 'package:smooth_app/widgets/loading_dialog.dart';
 
 /// Helper class about getting and caching the back-end ordered nutrients.
 class OrderedNutrientsCache {
-  const OrderedNutrientsCache(this.localDatabase);
+  OrderedNutrientsCache._(final LocalDatabase localDatabase)
+      : _daoString = DaoString(localDatabase);
 
-  final LocalDatabase localDatabase;
+  final DaoString _daoString;
+
+  OrderedNutrients? _orderedNutrients;
+  OrderedNutrients get orderedNutrients => _orderedNutrients!;
+
+  /// Returns a database/downloaded cache, or null if it failed.
+  static Future<OrderedNutrientsCache?> getCache(
+    final BuildContext context,
+  ) async {
+    final LocalDatabase localDatabase = context.read<LocalDatabase>();
+    final OrderedNutrientsCache cache = OrderedNutrientsCache._(localDatabase);
+    cache._orderedNutrients = await cache._get() ??
+        await LoadingDialog.run<OrderedNutrients>(
+          context: context,
+          future: cache._download(),
+        );
+    if (cache._orderedNutrients == null) {
+      await LoadingDialog.error(context: context);
+      return null;
+    }
+    return cache;
+  }
 
   /// Returns the ordered nutrients cached in the database.
-  Future<OrderedNutrients?> get() async {
-    final DaoString daoString = DaoString(localDatabase);
-    final String? string = await daoString.get(_getKey());
+  Future<OrderedNutrients?> _get() async {
+    final String? string = await _daoString.get(_getKey());
     if (string != null) {
       try {
         return OrderedNutrients.fromJson(
           jsonDecode(string) as Map<String, dynamic>,
         );
       } catch (e) {
-        await daoString.put(_getKey(), null);
+        await _daoString.put(_getKey(), null);
       }
     }
     return null;
   }
 
   /// Downloads the ordered nutrients and caches them in the database.
-  Future<OrderedNutrients> download() async {
+  Future<OrderedNutrients> _download() async {
     final String string = await OpenFoodAPIClient.getOrderedNutrientsJsonString(
       country: ProductQuery.getCountry()!,
       language: ProductQuery.getLanguage()!,
@@ -38,18 +63,14 @@ class OrderedNutrientsCache {
     final OrderedNutrients result = OrderedNutrients.fromJson(
       jsonDecode(string) as Map<String, dynamic>,
     );
-    final DaoString daoString = DaoString(localDatabase);
-    await daoString.put(_getKey(), string);
+    await _daoString.put(_getKey(), string);
     return result;
   }
 
   /// Clears the cache.
   ///
   /// Typical use case: when it's time to refresh the cached data.
-  Future<void> clear() async {
-    final DaoString daoString = DaoString(localDatabase);
-    daoString.put(_getKey(), null);
-  }
+  Future<void> clear() async => _daoString.put(_getKey(), null);
 
   /// Database key.
   String _getKey() {


### PR DESCRIPTION
Impacted files:
* `edit_product_page.dart`: now calling the edit nutrition page; now pops a "changed?" bool; refactored the `ListTile`s
* `knowledge_panels_builder.dart`: refactored with the new cache call
* `new_product_page.dart`: now refreshes the page after edits
* `ordered_nutrients_cache.dart`: refactored as a black box regarding the get/download combo

### What
- description of the PR

### Screenshot
![Simulator Screen Shot - iPhone 8 Plus - 2022-02-28 at 19 38 55](https://user-images.githubusercontent.com/11576431/156039347-f651d4f6-229f-40e3-9ad8-f72600e804ca.png)

### Part of 
- #1161, #954, 
