### PR TITLE
fix: Summary card doesn't honor dark mode #1321

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/question_card.dart
+++ b/packages/smooth_app/lib/cards/product_cards/question_card.dart
@@ -229,17 +229,14 @@ class _QuestionCardState extends State<QuestionCard>
             ),
           ],
         ),
-        Align(
-          alignment: Alignment.bottomCenter,
-          child: AspectRatio(
-            aspectRatio: 8,
-            child: _buildAnswerButton(
-              insightId: question.insightId,
-              insightAnnotation: InsightAnnotation.MAYBE,
-              backgroundColor: const Color(0xFFFFEFB7),
-              contentColor: Colors.black,
-              currentQuestionIndex: currentQuestionIndex,
-            ),
+        AspectRatio(
+          aspectRatio: 8,
+          child: _buildAnswerButton(
+            insightId: question.insightId,
+            insightAnnotation: InsightAnnotation.MAYBE,
+            backgroundColor: const Color(0xFFFFEFB7),
+            contentColor: Colors.black,
+            currentQuestionIndex: currentQuestionIndex,
           ),
         ),
       ],

--- a/packages/smooth_app/lib/cards/product_cards/question_card.dart
+++ b/packages/smooth_app/lib/cards/product_cards/question_card.dart
@@ -41,7 +41,7 @@ class _QuestionCardState extends State<QuestionCard>
         return true;
       },
       child: Scaffold(
-        backgroundColor: const Color(0xff4f4f4f),
+        backgroundColor: Theme.of(context).colorScheme.background,
         appBar: AppBar(),
         body: _buildAnimationSwitcher(),
       ),
@@ -170,7 +170,10 @@ class _QuestionCardState extends State<QuestionCard>
             padding: const EdgeInsets.only(bottom: SMALL_SPACE),
             child: Text(
               question.question!,
-              style: Theme.of(context).textTheme.headline4,
+              style: Theme.of(context)
+                  .textTheme
+                  .headline4!
+                  .apply(color: Colors.black),
             ),
           ),
           Container(
@@ -226,14 +229,17 @@ class _QuestionCardState extends State<QuestionCard>
             ),
           ],
         ),
-        AspectRatio(
-          aspectRatio: 8,
-          child: _buildAnswerButton(
-            insightId: question.insightId,
-            insightAnnotation: InsightAnnotation.MAYBE,
-            backgroundColor: Colors.white,
-            contentColor: Colors.grey,
-            currentQuestionIndex: currentQuestionIndex,
+        Align(
+          alignment: Alignment.bottomCenter,
+          child: AspectRatio(
+            aspectRatio: 8,
+            child: _buildAnswerButton(
+              insightId: question.insightId,
+              insightAnnotation: InsightAnnotation.MAYBE,
+              backgroundColor: const Color(0xFFFFEFB7),
+              contentColor: Colors.black,
+              currentQuestionIndex: currentQuestionIndex,
+            ),
           ),
         ),
       ],

--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -480,7 +480,7 @@ class _SummaryCardState extends State<SummaryCard> {
               },
               child: SmoothCard(
                 margin: EdgeInsets.zero,
-                color: const Color(0xfff5f6fa),
+                color: Theme.of(context).colorScheme.primary,
                 elevation: 0,
                 padding: const EdgeInsets.all(
                   SMALL_SPACE,


### PR DESCRIPTION
### What
fix #1321 : Summary card and question card doesn't honor dark mode.

### Screenshot
1) Summary card
<img width="262" alt="image" src="https://user-images.githubusercontent.com/47862474/159979400-692d96ce-5cb5-4418-994b-d007e09c55aa.png">

2) Question card
<img width="245" alt="image" src="https://user-images.githubusercontent.com/47862474/159979510-95096ace-8bee-4efb-9761-a3332d49d4da.png">

### Fixes bug(s)
- #1321 
- 
### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/525
(please be as granular as possible)
