### PR TITLE
feat: Add an autofocus flag to the new user list dialog

### DIFF
--- a/packages/smooth_app/lib/generic_lib/widgets/smooth_text_form_field.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/smooth_text_form_field.dart
@@ -22,6 +22,7 @@ class SmoothTextFormField extends StatefulWidget {
     this.prefixIcon,
     this.textInputType,
     this.onChanged,
+    this.autofocus,
   }) : super(key: key);
 
   final TextFieldTypes type;
@@ -37,6 +38,7 @@ class SmoothTextFormField extends StatefulWidget {
   final Color? backgroundColor;
   final TextInputType? textInputType;
   final void Function(String?)? onChanged;
+  final bool? autofocus;
 
   @override
   State<SmoothTextFormField> createState() => _SmoothTextFormFieldState();
@@ -66,6 +68,7 @@ class _SmoothTextFormFieldState extends State<SmoothTextFormField> {
       enableSuggestions: enableSuggestions,
       autocorrect: autocorrect,
       autofillHints: widget.autofillHints,
+      autofocus: widget.autofocus ?? false,
       autovalidateMode: AutovalidateMode.onUserInteraction,
       onChanged: widget.onChanged ??
           (String data) {

--- a/packages/smooth_app/lib/pages/product_list_user_dialog_helper.dart
+++ b/packages/smooth_app/lib/pages/product_list_user_dialog_helper.dart
@@ -31,6 +31,7 @@ class ProductListUserDialogHelper {
             type: TextFieldTypes.PLAIN_TEXT,
             controller: textEditingController,
             hintText: appLocalizations.user_list_name_hint,
+            autofocus: true,
             textInputAction: TextInputAction.done,
             validator: (String? value) {
               final List<String> lists = daoProductList.getUserLists();


### PR DESCRIPTION
Will fix #1852

Simply add an `autofocus` attribute to `SmoothTextFormField` (false by default).
For the dialog allowing to create a new list, autofocus is enabled.