### PR TITLE
fix: Login and logout UX

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -86,6 +86,8 @@
     "@login": {
         "description": "Text field hint: unified name for either username or e-mail address"
     },
+    "login_page_username_or_email": "Please enter username or e-mail",
+    "login_page_password_error_empty": "Please enter a password",
     "create_account": "Create account",
     "@create_account": {
         "description": "Button label: Opens a page where a new user can register"

--- a/packages/smooth_app/lib/pages/user_management/login_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/login_page.dart
@@ -128,7 +128,7 @@ class _LoginPageState extends State<LoginPage> {
                   SmoothTextFormField(
                     type: TextFieldTypes.PLAIN_TEXT,
                     controller: userIdController,
-                    hintText: appLocalizations.login,
+                    hintText: appLocalizations.username_or_email,
                     textColor: _customGrey,
                     backgroundColor: _textFieldBackgroundColor,
                     prefixIcon: const Icon(Icons.person),
@@ -141,7 +141,7 @@ class _LoginPageState extends State<LoginPage> {
                     ],
                     validator: (String? value) {
                       if (value == null || value.isEmpty) {
-                        return appLocalizations.enter_some_text;
+                        return appLocalizations.login_page_username_or_email;
                       }
                       return null;
                     },
@@ -164,7 +164,7 @@ class _LoginPageState extends State<LoginPage> {
                     ],
                     validator: (String? value) {
                       if (value == null || value.isEmpty) {
-                        return appLocalizations.enter_some_text;
+                        return appLocalizations.login_page_password_error_empty;
                       }
                       return null;
                     },


### PR DESCRIPTION
### What
fixes the issue: login terminology is not consistent with signup. We should mention username or email, especially in the Red warning text (currently: "Please enter some text").

### Screenshot
<img width="248" alt="image" src="https://user-images.githubusercontent.com/47862474/160654883-e9be57e3-97b8-40d8-b609-9f9eb3f0fc6e.png">

### Fixes bug(s)
- #1389 

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/525
(please be as granular as possible)
