### PR TITLE
fix: AppBar does not fit theme

### DIFF
--- a/packages/smooth_app/lib/pages/product/common/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_page.dart
@@ -52,6 +52,7 @@ class _ProductListPageState extends State<ProductListPage> {
     }
     return Scaffold(
       appBar: AppBar(
+        elevation: 0,
         backgroundColor: Colors.white, // TODO(monsieurtanuki): night mode
         foregroundColor: Colors.black,
         title: Row(


### PR DESCRIPTION
### What
- Fixes the elevation of AppBar in the history tab.

### Impacted files
 - `product_list_page.dart`

### Screenshot
<div align="center">
<h3>Before</h3>
<img src="https://user-images.githubusercontent.com/63305824/157932507-618cf8e4-69b3-4156-9601-e79ca8ee81e4.png" width="200" height="400" />
</div>

<div align="center">
<h3>After</h3>
<img src="https://user-images.githubusercontent.com/63305824/157932494-ae4deb6c-562e-488f-9c68-3483b5882bdb.png" width="200" height="400" />
</div>


### Fixes bug
- #1172 