### PR TITLE
fix: #2051 - fixed icon color on dark mode

### DIFF
--- a/packages/smooth_app/lib/pages/preferences/user_preferences_list_tile.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_list_tile.dart
@@ -25,7 +25,7 @@ class UserPreferencesListTile extends StatelessWidget {
   ) =>
       Icon(
         iconData,
-        color: Theme.of(context).colorScheme.onBackground,
+        color: Theme.of(context).colorScheme.onSurface,
       );
 
   @override


### PR DESCRIPTION
Impacted file:
* `user_preferences_list_tile.dart`: `onSurface` color instead of `onBackground` (should be the same, though)

### What
- Fixed color for icons on preference pages

### Screenshot
![Capture d’écran 2022-05-28 à 18 17 34](https://user-images.githubusercontent.com/11576431/170833778-51acb98f-a06b-4eed-b2b0-e80a7ceebce1.png)

![Capture d’écran 2022-05-28 à 18 18 19](https://user-images.githubusercontent.com/11576431/170833801-b6448ad5-2c17-41f0-9e07-c8b5e868dec4.png)

### Fixes bug(s)
- Fixes: #2051