### PR TITLE
fix: #1820 - incoherence nutrition ingredients buttons

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panels_builder.dart
+++ b/packages/smooth_app/lib/cards/product_cards/knowledge_panels/knowledge_panels_builder.dart
@@ -125,38 +125,46 @@ class KnowledgePanelsBuilder {
                 ?.contains('en:nutrition-facts-to-be-completed') ??
             false;
         final AppLocalizations appLocalizations = AppLocalizations.of(context);
-        knowledgePanelElementWidgets.add(
-          addPanelButton(
-            nutritionAddOrUpdate
-                ? appLocalizations.score_add_missing_nutrition_facts
-                : appLocalizations.score_update_nutrition_facts,
-            iconData: nutritionAddOrUpdate ? Icons.add : Icons.edit,
-            onPressed: () async {
-              final OrderedNutrientsCache? cache =
-                  await OrderedNutrientsCache.getCache(context);
-              if (cache == null) {
-                return;
-              }
-              //ignore: use_build_context_synchronously
-              final bool? refreshed = await Navigator.push<bool>(
-                context,
-                MaterialPageRoute<bool>(
-                  builder: (BuildContext context) => NutritionPageLoaded(
-                    product,
-                    cache.orderedNutrients,
+        if (nutritionAddOrUpdate) {
+          knowledgePanelElementWidgets.add(
+            addPanelButton(
+              nutritionAddOrUpdate
+                  ? appLocalizations.score_add_missing_nutrition_facts
+                  : appLocalizations.score_update_nutrition_facts,
+              iconData: nutritionAddOrUpdate ? Icons.add : Icons.edit,
+              onPressed: () async {
+                final OrderedNutrientsCache? cache =
+                    await OrderedNutrientsCache.getCache(context);
+                if (cache == null) {
+                  return;
+                }
+                //ignore: use_build_context_synchronously
+                final bool? refreshed = await Navigator.push<bool>(
+                  context,
+                  MaterialPageRoute<bool>(
+                    builder: (BuildContext context) => NutritionPageLoaded(
+                      product,
+                      cache.orderedNutrients,
+                    ),
                   ),
-                ),
-              );
-              if (refreshed ?? false) {
-                setState?.call();
-              }
-              // TODO(monsieurtanuki): refresh the data if changed
-            },
-          ),
-        );
-        if (context.read<UserPreferences>().getFlag(
-                UserPreferencesDevMode.userPreferencesFlagEditIngredients) ??
-            false) {
+                );
+                if (refreshed ?? false) {
+                  setState?.call();
+                }
+                // TODO(monsieurtanuki): refresh the data if changed
+              },
+            ),
+          );
+        }
+
+        final bool needEditIngredients = context
+                .read<UserPreferences>()
+                .getFlag(UserPreferencesDevMode
+                    .userPreferencesFlagEditIngredients) ??
+            false;
+        if ((product.ingredientsText == null ||
+                product.ingredientsText!.isEmpty) &&
+            needEditIngredients) {
           // When the flag is removed, this should be the following:
           // if (product.statesTags?.contains('en:ingredients-to-be-completed') ?? false) {
           knowledgePanelElementWidgets.add(


### PR DESCRIPTION
### What
<!-- description of the PR -->
Hide ingredients button if ingredients are completed
Hide nutrition button if nutrition is completed

### Screenshot
| 3017620429484 | 8717472253385 (tag: nutrition-facts-to-be-completed |
| -- | -- |
| ![Simulator Screen Shot - iPhone 13 - 2022-05-20 at 16 09 51](https://user-images.githubusercontent.com/87010739/169549426-78270e70-0f86-4295-a5d6-1cb1bf1e41de.png) | ![Simulator Screen Shot - iPhone 13 - 2022-05-20 at 16 09 33](https://user-images.githubusercontent.com/87010739/169549414-f733f6f6-bab5-4338-9a7d-0c685a0533e1.png) |
| -- | -- |

### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- #1820 

