### PR TITLE
fix: Unequal padding for cards in scan carousel

### DIFF
--- a/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
+++ b/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
@@ -111,7 +111,6 @@ class SearchCard extends StatelessWidget {
     final AppLocalizations localizations = AppLocalizations.of(context)!;
     return SmoothCard(
       color: Theme.of(context).colorScheme.background.withOpacity(0.85),
-      margin: EdgeInsets.only(bottom: height * 0.05),
       elevation: 0,
       padding: const EdgeInsets.symmetric(horizontal: 20.0),
       child: SizedBox(


### PR DESCRIPTION
### What
- Follow up for #1369, the Cards in the carousel already got some margin in #1296 but not the search card. Here I'm removing the margin so that all cards have the same space to the bottom

cc: @bhattabhi013 