### PR TITLE
fix: different background color on sliverAppBar

### DIFF
--- a/packages/smooth_app/lib/pages/product/common/product_query_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_query_page.dart
@@ -203,6 +203,7 @@ class _ProductQueryPageState extends State<ProductQueryPage> {
                                     style: themeData.textTheme.subtitle1!
                                         .copyWith(color: widget.mainColor)),
                                 style: TextButton.styleFrom(
+                                  primary: widget.mainColor,
                                   textStyle: TextStyle(
                                     color: widget.mainColor,
                                   ),
@@ -336,6 +337,7 @@ class _ProductQueryPageState extends State<ProductQueryPage> {
       Padding(
         padding: const EdgeInsets.only(top: 28.0),
         child: IconButton(
+          splashColor: color,
           icon: Icon(
             ConstantIcons.instance.getBackIcon(),
             color: color,


### PR DESCRIPTION
### What
It Fixes different background colors on sliverAppBar.

### Screenshot
<img width="267" alt="image" src="https://user-images.githubusercontent.com/47862474/161387989-a9ecbb98-5a48-4566-8ba5-573815ca1414.png">
<img width="262" alt="image" src="https://user-images.githubusercontent.com/47862474/161388003-10f8b45d-9b00-42f6-be45-aff3641bd331.png">

### Fixes bug(s)
- #1456 

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/525
(please be as granular as possible)
