### PR TITLE
fix: Custom layout for the scan page

### DIFF
--- a/packages/smooth_app/lib/pages/scan/scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/scan_page.dart
@@ -12,6 +12,7 @@ import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/helpers/permission_helper.dart';
 import 'package:smooth_app/pages/scan/ml_kit_scan_page.dart';
+import 'package:smooth_app/pages/scan/scan_visor.dart';
 import 'package:smooth_app/pages/scan/scanner_overlay.dart';
 import 'package:smooth_app/widgets/smooth_product_carousel.dart';
 

--- a/packages/smooth_app/lib/pages/scan/scan_visor.dart
+++ b/packages/smooth_app/lib/pages/scan/scan_visor.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:smooth_app/generic_lib/widgets/smooth_view_finder.dart';
+import 'package:smooth_app/pages/scan/scanner_overlay.dart';
+
+class ScannerVisorWidget extends StatelessWidget {
+  const ScannerVisorWidget({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final Size screenSize = MediaQuery.of(context).size;
+
+    final Size scannerSize = Size(
+      screenSize.width * ScannerOverlay.scannerWidthPct,
+      getVisorHeight(screenSize),
+    );
+
+    return SmoothViewFinder(
+      boxSize: scannerSize,
+      lineLength: screenSize.width * 0.8,
+    );
+  }
+
+  static double getVisorHeight(Size size) {
+    return size.width * ScannerOverlay.scannerHeightPct;
+  }
+}

--- a/packages/smooth_app/lib/pages/scan/scanner_overlay.dart
+++ b/packages/smooth_app/lib/pages/scan/scanner_overlay.dart
@@ -4,6 +4,7 @@ import 'package:smooth_app/data_models/continuous_scan_model.dart';
 import 'package:smooth_app/generic_lib/animations/smooth_reveal_animation.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_view_finder.dart';
 import 'package:smooth_app/pages/scan/scan_header.dart';
+import 'package:smooth_app/pages/scan/scan_visor.dart';
 import 'package:smooth_app/widgets/smooth_product_carousel.dart';
 
 /// This builds all the essential widgets which are displayed above the camera
@@ -29,98 +30,204 @@ class ScannerOverlay extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ContinuousScanModel model = context.watch<ContinuousScanModel>();
-    return LayoutBuilder(
-      builder: (
-        BuildContext context,
-        BoxConstraints constraints,
-      ) {
-        final Size screenSize = MediaQuery.of(context).size;
 
-        final double carouselHeight =
-            constraints.maxHeight * ScannerOverlay.carouselHeightPct;
-        final double buttonRowHeight = model.getBarcodes().isNotEmpty
-            ? ScannerOverlay.buttonRowHeightPx
-            : 0;
-        final double availableScanHeight =
-            constraints.maxHeight - carouselHeight - buttonRowHeight;
+    return CustomMultiChildLayout(
+      delegate: _ScannerOverlayDelegate(
+        devicePadding: MediaQuery.of(context).padding,
+        visibleActions: model.getBarcodes().isNotEmpty,
+        hasVisor: _topItem is ScannerVisorWidget,
+      ),
+      children: <Widget>[
+        _background,
+        _topItem,
+        _actions,
+        _carousel,
+      ],
+    );
+  }
 
-        final Size scannerContainerSize = Size(
-          screenSize.width,
-          availableScanHeight - carouselBottomPadding,
-        );
+  Widget get _background {
+    if (backgroundChild == null) {
+      return const ColoredBox(color: Colors.black);
+    }
 
-        return Container(
-          color: Colors.black,
-          child: Stack(
-            children: <Widget>[
-              //Scanner
-              if (backgroundChild != null)
-                // Force the child to take the full space, otherwise the
-                // [VisibilityDetector] may return incorrect results
-                SmoothRevealAnimation(
-                  delay: 400,
-                  startOffset: Offset.zero,
-                  animationCurve: Curves.easeInOutBack,
-                  child: SizedBox.expand(
-                    child: backgroundChild,
-                  ),
-                ),
-              // Scanning area overlay
-              SmoothRevealAnimation(
-                delay: 400,
-                startOffset: const Offset(0.0, 0.1),
-                animationCurve: Curves.easeInOutBack,
-                child: ConstrainedBox(
-                  constraints: BoxConstraints.tight(
-                    scannerContainerSize,
-                  ),
-                  child: Center(child: topChild),
-                ),
-              ),
-              // Product carousel
-              SmoothRevealAnimation(
-                delay: 400,
-                startOffset: const Offset(0.0, -0.1),
-                animationCurve: Curves.easeInOutBack,
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.start,
-                  children: <Widget>[
-                    const SafeArea(top: true, child: ScanHeader()),
-                    const Spacer(),
-                    Padding(
-                      padding:
-                          const EdgeInsets.only(bottom: carouselBottomPadding),
-                      child: SmoothProductCarousel(
-                        containSearchCard: true,
-                        height: carouselHeight,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ],
+    return LayoutId(
+      id: _LayoutIds.background,
+      child: SmoothRevealAnimation(
+        delay: 400,
+        startOffset: Offset.zero,
+        animationCurve: Curves.easeInOutBack,
+        child: backgroundChild!,
+      ),
+    );
+  }
+
+  /// Visor or message (eg: permission not granted)
+  Widget get _topItem {
+    return LayoutId(
+      id: _LayoutIds.topItem,
+      child: SmoothRevealAnimation(
+        delay: 400,
+        startOffset: const Offset(0.0, 0.1),
+        animationCurve: Curves.easeInOutBack,
+        child: Center(child: topChild),
+      ),
+    );
+  }
+
+  Widget get _actions {
+    return LayoutId(
+      id: _LayoutIds.actions,
+      child: const SmoothRevealAnimation(
+        delay: 400,
+        startOffset: Offset(0.0, -0.1),
+        animationCurve: Curves.easeInOutBack,
+        child: ScanHeader(),
+      ),
+    );
+  }
+
+  Widget get _carousel {
+    return LayoutId(
+      id: _LayoutIds.carousel,
+      child: const SmoothRevealAnimation(
+        delay: 400,
+        startOffset: Offset(0.0, -0.1),
+        animationCurve: Curves.easeInOutBack,
+        child: Padding(
+          padding: EdgeInsets.only(
+            bottom: carouselBottomPadding,
           ),
-        );
-      },
+          child: SmoothProductCarousel(
+            containSearchCard: true,
+          ),
+        ),
+      ),
     );
   }
 }
 
-class ScannerVisorWidget extends StatelessWidget {
-  const ScannerVisorWidget({Key? key}) : super(key: key);
+enum _LayoutIds { background, actions, topItem, carousel }
+
+class _ScannerOverlayDelegate extends MultiChildLayoutDelegate {
+  _ScannerOverlayDelegate({
+    required this.devicePadding,
+    required this.visibleActions,
+    required this.hasVisor,
+  });
+
+  final EdgeInsets devicePadding;
+  final bool visibleActions;
+  final bool hasVisor;
 
   @override
-  Widget build(BuildContext context) {
-    final Size screenSize = MediaQuery.of(context).size;
+  void performLayout(Size size) {
+    _layoutBackground(size);
+    final double carouselHeight = _layoutAndPositionCarousel(size);
+    final double actionsHeight = _layoutAndPositionActions(size);
 
-    final Size scannerSize = Size(
-      screenSize.width * ScannerOverlay.scannerWidthPct,
-      screenSize.width * ScannerOverlay.scannerHeightPct,
-    );
+    if (hasVisor) {
+      _layoutAndPositionVisor(size, carouselHeight, actionsHeight);
+    } else {
+      _layoutAndPositionTopItem(size, carouselHeight);
+    }
+  }
 
-    return SmoothViewFinder(
-      boxSize: scannerSize,
-      lineLength: screenSize.width * 0.8,
+  /// Background: Take the full width
+  void _layoutBackground(Size size) {
+    layoutChild(
+      _LayoutIds.background,
+      BoxConstraints(
+        maxWidth: size.width,
+        maxHeight: size.height,
+      ),
     );
   }
+
+  /// Product carousel: bottom of the screen
+  /// Will return the height of the carousel
+  double _layoutAndPositionCarousel(Size size) {
+    final double carouselHeight =
+        size.height * ScannerOverlay.carouselHeightPct;
+
+    layoutChild(
+      _LayoutIds.carousel,
+      BoxConstraints.tightFor(
+        width: size.width,
+        height: carouselHeight,
+      ),
+    );
+
+    positionChild(_LayoutIds.carousel, Offset(0, size.height - carouselHeight));
+    return carouselHeight;
+  }
+
+  /// Visor: between the bottom of the  status bar (or the actions if there is
+  /// not enough space) and the carousel
+  void _layoutAndPositionVisor(
+    Size size,
+    double carouselHeight,
+    double actionsHeight,
+  ) {
+    layoutChild(
+      _LayoutIds.topItem,
+      BoxConstraints.tightFor(
+        width: size.width,
+        height: size.height - carouselHeight - devicePadding.top,
+      ),
+    );
+  }
+
+  /// Top item: below the status bar
+  void _layoutAndPositionTopItem(
+    Size size,
+    double carouselHeight,
+  ) {
+    layoutChild(
+      _LayoutIds.topItem,
+      BoxConstraints.tightFor(
+        width: size.width,
+        height: size.height - carouselHeight - devicePadding.top,
+      ),
+    );
+
+    positionChild(
+      _LayoutIds.topItem,
+      Offset(
+        0,
+        devicePadding.top,
+      ),
+    );
+  }
+
+  /// Actions: top of the screen and limit the height
+  /// Returns the height
+  double _layoutAndPositionActions(Size size) {
+    if (hasChild(_LayoutIds.actions)) {
+      final Size actionsSize = layoutChild(
+        _LayoutIds.actions,
+        BoxConstraints(
+          minWidth: size.width,
+          maxWidth: size.width,
+          maxHeight: size.height * 0.2,
+        ),
+      );
+
+      positionChild(
+        _LayoutIds.actions,
+        Offset(
+          0,
+          devicePadding.top,
+        ),
+      );
+
+      return actionsSize.height;
+    } else {
+      return 0.0;
+    }
+  }
+
+  @override
+  bool shouldRelayout(covariant MultiChildLayoutDelegate oldDelegate) =>
+      oldDelegate != this;
 }

--- a/packages/smooth_app/lib/pages/scan/scanner_overlay.dart
+++ b/packages/smooth_app/lib/pages/scan/scanner_overlay.dart
@@ -203,28 +203,24 @@ class _ScannerOverlayDelegate extends MultiChildLayoutDelegate {
   /// Actions: top of the screen and limit the height
   /// Returns the height
   double _layoutAndPositionActions(Size size) {
-    if (hasChild(_LayoutIds.actions)) {
-      final Size actionsSize = layoutChild(
-        _LayoutIds.actions,
-        BoxConstraints(
-          minWidth: size.width,
-          maxWidth: size.width,
-          maxHeight: size.height * 0.2,
-        ),
-      );
+    final Size actionsSize = layoutChild(
+      _LayoutIds.actions,
+      BoxConstraints(
+        minWidth: size.width,
+        maxWidth: size.width,
+        maxHeight: size.height * 0.2,
+      ),
+    );
 
-      positionChild(
-        _LayoutIds.actions,
-        Offset(
-          0,
-          devicePadding.top,
-        ),
-      );
+    positionChild(
+      _LayoutIds.actions,
+      Offset(
+        0,
+        devicePadding.top,
+      ),
+    );
 
-      return actionsSize.height;
-    } else {
-      return 0.0;
-    }
+    return actionsSize.height;
   }
 
   @override

--- a/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
+++ b/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
@@ -17,11 +17,9 @@ import 'package:smooth_app/pages/scan/search_page.dart';
 class SmoothProductCarousel extends StatefulWidget {
   const SmoothProductCarousel({
     this.containSearchCard = false,
-    required this.height,
   });
 
   final bool containSearchCard;
-  final double height;
 
   static const EdgeInsets carouselItemHorizontalPadding =
       EdgeInsets.symmetric(horizontal: 20.0);
@@ -81,39 +79,45 @@ class _SmoothProductCarouselState extends State<SmoothProductCarousel> {
   @override
   Widget build(BuildContext context) {
     barcodes = _model.getBarcodes();
-    return CarouselSlider.builder(
-      itemCount: barcodes.length + _searchCardAdjustment,
-      itemBuilder: (BuildContext context, int itemIndex, int itemRealIndex) {
-        return Padding(
-          padding: SmoothProductCarousel.carouselItemInternalPadding,
-          child: widget.containSearchCard && itemIndex == 0
-              ? SearchCard(height: widget.height)
-              : _getWidget(itemIndex - _searchCardAdjustment),
+
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        return CarouselSlider.builder(
+          itemCount: barcodes.length + _searchCardAdjustment,
+          itemBuilder:
+              (BuildContext context, int itemIndex, int itemRealIndex) {
+            return Padding(
+              padding: SmoothProductCarousel.carouselItemInternalPadding,
+              child: widget.containSearchCard && itemIndex == 0
+                  ? SearchCard(height: constraints.maxHeight)
+                  : _getWidget(itemIndex - _searchCardAdjustment),
+            );
+          },
+          carouselController: _controller,
+          options: CarouselOptions(
+            enlargeCenterPage: false,
+            viewportFraction: SmoothProductCarousel.carouselViewPortFraction,
+            height: constraints.maxHeight,
+            enableInfiniteScroll: false,
+            onPageChanged: (int index, CarouselPageChangedReason reason) {
+              _lastIndex = index;
+              final InheritedDataManagerState inheritedDataManager =
+                  InheritedDataManager.of(context);
+              if (inheritedDataManager.showSearchCard) {
+                inheritedDataManager.resetShowSearchCard(false);
+              }
+              if (index > 0) {
+                if (reason == CarouselPageChangedReason.manual) {
+                  _model.lastConsultedBarcode =
+                      barcodes[index - _searchCardAdjustment];
+                }
+              } else if (index == 0) {
+                _model.lastConsultedBarcode = null;
+              }
+            },
+          ),
         );
       },
-      carouselController: _controller,
-      options: CarouselOptions(
-        enlargeCenterPage: false,
-        viewportFraction: SmoothProductCarousel.carouselViewPortFraction,
-        height: widget.height,
-        enableInfiniteScroll: false,
-        onPageChanged: (int index, CarouselPageChangedReason reason) {
-          _lastIndex = index;
-          final InheritedDataManagerState inheritedDataManager =
-              InheritedDataManager.of(context);
-          if (inheritedDataManager.showSearchCard) {
-            inheritedDataManager.resetShowSearchCard(false);
-          }
-          if (index > 0) {
-            if (reason == CarouselPageChangedReason.manual) {
-              _model.lastConsultedBarcode =
-                  barcodes[index - _searchCardAdjustment];
-            }
-          } else if (index == 0) {
-            _model.lastConsultedBarcode = null;
-          }
-        },
-      ),
     );
   }
 


### PR DESCRIPTION
"The same but different"

The Scan Page now uses a custom layout.
The only "visible" change: if action buttons are visible and there is not enough space for the visor, it will be shifted a little bit.

Will fix #1708 and #1794