### PR TITLE
feat: Half image focus

### DIFF
--- a/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
@@ -29,8 +29,10 @@ class MLKitScannerPageState extends State<MLKitScannerPage> {
   CameraController? _controller;
   int _cameraIndex = 0;
   bool isBusy = false;
+
   //Used when rebuilding to stop the camera
   bool stoppingCamera = false;
+
   //We don't scan every image for performance reasons
   int frameCounter = 0;
 
@@ -149,6 +151,7 @@ class MLKitScannerPageState extends State<MLKitScannerPage> {
     try {
       await _controller?.initialize();
       _controller?.setFocusMode(FocusMode.auto);
+      _controller?.setFocusPoint(_focusPoint);
       _controller?.lockCaptureOrientation(DeviceOrientation.portraitUp);
       _controller?.startImageStream(_processCameraImage);
     } on CameraException catch (e) {
@@ -195,6 +198,26 @@ class MLKitScannerPageState extends State<MLKitScannerPage> {
     await _scan(image);
 
     isBusy = false;
+  }
+
+  Offset? get _focusPoint {
+    final DevModeScanMode scanMode = DevModeScanModeExtension.fromIndex(
+      _userPreferences
+          .getDevModeIndex(UserPreferencesDevMode.userPreferencesEnumScanMode),
+    );
+
+    switch (scanMode) {
+      case DevModeScanMode.PREPROCESS_HALF_IMAGE:
+      case DevModeScanMode.SCAN_HALF_IMAGE:
+        // Half center top
+        return const Offset(0.5, 0.25);
+      case DevModeScanMode.CAMERA_ONLY:
+      case DevModeScanMode.PREPROCESS_FULL_IMAGE:
+      case DevModeScanMode.SCAN_FULL_IMAGE:
+      default:
+        // Center
+        return const Offset(0.5, 0.5);
+    }
   }
 
   Future<void> _scan(final CameraImage image) async {

--- a/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
@@ -64,8 +64,6 @@ class MLKitScannerPageState extends State<MLKitScannerPage> {
         ),
       );
     }
-
-    _startLiveFeed();
   }
 
   @override
@@ -150,10 +148,10 @@ class MLKitScannerPageState extends State<MLKitScannerPage> {
 
     try {
       await _controller?.initialize();
-      _controller?.setFocusMode(FocusMode.auto);
-      _controller?.setFocusPoint(_focusPoint);
-      _controller?.lockCaptureOrientation(DeviceOrientation.portraitUp);
-      _controller?.startImageStream(_processCameraImage);
+      await _controller?.setFocusMode(FocusMode.auto);
+      await _controller?.setFocusPoint(_focusPoint);
+      await _controller?.lockCaptureOrientation(DeviceOrientation.portraitUp);
+      await _controller?.startImageStream(_processCameraImage);
     } on CameraException catch (e) {
       if (kDebugMode) {
         // TODO(M123): Show error message


### PR DESCRIPTION
When the barcode decoder uses the half image decoder, the camera should focus in this area.
Kind of fix #1384