### PR TITLE
feat: Make attributes clickable

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panel_card.dart
+++ b/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panel_card.dart
@@ -3,10 +3,9 @@ import 'package:openfoodfacts/model/KnowledgePanel.dart';
 import 'package:openfoodfacts/model/KnowledgePanels.dart';
 import 'package:smooth_app/cards/product_cards/knowledge_panels/knowledge_panel_expanded_card.dart';
 import 'package:smooth_app/cards/product_cards/knowledge_panels/knowledge_panel_summary_card.dart';
-import 'package:smooth_app/generic_lib/design_constants.dart';
-import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
-import 'package:smooth_app/themes/smooth_theme.dart';
+
+import 'knowledge_panel_full_page.dart';
 
 class KnowledgePanelCard extends StatelessWidget {
   const KnowledgePanelCard({
@@ -19,7 +18,6 @@ class KnowledgePanelCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final ThemeData themeData = Theme.of(context);
     // If [expanded] = true, render all panel elements (including summary), otherwise just renders panel summary.
     if (panel.expanded ?? false) {
       return KnowledgePanelExpandedCard(
@@ -36,24 +34,9 @@ class KnowledgePanelCard extends StatelessWidget {
         Navigator.push<Widget>(
           context,
           MaterialPageRoute<Widget>(
-            builder: (BuildContext context) => Scaffold(
-              backgroundColor: SmoothTheme.getColor(
-                themeData.colorScheme,
-                SmoothTheme.getMaterialColor(context),
-                ColorDestination.SURFACE_BACKGROUND,
-              ),
-              appBar: AppBar(),
-              body: SingleChildScrollView(
-                child: SmoothCard(
-                  padding: const EdgeInsets.all(
-                    SMALL_SPACE,
-                  ),
-                  child: KnowledgePanelExpandedCard(
-                    panel: panel,
-                    allPanels: allPanels,
-                  ),
-                ),
-              ),
+            builder: (BuildContext context) => KnowledgePanelFullPage(
+              panel: panel,
+              allPanels: allPanels,
             ),
           ),
         );

--- a/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panel_card.dart
+++ b/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panel_card.dart
@@ -2,10 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:openfoodfacts/model/KnowledgePanel.dart';
 import 'package:openfoodfacts/model/KnowledgePanels.dart';
 import 'package:smooth_app/cards/product_cards/knowledge_panels/knowledge_panel_expanded_card.dart';
+import 'package:smooth_app/cards/product_cards/knowledge_panels/knowledge_panel_full_page.dart';
 import 'package:smooth_app/cards/product_cards/knowledge_panels/knowledge_panel_summary_card.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
-
-import 'knowledge_panel_full_page.dart';
 
 class KnowledgePanelCard extends StatelessWidget {
   const KnowledgePanelCard({

--- a/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panel_full_loading_page.dart
+++ b/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panel_full_loading_page.dart
@@ -4,8 +4,7 @@ import 'package:openfoodfacts/model/KnowledgePanel.dart';
 import 'package:openfoodfacts/model/KnowledgePanels.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/cards/product_cards/knowledge_panels/knowledge_panel_full_page.dart';
-
-import '../../../data_models/data_provider.dart';
+import 'package:smooth_app/data_models/data_provider.dart';
 
 class KnowledgePanelFullLoadingPage extends StatelessWidget {
   const KnowledgePanelFullLoadingPage(

--- a/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panel_full_loading_page.dart
+++ b/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panel_full_loading_page.dart
@@ -3,17 +3,23 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/model/KnowledgePanel.dart';
 import 'package:openfoodfacts/model/KnowledgePanels.dart';
 import 'package:provider/provider.dart';
+import 'package:smooth_app/cards/product_cards/knowledge_panels/knowledge_panel_full_page.dart';
 
-import 'knowledge_panel_full_page.dart';
+import '../../../data_models/data_provider.dart';
 
 class KnowledgePanelFullLoadingPage extends StatelessWidget {
-  const KnowledgePanelFullLoadingPage({required this.panelId});
+  const KnowledgePanelFullLoadingPage(
+      {required this.panelId, required this.barcode});
 
   final String panelId;
+  final String barcode;
 
   @override
   Widget build(BuildContext context) {
-    final KnowledgePanels? knowledgePanels = context.watch<KnowledgePanels?>();
+    final KnowledgePanels? knowledgePanels = context
+        .select<DataProvider<Map<String, KnowledgePanels?>>, KnowledgePanels?>(
+            (DataProvider<Map<String, KnowledgePanels?>> value) =>
+                value.value[barcode]);
 
     if (knowledgePanels == null) {
       return Scaffold(
@@ -31,19 +37,22 @@ class KnowledgePanelFullLoadingPage extends StatelessWidget {
         knowledgePanels.panelIdToPanelMap[panelId];
 
     if (knowledgePanel == null) {
-      Navigator.pop(context);
+      Future<void>.delayed(Duration.zero, () {
+        Navigator.pop(context);
+      });
       return Container();
     }
-
-    Navigator.pushReplacement(
-      context,
-      MaterialPageRoute<Widget>(
-        builder: (BuildContext context) => KnowledgePanelFullPage(
-          panel: knowledgePanel,
-          allPanels: knowledgePanels,
+    Future<void>.delayed(Duration.zero, () {
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute<Widget>(
+          builder: (BuildContext context) => KnowledgePanelFullPage(
+            panel: knowledgePanel,
+            allPanels: knowledgePanels,
+          ),
         ),
-      ),
-    );
+      );
+    });
 
     return Scaffold(
       body: Container(),

--- a/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panel_full_loading_page.dart
+++ b/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panel_full_loading_page.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:openfoodfacts/model/KnowledgePanel.dart';
+import 'package:openfoodfacts/model/KnowledgePanels.dart';
+import 'package:provider/provider.dart';
+
+import 'knowledge_panel_full_page.dart';
+
+class KnowledgePanelFullLoadingPage extends StatelessWidget {
+  const KnowledgePanelFullLoadingPage({required this.panelId});
+
+  final String panelId;
+
+  @override
+  Widget build(BuildContext context) {
+    final KnowledgePanels? knowledgePanels = context.watch<KnowledgePanels?>();
+
+    if (knowledgePanels == null) {
+      return Scaffold(
+        appBar: AppBar(
+          title:
+              Text(AppLocalizations.of(context)!.loading_dialog_default_title),
+        ),
+        body: const Center(
+          child: CircularProgressIndicator(),
+        ),
+      );
+    }
+
+    final KnowledgePanel? knowledgePanel =
+        knowledgePanels.panelIdToPanelMap[panelId];
+
+    if (knowledgePanel == null) {
+      Navigator.pop(context);
+      return Container();
+    }
+
+    Navigator.pushReplacement(
+      context,
+      MaterialPageRoute<Widget>(
+        builder: (BuildContext context) => KnowledgePanelFullPage(
+          panel: knowledgePanel,
+          allPanels: knowledgePanels,
+        ),
+      ),
+    );
+
+    return Scaffold(
+      body: Container(),
+    );
+  }
+}

--- a/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panel_full_page.dart
+++ b/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panel_full_page.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:openfoodfacts/model/KnowledgePanel.dart';
+import 'package:openfoodfacts/model/KnowledgePanels.dart';
+import 'package:smooth_app/cards/product_cards/knowledge_panels/knowledge_panel_expanded_card.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
+import 'package:smooth_app/themes/smooth_theme.dart';
+
+class KnowledgePanelFullPage extends StatelessWidget {
+  const KnowledgePanelFullPage({
+    required this.panel,
+    required this.allPanels,
+  });
+
+  final KnowledgePanel panel;
+  final KnowledgePanels allPanels;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData themeData = Theme.of(context);
+    return Scaffold(
+      backgroundColor: SmoothTheme.getColor(
+        themeData.colorScheme,
+        SmoothTheme.getMaterialColor(context),
+        ColorDestination.SURFACE_BACKGROUND,
+      ),
+      appBar: AppBar(
+        title: Text(panel.titleElement?.title ?? ''),
+      ),
+      body: SingleChildScrollView(
+        child: SmoothCard(
+          padding: const EdgeInsets.all(
+            SMALL_SPACE,
+          ),
+          child: KnowledgePanelExpandedCard(
+            panel: panel,
+            allPanels: allPanels,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/smooth_app/lib/data_models/data_provider.dart
+++ b/packages/smooth_app/lib/data_models/data_provider.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+class DataProvider<T> with ChangeNotifier {
+  DataProvider(this._value);
+
+  T _value;
+
+  T get value => _value;
+
+  void setValue(T newValue) {
+    _value = newValue;
+    notifyListeners();
+  }
+}

--- a/packages/smooth_app/lib/data_models/user_management_provider.dart
+++ b/packages/smooth_app/lib/data_models/user_management_provider.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/utils/OpenFoodAPIConfiguration.dart';
 import 'package:smooth_app/database/dao_secured_string.dart';

--- a/packages/smooth_app/lib/helpers/smooth_matched_product.dart
+++ b/packages/smooth_app/lib/helpers/smooth_matched_product.dart
@@ -4,8 +4,8 @@ import 'package:openfoodfacts/model/Product.dart';
 import 'package:openfoodfacts/personalized_search/preference_importance.dart';
 import 'package:openfoodfacts/personalized_search/product_preferences_manager.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
+import 'package:smooth_app/helpers/attributes_card_helper.dart';
 import 'package:smooth_app/pages/user_preferences_dev_mode.dart';
-import 'attributes_card_helper.dart';
 
 /// Match and score of a [Product] vs. Preferences
 ///

--- a/packages/smooth_app/lib/main.dart
+++ b/packages/smooth_app/lib/main.dart
@@ -8,11 +8,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
+import 'package:openfoodfacts/model/KnowledgePanels.dart';
 import 'package:openfoodfacts/model/UserAgent.dart';
 import 'package:openfoodfacts/personalized_search/product_preferences_selection.dart';
 import 'package:openfoodfacts/utils/OpenFoodAPIConfiguration.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:provider/provider.dart';
+import 'package:provider/single_child_widget.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:smooth_app/data_models/product_preferences.dart';
 import 'package:smooth_app/data_models/user_management_provider.dart';
@@ -24,6 +26,8 @@ import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/pages/onboarding/onboarding_flow_navigator.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
 import 'package:smooth_app/themes/theme_provider.dart';
+
+import 'data_models/data_provider.dart';
 
 List<CameraDescription> cameras = <CameraDescription>[];
 
@@ -161,12 +165,18 @@ class _SmoothAppState extends State<SmoothApp> {
         }
 
         return MultiProvider(
-          providers: <ChangeNotifierProvider<ChangeNotifier>>[
+          providers: <SingleChildWidget>[
             provide<UserPreferences>(_userPreferences),
             provide<ProductPreferences>(_productPreferences),
             provide<LocalDatabase>(_localDatabase),
             provide<ThemeProvider>(_themeProvider),
             provide<UserManagementProvider>(_userManagementProvider),
+            //Needs to be created here to be visible after calling Navigator.push
+            provide<DataProvider<Map<String, KnowledgePanels?>>>(
+              DataProvider<Map<String, KnowledgePanels?>>(
+                <String, KnowledgePanels?>{},
+              ),
+            ),
           ],
           builder: _buildApp,
         );

--- a/packages/smooth_app/lib/main.dart
+++ b/packages/smooth_app/lib/main.dart
@@ -14,7 +14,6 @@ import 'package:openfoodfacts/personalized_search/product_preferences_selection.
 import 'package:openfoodfacts/utils/OpenFoodAPIConfiguration.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:provider/provider.dart';
-import 'package:provider/single_child_widget.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:smooth_app/data_models/data_provider.dart';
 import 'package:smooth_app/data_models/product_preferences.dart';
@@ -164,7 +163,7 @@ class _SmoothAppState extends State<SmoothApp> {
         }
 
         return MultiProvider(
-          providers: <SingleChildWidget>[
+          providers: <ChangeNotifierProvider<ChangeNotifier>>[
             provide<UserPreferences>(_userPreferences),
             provide<ProductPreferences>(_productPreferences),
             provide<LocalDatabase>(_localDatabase),

--- a/packages/smooth_app/lib/main.dart
+++ b/packages/smooth_app/lib/main.dart
@@ -16,6 +16,7 @@ import 'package:package_info_plus/package_info_plus.dart';
 import 'package:provider/provider.dart';
 import 'package:provider/single_child_widget.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
+import 'package:smooth_app/data_models/data_provider.dart';
 import 'package:smooth_app/data_models/product_preferences.dart';
 import 'package:smooth_app/data_models/user_management_provider.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
@@ -26,8 +27,6 @@ import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/pages/onboarding/onboarding_flow_navigator.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
 import 'package:smooth_app/themes/theme_provider.dart';
-
-import 'data_models/data_provider.dart';
 
 List<CameraDescription> cameras = <CameraDescription>[];
 

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -5,11 +5,13 @@ import 'package:openfoodfacts/model/KnowledgePanels.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/cards/product_cards/product_image_carousel.dart';
+import 'package:smooth_app/data_models/data_provider.dart';
 import 'package:smooth_app/data_models/fetched_product.dart';
 import 'package:smooth_app/data_models/product_list.dart';
 import 'package:smooth_app/data_models/product_preferences.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/database/dao_product_list.dart';
+import 'package:smooth_app/database/knowledge_panels_query.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/database/product_query.dart';
 import 'package:smooth_app/generic_lib/buttons/smooth_action_button.dart';
@@ -24,9 +26,6 @@ import 'package:smooth_app/pages/product/summary_card.dart';
 import 'package:smooth_app/pages/user_preferences_dev_mode.dart';
 import 'package:smooth_app/themes/constant_icons.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
-
-import '../../data_models/data_provider.dart';
-import '../../database/knowledge_panels_query.dart';
 
 class ProductPage extends StatefulWidget {
   const ProductPage(this.product);

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -193,7 +193,7 @@ class _ProductPageState extends State<ProductPage> {
             ),
           ),
         ),
-                ProductPageKnowledgePanels(
+        ProductPageKnowledgePanels(
           product: _product,
           setState: setState,
         ),
@@ -245,22 +245,6 @@ class _ProductPageState extends State<ProductPage> {
             child: const Text('Additional Button (CategoryPicker)'),
           ),
       ]),
-    );
-  }
-
-  Widget _buildLoadingWidget() {
-    return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: const <Widget>[
-          SizedBox(
-            child: CircularProgressIndicator(),
-            width: 60,
-            height: 60,
-          ),
-        ],
-      ),
     );
   }
 
@@ -380,5 +364,4 @@ class _ProductPageState extends State<ProductPage> {
       ),
     );
   }
-
 }

--- a/packages/smooth_app/lib/pages/product/product_knowledge_panels.dart
+++ b/packages/smooth_app/lib/pages/product/product_knowledge_panels.dart
@@ -5,6 +5,8 @@ import 'package:provider/provider.dart';
 import 'package:smooth_app/cards/product_cards/knowledge_panels/knowledge_panels_builder.dart';
 import 'package:smooth_app/pages/product/knowledge_panel_product_cards.dart';
 
+import '../../data_models/data_provider.dart';
+
 // Just to be called from the product page with the right provider set up
 class ProductPageKnowledgePanels extends StatelessWidget {
   const ProductPageKnowledgePanels({
@@ -17,7 +19,10 @@ class ProductPageKnowledgePanels extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final KnowledgePanels? knowledgePanels = context.watch<KnowledgePanels?>();
+    final KnowledgePanels? knowledgePanels = context
+        .select<DataProvider<Map<String, KnowledgePanels?>>, KnowledgePanels?>(
+            (DataProvider<Map<String, KnowledgePanels?>> value) =>
+                value.value[product.barcode]);
 
     List<Widget> knowledgePanelWidgets = <Widget>[];
 

--- a/packages/smooth_app/lib/pages/product/product_knowledge_panels.dart
+++ b/packages/smooth_app/lib/pages/product/product_knowledge_panels.dart
@@ -3,9 +3,8 @@ import 'package:openfoodfacts/model/KnowledgePanels.dart';
 import 'package:openfoodfacts/model/Product.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/cards/product_cards/knowledge_panels/knowledge_panels_builder.dart';
+import 'package:smooth_app/data_models/data_provider.dart';
 import 'package:smooth_app/pages/product/knowledge_panel_product_cards.dart';
-
-import '../../data_models/data_provider.dart';
 
 // Just to be called from the product page with the right provider set up
 class ProductPageKnowledgePanels extends StatelessWidget {

--- a/packages/smooth_app/lib/pages/product/product_knowledge_panels.dart
+++ b/packages/smooth_app/lib/pages/product/product_knowledge_panels.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:openfoodfacts/model/KnowledgePanels.dart';
+import 'package:openfoodfacts/model/Product.dart';
+import 'package:provider/provider.dart';
+import 'package:smooth_app/cards/product_cards/knowledge_panels/knowledge_panels_builder.dart';
+import 'package:smooth_app/pages/product/knowledge_panel_product_cards.dart';
+
+// Just to be called from the product page with the right provider set up
+class ProductPageKnowledgePanels extends StatelessWidget {
+  const ProductPageKnowledgePanels({
+    required this.product,
+    required this.setState,
+  });
+
+  final Function(Function()) setState;
+  final Product product;
+
+  @override
+  Widget build(BuildContext context) {
+    final KnowledgePanels? knowledgePanels = context.watch<KnowledgePanels?>();
+
+    List<Widget> knowledgePanelWidgets = <Widget>[];
+
+    if (knowledgePanels != null) {
+      // Render all KnowledgePanels
+      knowledgePanelWidgets =
+          KnowledgePanelsBuilder(setState: () => setState(() {})).buildAll(
+        knowledgePanels,
+        context: context,
+        product: product,
+      );
+    } else {
+      // Query results not available yet.
+      knowledgePanelWidgets = <Widget>[
+        Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: const <Widget>[
+              SizedBox(
+                child: CircularProgressIndicator(),
+                width: 60,
+                height: 60,
+              ),
+            ],
+          ),
+        ),
+      ];
+    }
+    return KnowledgePanelProductCards(knowledgePanelWidgets);
+  }
+}

--- a/packages/smooth_app/lib/pages/product/product_knowledge_panels.dart
+++ b/packages/smooth_app/lib/pages/product/product_knowledge_panels.dart
@@ -23,7 +23,7 @@ class ProductPageKnowledgePanels extends StatelessWidget {
             (DataProvider<Map<String, KnowledgePanels?>> value) =>
                 value.value[product.barcode]);
 
-    List<Widget> knowledgePanelWidgets = <Widget>[];
+    final List<Widget> knowledgePanelWidgets;
 
     if (knowledgePanels != null) {
       // Render all KnowledgePanels

--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/model/Attribute.dart';
 import 'package:openfoodfacts/model/AttributeGroup.dart';
+import 'package:openfoodfacts/model/KnowledgePanels.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/personalized_search/preference_importance.dart';
 import 'package:provider/provider.dart';
@@ -25,6 +26,8 @@ import 'package:smooth_app/helpers/smooth_matched_product.dart';
 import 'package:smooth_app/helpers/ui_helpers.dart';
 import 'package:smooth_app/pages/product/common/product_query_page_helper.dart';
 import 'package:smooth_app/pages/question_page.dart';
+
+import '../../cards/product_cards/knowledge_panels/knowledge_panel_full_loading_page.dart';
 
 const List<String> _ATTRIBUTE_GROUP_ORDER = <String>[
   AttributeGroup.ATTRIBUTE_GROUP_ALLERGENS,
@@ -74,10 +77,7 @@ class _SummaryCardState extends State<SummaryCard> {
   final Set<String> _attributesToExcludeIfStatusIsUnknown = <String>{};
   bool _annotationVoted = false;
 
-  @override
-  void initState() {
-    super.initState();
-  }
+  KnowledgePanels? knowledgePanels;
 
   @override
   Widget build(BuildContext context) {
@@ -388,17 +388,38 @@ class _SummaryCardState extends State<SummaryCard> {
       return null;
     }
     return LayoutBuilder(
-        builder: (BuildContext context, BoxConstraints constraints) {
-      return SizedBox(
-          width: constraints.maxWidth / 2,
-          child: Row(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        return InkWell(
+          enableFeedback: widget.isFullVersion,
+          onTap: () async {
+            if (!widget.isFullVersion || attribute.panelId == null) {
+              return;
+            }
+
+            Navigator.push<Widget>(
+              context,
+              MaterialPageRoute<Widget>(
+                builder: (BuildContext context) =>
+                    KnowledgePanelFullLoadingPage(
+                  panelId: attribute.panelId!,
+                ),
+              ),
+            );
+          },
+          child: SizedBox(
+            width: constraints.maxWidth / 2,
+            child: Row(
               mainAxisAlignment: MainAxisAlignment.start,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
                 attributeIcon,
                 Expanded(child: Text(attributeDisplayTitle).selectable()),
-              ]));
-    });
+              ],
+            ),
+          ),
+        );
+      },
+    );
   }
 
   /// Returns the mandatory attributes, ordered by attribute group order

--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -7,6 +7,7 @@ import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/personalized_search/preference_importance.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/cards/data_cards/score_card.dart';
+import 'package:smooth_app/cards/product_cards/knowledge_panels/knowledge_panel_full_loading_page.dart';
 import 'package:smooth_app/cards/product_cards/product_title_card.dart';
 import 'package:smooth_app/data_models/product_preferences.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
@@ -26,8 +27,6 @@ import 'package:smooth_app/helpers/smooth_matched_product.dart';
 import 'package:smooth_app/helpers/ui_helpers.dart';
 import 'package:smooth_app/pages/product/common/product_query_page_helper.dart';
 import 'package:smooth_app/pages/question_page.dart';
-
-import '../../cards/product_cards/knowledge_panels/knowledge_panel_full_loading_page.dart';
 
 const List<String> _ATTRIBUTE_GROUP_ORDER = <String>[
   AttributeGroup.ATTRIBUTE_GROUP_ALLERGENS,
@@ -402,6 +401,7 @@ class _SummaryCardState extends State<SummaryCard> {
                 builder: (BuildContext context) =>
                     KnowledgePanelFullLoadingPage(
                   panelId: attribute.panelId!,
+                  barcode: widget._product.barcode!,
                 ),
               ),
             );

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -84,14 +84,14 @@ packages:
       name: camera
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.4+19"
+    version: "0.9.4+20"
   camera_platform_interface:
     dependency: transitive
     description:
       name: camera_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.5"
+    version: "2.1.6"
   camera_web:
     dependency: transitive
     description:
@@ -105,7 +105,7 @@ packages:
       name: carousel_slider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.0"
+    version: "4.1.1"
   characters:
     dependency: transitive
     description:
@@ -459,7 +459,7 @@ packages:
       name: image_picker_ios
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.4+11"
+    version: "0.8.5"
   image_picker_platform_interface:
     dependency: transitive
     description:
@@ -604,7 +604,7 @@ packages:
       name: openfoodfacts
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   package_config:
     dependency: transitive
     description:
@@ -856,14 +856,14 @@ packages:
       name: sentry
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.4.0"
+    version: "6.5.1"
   sentry_flutter:
     dependency: "direct main"
     description:
       name: sentry_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.4.0"
+    version: "6.5.1"
   shared_preferences:
     dependency: transitive
     description:


### PR DESCRIPTION
### What
- Fixes: #1029


- Created `knowledge_panel_full_page` moved from `knowledge_panel_card` into a own file
- Created `knowledge_panel_full_loading_page` a new page which opens when clicking on a attribute, shows a loading indicator as long as the knowledge panel's aren't loaded yet. Replaces itself automatically.
- Created `DataProvider` class for sharing custom data via Provider

- `main.dart` created new DataProvider provider for sharing knowledge panel data, my first approach was to create a local provider on the product page, this turned out to not work as the provider isn't in the widget tree anymore when calling navigator.push (when the Provider is created below the MaterialApp)

- `new_product_page` minor refactoring + updated to write and delete data from DataProvider
- Created `product_knowledge_panels` moved from product page with accessing knowledge panel data via provider
- `summary_card` make attributes clickable


