### PR TITLE
fix: Button resized with max line= 1 for change in language bug

### DIFF
--- a/packages/smooth_app/lib/widgets/attribute_button.dart
+++ b/packages/smooth_app/lib/widgets/attribute_button.dart
@@ -1,3 +1,4 @@
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/model/Attribute.dart';
 import 'package:openfoodfacts/personalized_search/preference_importance.dart';
@@ -47,31 +48,24 @@ class AttributeButton extends StatelessWidget {
         children: <Widget>[
           SizedBox(
             width: screenWidth * .45,
-            child: FittedBox(
-              alignment: Alignment.centerLeft,
-              fit: BoxFit.scaleDown,
-              child: Text(attribute.name!, style: style),
-            ),
+            child: Text(attribute.name!, style: style),
           ),
           SizedBox(
             width: screenWidth * .45,
-            child: FittedBox(
-              fit: BoxFit.scaleDown,
-              alignment: Alignment.centerRight,
-              child: ElevatedButton(
-                child: Text(
-                  productPreferences
-                      .getPreferenceImportanceFromImportanceId(importanceId)!
-                      .name!,
-                  style: style.copyWith(color: Colors.white),
-                ),
-                style: ElevatedButton.styleFrom(
-                  primary: _colors[importanceId],
-                  onPrimary: Colors.white,
-                ),
-                onPressed: () async => productPreferences.setImportance(
-                    attribute.id!, _nextValues[importanceId]!),
+            child: ElevatedButton(
+              child: AutoSizeText(
+                productPreferences
+                    .getPreferenceImportanceFromImportanceId(importanceId)!
+                    .name!,
+                style: style.copyWith(color: Colors.white),
+                maxLines: 1,
               ),
+              style: ElevatedButton.styleFrom(
+                primary: _colors[importanceId],
+                onPrimary: Colors.white,
+              ),
+              onPressed: () async => productPreferences.setImportance(
+                  attribute.id!, _nextValues[importanceId]!),
             ),
           ),
         ],


### PR DESCRIPTION
### What
- This PR includes fixing of button size of each category  with the standard width of the button irrespective of language chosen

### Screenshot
| [**Button Resized Same**]()      | [**Italian language**]()     | 
|------------|-------------|
|  <img src="https://user-images.githubusercontent.com/55257452/161325237-8667bd9b-cf2a-4496-91d1-7c18030241b9.jpeg" width="250"> |  <img src="https://user-images.githubusercontent.com/55257452/161325176-dda58606-3377-4419-b894-ecb5937f4f7b.jpeg" width="250"> | 



### Fixes bug(s)
- #1440 
