### PR TITLE
fix: #890 - use setting name as attribute name

### DIFF
--- a/packages/smooth_app/lib/widgets/attribute_button.dart
+++ b/packages/smooth_app/lib/widgets/attribute_button.dart
@@ -38,7 +38,8 @@ class AttributeButton extends StatelessWidget {
     const double horizontalPadding = LARGE_SPACE;
     final double screenWidth =
         MediaQuery.of(context).size.width - 2 * horizontalPadding;
-    final TextStyle style = themeData.textTheme.headline3!;
+    final TextStyle styleLabel = themeData.textTheme.bodyMedium!;
+    final TextStyle styleButton = themeData.textTheme.headline4!;
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: horizontalPadding),
       child: Row(
@@ -47,7 +48,7 @@ class AttributeButton extends StatelessWidget {
         children: <Widget>[
           SizedBox(
             width: screenWidth * .45,
-            child: Text(attribute.name!, style: style),
+            child: Text(attribute.settingName!, style: styleLabel),
           ),
           SizedBox(
             width: screenWidth * .45,
@@ -56,7 +57,7 @@ class AttributeButton extends StatelessWidget {
                 productPreferences
                     .getPreferenceImportanceFromImportanceId(importanceId)!
                     .name!,
-                style: style.copyWith(color: Colors.white),
+                style: styleButton.copyWith(color: Colors.white),
               ),
               style: ElevatedButton.styleFrom(
                 primary: _colors[importanceId],


### PR DESCRIPTION
### What
In preferences, use setting name as attribute name
More details in : https://github.com/openfoodfacts/smooth-app/issues/890#issuecomment-1081766950

### Screenshot
![Simulator Screen Shot - iPhone 13 - 2022-03-29 at 13 36 37](https://user-images.githubusercontent.com/87010739/160609412-73a4f6c6-4069-46a4-994f-f8f861a4c123.png)

### Fixes bug(s)
- #890

### Part of 
- #506
