### PR TITLE
feat: Migrate to OFF fork of `google_ml_barcode_scanner`

### DIFF
--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -387,7 +387,7 @@ packages:
       path: "."
       ref: master
       resolved-ref: "5427e2a735be24b5f6b646a2554c636845ce9597"
-      url: "https://github.com/cli1005/google_ml_barcode_scanner.git"
+      url: "https://github.com/openfoodfacts/google_ml_barcode_scanner.git"
     source: git
     version: "0.0.2"
   hive:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -49,10 +49,10 @@ dependencies:
   percent_indicator: ^4.2.2
   mailto: ^2.0.0
   flutter_native_splash: ^2.1.6
-  # Fork from cli1005 with iOS fix cf: https://github.com/openfoodfacts/smooth-app/issues/1155
+  # OFF fork, because the maintainer doesn't answer to our requests: https://github.com/openfoodfacts/smooth-app/issues/1155
   google_ml_barcode_scanner:
     git:
-      url: https://github.com/cli1005/google_ml_barcode_scanner.git
+      url: https://github.com/openfoodfacts/google_ml_barcode_scanner.git
       ref: master
   image_cropper: ^2.0.2
   auto_size_text: ^3.0.0


### PR DESCRIPTION
Following discussions on #1880, we now have a fork of the MLKit library.