### PR TITLE
fix: Camera restarted whereas it shouldn't 

### DIFF
--- a/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
@@ -317,8 +317,8 @@ class MLKitScannerPageState extends LifecycleAwareState<MLKitScannerPage>
     );
 
     // On visibility == true, may call us, but we have to ensure that this tab
-    // is visible
-    if (tab != BottomNavigationTab.Scan) {
+    // is visible AND displays the camera (canPop returns false in that case)
+    if (tab != BottomNavigationTab.Scan || Navigator.of(context).canPop()) {
       pendingResume = _controller?.isInitialized != true;
       return;
     }


### PR DESCRIPTION
Ensure the camera is restarted only if the "MLKitScanPage" is visible
Will fix #2077 