### PR TITLE
feat: #1160 - added a "delete account" option

### DIFF
--- a/packages/smooth_app/lib/pages/user_preferences_profile.dart
+++ b/packages/smooth_app/lib/pages/user_preferences_profile.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:mailto/mailto.dart';
 import 'package:openfoodfacts/utils/OpenFoodAPIConfiguration.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/generic_lib/buttons/smooth_action_button.dart';
@@ -10,6 +11,7 @@ import 'package:smooth_app/helpers/user_management_helper.dart';
 import 'package:smooth_app/pages/abstract_user_preferences.dart';
 import 'package:smooth_app/pages/onboarding/country_selector.dart';
 import 'package:smooth_app/pages/user_management/login_page.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 /// Collapsed/expanded display of profile for the preferences page.
 class UserPreferencesProfile extends AbstractUserPreferences {
@@ -53,55 +55,36 @@ class UserPreferencesProfile extends AbstractUserPreferences {
 
     //Credentials exist
     if (OpenFoodAPIConfiguration.globalUser != null) {
+      final String userId = OpenFoodAPIConfiguration.globalUser!.userId;
       result.add(
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: <Widget>[
-            ElevatedButton.icon(
-              onPressed: () => LaunchUrlHelper.launchURL(
-                'https://openfoodfacts.org/editor/${OpenFoodAPIConfiguration.globalUser!.userId}',
-                true,
-              ),
-              label: Text(
-                appLocalizations.view_profile,
-                style: theme.textTheme.bodyText2?.copyWith(
-                  fontSize: 18.0,
-                  color: theme.colorScheme.surface,
-                ),
-              ),
-              icon: const Icon(Icons.open_in_new),
-              style: ButtonStyle(
-                minimumSize: MaterialStateProperty.all<Size>(
-                  Size(size.width * 0.33, theme.buttonTheme.height + 10),
-                ),
-                shape: MaterialStateProperty.all<RoundedRectangleBorder>(
-                  const RoundedRectangleBorder(
-                    borderRadius: CIRCULAR_BORDER_RADIUS,
-                  ),
-                ),
-              ),
-            ),
-            ElevatedButton(
-              onPressed: () => _confirmLogout(context),
-              child: Text(
-                appLocalizations.sign_out,
-                style: theme.textTheme.bodyText2?.copyWith(
-                  fontSize: 18.0,
-                  color: theme.colorScheme.surface,
-                ),
-              ),
-              style: ButtonStyle(
-                minimumSize: MaterialStateProperty.all<Size>(
-                  Size(size.width * 0.33, theme.buttonTheme.height + 10),
-                ),
-                shape: MaterialStateProperty.all<RoundedRectangleBorder>(
-                  const RoundedRectangleBorder(
-                    borderRadius: CIRCULAR_BORDER_RADIUS,
-                  ),
-                ),
-              ),
-            ),
-          ],
+        ListTile(
+          onTap: () async => LaunchUrlHelper.launchURL(
+            'https://openfoodfacts.org/editor/$userId',
+            true,
+          ),
+          title: Text(appLocalizations.view_profile),
+          leading: const Icon(Icons.open_in_new),
+        ),
+      );
+      result.add(
+        ListTile(
+          onTap: () => _confirmLogout(context),
+          title: Text(appLocalizations.sign_out),
+          leading: const Icon(Icons.clear),
+        ),
+      );
+      result.add(
+        ListTile(
+          onTap: () async {
+            final Mailto mailtoLink = Mailto(
+              to: <String>['contact@openfoodfacts.org'],
+              subject: 'Delete account', // TODO(monsieurtanuki): localize
+              body: 'Hi there, please delete my openfoodfacts account: $userId',
+            );
+            await launch('$mailtoLink');
+          },
+          title: const Text('Delete account'),
+          leading: const Icon(Icons.delete),
         ),
       );
     } else {


### PR DESCRIPTION
Impacted file:
* `user_preferences_profile.dart`: added a "delete account" option; had to refactor the UI

### What
- we just open a "please delete my account" mail with a new `ListTile`
- I had to change the UI: it was not possible to see 3 large green buttons side by side. I'm open to suggestions.

### Screenshot

![Simulator Screen Shot - iPhone 8 Plus - 2022-03-12 at 16 24 32](https://user-images.githubusercontent.com/11576431/158024121-71d7b48c-1e5e-4851-9118-c1b9b7c4e194.png)


### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/1160 (just the first part)