### PR TITLE
fix: Change ScoreCards & Robotoff cards radius

### DIFF
--- a/packages/smooth_app/lib/cards/data_cards/score_card.dart
+++ b/packages/smooth_app/lib/cards/data_cards/score_card.dart
@@ -44,7 +44,7 @@ class ScoreCard extends StatelessWidget {
       padding: const EdgeInsets.all(8.0),
       decoration: BoxDecoration(
         color: backgroundColor,
-        borderRadius: ROUNDED_BORDER_RADIUS,
+        borderRadius: ANGULAR_BORDER_RADIUS,
       ),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/packages/smooth_app/lib/generic_lib/widgets/smooth_card.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/smooth_card.dart
@@ -18,7 +18,19 @@ class SmoothCard extends StatelessWidget {
     ),
     this.padding = const EdgeInsets.all(5.0),
     this.elevation = 8,
+    this.borderRadius,
   });
+
+  const SmoothCard.angular({
+    required this.child,
+    this.color,
+    this.margin = const EdgeInsets.symmetric(
+      horizontal: SMALL_SPACE,
+      vertical: VERY_SMALL_SPACE,
+    ),
+    this.padding = const EdgeInsets.all(5.0),
+    this.elevation = 8,
+  }) : borderRadius = ANGULAR_BORDER_RADIUS;
 
   const SmoothCard.flat({
     required this.child,
@@ -31,12 +43,14 @@ class SmoothCard extends StatelessWidget {
     ),
     this.padding = const EdgeInsets.all(5.0),
     this.elevation = 0,
+    this.borderRadius,
   });
 
   final Widget child;
   final Color? color;
   final EdgeInsetsGeometry? margin;
   final EdgeInsetsGeometry? padding;
+  final BorderRadiusGeometry? borderRadius;
   final double elevation;
 
   @override
@@ -44,7 +58,7 @@ class SmoothCard extends StatelessWidget {
     final Widget result = Material(
       elevation: elevation,
       shadowColor: const Color.fromARGB(25, 0, 0, 0),
-      borderRadius: ROUNDED_BORDER_RADIUS,
+      borderRadius: borderRadius ?? ROUNDED_BORDER_RADIUS,
       color: color ??
           (Theme.of(context).brightness == Brightness.light
               ? Colors.white

--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -555,7 +555,7 @@ class _SummaryCardState extends State<SummaryCard> {
                   ),
                 );
               },
-              child: SmoothCard(
+              child: SmoothCard.angular(
                 margin: EdgeInsets.zero,
                 color: Theme.of(context).colorScheme.primary,
                 elevation: 0,


### PR DESCRIPTION
Following the design on Figma, score & robotoff cards should have a radius of 8.0 (or angular)
Will fix #1896

![Screenshot_1653309941](https://user-images.githubusercontent.com/246838/169822768-db14ef77-4a59-4a8c-ad2a-7ba944aeffbd.png)

