### PR TITLE
Username validation hint only appears when username is incorrect

### DIFF
--- a/packages/smooth_app/lib/generic_lib/widgets/smooth_text_form_field.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/smooth_text_form_field.dart
@@ -104,6 +104,7 @@ class _SmoothTextFormFieldState extends State<SmoothTextFormField> {
                     : const Icon(Icons.visibility),
               )
             : null,
+        errorMaxLines: 2,
       ),
     );
   }

--- a/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
@@ -105,7 +105,7 @@ class _SignUpPageState extends State<SignUpPage> {
                   return appLocalizations.sign_up_page_username_error_empty;
                 }
                 if (!UserManagementHelper.isUsernameValid(value)) {
-                  return appLocalizations.sign_up_page_username_error_invalid;
+                  return appLocalizations.sign_up_page_username_description;
                 }
                 return null;
               },
@@ -113,8 +113,6 @@ class _SignUpPageState extends State<SignUpPage> {
 
             const SizedBox(height: space),
 
-            Text(appLocalizations.sign_up_page_username_description),
-            const SizedBox(height: space),
             SmoothTextFormField(
               type: TextFieldTypes.PASSWORD,
               controller: _password1Controller,

--- a/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
@@ -110,6 +110,10 @@ class _SignUpPageState extends State<SignUpPage> {
                 return null;
               },
             ),
+
+            const SizedBox(height: space),
+
+            Text(appLocalizations.sign_up_page_username_description),
             const SizedBox(height: space),
             SmoothTextFormField(
               type: TextFieldTypes.PASSWORD,
@@ -151,8 +155,7 @@ class _SignUpPageState extends State<SignUpPage> {
               },
             ),
             const SizedBox(height: space),
-            Text(appLocalizations.sign_up_page_username_description),
-            const SizedBox(height: space),
+
             // careful with CheckboxListTile and hyperlinks
             // cf. https://github.com/flutter/flutter/issues/31437
             ListTile(

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -357,13 +357,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.2"
-  google_ml_barcode_scanner:
+  google_ml_kit:
     dependency: "direct main"
     description:
-      name: google_ml_barcode_scanner
+      name: google_ml_kit
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.2"
+    version: "0.6.0"
   hive:
     dependency: "direct main"
     description:


### PR DESCRIPTION
### What
- Move the username warning closer to the username field
- make validation error appear only when the username contains any of the unnecessary symbols.

### Screenshot
![WhatsApp Image 2022-03-17 at 12 42 20 PM](https://user-images.githubusercontent.com/61955589/158854566-488166f8-aaf2-4ee4-a5b5-f992583fadde.jpeg)
### Fixes bug(s)
- https://github.com/openfoodfacts/smooth-app/issues/1216
### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/1216
