### PR TITLE
fix: String too long in nutrition edit

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -431,7 +431,7 @@
   "score_add_missing_nutrition_facts": "Add missing nutrition facts",
   "score_add_missing_product_category": "Add missing product category",
   "score_update_nutrition_facts": "Update nutrition facts",
-  "nutrition_page_title": "Product Nutrition Facts",
+  "nutrition_page_title": "Nutrition Facts",
   "nutrition_page_unspecified": "Nutrition facts are not specified on the product",
   "nutrition_page_per_100g": "per 100g",
   "nutrition_page_per_serving": "per serving",

--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -1,3 +1,4 @@
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/model/Product.dart';
@@ -22,8 +23,9 @@ class _EditProductPageState extends State<EditProductPage> {
     final AppLocalizations appLocalizations = AppLocalizations.of(context)!;
     return Scaffold(
       appBar: AppBar(
-        title: Text(
+        title: AutoSizeText(
           widget.product.productName ?? appLocalizations.unknownProductName,
+          maxLines: 2,
         ),
       ),
       body: WillPopScope(

--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -89,7 +89,10 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
     return WillPopScope(
       child: Scaffold(
         appBar: AppBar(
-          title: Text(localizations.nutrition_page_title),
+          title: AutoSizeText(
+            localizations.nutrition_page_title,
+            maxLines: 2,
+          ),
           actions: <Widget>[
             IconButton(
               onPressed: () => _validateAndSave(localizations, localDatabase),


### PR DESCRIPTION
### What
fixes long string issue in the nutrition edit page.

### Screenshot
Before:

1. Nutrition edit page
<img width="649" alt="image" src="https://user-images.githubusercontent.com/47862474/162494041-1b221202-8963-4927-ba24-f8ac8cca7e69.png">


2. Edit product page
<img width="266" alt="image" src="https://user-images.githubusercontent.com/47862474/162493688-b3a05447-a5ba-4062-a2bf-d60680ffaf46.png">

After:
1. Nutrition edit page
<img width="274" alt="image" src="https://user-images.githubusercontent.com/47862474/162493789-afa4c111-62cf-448c-b641-5de628063d11.png">


2. Edit product page
<img width="272" alt="image" src="https://user-images.githubusercontent.com/47862474/162493833-9b5e6c70-37b0-40e6-9a2a-e7a2e2dde6cf.png">





### Fixes bug(s)
- #1517 

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/525
(please be as granular as possible)
