### PR TITLE
feat: Migration to google_mlkit_barcode_scanning

### DIFF
--- a/packages/smooth_app/ios/Podfile.lock
+++ b/packages/smooth_app/ios/Podfile.lock
@@ -2,22 +2,28 @@ PODS:
   - camera (0.0.1):
     - Flutter
   - Flutter (1.0.0)
+  - flutter_isolate (0.0.1):
+    - Flutter
   - flutter_native_splash (0.0.1):
     - Flutter
   - flutter_secure_storage (3.3.1):
     - Flutter
-  - google_ml_barcode_scanner (0.0.1):
+  - google_mlkit_barcode_scanning (0.3.0):
     - Flutter
-    - GoogleMLKit/BarcodeScanning (~> 2.2.0)
+    - google_mlkit_commons
+    - GoogleMLKit/BarcodeScanning (~> 2.6.0)
+  - google_mlkit_commons (0.2.0):
+    - Flutter
+    - MLKitVision
   - GoogleDataTransport (9.1.2):
     - GoogleUtilities/Environment (~> 7.2)
     - nanopb (~> 2.30908.0)
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleMLKit/BarcodeScanning (2.2.0):
+  - GoogleMLKit/BarcodeScanning (2.6.0):
     - GoogleMLKit/MLKitCore
-    - MLKitBarcodeScanning (~> 1.3.0)
-  - GoogleMLKit/MLKitCore (2.2.0):
-    - MLKitCommon (~> 3.0.0)
+    - MLKitBarcodeScanning (~> 1.7.0)
+  - GoogleMLKit/MLKitCore (2.6.0):
+    - MLKitCommon (~> 5.0.0)
   - GoogleToolboxForMac/DebugUtils (2.3.2):
     - GoogleToolboxForMac/Defines (= 2.3.2)
   - GoogleToolboxForMac/Defines (2.3.2)
@@ -50,11 +56,11 @@ PODS:
     - Flutter
   - matomo_forever (0.0.1):
     - Flutter
-  - MLImage (1.0.0-beta1)
-  - MLKitBarcodeScanning (1.3.0):
-    - MLKitCommon (~> 3.0)
-    - MLKitVision (~> 1.3)
-  - MLKitCommon (3.0.0):
+  - MLImage (1.0.0-beta2)
+  - MLKitBarcodeScanning (1.7.0):
+    - MLKitCommon (~> 5.0)
+    - MLKitVision (~> 3.0)
+  - MLKitCommon (5.0.0):
     - GoogleDataTransport (~> 9.0)
     - GoogleToolboxForMac/Logger (~> 2.1)
     - "GoogleToolboxForMac/NSData+zlib (~> 2.1)"
@@ -63,12 +69,12 @@ PODS:
     - GoogleUtilitiesComponents (~> 1.0)
     - GTMSessionFetcher/Core (~> 1.1)
     - Protobuf (~> 3.12)
-  - MLKitVision (1.3.0):
+  - MLKitVision (3.0.0):
     - GoogleToolboxForMac/Logger (~> 2.1)
     - "GoogleToolboxForMac/NSData+zlib (~> 2.1)"
     - GTMSessionFetcher/Core (~> 1.1)
-    - MLImage (= 1.0.0-beta1)
-    - MLKitCommon (~> 3.0)
+    - MLImage (= 1.0.0-beta2)
+    - MLKitCommon (~> 5.0)
     - Protobuf (~> 3.12)
   - MTBBarcodeScanner (5.0.11)
   - nanopb (2.30908.0):
@@ -103,9 +109,11 @@ PODS:
 DEPENDENCIES:
   - camera (from `.symlinks/plugins/camera/ios`)
   - Flutter (from `Flutter`)
+  - flutter_isolate (from `.symlinks/plugins/flutter_isolate/ios`)
   - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
-  - google_ml_barcode_scanner (from `.symlinks/plugins/google_ml_barcode_scanner/ios`)
+  - google_mlkit_barcode_scanning (from `.symlinks/plugins/google_mlkit_barcode_scanning/ios`)
+  - google_mlkit_commons (from `.symlinks/plugins/google_mlkit_commons/ios`)
   - image_cropper (from `.symlinks/plugins/image_cropper/ios`)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
@@ -143,12 +151,16 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/camera/ios"
   Flutter:
     :path: Flutter
+  flutter_isolate:
+    :path: ".symlinks/plugins/flutter_isolate/ios"
   flutter_native_splash:
     :path: ".symlinks/plugins/flutter_native_splash/ios"
   flutter_secure_storage:
     :path: ".symlinks/plugins/flutter_secure_storage/ios"
-  google_ml_barcode_scanner:
-    :path: ".symlinks/plugins/google_ml_barcode_scanner/ios"
+  google_mlkit_barcode_scanning:
+    :path: ".symlinks/plugins/google_mlkit_barcode_scanning/ios"
+  google_mlkit_commons:
+    :path: ".symlinks/plugins/google_mlkit_commons/ios"
   image_cropper:
     :path: ".symlinks/plugins/image_cropper/ios"
   image_picker_ios:
@@ -177,11 +189,13 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   camera: 9993f92f2c793e87b65e35f3a23c70582afb05b1
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
+  flutter_isolate: 0edf5081826d071adf21759d1eb10ff5c24503b5
   flutter_native_splash: 52501b97d1c0a5f898d687f1646226c1f93c56ef
   flutter_secure_storage: 7953c38a04c3fdbb00571bcd87d8e3b5ceb9daec
-  google_ml_barcode_scanner: 469be1279c5ab275846f0957c85015b7b30d0c16
+  google_mlkit_barcode_scanning: 56e88993b6c915ce7134f9d77cb5b2de2fca8cfa
+  google_mlkit_commons: e9070f57232c3a3e4bd42fdfa621bb1f4bb3e709
   GoogleDataTransport: 629c20a4d363167143f30ea78320d5a7eb8bd940
-  GoogleMLKit: 85ffdc9641d05311c76dbba5bbf93059087be12f
+  GoogleMLKit: 755661c46990a85e42278015f26400286d98ad95
   GoogleToolboxForMac: 8bef7c7c5cf7291c687cf5354f39f9db6399ad34
   GoogleUtilities: e0913149f6b0625b553d70dae12b49fc62914fd1
   GoogleUtilitiesComponents: 679b2c881db3b615a2777504623df6122dd20afe
@@ -191,10 +205,10 @@ SPEC CHECKSUMS:
   integration_test: a1e7d09bd98eca2fc37aefd79d4f41ad37bdbbe5
   iso_countries: eb09d40f388e4c65e291e0bb36a701dfe7de6c74
   matomo_forever: 7e5e5fd8f355f64979591282cad4e858fa4c9fae
-  MLImage: 647f3d580c10b3c9a3f6154f5d7baead60c42a0c
-  MLKitBarcodeScanning: 6b998bd1cfe471ae407a7f647d649494617787c0
-  MLKitCommon: 6d6be0a2e9a6340aad1c1f2b9449c11dee8af70f
-  MLKitVision: 26da299aef93291f24f5200e8372919f73abf3b5
+  MLImage: a454f9f8ecfd537783a12f9488f5be1a68820829
+  MLKitBarcodeScanning: b8257854f6afc1c8443d61ec6b98c28b35625df6
+  MLKitCommon: 3bc17c6f7d25ce3660f030350b46ae7ec9ebca6e
+  MLKitVision: e87dc3f2e456a6ab32361ebd985e078dd2746143
   MTBBarcodeScanner: f453b33c4b7dfe545d8c6484ed744d55671788cb
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
   package_info_plus: 6c92f08e1f853dc01228d6f553146438dafcd14e

--- a/packages/smooth_app/ios/Runner/Info.plist
+++ b/packages/smooth_app/ios/Runner/Info.plist
@@ -53,5 +53,7 @@
 		</array>
 		<key>UIRequiresFullScreen</key>
 		<true/>
-	</dict>
+		<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
+</dict>
 </plist>

--- a/packages/smooth_app/lib/pages/scan/abstract_camera_image_getter.dart
+++ b/packages/smooth_app/lib/pages/scan/abstract_camera_image_getter.dart
@@ -1,7 +1,8 @@
 import 'dart:typed_data';
+
 import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
-import 'package:google_ml_barcode_scanner/google_ml_barcode_scanner.dart';
+import 'package:google_mlkit_barcode_scanning/google_mlkit_barcode_scanning.dart';
 
 /// Abstract getter of Camera Image, for barcode scan.
 ///
@@ -14,12 +15,12 @@ abstract class AbstractCameraImageGetter {
 
   InputImage getInputImage() {
     final InputImageRotation imageRotation =
-        InputImageRotationMethods.fromRawValue(
+        InputImageRotationValue.fromRawValue(
                 cameraDescription.sensorOrientation) ??
-            InputImageRotation.Rotation_0deg;
+            InputImageRotation.rotation0deg;
 
     final InputImageFormat inputImageFormat =
-        InputImageFormatMethods.fromRawValue(
+        InputImageFormatValue.fromRawValue(
       int.parse(cameraImage.format.raw.toString()),
     )!;
 

--- a/packages/smooth_app/lib/pages/scan/camera_image_cropper.dart
+++ b/packages/smooth_app/lib/pages/scan/camera_image_cropper.dart
@@ -1,7 +1,8 @@
 import 'dart:typed_data';
+
 import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
-import 'package:google_ml_barcode_scanner/google_ml_barcode_scanner.dart';
+import 'package:google_mlkit_barcode_scanning/google_mlkit_barcode_scanning.dart';
 import 'package:smooth_app/pages/scan/abstract_camera_image_getter.dart';
 import 'package:typed_data/typed_buffers.dart';
 

--- a/packages/smooth_app/lib/pages/scan/camera_image_full_getter.dart
+++ b/packages/smooth_app/lib/pages/scan/camera_image_full_getter.dart
@@ -1,8 +1,9 @@
 import 'dart:typed_data';
+
 import 'package:camera/camera.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:google_ml_barcode_scanner/google_ml_barcode_scanner.dart';
+import 'package:google_mlkit_barcode_scanning/google_mlkit_barcode_scanning.dart';
 import 'package:smooth_app/pages/scan/abstract_camera_image_getter.dart';
 
 /// Camera Image helper where we get the full image.

--- a/packages/smooth_app/lib/pages/scan/mkit_scan_helper.dart
+++ b/packages/smooth_app/lib/pages/scan/mkit_scan_helper.dart
@@ -3,7 +3,7 @@ import 'dart:isolate';
 
 import 'package:camera/camera.dart';
 import 'package:flutter_isolate/flutter_isolate.dart';
-import 'package:google_ml_barcode_scanner/google_ml_barcode_scanner.dart';
+import 'package:google_mlkit_barcode_scanning/google_mlkit_barcode_scanning.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_dev_mode.dart';
 import 'package:smooth_app/pages/scan/abstract_camera_image_getter.dart';
 import 'package:smooth_app/pages/scan/camera_image_cropper.dart';
@@ -154,9 +154,8 @@ class _MLKitScanDecoderMainIsolate {
 class _MLKitScanDecoderIsolate {
   // Only 1D barcodes. More info on:
   // [https://www.scandit.com/blog/types-barcodes-choosing-right-barcode/]
-  static final BarcodeScanner _barcodeScanner =
-      GoogleMlKit.vision.barcodeScanner(
-    <BarcodeFormat>[
+  static final BarcodeScanner _barcodeScanner = BarcodeScanner(
+    formats: <BarcodeFormat>[
       BarcodeFormat.ean8,
       BarcodeFormat.ean13,
       BarcodeFormat.upca,
@@ -234,7 +233,7 @@ class _MLKitScanDecoderIsolate {
 
     port.send(
       barcodes
-          .map((Barcode barcode) => barcode.value.rawValue)
+          .map((Barcode barcode) => barcode.rawValue)
           .where((String? barcode) => barcode?.isNotEmpty == true)
           .cast<String>()
           .toList(growable: false),

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -84,7 +84,7 @@ packages:
       name: camera
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.5"
+    version: "0.9.5+1"
   camera_platform_interface:
     dependency: transitive
     description:
@@ -381,15 +381,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.2"
-  google_ml_barcode_scanner:
+  google_mlkit_barcode_scanning:
     dependency: "direct main"
     description:
-      path: "."
-      ref: master
-      resolved-ref: "5427e2a735be24b5f6b646a2554c636845ce9597"
-      url: "https://github.com/cli1005/google_ml_barcode_scanner.git"
-    source: git
-    version: "0.0.2"
+      name: google_mlkit_barcode_scanning
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.0"
+  google_mlkit_commons:
+    dependency: transitive
+    description:
+      name: google_mlkit_commons
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.0"
   hive:
     dependency: "direct main"
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -45,15 +45,11 @@ dependencies:
   sentry_flutter: ^6.5.1 # careful with upgrading cf: https://github.com/openfoodfacts/smooth-app/issues/1300
   url_launcher: ^6.1.2
   visibility_detector: ^0.3.3
-  camera: ^0.9.5
+  camera: ^0.9.5+1
   percent_indicator: ^4.2.2
   mailto: ^2.0.0
   flutter_native_splash: ^2.1.6
-  # Fork from cli1005 with iOS fix cf: https://github.com/openfoodfacts/smooth-app/issues/1155
-  google_ml_barcode_scanner:
-    git:
-      url: https://github.com/cli1005/google_ml_barcode_scanner.git
-      ref: master
+  google_mlkit_barcode_scanning: ^0.3.0
   image_cropper: ^2.0.2
   auto_size_text: ^3.0.0
   shared_preferences: ^2.0.15


### PR DESCRIPTION
The current library used to embed MLKit `google_mlkit_barcode_scanning` seems to be unmaintained.
As suggested by @M123-dev, `google_ml_kit` is a perfect replacement by providing latest versions of MLKit (both on Android and iOS).

Furthermore, the bug requiring of fork (following #1155) is also fixed in this dependency.