### PR TITLE
fix: Align text in center

### DIFF
--- a/packages/smooth_app/lib/pages/product/common/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_page.dart
@@ -160,6 +160,7 @@ class _ProductListPageState extends State<ProductListPage>
                   padding: const EdgeInsets.all(VERY_LARGE_SPACE),
                   child: Text(
                     appLocalizations.product_list_empty_message,
+                    textAlign: TextAlign.center,
                     style: themeData.textTheme.bodyText2?.apply(
                       color: colorScheme.onSurface,
                     ),


### PR DESCRIPTION
### What
<!-- description of the PR -->
- Centered the text in empty history screen

### Screenshot
<!-- Insert a screenshot to provide visual record of your changes, if visible -->
![image](https://user-images.githubusercontent.com/57723319/170833744-8e03339f-adf6-4b12-a4af-d8195533978c.png)


### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes: #2047 

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/525
<!-- please be as granular as possible -->
