### PR TITLE
feat: #1492 - added call to "edit ingredients" from "edit product"

### DIFF
--- a/packages/smooth_app/lib/pages/product/edit_ingredients_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_ingredients_page.dart
@@ -43,14 +43,12 @@ class _EditIngredientsPageState extends State<EditIngredientsPage> {
   }
 
   Future<void> _onSubmitField() async {
-    final User user = ProductQuery.getUser();
-
     setState(() {
       _updatingIngredients = true;
     });
 
     try {
-      await _updateIngredientsText(_controller.text, user);
+      await _updateIngredientsText(_controller.text);
     } catch (error) {
       final AppLocalizations appLocalizations = AppLocalizations.of(context)!;
       _showError(appLocalizations.ingredients_editing_error);
@@ -144,7 +142,7 @@ class _EditIngredientsPageState extends State<EditIngredientsPage> {
     }
   }
 
-  Future<void> _updateIngredientsText(String ingredientsText, User user) async {
+  Future<void> _updateIngredientsText(String ingredientsText) async {
     widget.product.ingredientsText = ingredientsText;
     final LocalDatabase localDatabase = context.read<LocalDatabase>();
     final bool savedAndRefreshed = await ProductRefresher().saveAndRefresh(

--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/model/Product.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
+import 'package:smooth_app/pages/product/edit_ingredients_page.dart';
 import 'package:smooth_app/pages/product/nutrition_page_loaded.dart';
 import 'package:smooth_app/pages/product/ordered_nutrients_cache.dart';
 
@@ -62,6 +63,19 @@ class _EditProductPageState extends State<EditProductPage> {
             ),
             _ListTitleItem(
               title: appLocalizations.edit_product_form_item_ingredients_title,
+              onTap: () async {
+                final bool? refreshed = await Navigator.push<bool>(
+                  context,
+                  MaterialPageRoute<bool>(
+                    builder: (BuildContext context) => EditIngredientsPage(
+                      product: widget.product,
+                    ),
+                  ),
+                );
+                if (refreshed ?? false) {
+                  _changes++;
+                }
+              },
             ),
             _ListTitleItem(
               title: appLocalizations.edit_product_form_item_packaging_title,

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -305,8 +305,8 @@ class _ProductPageState extends State<ProductPage> {
                         EditProductPage(_product),
                   ),
                 );
-                if (refreshed ?? false) {
-                  setState(() {});
+                if (refreshed == true) {
+                  await _refreshProduct(context);
                 }
               },
             ),


### PR DESCRIPTION
Impacted files:
* `edit_ingredients_page.dart`: unrelated refactoring
* `edit_product_page.dart`: added call to "edit ingredients"
* `new_product_page.dart`: refactored

### What
- added call to "edit ingredients" from "edit product"

### Screenshot

![Simulator Screen Shot - iPhone 8 Plus - 2022-04-28 at 16 01 21](https://user-images.githubusercontent.com/11576431/165769846-f598e7bd-b359-41c0-8189-a1bfe28a4684.png)


### Fixes bug(s)
- #1492
