### PR TITLE
fix: Text on the scanner should not be selectable

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/product_title_card.dart
+++ b/packages/smooth_app/lib/cards/product_cards/product_title_card.dart
@@ -4,10 +4,11 @@ import 'package:openfoodfacts/model/Product.dart';
 import 'package:smooth_app/helpers/extension_on_text_helper.dart';
 
 class ProductTitleCard extends StatelessWidget {
-  const ProductTitleCard(this.product, {this.dense = false});
+  const ProductTitleCard(this.product, this.isSelectable, {this.dense = false});
 
   final Product product;
   final bool dense;
+  final bool isSelectable;
 
   @override
   Widget build(BuildContext context) {
@@ -18,10 +19,15 @@ class ProductTitleCard extends StatelessWidget {
       child: ListTile(
         dense: dense,
         contentPadding: EdgeInsets.zero,
-        title: Text(
-          _getProductName(appLocalizations),
-          style: themeData.textTheme.headline4,
-        ).selectable(),
+        title: isSelectable
+            ? Text(
+                _getProductName(appLocalizations),
+                style: themeData.textTheme.headline4,
+              ).selectable()
+            : Text(
+                _getProductName(appLocalizations),
+                style: themeData.textTheme.headline4,
+              ),
         subtitle: Text(product.brands ?? appLocalizations.unknownBrand),
         trailing: Text(
           product.quantity ?? '',

--- a/packages/smooth_app/lib/cards/product_cards/product_title_card.dart
+++ b/packages/smooth_app/lib/cards/product_cards/product_title_card.dart
@@ -19,20 +19,15 @@ class ProductTitleCard extends StatelessWidget {
       child: ListTile(
         dense: dense,
         contentPadding: EdgeInsets.zero,
-        title: isSelectable
-            ? Text(
-                _getProductName(appLocalizations),
-                style: themeData.textTheme.headline4,
-              ).selectable()
-            : Text(
-                _getProductName(appLocalizations),
-                style: themeData.textTheme.headline4,
-              ),
+        title: Text(
+          _getProductName(appLocalizations),
+          style: themeData.textTheme.headline4,
+        ).selectable(isSelectable: isSelectable),
         subtitle: Text(product.brands ?? appLocalizations.unknownBrand),
         trailing: Text(
           product.quantity ?? '',
           style: themeData.textTheme.headline3,
-        ).selectable(),
+        ).selectable(isSelectable: isSelectable),
       ),
     );
   }

--- a/packages/smooth_app/lib/cards/product_cards/question_card.dart
+++ b/packages/smooth_app/lib/cards/product_cards/question_card.dart
@@ -149,7 +149,11 @@ class _QuestionCardState extends State<QuestionCard>
             padding: const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
             child: Column(
               children: <Widget>[
-                ProductTitleCard(widget.product, dense: true),
+                ProductTitleCard(
+                  widget.product,
+                  true,
+                  dense: true,
+                ),
               ],
             ),
           ),

--- a/packages/smooth_app/lib/helpers/extension_on_text_helper.dart
+++ b/packages/smooth_app/lib/helpers/extension_on_text_helper.dart
@@ -1,14 +1,16 @@
 import 'package:flutter/material.dart';
 
 extension Selectable on Text {
-  Widget selectable() {
-    return SelectableText(
-      data!,
-      style: style,
-      toolbarOptions: const ToolbarOptions(
-        copy: true,
-        selectAll: true,
-      ),
-    );
+  Widget selectable({bool isSelectable = true}) {
+    return isSelectable
+        ? SelectableText(
+            data!,
+            style: style,
+            toolbarOptions: const ToolbarOptions(
+              copy: true,
+              selectAll: true,
+            ),
+          )
+        : Text(data!);
   }
 }

--- a/packages/smooth_app/lib/helpers/extension_on_text_helper.dart
+++ b/packages/smooth_app/lib/helpers/extension_on_text_helper.dart
@@ -11,6 +11,9 @@ extension Selectable on Text {
               selectAll: true,
             ),
           )
-        : Text(data!);
+        : Text(
+            data!,
+            style: style,
+          );
   }
 }

--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -237,7 +237,9 @@ class _SummaryCardState extends State<SummaryCard> {
     }
     return Column(
       children: <Widget>[
-        ProductTitleCard(widget._product),
+        widget.isFullVersion
+            ? ProductTitleCard(widget._product, true)
+            : ProductTitleCard(widget._product, false), // for scanner
         for (final Attribute attribute in scoreAttributes)
           ScoreCard(
             iconUrl: attribute.iconUrl,

--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -237,9 +237,10 @@ class _SummaryCardState extends State<SummaryCard> {
     }
     return Column(
       children: <Widget>[
-        widget.isFullVersion
-            ? ProductTitleCard(widget._product, true)
-            : ProductTitleCard(widget._product, false), // for scanner
+        if (widget.isFullVersion)
+          ProductTitleCard(widget._product, true)
+        else
+          ProductTitleCard(widget._product, false), // for scanner
         for (final Attribute attribute in scoreAttributes)
           ScoreCard(
             iconUrl: attribute.iconUrl,

--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -237,10 +237,7 @@ class _SummaryCardState extends State<SummaryCard> {
     }
     return Column(
       children: <Widget>[
-        if (widget.isFullVersion)
-          ProductTitleCard(widget._product, true)
-        else
-          ProductTitleCard(widget._product, false), // for scanner
+        ProductTitleCard(widget._product, widget.isFullVersion),
         for (final Attribute attribute in scoreAttributes)
           ScoreCard(
             iconUrl: attribute.iconUrl,


### PR DESCRIPTION
### What
Text on the scanner should not be selectable

### Screenshot

https://user-images.githubusercontent.com/47862474/161123877-e5703af7-3e8f-4ccc-b699-b22fd4ea3943.mp4


### Fixes bug(s)
- #1426 

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/525
(please be as granular as possible)
