### PR TITLE
fix: #2129 - SafeArea for preferences with sliver

### DIFF
--- a/packages/smooth_app/lib/pages/preferences/user_preferences_page.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_page.dart
@@ -129,43 +129,45 @@ class _UserPreferencesPageState extends State<UserPreferencesPage>
     // TODO(monsieurtanuki): get rid of explicit foregroundColor when appbartheme colors are correct
     final Color? foregroundColor = dark ? null : Colors.black;
     return Scaffold(
-      body: CustomScrollView(
-        slivers: <Widget>[
-          SliverAppBar(
-            pinned: true,
-            snap: false,
-            floating: false,
-            stretch: true,
-            backgroundColor: dark ? null : headerColor,
-            expandedHeight: backgroundHeight + titleHeightInExpandedMode,
-            foregroundColor: foregroundColor,
-            // Force a light status bar
-            systemOverlayStyle: const SystemUiOverlayStyle(
-              statusBarIconBrightness: Brightness.light,
-              statusBarBrightness: Brightness.dark,
-            ),
-            flexibleSpace: FlexibleSpaceBar(
-              title: Text(
-                appBarTitle,
-                style: TextStyle(color: foregroundColor),
+      body: SafeArea(
+        child: CustomScrollView(
+          slivers: <Widget>[
+            SliverAppBar(
+              pinned: true,
+              snap: false,
+              floating: false,
+              stretch: true,
+              backgroundColor: dark ? null : headerColor,
+              expandedHeight: backgroundHeight + titleHeightInExpandedMode,
+              foregroundColor: foregroundColor,
+              // Force a light status bar
+              systemOverlayStyle: const SystemUiOverlayStyle(
+                statusBarIconBrightness: Brightness.light,
+                statusBarBrightness: Brightness.dark,
               ),
-              background: Padding(
-                padding:
-                    const EdgeInsets.only(bottom: titleHeightInExpandedMode),
-                child: SvgPicture.asset(
-                  headerAsset,
-                  height: backgroundHeight,
+              flexibleSpace: FlexibleSpaceBar(
+                title: Text(
+                  appBarTitle,
+                  style: TextStyle(color: foregroundColor),
+                ),
+                background: Padding(
+                  padding:
+                      const EdgeInsets.only(bottom: titleHeightInExpandedMode),
+                  child: SvgPicture.asset(
+                    headerAsset,
+                    height: backgroundHeight,
+                  ),
                 ),
               ),
             ),
-          ),
-          SliverList(
-            delegate: SliverChildBuilderDelegate(
-              (BuildContext context, int index) => children[index],
-              childCount: children.length,
+            SliverList(
+              delegate: SliverChildBuilderDelegate(
+                (BuildContext context, int index) => children[index],
+                childCount: children.length,
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
Impacted file:
* `user_preferences_page.dart`: `SafeArea` for sliver

### What
- Preference pages with sliver started from the very top of the screen, including the device status bar.
- Added a `SafeArea` to fix that for all concerned preference pages.

### Screenshot

![Capture d’écran 2022-06-02 à 07 41 33](https://user-images.githubusercontent.com/11576431/171560754-3ed1358c-c9ec-4b02-9824-41cdfe1ccca7.png)


### Fixes bug(s)
- Fixes: #2129