### PR TITLE
fix: OnBoarding still accessible via the back button

### DIFF
--- a/packages/smooth_app/lib/pages/onboarding/knowledge_panel_page_template.dart
+++ b/packages/smooth_app/lib/pages/onboarding/knowledge_panel_page_template.dart
@@ -149,9 +149,9 @@ class _KnowledgePanelPageTemplateState
     );
     final List<Widget> hitPopup = <Widget>[];
     if (!_isHintDismissed &&
-        !OnboardingFlowNavigator.isOnboradingPagedInHistory(
+        !OnboardingFlowNavigator.isOnboardingPagedInHistory(
             OnboardingPage.HEALTH_CARD_EXAMPLE) &&
-        !OnboardingFlowNavigator.isOnboradingPagedInHistory(
+        !OnboardingFlowNavigator.isOnboardingPagedInHistory(
             OnboardingPage.ECO_CARD_EXAMPLE)) {
       hitPopup.add(InkWell(
         child: const DecoratedBox(

--- a/packages/smooth_app/lib/pages/onboarding/onboarding_flow_navigator.dart
+++ b/packages/smooth_app/lib/pages/onboarding/onboarding_flow_navigator.dart
@@ -101,12 +101,20 @@ class OnboardingFlowNavigator {
   void navigateToPage(BuildContext context, OnboardingPage page) {
     _userPreferences.setLastVisitedOnboardingPage(page);
     _historyOnboardingNav.add(page);
-    Navigator.push<Widget>(
-      context,
-      MaterialPageRoute<Widget>(
-        builder: (BuildContext context) => getPageWidget(context, page),
-      ),
+
+    final MaterialPageRoute<Widget> route = MaterialPageRoute<Widget>(
+      builder: (BuildContext context) => getPageWidget(context, page),
     );
+
+    if (page == OnboardingPage.ONBOARDING_COMPLETE) {
+      Navigator.pushAndRemoveUntil(
+        context,
+        route,
+        (Route<dynamic> route) => false,
+      );
+    } else {
+      Navigator.push<Widget>(context, route);
+    }
   }
 
   Widget getPageWidget(BuildContext context, OnboardingPage page) {
@@ -188,7 +196,7 @@ class OnboardingFlowNavigator {
     );
   }
 
-  static bool isOnboradingPagedInHistory(OnboardingPage page) {
+  static bool isOnboardingPagedInHistory(OnboardingPage page) {
     bool exists = false;
     if (_historyOnboardingNav.isNotEmpty) {
       final int indexPage = _historyOnboardingNav.indexOf(page);


### PR DESCRIPTION
Once the onboarding finished (after the Analytics screen), the back button should never return to it.
Will fix #2124 