### PR TITLE
fix: DevMode AlertDialog non barrierDismissible

### DIFF
--- a/packages/smooth_app/lib/pages/user_management/forgot_password_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/forgot_password_page.dart
@@ -3,7 +3,9 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
+import 'package:smooth_app/generic_lib/buttons/smooth_action_button.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_text_form_field.dart';
 import 'package:smooth_app/themes/theme_provider.dart';
@@ -146,15 +148,17 @@ class _ForgotPasswordPageState extends State<ForgotPasswordPage> {
                           if (_devModeCounter >= 10) {
                             if (userPreferences.devMode == 0) {
                               showDialog<void>(
+                                barrierDismissible: false,
                                 context: context,
-                                builder: (BuildContext context) => AlertDialog(
-                                  title: Text(
+                                builder: (BuildContext context) =>
+                                    SmoothAlertDialog(
+                                  body: Text(
                                     appLocalizations
                                         .enable_dev_mode_dialog_title,
                                   ),
-                                  actions: <Widget>[
-                                    TextButton(
-                                      child: Text(appLocalizations.yes),
+                                  actions: <SmoothActionButton>[
+                                    SmoothActionButton(
+                                      text: appLocalizations.yes,
                                       onPressed: () async {
                                         await userPreferences.setDevMode(1);
                                         if (!mounted) {
@@ -163,8 +167,8 @@ class _ForgotPasswordPageState extends State<ForgotPasswordPage> {
                                         Navigator.pop(context);
                                       },
                                     ),
-                                    TextButton(
-                                      child: Text(appLocalizations.no),
+                                    SmoothActionButton(
+                                      text: appLocalizations.no,
                                       onPressed: () => Navigator.pop(context),
                                     )
                                   ],


### PR DESCRIPTION
### What
When activating the DevMode you  oftentimes clicked away the dialog now it's not dismissable by clicking outside anymore.
&Switching to SmoothAlertDialog
