### PR TITLE
feat: Preference to define which camera quality preset to use

### DIFF
--- a/packages/smooth_app/lib/data_models/user_preferences.dart
+++ b/packages/smooth_app/lib/data_models/user_preferences.dart
@@ -27,6 +27,8 @@ class UserPreferences extends ChangeNotifier {
   static const String _TAG_CRASH_REPORTS = 'crash_reports';
   static const String _TAG_EXCLUDED_ATTRIBUTE_IDS = 'excluded_attributes';
   static const String _TAG_IS_FIRST_SCAN = 'is_first_scan';
+  static const String _TAG_SCAN_CAMERA_RESOLUTION_PRESET =
+      'camera_resolution_preset';
 
   /// Attribute group that is not collapsed
   static const String _TAG_ACTIVE_ATTRIBUTE_GROUP = 'activeAttributeGroup';
@@ -138,6 +140,15 @@ class UserPreferences extends ChangeNotifier {
 
   Future<void> setExcludedAttributeIds(final List<String> value) async {
     await _sharedPreferences.setStringList(_TAG_EXCLUDED_ATTRIBUTE_IDS, value);
+    notifyListeners();
+  }
+
+  bool get useVeryHighResolutionPreset =>
+      _sharedPreferences.getBool(_TAG_SCAN_CAMERA_RESOLUTION_PRESET) ?? false;
+
+  Future<void> setUseVeryHighResolutionPreset(bool enableFeature) async {
+    await _sharedPreferences.setBool(
+        _TAG_SCAN_CAMERA_RESOLUTION_PRESET, enableFeature);
     notifyListeners();
   }
 

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -789,7 +789,7 @@
     "@camera_high_resolution_preset_toggle_title": {
         "description": "Title for the Camera high resolution toggle"
     },
-    "camera_high_resolution_preset_toggle_subtitle": "When enabled, barcodes decoding quality should be better, but may impact performance and battery life. Require an application restart.",
+    "camera_high_resolution_preset_toggle_subtitle": "When enabled, barcodes decoding quality should be better, but may impact performance and battery life. Requires an application restart.",
     "@camera_high_resolution_preset_toggle_subtitle": {
         "description": "SubTitle for the Camera high resolution toggle"
     },

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -789,7 +789,7 @@
     "@camera_high_resolution_preset_toggle_title": {
         "description": "Title for the Camera high resolution toggle"
     },
-    "camera_high_resolution_preset_toggle_subtitle": "When enabled, barcodes decoding quality should be better, but may impact performance and battery life. May require an application restart.",
+    "camera_high_resolution_preset_toggle_subtitle": "When enabled, barcodes decoding quality should be better, but may impact performance and battery life. Require an application restart.",
     "@camera_high_resolution_preset_toggle_subtitle": {
         "description": "SubTitle for the Camera high resolution toggle"
     },

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -785,6 +785,14 @@
             }
         }
     },
+    "camera_high_resolution_preset_toggle_title": "Camera high performance mode",
+    "@camera_high_resolution_preset_toggle_title": {
+        "description": "Title for the Camera high resolution toggle"
+    },
+    "camera_high_resolution_preset_toggle_subtitle": "When enabled, barcodes decoding quality should be better, but may impact performance and battery life. May require an application restart.",
+    "@camera_high_resolution_preset_toggle_subtitle": {
+        "description": "SubTitle for the Camera high resolution toggle"
+    },
     "crash_reporting_toggle_title": "Crash reporting",
     "@crash_reporting_toggle_title": {
         "description": "Title for the Crash reporting toggle"

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_settings.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_settings.dart
@@ -84,6 +84,8 @@ class UserPreferencesSettings extends AbstractUserPreferences {
         const UserPreferencesListItemDivider(),
         const _CountryPickerSetting(),
         const UserPreferencesListItemDivider(),
+        const _CameraHighResolutionPresetSetting(),
+        const UserPreferencesListItemDivider(),
         const _CrashReportingSetting(),
         const UserPreferencesListItemDivider(),
         const _SendAnonymousDataSetting(),
@@ -152,6 +154,25 @@ class _CrashReportingSetting extends StatelessWidget {
       onChanged: (final bool value) async {
         await userPreferences.setCrashReports(value);
         AnalyticsHelper.setCrashReports(value);
+      },
+    );
+  }
+}
+
+class _CameraHighResolutionPresetSetting extends StatelessWidget {
+  const _CameraHighResolutionPresetSetting({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final UserPreferences userPreferences = context.watch<UserPreferences>();
+
+    return UserPreferencesSwitchItem(
+      title: appLocalizations.camera_high_resolution_preset_toggle_title,
+      subtitle: appLocalizations.camera_high_resolution_preset_toggle_subtitle,
+      value: userPreferences.useVeryHighResolutionPreset,
+      onChanged: (final bool value) async {
+        await userPreferences.setUseVeryHighResolutionPreset(value);
       },
     );
   }

--- a/packages/smooth_app/lib/pages/scan/camera_controller.dart
+++ b/packages/smooth_app/lib/pages/scan/camera_controller.dart
@@ -10,7 +10,6 @@ class SmoothCameraController extends CameraController {
   SmoothCameraController(
     CameraDescription description,
     ResolutionPreset resolutionPreset, {
-    bool? enableAudio,
     ImageFormatGroup? imageFormatGroup,
   })  : _isPaused = false,
         _isInitialized = false,
@@ -18,7 +17,7 @@ class SmoothCameraController extends CameraController {
         super(
           description,
           resolutionPreset,
-          enableAudio: enableAudio ?? true,
+          enableAudio: false,
           imageFormatGroup: imageFormatGroup,
         );
 

--- a/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
@@ -215,8 +215,9 @@ class MLKitScannerPageState extends LifecycleAwareState<MLKitScannerPage>
     CameraHelper.initController(
       SmoothCameraController(
         _camera!,
-        ResolutionPreset.veryHigh,
-        enableAudio: false,
+        _userPreferences.useVeryHighResolutionPreset
+            ? ResolutionPreset.veryHigh
+            : ResolutionPreset.high,
         imageFormatGroup: ImageFormatGroup.yuv420,
       ),
     );


### PR DESCRIPTION
Allows the user to change between `veryHigh` and `high` camera presets.
![app](https://user-images.githubusercontent.com/246838/172217351-a15bd1a3-1a2e-4648-b665-bdfb3ceb3e73.png)


(If you have scanning issues, enabling this should improve the detection, but may impact battery life)