### PR TITLE
fix: Removed hardcoded "See more" color from scan card

### DIFF
--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -133,9 +133,10 @@ class _SummaryCardState extends State<SummaryCard> {
               padding: const EdgeInsets.symmetric(
                 vertical: SMALL_SPACE,
               ),
-              decoration: const BoxDecoration(
-                color: Colors.white,
-                borderRadius: BorderRadius.vertical(bottom: ROUNDED_RADIUS),
+              decoration: BoxDecoration(
+                color: Theme.of(context).cardColor,
+                borderRadius:
+                    const BorderRadius.vertical(bottom: ROUNDED_RADIUS),
               ),
               child: Center(
                 child: Text(


### PR DESCRIPTION
### What
- changed the white color on the info card to theme color so as to honor the dark theme, 
- it appears grey on the dark theme and remains white as usual on a light theme

### Screenshot
![image](https://user-images.githubusercontent.com/57723319/160339218-31b96ec2-c531-445c-a5e2-8c8cd58969f3.png)


### Fixes bug(s)
- #1356 
### Part of 
- #684 
