### PR TITLE
feat: Scanner improvements

### DIFF
--- a/packages/smooth_app/lib/data_models/continuous_scan_model.dart
+++ b/packages/smooth_app/lib/data_models/continuous_scan_model.dart
@@ -97,23 +97,25 @@ class ContinuousScanModel with ChangeNotifier {
 
   Product getProduct(final String barcode) => _productList.getProduct(barcode);
 
-  Future<void> onScan(String? code) async {
+  /// Adds a barcode
+  /// Will return if this barcode is successfully added
+  Future<bool> onScan(String? code) async {
     if (code == null) {
-      return;
+      return false;
     }
 
     if (_barcodeTrustCheck != code) {
       _barcodeTrustCheck = code;
-      return;
+      return false;
     }
     if (_latestScannedBarcode == code || _barcodes.contains(code)) {
       lastConsultedBarcode = code;
-      return;
+      return false;
     }
     AnalyticsHelper.trackScannedProduct(barcode: code);
 
     _latestScannedBarcode = code;
-    _addBarcode(code);
+    return _addBarcode(code);
   }
 
   Future<bool> onCreateProduct(String? barcode) async {

--- a/packages/smooth_app/lib/data_models/continuous_scan_model.dart
+++ b/packages/smooth_app/lib/data_models/continuous_scan_model.dart
@@ -98,7 +98,7 @@ class ContinuousScanModel with ChangeNotifier {
   Product getProduct(final String barcode) => _productList.getProduct(barcode);
 
   /// Adds a barcode
-  /// Will return if this barcode is successfully added
+  /// Will return [true] if this barcode is successfully added
   Future<bool> onScan(String? code) async {
     if (code == null) {
       return false;

--- a/packages/smooth_app/lib/helpers/collections_helper.dart
+++ b/packages/smooth_app/lib/helpers/collections_helper.dart
@@ -1,0 +1,47 @@
+import 'dart:collection';
+
+import 'package:collection/collection.dart';
+
+/// List of [num] with a max length of [_maxCapacity], where we can easily
+/// compute the average value
+class AverageList<T extends num> with ListMixin<T> {
+  static const int _maxCapacity = 10;
+  final List<T> _elements = <T>[];
+
+  int average(int defaultValueIfEmpty) {
+    if (_elements.isEmpty) {
+      return defaultValueIfEmpty;
+    } else {
+      return _elements.average.floor();
+    }
+  }
+
+  @override
+  int get length => _elements.length;
+
+  @override
+  T operator [](int index) => throw UnsupportedError(
+        'Please only use the "add" method',
+      );
+
+  @override
+  void operator []=(int index, T value) {
+    if (index > _maxCapacity) {
+      throw UnsupportedError('The index is above the capacity!');
+    }
+  }
+
+  @override
+  void add(T element) {
+    _elements.insert(0, element);
+
+    if (_elements.length >= _maxCapacity) {
+      _elements.removeLast();
+    }
+  }
+
+  @override
+  set length(int newLength) {
+    throw UnimplementedError('This list has a fixed size of $_maxCapacity');
+  }
+}

--- a/packages/smooth_app/lib/helpers/collections_helper.dart
+++ b/packages/smooth_app/lib/helpers/collections_helper.dart
@@ -3,7 +3,7 @@ import 'dart:collection';
 import 'package:collection/collection.dart';
 
 /// List of [num] with a max length of [_maxCapacity], where we can easily
-/// compute the average value
+/// compute the average value of all elements.
 class AverageList<T extends num> with ListMixin<T> {
   static const int _maxCapacity = 10;
   final List<T> _elements = <T>[];
@@ -28,11 +28,14 @@ class AverageList<T extends num> with ListMixin<T> {
   void operator []=(int index, T value) {
     if (index > _maxCapacity) {
       throw UnsupportedError('The index is above the capacity!');
+    } else {
+      _elements[index] = value;
     }
   }
 
   @override
   void add(T element) {
+    // The first element is always the latest added
     _elements.insert(0, element);
 
     if (_elements.length >= _maxCapacity) {

--- a/packages/smooth_app/lib/pages/scan/mkit_scan_helper.dart
+++ b/packages/smooth_app/lib/pages/scan/mkit_scan_helper.dart
@@ -102,7 +102,7 @@ class _MLKitScanDecoderMainIsolate {
   /// Flag used when the Isolate is both started and ready to receive images
   bool _isIsolateInitialized = false;
 
-  /// When an image is provided, this [Completer] allows to notify to response
+  /// When an image is provided, this [Completer] allows to notify the response
   Completer<List<String>?>? _completer;
 
   /// When the Isolate is started, we have to wait until [_isIsolateInitialized]
@@ -110,7 +110,7 @@ class _MLKitScanDecoderMainIsolate {
   /// decoded.
   CameraImage? _queuedImage;
 
-  /// Decode barcodes from a [CameraImage]
+  /// Decodes barcodes from a [CameraImage]
   /// A null result will be sent until the Isolate isn't ready
   Future<List<String>?> decode(CameraImage image) async {
     // If a decoding process is running -> ignore new requests
@@ -150,7 +150,7 @@ class _MLKitScanDecoderMainIsolate {
 
 // ignore: avoid_classes_with_only_static_members
 class _MLKitScanDecoderIsolate {
-  // Only accept 1D barcodes. More info on:
+  // Only 1D barcodes. More info on:
   // [https://www.scandit.com/blog/types-barcodes-choosing-right-barcode/]
   static final BarcodeScanner _barcodeScanner =
       GoogleMlKit.vision.barcodeScanner(
@@ -267,7 +267,7 @@ class _MLKitScanDecoderIsolate {
 }
 
 /// [Isolate]s don't support custom classes.
-/// This extension export raw data from a [CameraImage], to be able to call
+/// This extension exports raw data from a [CameraImage], to be able to call
 /// [CameraImage.fromPlatformData]
 extension _CameraImageExtension on CameraImage {
   Map<String, dynamic> export() => <String, dynamic>{
@@ -292,7 +292,7 @@ extension _CameraImageExtension on CameraImage {
 }
 
 /// [Isolate]s don't support custom classes.
-/// This extension export raw data from a [CameraDescription], to be able to
+/// This extension exports raw data from a [CameraDescription], to be able to
 /// call the [CameraDescription] constructor via [_CameraDescriptionUtils.import].
 extension _CameraDescriptionExtension on CameraDescription {
   Map<String, dynamic> export() => <String, dynamic>{

--- a/packages/smooth_app/lib/pages/scan/mkit_scan_helper.dart
+++ b/packages/smooth_app/lib/pages/scan/mkit_scan_helper.dart
@@ -46,7 +46,7 @@ class MLKitScanDecoder {
 }
 
 /// Main class allowing to communicate with [_MLKitScanDecoderIsolate]
-/// The communication is bi-directionnal:
+/// The communication is bi-directional:
 /// -> From the main Isolate to the "decoder" Isolate
 ///   -> Send the configuration (camera description + scan mode)
 ///   -> Send a camera image to decode

--- a/packages/smooth_app/lib/pages/scan/mkit_scan_helper.dart
+++ b/packages/smooth_app/lib/pages/scan/mkit_scan_helper.dart
@@ -27,7 +27,7 @@ class MLKitScanDecoder {
   /// A null result is sent when the [scanMode] is unsupported or if a current
   /// decoding is already in progress
   /// Otherwise a list of decoded barcoded is returned
-  /// Note: This list may be empty if not barcoded is detected
+  /// Note: This list may be empty if no barcode is detected
   Future<List<String>?> processImage(CameraImage image) async {
     // ignore: missing_enum_constant_in_switch
     switch (scanMode) {

--- a/packages/smooth_app/lib/pages/scan/mkit_scan_helper.dart
+++ b/packages/smooth_app/lib/pages/scan/mkit_scan_helper.dart
@@ -1,0 +1,311 @@
+import 'dart:async';
+import 'dart:isolate';
+
+import 'package:camera/camera.dart';
+import 'package:flutter_isolate/flutter_isolate.dart';
+import 'package:google_ml_barcode_scanner/google_ml_barcode_scanner.dart';
+import 'package:smooth_app/pages/scan/abstract_camera_image_getter.dart';
+import 'package:smooth_app/pages/scan/camera_image_cropper.dart';
+import 'package:smooth_app/pages/scan/camera_image_full_getter.dart';
+import 'package:smooth_app/pages/user_preferences_dev_mode.dart';
+
+/// ML Kit bar code decoder (within an Isolate)
+class MLKitScanDecoder {
+  MLKitScanDecoder({
+    required CameraDescription camera,
+    required this.scanMode,
+  }) : _mainIsolate = _MLKitScanDecoderMainIsolate(
+          camera: camera,
+          scanMode: scanMode,
+        );
+
+  final DevModeScanMode scanMode;
+  final _MLKitScanDecoderMainIsolate _mainIsolate;
+
+  /// Extract barcodes from an image
+  ///
+  /// A null result is sent when the [scanMode] is unsupported or if a current
+  /// decoding is already in progress
+  /// Otherwise a list of decoded barcoded is returned
+  /// Note: This list may be empty if not barcoded is detected
+  Future<List<String>?> processImage(CameraImage image) async {
+    // ignore: missing_enum_constant_in_switch
+    switch (scanMode) {
+      case DevModeScanMode.CAMERA_ONLY:
+      case DevModeScanMode.PREPROCESS_FULL_IMAGE:
+      case DevModeScanMode.PREPROCESS_HALF_IMAGE:
+        return null;
+    }
+
+    return _mainIsolate.decode(image);
+  }
+
+  Future<void> dispose() async {
+    _mainIsolate.dispose();
+  }
+}
+
+/// Main class allowing to communicate with [_MLKitScanDecoderIsolate]
+/// The communication is bi-directionnal:
+/// -> From the main Isolate to the "decoder" Isolate
+///   -> Send the configuration (camera description + scan mode)
+///   -> Send a camera image to decode
+/// <- From the "decoder" Isolate
+///   -> When the Isolate is started (a [SendPort] is provided to communicate)
+///   -> When the Isolate is ready (camera description & scan mode are provided)
+///   -> When an image is decoded
+class _MLKitScanDecoderMainIsolate {
+  _MLKitScanDecoderMainIsolate({
+    required this.camera,
+    required this.scanMode,
+  }) : _port = ReceivePort() {
+    _port.listen((dynamic message) {
+      if (message is SendPort) {
+        _sendPort = message;
+
+        _sendPort!.send(
+          _MLKitScanDecoderIsolate._createConfig(
+            camera,
+            scanMode,
+          ),
+        );
+      } else if (message is bool) {
+        _isIsolateInitialized = true;
+
+        if (_queuedImage != null && _completer != null) {
+          _sendPort!.send(_queuedImage!.export());
+          _queuedImage = null;
+        }
+      } else if (message is List) {
+        _completer?.complete(message as List<String>);
+        _completer = null;
+      }
+    });
+  }
+
+  final CameraDescription camera;
+  final DevModeScanMode scanMode;
+
+  /// Port used by the Isolate to send us events:
+  /// - when a [SendPort] is available
+  /// - when the Isolate is ready to receive images
+  /// - when the Isolate has finished a detection
+  final ReceivePort _port;
+
+  /// Port provided by the Isolate to send instructions
+  /// - send the configuration (camera & scan mode)
+  /// - send a camera image
+  SendPort? _sendPort;
+
+  FlutterIsolate? _isolate;
+
+  /// Flag used when the Isolate is both started and ready to receive images
+  bool _isIsolateInitialized = false;
+
+  /// When an image is provided, this [Completer] allows to notify to response
+  Completer<List<String>?>? _completer;
+
+  /// When the Isolate is started, we have to wait until [_isIsolateInitialized]
+  /// is [true]. This variable temporary contains the image waiting to be
+  /// decoded.
+  CameraImage? _queuedImage;
+
+  /// Decode barcodes from a [CameraImage]
+  /// A null result will be sent until the Isolate isn't ready
+  Future<List<String>?> decode(CameraImage image) async {
+    // If a decoding process is running -> ignore new requests
+    if (_completer != null) {
+      return null;
+    }
+
+    _completer = Completer<List<String>?>();
+
+    if (_isolate == null) {
+      _isolate = await FlutterIsolate.spawn(
+        _MLKitScanDecoderIsolate.startIsolate,
+        _port.sendPort,
+      );
+      _queuedImage = image;
+      return _completer!.future;
+    } else if (_isIsolateInitialized) {
+      _sendPort?.send(image.export());
+      return _completer!.future;
+    }
+
+    return null;
+  }
+
+  void dispose() {
+    _isIsolateInitialized = false;
+
+    _completer?.completeError(Exception('Isolate stopped'));
+    _completer = null;
+
+    _sendPort = null;
+
+    _isolate?.kill(priority: Isolate.immediate);
+    _isolate = null;
+  }
+}
+
+// ignore: avoid_classes_with_only_static_members
+class _MLKitScanDecoderIsolate {
+  static final BarcodeScanner _barcodeScanner =
+      GoogleMlKit.vision.barcodeScanner(
+    <BarcodeFormat>[
+      BarcodeFormat.ean8,
+      BarcodeFormat.ean13,
+    ],
+  );
+
+  static const String _cameraKey = 'camera';
+  static const String _scanModeKey = 'scanMode';
+
+  /// Port to communicate with the main Isolate
+  static late ReceivePort? _port;
+  static CameraDescription? _camera;
+  static DevModeScanMode? _scanMode;
+
+  static void startIsolate(SendPort port) {
+    _port = ReceivePort();
+
+    _port!.listen(
+      (dynamic message) async {
+        if (message is Map<String, dynamic>) {
+          if (message.containsKey(_cameraKey)) {
+            _initIsolate(message);
+            port.send(true);
+          } else {
+            await onNewBarcode(message, port);
+          }
+        }
+      },
+    );
+
+    port.send(_port!.sendPort);
+  }
+
+  /// Content required for this Isolate to be "ready"
+  static Map<String, dynamic> _createConfig(
+    CameraDescription camera,
+    DevModeScanMode scanMode,
+  ) {
+    return <String, dynamic>{
+      _cameraKey: camera.export(),
+      _scanModeKey: scanMode.index,
+    };
+  }
+
+  /// Parse content containing the configuration of this Isolate
+  // ignore: avoid_dynamic_calls
+  static void _initIsolate(Map<String, dynamic> message) {
+    _camera = _CameraDescriptionUtils.import(
+      message[_cameraKey] as Map<String, dynamic>,
+    );
+    _scanMode = DevModeScanMode.values[message[_scanModeKey] as int];
+  }
+
+  static bool get isReady => _camera != null && _scanMode != null;
+
+  static Future<void> onNewBarcode(
+    Map<dynamic, dynamic> message,
+    SendPort port,
+  ) async {
+    if (!isReady) {
+      return;
+    }
+
+    final CameraImage image = CameraImage.fromPlatformData(message);
+    final InputImage cropImage = _cropImage(image);
+
+    final List<Barcode> barcodes =
+        await _barcodeScanner.processImage(cropImage);
+
+    port.send(
+      barcodes
+          .map((Barcode barcode) => barcode.value.rawValue)
+          .where((String? barcode) => barcode?.isNotEmpty == true)
+          .cast<String>()
+          .toList(growable: false),
+    );
+  }
+
+  static InputImage _cropImage(CameraImage image) {
+    final AbstractCameraImageGetter getter;
+
+    switch (_scanMode!) {
+      case DevModeScanMode.CAMERA_ONLY:
+      case DevModeScanMode.PREPROCESS_FULL_IMAGE:
+      case DevModeScanMode.PREPROCESS_HALF_IMAGE:
+        throw Exception('Unsupported mode $_scanMode!');
+      case DevModeScanMode.SCAN_FULL_IMAGE:
+        getter = CameraImageFullGetter(image, _camera!);
+        break;
+      case DevModeScanMode.SCAN_HALF_IMAGE:
+        getter = CameraImageCropper(
+          image,
+          _camera!,
+          left01: 0,
+          top01: 0,
+          width01: 1,
+          height01: .5,
+        );
+        break;
+    }
+
+    return getter.getInputImage();
+  }
+}
+
+/// [Isolate]s don't support custom classes.
+/// This extension export raw data from a [CameraImage], to be able to call
+/// [CameraImage.fromPlatformData]
+extension _CameraImageExtension on CameraImage {
+  Map<String, dynamic> export() => <String, dynamic>{
+        'format': format.raw,
+        'width': width,
+        'height': height,
+        'lensAperture': lensAperture,
+        'sensorExposureTime': sensorExposureTime,
+        'sensorSensitivity': sensorSensitivity,
+        'planes': planes
+            .map((Plane p) => <dynamic, dynamic>{
+                  'bytes': p.bytes,
+                  'bytesPerPixel': p.bytesPerPixel,
+                  'bytesPerRow': p.bytesPerRow,
+                  'height': p.height,
+                  'width': p.width,
+                })
+            .toList(
+              growable: false,
+            )
+      };
+}
+
+/// [Isolate]s don't support custom classes.
+/// This extension export raw data from a [CameraDescription], to be able to
+/// call the [CameraDescription] constructor via [_CameraDescriptionUtils.import].
+extension _CameraDescriptionExtension on CameraDescription {
+  Map<String, dynamic> export() => <String, dynamic>{
+        _CameraDescriptionUtils._nameKey: name,
+        _CameraDescriptionUtils._lensDirectionKey: lensDirection.index,
+        _CameraDescriptionUtils._sensorOrientationKey: sensorOrientation,
+      };
+}
+
+/// Recreate a [CameraDescription] from [_CameraDescriptionExtension.export]
+class _CameraDescriptionUtils {
+  const _CameraDescriptionUtils._();
+
+  static const String _nameKey = 'name';
+  static const String _lensDirectionKey = 'lensDirection';
+  static const String _sensorOrientationKey = 'sensorOrientation';
+
+  static CameraDescription import(Map<String, dynamic> map) {
+    return CameraDescription(
+      name: map[_nameKey] as String,
+      lensDirection: CameraLensDirection.values[map[_lensDirectionKey] as int],
+      sensorOrientation: map[_sensorOrientationKey] as int,
+    );
+  }
+}

--- a/packages/smooth_app/lib/pages/scan/mkit_scan_helper.dart
+++ b/packages/smooth_app/lib/pages/scan/mkit_scan_helper.dart
@@ -150,11 +150,20 @@ class _MLKitScanDecoderMainIsolate {
 
 // ignore: avoid_classes_with_only_static_members
 class _MLKitScanDecoderIsolate {
+  // Only accept 1D barcodes. More info on:
+  // [https://www.scandit.com/blog/types-barcodes-choosing-right-barcode/]
   static final BarcodeScanner _barcodeScanner =
       GoogleMlKit.vision.barcodeScanner(
     <BarcodeFormat>[
       BarcodeFormat.ean8,
       BarcodeFormat.ean13,
+      BarcodeFormat.upca,
+      BarcodeFormat.upce,
+      BarcodeFormat.code39,
+      BarcodeFormat.code93,
+      BarcodeFormat.code128,
+      BarcodeFormat.itf,
+      BarcodeFormat.codabar,
     ],
   );
 

--- a/packages/smooth_app/lib/pages/scan/mkit_scan_helper.dart
+++ b/packages/smooth_app/lib/pages/scan/mkit_scan_helper.dart
@@ -29,12 +29,14 @@ class MLKitScanDecoder {
   /// Otherwise a list of decoded barcoded is returned
   /// Note: This list may be empty if no barcode is detected
   Future<List<String>?> processImage(CameraImage image) async {
-    // ignore: missing_enum_constant_in_switch
     switch (scanMode) {
       case DevModeScanMode.CAMERA_ONLY:
       case DevModeScanMode.PREPROCESS_FULL_IMAGE:
       case DevModeScanMode.PREPROCESS_HALF_IMAGE:
         return null;
+      case DevModeScanMode.SCAN_FULL_IMAGE:
+      case DevModeScanMode.SCAN_HALF_IMAGE:
+      // OK -> continue
     }
 
     return _mainIsolate.decode(image);

--- a/packages/smooth_app/lib/pages/scan/mkit_scan_helper.dart
+++ b/packages/smooth_app/lib/pages/scan/mkit_scan_helper.dart
@@ -4,10 +4,10 @@ import 'dart:isolate';
 import 'package:camera/camera.dart';
 import 'package:flutter_isolate/flutter_isolate.dart';
 import 'package:google_ml_barcode_scanner/google_ml_barcode_scanner.dart';
+import 'package:smooth_app/pages/preferences/user_preferences_dev_mode.dart';
 import 'package:smooth_app/pages/scan/abstract_camera_image_getter.dart';
 import 'package:smooth_app/pages/scan/camera_image_cropper.dart';
 import 'package:smooth_app/pages/scan/camera_image_full_getter.dart';
-import 'package:smooth_app/pages/user_preferences_dev_mode.dart';
 
 /// ML Kit bar code decoder (within an Isolate)
 class MLKitScanDecoder {

--- a/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
@@ -52,16 +52,17 @@ class MLKitScannerPageState
 
   /// To improve battery life & lower the CPU consumption, we decode barcodes
   /// every [_processingTimeWindows] time windows.
-  /// A time window is the average time a decoding takes
 
   /// Until the first barcode is decoded, this is default timeout
   static const int _defaultProcessingTime = 50; // in milliseconds
   /// Minimal processing windows between two decodings
   static const int _processingTimeWindows = 5;
 
+  /// A time window is the average time decodings took
+  final AverageList<int> _averageProcessingTime = AverageList<int>();
+
   /// Subject notifying when a new image is available
   PublishSubject<CameraImage> _subject = PublishSubject<CameraImage>();
-  final AverageList<int> _averageProcessingTime = AverageList<int>();
 
   /// Stream calling the barcode detection
   StreamSubscription<List<String>?>? _streamSubscription;

--- a/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
@@ -12,6 +12,7 @@ import 'package:smooth_app/helpers/camera_helper.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_dev_mode.dart';
 import 'package:smooth_app/pages/scan/lifecycle_manager.dart';
 import 'package:smooth_app/pages/scan/mkit_scan_helper.dart';
+import 'package:smooth_app/widgets/lifecycle_aware_widget.dart';
 import 'package:smooth_app/widgets/screen_visibility.dart';
 
 class MLKitScannerPage extends StatelessWidget {
@@ -27,7 +28,7 @@ class MLKitScannerPage extends StatelessWidget {
   }
 }
 
-class _MLKitScannerPageContent extends StatefulWidget {
+class _MLKitScannerPageContent extends LifecycleAwareStatefulWidget {
   const _MLKitScannerPageContent({
     Key? key,
   }) : super(key: key);
@@ -36,7 +37,8 @@ class _MLKitScannerPageContent extends StatefulWidget {
   MLKitScannerPageState createState() => MLKitScannerPageState();
 }
 
-class MLKitScannerPageState extends State<_MLKitScannerPageContent> {
+class MLKitScannerPageState
+    extends LifecycleAwareState<_MLKitScannerPageContent> {
   /// If the camera is being closed (when [stoppingCamera] == true) and this
   /// Widget is visible again, we add a post frame callback to detect if the
   /// Widget is still visible
@@ -93,7 +95,7 @@ class MLKitScannerPageState extends State<_MLKitScannerPageContent> {
     return LifeCycleManager(
       onStart: _startLiveFeed,
       onResume: _startLiveFeed,
-      onPause: () => _stopImageStream(onlyPause: true),
+      onPause: () => _stopImageStream(fromPauseEvent: true),
       child: _buildScannerWidget(),
     );
   }
@@ -217,7 +219,7 @@ class MLKitScannerPageState extends State<_MLKitScannerPageContent> {
     }
   }
 
-  Future<void> _stopImageStream({bool onlyPause = false}) async {
+  Future<void> _stopImageStream({bool fromPauseEvent = false}) async {
     if (stoppingCamera) {
       return;
     }
@@ -227,7 +229,7 @@ class MLKitScannerPageState extends State<_MLKitScannerPageContent> {
 
     _controller?.removeListener(_cameraListener);
 
-    if (onlyPause) {
+    if (fromPauseEvent) {
       _streamSubscription?.pause();
     } else {
       await _streamSubscription?.cancel();
@@ -243,9 +245,7 @@ class MLKitScannerPageState extends State<_MLKitScannerPageContent> {
   }
 
   void _redrawScreen() {
-    if (mounted) {
-      setState(() {});
-    }
+    setStateSafe(() {});
   }
 
   /// The camera is fully closed at this step.
@@ -281,7 +281,7 @@ class MLKitScannerPageState extends State<_MLKitScannerPageContent> {
   void dispose() {
     // /!\ This call is a Future, which may leads to some issues.
     // This should be handled by [_restartCameraIfNecessary]
-    _stopImageStream(onlyPause: false);
+    _stopImageStream(fromPauseEvent: false);
     super.dispose();
   }
 

--- a/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
@@ -237,11 +237,9 @@ class MLKitScannerPageState
   }
 
   void _cameraListener() {
-    if (mounted) {
-      if (_controller?.value.hasError == true) {
-        // TODO(M123): Handle errors better
-        debugPrint(_controller!.value.errorDescription);
-      }
+    if (_controller?.value.hasError == true) {
+      // TODO(M123): Handle errors better
+      debugPrint(_controller!.value.errorDescription);
     }
   }
 

--- a/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
@@ -1,17 +1,17 @@
+import 'dart:async';
+
 import 'package:camera/camera.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:google_ml_barcode_scanner/google_ml_barcode_scanner.dart';
 import 'package:provider/provider.dart';
+import 'package:rxdart/rxdart.dart';
 import 'package:smooth_app/data_models/continuous_scan_model.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/helpers/camera_helper.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_dev_mode.dart';
-import 'package:smooth_app/pages/scan/abstract_camera_image_getter.dart';
-import 'package:smooth_app/pages/scan/camera_image_cropper.dart';
-import 'package:smooth_app/pages/scan/camera_image_full_getter.dart';
 import 'package:smooth_app/pages/scan/lifecycle_manager.dart';
+import 'package:smooth_app/pages/scan/mkit_scan_helper.dart';
 import 'package:smooth_app/widgets/screen_visibility.dart';
 
 class MLKitScannerPage extends StatelessWidget {
@@ -28,7 +28,9 @@ class MLKitScannerPage extends StatelessWidget {
 }
 
 class _MLKitScannerPageContent extends StatefulWidget {
-  const _MLKitScannerPageContent({Key? key}) : super(key: key);
+  const _MLKitScannerPageContent({
+    Key? key,
+  }) : super(key: key);
 
   @override
   MLKitScannerPageState createState() => MLKitScannerPageState();
@@ -45,31 +47,38 @@ class MLKitScannerPageState extends State<_MLKitScannerPageContent> {
   /// On a 60Hz display, one frame =~ 16 ms => 100 ms =~ 6 frames.
   static const int postFrameCallbackStandardDelay = 100; // in milliseconds
 
-  static const int _SKIPPED_FRAMES = 10;
-  BarcodeScanner? barcodeScanner;
+  /// Subject notifying when a new image is available
+  PublishSubject<CameraImage> _subject = PublishSubject<CameraImage>();
+
+  /// Stream calling the barcode detection
+  StreamSubscription<String>? _streamSubscription;
+  MLKitScanDecoder? _barcodeDecoder;
+
   late ContinuousScanModel _model;
   late UserPreferences _userPreferences;
   CameraController? _controller;
   CameraDescription? _camera;
-  bool isBusy = false;
   double _previewScale = 1.0;
 
   /// Flag used to prevent the camera from being initialized.
   /// When set to [false], [_startLiveStream] can be called.
   bool stoppingCamera = false;
 
-  //We don't scan every image for performance reasons
-  int frameCounter = 0;
-
   @override
   void initState() {
     super.initState();
     _camera = CameraHelper.findBestCamera();
+    _subject = PublishSubject<CameraImage>();
   }
 
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
+
+    if (mounted) {
+      _model = context.watch<ContinuousScanModel>();
+      _userPreferences = context.watch<UserPreferences>();
+    }
 
     // Relaunch the feed after a hot reload
     if (_controller == null) {
@@ -79,15 +88,12 @@ class MLKitScannerPageState extends State<_MLKitScannerPageContent> {
 
   @override
   Widget build(BuildContext context) {
-    _model = context.watch<ContinuousScanModel>();
-    _userPreferences = context.watch<UserPreferences>();
-
     // [_startLiveFeed] is called both with [onResume] and [onPause] to cover
     // all entry points
     return LifeCycleManager(
       onStart: _startLiveFeed,
       onResume: _startLiveFeed,
-      onPause: _stopImageStream,
+      onPause: () => _stopImageStream(onlyPause: true),
       child: _buildScannerWidget(),
     );
   }
@@ -96,7 +102,7 @@ class MLKitScannerPageState extends State<_MLKitScannerPageContent> {
     // Showing the black scanner background + the icon when the scanner is
     // loading or stopped
     if (isCameraNotInitialized) {
-      return const SizedBox();
+      return const SizedBox.shrink();
     }
 
     final Size size = MediaQuery.of(context).size;
@@ -139,7 +145,6 @@ class MLKitScannerPageState extends State<_MLKitScannerPageContent> {
       return;
     }
 
-    barcodeScanner = GoogleMlKit.vision.barcodeScanner();
     stoppingCamera = false;
 
     _controller = CameraController(
@@ -150,14 +155,49 @@ class MLKitScannerPageState extends State<_MLKitScannerPageContent> {
     );
 
     // If the controller is initialized update the UI.
+    _barcodeDecoder ??= MLKitScanDecoder(
+      camera: _camera!,
+      scanMode: DevModeScanModeExtension.fromIndex(
+        _userPreferences.getDevModeIndex(
+          UserPreferencesDevMode.userPreferencesEnumScanMode,
+        ),
+      ),
+    );
     _controller?.addListener(_cameraListener);
+
+    // Restart the subscription if necessary
+    if (_streamSubscription?.isPaused == true) {
+      _streamSubscription!.resume();
+    } else {
+      _streamSubscription = _subject
+          // TODO(g123k): Improve this duration by computing an average
+          //  computation duration
+          .throttleTime(
+            const Duration(milliseconds: 200),
+          )
+          .asyncMap<List<String>?>(
+            (CameraImage image) => _barcodeDecoder?.processImage(image),
+          )
+          .where(
+            (List<String>? barcodes) => barcodes?.isNotEmpty == true,
+          )
+          // TODO(g123k): What should we do with multiple barcodes?
+          .map(
+            (List<String>? barcodes) => barcodes!.first,
+          )
+          .listen(
+            (String barcode) => _model.onScan(barcode),
+          );
+    }
 
     try {
       await _controller?.initialize();
       await _controller?.setFocusMode(FocusMode.auto);
       await _controller?.setFocusPoint(_focusPoint);
       await _controller?.lockCaptureOrientation(DeviceOrientation.portraitUp);
-      await _controller?.startImageStream(_processCameraImage);
+      await _controller?.startImageStream(
+        (CameraImage image) => _subject.add(image),
+      );
     } on CameraException catch (e) {
       if (kDebugMode) {
         // TODO(M123): Show error message
@@ -165,15 +205,11 @@ class MLKitScannerPageState extends State<_MLKitScannerPageContent> {
       }
     }
 
-    if (mounted) {
-      setState(() {});
-    }
+    _redrawScreen();
   }
 
   void _cameraListener() {
     if (mounted) {
-      setState(() {});
-
       if (_controller?.value.hasError == true) {
         // TODO(M123): Handle errors better
         debugPrint(_controller!.value.errorDescription);
@@ -181,28 +217,35 @@ class MLKitScannerPageState extends State<_MLKitScannerPageContent> {
     }
   }
 
-  /// Stop the camera feed
-  /// [fromDispose] allows us to know if we can call [setState]
-  Future<void> _stopImageStream({
-    bool fromDispose = false,
-  }) async {
+  Future<void> _stopImageStream({bool onlyPause = false}) async {
     if (stoppingCamera) {
       return;
     }
 
     stoppingCamera = true;
-    if (mounted && !fromDispose) {
-      setState(() {});
-    }
+    _redrawScreen();
 
     _controller?.removeListener(_cameraListener);
-    await _controller?.dispose();
-    await barcodeScanner?.close();
 
-    barcodeScanner = null;
+    if (onlyPause) {
+      _streamSubscription?.pause();
+    } else {
+      await _streamSubscription?.cancel();
+    }
+
+    await _controller?.dispose();
+    await _barcodeDecoder?.dispose();
+
+    _barcodeDecoder = null;
     _controller = null;
 
     _restartCameraIfNecessary();
+  }
+
+  void _redrawScreen() {
+    if (mounted) {
+      setState(() {});
+    }
   }
 
   /// The camera is fully closed at this step.
@@ -238,31 +281,8 @@ class MLKitScannerPageState extends State<_MLKitScannerPageContent> {
   void dispose() {
     // /!\ This call is a Future, which may leads to some issues.
     // This should be handled by [_restartCameraIfNecessary]
-    _stopImageStream(fromDispose: true);
+    _stopImageStream(onlyPause: false);
     super.dispose();
-  }
-
-  // Convert the [CameraImage] to a [InputImage] and checking this for barcodes
-  // with help from ML Kit
-  Future<void> _processCameraImage(CameraImage image) async {
-    //Only scanning every xth image, but not resetting until the current one
-    //is done, so that we don't have idle time when the scanning takes longer
-    // TODO(M123): Can probably be merged with isBusy + checking if we should
-    // Count when ML Kit is busy
-    if (frameCounter < _SKIPPED_FRAMES) {
-      frameCounter++;
-      return;
-    }
-
-    if (isBusy || barcodeScanner == null) {
-      return;
-    }
-    isBusy = true;
-    frameCounter = 0;
-
-    await _scan(image);
-
-    isBusy = false;
   }
 
   /// Whatever the scan mode is, we always want the focus point to be on
@@ -274,52 +294,6 @@ class MLKitScannerPageState extends State<_MLKitScannerPageContent> {
       // Since we use a [Alignment.topCenter] alignment for the preview, we
       // have to recompute the position of the focus point
       return Offset(0.5, 0.25 / _previewScale);
-    }
-  }
-
-  Future<void> _scan(final CameraImage image) async {
-    final DevModeScanMode scanMode = DevModeScanModeExtension.fromIndex(
-      _userPreferences
-          .getDevModeIndex(UserPreferencesDevMode.userPreferencesEnumScanMode),
-    );
-
-    final AbstractCameraImageGetter getter;
-    switch (scanMode) {
-      case DevModeScanMode.CAMERA_ONLY:
-        return;
-      case DevModeScanMode.PREPROCESS_FULL_IMAGE:
-      case DevModeScanMode.SCAN_FULL_IMAGE:
-        getter = CameraImageFullGetter(image, _camera!);
-        break;
-      case DevModeScanMode.PREPROCESS_HALF_IMAGE:
-      case DevModeScanMode.SCAN_HALF_IMAGE:
-        getter = CameraImageCropper(
-          image,
-          _camera!,
-          left01: 0,
-          top01: 0,
-          width01: 1,
-          height01: .5,
-        );
-        break;
-    }
-    final InputImage inputImage = getter.getInputImage();
-
-    switch (scanMode) {
-      case DevModeScanMode.CAMERA_ONLY:
-      case DevModeScanMode.PREPROCESS_FULL_IMAGE:
-      case DevModeScanMode.PREPROCESS_HALF_IMAGE:
-        return;
-      case DevModeScanMode.SCAN_FULL_IMAGE:
-      case DevModeScanMode.SCAN_HALF_IMAGE:
-        break;
-    }
-    final List<Barcode> barcodes =
-        await barcodeScanner!.processImage(inputImage);
-
-    for (final Barcode barcode in barcodes) {
-      _model
-          .onScan(barcode.value.rawValue); // TODO(monsieurtanuki): add "await"?
     }
   }
 }

--- a/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
@@ -162,7 +162,7 @@ class MLKitScannerPageState
 
     _controller = CameraController(
       _camera!,
-      ResolutionPreset.high,
+      ResolutionPreset.medium,
       enableAudio: false,
       imageFormatGroup: ImageFormatGroup.yuv420,
     );

--- a/packages/smooth_app/lib/widgets/lifecycle_aware_widget.dart
+++ b/packages/smooth_app/lib/widgets/lifecycle_aware_widget.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/widgets.dart';
+
+abstract class LifecycleAwareStatefulWidget extends StatefulWidget {
+  /// Initializes [key] for subclasses.
+  const LifecycleAwareStatefulWidget({
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  StatefulElement createElement() {
+    return _LifecycleAwareStatefulElement(this);
+  }
+}
+
+class _LifecycleAwareStatefulElement extends StatefulElement {
+  _LifecycleAwareStatefulElement(StatefulWidget widget) : super(widget);
+
+  @override
+  LifecycleAwareState<StatefulWidget> get state =>
+      super.state as LifecycleAwareState<StatefulWidget>;
+
+  @override
+  void mount(Element? parent, Object? newSlot) {
+    state._debugLifecycleState = StateLifecycle.initialized;
+    super.mount(parent, newSlot);
+  }
+
+  @override
+  void unmount() {
+    state._debugLifecycleState = StateLifecycle.defunct;
+    super.unmount();
+  }
+}
+
+/// Make the private [_debugLifecycleState] attribute from the [State]
+/// accessible
+abstract class LifecycleAwareState<T extends StatefulWidget> extends State<T> {
+  /// The current stage in the lifecycle for this state object.
+  ///
+  /// This field is used by the framework when asserts are enabled to verify
+  /// that [State] objects move through their lifecycle in an orderly fashion.
+  StateLifecycle _debugLifecycleState = StateLifecycle.created;
+
+  @override
+  @mustCallSuper
+  void initState() {
+    _debugLifecycleState = StateLifecycle.created;
+    super.initState();
+  }
+
+  @override
+  @mustCallSuper
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _debugLifecycleState = StateLifecycle.ready;
+  }
+
+  /// Will call [setState] only if the current lifecycle state allows it
+  void setStateSafe(VoidCallback fn) {
+    if (_debugLifecycleState != StateLifecycle.defunct) {
+      setState(fn);
+    }
+  }
+
+  StateLifecycle get lifecycleState => _debugLifecycleState;
+}
+
+/// Extracted from [State] class
+enum StateLifecycle {
+  /// The [State] object has been created. [State.initState] is called at this
+  /// time.
+  created,
+
+  /// The [State.initState] method has been called but the [State] object is
+  /// not yet ready to build. [State.didChangeDependencies] is called at this time.
+  initialized,
+
+  /// The [State] object is ready to build and [State.dispose] has not yet been
+  /// called.
+  ready,
+
+  /// The [State.dispose] method has been called and the [State] object is
+  /// no longer able to build.
+  defunct,
+}

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -77,7 +77,7 @@ packages:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.2.3"
+    version: "8.3.0"
   camera:
     dependency: "direct main"
     description:
@@ -235,6 +235,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_isolate:
+    dependency: "direct main"
+    description:
+      name: flutter_isolate
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.2"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
@@ -864,6 +871,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.1"
+  rxdart:
+    dependency: "direct main"
+    description:
+      name: rxdart
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.27.3"
   sentry:
     dependency: transitive
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -37,11 +37,13 @@ dependencies:
   uuid: ^3.0.6
   provider: ^6.0.2
   qr_code_scanner: ^0.7.0
+  rxdart: ^0.27.3
+  flutter_isolate: ^2.0.2
   rubber: ^1.0.1
   sentry_flutter: ^6.5.1 # careful with upgrading cf: https://github.com/openfoodfacts/smooth-app/issues/1300
   url_launcher: ^6.1.0
   visibility_detector: ^0.2.2
-  camera: ^0.9.4+20
+  camera: ^0.9.4+21
   percent_indicator: ^4.0.1
   mailto: ^2.0.0
   flutter_native_splash: ^2.1.6


### PR DESCRIPTION
This PR contains several improvements for the scanner:
- Move the decoding part in an `Isolate`
- Improve the MLKit algorithm by limiting the types of supported barcodes
- "Adaptive algorithm" to start the decoding (cf below for more details)
- Ask for a camera lower resolution (`high` -> `medium`)
- [UX] When a barcode is scanned, a small vibration notifies the user

"Adaptive algorithm" :
- The duration of each decoding is now stored.
- An average value of the last 10 decodings is computed.
- The average time (what I call a window) is then multiplied by 10 (this value is arbitrary, we can change it)
- This sum is then used as the time between two decodings

~~What's still missing: pause the barcode when scrolling between the carousel's cards.~~
-> Will be implemented in a separated PR