### PR TITLE
fix: Tagline: wrong color used

### DIFF
--- a/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
+++ b/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
@@ -18,6 +18,7 @@ import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/pages/scan/inherited_data_manager.dart';
 import 'package:smooth_app/pages/scan/scan_product_card.dart';
 import 'package:smooth_app/pages/scan/search_page.dart';
+import 'package:smooth_app/themes/theme_provider.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 
@@ -239,6 +240,8 @@ class _SearchCardTagLine extends StatelessWidget {
             return const _SearchCardTagLineDefaultText();
           }
 
+          final ThemeProvider themeProvider = context.read<ThemeProvider>();
+
           return FutureBuilder<TagLineItem?>(
             future: fetchTagLine(Platform.localeName),
             builder: (BuildContext context, AsyncSnapshot<TagLineItem?> data) {
@@ -266,7 +269,7 @@ class _SearchCardTagLine extends StatelessWidget {
                     style: TextStyle(
                       fontSize: 18.0,
                       height: 1.5,
-                      color: Theme.of(context).primaryColor,
+                      color: themeProvider.color,
                     ),
                   ),
                 );


### PR DESCRIPTION
I use the wrong color for the tagline (from `Theme` instead of `ThemeProvider`), which leads to the wrong color in dark mode.
Will fix #1984

![Screenshot_1653484139](https://user-images.githubusercontent.com/246838/170269548-9064bc7a-5da3-4e31-9d09-9b4c5b3ce510.png)
