### PR TITLE
fix: Switch dark mode color

### DIFF
--- a/packages/smooth_app/lib/themes/smooth_theme.dart
+++ b/packages/smooth_app/lib/themes/smooth_theme.dart
@@ -127,6 +127,7 @@ class SmoothTheme {
       appBarTheme: AppBarTheme(
         color: brightness == Brightness.dark ? null : myColorScheme.primary,
       ),
+      toggleableActiveColor: myColorScheme.primary,
     );
   }
 


### PR DESCRIPTION
### What
- Fixes the switch dark mode color

### Impacted files
 - `smooth_theme.dart`

### Screenshot
<div align="center">
<h3>Before</h3>
<img src="https://user-images.githubusercontent.com/63305824/158385271-dd12be48-56d2-42d5-8511-ff9e035a36f4.png" width="200" height="400" />
</div>

<div align="center">
<h3>After</h3>
<img src="https://user-images.githubusercontent.com/63305824/158385248-1b1a52ff-2ec1-48b5-8bba-81562538f715.png" width="200" height="400" />
</div>

### Fixes bug
- #1211 