### PR TITLE
fix: A clear alert message after changing preference.

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -906,9 +906,17 @@
     "@confirm_clear": {
         "description": "Asking about whether to clear the list or not"
     },
-    "importance_label": "importance",
+    "importance_label": "{name} importance: {id}",
     "@importance_label": {
-        "description": "Used when user selects a food preference"
+        "description": "Used when user selects a food preference",
+         "placeholders": {
+            "name": {
+                "type": "String"
+            },
+            "id": {
+                "type": "String"
+            }
+        }
     }
 }
 

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -908,7 +908,7 @@
     },
     "importance_label": "{name} importance: {id}",
     "@importance_label": {
-        "description": "Used when user selects a food preference",
+        "description": "Used when user selects a food preference. example: Vegan importance; mandatory",
          "placeholders": {
             "name": {
                 "type": "String"

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -905,6 +905,10 @@
     "confirm_clear": "Do you really want to clear?",
     "@confirm_clear": {
         "description": "Asking about whether to clear the list or not"
+    },
+    "importance_label": "importance",
+    "@importance_label": {
+        "description": "Used when user selects a food preference"
     }
 }
 

--- a/packages/smooth_app/lib/widgets/attribute_button.dart
+++ b/packages/smooth_app/lib/widgets/attribute_button.dart
@@ -48,7 +48,9 @@ class AttributeButton extends StatelessWidget {
               context: context,
               builder: (BuildContext context) => SmoothAlertDialog(
                 body: Text(
-                    ' ${attribute.name} ${appLocalizations!.importance_label} "$importanceId"'),
+                  appLocalizations!.importance_label(
+                      attribute.name.toString(), importanceId),
+                ),
                 actions: <SmoothActionButton>[
                   SmoothActionButton(
                     text: appLocalizations.close,

--- a/packages/smooth_app/lib/widgets/attribute_button.dart
+++ b/packages/smooth_app/lib/widgets/attribute_button.dart
@@ -48,10 +48,10 @@ class AttributeButton extends StatelessWidget {
               context: context,
               builder: (BuildContext context) => SmoothAlertDialog(
                 body: Text(
-                    'blah blah blah importance "$importanceId"'), // TODO(monsieurtanuki): find translations
+                    ' ${attribute.name} ${appLocalizations!.importance_label} "$importanceId"'),
                 actions: <SmoothActionButton>[
                   SmoothActionButton(
-                    text: appLocalizations!.close,
+                    text: appLocalizations.close,
                     onPressed: () => Navigator.pop(context),
                   ),
                 ],


### PR DESCRIPTION
### What
A logical alert message after changing the preference.

### Screenshot
<img width="270" alt="image" src="https://user-images.githubusercontent.com/47862474/167264890-be02bc17-48dc-43d4-b506-89d1b8f46928.png">

### Fixes bug(s)
#1782 

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/525
<!-- please be as granular as possible -->
