### PR TITLE
fix: Onboarding - wrong splash color

### DIFF
--- a/packages/smooth_app/lib/pages/onboarding/next_button.dart
+++ b/packages/smooth_app/lib/pages/onboarding/next_button.dart
@@ -38,7 +38,6 @@ class NextButton extends StatelessWidget {
               backgroundColor: Theme.of(context).cardColor,
               shape: const RoundedRectangleBorder(
                   borderRadius: ANGULAR_BORDER_RADIUS),
-              primary: const Color.fromRGBO(75, 0, 130, 1.0),
             ),
             onPressed: () async {
               await OnboardingLoader(localDatabase)


### PR DESCRIPTION
A purple color was hard-coded in the app

Before:
![screen](https://user-images.githubusercontent.com/246838/169787850-3eb1c0fe-9bf9-442e-9563-9a41312b8f65.png)

After:
![screen1](https://user-images.githubusercontent.com/246838/169787875-8309096e-9970-45d9-b626-8ceb75d92f43.png)

Will fix #1939 

