### PR TITLE
fix: Country selector with right overflow

### DIFF
--- a/packages/smooth_app/lib/pages/onboarding/country_selector.dart
+++ b/packages/smooth_app/lib/pages/onboarding/country_selector.dart
@@ -67,8 +67,9 @@ class _CountrySelectorState extends State<CountrySelector> {
                 selectedItemBuilder: (BuildContext context) {
                   return _countryList
                       .map(
-                        (Country country) => Text(
-                          country.name,
+                        (Country country) => _CountrySelectorItem(
+                          country: country,
+                          parentWidth: parentWidth,
                         ),
                       )
                       .toList(growable: false);
@@ -79,16 +80,13 @@ class _CountrySelectorState extends State<CountrySelector> {
 
                   return DropdownMenuItem<Country>(
                     value: country,
-                    child: Container(
-                      // Set the maxWidth so the dropdown arrow icon doesn't overflow.
-                      // 48 dp is needed to account for dropdown arrow icon and padding.
-                      constraints: BoxConstraints(maxWidth: parentWidth - 48)
-                          .normalize(),
-                      child: Text(
-                        country.name,
-                        style: TextStyle(
-                          fontWeight: isSelected ? FontWeight.bold : null,
-                        ),
+                    child: DefaultTextStyle.merge(
+                      child: _CountrySelectorItem(
+                        country: country,
+                        parentWidth: parentWidth,
+                      ),
+                      style: TextStyle(
+                        fontWeight: isSelected ? FontWeight.bold : null,
                       ),
                     ),
                   );
@@ -172,5 +170,29 @@ class _CountrySelectorState extends State<CountrySelector> {
       }
     }
     return countries;
+  }
+}
+
+class _CountrySelectorItem extends StatelessWidget {
+  const _CountrySelectorItem({
+    required this.country,
+    required this.parentWidth,
+    Key? key,
+  })  : assert(parentWidth >= 0),
+        super(key: key);
+
+  final Country country;
+  final double parentWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    return ConstrainedBox(
+      // Set the maxWidth so the dropdown arrow icon doesn't overflow.
+      // 48 dp is needed to account for dropdown arrow icon and padding.
+      constraints: BoxConstraints(maxWidth: parentWidth - 48).normalize(),
+      child: Text(
+        country.name,
+      ),
+    );
   }
 }


### PR DESCRIPTION
Will fix #1552 

This issue is only reproducible on iOS.
Basically, the itemBuilder doesn't constraint the width.

I have created a single Widget for both usages.
To differentiate the style, I use a copy of `DefaultTextStyle`. But if you prefer, I can pass a parameter to the new Widget instead.

Also, to enhance performance, I use directly a `ConstraintedBox` (vs a `Container`)

Before:
![Simulator Screen Shot - iPhone SE (3rd generation) - 2022-04-11 at 22 16 23](https://user-images.githubusercontent.com/246838/162825190-8b6f4219-5584-4f0e-916b-45bf09c6307d.png)

After:
![Simulator Screen Shot - iPhone SE (3rd generation) - 2022-04-11 at 22 16 00](https://user-images.githubusercontent.com/246838/162825219-13618654-5f3f-47a6-92a9-6363b2da63af.png)



