### PR TITLE
fix: Fix "Episode 2" with the Camera

### DIFF
--- a/packages/smooth_app/lib/pages/page_manager.dart
+++ b/packages/smooth_app/lib/pages/page_manager.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:provider/provider.dart';
 import 'package:smooth_app/pages/scan/inherited_data_manager.dart';
+import 'package:smooth_app/widgets/screen_visibility.dart';
 import 'package:smooth_app/widgets/tab_navigator.dart';
 
 enum BottomNavigationTab {
@@ -118,13 +120,16 @@ class PageManagerState extends State<PageManager> {
   }
 
   Widget _buildOffstageNavigator(BottomNavigationTab tabItem) {
-    final bool offstage = _currentPage != tabItem;
     return Offstage(
-      offstage: offstage,
-      child: TabNavigator(
-        offstage: offstage,
-        navigatorKey: _navigatorKeys[tabItem]!,
-        tabItem: tabItem,
+      offstage: _currentPage != tabItem,
+      child: Provider<BottomNavigationTab>.value(
+        value: _currentPage,
+        child: ScreenVisibilityDetector(
+          child: TabNavigator(
+            navigatorKey: _navigatorKeys[tabItem]!,
+            tabItem: tabItem,
+          ),
+        ),
       ),
     );
   }

--- a/packages/smooth_app/lib/pages/scan/camera_controller.dart
+++ b/packages/smooth_app/lib/pages/scan/camera_controller.dart
@@ -68,8 +68,10 @@ class SmoothCameraController extends CameraController {
 
   @override
   Future<void> pausePreview() async {
-    await super.pausePreview();
-    _isPaused = true;
+    if (_isInitialized) {
+      await super.pausePreview();
+      _isPaused = true;
+    }
   }
 
   Future<void> resumePreviewIfNecessary() async {

--- a/packages/smooth_app/lib/widgets/screen_visibility.dart
+++ b/packages/smooth_app/lib/widgets/screen_visibility.dart
@@ -25,13 +25,13 @@ class _ScreenVisibilityDetectorState extends State<ScreenVisibilityDetector> {
 
   @override
   Widget build(BuildContext context) {
-    return ChangeNotifierProvider<ScreenVisibility>.value(
-      value: _notifier,
-      child: VisibilityDetector(
-        key: const ValueKey<String>('ScreenVisibility'),
-        onVisibilityChanged: (VisibilityInfo info) {
-          _notifier.updateValue(info);
-        },
+    return VisibilityDetector(
+      key: const ValueKey<String>('ScreenVisibility'),
+      onVisibilityChanged: (VisibilityInfo info) {
+        _notifier.updateValue(info);
+      },
+      child: ChangeNotifierProvider<ScreenVisibility>.value(
+        value: _notifier,
         child: widget.child,
       ),
     );

--- a/packages/smooth_app/lib/widgets/tab_navigator.dart
+++ b/packages/smooth_app/lib/widgets/tab_navigator.dart
@@ -8,11 +8,10 @@ class TabNavigator extends StatelessWidget {
   const TabNavigator({
     required this.navigatorKey,
     required this.tabItem,
-    required this.offstage,
   });
+
   final GlobalKey<NavigatorState> navigatorKey;
   final BottomNavigationTab tabItem;
-  final bool offstage;
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
This will fix #1948 

To be more precise, the PR fixes:
- If the Isolate is destroyed, the app will just ignore events (https://github.com/openfoodfacts/smooth-app/issues/1869)
- A black background is forced when the camera isn't initialized
- The following issue was affecting the app : 
  1. Switch to History or Settings
  2. Leave the app and open the Camera app
  3. Relaunch Smoothie
  4. Open the Scan -> no camera

After digging a few minutes, the resume call is sometimes called when the tab is not visible.
In that case, we store that info, to restart the camera once the tab is back to the scan.

To have access to this kind of information, the current tab is now "provided" to each tab.