### PR TITLE
fix: #1455 - make tappable header no selectable

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panel_table_card.dart
+++ b/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panel_table_card.dart
@@ -274,13 +274,17 @@ class _TableCellWidgetState extends State<TableCellWidget> {
     if (widget.cell.color != null) {
       style = style.apply(color: widget.cell.color);
     }
-    if (!widget.cell.isHeader || widget.cell.columnGroup!.columns.length == 1) {
-      return _buildHtmlCell(padding, style);
+    if (widget.cell.isHeader && widget.cell.columnGroup!.columns.length == 1) {
+      return _buildHtmlCell(padding, style, false);
+    } else if (!widget.cell.isHeader ||
+        widget.cell.columnGroup!.columns.length == 1) {
+      return _buildHtmlCell(padding, style, true);
     }
     return _buildDropDownColumnHeader(padding, style);
   }
 
-  Widget _buildHtmlCell(EdgeInsets padding, TextStyle style) {
+  Widget _buildHtmlCell(
+      EdgeInsets padding, TextStyle style, bool isSelectable) {
     String cellText = widget.cell.text;
     if (!_isExpanded) {
       const String htmlStyle = '''
@@ -301,6 +305,7 @@ class _TableCellWidgetState extends State<TableCellWidget> {
           child: SmoothHtmlWidget(
             cellText,
             textStyle: style,
+            isSelectable: isSelectable,
           ),
         ),
       ),

--- a/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panel_table_card.dart
+++ b/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panel_table_card.dart
@@ -275,16 +275,16 @@ class _TableCellWidgetState extends State<TableCellWidget> {
       style = style.apply(color: widget.cell.color);
     }
     if (widget.cell.isHeader && widget.cell.columnGroup!.columns.length == 1) {
-      return _buildHtmlCell(padding, style, false);
+      return _buildHtmlCell(padding, style, isSelectable: false);
     } else if (!widget.cell.isHeader ||
         widget.cell.columnGroup!.columns.length == 1) {
-      return _buildHtmlCell(padding, style, true);
+      return _buildHtmlCell(padding, style, isSelectable: true);
     }
     return _buildDropDownColumnHeader(padding, style);
   }
 
-  Widget _buildHtmlCell(
-      EdgeInsets padding, TextStyle style, bool isSelectable) {
+  Widget _buildHtmlCell(EdgeInsets padding, TextStyle style,
+      {required bool isSelectable}) {
     String cellText = widget.cell.text;
     if (!_isExpanded) {
       const String htmlStyle = '''

--- a/packages/smooth_app/lib/generic_lib/smooth_html_widget.dart
+++ b/packages/smooth_app/lib/generic_lib/smooth_html_widget.dart
@@ -4,10 +4,12 @@ import 'package:fwfh_selectable_text/fwfh_selectable_text.dart';
 import 'package:smooth_app/helpers/launch_url_helper.dart';
 
 class SmoothHtmlWidget extends StatelessWidget {
-  const SmoothHtmlWidget(this.htmlString, {this.textStyle});
+  const SmoothHtmlWidget(this.htmlString,
+      {this.textStyle, this.isSelectable = true});
 
   final String htmlString;
   final TextStyle? textStyle;
+  final bool isSelectable;
 
   @override
   Widget build(BuildContext context) {
@@ -18,7 +20,8 @@ class SmoothHtmlWidget extends StatelessWidget {
         await LaunchUrlHelper.launchURL(url, false);
         return true;
       },
-      factoryBuilder: () => SelectableHtmlWidgetFactory(),
+      factoryBuilder: () =>
+          isSelectable ? SelectableHtmlWidgetFactory() : WidgetFactory(),
       enableCaching: false,
     );
   }


### PR DESCRIPTION
### What
Make tappable header no selectable (Nutrition facts, 100g, Compare to ...)

### Screenshot
<!-- Insert a screenshot to provide visual record of your changes, if visible -->
![Simulator Screen Shot - iPhone 13 - 2022-05-17 at 11 18 53](https://user-images.githubusercontent.com/87010739/168777415-6d68c2c1-2c03-4f83-a76b-752acdb02fab.png)


### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes: #1455

