### PR TITLE
feat: #1234 - new "copy" / "paste" features in product list page

### DIFF
--- a/packages/smooth_app/lib/pages/product/common/product_list_clipboard_helper.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_clipboard_helper.dart
@@ -1,0 +1,64 @@
+import 'dart:convert';
+import 'package:clipboard/clipboard.dart';
+import 'package:flutter/material.dart';
+import 'package:smooth_app/data_models/product_list.dart';
+import 'package:smooth_app/database/dao_product_list.dart';
+import 'package:smooth_app/database/local_database.dart';
+
+/// Helper class around [ProductList] and clipboard operations (copy/paste).
+class ProductListClipboardHelper {
+  ProductListClipboardHelper(this.productList);
+
+  final ProductList productList;
+
+  Future<bool> copy(final Iterable<String> selectedBarcodes) async {
+    try {
+      final String copied = _getCopyString(selectedBarcodes);
+      await FlutterClipboard.copy(copied);
+      return true;
+    } catch (e) {
+      debugPrint('error copying: $e');
+      return false;
+    }
+  }
+
+  /// Returns the number of barcodes actually added, or null if exception.
+  Future<int?> paste(final LocalDatabase localDatabase) async {
+    try {
+      final String pasted = await FlutterClipboard.paste();
+      final List<String>? barcodes = _getPastedBarcodes(pasted);
+      if (barcodes == null) {
+        return null;
+      }
+      final DaoProductList daoProductList = DaoProductList(localDatabase);
+      final int result =
+          await daoProductList.setAll(productList, barcodes, true);
+      if (result > 0) {
+        await daoProductList.get(productList);
+      }
+      return result;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  String _getCopyString(final Iterable<String> barcodes) {
+    final List<String> list = <String>[];
+    list.addAll(barcodes);
+    return jsonEncode(list);
+  }
+
+  List<String>? _getPastedBarcodes(final String paste) {
+    try {
+      final List<dynamic> pasted = jsonDecode(paste) as List<dynamic>;
+      final List<String> list = <String>[];
+      for (final dynamic item in pasted) {
+        list.add(item.toString());
+      }
+      return list;
+    } catch (e) {
+      debugPrint('error pasting: $e');
+      return null;
+    }
+  }
+}

--- a/packages/smooth_app/lib/pages/user_preferences_dev_mode.dart
+++ b/packages/smooth_app/lib/pages/user_preferences_dev_mode.dart
@@ -3,9 +3,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/model/Attribute.dart';
 import 'package:openfoodfacts/utils/OpenFoodAPIConfiguration.dart';
 import 'package:provider/provider.dart';
-import 'package:smooth_app/data_models/product_list.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
-import 'package:smooth_app/database/dao_product_list.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/database/product_query.dart';
 import 'package:smooth_app/helpers/product_list_import_export.dart';
@@ -139,52 +137,6 @@ class UserPreferencesDevMode extends AbstractUserPreferences {
                 userPreferencesFlagEditIngredients, value);
             ScaffoldMessenger.of(context)
                 .showSnackBar(const SnackBar(content: Text('Ok')));
-          },
-        ),
-        ListTile(
-          title: const Text('Export History'),
-          onTap: () async {
-            final LocalDatabase localDatabase = context.read<LocalDatabase>();
-            final Map<String, dynamic> export =
-                await DaoProductList(localDatabase).export(
-              ProductList.history(),
-            );
-            final List<Widget> children = <Widget>[];
-            for (final String barcode in export.keys) {
-              final bool? exists = export[barcode] as bool?;
-              children.add(
-                ListTile(
-                  leading: Icon(exists == null
-                      ? Icons.error
-                      : exists
-                          ? Icons.check
-                          : Icons.help_outline),
-                  title: Text(barcode),
-                  subtitle: Text(exists == null
-                      ? 'exception'
-                      : exists
-                          ? 'product found'
-                          : 'product NOT found'),
-                ),
-              );
-            }
-            showDialog<void>(
-              context: context,
-              builder: (BuildContext context) => AlertDialog(
-                title: const Text('export history'),
-                content: SizedBox(
-                  height: 400,
-                  width: 300,
-                  child: ListView(children: children),
-                ),
-                actions: <Widget>[
-                  ElevatedButton(
-                    child: Text(AppLocalizations.of(context)!.okay),
-                    onPressed: () => Navigator.pop(context),
-                  ),
-                ],
-              ),
-            );
           },
         ),
         ListTile(

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -120,6 +120,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.1"
+  clipboard:
+    dependency: "direct main"
+    description:
+      name: clipboard
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   clock:
     dependency: transitive
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   flutter_widget_from_html_core: any
   fwfh_selectable_text: ^0.8.3+1
   flutter_secure_storage: ^5.0.2
+  clipboard: ^0.1.3
   hive: ^2.1.0
   hive_flutter: ^1.1.0
   http: ^0.13.4


### PR DESCRIPTION
New file:
* `product_list_clipboard_helper.dart`: Helper class around [ProductList] and clipboard operations (copy/paste).

Impacted files:
* `dao_product_list.dart`: new method `setAll` in order to add/remove barcodes; removed a now useless product list export method
* `product_list_page.dart`: added popup menu items "copy" and "paste"; refactored with `_SelectionMode` as we can now select items for copy too (not only compare); added icons to popup menu items
* `pubspec.lock`: wtf
* `pubspec.yaml`: added `clipboard` as dependency
* `user_preferences_dev_mode.dart`: removed a now useless product list export feature

### What
- New "copy" / "paste" features in product list page
- We use the clipboard
- For the moment the structure is very basic, but will be improved

### Screenshot

![Simulator Screen Shot - iPhone 8 Plus - 2022-05-04 at 13 05 27](https://user-images.githubusercontent.com/11576431/166669912-07f436e3-586f-4199-9dce-4d94dbcc6eb6.png)

![Simulator Screen Shot - iPhone 8 Plus - 2022-05-04 at 13 05 54](https://user-images.githubusercontent.com/11576431/166669987-898a89e3-e1e4-4a33-bad6-04d2d7efa5f4.png)

![Simulator Screen Shot - iPhone 8 Plus - 2022-05-04 at 13 06 51](https://user-images.githubusercontent.com/11576431/166670115-29ae734c-70fd-4e14-97b5-6365b13d35ac.png)


### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/1234