### PR TITLE
fix: #1673 - force preferences refresh when we changed languages

### DIFF
--- a/packages/smooth_app/lib/data_models/product_preferences.dart
+++ b/packages/smooth_app/lib/data_models/product_preferences.dart
@@ -108,19 +108,25 @@ class ProductPreferences extends ProductPreferencesManager with ChangeNotifier {
   /// The downloaded strings are automatically stored in the database.
   Future<bool> _loadFromNetwork(String languageCode) async {
     try {
+      final bool differentLanguages;
+      if (daoString != null) {
+        final String? latestLanguage =
+            await daoString!.get(_DAO_STRING_KEY_LANGUAGE);
+        differentLanguages = latestLanguage != languageCode;
+      } else {
+        differentLanguages = true;
+      }
       final String importanceUrl =
           AvailablePreferenceImportances.getUrl(languageCode);
       final String attributeGroupUrl =
           AvailableAttributeGroups.getUrl(languageCode);
-      final DownloadableString downloadableImportance;
-      downloadableImportance =
+      final DownloadableString downloadableImportance =
           DownloadableString(Uri.parse(importanceUrl), dao: daoString);
       final bool differentImportance = await downloadableImportance.download();
       final DownloadableString downloadableAttributes =
           DownloadableString(Uri.parse(attributeGroupUrl), dao: daoString);
       final bool differentAttributes = await downloadableAttributes.download();
-      // the downloaded values are identical to what was stored locally.
-      if ((!differentImportance) && (!differentAttributes)) {
+      if (!(differentImportance || differentAttributes || differentLanguages)) {
         return false;
       }
       final String preferenceImportancesString = downloadableImportance.value!;


### PR DESCRIPTION
Impacted file:
* `product_preferences.dart`

### What
- cf. #1673: now we force the preferences refresh when we've changed languages
- as a consequence, every time the language changes, the preferences will be in the latest language
- that was not the case in rare moments (or during demo) where we use the same language back and forth

### Fixes bug(s)
- Fixes: #1673
- Closes: #1673