### PR TITLE
fix: Attribute indicator addition

### DIFF
--- a/packages/smooth_app/lib/cards/data_cards/score_card.dart
+++ b/packages/smooth_app/lib/cards/data_cards/score_card.dart
@@ -62,6 +62,9 @@ class ScoreCard extends StatelessWidget {
             ),
             flex: 3,
           ),
+          const Icon(
+            Icons.keyboard_arrow_down_outlined,
+          ),
         ],
       ),
       decoration: BoxDecoration(

--- a/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panel_title_card.dart
+++ b/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panel_title_card.dart
@@ -53,9 +53,9 @@ class KnowledgePanelTitleCard extends StatelessWidget {
         children: <Widget>[
           ...iconWidget,
           Expanded(
-              flex: IconWidgetSizer.getRemainingWidgetFlex(),
-              child: LayoutBuilder(
-                  builder: (BuildContext context, BoxConstraints constraints) {
+            flex: IconWidgetSizer.getRemainingWidgetFlex(),
+            child: LayoutBuilder(
+              builder: (BuildContext context, BoxConstraints constraints) {
                 return Wrap(
                   direction: Axis.vertical,
                   children: <Widget>[
@@ -74,7 +74,9 @@ class KnowledgePanelTitleCard extends StatelessWidget {
                       ),
                   ],
                 );
-              })),
+              },
+            ),
+          ),
           const Icon(
             Icons.keyboard_arrow_down_outlined,
           ),

--- a/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panel_title_card.dart
+++ b/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panel_title_card.dart
@@ -75,6 +75,9 @@ class KnowledgePanelTitleCard extends StatelessWidget {
                   ],
                 );
               })),
+          const Icon(
+            Icons.keyboard_arrow_down_outlined,
+          ),
         ],
       ),
     );


### PR DESCRIPTION
### What
<!-- description of the PR -->
- Added indicators on cards to let it be visible that the cards can be tapped

### Screenshot

![Screenshot_1652149963](https://user-images.githubusercontent.com/57723319/167531208-06825b5e-7f3a-455f-b48c-5b826cc24ae5.png)
![Screenshot_1652149980](https://user-images.githubusercontent.com/57723319/167531215-33bb8799-926f-42d2-912e-9d05eab1d609.png)



### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes: #1668 

### Part of 

