### PR TITLE
fix: Black bars on top of the screen

### DIFF
--- a/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
@@ -116,7 +116,6 @@ class MLKitScannerPageState extends State<_MLKitScannerPageContent> {
     }
 
     return Transform.scale(
-      alignment: Alignment.topCenter,
       scale: _previewScale,
       child: Center(
         key: ValueKey<bool>(stoppingCamera),


### PR DESCRIPTION
I'm really sorry for the regression introduced in #1753, as it was working perfectly well on my devices & the emulator.
Basically, the `topCenter` alignement is unnecessary, as the scaling is made from the center point.

![](https://media1.giphy.com/media/7SF5scGB2AFrgsXP63/giphy.gif)
