### PR TITLE
fix: remove compare with category from scan screen

### DIFF
--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -252,22 +252,23 @@ class _SummaryCardState extends State<SummaryCard> {
             false)
           addPanelButton(appLocalizations.score_add_missing_product_category,
               onPressed: () {}),
-        if (categoryTag != null && categoryLabel != null)
-          addPanelButton(
-            appLocalizations.product_search_same_category,
-            iconData: Icons.leaderboard,
-            onPressed: () async => ProductQueryPageHelper().openBestChoice(
-              color: Colors.deepPurple,
-              heroTag: 'search_bar',
-              name: categoryLabel!,
-              localDatabase: localDatabase,
-              productQuery: CategoryProductQuery(
-                categoryTag: widget._product.categoriesTags!.last,
-                size: 500,
+        if (widget.isFullVersion)
+          if (categoryTag != null && categoryLabel != null)
+            addPanelButton(
+              appLocalizations.product_search_same_category,
+              iconData: Icons.leaderboard,
+              onPressed: () async => ProductQueryPageHelper().openBestChoice(
+                color: Colors.deepPurple,
+                heroTag: 'search_bar',
+                name: categoryLabel!,
+                localDatabase: localDatabase,
+                productQuery: CategoryProductQuery(
+                  categoryTag: widget._product.categoriesTags!.last,
+                  size: 500,
+                ),
+                context: context,
               ),
-              context: context,
             ),
-          ),
         if ((widget._product.statesTags
                     ?.contains('en:product-name-to-be-completed') ??
                 false) ||


### PR DESCRIPTION
### What
Removed compare with category from scan screen

### Screenshot
<img width="250" alt="image" src="https://user-images.githubusercontent.com/47862474/161254868-58027522-ce01-41dd-9a45-d29dd3ac07ff.png">


### Fixes bug(s)
- #1425 

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/525
(please be as granular as possible)
