### PR TITLE
fix: Don't show un-necessary alert dialog on nutrient page

### DIFF
--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -360,28 +360,33 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
         label: Text(appLocalizations.nutrition_page_add_nutrient),
       );
 
-  Future<bool> _showCancelPopup(AppLocalizations localizations) async =>
-      await showDialog<bool>(
-        context: context,
-        builder: (BuildContext context) => AlertDialog(
-          shape: const RoundedRectangleBorder(
-            borderRadius: ROUNDED_BORDER_RADIUS,
+  Future<bool> _showCancelPopup(AppLocalizations localizations) async {
+    if (!isEdited()) {
+      Navigator.pop(context, true);
+      return false;
+    }
+    return await showDialog<bool>(
+          context: context,
+          builder: (BuildContext context) => AlertDialog(
+            shape: const RoundedRectangleBorder(
+              borderRadius: ROUNDED_BORDER_RADIUS,
+            ),
+            title: Text(localizations.general_confirmation),
+            content: Text(localizations.nutrition_page_close_confirmation),
+            actions: <TextButton>[
+              TextButton(
+                child: Text(localizations.cancel.toUpperCase()),
+                onPressed: () => Navigator.pop(context, false),
+              ),
+              TextButton(
+                child: Text(localizations.close.toUpperCase()),
+                onPressed: () => Navigator.pop(context, true),
+              ),
+            ],
           ),
-          title: Text(localizations.general_confirmation),
-          content: Text(localizations.nutrition_page_close_confirmation),
-          actions: <TextButton>[
-            TextButton(
-              child: Text(localizations.cancel.toUpperCase()),
-              onPressed: () => Navigator.pop(context, false),
-            ),
-            TextButton(
-              child: Text(localizations.close.toUpperCase()),
-              onPressed: () => Navigator.pop(context, true),
-            ),
-          ],
-        ),
-      ) ??
-      false;
+        ) ??
+        false;
+  }
 
   Future<void> _validateAndSave(final AppLocalizations localizations,
       final LocalDatabase localDatabase) async {
@@ -436,5 +441,18 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
     if (savedAndRefreshed) {
       Navigator.of(context).pop(true);
     }
+  }
+
+  bool isEdited() {
+    for (final String key in _controllers.keys) {
+      final TextEditingController controller = _controllers[key]!;
+      if (_nutritionContainer.getValue(key) != null) {
+        if (_numberFormat.format(_nutritionContainer.getValue(key)) !=
+            controller.value.text) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 }

--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -111,6 +111,7 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
           ),
         ),
       ),
+      //return a boolean to decide whether to return to previous page or not
       onWillPop: () => _showCancelPopup(localizations),
     );
   }
@@ -361,6 +362,8 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
       );
 
   Future<bool> _showCancelPopup(AppLocalizations localizations) async {
+    //if no changes made then returns true to the onWillPop
+    // allowing it to let the user return back to previous screen
     if (!_isEdited()) {
       return true;
     }
@@ -375,15 +378,21 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
             actions: <TextButton>[
               TextButton(
                 child: Text(localizations.cancel.toUpperCase()),
+                // returns false to onWillPop after the alert dialog is closed with cancel button
+                //blocking return to the previous screen
                 onPressed: () => Navigator.pop(context, false),
               ),
               TextButton(
                 child: Text(localizations.close.toUpperCase()),
+                // returns true to onWillPop after the alert dialog is closed with close button
+                //letting return to the previous screen
                 onPressed: () => Navigator.pop(context, true),
               ),
             ],
           ),
         ) ??
+        // in case alert dialog is closed, a false is return
+        // blocking the return to the previous screen
         false;
   }
 
@@ -448,10 +457,13 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
       if (_nutritionContainer.getValue(key) != null) {
         if (_numberFormat.format(_nutritionContainer.getValue(key)) !=
             controller.value.text) {
+          //if any controller is not equal to the value in the container
+          // then the form is edited, return true
           return true;
         }
       }
     }
+    //else form is not edited just return false
     return false;
   }
 }

--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -361,7 +361,7 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
       );
 
   Future<bool> _showCancelPopup(AppLocalizations localizations) async {
-    if (!isEdited()) {
+    if (!_isEdited()) {
       Navigator.pop(context, true);
       return false;
     }
@@ -443,7 +443,7 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
     }
   }
 
-  bool isEdited() {
+  bool _isEdited() {
     for (final String key in _controllers.keys) {
       final TextEditingController controller = _controllers[key]!;
       if (_nutritionContainer.getValue(key) != null) {

--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -383,7 +383,7 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
                 onPressed: () => Navigator.pop(context, false),
               ),
               TextButton(
-                child: Text(localizations.close.toUpperCase()),
+                child: Text(localizations.okay.toUpperCase()),
                 // returns true to onWillPop after the alert dialog is closed with close button
                 //letting return to the previous screen
                 onPressed: () => Navigator.pop(context, true),

--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -362,8 +362,7 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
 
   Future<bool> _showCancelPopup(AppLocalizations localizations) async {
     if (!_isEdited()) {
-      Navigator.pop(context, true);
-      return false;
+      return true;
     }
     return await showDialog<bool>(
           context: context,


### PR DESCRIPTION

### What
- solves the issue of alert dialogs appearing even without edits.
- Not sure if it's the best approach, would love to hear more suggestions on this one

### Screenshot
https://user-images.githubusercontent.com/57723319/165146704-8059d28e-79cf-4bdb-acd1-5f22e911d073.mp4

### Fixes bug(s)
- #1575 
