### PR TITLE
feat: Country selector moved to app settings

### DIFF
--- a/packages/smooth_app/lib/pages/onboarding/country_selector.dart
+++ b/packages/smooth_app/lib/pages/onboarding/country_selector.dart
@@ -4,6 +4,7 @@ import 'package:iso_countries/iso_countries.dart';
 import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/database/product_query.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_text_form_field.dart';
 
@@ -60,6 +61,7 @@ class _CountrySelectorState extends State<CountrySelector> {
         }
 
         return InkWell(
+          borderRadius: ANGULAR_BORDER_RADIUS,
           onTap: () async {
             List<Country> filteredList = List<Country>.from(_countryList);
             final Country? country = await showDialog<Country>(
@@ -109,6 +111,9 @@ class _CountrySelectorState extends State<CountrySelector> {
                                   final bool isSelected =
                                       country == _chosenValue;
                                   return ListTile(
+                                    shape: const RoundedRectangleBorder(
+                                      borderRadius: ANGULAR_BORDER_RADIUS,
+                                    ),
                                     title: Text(
                                       country.name,
                                       style: TextStyle(

--- a/packages/smooth_app/lib/pages/onboarding/welcome_page.dart
+++ b/packages/smooth_app/lib/pages/onboarding/welcome_page.dart
@@ -66,22 +66,22 @@ class WelcomePage extends StatelessWidget {
                   appLocalizations.country_chooser_label,
                   style: bodyTextStyle,
                 ),
-                Container(
-                  decoration: BoxDecoration(
-                    border: Border.all(
-                      color: Colors.white,
-                      width: 1,
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: MEDIUM_SPACE),
+                  child: Ink(
+                    decoration: BoxDecoration(
+                      border: Border.all(
+                        color: Colors.white,
+                        width: 1,
+                      ),
+                      borderRadius: ANGULAR_BORDER_RADIUS,
+                      color: Theme.of(context).cardColor,
                     ),
-                    borderRadius: BorderRadius.circular(
-                      LARGE_SPACE,
+                    child: CountrySelector(
+                      initialCountryCode: WidgetsBinding
+                          .instance.window.locale.countryCode
+                          ?.toLowerCase(),
                     ),
-                    color: Theme.of(context).cardColor,
-                  ),
-                  margin: const EdgeInsets.symmetric(vertical: MEDIUM_SPACE),
-                  child: CountrySelector(
-                    initialCountryCode: WidgetsBinding
-                        .instance.window.locale.countryCode
-                        ?.toLowerCase(),
                   ),
                 ),
                 Padding(

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_account.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_account.dart
@@ -9,7 +9,6 @@ import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/helpers/launch_url_helper.dart';
 import 'package:smooth_app/helpers/user_management_helper.dart';
-import 'package:smooth_app/pages/onboarding/country_selector.dart';
 import 'package:smooth_app/pages/preferences/abstract_user_preferences.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_page.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_widgets.dart';
@@ -180,9 +179,10 @@ class UserPreferencesSection extends StatefulWidget {
 }
 
 class _UserPreferencesPageState extends State<UserPreferencesSection> {
-  void _confirmLogout(BuildContext context) {
+  Future<bool?> _confirmLogout(BuildContext context) {
     final AppLocalizations localizations = AppLocalizations.of(context);
-    showDialog<void>(
+
+    return showDialog<bool>(
       context: context,
       builder: (BuildContext context) {
         return SmoothAlertDialog(
@@ -194,7 +194,7 @@ class _UserPreferencesPageState extends State<UserPreferencesSection> {
             text: localizations.yes,
             onPressed: () async {
               context.read<UserManagementProvider>().logout();
-              Navigator.pop(context);
+              Navigator.pop(context, true);
             },
           ),
           negativeAction: SmoothActionButton(
@@ -218,13 +218,13 @@ class _UserPreferencesPageState extends State<UserPreferencesSection> {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final Size size = MediaQuery.of(context).size;
 
-    final List<Widget> result = <Widget>[];
+    final List<Widget> result;
 
     if (OpenFoodAPIConfiguration.globalUser != null) {
       // Credentials
       final String userId = OpenFoodAPIConfiguration.globalUser!.userId;
 
-      result.addAll(<Widget>[
+      result = <Widget>[
         ListTile(
           onTap: () async => LaunchUrlHelper.launchURL(
             'https://openfoodfacts.org/editor/$userId',
@@ -235,7 +235,11 @@ class _UserPreferencesPageState extends State<UserPreferencesSection> {
         ),
         const UserPreferencesListItemDivider(),
         ListTile(
-          onTap: () => _confirmLogout(context),
+          onTap: () async {
+            if (await _confirmLogout(context) == true) {
+              Navigator.pop(context);
+            }
+          },
           title: Text(appLocalizations.sign_out),
           leading: const Icon(Icons.clear),
         ),
@@ -253,10 +257,10 @@ class _UserPreferencesPageState extends State<UserPreferencesSection> {
           leading: const Icon(Icons.delete),
         ),
         const UserPreferencesListItemDivider(),
-      ]);
+      ];
     } else {
       // No credentials
-      result.add(
+      result = <Widget>[
         Center(
           child: ElevatedButton(
             onPressed: () async {
@@ -286,13 +290,8 @@ class _UserPreferencesPageState extends State<UserPreferencesSection> {
             ),
           ),
         ),
-      );
+      ];
     }
-    result.add(
-      CountrySelector(
-        initialCountryCode: widget.userPreferences.userCountryCode,
-      ),
-    );
 
     return Column(children: result);
   }

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_page.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_page.dart
@@ -117,7 +117,7 @@ class _UserPreferencesPageState extends State<UserPreferencesPage>
     if (headerAsset == null) {
       return Scaffold(
         appBar: AppBar(title: Text(appBarTitle)),
-        body: list,
+        body: Scrollbar(child: list),
       );
     }
     final MediaQueryData mediaQueryData = MediaQuery.of(context);

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_settings.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_settings.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
+import 'package:smooth_app/pages/onboarding/country_selector.dart';
 import 'package:smooth_app/pages/preferences/abstract_user_preferences.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_page.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_widgets.dart';
@@ -116,6 +117,8 @@ class UserPreferencesSettings extends AbstractUserPreferences {
           ),
         ),
         const UserPreferencesListItemDivider(),
+        const _CountryPickerSetting(),
+        const UserPreferencesListItemDivider(),
         const _CrashReportingSetting(),
         const UserPreferencesListItemDivider(),
         const _SendAnonymousDataSetting(),
@@ -145,6 +148,27 @@ class UserPreferencesSettings extends AbstractUserPreferences {
           ),
         ),
       );
+}
+
+class _CountryPickerSetting extends StatelessWidget {
+  const _CountryPickerSetting({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final UserPreferences userPreferences = context.watch<UserPreferences>();
+
+    return ListTile(
+      title: Text(
+        appLocalizations.country_chooser_label,
+        style: Theme.of(context).textTheme.headline4,
+      ),
+      subtitle: CountrySelector(
+        initialCountryCode: userPreferences.userCountryCode,
+      ),
+      minVerticalPadding: MEDIUM_SPACE,
+    );
+  }
 }
 
 class _SendAnonymousDataSetting extends StatefulWidget {


### PR DESCRIPTION
Country picker is now on App Settings.
Once the user is logged out, instead of an empty screen, it will be redirected back to the home preferences page.

Will fix #2104 

![Screenshot_1654039353](https://user-images.githubusercontent.com/246838/171299501-0d8e89b4-f65f-4708-aece-444d991a0a97.png)

