### PR TITLE
fix: Upgrade XCode version used by fastlane

### DIFF
--- a/packages/smooth_app/ios/fastlane/Fastfile
+++ b/packages/smooth_app/ios/fastlane/Fastfile
@@ -2,7 +2,7 @@ setup_travis
 default_platform(:ios)
 
 before_all do
-  xcversion(version: "~> 12.3")
+  xcversion(version: "~> 13.3")
 end
 
 platform :ios do


### PR DESCRIPTION
This should fix #1736 

The change only consists on upgrading XCode to the latest stable version.
<img width="530" alt="Screen Shot 2022-05-05 at 07 23 59" src="https://user-images.githubusercontent.com/246838/166867440-baa28ce8-0abe-48bb-85e1-11198c87e5ab.png">

(I don't know if it's possible, but it would be nice if the dependabot could notify us when a new version is available)
