### PR TITLE
fix: User lists: FAB with an incorrect color

### DIFF
--- a/packages/smooth_app/lib/pages/all_user_product_list_page.dart
+++ b/packages/smooth_app/lib/pages/all_user_product_list_page.dart
@@ -68,7 +68,8 @@ class _AllUserProductListState extends State<AllUserProductList> {
               },
             ),
       floatingActionButton: FloatingActionButton(
-        child: const Icon(Icons.add),
+        backgroundColor: Theme.of(context).colorScheme.primary,
+        foregroundColor: Theme.of(context).colorScheme.onPrimary,
         onPressed: () async {
           final ProductList? newProductList =
               await ProductListUserDialogHelper(daoProductList)
@@ -78,6 +79,7 @@ class _AllUserProductListState extends State<AllUserProductList> {
           }
           setState(() {});
         },
+        child: const Icon(Icons.add),
       ),
     );
   }

--- a/packages/smooth_app/lib/pages/all_user_product_list_page.dart
+++ b/packages/smooth_app/lib/pages/all_user_product_list_page.dart
@@ -68,8 +68,6 @@ class _AllUserProductListState extends State<AllUserProductList> {
               },
             ),
       floatingActionButton: FloatingActionButton(
-        backgroundColor: Theme.of(context).colorScheme.primary,
-        foregroundColor: Theme.of(context).colorScheme.onPrimary,
         onPressed: () async {
           final ProductList? newProductList =
               await ProductListUserDialogHelper(daoProductList)

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -75,7 +75,6 @@ class _ProductPageState extends State<ProductPage> {
       ),
       floatingActionButton: scrollingUp
           ? FloatingActionButton(
-              backgroundColor: colorScheme.primary,
               onPressed: () {
                 Navigator.maybePop(context);
               },

--- a/packages/smooth_app/lib/themes/smooth_theme.dart
+++ b/packages/smooth_app/lib/themes/smooth_theme.dart
@@ -104,13 +104,16 @@ class SmoothTheme {
   ) {
     ColorScheme myColorScheme;
     if (brightness == Brightness.dark) {
-      myColorScheme = const ColorScheme.dark();
+      myColorScheme = const ColorScheme.dark(
+        secondary: Color(0xffbb86fc),
+      );
     } else {
       final MaterialColor materialColor =
           MATERIAL_COLORS[colorTag] ?? MATERIAL_COLORS[COLOR_TAG_BLUE]!;
       myColorScheme = ColorScheme.light(
         primary: materialColor[600]!,
         primaryContainer: materialColor[900],
+        secondary: materialColor[600]!,
       );
     }
 
@@ -122,8 +125,8 @@ class SmoothTheme {
       ),
       textTheme: _TEXT_THEME,
       floatingActionButtonTheme: FloatingActionButtonThemeData(
-        backgroundColor: myColorScheme.primary,
-        foregroundColor: myColorScheme.onPrimary,
+        backgroundColor: myColorScheme.secondary,
+        foregroundColor: myColorScheme.onSecondary,
       ),
       appBarTheme: AppBarTheme(
         color: brightness == Brightness.dark ? null : myColorScheme.primary,

--- a/packages/smooth_app/lib/themes/smooth_theme.dart
+++ b/packages/smooth_app/lib/themes/smooth_theme.dart
@@ -122,8 +122,8 @@ class SmoothTheme {
       ),
       textTheme: _TEXT_THEME,
       floatingActionButtonTheme: FloatingActionButtonThemeData(
-        backgroundColor: myColorScheme.secondary,
-        foregroundColor: myColorScheme.onSecondary,
+        backgroundColor: myColorScheme.primary,
+        foregroundColor: myColorScheme.onPrimary,
       ),
       appBarTheme: AppBarTheme(
         color: brightness == Brightness.dark ? null : myColorScheme.primary,


### PR DESCRIPTION
### What
Added`backgroundColor` and `foregroundColor` to FAB on `all_user_product_list_page.dart`.

### Screenshot
Light Mode:
<img width="267" alt="image" src="https://user-images.githubusercontent.com/47862474/168641994-810e5713-1b25-40d4-b87a-39fda4c0e981.png">

Dark Mode:
<img width="265" alt="image" src="https://user-images.githubusercontent.com/47862474/168642021-d51eaf5e-a9ec-43f7-b99a-bf156e0527dd.png">


### Fixes bug(s)
- Fixes: #1851 

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/525
<!-- please be as granular as possible -->
