### PR TITLE
fix: Product compatibility overflow

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
@@ -117,11 +117,17 @@ class SmoothProductCardFound extends StatelessWidget {
                           ),
                           const Padding(
                               padding: EdgeInsets.only(left: VERY_SMALL_SPACE)),
-                          Text(
-                            helper.getSubtitle(appLocalizations),
-                            style: themeData.textTheme.bodyText2!.apply(
-                                color: helper
-                                    .getButtonForegroundColor(isDarkMode)),
+                          Expanded(
+                            child: FittedBox(
+                              fit: BoxFit.scaleDown,
+                              alignment: AlignmentDirectional.centerStart,
+                              child: Text(
+                                helper.getSubtitle(appLocalizations),
+                                style: themeData.textTheme.bodyText2!.apply(
+                                    color: helper
+                                        .getButtonForegroundColor(isDarkMode)),
+                              ),
+                            ),
                           ),
                         ],
                       ),


### PR DESCRIPTION
Before 
![ov](https://user-images.githubusercontent.com/246838/171304358-50cf9710-16ed-4bde-ab2d-7ac14a35d495.png)

After (still on one line, but scaled down)
![ov](https://user-images.githubusercontent.com/246838/171304428-606278a5-5409-41ed-8245-443ebf8aca3a.png)

