### PR TITLE
fix: Matomo errors

### DIFF
--- a/packages/smooth_app/lib/helpers/analytics_helper.dart
+++ b/packages/smooth_app/lib/helpers/analytics_helper.dart
@@ -71,19 +71,25 @@ class AnalyticsHelper {
       setAnalyticsReports(false);
       return;
     }
-    MatomoTracker.instance.initialize(
-      url: 'https://analytics.openfoodfacts.org/matomo.php',
-      siteId: 2,
-      visitorId: uuid,
-    );
-    MatomoTracker.instance.visitor = Visitor(
-      id: uuid,
-      userId: OpenFoodAPIConfiguration.globalUser?.userId,
-    );
+
+    try {
+      MatomoTracker.instance.initialize(
+        url: 'https://analytics.openfoodfacts.org/matomo.php',
+        siteId: 2,
+        visitorId: uuid,
+      );
+      MatomoTracker.instance.visitor = Visitor(
+        id: uuid,
+        userId: OpenFoodAPIConfiguration.globalUser?.userId,
+      );
+    } catch (err) {
+      // With Hot Reload, this may trigger a late field already initialized
+    }
   }
 
+  /// A UUID must be at least one 16 characters
   static String? get uuid =>
-      kDebugMode ? 'smoothie-debug' : OpenFoodAPIConfiguration.uuid;
+      kDebugMode ? 'smoothie-debug--' : OpenFoodAPIConfiguration.uuid;
 
   // TODO(m123): Matomo removes leading 0 from the barcode
   static void trackScannedProduct({required String barcode}) =>


### PR DESCRIPTION
The `visitorId` must at least contains 16 characters.
In case of Hot Restart, a `LateInitializationError` is trigerred => ignoring it 

Will fix #1987 