### PR TITLE
fix: #1697 - checking hasError instead of hasData in FutureBuilder

### DIFF
--- a/packages/smooth_app/lib/generic_lib/loading_dialog.dart
+++ b/packages/smooth_app/lib/generic_lib/loading_dialog.dart
@@ -93,19 +93,22 @@ class LoadingDialog<T> {
       body: FutureBuilder<T>(
         future: future,
         builder: (BuildContext context, AsyncSnapshot<T> snapshot) {
-          if (snapshot.hasData) {
+          if (snapshot.connectionState == ConnectionState.done) {
+            // Now it's either hasError or successful.
+            // We cannot check hasData because data can be null or void.
+            if (snapshot.hasError) {
+              return ListTile(
+                title: Text(appLocalizations!.error_occurred),
+              );
+            }
             _popDialog(context, snapshot.data);
+            // whatever, anyway we've just pop'ed
             return Container();
-          } else if (snapshot.hasError) {
-            return ListTile(
-              title: Text(appLocalizations!.error_occurred),
-            );
-          } else {
-            return ListTile(
-              leading: const CircularProgressIndicator(),
-              title: Text(title),
-            );
           }
+          return ListTile(
+            leading: const CircularProgressIndicator(),
+            title: Text(title),
+          );
         },
       ),
       actions: <SmoothActionButton>[


### PR DESCRIPTION
Impacted file:
* `loading_dialog.dart`: checking hasError instead of hasData - hasData is not reliable as data can be void or null.

### What
- Interesting case!
- Here we use `LoadingDialog.run<void>`. Therefore if we test `snapshot.hasData`, we'll always get `false` (as void is not really a data).
- When the snapshot is "done", it's either `hasError` or successful.
- This PR is just about moving the tests order.
- The app does not look good a few pages after, but that's another story.

### Fixes bug(s)
- #1697