### PR TITLE
feat: #1349 - now we get the default importances from the reference itself

### DIFF
--- a/packages/smooth_app/assets/metadata/init_attribute_groups_en.json
+++ b/packages/smooth_app/assets/metadata/init_attribute_groups_en.json
@@ -151,7 +151,7 @@
     "setting_name": "Organic farming",
     "id": "labels_organic"
   }, {
-    "description_short": "Fair trade products help producers in developping countries.",
+    "description_short": "Fair trade products help producers in developing countries.",
     "icon_url": "https://static.openfoodfacts.org/images/attributes/fair-trade.svg",
     "name": "Fair trade",
     "description": "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",

--- a/packages/smooth_app/lib/data_models/user_preferences.dart
+++ b/packages/smooth_app/lib/data_models/user_preferences.dart
@@ -50,11 +50,6 @@ class UserPreferences extends ChangeNotifier {
       _sharedPreferences.getString(_getImportanceTag(attributeId)) ??
       PreferenceImportance.ID_NOT_IMPORTANT;
 
-  Future<void> resetImportances(
-    final ProductPreferences productPreferences,
-  ) async =>
-      productPreferences.resetImportances();
-
   Future<void> setThemeDark(final bool state) async =>
       _sharedPreferences.setBool(_TAG_THEME_DARK, state);
 

--- a/packages/smooth_app/lib/helpers/smooth_matched_product.dart
+++ b/packages/smooth_app/lib/helpers/smooth_matched_product.dart
@@ -117,7 +117,6 @@ class _StrongMatchedProduct extends MatchedProduct {
 
 const Map<String, int> _attributeImportanceWeight = <String, int>{
   PreferenceImportance.ID_MANDATORY: 4,
-  PreferenceImportance.ID_VERY_IMPORTANT: 1, // same as important from now on
   PreferenceImportance.ID_IMPORTANT: 1,
   PreferenceImportance.ID_NOT_IMPORTANT: 0,
 };

--- a/packages/smooth_app/lib/widgets/attribute_button.dart
+++ b/packages/smooth_app/lib/widgets/attribute_button.dart
@@ -29,12 +29,8 @@ class AttributeButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ThemeData themeData = Theme.of(context);
-    String importanceId =
+    final String importanceId =
         productPreferences.getImportanceIdForAttributeId(attribute.id!);
-    // We switch from 4 to 3 choices: very important is downgraded to important
-    if (importanceId == PreferenceImportance.ID_VERY_IMPORTANT) {
-      importanceId = PreferenceImportance.ID_IMPORTANT;
-    }
     const double horizontalPadding = LARGE_SPACE;
     final double screenWidth =
         MediaQuery.of(context).size.width - 2 * horizontalPadding;


### PR DESCRIPTION
Impacted files:
* `attribute_button.dart`: now the downgrade from "very important" to "important" is done from the preference manager itself
* `init_attribute_groups_en.json`: minor change due to data refresh
* `product_preferences.dart`: now we get the default importances from the reference itself; now we downgrade here "very important" to "important"
* `smooth_matched_product.dart`: minor refactoring
* `user_preferences.dart`: minor refactoring

### What
- Now we use the default settings exposed by the API regarding attribute importance

### Part of 
- #1349