### PR TITLE
feat: If camera permission is denied, allow the user to approve it again

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -3,8 +3,6 @@ name: Crowdin Action
 on:
   push:
     branches: [ crowdin-trigger ]
-  schedule:
-  - cron: "0 0 * * *"
 
 jobs:
   synchronize-with-crowdin:

--- a/packages/smooth_app/lib/data_models/user_preferences.dart
+++ b/packages/smooth_app/lib/data_models/user_preferences.dart
@@ -24,7 +24,6 @@ class UserPreferences extends ChangeNotifier {
       'lastVisitedOnboardingPage';
   static const String _TAG_PREFIX_FLAG = 'FLAG_PREFIX_';
   static const String _TAG_DEV_MODE = 'devMode';
-  static const String _TAG_CAMERA_DECLINE = 'declined_camera_use_once';
   static const String _TAG_CRASH_REPORTS = 'crash_reports';
   static const String _TAG_ANALYTICS_REPORTS = 'analytics_reports';
   static const String _TAG_EXCLUDED_ATTRIBUTE_IDS = 'excluded_attributes';
@@ -89,13 +88,6 @@ class UserPreferences extends ChangeNotifier {
         ? OnboardingPage.NOT_STARTED
         : OnboardingPage.values[pageIndex];
   }
-
-  Future<void> setCameraDecline(final bool declined) async {
-    _sharedPreferences.setBool(_TAG_CAMERA_DECLINE, declined);
-  }
-
-  bool get cameraDeclinedOnce =>
-      _sharedPreferences.getBool(_TAG_CAMERA_DECLINE) ?? false;
 
   String _getFlagTag(final String key) => _TAG_PREFIX_FLAG + key;
 

--- a/packages/smooth_app/lib/generic_lib/widgets/smooth_card.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/smooth_card.dart
@@ -35,8 +35,8 @@ class SmoothCard extends StatelessWidget {
 
   final Widget child;
   final Color? color;
-  final EdgeInsets? margin;
-  final EdgeInsets? padding;
+  final EdgeInsetsGeometry? margin;
+  final EdgeInsetsGeometry? padding;
   final double elevation;
 
   @override

--- a/packages/smooth_app/lib/helpers/permission_helper.dart
+++ b/packages/smooth_app/lib/helpers/permission_helper.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:permission_handler/permission_handler.dart';
+
+class PermissionListener extends ValueNotifier<DevicePermission> {
+  PermissionListener({
+    required this.permission,
+  }) : super(DevicePermission._initial(permission)) {
+    checkPermission();
+  }
+
+  final Permission permission;
+
+  Future<void> checkPermission() async {
+    value = DevicePermission._(
+      permission,
+      DevicePermissionStatus.checking,
+    );
+
+    _onNewPermissionStatus(await permission.request());
+  }
+
+  Future<void> askPermission(
+    Future<bool?> Function() onRationaleNotAvailable,
+  ) async {
+    final bool showRationale = await permission.shouldShowRequestRationale;
+
+    if (showRationale) {
+      _onNewPermissionStatus(await permission.request());
+    } else {
+      final bool? shouldOpenSettings = await onRationaleNotAvailable.call();
+
+      if (shouldOpenSettings == true) {
+        await openAppSettings();
+        return checkPermission();
+      }
+    }
+  }
+
+  void _onNewPermissionStatus(PermissionStatus status) {
+    value = DevicePermission._fromPermissionStatus(
+      permission,
+      status,
+    );
+  }
+}
+
+class DevicePermission {
+  const DevicePermission._(this.permission, this.status);
+
+  const DevicePermission._initial(this.permission)
+      : status = DevicePermissionStatus.checking;
+
+  DevicePermission._fromPermissionStatus(
+      this.permission, PermissionStatus status)
+      : status = _extractFromPermissionStatus(status);
+
+  final Permission permission;
+  final DevicePermissionStatus status;
+
+  static DevicePermissionStatus _extractFromPermissionStatus(
+    PermissionStatus status,
+  ) {
+    switch (status) {
+      case PermissionStatus.denied:
+        return DevicePermissionStatus.denied;
+      case PermissionStatus.granted:
+        return DevicePermissionStatus.granted;
+      case PermissionStatus.restricted:
+        return DevicePermissionStatus.restricted;
+      case PermissionStatus.limited:
+        return DevicePermissionStatus.limited;
+      case PermissionStatus.permanentlyDenied:
+        return DevicePermissionStatus.permanentlyDenied;
+    }
+  }
+
+  bool get isGranted => status == DevicePermissionStatus.granted;
+
+  @override
+  String toString() {
+    return 'DevicePermission{permission: $permission, status: $status}';
+  }
+}
+
+enum DevicePermissionStatus {
+  checking,
+  denied,
+  granted,
+  restricted,
+  limited,
+  permanentlyDenied,
+}

--- a/packages/smooth_app/lib/helpers/picture_capture_helper.dart
+++ b/packages/smooth_app/lib/helpers/picture_capture_helper.dart
@@ -26,10 +26,7 @@ Future<bool> uploadCapturedPicture(
       ProductQuery.getUser(),
       image,
     ),
-    title: _imageFieldLabel(
-      appLocalizations,
-      imageField,
-    ),
+    title: appLocalizations.uploading_image,
   );
   if (result == null || result.error != null || result.status != 'status ok') {
     await LoadingDialog.error(
@@ -40,26 +37,6 @@ Future<bool> uploadCapturedPicture(
   }
   await _updateContinuousScanModel(context, barcode);
   return true;
-}
-
-String _imageFieldLabel(
-  AppLocalizations appLocalizations,
-  ImageField field,
-) {
-  switch (field) {
-    case ImageField.FRONT:
-      return appLocalizations.uploading_image_type_front;
-    case ImageField.INGREDIENTS:
-      return appLocalizations.uploading_image_type_ingredients;
-    case ImageField.NUTRITION:
-      return appLocalizations.uploading_image_type_nutrition;
-    case ImageField.PACKAGING:
-      return appLocalizations.uploading_image_type_packaging;
-    case ImageField.OTHER:
-      return appLocalizations.uploading_image_type_other;
-    default:
-      return appLocalizations.uploading_image_type_generic;
-  }
 }
 
 Future<void> _updateContinuousScanModel(

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -728,6 +728,7 @@
   "@permission_photo_error": {
     "description": "When the camera/photo permission failed to be acquired (!= denied)"
   },
+  "permission_photo_denied_title": "Allow camera use to scan barcodes",
   "permission_photo_denied_message": "For an enhanced experience, please allow {appName} to access your camera. You will be able to directly scan barcodes.",
   "@permission_photo_denied_message": {
     "description": "When the camera/photo permission is denied by user",

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1,789 +1,803 @@
 {
-    "@Utils": {},
-    "yes": "Yes",
-    "@yes": {},
-    "add": "Add",
-    "@add": {},
-    "okay": "Okay",
-    "@okay": {},
-    "applyButtonText": "Apply",
-    "@applyButtonText": {},
-    "next_label": "Next",
-    "@next_label": {
-        "description": "A label on a button that says 'Next', pressing the button takes the user to the next screen."
-    },
-    "save": "Save",
-    "save_confirmation": "Are you sure you want to save?",
-    "skip": "Skip",
-    "cancel": "Cancel",
-    "@cancel": {},
-    "close": "Close",
-    "@close": {},
-    "no": "No",
-    "@no": {},
-    "stop": "Stop",
-    "@stop": {},
-    "finish": "Finish",
-    "@finish": {},
-    "reset_food_prefs": "Reset food preferences",
-    "@reset": {
-        "description": "Button label, clicking on the button will reset user's food preferences."
-    },
-    "error": "Something went wrong",
-    "@error": {},
-    "error_occurred": "An error occurred",
-    "@error_occurred": {},
-    "featureInProgress": "We're still working on this feature, stay tuned",
-    "@featureInProgress": {},
-    "label_web": "View on the Web",
-    "@label_web": {},
-    "learnMore": "Learn more",
-    "@learnMore": {},
-    "general_confirmation": "Are you sure?",
-    "incompatible": "Incompatible",
-    "@incompatible": {
-        "description": "Short label for product list view: the product is incompatible with your preferences"
-    },
-    "compatible": "Compatible",
-    "@compatible": {
-        "description": "Short label for product list view: the product is compatible with your preferences"
-    },
-    "unknown": "Unknown",
-    "@unknown": {
-        "description": "Short label for product list view: the compatibility of that product with your preferences is unknown"
-    },
-    "licenses": "Licences",
-    "@licenses": {},
-    "looking_for": "Looking for",
-    "@looking_for": {
-        "description": "Looking for: ${BARCODE}"
-    },
-    "@Introduction screen": {},
-    "welcomeToOpenFoodFacts": "Welcome to Open Food Facts",
-    "@welcomeToOpenFoodFacts": {},
-    "whatIsOff": "Open Food Facts is a global non-profit powered by local communities.",
-    "@whatIsOff": {
-        "description": "Description of Open Food Facts organization."
-    },
-    "offUtility": "Choose foods that are good for you and the planet.",
-    "@offUtility": {
-        "description": "Description of what a user can use Open Food Facts for."
-    },
-    "productDataUtility": "See the food data relevant to your preferences.",
-    "@productDataUtility": {
-        "description": "Description of what a user can use the product data for."
-    },
-    "healthCardUtility": "Choose foods that are good for you.",
-    "@healthCardUtility": {
-        "description": "Description of what a user can use the health data in a product for."
-    },
-    "ecoCardUtility": "Choose foods that are good for the planet.",
-    "@ecoCardUtility": {
-        "description": "Description of what a user can use the Eco data in a product for."
-    },
-    "@user_management": {},
-    "sign_in_text": "Sign in to your Open Food Facts account to save your contributions",
-    "incorrect_credentials": "Incorrect username or password.",
-    "login": "Login",
-    "@login": {
-        "description": "Text field hint: unified name for either username or e-mail address"
-    },
-    "login_page_username_or_email": "Please enter username or e-mail",
-    "login_page_password_error_empty": "Please enter a password",
-    "create_account": "Create account",
-    "@create_account": {
-        "description": "Button label: Opens a page where a new user can register"
-    },
-    "sign_in": "Sign in",
-    "@sign_in": {
-        "description": "Button label: For sign in"
-    },
-    "sign_out": "Sign out",
-    "@sign_out": {
-        "description": "Button label: For sign out"
-    },
-    "sign_out_confirmation": "Are you sure you want to sign out?",
-    "@sign_out_confirmation": {
-        "description": "Pop up title: Reassuring if the user really want to sign out"
-    },
-    "password": "Password",
-    "forgot_password": "Forgot password",
-    "@forgot_password": {
-        "description": "Button label: Opens a page where a password reset e-mail can be requested"
-    },
-    "view_profile": "View profile",
-    "@view_profile": {
-        "description": "Button label: For to show your account"
-    },
-    "reset_password": "Reset password",
-    "@reset_password": {
-        "description": "Forgot password page title"
-    },
-    "reset_password_explanation_text": "In case of a forgotten password, enter your username or e-mail address to receive instructions for a password reset. Also, remember to check the Spam folder.",
-    "username_or_email": "Username or e-mail",
-    "@username_or_email": {
-        "description": "Text field hint for password reset"
-    },
-    "reset_password_done": "An e-mail with a link to reset your password has been sent to the e-mail address associated with your account. Also check your spam",
-    "send_reset_password_mail": "Change password",
-    "@send_reset_password_mail": {
-        "description": "Button label: Submit the password reset e-mail request"
-    },
-    "enter_some_text": "Please enter some text",
-    "@enter_some_text": {
-        "description": "Error when a required text field is empty"
-    },
-    "sign_up_page_title": "Sign Up",
-    "@sign_up_page_title": {
-        "description": "Header"
-    },
-    "sign_up_page_action_button": "Sign Up",
-    "@sign_up_page_action_button": {
-        "description": "Button for signing up"
-    },
-    "sign_up_page_action_doing_it": "Signing up...",
-    "@sign_up_page_action_doing_it": {
-        "description": "Progress indicator dialog during the actual signing up process"
-    },
-    "sign_up_page_action_ok": "Congratulations! Your account has just been created.",
-    "sign_up_page_display_name_hint": "Name",
-    "sign_up_page_display_name_error_empty": "Please enter the display name you want to use",
-    "sign_up_page_email_hint": "E-mail",
-    "sign_up_page_email_error_empty": "E-mail is required",
-    "sign_up_page_email_error_invalid": "This e-mail is invalid",
-    "sign_up_page_username_hint": "Username",
-    "sign_up_page_username_error_empty": "Please enter a username",
-    "sign_up_page_username_error_invalid": "Please enter a valid username",
-    "sign_up_page_username_description": "Username cannot contains spaces, caps or special characters",
-    "sign_up_page_password_hint": "Password",
-    "sign_up_page_password_error_empty": "Please enter a password",
-    "sign_up_page_password_error_invalid": "Please enter a valid password (at least 6 characters)",
-    "sign_up_page_confirm_password_hint": "Confirm Password",
-    "sign_up_page_confirm_password_error_empty": "Please confirm the password",
-    "sign_up_page_confirm_password_error_invalid": "Passwords don't match",
-    "sign_up_page_agree_text": "I agree to the Open Food Facts",
-    "@sign_up_page_agree_text": {
-        "description": "I agree to the Open Food Facts is followed by sign_up_page_terms_text"
-    },
-    "sign_up_page_terms_text": "terms of use and contribution",
-    "@sign_up_page_terms_text": {
-        "description": "terms of use and contribution is preceded by sign_up_page_agree_text"
-    },
-    "sign_up_page_agree_url": "https://world-en.openfoodfacts.org/terms-of-use",
-    "@sign_up_page_agree_url": {
-        "description": "Please insert the right url here. Go to the openfoodfacts homepage, switch to your country and then on the bottom left footer is Terms of use from which the url should be taken"
-    },
-    "donate_url": "https://donate.openfoodfacts.org/",
-    "@donate_url": {
-        "description": "Please insert the right url from the website here."
-    },
-    "sign_up_page_agree_error_invalid": "When creating an account, agreeing to the Terms of Use is mandatory, however, anonymous contributions can still be made through the app",
-    "@sign_up_page_agree_error_invalid": {
-        "description": "Error message: You have to agree to the terms-of-use (A checkbox to do so is above this error message)"
-    },
-    "sign_up_page_producer_checkbox": "I am a food producer",
-    "sign_up_page_producer_hint": "Producer/brand",
-    "sign_up_page_producer_error_empty": "Please enter a producer or a brand name",
-    "sign_up_page_subscribe_checkbox": "I'd like to subscribe to the Open Food Facts newsletter (You can unsubscribe from it at any time)",
-    "@Settings": {},
-    "settingsTitle": "Settings",
-    "@settingsTitle": {
-        "description": "The title of the Settings page"
-    },
-    "darkmode": "Darkmode",
-    "@darkmode": {
-        "description": "The name of the darkmode on off switch"
-    },
-    "darkmode_dark": "Dark",
-    "@darkmode_dark": {
-        "description": "Indicator inside the darkmode switch (dark)"
-    },
-    "darkmode_light": "Light",
-    "@darkmode_light": {
-        "description": "Indicator inside the darkmode switch (light)"
-    },
-    "darkmode_system_default": "System default",
-    "@darkmode_system_default": {
-        "description": "Indicator inside the darkmode switch (system default)"
-    },
-    "thanks_for_contributing": "Thanks for contributing",
-    "@contributors": {
-        "description": "Button label: Opens a pop up window where all contributors of this app are shown"
-    },
-    "contributors": "Contributors",
-    "support": "Support",
-    "@support": {
-        "description": "Button label: Opens a pop up window where all ways to get support are shown"
-    },
-    "support_join_slack": "Ask for help in our Slack channel",
-    "support_via_email": "Send us an e-mail",
-    "termsOfUse": "Terms of use",
-    "@termsOfUse": {},
-    "about_this_app": "About this app",
-    "@about_this_app": {
-        "description": "Button label: Opens a pop up window which shows information about the app"
-    },
-    "@About this app section": {},
-    "contribute": "Contribute",
-    "@contribute": {
-        "description": "Button label: Shows multiple ways how users can contribute to OFF"
-    },
-    "contribute_sw_development": "Software development",
-    "@contribute_sw_development": {
-        "description": "Button label + page title: Ways to help"
-    },
-    "contribute_develop_text": "The code for every Open Food Facts product is available on GitHub. You are welcome to reuse the code (it's open source) and help us improve it, for everyone, on all the planet.",
-    "@contribute_develop_text": {},
-    "contribute_develop_text_2": "You can join the Open Food Facts Slack chatroom which is the preferred way to ask questions.",
-    "@contribute_develop_text_2": {},
-    "contribute_donate_header": "Donate to Open Food Facts",
-    "@contribute_donate_header": {},
-    "contribute_improve_ProductsToBeCompleted": "Products to be completed",
-    "@contribute_improve_ProductsToBeCompleted": {
-        "description": "Button label: Shows a list of products which aren't completed"
-    },
-    "contribute_improve_header": "Improving",
-    "@contribute_improve_header": {
-        "description": "Button label + page title: Ways to improve the database"
-    },
-    "contribute_improve_text": "The database is the core of the project. It's easy and very quick to help. You can download the mobile app for your phone, and start adding or improving products.\n\nOn the other hand, Open Food Facts website offers many ways to contribute: ",
-    "@contribute_improve_text": {},
-    "contribute_translate_header": "Translate",
-    "@contribute_translate_header": {
-        "description": "Button label + pop up window title: Shows information about helping by translating"
-    },
-    "contribute_translate_link_text": "Start Translating",
-    "@contribute_translate_link_text": {
-        "description": "Button label: Opens the Crowdin translation portal"
-    },
-    "contribute_translate_text": "Open Food Facts is a global project, containing products from more than 160 countries. Open Food Facts is translated into dozens of languages, with constantly evolving content.",
-    "@contribute_translate_text": {},
-    "contribute_translate_text_2": "Translations is one of the key tasks of the project",
-    "@contribute_translate_text_2": {},
-    "tap_to_answer": "Tap here to answer questions",
-    "@tap_to_answer": {
-        "description": "Button label shown on a product, clicking the button opens a card with unanswered product questions, users can answer these to contribute to Open food facts and gain rewards."
-    },
-    "saving_answer": "Saving your answer",
-    "@saving_answer": {
-        "description": "Dialog shown to users after they have answered a question, while the answer is being saved in the BE."
-    },
-    "contribute_to_get_rewards": "Help improve food transparency and get rewards",
-    "@contribute_to_get_rewards": {
-        "description": "Button description shown on a product, clicking the button opens a card with unanswered product questions, users can answer these to contribute to Open food facts and gain rewards."
-    },
-    "question_sign_in_text": "Sign in to your Open Food Facts account to claim your contribution and to increase your creditability",
-    "@Personal preferences": {},
-    "myPreferences": "My preferences",
-    "@myPreferences": {
-        "description": "Page title: Page where the ranking preferences can be changed"
-    },
-    "myPreferences_profile_title": "Your Profile",
-    "myPreferences_profile_subtitle": "Change app settings and get advice.",
-    "myPreferences_settings_title": "App Settings",
-    "myPreferences_settings_subtitle": "Dark mode, Theme, ...",
-    "myPreferences_food_title": "Food Preferences",
-    "myPreferences_food_subtitle": "Choose what information about food matters most to you.",
-    "confirmResetPreferences": "Reset your food preferences?",
-    "@confirmResetPreferences": {
-        "description": "Pop up title: Reassuring if the food preferences should really be reset"
-    },
-    "myPersonalizedRanking": "My personalized ranking",
-    "@myPersonalizedRanking": {
-        "description": "When you press this button, all products (in list or category) are sorted according to your preferences."
-    },
-    "ranking_tab_all": "All",
-    "ranking_subtitle_match_yes": "A great match for you",
-    "ranking_subtitle_match_no": "Very poor match",
-    "ranking_subtitle_match_maybe": "Unknown match",
-    "reloaded_with_new_preferences": "Reloaded with your new preferences",
-    "@reloaded_with_new_preferences": {
-        "description": "Snackbar title: Shows that the modified settings have been applied"
-    },
-    "@other": {},
-    "profile_navbar_label": "Profile",
-    "@profile_navbar_label": {
-        "description": "BottomNavigationBarLabel: For the profile and personal preferences page"
-    },
-    "scan_navbar_label": "Search",
-    "@scan_navbar_label": {
-        "description": "BottomNavigationBarLabel: For the searching of products"
-    },
-    "history_navbar_label": "History",
-    "@history_navbar_label": {
-        "description": "BottomNavigationBarLabel: For the history and compare mode"
-    },
-    "category": "Filter by category",
-    "@category": {
-        "description": "From a product list, there's a category filter: this is its title"
-    },
-    "category_all": "All",
-    "@category_al": {
-        "description": "Top meta-entry on a category filter"
-    },
-    "category_search": "(category search)",
-    "filter": "Filter",
-    "@filter": {
-        "description": "A button that opens a menu where you can filter within categories. Juices => Apple juices/Orange juices"
-    },
-    "scan": "Scan",
-    "@scan": {
-        "description": "Page title: List type: Scanned products"
-    },
-    "search": "Search",
-    "@search": {
-        "description": "Hint text of a search text input field"
-    },
-    "tab_for_more": "Tap to see more info...",
-    "@Product": {},
-    "product": "Product",
-    "@product": {},
-    "unknownBrand": "Unknown brand",
-    "@unknownBrand": {},
-    "unknownProductName": "Unknown product name",
-    "@unknownProductName": {},
-    "label_refresh": "Refresh",
-    "@label_refresh": {
-        "description": "Refresh the cached product"
-    },
-    "image": "Image",
-    "front_photo": "Front photo",
-    "@front_photo": {
-        "description": "Button label: For adding a picture of the front of a product"
-    },
-    "ingredients": "Ingredients",
-    "@ingredients": {},
-    "ingredients_editing_instructions": "Keep the original order. Indicate the percentage when specified. Separate with a comma or hyphen, use parentheses for ingredients of an ingredient, and indicate allergens between underscores.",
-    "ingredients_editing_error": "Failed to save the ingredients.",
-    "ingredients_editing_image_error": "Failed to get a new ingredients image.",
-    "ingredients_editing_title": "Edit Ingredients",
-    "ingredients_photo": "Ingredients photo",
-    "@ingredients_photo": {
-        "description": "Button label: For adding a picture of the Ingredients of a product"
-    },
-    "nutrition": "Nutrition",
-    "@nutrition": {},
-    "nutrition_page_close_confirmation": "Are you sure you want to close without saving?",
-    "nutrition_facts_photo": "Nutrition facts photo",
-    "@nutrition_facts_photo": {
-        "description": "Button label: For adding a picture of the nutrition facts of a product"
-    },
-    "packaging_information": "Packaging information",
-    "@packaging_information": {
-        "description": "Button label: For adding a picture of the packaging of a product"
-    },
-    "packaging_information_photo": "Packaging information photo",
-    "@packaging_information_photo": {},
-    "missing_product": "You found a new product!",
-    "@missing_product": {},
-    "add_product_take_photos": "Take photos of the packaging to add this product to Open Food Facts",
-    "@add_product_take_photos": {},
-    "add_product_take_photos_descriptive": "Please take some photos and the Open Food Facts engine can work out the rest!",
-    "@add_product_take_photos_descriptive": {},
-    "add_product_information_button_label": "Add product information",
-    "@add_product_information_button_label": {},
-    "new_product": "New Product",
-    "@new_product": {},
-    "front_packaging_photo_button_label": "Front of product photo",
-    "@front_packaging_photo_button_label": {},
-    "confirm_front_packaging_photo_button_label": "Confirm front of product photo",
-    "@confirm_front_packaging_photo_button_label": {
-        "description": "Button clicking on which confirms the picture of the front of product that user just took."
-    },
-    "confirm_button_label": "Confirm",
-    "front_packaging_photo_title": "Front Packaging Photo",
-    "ingredients_photo_title": "Ingredients Photo",
-    "nutritional_facts_photo_title": "Nutritional Facts Photo",
-    "recycling_photo_title": "Recycling Photo",
-    "other_interesting_photo_title": "Other Interesting Photo",
-    "front_photo_uploaded": "Front photo uploaded",
-    "@front_photo_uploaded": {},
-    "ingredients_photo_button_label": "Ingredients photo",
-    "@ingredients_photo_button_label": {},
-    "confirm_ingredients_photo_button_label": "Confirm ingredients photo",
-    "@confirm_ingredients_photo_button_label": {
-        "description": "Button clicking on which confirms the picture of ingredients that user just took."
-    },
-    "ingredients_photo_uploaded": "Ingredients photo uploaded",
-    "@ingredients_photo_uploaded": {},
-    "nutritional_facts_photo_button_label": "Nutrition facts photo",
-    "@nutritional_facts_photo_button_label": {},
-    "confirm_nutritional_facts_photo_button_label": "Confirm nutrition facts photo",
-    "@confirm_nutritional_facts_photo_button_label": {
-        "description": "Button clicking on which confirms the picture of nutritional facts that user just took."
-    },
-    "nutritional_facts_photo_uploaded": "Nutrition facts photo uploaded",
-    "@nutritional_facts_photo_uploaded": {},
-    "recycling_photo_button_label": "Recycling information photo",
-    "@recycling_photo_button_label": {},
-    "confirm_recycling_photo_button_label": "Confirm Recycling information photo",
-    "@confirm_recycling_photo_button_label": {
-        "description": "Button clicking on which confirms the picture of recycling information that user just took."
-    },
-    "recycling_photo_uploaded": "Recycling photo uploaded",
-    "@recycling_photo_uploaded": {},
-    "other_interesting_photo_button_label": "Other interesting photos",
-    "@other_interesting_photo_button_label": {},
-    "confirm_other_interesting_photo_button_label": "Confirm photo",
-    "@confirm_other_interesting_photo_button_label": {
-        "description": "Button clicking on which confirms a miscellaneous photo of the product."
-    },
-    "other_photo_uploaded": "Miscellaneous photo uploaded",
-    "@other_photo_uploaded": {},
-    "retake_photo_button_label": "Retake",
-    "@retake_photo_button_label": {
-        "description": "Button clicking on which allows users to retake the last photo they took."
-    },
-    "selecting_photo": "Selecting photo",
-    "@selecting_photo": {
-        "description": "Progress indicator when the users takes a photo"
-    },
-    "uploading_image": "Uploading photo to the server",
-    "@uploading_image": {
-        "description": "Message when a new picture is uploading to the server"
-    },
-    "score_add_missing_ingredients": "Add missing ingredients",
-    "score_add_missing_nutrition_facts": "Add missing nutrition facts",
-    "score_add_missing_product_category": "Add missing product category",
-    "score_update_nutrition_facts": "Update nutrition facts",
-    "nutrition_page_title": "Nutrition Facts",
-    "nutrition_page_unspecified": "Nutrition facts are not specified on the product",
-    "nutrition_page_per_100g": "per 100g",
-    "nutrition_page_per_serving": "per serving",
-    "nutrition_page_add_nutrient": "Add a nutrient",
-    "nutrition_page_serving_size": "Serving size",
-    "nutrition_page_invalid_number": "Invalid number",
-    "nutrition_page_update_running": "Updating the product on the server...",
-    "nutrition_page_update_done": "Product updated!",
-    "more_photos": "More interesting photos",
-    "@more_photos": {},
-    "no_product_found": "No product found",
-    "@no_product_found": {},
-    "not_found": "not found:",
-    "searchPanelHeader": "Search or scan your first product",
-    "@Product query status": {},
-    "refreshing_product": "Refreshing product",
-    "@refreshing_product": {
-        "description": "Confirmation, that the product data of a cached product is queried again"
-    },
-    "product_refreshed": "Product refreshed",
-    "@product_refreshed": {
-        "description": "Confirmation, that the product data refresh is done"
-    },
-    "could_not_refresh": "Could not refresh product",
-    "@could_not_refresh": {
-        "description": "The product data couldn't be refreshed"
-    },
-    "product_internet_error": "Impossible to fetch information about this product due to a network error.",
-    "cached_results_from": "Show results from:",
-    "@cached_results_from": {
-        "description": "Cached results from: x time ago (time ago should not be added to the string)"
-    },
-    "@Product Addition": {},
-    "added_product_thanks": "Thank you for adding this product!",
-    "@added_product_thanks": {},
-    "product_search_same_category": "Compare to Category",
-    "@product_search_same_category": {
-        "description": "Button looking for the other products within the same category. Less than 30 characters"
-    },
-    "product_improvement_add_category": "Add a category to calculate the Nutri-Score.",
-    "@product_improvement_add_category": {
-        "description": "Message for ProductImprovement.ADD_CATEGORY"
-    },
-    "product_improvement_add_nutrition_facts": "Add nutrition facts to calculate the Nutri-Score.",
-    "@product_improvement_add_nutrition_facts": {
-        "description": "Message for ProductImprovement.ADD_NUTRITION_FACTS"
-    },
-    "product_improvement_add_nutrition_facts_and_category": "Add nutrition facts and a category to calculate the Nutri-Score.",
-    "@product_improvement_add_nutrition_facts_and_category": {
-        "description": "Message for ProductImprovement.ADD_NUTRITION_FACTS_AND_CATEGORY"
-    },
-    "product_improvement_categories_but_no_nutriscore": "The Nutri-Score for this product can't be calculated, which may be due to e.g. a non-standard category. If this is considered an error, please contact us.",
-    "@product_improvement_categories_but_no_nutriscore": {
-        "description": "Message for ProductImprovement.CATEGORIES_BUT_NO_NUTRISCORE"
-    },
-    "product_improvement_obsolete_nutrition_image": "The nutrition image is obsolete: please refresh it.",
-    "@product_improvement_obsolete_nutrition_image": {
-        "description": "Message for ProductImprovement.OBSOLETE_NUTRITION_IMAGE"
-    },
-    "product_improvement_origins_to_be_completed": "The Eco-Score takes into account the origins of the ingredients. Please take a photo of the ingredient list and/or any geographic claim or edit the product, so they can be taken into account.",
-    "@product_improvement_origins_to_be_completed": {
-        "description": "Message for ProductImprovement.ORIGINS_TO_BE_COMPLETED"
-    },
-    "country_chooser_label": "Please choose a country",
-    "@country_chooser_label": {
-        "description": "Label shown above a selector where the user can select their country"
-    },
-    "country_selection_explanation": "Some environmental features are location-specific",
-    "@country_label": {
-        "description": "Explanation as to why users should select their country."
-    },
-    "product_removed_comparison": "Product removed from comparison",
-    "@product_removed_comparison": {
-        "description": "Product got removed from comparison list"
-    },
-    "product_removed_history": "Product removed from history",
-    "@product_removed_history": {
-        "description": "Product got removed from history"
-    },
-    "product_could_not_remove": "Could not remove product",
-    "@product_could_not_remove": {
-        "description": "Could not remove product from a list"
-    },
-    "@Lists": {},
-    "no_prodcut_in_list": "There is no product in this list",
-    "no_product_in_section": "There is no product in this section",
-    "recently_seen_products": "History",
-    "clear": "Clear",
-    "@clear": {
-        "description": "Clears a product list"
-    },
-    "really_clear": "Do you really want to delete this list?",
-    "product_compatibility_unknown": "Compatibility Unknown",
-    "@product_compatibility_unknown": {
-        "description": "Product compatibility summary title"
-    },
-    "product_compatibility_incompatible": "Does not match",
-    "@product_compatibility_incompatible": {
-        "description": "Product compatibility summary title"
-    },
-    "product_compatibility_good": "Good Match",
-    "@product_compatibility_good": {
-        "description": "Product compatibility summary title"
-    },
-    "@Plural": {},
-    "pct_match": "{percent}% match",
-    "@pct_match": {
-        "description": "This product has a x percent match with your preferences",
-        "placeholders": {
-            "percent": {}
-        }
-    },
-    "plural_ago_days": "{count,plural, one {} =1{one day ago} other{{count} days ago}}",
-    "@plural_ago_days": {
-        "description": "Cached results from: x days ago",
-        "placeholders": {
-            "count": {}
-        }
-    },
-    "plural_ago_hours": "{count,plural, one {} =1{one hour ago} other{{count} hours ago}}",
-    "@plural_ago_hours": {
-        "description": "Cached results from: x hours ago",
-        "placeholders": {
-            "count": {}
-        }
-    },
-    "plural_ago_minutes": "{count,plural, one {} =0{less than a minute ago} =1{one minute ago} other{{count} minutes ago}}",
-    "@plural_ago_minutes": {
-        "description": "Cached results from: x minutes ago",
-        "placeholders": {
-            "count": {}
-        }
-    },
-    "plural_ago_months": "{count,plural, one {} =1{one month ago} other{{count} months ago}}",
-    "@plural_ago_months": {
-        "description": "Cached results from: x months ago",
-        "placeholders": {
-            "count": {}
-        }
-    },
-    "plural_ago_weeks": "{count,plural, one {} =1{one week ago} other{{count} weeks ago}}",
-    "@plural_ago_weeks": {
-        "description": "Cached results from: x weeks ago",
-        "placeholders": {
-            "count": {}
-        }
-    },
-    "plural_compare_x_products": "{count,plural, other{Compare {count} Products}",
-    "@plural_compare_x_products": {
-        "description": "Button label",
-        "placeholders": {
-            "count": {}
-        }
-    },
-    "compare_products_mode": "Compare",
-    "@compare_products_mode": {
-        "description": "Button to switch to 'compare products mode'"
-    },
-    "retry_button_label": "Retry",
-    "connect_with_us": "Connect with us",
-    "instagram": "Instagram",
-    "twitter": "Twitter",
-    "blog": "Blog",
-    "faq": "FAQ",
-    "discover": "Discover",
-    "how_to_contribute": "How to Contribute",
-    "main_app_color": "Theme",
-    "@main_app_color": {
-        "description": "Heading for the section to pick the main app color"
-    },
-    "hint_knowledge_panel_message": "Your can tap on any part of the card to get more details about what you see. Try it now!",
-    "@hint_knowledge_panel_message": {
-        "description": "Hint popup indicating the card is clickable during onboarding"
-    },
-    "consent_analytics_title": "Send anonymous analytics",
-    "@consent_analytics_title": {
-        "description": "Title for the consent analytics UI Page"
-    },
-    "consent_analytics_body1": "Help the Open Food Facts volunteers to improve the app. You decide if you want to send anonymous analytics.",
-    "@conset_analytics_body1": {
-        "description": "first paragraph for the consent analytics UI Page"
-    },
-    "consent_analytics_body2": "If you change your mind, this option can be enabled and disabled at any time from the settings.",
-    "@consent_analytics_body2": {
-        "description": "second paragraph for the consent analytics UI Page"
-    },
-    "authorize_button_label": "Authorize",
-    "@authorize": {
-        "description": "Button to accept the request of sending the anonymous analytics"
-    },
-    "refuse_button_label": "Refuse",
-    "@refuse": {
-        "description": "Button to decline the request of sending the anonymous analytics"
-    },
-    "knowledge_panel_text_source": "Go further on {source_name}",
-    "@knowledge_panel_text_source": {
-        "description": "Source field within a text knowledge panel.",
-        "placeholders": {
-            "source_name": {
-                "type": "String"
-            }
-        }
-    },
-    "onboarding_welcome_loading_dialog_title": "Loading your first example product",
-    "@onboarding_welcome_loading_dialog_title": {
-        "description": "Title for the onboarding loading dialog"
-    },
-    "product_list_your_ranking": "Your ranking",
-    "@product_list_your_ranking": {
-        "description": "Your ranking screen title"
-    },
-    "product_list_empty_icon_desc": "History not available",
-    "@product_list_icon_desc": {
-        "description": "When the history list is empty, icon description (for accessibility) of the message explaining to start scanning"
-    },
-    "product_list_empty_title": "Start scanning !",
-    "@product_list_empty_title": {
-        "description": "When the history list is empty, title of the message explaining to start scanning"
-    },
-    "product_list_empty_message": "Products you scan will appear here and you can check detailed information about them",
-    "@product_list_empty_message": {
-        "description": "When the history list is empty, body of the message explaining to start scanning"
-    },
-    "product_list_reloading_in_progress": "Refreshing products in your History",
-    "@product_list_reloading_in_progress": {
-        "description": "Message to show while loading previous scanned items"
-    },
-    "product_list_reloading_success": "Product refresh complete",
-    "@product_list_reloading_success": {
-        "description": "Message to show once previous scanned items are loaded"
-    },
-    "loading_dialog_default_title": "Downloading data",
-    "@loading_dialog_default_title": {
-        "description": "Default loading dialog title"
-    },
-    "loading_dialog_default_error_message": "Could not download data",
-    "@loading_dialog_default_error_message": {
-        "description": "Default loading dialog error message"
-    },
-    "account_delete": "Delete account",
-    "@account_delete": {
-        "description": "Delete account button (user profile)"
-    },
-    "email_subject_account_deletion": "Delete account",
-    "@email_subject_account_deletion": {
-        "description": "Email subject for an account deletion"
-    },
-    "email_body_account_deletion": "Hi there, please delete my Open Food Facts account: {userId}",
-    "@email_body_account_deletion": {
-        "description": "Email body for an account deletion",
-        "placeholders": {
-            "userId": {
-                "type": "String"
-            }
-        }
-    },
-    "crash_reporting_toggle_title": "Crash reporting",
-    "@crash_reporting_toggle_title": {
-        "description": "Title for the Crash reporting toggle"
-    },
-    "crash_reporting_toggle_subtitle": "When enabled, crash reports will be sent to the Open Food Facts bug system automatically, so that we can fix bugs and improve the app.",
-    "@crash_reporting_toggle_subtitle": {
-        "description": "SubTitle for the Crash reporting toggle"
-    },
-    "send_anonymous_data_toggle_title": "Send anonymous data",
-    "@send_anonymous_toggle_title": {
-        "description": "Title for the Send anonymous data toggle"
-    },
-    "send_anonymous_data_toggle_subtitle": "When enabled, some anonymous information regarding app usage will be sent to the Open Food Facts servers, so that we can understand how and how much features are used in order to improve them.",
-    "@send_anonymous_toggle_subtitle": {
-        "description": "SubTitle for the Send anonymous data toggle"
-    },
-    "product_edit_photo_title": "Edit Photo",
-    "@product_edit_photo_title": {
-        "description": "Toolbar Title while editing a photo (Android only)"
-    },
-    "permission_photo_error": "Error",
-    "@permission_photo_error": {
-        "description": "When the camera/photo permission failed to be acquired (!= denied)"
-    },
-    "permission_photo_denied": "No camera access granted",
-    "@permission_photo_denied": {
-        "description": "When the camera/photo permission is denied by user"
-    },
-    "edit_product_label": "Edit product",
-    "@edit_product_label": {
-        "description": "Edit product button label"
-    },
-    "edit_product_form_item_barcode": "Barcode",
-    "@edit_product_form_item_barcode": {
-        "description": "Product edition - Barcode"
-    },
-    "edit_product_form_item_details_title": "Basic details",
-    "@edit_product_form_item_details_title": {
-        "description": "Product edition - Basic Details - Title"
-    },
-    "edit_product_form_item_details_subtitle": "Product name, brand, quantity",
-    "@edit_product_form_item_details_subtitle": {
-        "description": "Product edition - Basic Details - Title"
-    },
-    "edit_product_form_item_photos_title": "Photos",
-    "@edit_product_form_item_photos_title": {
-        "description": "Product edition - Photos - Title"
-    },
-    "edit_product_form_item_photos_subtitle": "Add or refresh photos",
-    "@edit_product_form_item_photos_subtitle": {
-        "description": "Product edition - Photos - SubTitle"
-    },
-    "edit_product_form_item_labels_title": "Labels & Certifications",
-    "@edit_product_form_item_labels_title": {
-        "description": "Product edition - Labels - Title"
-    },
-    "edit_product_form_item_labels_subtitle": "Environmental, Quality labels, ...",
-    "@edit_product_form_item_labels_subtitle": {
-        "description": "Product edition - Labels - SubTitle"
-    },
-    "edit_product_form_item_ingredients_title": "Ingredients & Origins",
-    "@edit_product_form_item_ingredients_title": {
-        "description": "Product edition - Ingredients - Title"
-    },
-    "edit_product_form_item_packaging_title": "Packaging",
-    "@edit_product_form_item_packaging_title": {
-        "description": "Product edition - Packaging - Title"
-    },
-    "edit_product_form_item_nutrition_facts_title": "Nutrition facts",
-    "@edit_product_form_item_nutrition_facts_title": {
-        "description": "Product edition - Nutrition facts - Title"
-    },
-    "edit_product_form_item_nutrition_facts_subtitle": "Nutrition, alcohol content…",
-    "@edit_product_form_item_nutrition_facts_subtitle": {
-        "description": "Product edition - Nutrition facts - SubTitle"
-    },
-    "edit_product_form_save": "Edit",
-    "@edit_product_form_save": {
-        "description": "Product edition - Nutrition facts - Save button"
-    },
-    "completed_basic_details_btn_text": "Complete basic details",
-    "not_implemented_snackbar_text": "Not implemented yet",
-    "category_picker_page_appbar_text": "Categories"
+  "app_name": "Smoothie",
+  "@Utils": {},
+  "yes": "Yes",
+  "@yes": {},
+  "add": "Add",
+  "@add": {},
+  "okay": "Okay",
+  "@okay": {},
+  "applyButtonText": "Apply",
+  "@applyButtonText": {},
+  "next_label": "Next",
+  "@next_label": {
+    "description": "A label on a button that says 'Next', pressing the button takes the user to the next screen."
+  },
+  "save": "Save",
+  "save_confirmation": "Are you sure you want to save?",
+  "skip": "Skip",
+  "cancel": "Cancel",
+  "@cancel": {},
+  "close": "Close",
+  "@close": {},
+  "no": "No",
+  "@no": {},
+  "stop": "Stop",
+  "@stop": {},
+  "finish": "Finish",
+  "@finish": {},
+  "reset_food_prefs": "Reset food preferences",
+  "@reset": {
+    "description": "Button label, clicking on the button will reset user's food preferences."
+  },
+  "error": "Something went wrong",
+  "@error": {},
+  "error_occurred": "An error occurred",
+  "@error_occurred": {},
+  "featureInProgress": "We're still working on this feature, stay tuned",
+  "@featureInProgress": {},
+  "label_web": "View on the Web",
+  "@label_web": {},
+  "learnMore": "Learn more",
+  "@learnMore": {},
+  "general_confirmation": "Are you sure?",
+  "incompatible": "Incompatible",
+  "@incompatible": {
+    "description": "Short label for product list view: the product is incompatible with your preferences"
+  },
+  "compatible": "Compatible",
+  "@compatible": {
+    "description": "Short label for product list view: the product is compatible with your preferences"
+  },
+  "unknown": "Unknown",
+  "@unknown": {
+    "description": "Short label for product list view: the compatibility of that product with your preferences is unknown"
+  },
+  "licenses": "Licences",
+  "@licenses": {},
+  "looking_for": "Looking for",
+  "@looking_for": {
+    "description": "Looking for: ${BARCODE}"
+  },
+  "@Introduction screen": {},
+  "welcomeToOpenFoodFacts": "Welcome to Open Food Facts",
+  "@welcomeToOpenFoodFacts": {},
+  "whatIsOff": "Open Food Facts is a global non-profit powered by local communities.",
+  "@whatIsOff": {
+    "description": "Description of Open Food Facts organization."
+  },
+  "offUtility": "Choose foods that are good for you and the planet.",
+  "@offUtility": {
+    "description": "Description of what a user can use Open Food Facts for."
+  },
+  "productDataUtility": "See the food data relevant to your preferences.",
+  "@productDataUtility": {
+    "description": "Description of what a user can use the product data for."
+  },
+  "healthCardUtility": "Choose foods that are good for you.",
+  "@healthCardUtility": {
+    "description": "Description of what a user can use the health data in a product for."
+  },
+  "ecoCardUtility": "Choose foods that are good for the planet.",
+  "@ecoCardUtility": {
+    "description": "Description of what a user can use the Eco data in a product for."
+  },
+  "@user_management": {},
+  "sign_in_text": "Sign in to your Open Food Facts account to save your contributions",
+  "incorrect_credentials": "Incorrect username or password.",
+  "login": "Login",
+  "@login": {
+    "description": "Text field hint: unified name for either username or e-mail address"
+  },
+  "login_page_username_or_email": "Please enter username or e-mail",
+  "login_page_password_error_empty": "Please enter a password",
+  "create_account": "Create account",
+  "@create_account": {
+    "description": "Button label: Opens a page where a new user can register"
+  },
+  "sign_in": "Sign in",
+  "@sign_in": {
+    "description": "Button label: For sign in"
+  },
+  "sign_out": "Sign out",
+  "@sign_out": {
+    "description": "Button label: For sign out"
+  },
+  "sign_out_confirmation": "Are you sure you want to sign out?",
+  "@sign_out_confirmation": {
+    "description": "Pop up title: Reassuring if the user really want to sign out"
+  },
+  "password": "Password",
+  "forgot_password": "Forgot password",
+  "@forgot_password": {
+    "description": "Button label: Opens a page where a password reset e-mail can be requested"
+  },
+  "view_profile": "View profile",
+  "@view_profile": {
+    "description": "Button label: For to show your account"
+  },
+  "reset_password": "Reset password",
+  "@reset_password": {
+    "description": "Forgot password page title"
+  },
+  "reset_password_explanation_text": "In case of a forgotten password, enter your username or e-mail address to receive instructions for a password reset. Also, remember to check the Spam folder.",
+  "username_or_email": "Username or e-mail",
+  "@username_or_email": {
+    "description": "Text field hint for password reset"
+  },
+  "reset_password_done": "An e-mail with a link to reset your password has been sent to the e-mail address associated with your account. Also check your spam",
+  "send_reset_password_mail": "Change password",
+  "@send_reset_password_mail": {
+    "description": "Button label: Submit the password reset e-mail request"
+  },
+  "enter_some_text": "Please enter some text",
+  "@enter_some_text": {
+    "description": "Error when a required text field is empty"
+  },
+  "sign_up_page_title": "Sign Up",
+  "@sign_up_page_title": {
+    "description": "Header"
+  },
+  "sign_up_page_action_button": "Sign Up",
+  "@sign_up_page_action_button": {
+    "description": "Button for signing up"
+  },
+  "sign_up_page_action_doing_it": "Signing up...",
+  "@sign_up_page_action_doing_it": {
+    "description": "Progress indicator dialog during the actual signing up process"
+  },
+  "sign_up_page_action_ok": "Congratulations! Your account has just been created.",
+  "sign_up_page_display_name_hint": "Name",
+  "sign_up_page_display_name_error_empty": "Please enter the display name you want to use",
+  "sign_up_page_email_hint": "E-mail",
+  "sign_up_page_email_error_empty": "E-mail is required",
+  "sign_up_page_email_error_invalid": "This e-mail is invalid",
+  "sign_up_page_username_hint": "Username",
+  "sign_up_page_username_error_empty": "Please enter a username",
+  "sign_up_page_username_error_invalid": "Please enter a valid username",
+  "sign_up_page_username_description": "Username cannot contains spaces, caps or special characters",
+  "sign_up_page_password_hint": "Password",
+  "sign_up_page_password_error_empty": "Please enter a password",
+  "sign_up_page_password_error_invalid": "Please enter a valid password (at least 6 characters)",
+  "sign_up_page_confirm_password_hint": "Confirm Password",
+  "sign_up_page_confirm_password_error_empty": "Please confirm the password",
+  "sign_up_page_confirm_password_error_invalid": "Passwords don't match",
+  "sign_up_page_agree_text": "I agree to the Open Food Facts",
+  "@sign_up_page_agree_text": {
+    "description": "I agree to the Open Food Facts is followed by sign_up_page_terms_text"
+  },
+  "sign_up_page_terms_text": "terms of use and contribution",
+  "@sign_up_page_terms_text": {
+    "description": "terms of use and contribution is preceded by sign_up_page_agree_text"
+  },
+  "sign_up_page_agree_url": "https://world-en.openfoodfacts.org/terms-of-use",
+  "@sign_up_page_agree_url": {
+    "description": "Please insert the right url here. Go to the openfoodfacts homepage, switch to your country and then on the bottom left footer is Terms of use from which the url should be taken"
+  },
+  "donate_url": "https://donate.openfoodfacts.org/",
+  "@donate_url": {
+    "description": "Please insert the right url from the website here."
+  },
+  "sign_up_page_agree_error_invalid": "When creating an account, agreeing to the Terms of Use is mandatory, however, anonymous contributions can still be made through the app",
+  "@sign_up_page_agree_error_invalid": {
+    "description": "Error message: You have to agree to the terms-of-use (A checkbox to do so is above this error message)"
+  },
+  "sign_up_page_producer_checkbox": "I am a food producer",
+  "sign_up_page_producer_hint": "Producer/brand",
+  "sign_up_page_producer_error_empty": "Please enter a producer or a brand name",
+  "sign_up_page_subscribe_checkbox": "I'd like to subscribe to the Open Food Facts newsletter (You can unsubscribe from it at any time)",
+  "@Settings": {},
+  "settingsTitle": "Settings",
+  "@settingsTitle": {
+    "description": "The title of the Settings page"
+  },
+  "darkmode": "Darkmode",
+  "@darkmode": {
+    "description": "The name of the darkmode on off switch"
+  },
+  "darkmode_dark": "Dark",
+  "@darkmode_dark": {
+    "description": "Indicator inside the darkmode switch (dark)"
+  },
+  "darkmode_light": "Light",
+  "@darkmode_light": {
+    "description": "Indicator inside the darkmode switch (light)"
+  },
+  "darkmode_system_default": "System default",
+  "@darkmode_system_default": {
+    "description": "Indicator inside the darkmode switch (system default)"
+  },
+  "thanks_for_contributing": "Thanks for contributing",
+  "@contributors": {
+    "description": "Button label: Opens a pop up window where all contributors of this app are shown"
+  },
+  "contributors": "Contributors",
+  "support": "Support",
+  "@support": {
+    "description": "Button label: Opens a pop up window where all ways to get support are shown"
+  },
+  "support_join_slack": "Ask for help in our Slack channel",
+  "support_via_email": "Send us an e-mail",
+  "termsOfUse": "Terms of use",
+  "@termsOfUse": {},
+  "about_this_app": "About this app",
+  "@about_this_app": {
+    "description": "Button label: Opens a pop up window which shows information about the app"
+  },
+  "@About this app section": {},
+  "contribute": "Contribute",
+  "@contribute": {
+    "description": "Button label: Shows multiple ways how users can contribute to OFF"
+  },
+  "contribute_sw_development": "Software development",
+  "@contribute_sw_development": {
+    "description": "Button label + page title: Ways to help"
+  },
+  "contribute_develop_text": "The code for every Open Food Facts product is available on GitHub. You are welcome to reuse the code (it's open source) and help us improve it, for everyone, on all the planet.",
+  "@contribute_develop_text": {},
+  "contribute_develop_text_2": "You can join the Open Food Facts Slack chatroom which is the preferred way to ask questions.",
+  "@contribute_develop_text_2": {},
+  "contribute_donate_header": "Donate to Open Food Facts",
+  "@contribute_donate_header": {},
+  "contribute_improve_ProductsToBeCompleted": "Products to be completed",
+  "@contribute_improve_ProductsToBeCompleted": {
+    "description": "Button label: Shows a list of products which aren't completed"
+  },
+  "contribute_improve_header": "Improving",
+  "@contribute_improve_header": {
+    "description": "Button label + page title: Ways to improve the database"
+  },
+  "contribute_improve_text": "The database is the core of the project. It's easy and very quick to help. You can download the mobile app for your phone, and start adding or improving products.\n\nOn the other hand, Open Food Facts website offers many ways to contribute: ",
+  "@contribute_improve_text": {},
+  "contribute_translate_header": "Translate",
+  "@contribute_translate_header": {
+    "description": "Button label + pop up window title: Shows information about helping by translating"
+  },
+  "contribute_translate_link_text": "Start Translating",
+  "@contribute_translate_link_text": {
+    "description": "Button label: Opens the Crowdin translation portal"
+  },
+  "contribute_translate_text": "Open Food Facts is a global project, containing products from more than 160 countries. Open Food Facts is translated into dozens of languages, with constantly evolving content.",
+  "@contribute_translate_text": {},
+  "contribute_translate_text_2": "Translations is one of the key tasks of the project",
+  "@contribute_translate_text_2": {},
+  "tap_to_answer": "Tap here to answer questions",
+  "@tap_to_answer": {
+    "description": "Button label shown on a product, clicking the button opens a card with unanswered product questions, users can answer these to contribute to Open food facts and gain rewards."
+  },
+  "saving_answer": "Saving your answer",
+  "@saving_answer": {
+    "description": "Dialog shown to users after they have answered a question, while the answer is being saved in the BE."
+  },
+  "contribute_to_get_rewards": "Help improve food transparency and get rewards",
+  "@contribute_to_get_rewards": {
+    "description": "Button description shown on a product, clicking the button opens a card with unanswered product questions, users can answer these to contribute to Open food facts and gain rewards."
+  },
+  "question_sign_in_text": "Sign in to your Open Food Facts account to claim your contribution and to increase your creditability",
+  "@Personal preferences": {},
+  "myPreferences": "My preferences",
+  "@myPreferences": {
+    "description": "Page title: Page where the ranking preferences can be changed"
+  },
+  "myPreferences_profile_title": "Your Profile",
+  "myPreferences_profile_subtitle": "Change app settings and get advice.",
+  "myPreferences_settings_title": "App Settings",
+  "myPreferences_settings_subtitle": "Dark mode, Theme, ...",
+  "myPreferences_food_title": "Food Preferences",
+  "myPreferences_food_subtitle": "Choose what information about food matters most to you.",
+  "confirmResetPreferences": "Reset your food preferences?",
+  "@confirmResetPreferences": {
+    "description": "Pop up title: Reassuring if the food preferences should really be reset"
+  },
+  "myPersonalizedRanking": "My personalized ranking",
+  "@myPersonalizedRanking": {
+    "description": "When you press this button, all products (in list or category) are sorted according to your preferences."
+  },
+  "ranking_tab_all": "All",
+  "ranking_subtitle_match_yes": "A great match for you",
+  "ranking_subtitle_match_no": "Very poor match",
+  "ranking_subtitle_match_maybe": "Unknown match",
+  "reloaded_with_new_preferences": "Reloaded with your new preferences",
+  "@reloaded_with_new_preferences": {
+    "description": "Snackbar title: Shows that the modified settings have been applied"
+  },
+  "@other": {},
+  "profile_navbar_label": "Profile",
+  "@profile_navbar_label": {
+    "description": "BottomNavigationBarLabel: For the profile and personal preferences page"
+  },
+  "scan_navbar_label": "Search",
+  "@scan_navbar_label": {
+    "description": "BottomNavigationBarLabel: For the searching of products"
+  },
+  "history_navbar_label": "History",
+  "@history_navbar_label": {
+    "description": "BottomNavigationBarLabel: For the history and compare mode"
+  },
+  "category": "Filter by category",
+  "@category": {
+    "description": "From a product list, there's a category filter: this is its title"
+  },
+  "category_all": "All",
+  "@category_al": {
+    "description": "Top meta-entry on a category filter"
+  },
+  "category_search": "(category search)",
+  "filter": "Filter",
+  "@filter": {
+    "description": "A button that opens a menu where you can filter within categories. Juices => Apple juices/Orange juices"
+  },
+  "scan": "Scan",
+  "@scan": {
+    "description": "Page title: List type: Scanned products"
+  },
+  "search": "Search",
+  "@search": {
+    "description": "Hint text of a search text input field"
+  },
+  "tab_for_more": "Tap to see more info...",
+  "@Product": {},
+  "product": "Product",
+  "@product": {},
+  "unknownBrand": "Unknown brand",
+  "@unknownBrand": {},
+  "unknownProductName": "Unknown product name",
+  "@unknownProductName": {},
+  "label_refresh": "Refresh",
+  "@label_refresh": {
+    "description": "Refresh the cached product"
+  },
+  "image": "Image",
+  "front_photo": "Front photo",
+  "@front_photo": {
+    "description": "Button label: For adding a picture of the front of a product"
+  },
+  "ingredients": "Ingredients",
+  "@ingredients": {},
+  "ingredients_editing_instructions": "Keep the original order. Indicate the percentage when specified. Separate with a comma or hyphen, use parentheses for ingredients of an ingredient, and indicate allergens between underscores.",
+  "ingredients_editing_error": "Failed to save the ingredients.",
+  "ingredients_editing_image_error": "Failed to get a new ingredients image.",
+  "ingredients_editing_title": "Edit Ingredients",
+  "ingredients_photo": "Ingredients photo",
+  "@ingredients_photo": {
+    "description": "Button label: For adding a picture of the Ingredients of a product"
+  },
+  "nutrition": "Nutrition",
+  "@nutrition": {},
+  "nutrition_page_close_confirmation": "Are you sure you want to close without saving?",
+  "nutrition_facts_photo": "Nutrition facts photo",
+  "@nutrition_facts_photo": {
+    "description": "Button label: For adding a picture of the nutrition facts of a product"
+  },
+  "packaging_information": "Packaging information",
+  "@packaging_information": {
+    "description": "Button label: For adding a picture of the packaging of a product"
+  },
+  "packaging_information_photo": "Packaging information photo",
+  "@packaging_information_photo": {},
+  "missing_product": "You found a new product!",
+  "@missing_product": {},
+  "add_product_take_photos": "Take photos of the packaging to add this product to Open Food Facts",
+  "@add_product_take_photos": {},
+  "add_product_take_photos_descriptive": "Please take some photos and the Open Food Facts engine can work out the rest!",
+  "@add_product_take_photos_descriptive": {},
+  "add_product_information_button_label": "Add product information",
+  "@add_product_information_button_label": {},
+  "new_product": "New Product",
+  "@new_product": {},
+  "front_packaging_photo_button_label": "Front of product photo",
+  "@front_packaging_photo_button_label": {},
+  "confirm_front_packaging_photo_button_label": "Confirm front of product photo",
+  "@confirm_front_packaging_photo_button_label": {
+    "description": "Button clicking on which confirms the picture of the front of product that user just took."
+  },
+  "confirm_button_label": "Confirm",
+  "front_packaging_photo_title": "Front Packaging Photo",
+  "ingredients_photo_title": "Ingredients Photo",
+  "nutritional_facts_photo_title": "Nutritional Facts Photo",
+  "recycling_photo_title": "Recycling Photo",
+  "other_interesting_photo_title": "Other Interesting Photo",
+  "front_photo_uploaded": "Front photo uploaded",
+  "@front_photo_uploaded": {},
+  "ingredients_photo_button_label": "Ingredients photo",
+  "@ingredients_photo_button_label": {},
+  "confirm_ingredients_photo_button_label": "Confirm ingredients photo",
+  "@confirm_ingredients_photo_button_label": {
+    "description": "Button clicking on which confirms the picture of ingredients that user just took."
+  },
+  "ingredients_photo_uploaded": "Ingredients photo uploaded",
+  "@ingredients_photo_uploaded": {},
+  "nutritional_facts_photo_button_label": "Nutrition facts photo",
+  "@nutritional_facts_photo_button_label": {},
+  "confirm_nutritional_facts_photo_button_label": "Confirm nutrition facts photo",
+  "@confirm_nutritional_facts_photo_button_label": {
+    "description": "Button clicking on which confirms the picture of nutritional facts that user just took."
+  },
+  "nutritional_facts_photo_uploaded": "Nutrition facts photo uploaded",
+  "@nutritional_facts_photo_uploaded": {},
+  "recycling_photo_button_label": "Recycling information photo",
+  "@recycling_photo_button_label": {},
+  "confirm_recycling_photo_button_label": "Confirm Recycling information photo",
+  "@confirm_recycling_photo_button_label": {
+    "description": "Button clicking on which confirms the picture of recycling information that user just took."
+  },
+  "recycling_photo_uploaded": "Recycling photo uploaded",
+  "@recycling_photo_uploaded": {},
+  "other_interesting_photo_button_label": "Other interesting photos",
+  "@other_interesting_photo_button_label": {},
+  "confirm_other_interesting_photo_button_label": "Confirm photo",
+  "@confirm_other_interesting_photo_button_label": {
+    "description": "Button clicking on which confirms a miscellaneous photo of the product."
+  },
+  "other_photo_uploaded": "Miscellaneous photo uploaded",
+  "@other_photo_uploaded": {},
+  "retake_photo_button_label": "Retake",
+  "@retake_photo_button_label": {
+    "description": "Button clicking on which allows users to retake the last photo they took."
+  },
+  "selecting_photo": "Selecting photo",
+  "@selecting_photo": {
+    "description": "Progress indicator when the users takes a photo"
+  },
+  "uploading_image": "Uploading photo to the server",
+  "@uploading_image": {
+    "description": "Message when a new picture is uploading to the server"
+  },
+  "score_add_missing_ingredients": "Add missing ingredients",
+  "score_add_missing_nutrition_facts": "Add missing nutrition facts",
+  "score_add_missing_product_category": "Add missing product category",
+  "score_update_nutrition_facts": "Update nutrition facts",
+  "nutrition_page_title": "Nutrition Facts",
+  "nutrition_page_unspecified": "Nutrition facts are not specified on the product",
+  "nutrition_page_per_100g": "per 100g",
+  "nutrition_page_per_serving": "per serving",
+  "nutrition_page_add_nutrient": "Add a nutrient",
+  "nutrition_page_serving_size": "Serving size",
+  "nutrition_page_invalid_number": "Invalid number",
+  "nutrition_page_update_running": "Updating the product on the server...",
+  "nutrition_page_update_done": "Product updated!",
+  "more_photos": "More interesting photos",
+  "@more_photos": {},
+  "no_product_found": "No product found",
+  "@no_product_found": {},
+  "not_found": "not found:",
+  "searchPanelHeader": "Search or scan your first product",
+  "@Product query status": {},
+  "refreshing_product": "Refreshing product",
+  "@refreshing_product": {
+    "description": "Confirmation, that the product data of a cached product is queried again"
+  },
+  "product_refreshed": "Product refreshed",
+  "@product_refreshed": {
+    "description": "Confirmation, that the product data refresh is done"
+  },
+  "could_not_refresh": "Could not refresh product",
+  "@could_not_refresh": {
+    "description": "The product data couldn't be refreshed"
+  },
+  "product_internet_error": "Impossible to fetch information about this product due to a network error.",
+  "cached_results_from": "Show results from:",
+  "@cached_results_from": {
+    "description": "Cached results from: x time ago (time ago should not be added to the string)"
+  },
+  "@Product Addition": {},
+  "added_product_thanks": "Thank you for adding this product!",
+  "@added_product_thanks": {},
+  "product_search_same_category": "Compare to Category",
+  "@product_search_same_category": {
+    "description": "Button looking for the other products within the same category. Less than 30 characters"
+  },
+  "product_improvement_add_category": "Add a category to calculate the Nutri-Score.",
+  "@product_improvement_add_category": {
+    "description": "Message for ProductImprovement.ADD_CATEGORY"
+  },
+  "product_improvement_add_nutrition_facts": "Add nutrition facts to calculate the Nutri-Score.",
+  "@product_improvement_add_nutrition_facts": {
+    "description": "Message for ProductImprovement.ADD_NUTRITION_FACTS"
+  },
+  "product_improvement_add_nutrition_facts_and_category": "Add nutrition facts and a category to calculate the Nutri-Score.",
+  "@product_improvement_add_nutrition_facts_and_category": {
+    "description": "Message for ProductImprovement.ADD_NUTRITION_FACTS_AND_CATEGORY"
+  },
+  "product_improvement_categories_but_no_nutriscore": "The Nutri-Score for this product can't be calculated, which may be due to e.g. a non-standard category. If this is considered an error, please contact us.",
+  "@product_improvement_categories_but_no_nutriscore": {
+    "description": "Message for ProductImprovement.CATEGORIES_BUT_NO_NUTRISCORE"
+  },
+  "product_improvement_obsolete_nutrition_image": "The nutrition image is obsolete: please refresh it.",
+  "@product_improvement_obsolete_nutrition_image": {
+    "description": "Message for ProductImprovement.OBSOLETE_NUTRITION_IMAGE"
+  },
+  "product_improvement_origins_to_be_completed": "The Eco-Score takes into account the origins of the ingredients. Please take a photo of the ingredient list and/or any geographic claim or edit the product, so they can be taken into account.",
+  "@product_improvement_origins_to_be_completed": {
+    "description": "Message for ProductImprovement.ORIGINS_TO_BE_COMPLETED"
+  },
+  "country_chooser_label": "Please choose a country",
+  "@country_chooser_label": {
+    "description": "Label shown above a selector where the user can select their country"
+  },
+  "country_selection_explanation": "Some environmental features are location-specific",
+  "@country_label": {
+    "description": "Explanation as to why users should select their country."
+  },
+  "product_removed_comparison": "Product removed from comparison",
+  "@product_removed_comparison": {
+    "description": "Product got removed from comparison list"
+  },
+  "product_removed_history": "Product removed from history",
+  "@product_removed_history": {
+    "description": "Product got removed from history"
+  },
+  "product_could_not_remove": "Could not remove product",
+  "@product_could_not_remove": {
+    "description": "Could not remove product from a list"
+  },
+  "@Lists": {},
+  "no_prodcut_in_list": "There is no product in this list",
+  "no_product_in_section": "There is no product in this section",
+  "recently_seen_products": "History",
+  "clear": "Clear",
+  "@clear": {
+    "description": "Clears a product list"
+  },
+  "really_clear": "Do you really want to delete this list?",
+  "product_compatibility_unknown": "Compatibility Unknown",
+  "@product_compatibility_unknown": {
+    "description": "Product compatibility summary title"
+  },
+  "product_compatibility_incompatible": "Does not match",
+  "@product_compatibility_incompatible": {
+    "description": "Product compatibility summary title"
+  },
+  "product_compatibility_good": "Good Match",
+  "@product_compatibility_good": {
+    "description": "Product compatibility summary title"
+  },
+  "@Plural": {},
+  "pct_match": "{percent}% match",
+  "@pct_match": {
+    "description": "This product has a x percent match with your preferences",
+    "placeholders": {
+      "percent": {}
+    }
+  },
+  "plural_ago_days": "{count,plural, one {} =1{one day ago} other{{count} days ago}}",
+  "@plural_ago_days": {
+    "description": "Cached results from: x days ago",
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "plural_ago_hours": "{count,plural, one {} =1{one hour ago} other{{count} hours ago}}",
+  "@plural_ago_hours": {
+    "description": "Cached results from: x hours ago",
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "plural_ago_minutes": "{count,plural, one {} =0{less than a minute ago} =1{one minute ago} other{{count} minutes ago}}",
+  "@plural_ago_minutes": {
+    "description": "Cached results from: x minutes ago",
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "plural_ago_months": "{count,plural, one {} =1{one month ago} other{{count} months ago}}",
+  "@plural_ago_months": {
+    "description": "Cached results from: x months ago",
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "plural_ago_weeks": "{count,plural, one {} =1{one week ago} other{{count} weeks ago}}",
+  "@plural_ago_weeks": {
+    "description": "Cached results from: x weeks ago",
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "plural_compare_x_products": "{count,plural, other{Compare {count} Products}",
+  "@plural_compare_x_products": {
+    "description": "Button label",
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "compare_products_mode": "Compare",
+  "@compare_products_mode": {
+    "description": "Button to switch to 'compare products mode'"
+  },
+  "retry_button_label": "Retry",
+  "connect_with_us": "Connect with us",
+  "instagram": "Instagram",
+  "twitter": "Twitter",
+  "blog": "Blog",
+  "faq": "FAQ",
+  "discover": "Discover",
+  "how_to_contribute": "How to Contribute",
+  "main_app_color": "Theme",
+  "@main_app_color": {
+    "description": "Heading for the section to pick the main app color"
+  },
+  "hint_knowledge_panel_message": "Your can tap on any part of the card to get more details about what you see. Try it now!",
+  "@hint_knowledge_panel_message": {
+    "description": "Hint popup indicating the card is clickable during onboarding"
+  },
+  "consent_analytics_title": "Send anonymous analytics",
+  "@consent_analytics_title": {
+    "description": "Title for the consent analytics UI Page"
+  },
+  "consent_analytics_body1": "Help the Open Food Facts volunteers to improve the app. You decide if you want to send anonymous analytics.",
+  "@conset_analytics_body1": {
+    "description": "first paragraph for the consent analytics UI Page"
+  },
+  "consent_analytics_body2": "If you change your mind, this option can be enabled and disabled at any time from the settings.",
+  "@consent_analytics_body2": {
+    "description": "second paragraph for the consent analytics UI Page"
+  },
+  "authorize_button_label": "Authorize",
+  "@authorize": {
+    "description": "Button to accept the request of sending the anonymous analytics"
+  },
+  "refuse_button_label": "Refuse",
+  "@refuse": {
+    "description": "Button to decline the request of sending the anonymous analytics"
+  },
+  "knowledge_panel_text_source": "Go further on {source_name}",
+  "@knowledge_panel_text_source": {
+    "description": "Source field within a text knowledge panel.",
+    "placeholders": {
+      "source_name": {
+        "type": "String"
+      }
+    }
+  },
+  "onboarding_welcome_loading_dialog_title": "Loading your first example product",
+  "@onboarding_welcome_loading_dialog_title": {
+    "description": "Title for the onboarding loading dialog"
+  },
+  "product_list_your_ranking": "Your ranking",
+  "@product_list_your_ranking": {
+    "description": "Your ranking screen title"
+  },
+  "product_list_empty_icon_desc": "History not available",
+  "@product_list_icon_desc": {
+    "description": "When the history list is empty, icon description (for accessibility) of the message explaining to start scanning"
+  },
+  "product_list_empty_title": "Start scanning !",
+  "@product_list_empty_title": {
+    "description": "When the history list is empty, title of the message explaining to start scanning"
+  },
+  "product_list_empty_message": "Products you scan will appear here and you can check detailed information about them",
+  "@product_list_empty_message": {
+    "description": "When the history list is empty, body of the message explaining to start scanning"
+  },
+  "product_list_reloading_in_progress": "Refreshing products in your History",
+  "@product_list_reloading_in_progress": {
+    "description": "Message to show while loading previous scanned items"
+  },
+  "product_list_reloading_success": "Product refresh complete",
+  "@product_list_reloading_success": {
+    "description": "Message to show once previous scanned items are loaded"
+  },
+  "loading_dialog_default_title": "Downloading data",
+  "@loading_dialog_default_title": {
+    "description": "Default loading dialog title"
+  },
+  "loading_dialog_default_error_message": "Could not download data",
+  "@loading_dialog_default_error_message": {
+    "description": "Default loading dialog error message"
+  },
+  "account_delete": "Delete account",
+  "@account_delete": {
+    "description": "Delete account button (user profile)"
+  },
+  "email_subject_account_deletion": "Delete account",
+  "@email_subject_account_deletion": {
+    "description": "Email subject for an account deletion"
+  },
+  "email_body_account_deletion": "Hi there, please delete my Open Food Facts account: {userId}",
+  "@email_body_account_deletion": {
+    "description": "Email body for an account deletion",
+    "placeholders": {
+      "userId": {
+        "type": "String"
+      }
+    }
+  },
+  "crash_reporting_toggle_title": "Crash reporting",
+  "@crash_reporting_toggle_title": {
+    "description": "Title for the Crash reporting toggle"
+  },
+  "crash_reporting_toggle_subtitle": "When enabled, crash reports will be sent to the Open Food Facts bug system automatically, so that we can fix bugs and improve the app.",
+  "@crash_reporting_toggle_subtitle": {
+    "description": "SubTitle for the Crash reporting toggle"
+  },
+  "send_anonymous_data_toggle_title": "Send anonymous data",
+  "@send_anonymous_toggle_title": {
+    "description": "Title for the Send anonymous data toggle"
+  },
+  "send_anonymous_data_toggle_subtitle": "When enabled, some anonymous information regarding app usage will be sent to the Open Food Facts servers, so that we can understand how and how much features are used in order to improve them.",
+  "@send_anonymous_toggle_subtitle": {
+    "description": "SubTitle for the Send anonymous data toggle"
+  },
+  "product_edit_photo_title": "Edit Photo",
+  "@product_edit_photo_title": {
+    "description": "Toolbar Title while editing a photo (Android only)"
+  },
+  "permission_photo_error": "Error",
+  "@permission_photo_error": {
+    "description": "When the camera/photo permission failed to be acquired (!= denied)"
+  },
+  "permission_photo_denied_message": "For an enhanced experience, please allow {appName} to access your camera. You will be able to directly scan barcodes.",
+  "@permission_photo_denied_message": {
+    "description": "When the camera/photo permission is denied by user",
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "permission_photo_denied_button": "Allow",
+  "@permission_photo_denied_button": {
+    "description": "When the camera/photo permission is denied by user"
+  },
+  "permission_photo_denied_dialog_settings_title": "Permission denied",
+  "permission_photo_denied_dialog_settings_message": "As you've previously denied the camera permission, you must allow it manually from the Settings.",
+  "permission_photo_denied_dialog_settings_button_open": "Open settings",
+  "permission_photo_denied_dialog_settings_button_cancel": "Cancel",
+  "edit_product_label": "Edit product",
+  "@edit_product_label": {
+    "description": "Edit product button label"
+  },
+  "edit_product_form_item_barcode": "Barcode",
+  "@edit_product_form_item_barcode": {
+    "description": "Product edition - Barcode"
+  },
+  "edit_product_form_item_details_title": "Basic details",
+  "@edit_product_form_item_details_title": {
+    "description": "Product edition - Basic Details - Title"
+  },
+  "edit_product_form_item_details_subtitle": "Product name, brand, quantity",
+  "@edit_product_form_item_details_subtitle": {
+    "description": "Product edition - Basic Details - Title"
+  },
+  "edit_product_form_item_photos_title": "Photos",
+  "@edit_product_form_item_photos_title": {
+    "description": "Product edition - Photos - Title"
+  },
+  "edit_product_form_item_photos_subtitle": "Add or refresh photos",
+  "@edit_product_form_item_photos_subtitle": {
+    "description": "Product edition - Photos - SubTitle"
+  },
+  "edit_product_form_item_labels_title": "Labels & Certifications",
+  "@edit_product_form_item_labels_title": {
+    "description": "Product edition - Labels - Title"
+  },
+  "edit_product_form_item_labels_subtitle": "Environmental, Quality labels, ...",
+  "@edit_product_form_item_labels_subtitle": {
+    "description": "Product edition - Labels - SubTitle"
+  },
+  "edit_product_form_item_ingredients_title": "Ingredients & Origins",
+  "@edit_product_form_item_ingredients_title": {
+    "description": "Product edition - Ingredients - Title"
+  },
+  "edit_product_form_item_packaging_title": "Packaging",
+  "@edit_product_form_item_packaging_title": {
+    "description": "Product edition - Packaging - Title"
+  },
+  "edit_product_form_item_nutrition_facts_title": "Nutrition facts",
+  "@edit_product_form_item_nutrition_facts_title": {
+    "description": "Product edition - Nutrition facts - Title"
+  },
+  "edit_product_form_item_nutrition_facts_subtitle": "Nutrition, alcohol content…",
+  "@edit_product_form_item_nutrition_facts_subtitle": {
+    "description": "Product edition - Nutrition facts - SubTitle"
+  },
+  "edit_product_form_save": "Edit",
+  "@edit_product_form_save": {
+    "description": "Product edition - Nutrition facts - Save button"
+  },
+  "completed_basic_details_btn_text": "Complete basic details",
+  "not_implemented_snackbar_text": "Not implemented yet",
+  "category_picker_page_appbar_text": "Categories"
 }

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -439,6 +439,10 @@
     "@selecting_photo": {
         "description": "Progress indicator when the users takes a photo"
     },
+  "uploading_image": "Uploading photo to the server",
+  "@uploading_image": {
+    "description": "Message when a new picture is uploading to the server"
+  },
     "uploading_image_type_front": "Uploading front image to Open Food Facts",
     "@uploading_image_type_front": {
         "description": "Message when a new front picture is being uploaded to the server"
@@ -748,6 +752,24 @@
     "@permission_photo_error": {
         "description": "When the camera/photo permission failed to be acquired (!= denied)"
     },
+  "permission_photo_denied_title": "Allow camera use to scan barcodes",
+  "permission_photo_denied_message": "For an enhanced experience, please allow {appName} to access your camera. You will be able to directly scan barcodes.",
+  "@permission_photo_denied_message": {
+    "description": "When the camera/photo permission is denied by user",
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "permission_photo_denied_button": "Allow",
+  "@permission_photo_denied_button": {
+    "description": "When the camera/photo permission is denied by user"
+  },
+  "permission_photo_denied_dialog_settings_title": "Permission denied",
+  "permission_photo_denied_dialog_settings_message": "As you've previously denied the camera permission, you must allow it manually from the Settings.",
+  "permission_photo_denied_dialog_settings_button_open": "Open settings",
+  "permission_photo_denied_dialog_settings_button_cancel": "Cancel",
     "permission_photo_denied": "No camera access granted",
     "@permission_photo_denied": {
         "description": "When the camera/photo permission is denied by user"

--- a/packages/smooth_app/lib/pages/scan/scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/scan_page.dart
@@ -114,18 +114,29 @@ class _ScanPageTopWidget extends StatelessWidget {
                 return Container(
                   alignment: Alignment.topCenter,
                   constraints: BoxConstraints.tightForFinite(
+                    width: constraints.maxWidth *
+                        SmoothProductCarousel.carouselViewPortFraction,
                     height: math.min(constraints.maxHeight * 0.9, 200),
                   ),
+                  padding: SmoothProductCarousel.carouselItemInternalPadding,
                   child: SmoothCard(
-                    margin: SmoothProductCarousel.carouselItemHorizontalPadding
-                        .add(SmoothProductCarousel.carouselItemInternalPadding),
+                    padding: const EdgeInsetsDirectional.only(
+                      top: 10.0,
+                      start: 8.0,
+                      end: 8.0,
+                      bottom: 5.0,
+                    ),
                     child: Align(
                       alignment: Alignment.topCenter,
                       child: Column(
                         children: <Widget>[
-                          Icon(
-                            Icons.warning_rounded,
-                            size: constraints.maxHeight * 0.15,
+                          Text(
+                            localizations.permission_photo_denied_title,
+                            style: const TextStyle(
+                              fontSize: 18.0,
+                              fontWeight: FontWeight.bold,
+                            ),
+                            textAlign: TextAlign.center,
                           ),
                           Expanded(
                             child: SingleChildScrollView(
@@ -141,7 +152,7 @@ class _ScanPageTopWidget extends StatelessWidget {
                                   textAlign: TextAlign.center,
                                   style: const TextStyle(
                                     height: 1.4,
-                                    fontSize: 16.0,
+                                    fontSize: 15.5,
                                   ),
                                 ),
                               ),

--- a/packages/smooth_app/lib/pages/scan/scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/scan_page.dart
@@ -36,20 +36,14 @@ class _ScanPageState extends State<ScanPage> {
     setState(() {});
   }
 
-  Future<PermissionStatus> _permissionCheck(
-    UserPreferences userPreferences,
-  ) async {
+  Future<PermissionStatus> _permissionCheck() async {
     final PermissionStatus status = await Permission.camera.status;
 
     // If is denied, is not restricted by for example parental control and is
     // not already declined once
     if (status.isDenied &&
-        !status.isRestricted &&
-        !userPreferences.cameraDeclinedOnce) {
+        !status.isRestricted) {
       final PermissionStatus newStatus = await Permission.camera.request();
-      if (!newStatus.isGranted && !newStatus.isLimited) {
-        userPreferences.setCameraDecline(true);
-      }
       return newStatus;
     } else {
       return status;
@@ -64,7 +58,7 @@ class _ScanPageState extends State<ScanPage> {
     }
 
     return FutureBuilder<PermissionStatus>(
-      future: _permissionCheck(userPreferences),
+      future: _permissionCheck(),
       builder: (
         BuildContext context,
         AsyncSnapshot<PermissionStatus> snapshot,

--- a/packages/smooth_app/lib/pages/scan/scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/scan_page.dart
@@ -41,8 +41,7 @@ class _ScanPageState extends State<ScanPage> {
 
     // If is denied, is not restricted by for example parental control and is
     // not already declined once
-    if (status.isDenied &&
-        !status.isRestricted) {
+    if (status.isDenied && !status.isRestricted) {
       final PermissionStatus newStatus = await Permission.camera.request();
       return newStatus;
     } else {
@@ -71,35 +70,55 @@ class _ScanPageState extends State<ScanPage> {
           return Center(child: Text(appLocalizations.permission_photo_error));
         }
 
-        // TODO(M123): show no camera access screen
-        if (snapshot.data!.isDenied ||
-            snapshot.data!.isPermanentlyDenied ||
-            snapshot.data!.isRestricted) {
-          Center(
-            child: Text(appLocalizations.permission_photo_denied),
+        final PermissionStatus status = snapshot.data!;
+
+        Widget? topChild;
+        Widget? backgroundChild;
+
+        if (!status.isGranted) {
+          topChild = PermissionDeniedWidget(
+            status: status,
           );
-        }
-
-        final Widget child;
-
-        if (userPreferences.getFlag(
+        } else if (userPreferences.getFlag(
               UserPreferencesDevMode.userPreferencesFlagUseMLKit,
             ) ??
             true) {
-          child = const MLKitScannerPage();
+          backgroundChild = const MLKitScannerPage();
         } else {
-          child = const ContinuousScanPage();
+          backgroundChild = const ContinuousScanPage();
         }
 
         return ChangeNotifierProvider<ContinuousScanModel>(
           create: (BuildContext context) => _model!,
           child: Scaffold(
             body: ScannerOverlay(
-              child: child,
+              backgroundChild: backgroundChild,
+              topChild: topChild,
             ),
           ),
         );
       },
+    );
+  }
+}
+
+class PermissionDeniedWidget extends StatelessWidget {
+  const PermissionDeniedWidget({
+    required this.status,
+    Key? key,
+  }) : super(key: key);
+
+  final PermissionStatus status;
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context)!;
+
+    return Container(
+      color: Colors.red,
+      child: Center(
+        child: Text(appLocalizations.permission_photo_denied),
+      ),
     );
   }
 }

--- a/packages/smooth_app/lib/pages/scan/scanner_overlay.dart
+++ b/packages/smooth_app/lib/pages/scan/scanner_overlay.dart
@@ -11,15 +11,14 @@ import 'package:smooth_app/widgets/smooth_product_carousel.dart';
 /// clear and compare buttons row.
 ///
 /// The camera preview should be passed to [backgroundChild].
-/// If no [topChild] is passed, a [SmoothViewFinder] with be displayed (= visor)
 class ScannerOverlay extends StatelessWidget {
   const ScannerOverlay({
-    this.topChild,
+    required this.topChild,
     this.backgroundChild,
   });
 
   final Widget? backgroundChild;
-  final Widget? topChild;
+  final Widget topChild;
 
   static const double carouselHeightPct = 0.55;
   static const double carouselBottomPadding = 10.0;
@@ -49,10 +48,6 @@ class ScannerOverlay extends StatelessWidget {
           screenSize.width,
           availableScanHeight - carouselBottomPadding,
         );
-        final Size scannerSize = Size(
-          screenSize.width * ScannerOverlay.scannerWidthPct,
-          screenSize.width * ScannerOverlay.scannerHeightPct,
-        );
 
         return Container(
           color: Colors.black,
@@ -75,12 +70,7 @@ class ScannerOverlay extends StatelessWidget {
                   constraints: BoxConstraints.tight(
                     scannerContainerSize,
                   ),
-                  child: Center(
-                    child: topChild ?? SmoothViewFinder(
-                      boxSize: scannerSize,
-                      lineLength: screenSize.width * 0.8,
-                    ),
-                  ),
+                  child: Center(child: topChild),
                 ),
               ),
               // Product carousel
@@ -108,6 +98,25 @@ class ScannerOverlay extends StatelessWidget {
           ),
         );
       },
+    );
+  }
+}
+
+class ScannerVisorWidget extends StatelessWidget {
+  const ScannerVisorWidget({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final Size screenSize = MediaQuery.of(context).size;
+
+    final Size scannerSize = Size(
+      screenSize.width * ScannerOverlay.scannerWidthPct,
+      screenSize.width * ScannerOverlay.scannerHeightPct,
+    );
+
+    return SmoothViewFinder(
+      boxSize: scannerSize,
+      lineLength: screenSize.width * 0.8,
     );
   }
 }

--- a/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
+++ b/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
@@ -23,6 +23,11 @@ class SmoothProductCarousel extends StatefulWidget {
   final bool containSearchCard;
   final double height;
 
+  static const EdgeInsets carouselItemHorizontalPadding =
+      EdgeInsets.symmetric(horizontal: 20.0);
+  static const EdgeInsets carouselItemInternalPadding =
+      EdgeInsets.symmetric(horizontal: 2.0);
+
   @override
   State<SmoothProductCarousel> createState() => _SmoothProductCarouselState();
 }
@@ -57,7 +62,7 @@ class _SmoothProductCarouselState extends State<SmoothProductCarousel> {
       itemCount: barcodes.length + _searchCardAdjustment,
       itemBuilder: (BuildContext context, int itemIndex, int itemRealIndex) {
         return Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 2.0),
+          padding: SmoothProductCarousel.carouselItemInternalPadding,
           child: widget.containSearchCard && itemIndex == 0
               ? SearchCard(height: widget.height)
               : _getWidget(itemIndex - _searchCardAdjustment),
@@ -129,7 +134,7 @@ class SearchCard extends StatelessWidget {
     return SmoothCard(
       color: Theme.of(context).colorScheme.background.withOpacity(0.85),
       elevation: 0,
-      padding: const EdgeInsets.symmetric(horizontal: 20.0),
+      padding: SmoothProductCarousel.carouselItemHorizontalPadding,
       child: SizedBox(
         height: height,
         child: Column(

--- a/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
+++ b/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
@@ -27,6 +27,7 @@ class SmoothProductCarousel extends StatefulWidget {
       EdgeInsets.symmetric(horizontal: 20.0);
   static const EdgeInsets carouselItemInternalPadding =
       EdgeInsets.symmetric(horizontal: 2.0);
+  static const double carouselViewPortFraction = 0.91;
 
   @override
   State<SmoothProductCarousel> createState() => _SmoothProductCarouselState();
@@ -71,7 +72,7 @@ class _SmoothProductCarouselState extends State<SmoothProductCarousel> {
       carouselController: _controller,
       options: CarouselOptions(
         enlargeCenterPage: false,
-        viewportFraction: 0.91,
+        viewportFraction: SmoothProductCarousel.carouselViewPortFraction,
         height: widget.height,
         enableInfiniteScroll: false,
         onPageChanged: (int index, CarouselPageChangedReason reason) {


### PR DESCRIPTION
- Support for rationale (Android)
- If the permission is denied, no barcode decoder is launched
- When the app is resumed, check if the permission is still available
- Value saved on user preferences was totally useless, since Android/iOS provide the same info

https://user-images.githubusercontent.com/246838/163579342-e2761a7d-6235-4153-834a-2ccc9e35ce24.mp4


Fix #1564