### PR TITLE
fix: #2180 - more simple app bar title for search results

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
@@ -19,21 +19,16 @@ class SmoothProductCardFound extends StatelessWidget {
   const SmoothProductCardFound({
     required this.product,
     required this.heroTag,
-    this.elevation = 0.0,
     this.backgroundColor,
-    this.handle,
     this.onLongPress,
-    this.refresh,
     this.onTap,
   });
 
   final Product product;
   final String heroTag;
-  final double elevation;
+  static const double elevation = 4.0;
   final Color? backgroundColor;
-  final Widget? handle;
   final VoidCallback? onLongPress;
-  final VoidCallback? refresh;
   final VoidCallback? onTap;
 
   @override
@@ -72,7 +67,6 @@ class SmoothProductCardFound extends StatelessWidget {
                 builder: (BuildContext context) => ProductPage(product),
               ),
             );
-            refresh?.call();
           },
       onLongPress: () {
         onLongPress?.call();

--- a/packages/smooth_app/lib/pages/personalized_ranking_page.dart
+++ b/packages/smooth_app/lib/pages/personalized_ranking_page.dart
@@ -157,7 +157,6 @@ class _PersonalizedRankingPageState extends State<PersonalizedRankingPage>
           child: SmoothProductCardFound(
             heroTag: matchedProduct.product.barcode!,
             product: matchedProduct.product,
-            elevation: 4.0,
             backgroundColor: ProductCompatibilityHelper.product(matchedProduct)
                 .getHeaderBackgroundColor(darkMode)
                 .withAlpha(_backgroundAlpha),

--- a/packages/smooth_app/lib/pages/product/common/product_query_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_query_page.dart
@@ -25,14 +25,12 @@ class ProductQueryPage extends StatefulWidget {
   const ProductQueryPage({
     required this.productListSupplier,
     required this.heroTag,
-    required this.mainColor,
     required this.name,
     this.lastUpdate,
   });
 
   final ProductListSupplier productListSupplier;
   final String heroTag;
-  final Color mainColor;
   final String name;
   final int? lastUpdate;
 
@@ -99,9 +97,7 @@ class _ProductQueryPageState extends State<ProductQueryPage>
             return _getEmptyScreen(
               screenSize,
               themeData,
-              CircularProgressIndicator(
-                valueColor: AlwaysStoppedAnimation<Color>(widget.mainColor),
-              ),
+              const CircularProgressIndicator(),
             );
           case LoadingStatus.COMPLETE:
             if (_model.isNotEmpty()) {
@@ -123,7 +119,6 @@ class _ProductQueryPageState extends State<ProductQueryPage>
               themeData,
               _getEmptyText(
                 themeData,
-                widget.mainColor,
                 appLocalizations.no_product_found,
               ),
             );
@@ -143,41 +138,19 @@ class _ProductQueryPageState extends State<ProductQueryPage>
       ScaffoldMessenger(
         key: _scaffoldKeyEmpty,
         child: Scaffold(
-          backgroundColor: widget.mainColor.withAlpha(32),
-          body: Stack(
-            children: <Widget>[
-              _getHero(screenSize, themeData),
-              CustomScrollView(
-                slivers: <Widget>[
-                  SliverAppBar(
-                      backgroundColor: themeData.scaffoldBackgroundColor,
-                      expandedHeight: screenSize.height * 0.15,
-                      collapsedHeight: screenSize.height * 0.09,
-                      pinned: true,
-                      elevation: 0,
-                      automaticallyImplyLeading: false,
-                      leading: _BackButton(
-                        color: widget.mainColor,
-                      ),
-                      flexibleSpace: LayoutBuilder(builder:
-                          (BuildContext context, BoxConstraints constraints) {
-                        return FlexibleSpaceBar(
-                          centerTitle: true,
-                          title: Text(
-                            widget.name,
-                            textAlign: TextAlign.center,
-                            style: themeData.textTheme.headline1!
-                                .copyWith(color: widget.mainColor),
-                          ),
-                        );
-                      })),
-                ],
-              ),
-              Center(child: emptiness),
-            ],
+          appBar: AppBar(
+            backgroundColor: themeData.scaffoldBackgroundColor,
+            leading: const _BackButton(),
+            title: _getAppBarTitle(),
+          ),
+          body: Hero(
+            tag: widget.heroTag,
+            child: Center(child: emptiness),
           ),
         ),
       );
+
+  Widget _getAppBarTitle() => AutoSizeText(widget.name, maxLines: 2);
 
   Widget _getNotEmptyScreen(
     final Size screenSize,
@@ -187,14 +160,12 @@ class _ProductQueryPageState extends State<ProductQueryPage>
       ScaffoldMessenger(
         key: _scaffoldKeyNotEmpty,
         child: Scaffold(
-          backgroundColor: widget.mainColor.withAlpha(32),
           floatingActionButton: Row(
             mainAxisAlignment: _showBackToTopButton
                 ? MainAxisAlignment.spaceBetween
                 : MainAxisAlignment.center,
             children: <Widget>[
               RankingFloatingActionButton(
-                color: widget.mainColor,
                 onPressed: () => Navigator.push<Widget>(
                   context,
                   MaterialPageRoute<Widget>(
@@ -221,10 +192,7 @@ class _ProductQueryPageState extends State<ProductQueryPage>
                           _scrollToTop();
                         },
                         tooltip: appLocalizations.go_back_to_top,
-                        child: Icon(
-                          Icons.arrow_upward,
-                          color: widget.mainColor,
-                        ),
+                        child: const Icon(Icons.arrow_upward),
                       ),
                     ),
                   ),
@@ -243,28 +211,16 @@ class _ProductQueryPageState extends State<ProductQueryPage>
                     slivers: <Widget>[
                       SliverAppBar(
                         backgroundColor: themeData.scaffoldBackgroundColor,
-                        expandedHeight: screenSize.height * 0.15,
-                        collapsedHeight: screenSize.height * 0.09,
                         pinned: true,
                         elevation: 0,
                         automaticallyImplyLeading: false,
-                        leading: _BackButton(
-                          color: widget.mainColor,
-                        ),
+                        leading: const _BackButton(),
                         actions: <Widget>[
                           TextButton.icon(
-                            icon: Icon(
-                              Icons.filter_list,
-                              color: widget.mainColor,
-                            ),
-                            label: Text(appLocalizations.filter,
-                                style: themeData.textTheme.subtitle1!
-                                    .copyWith(color: widget.mainColor)),
-                            style: TextButton.styleFrom(
-                              primary: widget.mainColor,
-                              textStyle: TextStyle(
-                                color: widget.mainColor,
-                              ),
+                            icon: const Icon(Icons.filter_list),
+                            label: Text(
+                              appLocalizations.filter,
+                              style: themeData.textTheme.subtitle1,
                             ),
                             onPressed: () {
                               showCupertinoModalBottomSheet<Widget>(
@@ -285,25 +241,7 @@ class _ProductQueryPageState extends State<ProductQueryPage>
                             },
                           )
                         ],
-                        flexibleSpace: LayoutBuilder(
-                          builder: (
-                            BuildContext context,
-                            BoxConstraints constraints,
-                          ) =>
-                              FlexibleSpaceBar(
-                            centerTitle: true,
-                            title: SizedBox(
-                              width: screenSize.width * 0.55,
-                              child: AutoSizeText(
-                                widget.name,
-                                textAlign: TextAlign.center,
-                                style: themeData.textTheme.headline1!
-                                    .copyWith(color: widget.mainColor),
-                                maxLines: 1,
-                              ),
-                            ),
-                          ),
-                        ),
+                        title: _getAppBarTitle(),
                       ),
                       SliverList(
                         delegate: SliverChildBuilderDelegate(
@@ -418,7 +356,6 @@ class _ProductQueryPageState extends State<ProductQueryPage>
 
   Widget _getEmptyText(
     final ThemeData themeData,
-    final Color color,
     final String message,
   ) =>
       Row(
@@ -426,10 +363,11 @@ class _ProductQueryPageState extends State<ProductQueryPage>
         mainAxisAlignment: MainAxisAlignment.center,
         children: <Widget>[
           Flexible(
-            child: Text(message,
-                textAlign: TextAlign.center,
-                style: themeData.textTheme.subtitle1!
-                    .copyWith(color: color, fontSize: 18.0)),
+            child: Text(
+              message,
+              textAlign: TextAlign.center,
+              style: themeData.textTheme.subtitle1!.copyWith(fontSize: 18.0),
+            ),
           ),
         ],
       );
@@ -502,22 +440,14 @@ class _ProductQueryPageState extends State<ProductQueryPage>
 }
 
 class _BackButton extends StatelessWidget {
-  const _BackButton({
-    required this.color,
-    Key? key,
-  }) : super(key: key);
-
-  final Color color;
+  const _BackButton();
 
   @override
-  Widget build(BuildContext context) {
-    return IconButton(
-      icon: Icon(ConstantIcons.instance.getBackIcon()),
-      color: color,
-      tooltip: MaterialLocalizations.of(context).backButtonTooltip,
-      onPressed: () {
-        Navigator.maybePop(context);
-      },
-    );
-  }
+  Widget build(BuildContext context) => IconButton(
+        icon: Icon(ConstantIcons.instance.getBackIcon()),
+        tooltip: MaterialLocalizations.of(context).backButtonTooltip,
+        onPressed: () {
+          Navigator.maybePop(context);
+        },
+      );
 }

--- a/packages/smooth_app/lib/pages/product/common/product_query_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_query_page.dart
@@ -187,12 +187,15 @@ class _ProductQueryPageState extends State<ProductQueryPage>
                     child: Padding(
                       padding: const EdgeInsets.only(left: 8.0),
                       child: FloatingActionButton(
-                        backgroundColor: Colors.white,
+                        backgroundColor: themeData.colorScheme.secondary,
                         onPressed: () {
                           _scrollToTop();
                         },
                         tooltip: appLocalizations.go_back_to_top,
-                        child: const Icon(Icons.arrow_upward),
+                        child: Icon(
+                          Icons.arrow_upward,
+                          color: themeData.colorScheme.onSecondary,
+                        ),
                       ),
                     ),
                   ),
@@ -309,11 +312,7 @@ class _ProductQueryPageState extends State<ProductQueryPage>
                               child: SmoothProductCardFound(
                                 heroTag: product.barcode!,
                                 product: product,
-                                elevation:
-                                    themeData.brightness == Brightness.light
-                                        ? 0.0
-                                        : 4.0,
-                              ).build(context),
+                              ),
                             );
                           },
                           childCount: _model.displayProducts!.length + 1,

--- a/packages/smooth_app/lib/pages/product/common/product_query_page_helper.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_query_page_helper.dart
@@ -10,7 +10,6 @@ class ProductQueryPageHelper {
   Future<void> openBestChoice({
     required final PagedProductQuery productQuery,
     required final LocalDatabase localDatabase,
-    required final Color color,
     required final String heroTag,
     required final String name,
     required final BuildContext context,
@@ -27,7 +26,6 @@ class ProductQueryPageHelper {
         builder: (BuildContext context) => ProductQueryPage(
           productListSupplier: supplier,
           heroTag: heroTag,
-          mainColor: color,
           name: name,
           lastUpdate: supplier.timestamp,
         ),

--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -294,7 +294,6 @@ class _SummaryCardState extends State<SummaryCard> {
             localizations.product_search_same_category,
             iconData: Icons.leaderboard,
             onPressed: () async => ProductQueryPageHelper().openBestChoice(
-              color: Colors.deepPurple,
               heroTag: 'search_bar',
               name: categoryLabel!,
               localDatabase: localDatabase,

--- a/packages/smooth_app/lib/pages/scan/search_page.dart
+++ b/packages/smooth_app/lib/pages/scan/search_page.dart
@@ -77,7 +77,6 @@ Future<void> _onSubmittedText(
   final LocalDatabase localDatabase,
 ) async =>
     ProductQueryPageHelper().openBestChoice(
-      color: Colors.deepPurple,
       heroTag: 'search_bar',
       name: value,
       localDatabase: localDatabase,

--- a/packages/smooth_app/lib/widgets/ranking_floating_action_button.dart
+++ b/packages/smooth_app/lib/widgets/ranking_floating_action_button.dart
@@ -6,11 +6,9 @@ import 'package:smooth_app/generic_lib/animations/smooth_reveal_animation.dart';
 /// Floating Action Button dedicated to Personal Ranking
 class RankingFloatingActionButton extends StatelessWidget {
   const RankingFloatingActionButton({
-    required this.color,
     required this.onPressed,
   });
 
-  final Color color;
   final VoidCallback onPressed;
 
   static const IconData rankingIconData = Icons.emoji_events_outlined;
@@ -26,15 +24,8 @@ class RankingFloatingActionButton extends StatelessWidget {
             SizedBox(width: MediaQuery.of(context).size.width * 0.09),
             FloatingActionButton.extended(
               elevation: 12.0,
-              icon: Icon(
-                rankingIconData,
-                color: color,
-              ),
-              label: Text(
-                AppLocalizations.of(context).myPersonalizedRanking,
-                style: TextStyle(color: color),
-              ),
-              backgroundColor: Colors.white,
+              icon: const Icon(rankingIconData),
+              label: Text(AppLocalizations.of(context).myPersonalizedRanking),
               onPressed: onPressed,
             ),
           ],


### PR DESCRIPTION
Impacted files:
* `product_query_page.dart`: removed color parameter; simplified app bars
* `product_query_page_helper.dart`: removed color parameter
* `ranking_floating_action_button.dart`: removed color parameter
* `search_page.dart`: refactored
* `summary_card.dart`: refactored

### What
- For historical reasons, the app bar for search results was problematic.
- The app bar used sliver effect without added value and with distorted texts.
- There was also a color (`deepPurple`) that was used as a theme for no specific reason, and that could cause UI consistency or accessibility issues without added value.
- Now the app bar is simplified, and the color was kicked out.

### Screenshot
| dark | light |
| --- | --- |
| ![Capture d’écran 2022-06-06 à 10 43 27](https://user-images.githubusercontent.com/11576431/172127371-69178a07-2737-423f-82fe-fcdb8c864222.png) | ![Capture d’écran 2022-06-06 à 10 43 50](https://user-images.githubusercontent.com/11576431/172127421-2827073e-684f-4e48-aec9-7a41ffc33f77.png) |

### Fixes bug(s)
- Fixes: #2180