### PR TITLE
fix: #1283 Fixed Labels icon colors

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panel_title_card.dart
+++ b/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panel_title_card.dart
@@ -21,7 +21,8 @@ class KnowledgePanelTitleCard extends StatelessWidget {
         (knowledgePanelTitleElement.iconColorFromEvaluation ?? false)) {
       colorFromEvaluation = _getColorFromEvaluation(evaluation!);
     }
-    if (colorFromEvaluation == null &&
+    if (evaluation != null &&
+        _getColorFromEvaluation(evaluation!) == null &&
         themeData.brightness == Brightness.dark) {
       colorFromEvaluation = Colors.white;
     }


### PR DESCRIPTION
### What
- fix: #1283 Fixed Labels icon colors

### Screenshot
**Before**
![Screenshot_1647872977](https://user-images.githubusercontent.com/46121493/159298181-3aa3a2e8-0c79-4769-891b-8eac8e1ac87d.png)

**After**
![Screenshot_1647877394](https://user-images.githubusercontent.com/46121493/159298557-cd915e85-5111-4e8b-97b3-a322c6e0b708.png)


### Fixes bug(s)
- #1283
