### PR TITLE
fix: #2125 product name clickable

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/product_title_card.dart
+++ b/packages/smooth_app/lib/cards/product_cards/product_title_card.dart
@@ -49,17 +49,18 @@ class ProductTitleCard extends StatelessWidget {
     return Align(
       alignment: Alignment.topLeft,
       child: InkWell(
-        onTap: () async {
-          if (getProductName(product, appLocalizations) ==
-              appLocalizations.unknownProductName) {
-            await Navigator.push<bool>(
-              context,
-              MaterialPageRoute<bool>(
-                builder: (BuildContext context) => AddBasicDetailsPage(product),
-              ),
-            );
-          }
-        },
+        onTap: (getProductName(product, appLocalizations) ==
+                appLocalizations.unknownProductName)
+            ? () async {
+                await Navigator.push<bool>(
+                  context,
+                  MaterialPageRoute<bool>(
+                    builder: (BuildContext context) =>
+                        AddBasicDetailsPage(product),
+                  ),
+                );
+              }
+            : null,
         child: ListTile(
           dense: dense,
           contentPadding: EdgeInsets.zero,


### PR DESCRIPTION
### What
<!-- description of the PR -->
No click effect more, open Basic Details Edition page by clicking the name of an unknown product, open Product page by clicking a normal product.

### Screenshot
[<!-- Insert a screenshot to provide visual record of your changes, if visible -->](https://user-images.githubusercontent.com/87010739/171675575-5ee303f5-550a-494e-a364-7b653f70ecde.mp4)

### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes: #2125