### PR TITLE
fix: #1720 - now we cannot remove a product from onboarding

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/product_title_card.dart
+++ b/packages/smooth_app/lib/cards/product_cards/product_title_card.dart
@@ -7,42 +7,37 @@ import 'package:smooth_app/helpers/extension_on_text_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 
 class ProductTitleCard extends StatelessWidget {
-  const ProductTitleCard(this.product, this.isSelectable, {this.dense = false});
+  const ProductTitleCard(
+    this.product,
+    this.isSelectable, {
+    this.dense = false,
+    this.isRemovable = true,
+  });
 
   final Product product;
   final bool dense;
   final bool isSelectable;
+  final bool isRemovable;
 
   @override
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context)!;
     final ThemeData themeData = Theme.of(context);
-    Widget subtitle;
-    Widget trailingWidget;
-    if (!isSelectable) {
+    final String subtitleText;
+    final Widget trailingWidget;
+    final String brands = product.brands ?? appLocalizations.unknownBrand;
+    final String quantity = product.quantity ?? '';
+    if (isRemovable) {
       final ContinuousScanModel model = context.watch<ContinuousScanModel>();
-      subtitle = RichText(
-        text: TextSpan(children: <InlineSpan>[
-          TextSpan(
-            text: product.brands ?? appLocalizations.unknownBrand,
-          ),
-          const TextSpan(text: ' , '),
-          TextSpan(
-            text: product.quantity ?? '',
-            style: themeData.textTheme.headline3,
-          ),
-        ]),
-      );
+      subtitleText = '$brands${quantity == '' ? '' : ', $quantity'}';
       trailingWidget = InkWell(
-        onTap: () {
-          model.removeBarcode(product.barcode!);
-        },
+        onTap: () async => model.removeBarcode(product.barcode!),
         child: const Icon(Icons.clear_rounded),
       );
     } else {
-      subtitle = Text(product.brands ?? appLocalizations.unknownBrand);
+      subtitleText = brands;
       trailingWidget = Text(
-        product.quantity ?? '',
+        quantity,
         style: themeData.textTheme.headline3,
       ).selectable(isSelectable: isSelectable);
     }
@@ -55,7 +50,9 @@ class ProductTitleCard extends StatelessWidget {
           getProductName(product, appLocalizations),
           style: themeData.textTheme.headline4,
         ).selectable(isSelectable: isSelectable),
-        subtitle: subtitle,
+        subtitle: Text(
+          subtitleText,
+        ).selectable(isSelectable: isSelectable),
         trailing: trailingWidget,
       ),
     );

--- a/packages/smooth_app/lib/pages/onboarding/preferences_page.dart
+++ b/packages/smooth_app/lib/pages/onboarding/preferences_page.dart
@@ -96,6 +96,7 @@ class _HelperState extends State<_Helper> {
             widget.product,
             productPreferences,
             isFullVersion: _isProductExpanded,
+            isRemovable: false,
           ),
         ),
       ),

--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -47,6 +47,7 @@ class SummaryCard extends StatefulWidget {
     this.isFullVersion = false,
     this.showUnansweredQuestions = false,
     this.refreshProductCallback,
+    this.isRemovable = true,
   });
 
   final Product _product;
@@ -61,6 +62,9 @@ class SummaryCard extends StatefulWidget {
   /// If true, the summary card will try to load unanswered questions about this
   /// product and give a prompt to answer those questions.
   final bool showUnansweredQuestions;
+
+  /// If true, there will be a button to remove the product from the carousel.
+  final bool isRemovable;
 
   /// Callback to refresh the product when necessary.
   final Function(BuildContext)? refreshProductCallback;
@@ -294,7 +298,11 @@ class _SummaryCardState extends State<SummaryCard> {
 
     return Column(
       children: <Widget>[
-        ProductTitleCard(widget._product, widget.isFullVersion),
+        ProductTitleCard(
+          widget._product,
+          widget.isFullVersion,
+          isRemovable: widget.isRemovable,
+        ),
         for (final Attribute attribute in scoreAttributes)
           InkWell(
             onTap: () async => openFullKnowledgePanel(


### PR DESCRIPTION
Impacted files:
* `preferences_page.dart`: used new parameter `isRemovable`
* `product_title_card.dart`: new parameter `isRemovable`
* `summary_card.dart`: new parameter `isRemovable`

### What
- We needed an extra parameter to say if this product could be removed from the carousel.
- That could obviously not happen during the onboarding.
- The issue was caused by the Carousel provider being called before it was created.

### Screenshot

![Simulator Screen Shot - iPhone 8 Plus - 2022-04-30 at 08 38 20](https://user-images.githubusercontent.com/11576431/166094818-d5ef8d2b-b022-4516-b7b5-9399848881bb.png)


### Fixes bug(s)
- #1720