### PR TITLE
Flattened the color/dark mode settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#671](https://www.github.com/openfoodfacts/smooth-app/issues/671) - removed the "very important" attribute importance ([#672](https://www.github.com/openfoodfacts/smooth-app/issues/672)) ([69bdefb](https://www.github.com/openfoodfacts/smooth-app/commit/69bdefbaab9b9379c16ef94ec038d51df70f27d5))
 * [#678](https://www.github.com/openfoodfacts/smooth-app/issues/678) - added bottom navigation bar to product page ([#679](https://www.github.com/openfoodfacts/smooth-app/issues/679)) ([212dd31](https://www.github.com/openfoodfacts/smooth-app/commit/212dd31d9171af22a412287091a920db2bba271a))
 * [#682](https://www.github.com/openfoodfacts/smooth-app/issues/682) - add a "Clear all" menu item in the product history page ([#683](https://www.github.com/openfoodfacts/smooth-app/issues/683)) ([b672d2a](https://www.github.com/openfoodfacts/smooth-app/commit/b672d2a1108cb1966c21498df7b3c61475825e40))
+* [#919](https://www.github.com/openfoodfacts/smooth-app/issues/919) - removed the shadow of the widgets for changing darkmode and color theme of the app in the user preferences screen
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@
 * [#671](https://www.github.com/openfoodfacts/smooth-app/issues/671) - removed the "very important" attribute importance ([#672](https://www.github.com/openfoodfacts/smooth-app/issues/672)) ([69bdefb](https://www.github.com/openfoodfacts/smooth-app/commit/69bdefbaab9b9379c16ef94ec038d51df70f27d5))
 * [#678](https://www.github.com/openfoodfacts/smooth-app/issues/678) - added bottom navigation bar to product page ([#679](https://www.github.com/openfoodfacts/smooth-app/issues/679)) ([212dd31](https://www.github.com/openfoodfacts/smooth-app/commit/212dd31d9171af22a412287091a920db2bba271a))
 * [#682](https://www.github.com/openfoodfacts/smooth-app/issues/682) - add a "Clear all" menu item in the product history page ([#683](https://www.github.com/openfoodfacts/smooth-app/issues/683)) ([b672d2a](https://www.github.com/openfoodfacts/smooth-app/commit/b672d2a1108cb1966c21498df7b3c61475825e40))
-* [#919](https://www.github.com/openfoodfacts/smooth-app/issues/919) - removed the shadow of the widgets for changing darkmode and color theme of the app in the user preferences screen
 
 
 ### Bug Fixes

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -577,5 +577,9 @@
     "@compare_products_mode": {
         "description": "Button to switch to 'compare products mode'"
     },
-    "retry_button_label": "Retry"
+    "retry_button_label": "Retry",
+    "main_app_color": "Main color of the app",
+    "@main_app_color": {
+        "description": "Heading for the section to pick the main app color"
+    }
 }

--- a/packages/smooth_app/lib/pages/user_preferences_settings.dart
+++ b/packages/smooth_app/lib/pages/user_preferences_settings.dart
@@ -8,6 +8,7 @@ import 'package:package_info_plus/package_info_plus.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/generic_lib/buttons/smooth_action_button.dart';
 import 'package:smooth_app/generic_lib/buttons/smooth_main_button.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_list_tile.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_toggle.dart';
@@ -62,7 +63,10 @@ class UserPreferencesSettings extends AbstractUserPreferences {
   @override
   List<Widget> getBody() => <Widget>[
         Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 10),
+          padding: const EdgeInsets.symmetric(
+            horizontal: LARGE_SPACE,
+            vertical: MEDIUM_SPACE,
+          ),
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: <Widget>[
@@ -90,7 +94,7 @@ class UserPreferencesSettings extends AbstractUserPreferences {
           ),
         ),
         Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 20.0),
+          padding: const EdgeInsets.symmetric(horizontal: LARGE_SPACE),
           child: Text(
             appLocalizations.main_app_color,
             style: themeData.textTheme.headline4,
@@ -98,8 +102,8 @@ class UserPreferencesSettings extends AbstractUserPreferences {
         ),
         Padding(
           padding: const EdgeInsets.symmetric(
-            horizontal: 20.0,
-            vertical: 5,
+            horizontal: LARGE_SPACE,
+            vertical: VERY_SMALL_SPACE,
           ),
           child: Wrap(
             spacing: 8.0,

--- a/packages/smooth_app/lib/pages/user_preferences_settings.dart
+++ b/packages/smooth_app/lib/pages/user_preferences_settings.dart
@@ -61,29 +61,47 @@ class UserPreferencesSettings extends AbstractUserPreferences {
 
   @override
   List<Widget> getBody() => <Widget>[
-        SmoothListTile(
-          text: appLocalizations.darkmode,
-          onPressed: null,
-          leadingWidget: SmoothToggle(
-            value: themeProvider.darkTheme,
-            width: 85.0,
-            height: 38.0,
-            textRight: appLocalizations.darkmode_light,
-            textLeft: appLocalizations.darkmode_dark,
-            colorRight: Colors.blue,
-            colorLeft: Colors.blueGrey.shade700,
-            iconRight: const Icon(Icons.wb_sunny_rounded),
-            iconLeft: const Icon(
-              Icons.nightlight_round,
-              color: Colors.black,
-            ),
-            onChanged: (bool newValue) async =>
-                themeProvider.setDarkTheme(newValue),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 10),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                appLocalizations.darkmode,
+                style: themeData.textTheme.headline4,
+              ),
+              SmoothToggle(
+                value: themeProvider.darkTheme,
+                width: 85.0,
+                height: 38.0,
+                textRight: appLocalizations.darkmode_light,
+                textLeft: appLocalizations.darkmode_dark,
+                colorRight: Colors.blue,
+                colorLeft: Colors.blueGrey.shade700,
+                iconRight: const Icon(Icons.wb_sunny_rounded),
+                iconLeft: const Icon(
+                  Icons.nightlight_round,
+                  color: Colors.black,
+                ),
+                onChanged: (bool newValue) async =>
+                    themeProvider.setDarkTheme(newValue),
+              ),
+            ],
           ),
         ),
-        SmoothListTile(
-          leadingWidget: Container(),
-          title: Wrap(
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20.0),
+          child: Text(
+            appLocalizations.main_app_color,
+            style: themeData.textTheme.headline4,
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: 20.0,
+            vertical: 5,
+          ),
+          child: Wrap(
             spacing: 8.0,
             children: List<Widget>.generate(
               _ORDERED_COLOR_TAGS.length,

--- a/packages/smooth_app/lib/pages/user_preferences_settings.dart
+++ b/packages/smooth_app/lib/pages/user_preferences_settings.dart
@@ -65,7 +65,7 @@ class UserPreferencesSettings extends AbstractUserPreferences {
           padding: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 10),
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
+            children: <Widget>[
               Text(
                 appLocalizations.darkmode,
                 style: themeData.textTheme.headline4,


### PR DESCRIPTION
### What
- Removed the shadow of the widgets for changing darkmode and color theme of the app in the user preferences screen

### Screenshot

![Screenshot_20220311-194225](https://user-images.githubusercontent.com/57158013/157884320-b126c436-2615-4871-8dca-aa567ccdbcd1.jpg)

### Fixes bug(s)
- #919 

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/919
(please be as granular as possible)
