### PR TITLE
fix: #1537 - moved the "slack" and "email" contact options

### DIFF
--- a/packages/smooth_app/lib/generic_lib/buttons/smooth_main_button.dart
+++ b/packages/smooth_app/lib/generic_lib/buttons/smooth_main_button.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 
+// TODO(monsieurtanuki): probably useless now, [SmoothActionButton] should be enough
 class SmoothMainButton extends StatelessWidget {
   const SmoothMainButton({
     required this.text,

--- a/packages/smooth_app/lib/pages/user_preferences_settings.dart
+++ b/packages/smooth_app/lib/pages/user_preferences_settings.dart
@@ -1,13 +1,9 @@
-import 'dart:io' show Platform;
-
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:mailto/mailto.dart';
 import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/generic_lib/buttons/smooth_action_button.dart';
-import 'package:smooth_app/generic_lib/buttons/smooth_main_button.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_list_tile.dart';
@@ -18,7 +14,6 @@ import 'package:smooth_app/themes/theme_provider.dart';
 import 'package:smooth_app/views/bottom_sheet_views/faq_handle_view.dart';
 import 'package:smooth_app/views/bottom_sheet_views/social_handle_view.dart';
 import 'package:smooth_app/views/bottom_sheet_views/user_contribution_view.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 /// Collapsed/expanded display of settings for the preferences page.
 class UserPreferencesSettings extends AbstractUserPreferences {
@@ -131,47 +126,6 @@ class UserPreferencesSettings extends AbstractUserPreferences {
             bounce: true,
             builder: (BuildContext context) => UserContributionView(),
           ),
-        ),
-        SmoothListTile(
-          text: appLocalizations.support,
-          onPressed: () {
-            showDialog<void>(
-              context: context,
-              builder: (BuildContext context) => SmoothAlertDialog.advanced(
-                body: Column(
-                  children: <Widget>[
-                    SmoothMainButton(
-                      important: false,
-                      text: appLocalizations.support_join_slack,
-                      onPressed: () {
-                        LaunchUrlHelper.launchURL(
-                          'https://slack.openfoodfacts.org/',
-                          false,
-                        );
-                      },
-                    ),
-                    const SizedBox(height: 20),
-                    SmoothMainButton(
-                      important: false,
-                      text: appLocalizations.support_via_email,
-                      onPressed: () async {
-                        final PackageInfo packageInfo =
-                            await PackageInfo.fromPlatform();
-                        // TODO(M123): Change subject name when we have a different app name
-                        final Mailto mailtoLink = Mailto(
-                          to: <String>['contact@openfoodfacts.org'],
-                          subject: 'Smoothie help',
-                          body:
-                              'Version:${packageInfo.version}+${packageInfo.buildNumber} running on ${Platform.operatingSystem}(${Platform.operatingSystemVersion})',
-                        );
-                        await launch('$mailtoLink');
-                      },
-                    ),
-                  ],
-                ),
-              ),
-            );
-          },
         ),
         SmoothListTile(
           text: appLocalizations.about_this_app,

--- a/packages/smooth_app/lib/views/bottom_sheet_views/social_handle_view.dart
+++ b/packages/smooth_app/lib/views/bottom_sheet_views/social_handle_view.dart
@@ -1,12 +1,20 @@
+import 'dart:io' show Platform;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:mailto/mailto.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_list_tile.dart';
 import 'package:smooth_app/helpers/launch_url_helper.dart';
 import 'package:smooth_app/widgets/modal_bottomsheet_header.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class SocialHandleView extends StatelessWidget {
+  static const Icon _icon = Icon(Icons.open_in_new);
+
   @override
   Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context)!;
     return Material(
       child: SizedBox(
         height: MediaQuery.of(context).size.height * 0.8,
@@ -14,29 +22,45 @@ class SocialHandleView extends StatelessWidget {
           shrinkWrap: true,
           scrollDirection: Axis.vertical,
           children: <Widget>[
-            ModalBottomSheetHeader(
-                title: AppLocalizations.of(context)!.connect_with_us),
-            // Instagram
+            ModalBottomSheetHeader(title: appLocalizations.connect_with_us),
             SmoothListTile(
-                text: AppLocalizations.of(context)!.instagram,
-                leadingWidget: const Icon(Icons.open_in_new),
+                text: appLocalizations.instagram,
+                leadingWidget: _icon,
                 onPressed: () => _launchUrl(
                     context, 'https://instagram.com/open.food.facts')),
-
-            //Twitter
             SmoothListTile(
-              text: AppLocalizations.of(context)!.twitter,
-              leadingWidget: const Icon(Icons.open_in_new),
+              text: appLocalizations.twitter,
+              leadingWidget: _icon,
               onPressed: () =>
                   _launchUrl(context, 'https://www.twitter.com/openfoodfacts'),
             ),
-
-            //Blog
             SmoothListTile(
-              text: AppLocalizations.of(context)!.blog,
-              leadingWidget: const Icon(Icons.open_in_new),
+              text: appLocalizations.blog,
+              leadingWidget: _icon,
               onPressed: () =>
                   _launchUrl(context, 'https://en.blog.openfoodfacts.org'),
+            ),
+            SmoothListTile(
+              text: appLocalizations.support_join_slack,
+              leadingWidget: _icon,
+              onPressed: () =>
+                  _launchUrl(context, 'https://slack.openfoodfacts.org/'),
+            ),
+            SmoothListTile(
+              text: appLocalizations.support_via_email,
+              leadingWidget: _icon,
+              onPressed: () async {
+                final PackageInfo packageInfo =
+                    await PackageInfo.fromPlatform();
+                // TODO(M123): Change subject name when we have a different app name
+                final Mailto mailtoLink = Mailto(
+                  to: <String>['contact@openfoodfacts.org'],
+                  subject: 'Smoothie help', // TODO(monsieurtanuki): localize
+                  body:
+                      'Version:${packageInfo.version}+${packageInfo.buildNumber} running on ${Platform.operatingSystem}(${Platform.operatingSystemVersion})',
+                );
+                await launch('$mailtoLink');
+              },
             ),
           ],
         ),


### PR DESCRIPTION
Impacted files:
* `smooth_main_button.dart`: added a `TODO` about probable deleting of this class.
* `social_handle_view.dart`: moved there "slack" and "email" contact options; refactored
* `user_preferences_settings.dart`: removed the "support" (slack or email) button

### What
- there was a "support" button that opened a very tall dialog with "slack" and "email" contact options
- the dialog was too tall, that's what triggered the issue
- after comment exchanges, as there's another button called "contact / connect with us", it seemed appropriate to move "slack" and "email" there, which removes the "faulty" tall dialog.

### Screenshot
![Simulator Screen Shot - iPhone 8 Plus - 2022-04-11 at 15 09 46](https://user-images.githubusercontent.com/11576431/162746319-0e94e6ca-1ad4-4fdb-932f-3fee747aadff.png)

### Fixes bug(s)
- #1537