### PR TITLE
fix: #1505 -  removed an unnecessary `final`

### DIFF
--- a/packages/smooth_app/lib/database/dao_product_list.dart
+++ b/packages/smooth_app/lib/database/dao_product_list.dart
@@ -54,7 +54,7 @@ class _BarcodeListAdapter extends TypeAdapter<_BarcodeList> {
   _BarcodeList read(BinaryReader reader) {
     final int timestamp = reader.readInt();
     final List<String> barcodes = reader.readStringList();
-    late final int totalSize;
+    late int totalSize;
     try {
       totalSize = reader.readInt();
     } catch (e) {


### PR DESCRIPTION
Impacted file:
* `dao_product_list.dart`: removed an unnecessary `final`

### What
- I could not reproduce the bug, but following to the error message I focused on the only `late final totalSize` of the project, and probably fixed the bug.

### Fixes bug(s)
- #1505
