### PR TITLE
make app name resize itself

### DIFF
--- a/packages/smooth_app/lib/pages/user_preferences_settings.dart
+++ b/packages/smooth_app/lib/pages/user_preferences_settings.dart
@@ -139,9 +139,11 @@ class UserPreferencesSettings extends AbstractUserPreferences {
                     ListTile(
                       leading:
                           Image.asset('assets/app/smoothie-icon.1200x1200.png'),
-                      title: Text(
-                        packageInfo.appName,
-                        style: themeData.textTheme.headline1,
+                      title: FittedBox(
+                        child: Text(
+                          packageInfo.appName,
+                          style: themeData.textTheme.headline1,
+                        ),
                       ),
                       subtitle: Text(
                         '${packageInfo.version}+${packageInfo.buildNumber}',


### PR DESCRIPTION
### What
<!-- description of the PR -->
- Changed app name widget to fit on the screen

### Screenshot
<!-- Insert a screenshot to provide visual record of your changes, if visible -->
![Screenshot_2022-05-05-11-03-15-01_cc729dbb1ea2c751a543590b5da9708c](https://user-images.githubusercontent.com/57723319/166868024-f6122d43-11b1-482a-8d35-8d53a2cfbd50.jpg)


### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes: #1742 


### Part of 

