### PR TITLE
fix: Welcome message split fixed in smaller device width phones

### DIFF
--- a/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
+++ b/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
@@ -1,3 +1,4 @@
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:carousel_slider/carousel_slider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -120,13 +121,14 @@ class SearchCard extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: <Widget>[
-            Text(
+            AutoSizeText(
               localizations.welcomeToOpenFoodFacts,
               textAlign: TextAlign.center,
               style: const TextStyle(
                 fontSize: 36.0,
                 fontWeight: FontWeight.bold,
               ),
+              maxLines: 2,
             ),
             Text(
               localizations.searchPanelHeader,

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -43,6 +43,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.8.2"
+  auto_size_text:
+    dependency: "direct main"
+    description:
+      name: auto_size_text
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.0"
   boolean_selector:
     dependency: transitive
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -51,6 +51,7 @@ dependencies:
     git:
       url: https://github.com/cli1005/google_ml_barcode_scanner.git
       ref: master
+  auto_size_text: ^3.0.0
 
 
   


### PR DESCRIPTION
### What
- This PR includes the fix of the Welcome message split issue in smaller device-width 

### Screenshot

| [**Small**]()      | [**Samsung Galaxy S20**]()     | [**One Plus 8 Pro**]()     |
|------------|-------------|-------------|
|  <img src="https://user-images.githubusercontent.com/55257452/161286802-920ef05c-a435-43c4-9b07-eeeec6ed9eb9.jpeg" width="250"> |  <img src="https://user-images.githubusercontent.com/55257452/161286292-4e2b8017-da1b-4ff4-a3a4-c3c99a09a5fb.jpeg" width="250"> |  <img src="https://user-images.githubusercontent.com/55257452/161286278-e8f246e8-6aba-452f-b04f-1ab7b3444a71.jpeg" width="250">


### Fixes bug(s)
- #1423 
### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/1171

