### PR TITLE
feat: Support for a "source" within a Knownledge Panel Text element (…

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panel_element_card.dart
+++ b/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panel_element_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/model/KnowledgePanelElement.dart';
 import 'package:openfoodfacts/model/KnowledgePanels.dart';
 import 'package:smooth_app/cards/product_cards/knowledge_panels/knowledge_panel_card.dart';
@@ -7,6 +8,8 @@ import 'package:smooth_app/cards/product_cards/knowledge_panels/knowledge_panel_
 import 'package:smooth_app/cards/product_cards/knowledge_panels/knowledge_panel_world_map_card.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/smooth_html_widget.dart';
+import 'package:smooth_app/helpers/launch_url_helper.dart';
+import 'package:smooth_app/helpers/product_cards_helper.dart';
 
 class KnowledgePanelElementCard extends StatelessWidget {
   const KnowledgePanelElementCard({
@@ -21,8 +24,8 @@ class KnowledgePanelElementCard extends StatelessWidget {
   Widget build(BuildContext context) {
     switch (knowledgePanelElement.elementType) {
       case KnowledgePanelElementType.TEXT:
-        return SmoothHtmlWidget(
-          knowledgePanelElement.textElement!.html,
+        return _KnowledgePanelTextElementCard(
+          textElement: knowledgePanelElement.textElement!,
         );
       case KnowledgePanelElementType.IMAGE:
         return Image.network(
@@ -50,4 +53,61 @@ class KnowledgePanelElementCard extends StatelessWidget {
         return EMPTY_WIDGET;
     }
   }
+}
+
+/// A Knowledge Panel Text element may contain a source.
+/// This widget add this information if needed and allows to open the url
+/// (if provided)
+class _KnowledgePanelTextElementCard extends StatelessWidget {
+  const _KnowledgePanelTextElementCard({
+    required this.textElement,
+    Key? key,
+  }) : super(key: key);
+
+  final KnowledgePanelTextElement textElement;
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context)!;
+
+    Widget text = SmoothHtmlWidget(
+      textElement.html,
+    );
+
+    if (hasSource) {
+      text = Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          text,
+          const SizedBox(
+            height: MEDIUM_SPACE,
+          ),
+          // Remove Icon
+          IconTheme.merge(
+            data: const IconThemeData(
+              size: 0.0,
+            ),
+            child: addPanelButton(
+              appLocalizations
+                  .knowledge_panel_text_source(textElement.sourceText!),
+              iconData: null,
+              onPressed: () {
+                LaunchUrlHelper.launchURL(
+                  textElement.sourceUrl!,
+                  false,
+                );
+              },
+            ),
+          ),
+        ],
+      );
+    }
+
+    return text;
+  }
+
+  bool get hasSource =>
+      textElement.sourceText?.isNotEmpty == true &&
+      textElement.sourceUrl?.isNotEmpty == true;
 }

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -622,5 +622,14 @@
     "refuse_button_label": "Refuse",
     "@refuse": {
         "description": "Button to decline the request of sending the anonymous analytics"
+    },
+    "knowledge_panel_text_source": "Go further on {source_name}",
+    "@knowledge_panel_text_source": {
+        "description": "Source field within a text knowledge panel.",
+        "placeholders": {
+            "source_name": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -618,5 +618,14 @@
     "refuse_button_label": "Refuse",
     "@refuse": {
         "description": "Button to decline the request of sending the anonymous analytics"
+    },
+    "knowledge_panel_text_source": "En savoir plus sur {source_,ame}",
+    "@knowledge_panel_text_source": {
+        "description": "Source field within a text knowledge panel.",
+        "placeholders": {
+            "source_name": {
+                "type": "String"
+            }
+        }
     }
 }


### PR DESCRIPTION
…#1458)

* Support for source field within a Knowledge Panel text element

* Move to a basic Button instead

### What
- description of the PR

### Screenshot
(Insert a screenshot to provide visual record of your changes, if visible)
### Fixes bug(s)
- #1, #2 and #3 (change by appropriate issues)
### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/525
(please be as granular as possible)
