### PR TITLE
feat: Improvements when resuming the camera

### DIFF
--- a/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
@@ -117,7 +117,7 @@ class MLKitScannerPageState
   Widget _buildScannerWidget() {
     // Showing the black scanner background + the icon when the scanner is
     // loading or stopped
-    if (isCameraNotInitialized) {
+    if (!isCameraInitialized) {
       return const SizedBox.shrink();
     }
 
@@ -148,7 +148,7 @@ class MLKitScannerPageState
     );
   }
 
-  bool get isCameraNotInitialized => _controller?.isInitialized != true;
+  bool get isCameraInitialized => _controller?.isInitialized == true;
 
   Future<void> _startLiveFeed() async {
     if (_camera == null) {
@@ -267,9 +267,9 @@ class MLKitScannerPageState
       return;
     }
 
-    _controller?.pausePreview();
-
     stoppingCamera = true;
+    await _controller?.pausePreview();
+
     _redrawScreen();
 
     _controller?.removeListener(_cameraListener);

--- a/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
@@ -244,8 +244,8 @@ class MLKitScannerPageState
       return;
     }
 
-    _controller?.pausePreview();
     _streamSubscription?.pause();
+    await _controller?.pausePreview();
   }
 
   Future<void> _onResumeImageStream({bool forceStartPreview = false}) async {
@@ -254,12 +254,12 @@ class MLKitScannerPageState
       return;
     }
 
-    _controller?.resumePreviewIfNecessary();
-    stoppingCamera = false;
-
     if (_streamSubscription?.isPaused == true) {
       _streamSubscription!.resume();
     }
+
+    await _controller?.resumePreviewIfNecessary();
+    stoppingCamera = false;
   }
 
   Future<void> _stopImageStream() async {
@@ -273,7 +273,7 @@ class MLKitScannerPageState
     _redrawScreen();
 
     _controller?.removeListener(_cameraListener);
-
+    await _controller?.pausePreview();
     await _streamSubscription?.cancel();
 
     await _controller?.dispose();


### PR DESCRIPTION
This single PR should fix #1839 #1837 #1861

Instead of recreating a `CameraController` every single time, we use the `pause/resumePreview` feature from the library.

Also, resuming the preview should only happen if the screen is visible.
That's why the `LifecycleManager` now differentiates `onResume` (from the lifecycle) and `onVisible` (from the visibility)