### PR TITLE
fix: #1694 - rotate to search card on removal

### DIFF
--- a/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
+++ b/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
@@ -54,6 +54,7 @@ class _SmoothProductCarouselState extends State<SmoothProductCarousel> {
     _model = context.watch<ContinuousScanModel>();
     barcodes = _model.getBarcodes();
     _returnToSearchCard = InheritedDataManager.of(context).showSearchCard;
+    final int cardsCount = barcodes.length + _searchCardAdjustment;
     if (_controller.ready) {
       if (_returnToSearchCard && widget.containSearchCard && _lastIndex > 0) {
         _controller.animateToPage(0);
@@ -61,8 +62,16 @@ class _SmoothProductCarouselState extends State<SmoothProductCarousel> {
           _model.latestConsultedBarcode!.isNotEmpty) {
         final int indexBarcode =
             barcodes.indexOf(_model.latestConsultedBarcode!);
-        final int indexCarousel = indexBarcode + _searchCardAdjustment;
-        _controller.animateToPage(indexCarousel);
+        if (indexBarcode >= 0) {
+          final int indexCarousel = indexBarcode + _searchCardAdjustment;
+          _controller.animateToPage(indexCarousel);
+        } else {
+          if (_lastIndex > cardsCount) {
+            _controller.animateToPage(cardsCount);
+          } else {
+            _controller.animateToPage(_lastIndex);
+          }
+        }
       } else {
         _controller.animateToPage(0);
       }


### PR DESCRIPTION
### What
Don't rotate to search card on single card removal, the carousel should stay on the same spot
More details:  https://github.com/openfoodfacts/smooth-app/issues/1694#issuecomment-1121016244

### Screenshot
https://user-images.githubusercontent.com/87010739/167406110-2ace62a6-4bfc-42ee-bc67-46976970d299.mp4

### Fixes bug(s)
- Fixes: #1694
