### PR TITLE
feat: Snackbar "Not a valid product barcode" when we scan a QR-Code #840

### DIFF
--- a/packages/smooth_app/lib/helpers/barcode_validator.dart
+++ b/packages/smooth_app/lib/helpers/barcode_validator.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:google_ml_barcode_scanner/google_ml_barcode_scanner.dart'
     as MlKit;
 import 'package:qr_code_scanner/qr_code_scanner.dart' as QrCodeScanner;
@@ -39,10 +40,12 @@ void showInvalidBarcodeSnackbar(BuildContext context) {
 
   disallowShowInvalidBarcodeSnackbar();
 
+  final AppLocalizations appLocalizations = AppLocalizations.of(context)!;
+
   ScaffoldMessenger.of(context)
       .showSnackBar(
-        const SnackBar(
-          content: Text('Yay! A SnackBar!'),
+        SnackBar(
+          content: Text(appLocalizations.not_valid_barcode),
         ),
       )
       .closed

--- a/packages/smooth_app/lib/helpers/barcode_validator.dart
+++ b/packages/smooth_app/lib/helpers/barcode_validator.dart
@@ -22,13 +22,22 @@ bool isValidBarcodeQrcodeScanner(QrCodeScanner.Barcode barcode) {
   return !invalidBarcodesQrCodeScanner.contains(barcode.format);
 }
 
-bool _canShowInvalidebarcodeSnackbar = true;
+bool _canShowInvalidBarcodeSnackbar = true;
+
+void disallowShowInvalidBarcodeSnackbar() {
+  _canShowInvalidBarcodeSnackbar = false;
+}
+
+void allowShowInvalidBarcodeSnackbar() {
+  _canShowInvalidBarcodeSnackbar = true;
+}
 
 void showInvalidBarcodeSnackbar(BuildContext context) {
-  if (!_canShowInvalidebarcodeSnackbar) {
+  if (!_canShowInvalidBarcodeSnackbar) {
     return;
   }
-  _canShowInvalidebarcodeSnackbar = false;
+
+  disallowShowInvalidBarcodeSnackbar();
 
   ScaffoldMessenger.of(context)
       .showSnackBar(
@@ -37,7 +46,5 @@ void showInvalidBarcodeSnackbar(BuildContext context) {
         ),
       )
       .closed
-      .then((_) {
-    _canShowInvalidebarcodeSnackbar = true;
-  });
+      .then((_) => allowShowInvalidBarcodeSnackbar());
 }

--- a/packages/smooth_app/lib/helpers/barcode_validator.dart
+++ b/packages/smooth_app/lib/helpers/barcode_validator.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:google_ml_barcode_scanner/google_ml_barcode_scanner.dart'
+    as MlKit;
+import 'package:qr_code_scanner/qr_code_scanner.dart' as QrCodeScanner;
+
+List<MlKit.BarcodeFormat> invalidBarcodesMlKit = <MlKit.BarcodeFormat>[
+  MlKit.BarcodeFormat.qrCode,
+  MlKit.BarcodeFormat.unknown,
+];
+
+List<QrCodeScanner.BarcodeFormat> invalidBarcodesQrCodeScanner =
+    <QrCodeScanner.BarcodeFormat>[
+  QrCodeScanner.BarcodeFormat.qrcode,
+  QrCodeScanner.BarcodeFormat.unknown,
+];
+
+bool isValidBarcodeMlKit(MlKit.Barcode barcode) {
+  return !invalidBarcodesMlKit.contains(barcode.value.format);
+}
+
+bool isValidBarcodeQrcodeScanner(QrCodeScanner.Barcode barcode) {
+  return !invalidBarcodesQrCodeScanner.contains(barcode.format);
+}
+
+bool _canShowInvalidebarcodeSnackbar = true;
+
+void showInvalidBarcodeSnackbar(BuildContext context) {
+  if (!_canShowInvalidebarcodeSnackbar) {
+    return;
+  }
+  _canShowInvalidebarcodeSnackbar = false;
+
+  ScaffoldMessenger.of(context)
+      .showSnackBar(
+        const SnackBar(
+          content: Text('Yay! A SnackBar!'),
+        ),
+      )
+      .closed
+      .then((_) {
+    _canShowInvalidebarcodeSnackbar = true;
+  });
+}

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -889,5 +889,10 @@
     "user_list_name_error_same": "That is the same name",
     "@user_list_name_error_same": {
         "description": "Validation error about the renamed name that is the same as the initial list name"
+    },
+
+    "not_valid_barcode":"Not a valid product barcode",
+    "@not_valid_barcode":{
+       "description": "Validation warning about reading a non-valid barcode"
     }
 }

--- a/packages/smooth_app/lib/l10n/app_pt.arb
+++ b/packages/smooth_app/lib/l10n/app_pt.arb
@@ -888,5 +888,6 @@
     "user_list_name_error_same": "That is the same name",
     "@user_list_name_error_same": {
         "description": "Validation error about the renamed name that is the same as the initial list name"
-    }
+    },
+    "not_valid_barcode":"Código de barras inválido"
 }

--- a/packages/smooth_app/lib/pages/scan/continuous_scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/continuous_scan_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:qr_code_scanner/qr_code_scanner.dart';
 import 'package:smooth_app/data_models/continuous_scan_model.dart';
+import 'package:smooth_app/helpers/barcode_validator.dart';
 import 'package:smooth_app/pages/scan/lifecycle_manager.dart';
 
 class ContinuousScanPage extends StatefulWidget {
@@ -45,8 +46,11 @@ class _ContinuousScanPageState extends State<ContinuousScanPage> {
 
   void setupScanner(QRViewController controller) {
     _controller = controller;
-    _controller?.scannedDataStream
-        .listen((Barcode barcode) => _model.onScan(barcode.code));
+    _controller?.scannedDataStream.listen((Barcode barcode) {
+      isValidBarcodeQrcodeScanner(barcode)
+          ? _model.onScan(barcode.code)
+          : showInvalidBarcodeSnackbar(context);
+    });
   }
 
   //Used when navigating away from the QRView itself

--- a/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
@@ -6,6 +6,7 @@ import 'package:google_ml_barcode_scanner/google_ml_barcode_scanner.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/continuous_scan_model.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
+import 'package:smooth_app/helpers/barcode_validator.dart';
 import 'package:smooth_app/main.dart';
 import 'package:smooth_app/pages/scan/abstract_camera_image_getter.dart';
 import 'package:smooth_app/pages/scan/camera_image_cropper.dart';
@@ -259,8 +260,10 @@ class MLKitScannerPageState extends State<MLKitScannerPage> {
         await barcodeScanner!.processImage(inputImage);
 
     for (final Barcode barcode in barcodes) {
-      _model
-          .onScan(barcode.value.rawValue); // TODO(monsieurtanuki): add "await"?
+      // TODO(monsieurtanuki): add "await"?
+      isValidBarcodeMlKit(barcode)
+          ? _model.onScan(barcode.value.rawValue)
+          : showInvalidBarcodeSnackbar(context);
     }
   }
 }


### PR DESCRIPTION
### What
The objective was to prevent the user from reading a QRCode. So, if the user reads a QRCode a snackbar with "Not a valid product barcode" should appear.

 - Create a list of invalid format to both readers, the MlKit and the QrCodeScanner
 - Create validations methods to both readers and use them accordingly
 - Create a method to show the "Not a valid product barcode" snackbar with a guard clause mechanism to prevent a endless stack of snackbar

### Screenshot
https://user-images.githubusercontent.com/50844424/166808536-16e9cdac-2f97-46b7-a7ba-3a5cb89e5ffb.mp4


### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/840

