### PR TITLE
fix: #1405 - added unbreakable spaces to welcome message

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -57,7 +57,7 @@
         "description": "Looking for: ${BARCODE}"
     },
     "@Introduction screen": {},
-    "welcomeToOpenFoodFacts": "Welcome to Open Food Facts",
+    "welcomeToOpenFoodFacts": "Welcome to Open\u00A0Food\u00A0Facts",
     "@welcomeToOpenFoodFacts": {},
     "whatIsOff": "Open Food Facts is a global non-profit powered by local communities.",
     "@whatIsOff": {

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -57,7 +57,7 @@
         "description": "Looking for: ${BARCODE}"
     },
     "@Introduction screen": {},
-    "welcomeToOpenFoodFacts": "Bienvenue sur Open Food Facts",
+    "welcomeToOpenFoodFacts": "Bienvenue sur Open Food Facts",
     "@welcomeToOpenFoodFacts": {},
     "whatIsOff": "Open Food Facts est une organisation mondiale à but non lucratif alimentée par les communautés locales.",
     "@whatIsOff": {

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -57,7 +57,7 @@
         "description": "Looking for: ${BARCODE}"
     },
     "@Introduction screen": {},
-    "welcomeToOpenFoodFacts": "Bienvenue sur Open Food Facts",
+    "welcomeToOpenFoodFacts": "Bienvenue sur Open\u00A0Food\u00A0Facts",
     "@welcomeToOpenFoodFacts": {},
     "whatIsOff": "Open Food Facts est une organisation mondiale à but non lucratif alimentée par les communautés locales.",
     "@whatIsOff": {


### PR DESCRIPTION
Impacted files:
* `app_en.arb`
* `app_fr.arb`

### What
- Added unbreakable spaces to welcome message, so that "Open Food Facts" will be on the same line
- The fix is only for English and French, and only for the welcome message
- It may be a good idea to extend that fix to other languages and to other messages
- In that case, perhaps we'd be better off
  - removing the unbreakable spaces from the translated strings
  - systematically replacing `'Open Food Facts'` with `'Open\u00A0Food\u00A0Facts'`

### Fixes bug(s)
- #1405