### PR TITLE
fix: setState shouldn't be called from onDispose

### DIFF
--- a/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
@@ -190,7 +190,7 @@ class MLKitScannerPageState extends State<_MLKitScannerPageContent> {
     }
 
     stoppingCamera = true;
-    if (mounted) {
+    if (!fromDispose && mounted) {
       setState(() {});
     }
 

--- a/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
@@ -182,7 +182,9 @@ class MLKitScannerPageState extends State<_MLKitScannerPageContent> {
     }
   }
 
-  Future<void> _stopImageStream() async {
+  Future<void> _stopImageStream({
+    bool fromDispose = false,
+  }) async {
     if (stoppingCamera) {
       return;
     }
@@ -229,7 +231,7 @@ class MLKitScannerPageState extends State<_MLKitScannerPageContent> {
   void dispose() {
     // /!\ This call is a Future, which may leads to some issues.
     // This should be handled by [_restartCameraIfNecessary]
-    _stopImageStream();
+    _stopImageStream(fromDispose: true);
     super.dispose();
   }
 

--- a/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
@@ -182,6 +182,8 @@ class MLKitScannerPageState extends State<_MLKitScannerPageContent> {
     }
   }
 
+  /// Stop the camera feed
+  /// [fromDispose] allows us to know if we can call [setState]
   Future<void> _stopImageStream({
     bool fromDispose = false,
   }) async {
@@ -190,7 +192,7 @@ class MLKitScannerPageState extends State<_MLKitScannerPageContent> {
     }
 
     stoppingCamera = true;
-    if (!fromDispose && mounted) {
+    if (mounted && !fromDispose) {
       setState(() {});
     }
 


### PR DESCRIPTION
A `setState()` call is launched whenever we were in a "paused" or "disposed" state.
In `disposed`, `setState` cannot be called.

Will fix #1768 