### PR TITLE
fix: #1787 - SMOOTHIE-V9

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panel_page.dart
+++ b/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panel_page.dart
@@ -25,7 +25,8 @@ class KnowledgePanelPage extends StatelessWidget {
         ColorDestination.SURFACE_BACKGROUND,
       ),
       appBar: AppBar(
-        title: Text(panel.titleElement!.title),
+        title:
+            panel.titleElement == null ? null : Text(panel.titleElement!.title),
       ),
       body: SingleChildScrollView(
         child: SmoothCard(


### PR DESCRIPTION
Impacted file:
* `knowledge_panel_page.dart`: handled the case when `panel.titleElement==null`

### What
- App used to crash in the rare cases when `panel.titleElement==null`
- the current PR fixes that

### Fixes bug(s)
Fixes: #1787
Fixes SMOOTHIE-V9