### PR TITLE
fix: ContinuousScanModel injected twice in the Widget tree

### DIFF
--- a/packages/smooth_app/lib/pages/scan/scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/scan_page.dart
@@ -51,17 +51,10 @@ class _ScanPageState extends State<ScanPage> {
     return AnnotatedRegion<SystemUiOverlayStyle>(
       value: SystemUiOverlayStyle.light,
       child: Scaffold(
-        body: MultiProvider(
-          providers: <ChangeNotifierProvider<ChangeNotifier>>[
-            ChangeNotifierProvider<PermissionListener>(
-              create: (_) => PermissionListener(
-                permission: Permission.camera,
-              ),
-            ),
-            ChangeNotifierProvider<ContinuousScanModel>(
-              create: (BuildContext context) => _model!,
-            )
-          ],
+        body: ChangeNotifierProvider<PermissionListener>(
+          create: (_) => PermissionListener(
+            permission: Permission.camera,
+          ),
           child: const ScannerOverlay(
             backgroundChild: _ScanPageBackgroundWidget(),
             topChild: _ScanPageTopWidget(),


### PR DESCRIPTION
The `ContinuousScanModel` is injected both at the top of the tree (main.dart) & in the `ScanPage`.
As the model in the `ScanPage` is exactly the same as the one on the top of the hierarchy, injecting it again is totally useless.