### PR TITLE
fix: #2181 - SmoothSimpleButton now uses the default app colors

### DIFF
--- a/packages/smooth_app/lib/generic_lib/buttons/smooth_simple_button.dart
+++ b/packages/smooth_app/lib/generic_lib/buttons/smooth_simple_button.dart
@@ -21,20 +21,22 @@ class SmoothSimpleButton extends StatelessWidget {
   final Color? buttonColor;
 
   @override
-  Widget build(BuildContext context) {
-    final ThemeData themeData = Theme.of(context);
-    return MaterialButton(
-      color: buttonColor ?? themeData.colorScheme.primary,
-      height: height,
-      minWidth: minWidth,
-      shape: RoundedRectangleBorder(
-        borderRadius: borderRadius,
-      ),
-      onPressed: onPressed,
-      child: Padding(
-        padding: padding,
-        child: child,
-      ),
-    );
-  }
+  Widget build(BuildContext context) => Container(
+        constraints: BoxConstraints(minWidth: minWidth, minHeight: height),
+        child: ElevatedButton(
+          style: ButtonStyle(
+            backgroundColor: buttonColor == null
+                ? null
+                : MaterialStateProperty.all<Color>(buttonColor!),
+            shape: MaterialStateProperty.all<RoundedRectangleBorder>(
+              RoundedRectangleBorder(borderRadius: borderRadius),
+            ),
+          ),
+          onPressed: onPressed,
+          child: Padding(
+            padding: padding,
+            child: child,
+          ),
+        ),
+      );
 }

--- a/packages/smooth_app/lib/generic_lib/widgets/smooth_error_card.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/smooth_error_card.dart
@@ -18,7 +18,6 @@ class SmoothErrorCard extends StatefulWidget {
 
 class _SmoothErrorCardState extends State<SmoothErrorCard> {
   late AppLocalizations _appLocalizations;
-  final TextStyle _buttonsTextStyle = const TextStyle(color: Colors.white);
   bool _showErrorText = false;
 
   final double _horizontalPaddingButtons = VERY_LARGE_SPACE * 4;
@@ -37,10 +36,7 @@ class _SmoothErrorCardState extends State<SmoothErrorCard> {
       child: SmoothSimpleButton(
         onPressed: widget.tryAgainFunction,
         minWidth: double.infinity,
-        child: Text(
-          _appLocalizations.try_again,
-          style: _buttonsTextStyle,
-        ),
+        child: Text(_appLocalizations.try_again),
       ),
     );
   }
@@ -98,10 +94,7 @@ class _SmoothErrorCardState extends State<SmoothErrorCard> {
       child: SmoothSimpleButton(
         onPressed: _setShowErrorText,
         minWidth: double.infinity,
-        child: Text(
-          _appLocalizations.learnMore,
-          style: _buttonsTextStyle,
-        ),
+        child: Text(_appLocalizations.learnMore),
       ),
     );
   }


### PR DESCRIPTION
Impacted files:
* `smooth_error_card.dart`: no more explicit white text
* `smooth_simple_button.dart`: now using the default primary colors provided by `ElevatedButton`

### What
- Some explicit "text color = white" code was still there.
- Now we use the default app colors for `SmoothSimpleButton`, and we don't need explicit colors.

### Screenshot
| light | dark |
| --- | --- |
| ![Capture d’écran 2022-06-06 à 09 21 38](https://user-images.githubusercontent.com/11576431/172114545-24e7284a-c3b1-477b-bcc8-1c1568ff5cce.png) | ![Capture d’écran 2022-06-06 à 09 21 59](https://user-images.githubusercontent.com/11576431/172114595-2cd93776-114c-4c41-86a3-6e1e3a6e6d29.png) |


### Fixes bug(s)
- Fixes: #2181
