### PR TITLE
fix: fixes for the UI rendering in the "Contributors" Smooth Alert box sheet

### DIFF
--- a/packages/smooth_app/lib/generic_lib/dialogs/smooth_alert_dialog.dart
+++ b/packages/smooth_app/lib/generic_lib/dialogs/smooth_alert_dialog.dart
@@ -35,12 +35,14 @@ class SmoothAlertDialog extends StatelessWidget {
       shape: const RoundedRectangleBorder(
         borderRadius: ROUNDED_BORDER_RADIUS,
       ),
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: <Widget>[
-          _buildTitle(context),
-          SizedBox(height: height, child: body),
-        ],
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            _buildTitle(context),
+            SizedBox(height: height, child: body),
+          ],
+        ),
       ),
       actions: actions == null
           ? null
@@ -66,21 +68,23 @@ class SmoothAlertDialog extends StatelessWidget {
     } else {
       return Column(
         children: <Widget>[
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: <Widget>[
-              _buildCross(true, context),
-              if (title != null)
-                SizedBox(
-                  height: height,
-                  child: Text(
-                    title!,
-                    style: Theme.of(context).textTheme.headline2,
+          FittedBox(
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: <Widget>[
+                _buildCross(true, context),
+                if (title != null)
+                  SizedBox(
+                    height: height,
+                    child: Text(
+                      title!,
+                      style: Theme.of(context).textTheme.headline2,
+                    ),
                   ),
-                ),
-              _buildCross(false, context),
-            ],
+                _buildCross(false, context),
+              ],
+            ),
           ),
           Divider(
             color: Theme.of(context).colorScheme.onBackground,

--- a/packages/smooth_app/lib/generic_lib/dialogs/smooth_alert_dialog.dart
+++ b/packages/smooth_app/lib/generic_lib/dialogs/smooth_alert_dialog.dart
@@ -35,14 +35,12 @@ class SmoothAlertDialog extends StatelessWidget {
       shape: const RoundedRectangleBorder(
         borderRadius: ROUNDED_BORDER_RADIUS,
       ),
-      content: SingleChildScrollView(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: <Widget>[
-            _buildTitle(context),
-            SizedBox(height: height, child: body),
-          ],
-        ),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          _buildTitle(context),
+          SizedBox(height: height, child: body),
+        ],
       ),
       actions: actions == null
           ? null


### PR DESCRIPTION
### What
-  This PR includes the fixes for the UI rendering in the contribut Smooth Alert box sheet which breaks on devices with smaller dimensions

### Screenshot
| [**Small**]()      |  [**One Plus 8 Pro**]()     |
|------------|-------------|
|  <img src="https://user-images.githubusercontent.com/55257452/159213998-6ba8af67-3b94-4889-89dc-0b743a52fd97.jpeg" width="250"> |  <img src="https://user-images.githubusercontent.com/55257452/159213908-6c53b54e-6fc9-4580-9c2d-da714128dfe4.jpeg" width="250"> |




### Fixes bug(s)
- #1229 
### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/1171
(please be as granular as possible)
