### PR TITLE
fix: overflow at update nutrition facts page

### DIFF
--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -1,3 +1,4 @@
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -258,7 +259,7 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
             ),
             SizedBox(
               width: getColumnSizeFromContext(context, 0.6),
-              child: Text(
+              child: AutoSizeText(
                 localizations.nutrition_page_unspecified,
                 style: Theme.of(context).primaryTextTheme.bodyText1,
                 maxLines: 2,

--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -256,11 +256,14 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
               onChanged: (final bool value) =>
                   setState(() => _unspecified = !_unspecified),
             ),
-            Text(
-              localizations.nutrition_page_unspecified,
-              style: Theme.of(context).primaryTextTheme.bodyText1,
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
+            SizedBox(
+              width: getColumnSizeFromContext(context, 0.6),
+              child: Text(
+                localizations.nutrition_page_unspecified,
+                style: Theme.of(context).primaryTextTheme.bodyText1,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
             ),
           ],
         ),


### PR DESCRIPTION
### What
fixes overflow at update nutrition facts page

### Screenshot
<img width="264" alt="image" src="https://user-images.githubusercontent.com/47862474/162130742-815ed0dc-ae04-42a4-9442-52b897ae8515.png">

### Fixes bug(s)
- #1508 

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/525
(please be as granular as possible)
