### PR TITLE
fix: product edition refresh product if needed

### DIFF
--- a/packages/smooth_app/lib/pages/product/edit_ingredients_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_ingredients_page.dart
@@ -322,7 +322,7 @@ class _EditIngredientsBody extends StatelessWidget {
                             SmoothActionButton(
                               text: appLocalizations.cancel,
                               onPressed: () {
-                                Navigator.pop(context);
+                                Navigator.pop(context, false);
                               },
                             ),
                             const SizedBox(width: LARGE_SPACE),
@@ -331,7 +331,7 @@ class _EditIngredientsBody extends StatelessWidget {
                               onPressed: () async {
                                 await onSubmitField();
                                 //ignore: use_build_context_synchronously
-                                Navigator.pop(context);
+                                Navigator.pop(context, true);
                               },
                             ),
                           ]),

--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -54,13 +54,16 @@ class _EditProductPageState extends State<EditProductPage> {
               subtitle:
                   appLocalizations.edit_product_form_item_details_subtitle,
               onTap: () async {
-                await Navigator.push<bool>(
+                final bool? refreshed = await Navigator.push<bool>(
                   context,
                   MaterialPageRoute<bool>(
                     builder: (BuildContext context) =>
                         AddBasicDetailsPage(widget.product),
                   ),
                 );
+                if (refreshed ?? false) {
+                  _changes++;
+                }
               },
             ),
             _ListTitleItem(


### PR DESCRIPTION
### What
<!-- description of the PR -->
- The product page isn't updated after editing nutrition
- The product page isn't updated after editing ingredients
- The product page isn't updated after editing basic details

### Screenshot
<!-- Insert a screenshot to provide visual record of your changes, if visible -->

https://user-images.githubusercontent.com/87010739/169987054-65d0e327-ac69-43d5-b030-9454af91de34.mp4


### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
#1927
#1928 
#1929 

### Part of 
- #1925
