### PR TITLE
fix: tab top padding hides text below it #1335

### DIFF
--- a/packages/smooth_app/lib/pages/user_preferences_page.dart
+++ b/packages/smooth_app/lib/pages/user_preferences_page.dart
@@ -71,9 +71,9 @@ class _UserPreferencesPageState extends State<UserPreferencesPage> {
     }
     return Scaffold(
       appBar: AppBar(title: Text(appLocalizations.myPreferences)),
-      body: Padding(
+      body: ListView(
         padding: const EdgeInsets.fromLTRB(0.0, MEDIUM_SPACE, 0.0, 0.0),
-        child: ListView(children: children),
+        children: children,
       ),
     );
   }


### PR DESCRIPTION
### What
- changed the padding into the listview so as to fix the top hiding of My profile title

### Screenshot
<img src="https://user-images.githubusercontent.com/39344769/160191488-0ad8e0a2-1e33-4c62-a013-dfb404c952e5.jpg" alt="earlier" width="300"/>

<img src="https://user-images.githubusercontent.com/57723319/160231885-d898cf5e-195f-49ad-9053-4042257e9576.png" alt="later" width="300"/>


### Fixes bug(s)
-  #1335 

