### PR TITLE
ci: run code coverage also for PRs

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -37,4 +37,10 @@ jobs:
       # Run tests
       - name: Run Tests with coverage
         run: ci/testing.sh
+      
+      - name: Upload coverage to codecov
+        uses: codecov/codecov-action@v2
+        with:
+          fail_ci_if_error: true
+          verbose: true
 


### PR DESCRIPTION
Was wrong in the last PRs because I always create branches on the openfoodfacts domain so it counts as a push to repo