### PR TITLE
fix: Autofill with better hints

### DIFF
--- a/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
@@ -67,7 +67,9 @@ class _SignUpPageState extends State<SignUpPage> {
               textInputAction: TextInputAction.next,
               hintText: appLocalizations.sign_up_page_display_name_hint,
               prefixIcon: const Icon(Icons.person),
-              autofillHints: const <String>[AutofillHints.name],
+              autofillHints: const <String>[
+                AutofillHints.name,
+              ],
               validator: (String? value) {
                 if (value == null || value.isEmpty) {
                   return appLocalizations.sign_up_page_display_name_error_empty;
@@ -83,7 +85,9 @@ class _SignUpPageState extends State<SignUpPage> {
               textInputAction: TextInputAction.next,
               hintText: appLocalizations.sign_up_page_email_hint,
               prefixIcon: const Icon(Icons.person),
-              autofillHints: const <String>[AutofillHints.email],
+              autofillHints: const <String>[
+                AutofillHints.email,
+              ],
               validator: (String? value) {
                 if (value == null || value.isEmpty) {
                   return appLocalizations.sign_up_page_email_error_empty;
@@ -103,7 +107,9 @@ class _SignUpPageState extends State<SignUpPage> {
               textInputAction: TextInputAction.next,
               hintText: appLocalizations.sign_up_page_username_hint,
               prefixIcon: const Icon(Icons.person),
-              autofillHints: const <String>[AutofillHints.username],
+              autofillHints: const <String>[
+                AutofillHints.newUsername,
+              ],
               validator: (String? value) {
                 if (value == null || value.isEmpty) {
                   return appLocalizations.sign_up_page_username_error_empty;
@@ -124,7 +130,9 @@ class _SignUpPageState extends State<SignUpPage> {
               textInputAction: TextInputAction.next,
               hintText: appLocalizations.sign_up_page_password_hint,
               prefixIcon: const Icon(Icons.vpn_key),
-              autofillHints: const <String>[AutofillHints.password],
+              autofillHints: const <String>[
+                AutofillHints.newPassword,
+              ],
               validator: (String? value) {
                 if (value == null || value.isEmpty) {
                   return appLocalizations.sign_up_page_password_error_empty;
@@ -143,7 +151,7 @@ class _SignUpPageState extends State<SignUpPage> {
               hintText: appLocalizations.sign_up_page_confirm_password_hint,
               prefixIcon: const Icon(Icons.vpn_key),
               autofillHints: const <String>[
-                AutofillHints.password,
+                AutofillHints.newPassword,
               ],
               validator: (String? value) {
                 if (value == null || value.isEmpty) {


### PR DESCRIPTION
Will fix #1346

Instead of `password` and `username` for autofill hints, we should use instead `newPassword` & `newUsername` [according to this doc](https://developer.android.com/guide/topics/text/autofill-optimize#account_credentials)