### PR TITLE
Compare button enabled only for two or more products

### DIFF
--- a/packages/smooth_app/lib/pages/product/common/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_page.dart
@@ -80,7 +80,7 @@ class _ProductListPageState extends State<ProductListPage> {
                             builder: (BuildContext context) =>
                                 PersonalizedRankingPage.fromItems(
                               products: list,
-                              title: 'Your ranking',
+                              title: 'Your ranking', // TODO(X): Translate
                             ),
                           ),
                         );

--- a/packages/smooth_app/lib/pages/product/common/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_page.dart
@@ -56,36 +56,37 @@ class _ProductListPageState extends State<ProductListPage> {
         backgroundColor: Colors.white, // TODO(monsieurtanuki): night mode
         foregroundColor: Colors.black,
         title: Row(
-          mainAxisAlignment: _selectionMode && _selectedBarcodes.isEmpty
-              ? MainAxisAlignment.end // just the cancel button, at the end
-              : MainAxisAlignment.spaceBetween,
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: <Widget>[
-            if (_selectionMode && _selectedBarcodes.isNotEmpty)
+            if (_selectionMode)
               ElevatedButton(
                 child: Text(
                   appLocalizations.plural_compare_x_products(
                     _selectedBarcodes.length,
                   ),
                 ),
-                onPressed: () async {
-                  final List<Product> list = <Product>[];
-                  for (final Product product in products) {
-                    if (_selectedBarcodes.contains(product.barcode)) {
-                      list.add(product);
-                    }
-                  }
-                  await Navigator.push<Widget>(
-                    context,
-                    MaterialPageRoute<Widget>(
-                      builder: (BuildContext context) =>
-                          PersonalizedRankingPage.fromItems(
-                        products: list,
-                        title: 'Your ranking',
-                      ),
-                    ),
-                  );
-                  setState(() => _selectionMode = false);
-                },
+                onPressed: _selectedBarcodes.length >=
+                        2 // compare button is enabled only if 2 or more products have been selected
+                    ? () async {
+                        final List<Product> list = <Product>[];
+                        for (final Product product in products) {
+                          if (_selectedBarcodes.contains(product.barcode)) {
+                            list.add(product);
+                          }
+                        }
+                        await Navigator.push<Widget>(
+                          context,
+                          MaterialPageRoute<Widget>(
+                            builder: (BuildContext context) =>
+                                PersonalizedRankingPage.fromItems(
+                              products: list,
+                              title: 'Your ranking',
+                            ),
+                          ),
+                        );
+                        setState(() => _selectionMode = false);
+                      }
+                    : null,
               ),
             if (_selectionMode)
               ElevatedButton(


### PR DESCRIPTION
### What
- In selecting products for comparison on the History page, the compare button is always visible in comparison mode, but will only be enabled when two or more products have been selected for comparison.

### Screenshot

![Screenshot_20220312-204455](https://user-images.githubusercontent.com/57158013/158023977-49949e11-65ae-4702-98fa-1224e63c53fb.jpg)

![Screenshot_20220312-204503](https://user-images.githubusercontent.com/57158013/158023972-7cce5b15-d0e2-42da-b6dc-2f2f6ac0d278.jpg)

![Screenshot_20220312-204508](https://user-images.githubusercontent.com/57158013/158023978-b45e2eb4-07f0-4fad-b689-2ee07014b638.jpg)


### Fixes bug(s)
- #1173 

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/1173
(please be as granular as possible)
