### PR TITLE
dep: Upgrade

### DIFF
--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.1"
+    version: "3.2.2"
   args:
     dependency: transitive
     description:
@@ -147,7 +147,7 @@ packages:
       name: crop_your_image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.2"
   cross_file:
     dependency: transitive
     description:
@@ -262,7 +262,7 @@ packages:
       name: flutter_native_splash
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -357,13 +357,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.2"
-  google_ml_kit:
+  google_ml_barcode_scanner:
     dependency: "direct main"
     description:
-      name: google_ml_kit
+      name: google_ml_barcode_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.0"
+    version: "0.0.2"
   hive:
     dependency: "direct main"
     description:
@@ -412,7 +412,7 @@ packages:
       name: image_picker
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.4+10"
+    version: "0.8.4+11"
   image_picker_for_web:
     dependency: transitive
     description:
@@ -552,7 +552,7 @@ packages:
       name: openfoodfacts
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.13.0"
+    version: "1.14.0"
   package_config:
     dependency: transitive
     description:
@@ -804,14 +804,14 @@ packages:
       name: sentry
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.3.0"
+    version: "6.4.0"
   sentry_flutter:
     dependency: "direct main"
     description:
       name: sentry_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.3.0"
+    version: "6.4.0"
   shared_preferences:
     dependency: transitive
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -22,12 +22,12 @@ dependencies:
   hive: ^2.0.6
   hive_flutter: ^1.1.0
   http: ^0.13.4
-  image_picker: ^0.8.4+10
+  image_picker: ^0.8.4+11
   iso_countries: 2.1.0
   latlong2: ^0.8.1
   matomo_forever: ^1.0.0+1
   modal_bottom_sheet: ^2.0.1
-  openfoodfacts: ^1.13.0
+  openfoodfacts: ^1.14.0
 #  openfoodfacts:
 #    path: ../../../openfoodfacts-dart
   package_info_plus: ^1.4.0
@@ -37,14 +37,14 @@ dependencies:
   provider: ^6.0.2
   qr_code_scanner: ^0.7.0
   rubber: ^1.0.1
-  sentry_flutter: ^6.3.0
+  sentry_flutter: ^6.4.0
   url_launcher: ^6.0.20
   visibility_detector: ^0.2.2
   camera: ^0.9.4+16
   percent_indicator: ^4.0.0
-  crop_your_image: ^0.7.0
+  crop_your_image: ^0.7.2
   mailto: ^2.0.0
-  flutter_native_splash: ^2.1.0
+  flutter_native_splash: ^2.1.1
   google_ml_barcode_scanner: ^0.0.2
 
 


### PR DESCRIPTION
iOS release failing again because of:


https://github.com/openfoodfacts/smooth-app/runs/5606037559?check_suite_focus=true
```
[!] CocoaPods could not find compatible versions for pod "Sentry":
      In snapshot (Podfile.lock):
        Sentry (= 7.9.0, ~> 7.9.0)
```

this should hopefully get fixed by this


