### PR TITLE
fix: #2054 - fixed colors in sign up page

### DIFF
--- a/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
@@ -48,13 +48,9 @@ class _SignUpPageState extends State<SignUpPage> with TraceableClientMixin {
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(
-          appLocalizations.sign_up_page_title,
-          style: TextStyle(color: theme.colorScheme.onBackground),
-        ),
+        title: Text(appLocalizations.sign_up_page_title),
         backgroundColor: Colors.transparent,
         elevation: 0,
-        iconTheme: IconThemeData(color: theme.colorScheme.primary),
       ),
       body: Form(
         onChanged: () => setState(() {}),
@@ -190,8 +186,8 @@ class _SignUpPageState extends State<SignUpPage> with TraceableClientMixin {
                 text: TextSpan(
                   children: <InlineSpan>[
                     TextSpan(
-                      text: appLocalizations.sign_up_page_agree_text,
-                      style: TextStyle(color: theme.colorScheme.onBackground),
+                      // additional space needed because of the next text span
+                      text: '${appLocalizations.sign_up_page_agree_text} ',
                     ),
                     TextSpan(
                       style: const TextStyle(


### PR DESCRIPTION
Impacted file:
* `sign_up_page.dart`: removed custom colors from app bar and text

### What
- Removed custom (= for light mode) colors from app bar and text
- Also added a space in a text in order to fix #2027

### Screenshot
![Capture d’écran 2022-05-28 à 18 50 04](https://user-images.githubusercontent.com/11576431/170834941-7c6439b2-6b6f-46e8-9486-0c56dfddf095.png)

### Fixes bug(s)
- Fixes: #2054
- Fixes: #2027
