### PR TITLE
fix: Question panel dark mode color

### DIFF
--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -464,7 +464,7 @@ class _SummaryCardState extends State<SummaryCard> {
               },
               child: SmoothCard(
                 margin: EdgeInsets.zero,
-                color: Theme.of(context).primaryColor,
+                color: Theme.of(context).colorScheme.primary,
                 elevation: 0,
                 padding: const EdgeInsets.all(
                   SMALL_SPACE,

--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -464,7 +464,7 @@ class _SummaryCardState extends State<SummaryCard> {
               },
               child: SmoothCard(
                 margin: EdgeInsets.zero,
-                color: const Color(0xfff5f6fa),
+                color: Theme.of(context).primaryColor,
                 elevation: 0,
                 padding: const EdgeInsets.all(
                   SMALL_SPACE,


### PR DESCRIPTION
### What
- Fixes question panel color for dark mode.

### Impacted files
 - `summary_card.dart`

### Screenshot
<div align="center">
<h3>Before</h3>
<img src="https://user-images.githubusercontent.com/63305824/158867129-94a74466-0da0-40a5-8645-c065efa85b49.png" width="200" height="400" />
</div>

<div align="center">
<h3>After</h3>
<img src="https://user-images.githubusercontent.com/63305824/158851119-7f3f86e3-a5ba-4a64-a737-3e71f7b7848b.png" width="200" height="400" />
</div>

### Fixes bug
- #1040 

### Part of
- https://github.com/openfoodfacts/smooth-app/issues/684