### PR TITLE
feat: #1234 - added a dev mode button to reset history with 3 products.

### DIFF
--- a/packages/smooth_app/lib/helpers/product_list_import_export.dart
+++ b/packages/smooth_app/lib/helpers/product_list_import_export.dart
@@ -1,0 +1,65 @@
+import 'dart:convert';
+
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:openfoodfacts/utils/ProductListQueryConfiguration.dart';
+import 'package:smooth_app/data_models/product_list.dart';
+import 'package:smooth_app/database/dao_product.dart';
+import 'package:smooth_app/database/dao_product_list.dart';
+import 'package:smooth_app/database/local_database.dart';
+import 'package:smooth_app/database/product_query.dart';
+
+/// Import / Export of product lists via json.
+class ProductListImportExport {
+  static const String TMP_IMPORT = '{'
+      '"list": ["3760020507350", "7300400481588", "3502110009449"],'
+      '"data":{'
+      '"12345": {"qty":5}'
+      '}'
+      '}';
+
+  Future<void> import(
+    final String jsonEncoded,
+    final LocalDatabase localDatabase,
+  ) async {
+    final dynamic map = json.decode(jsonEncoded);
+    if (map is! Map<String, dynamic>) {
+      throw Exception('Expected Map<String, dynamic>');
+    }
+    final dynamic list = map['list'];
+    if (list is! List<dynamic>) {
+      throw Exception('Expected List<dynamic>');
+    }
+    final List<String> inputBarcodes = <String>[];
+    for (final dynamic barcode in list) {
+      inputBarcodes.add(barcode as String);
+    }
+    final SearchResult searchResult = await OpenFoodAPIClient.getProductList(
+      ProductQuery.getUser(),
+      ProductListQueryConfiguration(
+        inputBarcodes,
+        fields: ProductQuery.fields,
+        language: ProductQuery.getLanguage(),
+        country: ProductQuery.getCountry(),
+      ),
+    );
+    if (searchResult.products == null) {
+      return;
+    }
+    final DaoProduct daoProduct = DaoProduct(localDatabase);
+    final DaoProductList daoProductList = DaoProductList(localDatabase);
+    final Map<String, Product> products = <String, Product>{};
+    for (final Product product in searchResult.products!) {
+      products[product.barcode!] = product;
+      await daoProduct.put(product);
+    }
+    final List<String> barcodes = <String>[];
+    for (final String barcode in inputBarcodes) {
+      if (products.containsKey(barcode)) {
+        barcodes.add(barcode);
+      }
+    }
+    final ProductList productList = ProductList.history();
+    productList.set(barcodes, products);
+    await daoProductList.put(productList);
+  }
+}

--- a/packages/smooth_app/lib/pages/user_preferences_dev_mode.dart
+++ b/packages/smooth_app/lib/pages/user_preferences_dev_mode.dart
@@ -7,6 +7,7 @@ import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/database/dao_product_list.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/database/product_query.dart';
+import 'package:smooth_app/helpers/product_list_import_export.dart';
 import 'package:smooth_app/pages/abstract_user_preferences.dart';
 import 'package:smooth_app/pages/onboarding/onboarding_flow_navigator.dart';
 
@@ -183,6 +184,21 @@ class UserPreferencesDevMode extends AbstractUserPreferences {
                 ],
               ),
             );
+          },
+        ),
+        ListTile(
+          title: const Text('Import History'),
+          subtitle:
+              const Text('Will clear history and put 3 products in there'),
+          onTap: () async {
+            final LocalDatabase localDatabase = context.read<LocalDatabase>();
+            await ProductListImportExport().import(
+              ProductListImportExport.TMP_IMPORT,
+              localDatabase,
+            );
+            ScaffoldMessenger.of(context)
+                .showSnackBar(const SnackBar(content: Text('Done')));
+            localDatabase.notifyListeners();
           },
         ),
         ListTile(


### PR DESCRIPTION
New file:
* `product_list_import_export.dart`: Import / Export of product lists via json.

Impacted file:
* `user_preferences_dev_mode.dart`: added a button that clears history and put 3 products in there.

### What
- this is preliminary work about data transfer between iOS, android and flutter versions
- here, a new button in the dev mode clears the history and loads it with products that come from a hard-coded json-encoded string
- futures PRs will be smarter regarding how we pass the string

### Screenshot
![Capture d’écran 2022-04-07 à 15 04 54](https://user-images.githubusercontent.com/11576431/162205383-03bf7bc7-817b-4aa0-89fa-1104660812f7.png)

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/1234

