### PR TITLE
fix: Harmonize the shape of the button on summary card

### DIFF
--- a/packages/smooth_app/lib/helpers/product_cards_helper.dart
+++ b/packages/smooth_app/lib/helpers/product_cards_helper.dart
@@ -74,6 +74,13 @@ Widget addPanelButton(
       width: double.infinity,
       child: ElevatedButton.icon(
         icon: Icon(iconData ?? Icons.add),
+        style: ButtonStyle(
+          shape: MaterialStateProperty.all<RoundedRectangleBorder>(
+            const RoundedRectangleBorder(
+              borderRadius: ROUNDED_BORDER_RADIUS,
+            ),
+          ),
+        ),
         label: Text(label),
         onPressed: onPressed,
       ),


### PR DESCRIPTION
### What
Harmonizes the shape of the button on the summary card as per edit product button.

### Screenshot
<img width="270" alt="image" src="https://user-images.githubusercontent.com/47862474/162738857-606b59b5-08de-47f8-b25b-18c556d5a45c.png">

### Fixes bug(s)
- #1539 

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/525
(please be as granular as possible)
