### PR TITLE
feat: #217 - added shell parameters to screenshot generation

### DIFF
--- a/packages/smooth_app/integration_test/app_test.dart
+++ b/packages/smooth_app/integration_test/app_test.dart
@@ -22,29 +22,34 @@ Future<void> _takeScreenshot(
   if ((!kIsWeb) && Platform.isAndroid) {
     await tester.pumpAndSettle();
   }
-  await binding.takeScreenshot(screenshotName);
+  await binding
+      .takeScreenshot('$platform/$device/$country/$language/$screenshotName');
 }
 
-// flutter drive --driver=test_driver/screenshot_driver.dart --target=integration_test/app_test.dart
-
+const String language = String.fromEnvironment('LANGUAGE'); // e.g. fr
+const String country = String.fromEnvironment('COUNTRY'); // e.g. BE
+const String platform = String.fromEnvironment('PLATFORM'); // e.g. ios
+const String device = String.fromEnvironment('DEVICE'); // e.g. iPhone8Plus
+/*
+flutter drive --driver=test_driver/screenshot_driver.dart --target=integration_test/app_test.dart \
+ --dart-define=LANGUAGE=fr --dart-define=COUNTRY=FR --dart-define=PLATFORM=ios --dart-define=DEVICE=iPhone8Plus
+ */
 /// Onboarding screenshots.
 void main() {
   final IntegrationTestWidgetsFlutterBinding binding =
       IntegrationTestWidgetsFlutterBinding.ensureInitialized()
           as IntegrationTestWidgetsFlutterBinding;
 
-  setUpAll(
-    () => SharedPreferences.setMockInitialValues(
-      const <String, Object>{
-        'IMPORTANCE_AS_STRINGnutriscore': 'important',
-        'IMPORTANCE_AS_STRINGnova': 'important',
-        'IMPORTANCE_AS_STRINGecoscore': 'important',
-      },
-    ),
-  );
-
   group('end-to-end test', () {
     testWidgets('just a single screenshot', (WidgetTester tester) async {
+      SharedPreferences.setMockInitialValues(
+        const <String, Object>{
+          'IMPORTANCE_AS_STRINGnutriscore': 'important',
+          'IMPORTANCE_AS_STRINGnova': 'important',
+          'IMPORTANCE_AS_STRINGecoscore': 'important',
+        },
+      );
+
       await tester.runAsync(() async {
         await _initScreenshot(binding);
 

--- a/packages/smooth_app/ios/Podfile.lock
+++ b/packages/smooth_app/ios/Podfile.lock
@@ -42,7 +42,7 @@ PODS:
   - image_cropper (0.0.4):
     - Flutter
     - TOCropViewController (~> 2.6.1)
-  - image_picker (0.0.1):
+  - image_picker_ios (0.0.1):
     - Flutter
   - integration_test (0.0.1):
     - Flutter
@@ -80,7 +80,7 @@ PODS:
     - Flutter
   - path_provider_ios (0.0.1):
     - Flutter
-  - permission_handler_apple (9.0.2):
+  - permission_handler_apple (9.0.4):
     - Flutter
   - PromisesObjC (2.0.0)
   - Protobuf (3.19.4)
@@ -107,7 +107,7 @@ DEPENDENCIES:
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
   - google_ml_barcode_scanner (from `.symlinks/plugins/google_ml_barcode_scanner/ios`)
   - image_cropper (from `.symlinks/plugins/image_cropper/ios`)
-  - image_picker (from `.symlinks/plugins/image_picker/ios`)
+  - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - iso_countries (from `.symlinks/plugins/iso_countries/ios`)
   - matomo_forever (from `.symlinks/plugins/matomo_forever/ios`)
@@ -151,8 +151,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/google_ml_barcode_scanner/ios"
   image_cropper:
     :path: ".symlinks/plugins/image_cropper/ios"
-  image_picker:
-    :path: ".symlinks/plugins/image_picker/ios"
+  image_picker_ios:
+    :path: ".symlinks/plugins/image_picker_ios/ios"
   integration_test:
     :path: ".symlinks/plugins/integration_test/ios"
   iso_countries:
@@ -187,7 +187,7 @@ SPEC CHECKSUMS:
   GoogleUtilitiesComponents: 679b2c881db3b615a2777504623df6122dd20afe
   GTMSessionFetcher: 4577a4cc914a5a07c40a8a0ad0acc22080418c2d
   image_cropper: 60c2789d1f1a78c873235d4319ca0c34a69f2d98
-  image_picker: 541dcbb3b9cf32d87eacbd957845d8651d6c62c3
+  image_picker_ios: b786a5dcf033a8336a657191401bfdf12017dabb
   integration_test: a1e7d09bd98eca2fc37aefd79d4f41ad37bdbbe5
   iso_countries: eb09d40f388e4c65e291e0bb36a701dfe7de6c74
   matomo_forever: 7e5e5fd8f355f64979591282cad4e858fa4c9fae
@@ -199,7 +199,7 @@ SPEC CHECKSUMS:
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
   package_info_plus: 6c92f08e1f853dc01228d6f553146438dafcd14e
   path_provider_ios: 14f3d2fd28c4fdb42f44e0f751d12861c43cee02
-  permission_handler_apple: d21b38e1a4b2e041c63af9568f9165e114e507a6
+  permission_handler_apple: 44366e37eaf29454a1e7b1b7d736c2cceaeb17ce
   PromisesObjC: 68159ce6952d93e17b2dfe273b8c40907db5ba58
   Protobuf: 235750e4696ff59fb07d949a9dbbc92b3c0700fe
   qr_code_scanner: bb67d64904c3b9658ada8c402e8b4d406d5d796e

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.3.0"
+    version: "3.1.6"
   args:
     dependency: transitive
     description:


### PR DESCRIPTION
Impacted files:
* `app_test.dart`: added shell parameters
* `Podfile.lock`: wtf
* `pubspec.lock`: wtf

### What
- "shell" parameters were added and taken into account
- the screenshot generation call is now something like that:
```
flutter drive --driver=test_driver/screenshot_driver.dart --target=integration_test/app_test.dart \
 --dart-define=LANGUAGE=fr --dart-define=COUNTRY=FR --dart-define=PLATFORM=ios --dart-define=DEVICE=iPhone8Plus
```

### Screenshot
![Capture d’écran 2022-04-11 à 16 28 40](https://user-images.githubusercontent.com/11576431/162761662-64528712-889b-4ca8-80ad-1716f420d993.png)

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/217