### PR TITLE
feat: #2057 - added illustration and color to food preferences header

### DIFF
--- a/packages/smooth_app/lib/pages/preferences/user_preferences_food.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_food.dart
@@ -50,6 +50,12 @@ class UserPreferencesFood extends AbstractUserPreferences {
   IconData getLeadingIconData() => Icons.ramen_dining;
 
   @override
+  String? getHeaderAsset() => 'assets/onboarding/preferences.svg';
+
+  @override
+  Color? getHeaderColor() => const Color(0xFFEBF1FF);
+
+  @override
   List<Widget> getBody() {
     final List<Widget> result = <Widget>[
       // we don't want this on the onboarding


### PR DESCRIPTION
Impacted file:
* `user_preferences_food.dart`

### What
- Added illustration and color to food preferences header

### Screenshot
![Capture d’écran 2022-05-30 à 19 21 11](https://user-images.githubusercontent.com/11576431/171037744-bccb0563-c0ba-4903-a98f-1622d269a93b.png)

![Capture d’écran 2022-05-30 à 19 21 36](https://user-images.githubusercontent.com/11576431/171037793-1e066098-1439-4073-827e-3df01841f5ba.png)


### Fixes bug(s)
- Closes: #2057

### Part of 
- #2001