### PR TITLE
fix: #2180 - Explicit color for snack bar actions

### DIFF
--- a/packages/smooth_app/lib/themes/smooth_theme.dart
+++ b/packages/smooth_app/lib/themes/smooth_theme.dart
@@ -53,6 +53,7 @@ class SmoothTheme {
       snackBarTheme: SnackBarThemeData(
         contentTextStyle:
             _TEXT_THEME.bodyText2?.copyWith(color: myColorScheme.onBackground),
+        actionTextColor: myColorScheme.onBackground,
       ),
     );
   }


### PR DESCRIPTION
Impacted file:
* `smooth_theme.dart`: Explicit color for snack bar actions

### What
- The snack bar actions were invisible with the latest theme/color change.
- Now they have an explicit color, now at least the text is visible.
- Unfortunately it's the same color as the snack bar text (for the moment): there is no obvious difference between both.

### Screenshot
| light | dark |
| --- | --- |
| ![Capture d’écran 2022-06-06 à 09 47 12](https://user-images.githubusercontent.com/11576431/172118343-f980d1c1-b053-4828-8b9c-fd3591fd9902.png) | ![Capture d’écran 2022-06-06 à 09 47 49](https://user-images.githubusercontent.com/11576431/172118424-40ea28a7-fccb-426d-9618-562f04ed0d0e.png) |


### Fixes bug(s)
- Fixes: #2180