### PR TITLE
feat: #1145 - added a preference for "test env host"

### DIFF
--- a/packages/smooth_app/lib/data_models/user_preferences.dart
+++ b/packages/smooth_app/lib/data_models/user_preferences.dart
@@ -110,4 +110,10 @@ class UserPreferences extends ChangeNotifier {
       _sharedPreferences.setInt(tag, index);
 
   int? getDevModeIndex(final String tag) => _sharedPreferences.getInt(tag);
+
+  Future<void> setDevModeString(final String tag, final String value) async =>
+      _sharedPreferences.setString(tag, value);
+
+  String? getDevModeString(final String tag) =>
+      _sharedPreferences.getString(tag);
 }

--- a/packages/smooth_app/lib/database/product_query.dart
+++ b/packages/smooth_app/lib/database/product_query.dart
@@ -67,12 +67,18 @@ abstract class ProductQuery {
       );
 
   /// Sets the query type according to the current [UserPreferences]
-  static void setQueryType(final UserPreferences userPreferences) =>
-      OpenFoodAPIConfiguration.globalQueryType = userPreferences
-                  .getFlag(UserPreferencesDevMode.userPreferencesFlagProd) ??
-              true
-          ? QueryType.PROD
-          : QueryType.TEST;
+  static void setQueryType(final UserPreferences userPreferences) {
+    OpenFoodAPIConfiguration.globalQueryType = userPreferences
+                .getFlag(UserPreferencesDevMode.userPreferencesFlagProd) ??
+            true
+        ? QueryType.PROD
+        : QueryType.TEST;
+    final String? testEnvHost = userPreferences
+        .getDevModeString(UserPreferencesDevMode.userPreferencesTestEnvHost);
+    if (testEnvHost != null) {
+      OpenFoodAPIConfiguration.uriTestHost = testEnvHost;
+    }
+  }
 
   static List<ProductField> get fields => <ProductField>[
         ProductField.NAME,

--- a/packages/smooth_app/lib/pages/user_preferences_dev_mode.dart
+++ b/packages/smooth_app/lib/pages/user_preferences_dev_mode.dart
@@ -35,11 +35,14 @@ class UserPreferencesDevMode extends AbstractUserPreferences {
         );
 
   static const String userPreferencesFlagProd = '__devWorkingOnProd';
+  static const String userPreferencesTestEnvHost = '__testEnvHost';
   static const String userPreferencesFlagUseMLKit = '__useMLKit';
   static const String userPreferencesFlagLenientMatching = '__lenientMatching';
   static const String userPreferencesFlagAdditionalButton =
       '__additionalButtonOnProductPage';
   static const String userPreferencesEnumScanMode = '__scanMode';
+
+  final TextEditingController _textFieldController = TextEditingController();
 
   @override
   bool isCollapsedByDefault() => true;
@@ -84,7 +87,8 @@ class UserPreferencesDevMode extends AbstractUserPreferences {
           },
         ),
         ListTile(
-          title: const Text('Switch between openfoodfacts.org and .net'),
+          title: const Text(
+              'Switch between openfoodfacts.org (PROD) and test env'),
           subtitle: Text(
             'Current query type is ${OpenFoodAPIConfiguration.globalQueryType}',
           ),
@@ -94,6 +98,13 @@ class UserPreferencesDevMode extends AbstractUserPreferences {
             ProductQuery.setQueryType(userPreferences);
             setState(() {});
           },
+        ),
+        ListTile(
+          title: const Text('Test env parameters'),
+          subtitle: Text(
+            'Current base URL of test env is ${OpenFoodAPIConfiguration.uriScheme}://${OpenFoodAPIConfiguration.uriTestHost}/',
+          ),
+          onTap: () async => _changeTestEnvHost(),
         ),
         SwitchListTile(
           title: const Text('Use ML Kit'),
@@ -221,6 +232,35 @@ class UserPreferencesDevMode extends AbstractUserPreferences {
           },
         ),
       ];
+
+  Future<void> _changeTestEnvHost() async {
+    _textFieldController.text =
+        userPreferences.getDevModeString(userPreferencesTestEnvHost) ??
+            OpenFoodAPIConfiguration.uriTestHost;
+    final bool? result = await showDialog<bool>(
+      context: context,
+      builder: (final BuildContext context) => AlertDialog(
+        title: const Text('Test Env Host'),
+        content: TextField(controller: _textFieldController),
+        actions: <Widget>[
+          TextButton(
+            child: const Text('Cancel'),
+            onPressed: () => Navigator.pop(context, false),
+          ),
+          ElevatedButton(
+            child: const Text('OK'),
+            onPressed: () => Navigator.pop(context, true),
+          ),
+        ],
+      ),
+    );
+    if (result == true) {
+      await userPreferences.setDevModeString(
+          userPreferencesTestEnvHost, _textFieldController.text);
+      ProductQuery.setQueryType(userPreferences);
+      setState(() {});
+    }
+  }
 }
 
 enum DevModeScanMode {


### PR DESCRIPTION
Impacted files:
* `product_query.dart`: improved method `setQueryType` in order to include the new "test env host" preference
* `user_preferences.dart`: added getter/setter for `String` in dev mode
* `user_preferences_dev_mode.dart`: added a dialog for "test env host"

### What
- now we can explicitly specify the host for the test env

### Screenshot
![Simulator Screen Shot - iPhone 8 Plus - 2022-03-13 at 12 31 03](https://user-images.githubusercontent.com/11576431/158057384-a817c640-3f84-44c0-aa00-fca7560b014f.png)

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/1145
