### PR TITLE
Fixed Darkmode scheme on extended panels

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panel_card.dart
+++ b/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panel_card.dart
@@ -48,7 +48,6 @@ class KnowledgePanelCard extends StatelessWidget {
               appBar: AppBar(),
               body: SingleChildScrollView(
                 child: SmoothCard(
-                  color: const Color(0xfff5f6fa),
                   padding: const EdgeInsets.all(
                     SMALL_SPACE,
                   ),


### PR DESCRIPTION
### What
- fix: #1043 Fixed Darkmode scheme on extended panels

### Screenshot
**Before**
![Screenshot_1647779270](https://user-images.githubusercontent.com/46121493/159162337-986ece2e-971b-40a5-92b5-2defe0032366.png)

**After**
![Screenshot_1647779286](https://user-images.githubusercontent.com/46121493/159162348-122ac3b6-f06a-4b77-9c62-5ad04005f9a3.png)

### Fixes bug(s)
- #1043 
### Part of 
- #684 
