### PR TITLE
fix: A missing weight should not be blocking

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1156,7 +1156,6 @@
     "brand_name": "Brand name",
     "add_basic_details_brand_name_error": "Please enter the brand name",
     "quantity": "Quantity and weight",
-    "add_basic_details_quantity_error": "Please enter the quantity and weight",
     "barcode": "Barcode",
     "basic_details_add_success": "Basic details added succesfully",
     "basic_details_add_error": "Unable to add basic details. Please try again after some time",

--- a/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
@@ -98,13 +98,6 @@ class _AddBasicDetailsPageState extends State<AddBasicDetailsPage> {
                       controller: _weightController,
                       type: TextFieldTypes.PLAIN_TEXT,
                       hintText: appLocalizations.quantity,
-                      validator: (String? value) {
-                        if (value == null || value.isEmpty) {
-                          return appLocalizations
-                              .add_basic_details_quantity_error;
-                        }
-                        return null;
-                      },
                     ),
                     SizedBox(height: _heightSpace),
                   ],


### PR DESCRIPTION
### What
Removed validations from weight/ quantity input field in add basic details page.

###Video

https://user-images.githubusercontent.com/47862474/167935530-845e173b-393c-41b4-b1ef-dc0f68460252.mp4




### Fixes bug(s)
- Fixes: #1810 

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/525
<!-- please be as granular as possible -->
