### PR TITLE
fix: delete option in history

### DIFF
--- a/packages/smooth_app/lib/pages/history_page.dart
+++ b/packages/smooth_app/lib/pages/history_page.dart
@@ -5,6 +5,8 @@ import 'package:smooth_app/database/dao_product_list.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/pages/product/common/product_list_page.dart';
 
+import 'product/common/product_hist_list_page.dart';
+
 class HistoryPage extends StatefulWidget {
   const HistoryPage();
   @override
@@ -26,6 +28,6 @@ class _HistoryPageState extends State<HistoryPage> {
 
   @override
   Widget build(BuildContext context) {
-    return ProductListPage(productList);
+    return ProductHistListPage(productList);
   }
 }

--- a/packages/smooth_app/lib/pages/product/common/product_hist_list_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_hist_list_page.dart
@@ -1,0 +1,324 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:openfoodfacts/utils/ProductListQueryConfiguration.dart';
+import 'package:provider/provider.dart';
+import 'package:smooth_app/data_models/product_list.dart';
+import 'package:smooth_app/database/dao_product.dart';
+import 'package:smooth_app/database/dao_product_list.dart';
+import 'package:smooth_app/database/local_database.dart';
+import 'package:smooth_app/database/product_query.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/generic_lib/loading_dialog.dart';
+import 'package:smooth_app/pages/personalized_ranking_page.dart';
+import 'package:smooth_app/pages/product/common/product_list_item_simple.dart';
+import 'package:smooth_app/pages/product/common/product_query_page_helper.dart';
+
+class ProductHistListPage extends StatefulWidget {
+  const ProductHistListPage(this.productList);
+
+  final ProductList productList;
+
+  @override
+  State<ProductHistListPage> createState() => _ProductHistListPageState();
+}
+
+class _ProductHistListPageState extends State<ProductHistListPage> {
+  late ProductList productList;
+  bool first = true;
+  final Set<String> _selectedBarcodes = <String>{};
+  bool _selectionMode = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final LocalDatabase localDatabase = context.watch<LocalDatabase>();
+    final DaoProductList daoProductList = DaoProductList(localDatabase);
+    final ThemeData themeData = Theme.of(context);
+    final ColorScheme colorScheme = Theme.of(context).colorScheme;
+    final AppLocalizations appLocalizations = AppLocalizations.of(context)!;
+    if (first) {
+      first = false;
+      productList = widget.productList;
+    }
+    final List<Product> products = productList.getList();
+    final bool dismissible;
+    switch (productList.listType) {
+      case ProductListType.SCAN_SESSION:
+      case ProductListType.HISTORY:
+        dismissible = productList.barcodes.isNotEmpty;
+        break;
+      case ProductListType.HTTP_SEARCH_CATEGORY:
+      case ProductListType.HTTP_SEARCH_KEYWORDS:
+        dismissible = false;
+    }
+    return Scaffold(
+      appBar: AppBar(
+        elevation: 0,
+        backgroundColor: colorScheme.background,
+        foregroundColor: colorScheme.onBackground,
+        title: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: <Widget>[
+            if (_selectionMode)
+              ElevatedButton(
+                child: Text(
+                  appLocalizations.plural_compare_x_products(
+                    _selectedBarcodes.length,
+                  ),
+                ),
+                onPressed: _selectedBarcodes.length >=
+                        2 // compare button is enabled only if 2 or more products have been selected
+                    ? () async {
+                        final List<Product> list = <Product>[];
+                        for (final Product product in products) {
+                          if (_selectedBarcodes.contains(product.barcode)) {
+                            list.add(product);
+                          }
+                        }
+                        await Navigator.push<Widget>(
+                          context,
+                          MaterialPageRoute<Widget>(
+                            builder: (BuildContext context) =>
+                                PersonalizedRankingPage(
+                              products: list,
+                              title: appLocalizations.product_list_your_ranking,
+                            ),
+                          ),
+                        );
+                        setState(() => _selectionMode = false);
+                      }
+                    : null,
+              ),
+            if (_selectionMode)
+              ElevatedButton(
+                onPressed: () async {
+                  for (final Product product in products) {
+                    if (_selectedBarcodes.contains(product.barcode)) {
+                      productList.remove(product.barcode.toString());
+                    }
+                  }
+
+                  daoProductList.clear(productList);
+                  setState(() => _selectionMode = false);
+                },
+                child: Icon(Icons.delete),
+              ),
+            if (_selectionMode)
+              ElevatedButton(
+                onPressed: () => setState(() => _selectionMode = false),
+                child: Text(appLocalizations.cancel),
+              ),
+            if (!_selectionMode)
+              Flexible(
+                child: Text(
+                  ProductQueryPageHelper.getProductListLabel(
+                    productList,
+                    context,
+                    verbose: false,
+                  ),
+                  overflow: TextOverflow.fade,
+                ),
+              ),
+            if ((!_selectionMode) && products.isNotEmpty)
+              Flexible(
+                child: ElevatedButton(
+                  child: Text(appLocalizations.compare_products_mode),
+                  onPressed: () => setState(() => _selectionMode = true),
+                ),
+              ),
+            if ((!_selectionMode) && products.isNotEmpty)
+              Flexible(
+                child: ElevatedButton(
+                  child: Icon(Icons.delete),
+                  onPressed: () => setState(() => _selectionMode = true),
+                ),
+              ),
+          ],
+        ),
+      ),
+      body: products.isEmpty
+          ? Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: <Widget>[
+                Icon(
+                  Icons.find_in_page_rounded,
+                  color: colorScheme.primary,
+                  size: VERY_LARGE_SPACE * 10,
+                  semanticLabel: appLocalizations.product_list_empty_icon_desc,
+                ),
+                Text(
+                  appLocalizations.product_list_empty_title,
+                  style: themeData.textTheme.headlineLarge
+                      ?.apply(color: colorScheme.onBackground),
+                ),
+                Padding(
+                  padding: const EdgeInsets.all(VERY_LARGE_SPACE),
+                  child: Text(
+                    appLocalizations.product_list_empty_message,
+                    style: TextStyle(
+                      color: colorScheme.onBackground,
+                    ),
+                  ),
+                )
+              ],
+            )
+          : RefreshIndicator(
+              //if it is in selectmode then refresh indicator is not shown
+              notificationPredicate:
+                  _selectionMode ? (_) => false : (_) => true,
+              onRefresh: () async => _refreshListProducts(
+                products,
+                localDatabase,
+                appLocalizations,
+              ),
+              child: ListView.builder(
+                itemCount: products.length,
+                itemBuilder: (BuildContext context, int index) {
+                  final Product product = products[index];
+                  final String barcode = product.barcode!;
+                  final bool selected = _selectedBarcodes.contains(barcode);
+                  void onTap() => setState(
+                        () {
+                          if (selected) {
+                            _selectedBarcodes.remove(barcode);
+                          } else {
+                            _selectedBarcodes.add(barcode);
+                          }
+                        },
+                      );
+                  final Widget child = GestureDetector(
+                    onTap: _selectionMode ? onTap : null,
+                    child: Container(
+                      padding: EdgeInsets.symmetric(
+                        horizontal: _selectionMode ? 0 : 12.0,
+                        vertical: 8.0,
+                      ),
+                      child: Row(
+                        children: <Widget>[
+                          if (_selectionMode)
+                            Icon(
+                              selected
+                                  ? Icons.check_box
+                                  : Icons.check_box_outline_blank,
+                            ),
+                          Expanded(
+                            child: ProductListItemSimple(
+                              product: product,
+                              onTap: _selectionMode ? onTap : null,
+                              onLongPress: !_selectionMode
+                                  ? () => setState(() => _selectionMode = true)
+                                  : null,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  );
+                  if (dismissible) {
+                    return Dismissible(
+                      direction: DismissDirection.endToStart,
+                      background: Container(
+                        alignment: Alignment.centerRight,
+                        margin: const EdgeInsets.symmetric(vertical: 14),
+                        color: RED_COLOR,
+                        padding: const EdgeInsets.only(right: 30),
+                        child: const Icon(
+                          Icons.delete,
+                          color: Colors.white,
+                        ),
+                      ),
+                      key: Key(product.barcode!),
+                      onDismissed: (final DismissDirection direction) async {
+                        final bool removed =
+                            productList.remove(product.barcode!);
+                        if (removed) {
+                          await daoProductList.put(productList);
+                          _selectedBarcodes.remove(product.barcode);
+                          setState(() => products.removeAt(index));
+                        }
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(
+                            content: Text(
+                              removed
+                                  ? appLocalizations.product_removed_history
+                                  : appLocalizations.product_could_not_remove,
+                            ),
+                            duration: const Duration(seconds: 3),
+                          ),
+                        );
+                        // TODO(monsieurtanuki): add a snackbar ("put back the food")
+                      },
+                      child: child,
+                    );
+                  }
+                  return Container(
+                    key: Key(product.barcode!),
+                    child: child,
+                  );
+                },
+              ),
+            ),
+    );
+  }
+
+  /// Calls the "refresh products" part with dialogs on top.
+  Future<void> _refreshListProducts(
+    final List<Product> products,
+    final LocalDatabase localDatabase,
+    final AppLocalizations appLocalizations,
+  ) async {
+    final bool? done = await LoadingDialog.run<bool>(
+      context: context,
+      title: appLocalizations.product_list_reloading_in_progress,
+      future: _reloadProducts(products, localDatabase),
+    );
+    switch (done) {
+      case null: // user clicked on "stop"
+        return;
+      case true:
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(appLocalizations.product_list_reloading_success),
+            duration: const Duration(seconds: 2),
+          ),
+        );
+        setState(() {});
+        return;
+      case false:
+        LoadingDialog.error(context: context);
+        return;
+    }
+  }
+
+  /// Fetches the products from the API and refreshes the local database
+  Future<bool> _reloadProducts(
+    final List<Product> products,
+    final LocalDatabase localDatabase,
+  ) async {
+    try {
+      final List<String> barcodes = <String>[];
+      for (final Product product in products) {
+        barcodes.add(product.barcode!);
+      }
+      final SearchResult searchResult = await OpenFoodAPIClient.getProductList(
+        ProductQuery.getUser(),
+        ProductListQueryConfiguration(
+          barcodes,
+          fields: ProductQuery.fields,
+          language: ProductQuery.getLanguage(),
+          country: ProductQuery.getCountry(),
+        ),
+      );
+      final List<Product>? freshProducts = searchResult.products;
+      if (freshProducts == null) {
+        return false;
+      }
+      await DaoProduct(localDatabase).putAll(freshProducts);
+      freshProducts.forEach(productList.refresh);
+      return true;
+    } catch (e) {
+      //
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
In first request, the code is not forked one so that's why its raises 608 changes.

I made changes in Historypage. I keep the option for delete the products in history from localdatabase.

change history_page.dart

```
class _HistoryPageState extends State<HistoryPage> {
  final ProductList productList = ProductList.history();

  @protected
  @mustCallSuper
  @override
  void didChangeDependencies() {
    super.didChangeDependencies();
    DaoProductList(context.watch<LocalDatabase>()).get(productList).then((_) {
      setState(() {});
    });
  }

  @override
  Widget build(BuildContext context) {
    return ProductHistListPage(productList);
  }
}
```
2.Change in ProductHistListPage

```
if ((!_selectionMode) && products.isNotEmpty)
              Flexible(
                child: ElevatedButton(
                  child: Icon(Icons.delete),
                  onPressed: () => setState(() => _selectionMode = true),
                ),
              ),

if (_selectionMode)
              ElevatedButton(
                onPressed: () async {
                  for (final Product product in products) {
                    if (_selectedBarcodes.contains(product.barcode)) {
                      productList.remove(product.barcode.toString());
                    }
                  }

                  daoProductList.clear(productList);
                  setState(() => _selectionMode = false);
                },
                child: Icon(Icons.delete),
              ),
```
![2](https://user-images.githubusercontent.com/72931833/163700925-b0a5e88a-6586-4131-aace-a77f44821f88.jpeg)
![3](https://user-images.githubusercontent.com/72931833/163700931-3ee9bbc0-024e-411c-9e5e-66ece24b8401.jpeg)
