### PR TITLE
feat: #1073 - user-defined product lists

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/product_title_card.dart
+++ b/packages/smooth_app/lib/cards/product_cards/product_title_card.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/model/Product.dart';
 import 'package:smooth_app/helpers/extension_on_text_helper.dart';
+import 'package:smooth_app/helpers/product_cards_helper.dart';
 
 class ProductTitleCard extends StatelessWidget {
   const ProductTitleCard(this.product, this.isSelectable, {this.dense = false});
@@ -20,7 +21,7 @@ class ProductTitleCard extends StatelessWidget {
         dense: dense,
         contentPadding: EdgeInsets.zero,
         title: Text(
-          _getProductName(appLocalizations),
+          getProductName(product, appLocalizations),
           style: themeData.textTheme.headline4,
         ).selectable(isSelectable: isSelectable),
         subtitle: Text(product.brands ?? appLocalizations.unknownBrand),
@@ -31,7 +32,4 @@ class ProductTitleCard extends StatelessWidget {
       ),
     );
   }
-
-  String _getProductName(final AppLocalizations appLocalizations) =>
-      product.productName ?? appLocalizations.unknownProductName;
 }

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
@@ -99,8 +99,7 @@ class SmoothProductCardFound extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: <Widget>[
                       Text(
-                        product.productName ??
-                            appLocalizations.unknownProductName,
+                        getProductName(product, appLocalizations),
                         overflow: TextOverflow.ellipsis,
                         style: Theme.of(context).textTheme.headline4,
                       ),

--- a/packages/smooth_app/lib/data_models/product_list.dart
+++ b/packages/smooth_app/lib/data_models/product_list.dart
@@ -12,6 +12,9 @@ enum ProductListType {
 
   /// History of products seen by the end-user
   HISTORY,
+
+  /// End-user product list
+  USER,
 }
 
 extension ProductListTypeExtension on ProductListType {
@@ -20,6 +23,7 @@ extension ProductListTypeExtension on ProductListType {
     ProductListType.HTTP_SEARCH_CATEGORY: 'http/search/category',
     ProductListType.SCAN_SESSION: 'scan_session',
     ProductListType.HISTORY: 'history',
+    ProductListType.USER: 'user',
   };
 
   String get key => _keys[this]!;
@@ -58,6 +62,12 @@ class ProductList {
   ProductList.history() : this._(listType: ProductListType.HISTORY);
 
   ProductList.scanSession() : this._(listType: ProductListType.SCAN_SESSION);
+
+  ProductList.user(final String name)
+      : this._(
+          listType: ProductListType.USER,
+          parameters: name,
+        );
 
   final ProductListType listType;
   final String parameters;
@@ -141,6 +151,7 @@ class ProductList {
     switch (listType) {
       case ProductListType.HTTP_SEARCH_KEYWORDS:
       case ProductListType.HTTP_SEARCH_CATEGORY:
+      case ProductListType.USER:
         return false;
       case ProductListType.SCAN_SESSION:
       case ProductListType.HISTORY:
@@ -152,6 +163,7 @@ class ProductList {
     switch (listType) {
       case ProductListType.SCAN_SESSION:
       case ProductListType.HISTORY:
+      case ProductListType.USER:
         return parameters;
       case ProductListType.HTTP_SEARCH_KEYWORDS:
       case ProductListType.HTTP_SEARCH_CATEGORY:

--- a/packages/smooth_app/lib/database/dao_product_list.dart
+++ b/packages/smooth_app/lib/database/dao_product_list.dart
@@ -75,6 +75,7 @@ class DaoProductList extends AbstractDao {
   DaoProductList(final LocalDatabase localDatabase) : super(localDatabase);
 
   static const String _hiveBoxName = 'barcodeLists';
+  static const String _keySeparator = '::';
 
   @override
   Future<void> init() async => Hive.openBox<_BarcodeList>(_hiveBoxName);
@@ -96,8 +97,34 @@ class DaoProductList extends AbstractDao {
   // As it's a list of keywords, there's a fairly high probability
   // that we'll be under the 255 character length.
   String _getKey(final ProductList productList) => '${productList.listType.key}'
-      '::'
+      '$_keySeparator'
       '${base64.encode(utf8.encode(productList.getParametersKey()))}';
+
+  static String getProductListParameters(final String key) {
+    final int pos = key.indexOf(_keySeparator);
+    if (pos < 0) {
+      throw Exception('Unknown key format without "$_keySeparator": $key');
+    }
+    if (pos + _keySeparator.length == key.length) {
+      return '';
+    }
+    final String tmp = key.substring(pos + _keySeparator.length);
+    return utf8.decode(base64.decode(tmp));
+  }
+
+  static ProductListType getProductListType(final String key) {
+    final int pos = key.indexOf(_keySeparator);
+    if (pos < 0) {
+      throw Exception('Unknown key format without "$_keySeparator": $key');
+    }
+    final String value = key.substring(0, pos);
+    for (final ProductListType productListType in ProductListType.values) {
+      if (productListType.key == value) {
+        return productListType;
+      }
+    }
+    throw Exception('Unknown product list type: "$value" from "$key"');
+  }
 
   Future<void> _put(final String key, final _BarcodeList barcodeList) async =>
       _getBox().put(key, barcodeList);
@@ -161,8 +188,54 @@ class DaoProductList extends AbstractDao {
     await _put(_getKey(productList), newList);
   }
 
-  Future<void> clear(final ProductList productList) async =>
-      _getBox().delete(_getKey(productList));
+  Future<void> clear(final ProductList productList) async {
+    final _BarcodeList newList = _BarcodeList.now(<String>[]);
+    await _put(_getKey(productList), newList);
+  }
+
+  /// Adds or removes a barcode within a product list (depending on [include])
+  ///
+  /// Returns true if there was a change in the list.
+  Future<bool> set(
+    final ProductList productList,
+    final String barcode,
+    final bool include,
+  ) async {
+    final _BarcodeList? list = await _get(productList);
+    final List<String> barcodes;
+    if (list == null) {
+      barcodes = <String>[];
+    } else {
+      barcodes = list.barcodes;
+    }
+    if (barcodes.contains(barcode)) {
+      if (include) {
+        return false;
+      }
+      barcodes.remove(barcode);
+    } else {
+      if (!include) {
+        return false;
+      }
+      barcodes.add(barcode);
+    }
+    final _BarcodeList newList = _BarcodeList.now(barcodes);
+    await _put(_getKey(productList), newList);
+    return true;
+  }
+
+  Future<ProductList> rename(
+    final ProductList initialList,
+    final String newName,
+  ) async {
+    final ProductList newList = ProductList.user(newName);
+    final _BarcodeList list =
+        (await _get(initialList)) ?? _BarcodeList.now(<String>[]);
+    await _put(_getKey(newList), list);
+    await delete(initialList);
+    await get(newList);
+    return newList;
+  }
 
   /// Exports a list - typically for debug purposes
   Future<Map<String, dynamic>> export(final ProductList productList) async {
@@ -182,6 +255,29 @@ class DaoProductList extends AbstractDao {
         present = null;
       }
       result[barcode] = present;
+    }
+    return result;
+  }
+
+  /// Returns the names of the user lists.
+  ///
+  /// Possibly restricted to the user lists that contain the given barcode.
+  List<String> getUserLists({String? withBarcode}) {
+    final List<String> result = <String>[];
+    for (final dynamic key in _getBox().keys) {
+      final String tmp = key.toString();
+      final ProductListType productListType = getProductListType(tmp);
+      if (productListType != ProductListType.USER) {
+        continue;
+      }
+      if (withBarcode != null) {
+        final _BarcodeList? barcodeList = _getBox().get(key);
+        if (barcodeList == null ||
+            !barcodeList.barcodes.contains(withBarcode)) {
+          continue;
+        }
+      }
+      result.add(getProductListParameters(tmp));
     }
     return result;
   }

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -836,5 +836,49 @@
     },
     "completed_basic_details_btn_text": "Complete basic details",
     "not_implemented_snackbar_text": "Not implemented yet",
-    "category_picker_page_appbar_text": "Categories"
+    "category_picker_page_appbar_text": "Categories",
+    "user_list_dialog_new_title": "New user list",
+    "@user_list_dialog_new_title": {
+        "description": "Title of the 'new user list' dialog"
+    },
+    "user_list_dialog_rename_title": "Rename user list",
+    "@user_list_dialog_rename_title": {
+        "description": "Title of the 'rename user list' dialog"
+    },
+    "user_list_subtitle_product": "Lists",
+    "@user_list_subtitle_product": {
+        "description": "Subtitle of a paragraph about user lists in a product context"
+    },
+    "user_list_button_new": "New list",
+    "@user_list_button_new": {
+        "description": "Short label of a 'new list' button"
+    },
+    "user_list_button_add_product": "Add to list",
+    "@user_list_button_add_product": {
+        "description": "Short label of an 'add to list' button from a product context"
+    },
+    "user_list_popup_clear": "Clear",
+    "@user_list_popup_clear": {
+        "description": "Short label of a 'clear list' popup"
+    },
+    "user_list_popup_rename": "Rename",
+    "@user_list_popup_rename": {
+        "description": "Short label of a 'rename list' popup"
+    },
+    "user_list_name_hint": "My list",
+    "@user_list_name_hint": {
+        "description": "Hint of a user list name text-field in a 'user list' dialog"
+    },
+    "user_list_name_error_empty": "The name cannot be empty",
+    "@user_list_name_error_empty": {
+        "description": "Validation error about the name that cannot be empty"
+    },
+    "user_list_name_error_already": "That name is already used",
+    "@user_list_name_error_already": {
+        "description": "Validation error about the name that is already used for another list"
+    },
+    "user_list_name_error_same": "That is the same name",
+    "@user_list_name_error_same": {
+        "description": "Validation error about the renamed name that is the same as the initial list name"
+    }
 }

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -841,7 +841,7 @@
     "@user_list_dialog_new_title": {
         "description": "Title of the 'new user list' dialog"
     },
-    "user_list_dialog_rename_title": "Rename user list",
+    "user_list_dialog_rename_title": "Rename list",
     "@user_list_dialog_rename_title": {
         "description": "Title of the 'rename user list' dialog"
     },

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -837,7 +837,7 @@
     "completed_basic_details_btn_text": "Complete basic details",
     "not_implemented_snackbar_text": "Not implemented yet",
     "category_picker_page_appbar_text": "Categories",
-    "user_list_dialog_new_title": "New user list",
+    "user_list_dialog_new_title": "New list of products",
     "@user_list_dialog_new_title": {
         "description": "Title of the 'new user list' dialog"
     },

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -836,5 +836,49 @@
     },
     "completed_basic_details_btn_text": "Complete basic details",
     "not_implemented_snackbar_text": "Not implemented yet",
-    "category_picker_page_appbar_text": "Catégories"
+    "category_picker_page_appbar_text": "Catégories",
+    "user_list_dialog_new_title": "Nouvelle liste",
+    "@user_list_dialog_new_title": {
+        "description": "Title of the 'new user list' dialog"
+    },
+    "user_list_dialog_rename_title": "Renommer une liste",
+    "@user_list_dialog_rename_title": {
+        "description": "Title of the 'rename user list' dialog"
+    },
+    "user_list_subtitle_product": "Listes",
+    "@user_list_subtitle_product": {
+        "description": "Subtitle of a paragraph about user lists in a product context"
+    },
+    "user_list_button_new": "Nouvelle liste",
+    "@user_list_button_new": {
+        "description": "Short label of a 'new list' button"
+    },
+    "user_list_button_add_product": "Listes",
+    "@user_list_button_add_product": {
+        "description": "Short label of an 'add to list' button from a product context"
+    },
+    "user_list_popup_clear": "Effacer",
+    "@user_list_popup_clear": {
+        "description": "Short label of a 'clear list' popup"
+    },
+    "user_list_popup_rename": "Renommer",
+    "@user_list_popup_rename": {
+        "description": "Short label of a 'rename list' popup"
+    },
+    "user_list_name_hint": "Ma liste",
+    "@user_list_name_hint": {
+        "description": "Hint of a user list name text-field in a 'user list' dialog"
+    },
+    "user_list_name_error_empty": "Le nom ne peut pas être vide",
+    "@user_list_name_error_empty": {
+        "description": "Validation error about the name that cannot be empty"
+    },
+    "user_list_name_error_already": "Ce nom est déjà utilisé",
+    "@user_list_name_error_already": {
+        "description": "Validation error about the name that is already used for another list"
+    },
+    "user_list_name_error_same": "C'est le même nom",
+    "@user_list_name_error_same": {
+        "description": "Validation error about the renamed name that is the same as the initial list name"
+    }
 }

--- a/packages/smooth_app/lib/pages/product/common/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_page.dart
@@ -31,6 +31,9 @@ class _ProductListPageState extends State<ProductListPage> {
   final Set<String> _selectedBarcodes = <String>{};
   bool _selectionMode = false;
 
+  static const String _popupActionClear = 'clear';
+  static const String _popupActionRename = 'rename';
+
   @override
   Widget build(BuildContext context) {
     final LocalDatabase localDatabase = context.watch<LocalDatabase>();
@@ -65,15 +68,15 @@ class _ProductListPageState extends State<ProductListPage> {
                 PopupMenuButton<String>(
                   onSelected: (final String action) async {
                     switch (action) {
-                      case 'clear':
+                      case _popupActionClear:
                         await daoProductList.clear(productList);
                         await daoProductList.get(productList);
                         setState(() {});
                         break;
-                      case 'rename':
+                      case _popupActionRename:
                         final ProductList? renamedProductList =
                             await ProductListUserDialogHelper(daoProductList)
-                                .showRename(context, productList);
+                                .showRenameUserListDialog(context, productList);
                         if (renamedProductList == null) {
                           return;
                         }
@@ -83,14 +86,14 @@ class _ProductListPageState extends State<ProductListPage> {
                   },
                   itemBuilder: (BuildContext context) =>
                       <PopupMenuEntry<String>>[
-                    const PopupMenuItem<String>(
-                      value: 'clear',
-                      child: Text('Clear'), // TODO(monsieurtanuki): localize
+                    PopupMenuItem<String>(
+                      value: _popupActionClear,
+                      child: Text(appLocalizations.user_list_popup_clear),
                     ),
                     if (productList.listType == ProductListType.USER)
-                      const PopupMenuItem<String>(
-                        value: 'rename',
-                        child: Text('Rename'), // TODO(monsieurtanuki): localize
+                      PopupMenuItem<String>(
+                        value: _popupActionRename,
+                        child: Text(appLocalizations.user_list_popup_rename),
                       ),
                   ],
                 )

--- a/packages/smooth_app/lib/pages/product/common/product_query_page_helper.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_query_page_helper.dart
@@ -86,6 +86,8 @@ class ProductQueryPageHelper {
         return appLocalizations.scan;
       case ProductListType.HISTORY:
         return appLocalizations.recently_seen_products;
+      case ProductListType.USER:
+        return productList.parameters;
     }
   }
 }

--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -2,6 +2,7 @@ import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/model/Product.dart';
+import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/pages/product/nutrition_page_loaded.dart';
 import 'package:smooth_app/pages/product/ordered_nutrients_cache.dart';
 
@@ -24,7 +25,7 @@ class _EditProductPageState extends State<EditProductPage> {
     return Scaffold(
       appBar: AppBar(
         title: AutoSizeText(
-          widget.product.productName ?? appLocalizations.unknownProductName,
+          getProductName(widget.product, appLocalizations),
           maxLines: 2,
         ),
       ),

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -290,7 +290,7 @@ class _ProductPageState extends State<ProductPage> {
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceAround,
           crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
+          children: <Widget>[
             _buildActionBarItem(
               Icons.bookmark_border,
               'Add to list', // TODO(monsieurtanuki): localize

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -275,11 +275,8 @@ class _ProductPageState extends State<ProductPage> {
   Future<void> _editList() async {
     final LocalDatabase localDatabase = context.read<LocalDatabase>();
     final DaoProductList daoProductList = DaoProductList(localDatabase);
-    final bool refreshed =
-        await ProductListUserDialogHelper(daoProductList).showBarcode(
-      context,
-      widget.product.barcode!,
-    );
+    final bool refreshed = await ProductListUserDialogHelper(daoProductList)
+        .showUserListsWithBarcodeDialog(context, widget.product);
     if (refreshed) {
       setState(() {});
     }
@@ -293,12 +290,12 @@ class _ProductPageState extends State<ProductPage> {
           children: <Widget>[
             _buildActionBarItem(
               Icons.bookmark_border,
-              'Add to list', // TODO(monsieurtanuki): localize
+              appLocalizations.user_list_button_add_product,
               _editList,
             ),
             _buildActionBarItem(
               Icons.edit,
-              'Edit', // TODO(monsieurtanuki): localize
+              appLocalizations.edit_product_label,
               () async {
                 final bool? refreshed = await Navigator.push<bool>(
                   context,
@@ -375,7 +372,7 @@ class _ProductPageState extends State<ProductPage> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
             ListTile(
-              title: const Text('Lists'), // TODO(monsieurtanuki): localize
+              title: Text(appLocalizations.user_list_subtitle_product),
               trailing: const Icon(Icons.bookmark),
               onTap: _editList,
             ),

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -16,13 +16,16 @@ import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/database/product_query.dart';
 import 'package:smooth_app/generic_lib/buttons/smooth_action_button.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/pages/product/category_cache.dart';
 import 'package:smooth_app/pages/product/category_picker_page.dart';
 import 'package:smooth_app/pages/product/common/product_dialog_helper.dart';
+import 'package:smooth_app/pages/product/common/product_list_page.dart';
 import 'package:smooth_app/pages/product/edit_product_page.dart';
 import 'package:smooth_app/pages/product/knowledge_panel_product_cards.dart';
 import 'package:smooth_app/pages/product/summary_card.dart';
+import 'package:smooth_app/pages/product_list_user_dialog_helper.dart';
 import 'package:smooth_app/pages/user_preferences_dev_mode.dart';
 import 'package:smooth_app/themes/constant_icons.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
@@ -139,7 +142,10 @@ class _ProductPageState extends State<ProductPage> {
 
   Widget _buildProductBody(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context)!;
-
+    final LocalDatabase localDatabase = context.read<LocalDatabase>();
+    final DaoProductList daoProductList = DaoProductList(localDatabase);
+    final List<String> productListNames =
+        daoProductList.getUserLists(withBarcode: widget.product.barcode);
     return RefreshIndicator(
       onRefresh: () => _refreshProduct(context),
       child: ListView(children: <Widget>[
@@ -168,23 +174,9 @@ class _ProductPageState extends State<ProductPage> {
           ),
         ),
         _buildKnowledgePanelCards(),
-        Padding(
-          padding: const EdgeInsets.all(SMALL_SPACE),
-          child: SmoothActionButton(
-            text: appLocalizations.edit_product_label,
-            onPressed: () async {
-              final bool? refreshed = await Navigator.push<bool>(
-                context,
-                MaterialPageRoute<bool>(
-                  builder: (BuildContext context) => EditProductPage(_product),
-                ),
-              );
-              if (refreshed ?? false) {
-                setState(() {});
-              }
-            },
-          ),
-        ),
+        _buildActionBar(appLocalizations),
+        if (productListNames.isNotEmpty)
+          _buildListWidget(appLocalizations, productListNames, daoProductList),
         if (context.read<UserPreferences>().getFlag(
                 UserPreferencesDevMode.userPreferencesFlagAdditionalButton) ??
             false)
@@ -276,6 +268,126 @@ class _ProductPageState extends State<ProductPage> {
             height: 60,
           ),
         ],
+      ),
+    );
+  }
+
+  Future<void> _editList() async {
+    final LocalDatabase localDatabase = context.read<LocalDatabase>();
+    final DaoProductList daoProductList = DaoProductList(localDatabase);
+    final bool refreshed =
+        await ProductListUserDialogHelper(daoProductList).showBarcode(
+      context,
+      widget.product.barcode!,
+    );
+    if (refreshed) {
+      setState(() {});
+    }
+  }
+
+  Widget _buildActionBar(final AppLocalizations appLocalizations) => Padding(
+        padding: const EdgeInsets.all(SMALL_SPACE),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceAround,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            _buildActionBarItem(
+              Icons.bookmark_border,
+              'Add to list', // TODO(monsieurtanuki): localize
+              _editList,
+            ),
+            _buildActionBarItem(
+              Icons.edit,
+              'Edit', // TODO(monsieurtanuki): localize
+              () async {
+                final bool? refreshed = await Navigator.push<bool>(
+                  context,
+                  MaterialPageRoute<bool>(
+                    builder: (BuildContext context) =>
+                        EditProductPage(_product),
+                  ),
+                );
+                if (refreshed ?? false) {
+                  setState(() {});
+                }
+              },
+            ),
+          ],
+        ),
+      );
+
+  Widget _buildActionBarItem(
+    final IconData iconData,
+    final String label,
+    final Function() onPressed,
+  ) {
+    final ThemeData themeData = Theme.of(context);
+    final ColorScheme colorScheme = themeData.colorScheme;
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: <Widget>[
+        ElevatedButton(
+          onPressed: onPressed,
+          child: Icon(iconData, color: colorScheme.onPrimary),
+          style: ElevatedButton.styleFrom(
+            shape: const CircleBorder(),
+            padding: const EdgeInsets.all(
+                18), // TODO(monsieurtanuki): cf. FloatingActionButton
+            primary: colorScheme.primary,
+          ),
+        ),
+        const SizedBox(height: VERY_SMALL_SPACE),
+        Text(label),
+      ],
+    );
+  }
+
+  Widget _buildListWidget(
+    final AppLocalizations appLocalizations,
+    final List<String> productListNames,
+    final DaoProductList daoProductList,
+  ) {
+    final List<Widget> children = <Widget>[];
+    for (final String productListName in productListNames) {
+      children.add(
+        SmoothActionButton(
+          text: productListName,
+          onPressed: () async {
+            final ProductList productList = ProductList.user(productListName);
+            await daoProductList.get(productList);
+            await Navigator.push<void>(
+              context,
+              MaterialPageRoute<void>(
+                builder: (BuildContext context) => ProductListPage(productList),
+              ),
+            );
+            setState(() {});
+          },
+        ),
+      );
+    }
+    return SmoothCard(
+      child: Padding(
+        padding: const EdgeInsets.all(SMALL_SPACE),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            ListTile(
+              title: const Text('Lists'), // TODO(monsieurtanuki): localize
+              trailing: const Icon(Icons.bookmark),
+              onTap: _editList,
+            ),
+            Wrap(
+              alignment: WrapAlignment.start,
+              direction: Axis.horizontal,
+              children: children,
+              spacing: VERY_SMALL_SPACE,
+              runSpacing: VERY_SMALL_SPACE,
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/packages/smooth_app/lib/pages/product_list_user_dialog_helper.dart
+++ b/packages/smooth_app/lib/pages/product_list_user_dialog_helper.dart
@@ -1,0 +1,221 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:smooth_app/data_models/product_list.dart';
+import 'package:smooth_app/database/dao_product_list.dart';
+import 'package:smooth_app/generic_lib/widgets/smooth_text_form_field.dart';
+
+/// Dialog helper class for user product list.
+class ProductListUserDialogHelper {
+  ProductListUserDialogHelper(this.daoProductList);
+
+  final DaoProductList daoProductList;
+
+  Future<ProductList?> showCreate(
+    final BuildContext context,
+  ) async {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context)!;
+
+    final TextEditingController _textEditingController =
+        TextEditingController();
+    final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+
+    final String? title = await showDialog<String>(
+      context: context,
+      builder: (final BuildContext context) => AlertDialog(
+        title: const Text('New user list'), // TODO(monsieurtanuki): localize
+        content: Form(
+          key: _formKey,
+          child: SmoothTextFormField(
+            type: TextFieldTypes.PLAIN_TEXT,
+            controller: _textEditingController,
+            hintText: appLocalizations
+                .username_or_email, // TODO(monsieurtanuki): localize
+            textInputAction: TextInputAction.done,
+            validator: (String? value) {
+              final List<String> lists = daoProductList.getUserLists();
+              if (value == null || value.isEmpty) {
+                return appLocalizations.login_page_username_or_email;
+              }
+              if (lists.contains(value)) {
+                return 'name already exists'; // TODO(monsieurtanuki): localize
+              }
+              return null;
+            },
+          ),
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: Text(appLocalizations.cancel),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              if (!_formKey.currentState!.validate()) {
+                return;
+              }
+              Navigator.pop(context, _textEditingController.text);
+            },
+            child: Text(appLocalizations.okay),
+          ),
+        ],
+      ),
+    );
+    if (title == null) {
+      return null;
+    }
+    final ProductList productList = ProductList.user(title);
+    await daoProductList.put(productList);
+    return productList;
+  }
+
+  Future<bool> showBarcode(
+    final BuildContext context,
+    final String barcode,
+  ) async {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context)!;
+    final List<String> all = daoProductList.getUserLists();
+    final List<String> withBarcode =
+        daoProductList.getUserLists(withBarcode: barcode);
+    final Set<String> newWithBarcode = <String>{};
+    newWithBarcode.addAll(withBarcode);
+    bool addedLists = false;
+    final bool? result = await showDialog<bool>(
+      context: context,
+      builder: (final BuildContext context) => StatefulBuilder(
+        builder:
+            (BuildContext context, void Function(VoidCallback fn) setState) =>
+                AlertDialog(
+          title: Text('Product $barcode'), // TODO(monsieurtanuki): localize
+          content: all.isEmpty
+              ? Container()
+              : SizedBox(
+                  // TODO(monsieurtanuki): proper sizes
+                  width: 300,
+                  height: 400,
+                  child: StatefulBuilder(
+                    builder: (BuildContext context,
+                        void Function(VoidCallback fn) setState) {
+                      final List<Widget> children = <Widget>[];
+                      for (final String name in all) {
+                        children.add(
+                          ListTile(
+                            leading: Icon(
+                              newWithBarcode.contains(name)
+                                  ? Icons.check_box
+                                  : Icons.check_box_outline_blank,
+                            ),
+                            title: Text(name),
+                            onTap: () => setState(
+                              () => newWithBarcode.contains(name)
+                                  ? newWithBarcode.remove(name)
+                                  : newWithBarcode.add(name),
+                            ),
+                          ),
+                        );
+                      }
+                      return ListView(children: children);
+                    },
+                  ),
+                ),
+          actions: <Widget>[
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: Text(appLocalizations.cancel),
+            ),
+            ElevatedButton(
+              onPressed: () async {
+                final ProductList? productList = await showCreate(context);
+                if (productList != null) {
+                  all.clear();
+                  all.addAll(daoProductList.getUserLists());
+                  setState(() => addedLists = true);
+                }
+              },
+              child: const Text('new list'), // TODO(monsieurtanuki): localize
+            ),
+            ElevatedButton(
+              onPressed: () => Navigator.pop(context, true),
+              child: Text(appLocalizations.okay),
+            ),
+          ],
+        ),
+      ),
+    );
+    if (addedLists == false && result != true) {
+      return false;
+    }
+    final Set<String> possibleChanges = <String>{};
+    possibleChanges.addAll(withBarcode);
+    possibleChanges.addAll(newWithBarcode);
+    for (final String name in possibleChanges) {
+      if (withBarcode.contains(name) && newWithBarcode.contains(name)) {
+        continue;
+      }
+      if ((!withBarcode.contains(name)) && (!newWithBarcode.contains(name))) {
+        continue;
+      }
+      final ProductList productList = ProductList.user(name);
+      await daoProductList.set(
+          productList, barcode, newWithBarcode.contains(name));
+    }
+    return true;
+  }
+
+  Future<ProductList?> showRename(
+    final BuildContext context,
+    final ProductList initialProductList,
+  ) async {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context)!;
+    final TextEditingController _textEditingController =
+        TextEditingController();
+    final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+
+    final String initialName = initialProductList.parameters;
+    _textEditingController.text = initialName;
+    final String? newName = await showDialog<String>(
+      context: context,
+      builder: (final BuildContext context) => AlertDialog(
+        title: const Text('Rename user list'), // TODO(monsieurtanuki): localize
+        content: Form(
+          key: _formKey,
+          child: SmoothTextFormField(
+            type: TextFieldTypes.PLAIN_TEXT,
+            controller: _textEditingController,
+            hintText: appLocalizations
+                .username_or_email, // TODO(monsieurtanuki): localize
+            textInputAction: TextInputAction.done,
+            validator: (String? value) {
+              final List<String> lists = daoProductList.getUserLists();
+              if (value == null || value.isEmpty) {
+                return appLocalizations.login_page_username_or_email;
+              }
+              if (lists.contains(value) && value != initialName) {
+                return 'name already exists';
+              }
+              return null;
+            },
+          ),
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: Text(appLocalizations.cancel),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              if (!_formKey.currentState!.validate()) {
+                return;
+              }
+              Navigator.pop(context, _textEditingController.text);
+            },
+            child: Text(appLocalizations.okay),
+          ),
+        ],
+      ),
+    );
+    if (newName == null) {
+      return null;
+    }
+    return daoProductList.rename(initialProductList, newName);
+  }
+}

--- a/packages/smooth_app/lib/themes/constant_icons.dart
+++ b/packages/smooth_app/lib/themes/constant_icons.dart
@@ -20,5 +20,9 @@ class ConstantIcons {
   IconData getShareIcon() =>
       _isApple() ? CupertinoIcons.square_arrow_up : Icons.share;
 
-  IconData getBackIcon() => _isApple() ? CupertinoIcons.back : Icons.arrow_back;
+  IconData getBackIcon() =>
+      _isApple() ? Icons.arrow_back_ios : Icons.arrow_back;
+
+  IconData getForwardIcon() =>
+      _isApple() ? Icons.arrow_forward_ios : Icons.arrow_forward;
 }


### PR DESCRIPTION
New file:
* `product_list_user_dialog_helper.dart`: Dialog helper class for user product list.

Impacted files:
* `constant_icons.dart`: added method `getForwardIcon`
* `dao_product_list.dart`: added methods related to user list management
* `new_product_page.dart`: action bar with "add to list" button instead of just "edit product" button; added "lists" widget
* `product_list.dart`: added `ProductListType.USER` as "End-user product list"
* `product_list_page.dart`: added "clear" and "rename" popup options
* `product_query_page_helper.dart`: impact of new `ProductListType.USER`

### What
- Product lists can now be created, cleared, renamed by the user, from the product page.
- They contain barcodes.

### Screenshot
![Simulator Screen Shot - iPhone 8 Plus - 2022-04-25 at 19 44 38](https://user-images.githubusercontent.com/11576431/165144447-a7c6c196-4c81-427d-a938-9935f58051f2.png)


![Simulator Screen Shot - iPhone 8 Plus - 2022-04-25 at 19 44 14](https://user-images.githubusercontent.com/11576431/165144378-4e051a93-3ff7-42fd-84c5-7947c4489dd3.png)

![Simulator Screen Shot - iPhone 8 Plus - 2022-04-25 at 19 45 16](https://user-images.githubusercontent.com/11576431/165144550-9c400b82-f60c-4e79-a96c-976bbbadd222.png)


### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/1073