### PR TITLE
fix: DarkMode Icon track fixed

### DIFF
--- a/packages/smooth_app/lib/pages/page_manager.dart
+++ b/packages/smooth_app/lib/pages/page_manager.dart
@@ -70,6 +70,7 @@ class PageManagerState extends State<PageManager> {
           _buildOffstageNavigator(BottomNavigationTab.History),
         ]),
         bottomNavigationBar: BottomNavigationBar(
+          unselectedItemColor: Theme.of(context).primaryColorLight,
           showSelectedLabels: false,
           showUnselectedLabels: false,
           selectedItemColor: Colors.white,


### PR DESCRIPTION
### What
- This PR includes the fix of the Dark Mode NavigationTab Icon track

### ScreenRecording

https://user-images.githubusercontent.com/55257452/161111042-f6a656cc-8adf-481e-8e2a-d3a29bb3e0e7.mov


### Fixes bug(s)
- #1424 
### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/1171

