### PR TITLE
fix: use title_element

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panel_card.dart
+++ b/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panel_card.dart
@@ -31,7 +31,7 @@ class KnowledgePanelCard extends StatelessWidget {
       child: KnowledgePanelSummaryCard(panel),
       onTap: () {
         AnalyticsHelper.trackKnowledgePanelOpen(
-          knowledgePanelName: panel.topics.toString(),
+          knowledgePanelName: panel.title_element.toString(),
         );
         Navigator.push<Widget>(
           context,

--- a/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panel_card.dart
+++ b/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panel_card.dart
@@ -31,7 +31,7 @@ class KnowledgePanelCard extends StatelessWidget {
       child: KnowledgePanelSummaryCard(panel),
       onTap: () {
         AnalyticsHelper.trackKnowledgePanelOpen(
-          knowledgePanelName: panel.title_element.toString(),
+          knowledgePanelName: panel.titleElement.toString(),
         );
         Navigator.push<Widget>(
           context,


### PR DESCRIPTION
### What
- Might solve: https://github.com/openfoodfacts/smooth-app/issues/1534
  - "title_element":{"title":"Santé"},"topics":["health"],"type":"card"}
  - "title_element":{"title":""},"topics":["environment"],"type":"card"}
- Unsure if will solve: https://github.com/openfoodfacts/smooth-app/issues/1540
