### PR TITLE
fix: Sliver App Bar 2 word title fixed to one line

### DIFF
--- a/packages/smooth_app/lib/pages/product/common/product_query_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_query_page.dart
@@ -282,11 +282,16 @@ class _ProductQueryPageState extends State<ProductQueryPage> {
                           (BuildContext context, BoxConstraints constraints) {
                         return FlexibleSpaceBar(
                             centerTitle: true,
-                            title: Text(
-                              widget.name,
-                              textAlign: TextAlign.center,
-                              style: themeData.textTheme.headline1!
-                                  .copyWith(color: widget.mainColor),
+                            title: SizedBox(
+                              width: screenSize.width * 0.50,
+                              child: FittedBox(
+                                child: Text(
+                                  widget.name,
+                                  textAlign: TextAlign.center,
+                                  style: themeData.textTheme.headline1!
+                                      .copyWith(color: widget.mainColor),
+                                ),
+                              ),
                             ),
                             background: _getHero(screenSize, themeData));
                       }),


### PR DESCRIPTION
### What
- This PR includes fix of the Sliver app bar title is fixed to one line

### Screenshot

https://user-images.githubusercontent.com/55257452/161488157-791982bb-97e6-4ae0-84e8-fd5b16591a68.mov



### Fixes bug(s)
- #1390 

