### PR TITLE
fix: repeated packing info button resolved

### DIFF
--- a/packages/smooth_app/lib/helpers/product_cards_helper.dart
+++ b/packages/smooth_app/lib/helpers/product_cards_helper.dart
@@ -118,7 +118,7 @@ List<ProductImageData> getAllProductImagesData(
       imageField: ImageField.OTHER,
       imageUrl: null,
       title: appLocalizations.more_photos,
-      buttonText: appLocalizations.packaging_information_photo,
+      buttonText: appLocalizations.more_photos,
     ),
   ];
   return allProductImagesData;


### PR DESCRIPTION
### What
<!-- description of the PR -->
- removed the repeating packing info button in the gallery

### Screenshot

https://user-images.githubusercontent.com/57723319/172032744-77a50191-ef74-4897-bded-49c264adb12c.mp4



### Fixes bug(s)
- Fixes: #2156 

