### PR TITLE
fix: #1669 - accepts both decimal points

### DIFF
--- a/packages/smooth_app/ios/Podfile.lock
+++ b/packages/smooth_app/ios/Podfile.lock
@@ -87,13 +87,13 @@ PODS:
   - qr_code_scanner (0.2.0):
     - Flutter
     - MTBBarcodeScanner
-  - Sentry (7.10.2):
-    - Sentry/Core (= 7.10.2)
-  - Sentry/Core (7.10.2)
+  - Sentry (7.11.0):
+    - Sentry/Core (= 7.11.0)
+  - Sentry/Core (7.11.0)
   - sentry_flutter (0.0.1):
     - Flutter
     - FlutterMacOS
-    - Sentry (~> 7.10.1)
+    - Sentry (~> 7.11.0)
   - shared_preferences_ios (0.0.1):
     - Flutter
   - TOCropViewController (2.6.1)
@@ -203,8 +203,8 @@ SPEC CHECKSUMS:
   PromisesObjC: 68159ce6952d93e17b2dfe273b8c40907db5ba58
   Protobuf: 235750e4696ff59fb07d949a9dbbc92b3c0700fe
   qr_code_scanner: bb67d64904c3b9658ada8c402e8b4d406d5d796e
-  Sentry: 7bf9bfe713692cf87812e55f0999260494ba7982
-  sentry_flutter: 77ccdac346608b8ce7e428e7284e7a3e4e7f4a02
+  Sentry: 0c5cd63d714187b4a39c331c1f0eb04ba7868341
+  sentry_flutter: efb3df2c203cd03aad255892a8d628a458656d14
   shared_preferences_ios: 548a61f8053b9b8a49ac19c1ffbc8b92c50d68ad
   TOCropViewController: edfd4f25713d56905ad1e0b9f5be3fbe0f59c863
   url_launcher_ios: 839c58cdb4279282219f5e248c3321761ff3c4de

--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -27,7 +27,10 @@ class NutritionPageLoaded extends StatefulWidget {
 }
 
 class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
-  late final RegExp _decimalRegExp;
+  // we admit both decimal points
+  // anyway, the keyboard will only show one
+  static final RegExp _decimalRegExp = RegExp(r'[0-9,.]');
+
   late final NumberFormat _numberFormat;
   late final NutritionContainer _nutritionContainer;
 
@@ -55,9 +58,6 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
       product: widget.product,
     );
     _numberFormat = NumberFormat('####0.#####', ProductQuery.getLocaleString());
-    _decimalRegExp = _numberFormat.format(1.2).contains('.')
-        ? RegExp(r'[0-9\.]') // TODO(monsieurtanuki): check if . or \.
-        : RegExp(r'[0-9,]');
   }
 
   @override


### PR DESCRIPTION
Impacted files:
* `nutrition_page_loaded.dart`: now we accept both decimal points and let the keyboard decide which one is right
* `Podfile.lock`: wtf

### What
- There are several ways to filter a text field as "number with decimals" field: keyboard type (the way the keyboard looks), input formatter (the accepted characters) and the number format (how we translate the String into a double)
- One problem is deciding which decimal point (`,` or `.`) we should use
- Now we let the keyboard type decide it. In the input formatter we accept both decimal points (where we previously chose only one, and in some cases it looks like it was not a good idea)

### Fixes bug(s)
- #1669