### PR TITLE
fix: Onboarding text is weirdly cropped

### DIFF
--- a/packages/smooth_app/lib/pages/onboarding/scan_example.dart
+++ b/packages/smooth_app/lib/pages/onboarding/scan_example.dart
@@ -1,3 +1,4 @@
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -56,8 +57,9 @@ class ScanExample extends StatelessWidget {
               child: Padding(
                 padding: EdgeInsets.only(
                     left: screenSize.width / 10, right: MEDIUM_SPACE),
-                child: Text(
+                child: AutoSizeText(
                   appLocalizations.offUtility,
+                  maxLines: 2,
                   style: Theme.of(context)
                       .textTheme
                       .headline1!
@@ -86,7 +88,7 @@ class ScanExample extends StatelessWidget {
                 ),
               ),
             ),
-            const Spacer(flex: 3),
+            const Spacer(flex: 2),
           ],
         ),
         const Positioned(


### PR DESCRIPTION
### What
Fixes onboarding text is weirdly cropped

### Screenshot
<img width="263" alt="image" src="https://user-images.githubusercontent.com/47862474/162275906-4ba858dd-51eb-42a8-b494-9db6a3bbeeb8.png">

### Fixes bug(s)
- #1506 

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/525
(please be as granular as possible)
