### PR TITLE
fix: Night mode: force the adaptive icon on Android 26+

### DIFF
--- a/packages/smooth_app/android/app/src/main/res/mipmap-night-anydpi-v26/ic_launcher.xml
+++ b/packages/smooth_app/android/app/src/main/res/mipmap-night-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background"/>
+    <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome"/>
+</adaptive-icon>


### PR DESCRIPTION
On Android and in night mode, force the adaptive icon.
Will fix #1931