### PR TITLE
fix: Splashscreen: Force Android 12 sizes

### DIFF
--- a/packages/smooth_app/android/app/src/main/res/drawable-night/launch_background.xml
+++ b/packages/smooth_app/android/app/src/main/res/drawable-night/launch_background.xml
@@ -21,8 +21,8 @@
             android:drawable="@drawable/logo_text"
             android:gravity="bottom|center_horizontal">
         <size
-                android:width="80px"
-                android:height="200px"/>
+                android:width="200px"
+                android:height="80px"/>
     </item>
 
 </layer-list>


### PR DESCRIPTION
On devices below Android 12, we now force the dimensions of the logo/brand text.
https://developer.android.com/guide/topics/ui/splash-screen

Will partially fix #2062 (iOS is another issue)