### PR TITLE
fix: #2147 - now using new product field `comparedToCategory`

### DIFF
--- a/packages/smooth_app/lib/database/product_query.dart
+++ b/packages/smooth_app/lib/database/product_query.dart
@@ -105,6 +105,7 @@ abstract class ProductQuery {
         ProductField.LABELS_TAGS,
         ProductField.LABELS_TAGS_IN_LANGUAGES,
         ProductField.ENVIRONMENT_IMPACT_LEVELS,
+        ProductField.COMPARED_TO_CATEGORY,
         ProductField.CATEGORIES_TAGS,
         ProductField.CATEGORIES_TAGS_IN_LANGUAGES,
         ProductField.LANGUAGE,

--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -240,27 +240,37 @@ class _SummaryCardState extends State<SummaryCard> {
       margin: const EdgeInsets.only(bottom: 16),
       child: Column(children: displayedGroups),
     );
+    // cf. https://github.com/openfoodfacts/smooth-app/issues/2147
+    const Set<String> blackListedCategories = <String>{
+      'fr:vegan',
+    };
     String? categoryTag;
     String? categoryLabel;
-    if (widget._product.categoriesTags?.isNotEmpty ?? false) {
-      // cf. https://github.com/openfoodfacts/smooth-app/issues/2147
-      const Set<String> blackListedCategories = <String>{
-        'fr:vegan',
-      };
-      int index = widget._product.categoriesTags!.length - 1;
-      // TODO(monsieurtanuki): should be widget._product.comparedToCategory, when ready
-      // cf. https://github.com/openfoodfacts/openfoodfacts-dart/pull/474
-      // looking for the most detailed non blacklisted category
-      categoryTag = widget._product.categoriesTags![index];
-      while (blackListedCategories.contains(categoryTag) && index > 0) {
-        index--;
-        categoryTag = widget._product.categoriesTags![index];
+    final List<String>? labels =
+        widget._product.categoriesTagsInLanguages?[ProductQuery.getLanguage()!];
+    final List<String>? tags = widget._product.categoriesTags;
+    if (tags != null &&
+        labels != null &&
+        tags.isNotEmpty &&
+        tags.length == labels.length) {
+      categoryTag = widget._product.comparedToCategory;
+      if (categoryTag == null || blackListedCategories.contains(categoryTag)) {
+        // fallback algorithm
+        int index = tags.length - 1;
+        // cf. https://github.com/openfoodfacts/openfoodfacts-dart/pull/474
+        // looking for the most detailed non blacklisted category
+        categoryTag = tags[index];
+        while (blackListedCategories.contains(categoryTag) && index > 0) {
+          index--;
+          categoryTag = tags[index];
+        }
       }
-
-      final List<String>? labels = widget
-          ._product.categoriesTagsInLanguages?[ProductQuery.getLanguage()!];
-      if (labels != null && labels.length >= index) {
-        categoryLabel = labels[index];
+      if (categoryTag != null) {
+        for (int i = 0; i < tags.length; i++) {
+          if (categoryTag == tags[i]) {
+            categoryLabel = labels[i];
+          }
+        }
       }
     }
     final List<String> statesTags =

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -177,7 +177,7 @@ packages:
       name: cupertino_icons
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   dart_style:
     dependency: transitive
     description:
@@ -531,7 +531,7 @@ packages:
       name: image_picker_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.4+13"
+    version: "0.8.5"
   image_picker_for_web:
     dependency: transitive
     description:
@@ -692,7 +692,7 @@ packages:
       name: openfoodfacts
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.17.1"
+    version: "1.18.0"
   package_config:
     dependency: transitive
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
       url: 'https://github.com/M123-dev/matomo-tracker.git'
       ref: 'fix-country'
   modal_bottom_sheet: ^2.0.1
-  openfoodfacts: ^1.17.1
+  openfoodfacts: ^1.18.0
   #  openfoodfacts:
   #    path: ../../../openfoodfacts-dart
   package_info_plus: ^1.4.2


### PR DESCRIPTION
Impacted files:
* `product_query.dart`: now retrieving new product field `COMPARED_TO_CATEGORY`
* `pubspec.lock`: wtf
* `pubspec.dart`: now using version `1.18.0` of `openfoodfacts`, that includes new product field `comparedToCategory`
* `summary_card.dart`: now uses the new product field `comparedToCategory`

### What
- Now using new product field `comparedToCategory` on the "compare to category" button of the product page

### Fixes bug(s)
- Closes: #2147