### PR TITLE
fix: Irrelevant wording in settings

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -287,7 +287,7 @@
         "description": "Page title: Page where the ranking preferences can be changed"
     },
     "myPreferences_profile_title": "Your Profile",
-    "myPreferences_profile_subtitle": "Change app settings and get advice.",
+    "myPreferences_profile_subtitle": "Manage your Open Food Facts contributor account.",
     "myPreferences_settings_title": "App Settings",
     "myPreferences_settings_subtitle": "Dark mode, Theme, ...",
     "myPreferences_food_title": "Food Preferences",


### PR DESCRIPTION
### What
Changed the translation of `myPreferences_profile_subtitle` to fix irrelevant wording in settings.

### Screenshot
<img width="262" alt="image" src="https://user-images.githubusercontent.com/47862474/168426333-527e1f71-2f13-4c88-bb87-27be45519e2b.png">

### Fixes bug(s)
- Fixes: #1832 

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/525
<!-- please be as granular as possible -->
