### PR TITLE
fix: Wrong colored create account button

### DIFF
--- a/packages/smooth_app/lib/pages/user_management/login_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/login_page.dart
@@ -239,7 +239,7 @@ class _LoginPageState extends State<LoginPage> {
                       ),
                       style: ButtonStyle(
                         side: MaterialStateProperty.all<BorderSide>(
-                          BorderSide(color: theme.primaryColor, width: 2.0),
+                          BorderSide(color: theme.colorScheme.primary, width: 2.0),
                         ),
                         minimumSize: MaterialStateProperty.all<Size>(
                           Size(size.width * 0.5, theme.buttonTheme.height),


### PR DESCRIPTION
### What
- Fixes wrongly colored create account button.

### Impacted files
 - `login_page.dart`

### Screenshot
<div align="center">
<h3>Before</h3>
<img src="https://user-images.githubusercontent.com/63305824/157648750-b223a116-3236-46c3-9f9c-384186e40568.png" data-canonical-src="https://gyazo.com/eb5c5741b6a9a16c692170a41a49c858.png" width="200" height="400" />
</div>

<div align="center">
<h3>After</h3>
<img src="https://user-images.githubusercontent.com/63305824/157648758-eaebf752-63ed-4e4a-be20-f365e1d75658.png" data-canonical-src="https://gyazo.com/eb5c5741b6a9a16c692170a41a49c858.png" width="200" height="400" />
</div>


### Fixes bug
- #1128 

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/1171