### PR TITLE
feat: #2072 - removed dialog from food preferences radio buttons

### DIFF
--- a/packages/smooth_app/lib/widgets/attribute_button.dart
+++ b/packages/smooth_app/lib/widgets/attribute_button.dart
@@ -40,27 +40,10 @@ class AttributeButton extends StatelessWidget {
       children.add(
         Expanded(
           child: InkWell(
-            onTap: () async {
-              await productPreferences.setImportance(
-                  attribute.id!, importanceId);
-
-              final AppLocalizations appLocalizations =
-                  //ignore: use_build_context_synchronously
-                  AppLocalizations.of(context);
-              await showDialog<void>(
-                context: context,
-                builder: (BuildContext context) => SmoothAlertDialog(
-                  body: Text(
-                    appLocalizations.importance_label(
-                        attribute.name.toString(), importanceId),
-                  ),
-                  positiveAction: SmoothActionButton(
-                    text: appLocalizations.close,
-                    onPressed: () => Navigator.pop(context),
-                  ),
-                ),
-              );
-            },
+            onTap: () async => productPreferences.setImportance(
+              attribute.id!,
+              importanceId,
+            ),
             child: Container(
               width: importanceWidth,
               constraints: const BoxConstraints(minHeight: MINIMUM_TARGET_SIZE),


### PR DESCRIPTION
Impacted file:
* `attribute_button.dart`

### What
- The dialog each time a food preference was changed seemed intrusive
- Now it's removed

### Fixes bug(s)
- Closes: #2072