### PR TITLE
fix: The app is now able to restart the camera if it was claimed by another app

### DIFF
--- a/packages/smooth_app/lib/helpers/camera_helper.dart
+++ b/packages/smooth_app/lib/helpers/camera_helper.dart
@@ -60,5 +60,9 @@ class CameraHelper {
     _controller ??= controller;
   }
 
+  static void destroyControllerInstance() {
+    _controller = null;
+  }
+
   static SmoothCameraController? get controller => _controller;
 }

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -123,12 +123,14 @@ packages:
   camera:
     dependency: "direct main"
     description:
-      name: camera
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "packages/camera/camera"
+      ref: camera_fix_debug
+      resolved-ref: "175e5acdcf9ef198819d953a29700450aca8e7a8"
+      url: "https://github.com/g123k/plugins.git"
+    source: git
     version: "0.9.6"
   camera_platform_interface:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: camera_platform_interface
       url: "https://pub.dartlang.org"

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -40,7 +40,13 @@ dependencies:
   sentry_flutter: ^6.5.1 # careful with upgrading cf: https://github.com/openfoodfacts/smooth-app/issues/1300
   url_launcher: ^6.1.2
   visibility_detector: ^0.3.3
-  camera: ^0.9.5+1
+  # Until the PR is merged, we have a fork of the camera plugin: https://github.com/openfoodfacts/smooth-app/issues/1892
+  camera:
+    git:
+      url: 'https://github.com/g123k/plugins.git'
+      ref: 'camera_fix_debug'
+      path: 'packages/camera/camera'
+  camera_platform_interface: any
   percent_indicator: ^4.2.2
   mailto: ^2.0.0
   flutter_native_splash: ^2.1.6


### PR DESCRIPTION
The camera, my favorite topic 😅!

In the current version, we have a blocking issue on Android, that is easily reproducible.
1. Use Smoothie
2. Open the Camera app (on some smartphones, a double tap on the "ON/OFF" button allows this)
3. Reopen Smoothie

When the camera is claimed by another app, the native code doesn't inform the Dart side, that the camera is not available anymore and should be restarted later. That's the goal of [my edits in the fork](https://github.com/g123k/plugins/tree/camera_fix_debug):
- There is a potential deadlock, due to a `join()` without any timeout. And no message was sent in that case.
- (Not mandatory) Calling `resumePreview` should send the potential native errors

On the Dart side now, we listen to `closed` events from the camera. In that case, the Controller is totally destroyed (a singleton) and recreated once the app is reopened.

Will fix #1892