### PR TITLE
feat: figma - product list with a FAB to compare products

### DIFF
--- a/packages/smooth_app/lib/pages/product/common/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_page.dart
@@ -71,6 +71,13 @@ class _ProductListPageState extends State<ProductListPage>
     final bool enableClear = products.isNotEmpty;
     final bool enableRename = productList.listType == ProductListType.USER;
     return Scaffold(
+      floatingActionButton: _selectionMode || products.length <= 1
+          ? null
+          : FloatingActionButton.extended(
+              onPressed: () => setState(() => _selectionMode = true),
+              label: Text(appLocalizations.compare_products_mode),
+              icon: const Icon(Icons.compare_arrows),
+            ),
       appBar: AppBar(
         actions: _selectionMode || !(enableClear || enableRename)
             ? null
@@ -180,10 +187,11 @@ class _ProductListPageState extends State<ProductListPage>
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.start,
                 children: <Widget>[
-                  Padding(
-                    padding: const EdgeInsets.all(SMALL_SPACE),
-                    child: _buildActionBar(products),
-                  ),
+                  if (_selectionMode)
+                    Padding(
+                      padding: const EdgeInsets.all(SMALL_SPACE),
+                      child: _buildCompareBar(products, appLocalizations),
+                    ),
                   Expanded(
                     child: ListView.builder(
                       itemCount: products.length,
@@ -353,10 +361,11 @@ class _ProductListPageState extends State<ProductListPage>
     return false;
   }
 
-  Widget _buildActionBar(final List<Product> products) {
-    final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    if (_selectionMode) {
-      return Row(
+  Widget _buildCompareBar(
+    final List<Product> products,
+    final AppLocalizations appLocalizations,
+  ) =>
+      Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: <Widget>[
           ElevatedButton(
@@ -394,15 +403,4 @@ class _ProductListPageState extends State<ProductListPage>
           ),
         ],
       );
-    }
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.end,
-      children: <Widget>[
-        ElevatedButton(
-          onPressed: () => setState(() => _selectionMode = true),
-          child: Text(appLocalizations.compare_products_mode),
-        ),
-      ],
-    );
-  }
 }


### PR DESCRIPTION
Impacted file:
* `product_list_page.dart`: replaced the header with a FAB to trigger the "compare" action

### What
- I noticed in figma that the product list page now had a FAB instead of a button in order to trigger the "compare" action

### Screenshot
Now with use a FAB to compare products:
![Capture d’écran 2022-05-30 à 19 10 46](https://user-images.githubusercontent.com/11576431/171036601-1eb31ee2-2890-4b1b-9ace-aa6974caf945.png)

The page where we select the products hasn't changed:
![Capture d’écran 2022-05-30 à 19 11 08](https://user-images.githubusercontent.com/11576431/171036641-8eb03cb8-a185-4d50-aed3-876c52f8ff55.png)



### Part of 
- #2001