### PR TITLE
fix: #1696 - compact dialog for "about"

### DIFF
--- a/packages/smooth_app/lib/pages/user_preferences_settings.dart
+++ b/packages/smooth_app/lib/pages/user_preferences_settings.dart
@@ -133,8 +133,7 @@ class UserPreferencesSettings extends AbstractUserPreferences {
             final PackageInfo packageInfo = await PackageInfo.fromPlatform();
             showDialog<void>(
               context: context,
-              builder: (BuildContext context) => SmoothAlertDialog.advanced(
-                close: false,
+              builder: (BuildContext context) => SmoothAlertDialog(
                 body: Column(
                   children: <Widget>[
                     ListTile(


### PR DESCRIPTION
Impacted file:
* `user_preferences_settings.dart`

### What
- Compact dialog for "about"
- The result doesn't look very good for other reasons, but at least it's compact

### Screenshot

![Simulator Screen Shot - iPhone 8 Plus - 2022-04-29 at 14 54 55](https://user-images.githubusercontent.com/11576431/165948225-8e4f76ca-97d2-4729-bd80-ea1d123df07e.png)

### Fixes bug(s)
- #1696
