### PR TITLE
feat: #2058 - added svg picture when no lists

### DIFF
--- a/packages/smooth_app/lib/pages/all_user_product_list_page.dart
+++ b/packages/smooth_app/lib/pages/all_user_product_list_page.dart
@@ -1,9 +1,12 @@
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/product_list.dart';
 import 'package:smooth_app/database/dao_product_list.dart';
 import 'package:smooth_app/database/local_database.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_list_tile.dart';
 import 'package:smooth_app/pages/product/common/product_list_page.dart';
 import 'package:smooth_app/pages/product_list_user_dialog_helper.dart';
@@ -23,11 +26,29 @@ class _AllUserProductListState extends State<AllUserProductList> {
     final LocalDatabase localDatabase = context.watch<LocalDatabase>();
     final DaoProductList daoProductList = DaoProductList(localDatabase);
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final ThemeData themeData = Theme.of(context);
     final List<String> userLists = daoProductList.getUserLists();
     return Scaffold(
       appBar: AppBar(title: Text(appLocalizations.user_list_all_title)),
       body: userLists.isEmpty
-          ? Center(child: Text(appLocalizations.user_list_all_empty))
+          ? Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: <Widget>[
+                SvgPicture.asset(
+                  'assets/misc/empty-list.svg',
+                  height: MediaQuery.of(context).size.height * .4,
+                ),
+                Padding(
+                  padding: const EdgeInsets.all(SMALL_SPACE),
+                  child: AutoSizeText(
+                    appLocalizations.user_list_all_empty,
+                    style: themeData.textTheme.headline1,
+                    textAlign: TextAlign.center,
+                    maxLines: 1,
+                  ),
+                ),
+              ],
+            )
           : ListView.builder(
               itemCount: userLists.length,
               itemBuilder: (final BuildContext context, final int index) {


### PR DESCRIPTION
Impacted file:
* `all_user_product_list_page.dart`: added svg picture when no lists

### What
- Added the "food dance" picture when no lists - same as empty list

### Screenshot
![Capture d’écran 2022-05-30 à 16 38 56](https://user-images.githubusercontent.com/11576431/171014821-9462565f-68a3-4dd2-92c6-42a2ceea3c49.png)

### Fixes bug(s)
- Closes: #2058