### PR TITLE
fix: no visual feedback on next button

### DIFF
--- a/packages/smooth_app/lib/pages/onboarding/next_button.dart
+++ b/packages/smooth_app/lib/pages/onboarding/next_button.dart
@@ -39,7 +39,7 @@ class NextButton extends StatelessWidget {
               ),
               shape: const RoundedRectangleBorder(
                   borderRadius: ANGULAR_BORDER_RADIUS),
-              primary: Colors.white,
+              primary: const Color.fromRGBO(75, 0, 130, 1.0),
             ),
             onPressed: () async {
               await OnboardingLoader(localDatabase)


### PR DESCRIPTION
### What
fixes no visual feedback on the next button.
Files affected:  `smooth_app\lib\pages\onboarding\next_button.dart`

### Video
https://user-images.githubusercontent.com/47862474/161424997-4755ce33-6e4d-4991-bfa3-8e5ba356cb49.mp4



### Fixes bug(s)
- #1453 

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/525
(please be as granular as possible)
