### PR TITLE
feat: #501 - added switches in preferences for crash and analytics reports

### DIFF
--- a/packages/smooth_app/lib/data_models/user_preferences.dart
+++ b/packages/smooth_app/lib/data_models/user_preferences.dart
@@ -25,6 +25,8 @@ class UserPreferences extends ChangeNotifier {
   static const String _TAG_PREFIX_FLAG = 'FLAG_PREFIX_';
   static const String _TAG_DEV_MODE = 'devMode';
   static const String _TAG_CAMERA_DECLINE = 'declined_camera_use_once';
+  static const String _TAG_CRASH_REPORTS = 'crash_reports';
+  static const String _TAG_ANALYTICS_REPORTS = 'analytics_reports';
 
   Future<void> init(final ProductPreferences productPreferences) async {
     if (_sharedPreferences.getBool(_TAG_INIT) != null) {
@@ -57,6 +59,18 @@ class UserPreferences extends ChangeNotifier {
       _sharedPreferences.setBool(_TAG_THEME_DARK, state);
 
   bool get isThemeDark => _sharedPreferences.getBool(_TAG_THEME_DARK) ?? false;
+
+  Future<void> setCrashReports(final bool state) async =>
+      _sharedPreferences.setBool(_TAG_CRASH_REPORTS, state);
+
+  bool get crashReports =>
+      _sharedPreferences.getBool(_TAG_CRASH_REPORTS) ?? true;
+
+  Future<void> setAnalyticsReports(final bool state) async =>
+      _sharedPreferences.setBool(_TAG_ANALYTICS_REPORTS, state);
+
+  bool get analyticsReports =>
+      _sharedPreferences.getBool(_TAG_ANALYTICS_REPORTS) ?? true;
 
   Future<void> setThemeColorTag(final String colorTag) async =>
       _sharedPreferences.setString(_TAG_THEME_COLOR_TAG, colorTag);

--- a/packages/smooth_app/lib/helpers/analytics_helper.dart
+++ b/packages/smooth_app/lib/helpers/analytics_helper.dart
@@ -11,8 +11,6 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/helpers/tracking_database_helper.dart';
 
-// TODO(m123): Check for user consent
-
 /// Helper for logging usage of core features and exceptions
 /// Logging:
 /// - Errors and Problems (sentry)
@@ -25,6 +23,9 @@ import 'package:smooth_app/helpers/tracking_database_helper.dart';
 /// - external links
 class AnalyticsHelper {
   AnalyticsHelper._();
+
+  static bool _crashReports = false;
+  static bool _analyticsReports = false;
 
   static const String _initAction = 'started app';
   static const String _scanAction = 'scanned product';
@@ -58,9 +59,24 @@ class AnalyticsHelper {
             'https://22ec5d0489534b91ba455462d3736680@o241488.ingest.sentry.io/5376745';
         options.sentryClientName =
             'sentry.dart.smoothie/${packageInfo.version}';
+        options.beforeSend = _beforeSend;
       },
       appRunner: appRunner,
     );
+  }
+
+  static void setCrashReports(final bool crashReports) =>
+      _crashReports = crashReports;
+
+  static void setAnalyticsReports(final bool analyticsReports) =>
+      _analyticsReports = analyticsReports;
+
+  static FutureOr<SentryEvent?> _beforeSend(SentryEvent event,
+      {dynamic hint}) async {
+    if (!_crashReports) {
+      return null;
+    }
+    return event;
   }
 
   static void initMatomo(final BuildContext context) {
@@ -200,7 +216,11 @@ class AnalyticsHelper {
         },
       );
 
-  static Future<bool> _track(String actionName, Map<String, String> data) {
+  static Future<bool> _track(
+      String actionName, Map<String, String> data) async {
+    if (!_analyticsReports) {
+      return false;
+    }
     final DateTime date = DateTime.now();
     final Map<String, String> addedData = <String, String>{
       'action_name': actionName,

--- a/packages/smooth_app/lib/main.dart
+++ b/packages/smooth_app/lib/main.dart
@@ -83,6 +83,8 @@ class _SmoothAppState extends State<SmoothApp> {
     );
     await _productPreferences.init(DefaultAssetBundle.of(context));
     await _userPreferences.init(_productPreferences);
+    AnalyticsHelper.setCrashReports(_userPreferences.crashReports);
+    AnalyticsHelper.setAnalyticsReports(_userPreferences.analyticsReports);
     ProductQuery.setCountry(_userPreferences.userCountryCode);
     _themeProvider = ThemeProvider(_userPreferences);
     ProductQuery.setQueryType(_userPreferences);

--- a/packages/smooth_app/lib/pages/user_preferences_profile.dart
+++ b/packages/smooth_app/lib/pages/user_preferences_profile.dart
@@ -6,6 +6,7 @@ import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/generic_lib/buttons/smooth_action_button.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
+import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/launch_url_helper.dart';
 import 'package:smooth_app/helpers/user_management_helper.dart';
 import 'package:smooth_app/pages/abstract_user_preferences.dart';
@@ -130,6 +131,32 @@ class UserPreferencesProfile extends AbstractUserPreferences {
           title: CountrySelector(
             initialCountryCode: userPreferences.userCountryCode,
           ),
+        ),
+        SwitchListTile(
+          title:
+              const Text('Crash reporting'), // TODO(monsieurtanuki): localize
+          subtitle: const Text(
+              'When enabled, crash reports will be sent to the Open Food Facts server automatically, so that we can fix bugs and improve the app.'),
+          isThreeLine: true,
+          value: userPreferences.crashReports,
+          onChanged: (final bool value) async {
+            await userPreferences.setCrashReports(value);
+            AnalyticsHelper.setCrashReports(value);
+            setState(() {});
+          },
+        ),
+        SwitchListTile(
+          title: const Text(
+              'Send anonymous data'), // TODO(monsieurtanuki): localize
+          subtitle: const Text(
+              'When enabled, some anonymous information regarding app usage will be sent to the Open Food Facts servers, so that we can understand how and how much features are used in order to improve them.'),
+          isThreeLine: true,
+          value: userPreferences.analyticsReports,
+          onChanged: (final bool value) async {
+            await userPreferences.setAnalyticsReports(value);
+            AnalyticsHelper.setAnalyticsReports(value);
+            setState(() {});
+          },
         ),
       ],
     );


### PR DESCRIPTION
Impacted files:
* `analytics_helper.dart`: added 2 static bool fields to say if we should or not send crash and analytics reports
* `main.dart`: init of the crash and analytics report flags
* `user_preferences.dart`: getters/setters for the report flags
* `user_preferences_profile.dart`: added switches for the report flags

### What
- one switch in the preferences for crash reports
- one switch in the preferences for analytics reports
- those flags enable/disable the reports - to be tested thoroughly

### Screenshot

![Simulator Screen Shot - iPhone 8 Plus - 2022-03-13 at 14 16 22](https://user-images.githubusercontent.com/11576431/158061155-77f37c3c-30d9-42a0-81a7-df73386fe526.png)


### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/501
