### PR TITLE
feat: Improved TagLine system

### DIFF
--- a/packages/smooth_app/lib/data_models/tagline.dart
+++ b/packages/smooth_app/lib/data_models/tagline.dart
@@ -22,7 +22,7 @@ Future<TagLineItem?> fetchTagLine(String locale) {
       .then((String value) =>
           _TagLine.fromJSON(jsonDecode(value) as List<dynamic>))
       .then((_TagLine tagLine) => tagLine[locale] ?? tagLine['en'])
-      .catchError((dynamic err) => print(err));
+      .catchError((dynamic err) => null);
 }
 
 class _TagLine {

--- a/packages/smooth_app/lib/helpers/collections_helper.dart
+++ b/packages/smooth_app/lib/helpers/collections_helper.dart
@@ -87,3 +87,32 @@ extension IterableExtensions<T> on Iterable<T> {
     return null;
   }
 }
+
+extension MapStringKeyExtensions<V> on Map<String, V> {
+  String? keyStartingWith(String key, {bool ignoreCase = false}) {
+    final String searchKey;
+
+    if (ignoreCase) {
+      searchKey = key.toLowerCase();
+    } else {
+      searchKey = key;
+    }
+
+    for (String mapKey in keys) {
+      if (ignoreCase) {
+        mapKey = mapKey.toLowerCase();
+      }
+
+      print('$mapKey / $searchKey');
+      if (mapKey.startsWith(searchKey)) {
+        return mapKey;
+      }
+    }
+    return null;
+  }
+
+  V? getValueByKeyStartWith(String key, {bool ignoreCase = false}) {
+    final String? mapKey = keyStartingWith(key, ignoreCase: ignoreCase);
+    return this[mapKey];
+  }
+}

--- a/packages/smooth_app/lib/helpers/collections_helper.dart
+++ b/packages/smooth_app/lib/helpers/collections_helper.dart
@@ -103,7 +103,6 @@ extension MapStringKeyExtensions<V> on Map<String, V> {
         mapKey = mapKey.toLowerCase();
       }
 
-      print('$mapKey / $searchKey');
       if (mapKey.startsWith(searchKey)) {
         return mapKey;
       }


### PR DESCRIPTION
This PR will fix/improve:
- Encoding issue (from #1971)
- Matching language : 
  -  If the device is in `fr` and the request only have `fr` => will return `fr`
  -  If the device is in `fr_FR` and the request only have `fr` => will return `fr`
  -  If the device is in `fr` and the request only have `fr_FR` => will return `fr_FR`
  -  If the device is in `fr_BE` and the request only have `fr_FR` => will return `fr_FR`