### PR TITLE
feat: Support for a "source" within a Knownledge Panel Text element

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panel_element_card.dart
+++ b/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panel_element_card.dart
@@ -9,6 +9,7 @@ import 'package:smooth_app/cards/product_cards/knowledge_panels/knowledge_panel_
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/smooth_html_widget.dart';
 import 'package:smooth_app/helpers/launch_url_helper.dart';
+import 'package:smooth_app/helpers/product_cards_helper.dart';
 
 class KnowledgePanelElementCard extends StatelessWidget {
   const KnowledgePanelElementCard({
@@ -79,44 +80,24 @@ class _KnowledgePanelTextElementCard extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
           text,
-          InkWell(
-            child: Padding(
-              padding: const EdgeInsetsDirectional.only(
-                top: 8.0,
-                bottom: 8.0,
-                end: 8.0,
-              ),
-              child: RichText(
-                text: TextSpan(
-                  children: <InlineSpan>[
-                    TextSpan(
-                      text: appLocalizations.knowledge_panel_text_source,
-                      style: const TextStyle(
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                    TextSpan(
-                      text: textElement.sourceText,
-                      style: const TextStyle(
-                        decoration: TextDecoration.underline,
-                        decorationStyle: TextDecorationStyle.dashed,
-                      ),
-                    ),
-                  ],
-                  style: DefaultTextStyle.of(context).style,
-                ),
-              ),
+          const SizedBox(
+            height: MEDIUM_SPACE,
+          ),
+          // Remove Icon
+          IconTheme.merge(
+            data: const IconThemeData(
+              size: 0.0,
             ),
-            onTap: hasSourceUrl
-                ? () {
-                    LaunchUrlHelper.launchURL(
-                      textElement.sourceUrl!,
-                      false,
-                    );
-                  }
-                : null,
-            borderRadius: BorderRadius.circular(
-              15.0,
+            child: addPanelButton(
+              appLocalizations
+                  .knowledge_panel_text_source(textElement.sourceText!),
+              iconData: null,
+              onPressed: () {
+                LaunchUrlHelper.launchURL(
+                  textElement.sourceUrl!,
+                  false,
+                );
+              },
             ),
           ),
         ],
@@ -126,7 +107,7 @@ class _KnowledgePanelTextElementCard extends StatelessWidget {
     return text;
   }
 
-  bool get hasSource => textElement.sourceText?.isNotEmpty == true;
-
-  bool get hasSourceUrl => textElement.sourceUrl?.isNotEmpty == true;
+  bool get hasSource =>
+      textElement.sourceText?.isNotEmpty == true &&
+      textElement.sourceUrl?.isNotEmpty == true;
 }

--- a/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panel_element_card.dart
+++ b/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panel_element_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/model/KnowledgePanelElement.dart';
 import 'package:openfoodfacts/model/KnowledgePanels.dart';
 import 'package:smooth_app/cards/product_cards/knowledge_panels/knowledge_panel_card.dart';
@@ -7,6 +8,7 @@ import 'package:smooth_app/cards/product_cards/knowledge_panels/knowledge_panel_
 import 'package:smooth_app/cards/product_cards/knowledge_panels/knowledge_panel_world_map_card.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/smooth_html_widget.dart';
+import 'package:smooth_app/helpers/launch_url_helper.dart';
 
 class KnowledgePanelElementCard extends StatelessWidget {
   const KnowledgePanelElementCard({
@@ -21,8 +23,8 @@ class KnowledgePanelElementCard extends StatelessWidget {
   Widget build(BuildContext context) {
     switch (knowledgePanelElement.elementType) {
       case KnowledgePanelElementType.TEXT:
-        return SmoothHtmlWidget(
-          knowledgePanelElement.textElement!.html,
+        return _KnowledgePanelTextElementCard(
+          textElement: knowledgePanelElement.textElement!,
         );
       case KnowledgePanelElementType.IMAGE:
         return Image.network(
@@ -50,4 +52,81 @@ class KnowledgePanelElementCard extends StatelessWidget {
         return EMPTY_WIDGET;
     }
   }
+}
+
+/// A Knowledge Panel Text element may contain a source.
+/// This widget add this information if needed and allows to open the url
+/// (if provided)
+class _KnowledgePanelTextElementCard extends StatelessWidget {
+  const _KnowledgePanelTextElementCard({
+    required this.textElement,
+    Key? key,
+  }) : super(key: key);
+
+  final KnowledgePanelTextElement textElement;
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context)!;
+
+    Widget text = SmoothHtmlWidget(
+      textElement.html,
+    );
+
+    if (hasSource) {
+      text = Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          text,
+          InkWell(
+            child: Padding(
+              padding: const EdgeInsetsDirectional.only(
+                top: 8.0,
+                bottom: 8.0,
+                end: 8.0,
+              ),
+              child: RichText(
+                text: TextSpan(
+                  children: <InlineSpan>[
+                    TextSpan(
+                      text: appLocalizations.knowledge_panel_text_source,
+                      style: const TextStyle(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    TextSpan(
+                      text: textElement.sourceText,
+                      style: const TextStyle(
+                        decoration: TextDecoration.underline,
+                        decorationStyle: TextDecorationStyle.dashed,
+                      ),
+                    ),
+                  ],
+                  style: DefaultTextStyle.of(context).style,
+                ),
+              ),
+            ),
+            onTap: hasSourceUrl
+                ? () {
+                    LaunchUrlHelper.launchURL(
+                      textElement.sourceUrl!,
+                      false,
+                    );
+                  }
+                : null,
+            borderRadius: BorderRadius.circular(
+              15.0,
+            ),
+          ),
+        ],
+      );
+    }
+
+    return text;
+  }
+
+  bool get hasSource => textElement.sourceText?.isNotEmpty == true;
+
+  bool get hasSourceUrl => textElement.sourceUrl?.isNotEmpty == true;
 }

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -623,8 +623,13 @@
     "@refuse": {
         "description": "Button to decline the request of sending the anonymous analytics"
     },
-    "knowledge_panel_text_source": "Source: ",
+    "knowledge_panel_text_source": "Go further on {source_name}",
     "@knowledge_panel_text_source": {
-        "description": "Source field within a text knowledge panel. Please add a space if required after, because it will be used as: 'Source: xxx'"
+        "description": "Source field within a text knowledge panel.",
+        "placeholders": {
+            "source_name": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -622,5 +622,9 @@
     "refuse_button_label": "Refuse",
     "@refuse": {
         "description": "Button to decline the request of sending the anonymous analytics"
+    },
+    "knowledge_panel_text_source": "Source: ",
+    "@knowledge_panel_text_source": {
+        "description": "Source field within a text knowledge panel. Please add a space if required after, because it will be used as: 'Source: xxx'"
     }
 }

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -619,8 +619,13 @@
     "@refuse": {
         "description": "Button to decline the request of sending the anonymous analytics"
     },
-    "knowledge_panel_text_source": "Source : ",
+    "knowledge_panel_text_source": "En savoir plus sur {source_,ame}",
     "@knowledge_panel_text_source": {
-        "description": "Source field within a text knowledge panel. Please add a space if required after, because it will be used as: 'Source: xxx'"
+        "description": "Source field within a text knowledge panel.",
+        "placeholders": {
+            "source_name": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -618,5 +618,9 @@
     "refuse_button_label": "Refuse",
     "@refuse": {
         "description": "Button to decline the request of sending the anonymous analytics"
+    },
+    "knowledge_panel_text_source": "Source : ",
+    "@knowledge_panel_text_source": {
+        "description": "Source field within a text knowledge panel. Please add a space if required after, because it will be used as: 'Source: xxx'"
     }
 }


### PR DESCRIPTION
### What
Implementation of the source (if provided) with a text element
Linked to issue #1026 

### Screenshot
<img width="350" alt="Screen Shot 2022-04-02 at 16 02 04" src="https://user-images.githubusercontent.com/246838/161393790-a59be7a2-415a-43b5-b6eb-7019f76d6f1a.png">


Initial impl:
<img width="348" alt="Screen Shot 2022-04-02 at 13 26 04" src="https://user-images.githubusercontent.com/246838/161381149-0fc251b4-526c-440c-9787-4032c48c664b.png">
