### PR TITLE
fix: Navigate to add basic details page 

### DIFF
--- a/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
@@ -133,7 +133,7 @@ class _AddBasicDetailsPageState extends State<AddBasicDetailsPage> {
                       ScaffoldMessenger.of(context).showSnackBar(SnackBar(
                           content: Text(
                               appLocalizations.basic_details_add_success)));
-                      Navigator.pop(context);
+                      Navigator.pop(context, true);
                     }),
               ],
             ),

--- a/packages/smooth_app/lib/pages/product/add_new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_new_product_page.dart
@@ -8,6 +8,7 @@ import 'package:smooth_app/generic_lib/buttons/smooth_action_button.dart';
 import 'package:smooth_app/generic_lib/buttons/smooth_large_button_with_icon.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/pages/image_crop_page.dart';
+import 'package:smooth_app/pages/product/add_basic_details_page.dart';
 import 'package:smooth_app/pages/product/confirm_and_upload_picture.dart';
 import 'package:smooth_app/pages/product/nutrition_page_loaded.dart';
 import 'package:smooth_app/pages/product/ordered_nutrients_cache.dart';
@@ -39,6 +40,7 @@ class _AddNewProductPageState extends State<AddNewProductPage> {
       <ImageField, List<File>>{};
 
   bool _nutritionFactsAdded = false;
+  bool _basicDetailsAdded = false;
   bool _isProductLoaded = false;
 
   @override
@@ -74,12 +76,13 @@ class _AddNewProductPageState extends State<AddNewProductPage> {
                   ),
                   ..._buildImageCaptureRows(context),
                   _buildNutritionInputButton(),
+                  _buildaddInputDetailsButton()
                 ],
               ),
             ),
             Positioned(
               child: Align(
-                alignment: Alignment.bottomRight,
+                alignment: Alignment.topRight,
                 child: SmoothActionButton(
                   text: appLocalizations.finish,
                   onPressed: () {
@@ -269,6 +272,55 @@ class _AddNewProductPageState extends State<AddNewProductPage> {
 
           setState(() {
             _nutritionFactsAdded = result;
+          });
+        },
+      ),
+    );
+  }
+
+  Widget _buildaddInputDetailsButton() {
+    if (_basicDetailsAdded) {
+      return Padding(
+          padding: _ROW_PADDING_TOP,
+          child: Row(
+            mainAxisSize: MainAxisSize.max,
+            mainAxisAlignment: MainAxisAlignment.start,
+            children: <Widget>[
+              const SizedBox(
+                width: 50.0,
+                child: Icon(
+                  Icons.check,
+                  color: Colors.greenAccent,
+                ),
+              ),
+              Expanded(
+                child: Center(
+                  child: Text(
+                      AppLocalizations.of(context)!.basic_details_add_success,
+                      style: Theme.of(context).textTheme.bodyText1),
+                ),
+              ),
+            ],
+          ));
+    }
+
+    return Padding(
+      padding: _ROW_PADDING_TOP,
+      child: SmoothLargeButtonWithIcon(
+        text: AppLocalizations.of(context)!.completed_basic_details_btn_text,
+        icon: Icons.edit,
+        onPressed: () async {
+          final bool result = await Navigator.push<bool>(
+                context,
+                MaterialPageRoute<bool>(
+                  builder: (BuildContext context) => AddBasicDetailsPage(
+                    Product(barcode: widget.barcode),
+                  ),
+                ),
+              ) ??
+              false;
+          setState(() {
+            _basicDetailsAdded = result;
           });
         },
       ),

--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/model/Product.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
+import 'package:smooth_app/pages/product/add_basic_details_page.dart';
 import 'package:smooth_app/pages/product/edit_ingredients_page.dart';
 import 'package:smooth_app/pages/product/nutrition_page_loaded.dart';
 import 'package:smooth_app/pages/product/ordered_nutrients_cache.dart';
@@ -52,6 +53,15 @@ class _EditProductPageState extends State<EditProductPage> {
               title: appLocalizations.edit_product_form_item_details_title,
               subtitle:
                   appLocalizations.edit_product_form_item_details_subtitle,
+              onTap: () async {
+                await Navigator.push<bool>(
+                  context,
+                  MaterialPageRoute<bool>(
+                    builder: (BuildContext context) =>
+                        AddBasicDetailsPage(widget.product),
+                  ),
+                );
+              },
             ),
             _ListTitleItem(
               title: appLocalizations.edit_product_form_item_photos_title,


### PR DESCRIPTION
### What
Added navigation to add basic details page from the full edit mode and in product addition screen.

### Video
https://user-images.githubusercontent.com/47862474/167701848-99129b3b-1ecc-49a7-9f13-ef909966f060.mp4



### Fixes bug(s)
-Fixes: #1804 

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/525
<!-- please be as granular as possible -->
