### PR TITLE
feat: #2089 - removed the blur effect around the product photo

### DIFF
--- a/packages/smooth_app/lib/generic_lib/widgets/smooth_product_image.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/smooth_product_image.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:openfoodfacts/model/Product.dart';
@@ -51,38 +49,26 @@ class SmoothProductImage extends StatelessWidget {
       ? null
       : ClipRRect(
           borderRadius: ROUNDED_BORDER_RADIUS,
-          child: FittedBox(
-            child: Container(
-              width: width,
-              height: height,
-              decoration: BoxDecoration(
-                borderRadius: ROUNDED_BORDER_RADIUS,
-                image: DecorationImage(
-                  fit: BoxFit.cover,
-                  image: NetworkImage(url, scale: 1.0),
-                ),
-              ),
-              child: BackdropFilter(
-                filter: ImageFilter.blur(sigmaX: 12.0, sigmaY: 12.0),
-                child: Image.network(
-                  url,
-                  fit: BoxFit.contain,
-                  loadingBuilder: (BuildContext context, Widget child,
-                          ImageChunkEvent? progress) =>
-                      progress == null
-                          ? child
-                          : Center(
-                              child: CircularProgressIndicator(
-                                strokeWidth: 2.5,
-                                valueColor: const AlwaysStoppedAnimation<Color>(
-                                  Colors.white,
-                                ),
-                                value: progress.cumulativeBytesLoaded /
-                                    progress.expectedTotalBytes!,
-                              ),
+          child: SizedBox(
+            width: width,
+            height: height,
+            child: Image.network(
+              url,
+              fit: BoxFit.contain,
+              loadingBuilder: (BuildContext context, Widget child,
+                      ImageChunkEvent? progress) =>
+                  progress == null
+                      ? child
+                      : Center(
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2.5,
+                            valueColor: const AlwaysStoppedAnimation<Color>(
+                              Colors.white,
                             ),
-                ),
-              ),
+                            value: progress.cumulativeBytesLoaded /
+                                progress.expectedTotalBytes!,
+                          ),
+                        ),
             ),
           ),
         );


### PR DESCRIPTION
Impacted file:
* `smooth_product_image.dart`: removed the blur effect around the product photo

### What
- There was a blur effect around the product photo.
- That effect brought confusion.
- The blur effect was removed.

### Screenshot
![Capture d’écran 2022-05-31 à 14 42 07](https://user-images.githubusercontent.com/11576431/171175766-c7a8c2af-bbe7-405a-a7cf-5d746af3ebe5.png)


### Fixes bug(s)
- Closes: #2089