### PR TITLE
fix: Use google_ml_barcode_scanner fork from cli1005

### DIFF
--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -363,7 +363,7 @@ packages:
       path: "."
       ref: master
       resolved-ref: "5427e2a735be24b5f6b646a2554c636845ce9597"
-      url: "https://github.com/cli1005/google_ml_barcode_scanner.git"
+      url: "https://github.com/m123-dev/google_ml_barcode_scanner.git"
     source: git
     version: "0.0.2"
   hive:

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -360,9 +360,11 @@ packages:
   google_ml_barcode_scanner:
     dependency: "direct main"
     description:
-      name: google_ml_barcode_scanner
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "."
+      ref: master
+      resolved-ref: "5427e2a735be24b5f6b646a2554c636845ce9597"
+      url: "https://github.com/cli1005/google_ml_barcode_scanner.git"
+    source: git
     version: "0.0.2"
   hive:
     dependency: "direct main"
@@ -370,7 +372,7 @@ packages:
       name: hive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.6"
+    version: "2.1.0"
   hive_flutter:
     dependency: "direct main"
     description:
@@ -1054,7 +1056,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.2"
   wkt_parser:
     dependency: transitive
     description:

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -363,7 +363,7 @@ packages:
       path: "."
       ref: master
       resolved-ref: "5427e2a735be24b5f6b646a2554c636845ce9597"
-      url: "https://github.com/m123-dev/google_ml_barcode_scanner.git"
+      url: "https://github.com/cli1005/google_ml_barcode_scanner.git"
     source: git
     version: "0.0.2"
   hive:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -45,7 +45,11 @@ dependencies:
   crop_your_image: ^0.7.2
   mailto: ^2.0.0
   flutter_native_splash: ^2.1.1
-  google_ml_barcode_scanner: ^0.0.2
+  # Fork from cli1005 with iOS fix cf: https://github.com/openfoodfacts/smooth-app/issues/1155
+  google_ml_barcode_scanner:
+    git:
+      url: https://github.com/cli1005/google_ml_barcode_scanner.git
+      ref: master
 
 
   

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -48,7 +48,7 @@ dependencies:
   # Fork from cli1005 with iOS fix cf: https://github.com/openfoodfacts/smooth-app/issues/1155
   google_ml_barcode_scanner:
     git:
-      url: https://github.com/m123-dev/google_ml_barcode_scanner.git
+      url: https://github.com/cli1005/google_ml_barcode_scanner.git
       ref: master
 
 

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -48,7 +48,7 @@ dependencies:
   # Fork from cli1005 with iOS fix cf: https://github.com/openfoodfacts/smooth-app/issues/1155
   google_ml_barcode_scanner:
     git:
-      url: https://github.com/cli1005/google_ml_barcode_scanner.git
+      url: https://github.com/m123-dev/google_ml_barcode_scanner.git
       ref: master
 
 


### PR DESCRIPTION
Co-Authored-By: cli1005 <87010739+cli1005@users.noreply.github.com>

### What
- We now use a fork google_ml_barcode_scanner from cli1005 to fix a MissingPluginException on iOS

cf: https://github.com/openfoodfacts/smooth-app/issues/1155

