### PR TITLE
feat: #1073 - more standard title style for "Lists"

### DIFF
--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -371,10 +371,9 @@ class _ProductPageState extends State<ProductPage> {
           mainAxisAlignment: MainAxisAlignment.start,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
-            ListTile(
-              title: Text(appLocalizations.user_list_subtitle_product),
-              trailing: const Icon(Icons.bookmark),
-              onTap: _editList,
+            Text(
+              appLocalizations.user_list_subtitle_product,
+              style: Theme.of(context).textTheme.headline3,
             ),
             Wrap(
               alignment: WrapAlignment.start,


### PR DESCRIPTION
Impacted file:
* `new_product_page.dart`: same title style as KP for "Lists"; no more confusing icon

### What
- same title style as KP for "Lists"
- no more confusing icon

### Screenshot

![Capture d’écran 2022-04-26 à 19 28 55](https://user-images.githubusercontent.com/11576431/165358286-86a801a9-f710-4bc9-9c0c-2a037d089e37.png)



### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/1657