### PR TITLE
feat: Added a button to close questions

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/question_card.dart
+++ b/packages/smooth_app/lib/cards/product_cards/question_card.dart
@@ -4,6 +4,7 @@ import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/utils/OpenFoodAPIConfiguration.dart';
 import 'package:smooth_app/cards/product_cards/product_image_carousel.dart';
 import 'package:smooth_app/cards/product_cards/product_title_card.dart';
+import 'package:smooth_app/generic_lib/buttons/smooth_action_button.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/loading_dialog.dart';
 import 'package:smooth_app/helpers/user_management_helper.dart';
@@ -379,6 +380,7 @@ class _QuestionCardState extends State<QuestionCard>
                         child: Text(
                           appLocalizations.sign_in_text,
                           style: bodyTextStyle,
+                          textAlign: TextAlign.center,
                         ),
                       ),
                     ],
@@ -387,6 +389,10 @@ class _QuestionCardState extends State<QuestionCard>
                   return EMPTY_WIDGET;
                 }
               }),
+              SmoothActionButton(
+                text: appLocalizations.close,
+                onPressed: () => Navigator.pop<Widget>(context),
+              )
         ],
       ),
     );

--- a/packages/smooth_app/lib/cards/product_cards/question_card.dart
+++ b/packages/smooth_app/lib/cards/product_cards/question_card.dart
@@ -389,10 +389,10 @@ class _QuestionCardState extends State<QuestionCard>
                   return EMPTY_WIDGET;
                 }
               }),
-              SmoothActionButton(
-                text: appLocalizations.close,
-                onPressed: () => Navigator.pop<Widget>(context),
-              )
+          SmoothActionButton(
+            text: appLocalizations.close,
+            onPressed: () => Navigator.pop<Widget>(context),
+          ),
         ],
       ),
     );


### PR DESCRIPTION
### What
- Adds a button to close questions
- Aligns the text below the "Sign in" button

### Impacted files
 - `question_card.dart`

### Screenshot
<div align="center">
<h3>Before</h3>
<img src="https://user-images.githubusercontent.com/63305824/158119618-9a9fa65c-f235-4ec2-8719-bfdf91901396.png" width="200" height="400" />
</div>

<div align="center">
<h3>After</h3>
<img src="https://user-images.githubusercontent.com/63305824/158119647-2f0fe383-3fc2-4f11-bae0-8a618b76507b.png" width="200" height="400" />
</div>

### Fixes bug
- #1100 

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/1171