### PR TITLE
fix: #1521 - immediate removal of the dismissed query

### DIFF
--- a/packages/smooth_app/lib/pages/scan/search_history_view.dart
+++ b/packages/smooth_app/lib/pages/scan/search_history_view.dart
@@ -46,7 +46,7 @@ class _SearchHistoryViewState extends State<SearchHistoryView> {
     return Dismissible(
       key: Key(query),
       direction: DismissDirection.endToStart,
-      onDismissed: (DismissDirection direction) =>
+      onDismissed: (DismissDirection direction) async =>
           _handleDismissed(context, query),
       background: Container(color: RED_COLOR),
       child: ListTile(
@@ -62,6 +62,9 @@ class _SearchHistoryViewState extends State<SearchHistoryView> {
   }
 
   Future<void> _handleDismissed(BuildContext context, String query) async {
+    // we need an immediate action for the display refresh
+    _queries.remove(query);
+    // and we need to impact the database too
     final LocalDatabase localDatabase = context.read<LocalDatabase>();
     await DaoStringList(localDatabase).remove(query);
     setState(() {});


### PR DESCRIPTION
Impacted file:
* `search_history_view.dart`: immediately removing the dismissed query

### What
- there were logged exceptions when a query was dismissed from the search history
- the problem was that the display refresh needed the query to be removed faster than the actual removal/refresh from database: the exception was about the "display of a dirty dismissible"
- the solution was to refresh the data asap, using the field we load the database to

### Fixes bug(s)
- #1521
