### PR TITLE
feat: #2169 - new simple input page for "Stores"

### DIFF
--- a/packages/smooth_app/lib/database/product_query.dart
+++ b/packages/smooth_app/lib/database/product_query.dart
@@ -95,6 +95,7 @@ abstract class ProductQuery {
         ProductField.SELECTED_IMAGE,
         ProductField.QUANTITY,
         ProductField.SERVING_SIZE,
+        ProductField.STORES,
         ProductField.PACKAGING_QUANTITY,
         ProductField.NUTRIMENTS,
         ProductField.NUTRIENT_LEVELS,

--- a/packages/smooth_app/lib/pages/product/category_picker_page.dart
+++ b/packages/smooth_app/lib/pages/product/category_picker_page.dart
@@ -161,12 +161,12 @@ class _CategoryPickerPageState extends State<CategoryPickerPage> {
       tag
     ]; // TODO(monsieurtanuki): is the last leaf good enough or should we go down to the roots?
 
-    final bool savedAndRefreshed = await ProductRefresher().saveAndRefresh(
+    final Product? savedAndRefreshed = await ProductRefresher().saveAndRefresh(
       context: context,
       localDatabase: localDatabase,
       product: product,
     );
-    if (savedAndRefreshed) {
+    if (savedAndRefreshed != null) {
       if (!mounted) {
         return;
       }

--- a/packages/smooth_app/lib/pages/product/common/product_refresher.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_refresher.dart
@@ -9,24 +9,26 @@ import 'package:smooth_app/generic_lib/loading_dialog.dart';
 
 /// Refreshes a product on the BE then on the local database.
 class ProductRefresher {
-  Future<bool> saveAndRefresh({
+  /// Returns a saved and refreshed [Product] if successful, or null.
+  Future<Product?> saveAndRefresh({
     required final BuildContext context,
     required final LocalDatabase localDatabase,
     required final Product product,
   }) async {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    final bool? savedAndRefreshed = await LoadingDialog.run<bool>(
+    final _MetaProductRefresher? savedAndRefreshed =
+        await LoadingDialog.run<_MetaProductRefresher>(
       future: _saveAndRefresh(product, localDatabase),
       context: context,
       title: appLocalizations.nutrition_page_update_running,
     );
     if (savedAndRefreshed == null) {
       // probably the end user stopped the dialog
-      return false;
+      return null;
     }
-    if (!savedAndRefreshed) {
+    if (savedAndRefreshed.product == null) {
       await LoadingDialog.error(context: context);
-      return false;
+      return null;
     }
     await showDialog<void>(
       context: context,
@@ -38,11 +40,11 @@ class ProductRefresher {
         ),
       ),
     );
-    return true;
+    return savedAndRefreshed.product;
   }
 
   /// Saves a product on the BE and refreshes the local database
-  Future<bool> _saveAndRefresh(
+  Future<_MetaProductRefresher> _saveAndRefresh(
     final Product inputProduct,
     final LocalDatabase localDatabase,
   ) async {
@@ -52,7 +54,7 @@ class ProductRefresher {
         inputProduct,
       );
       if (status.error != null) {
-        return false;
+        return _MetaProductRefresher.error(status.error);
       }
       final ProductQueryConfiguration configuration = ProductQueryConfiguration(
         inputProduct.barcode!,
@@ -65,11 +67,20 @@ class ProductRefresher {
       );
       if (result.product != null) {
         await DaoProduct(localDatabase).put(result.product!);
-        return true;
+        localDatabase.notifyListeners();
+        return _MetaProductRefresher.product(result.product);
       }
     } catch (e) {
       //
     }
-    return false;
+    return const _MetaProductRefresher.error(null);
   }
+}
+
+class _MetaProductRefresher {
+  const _MetaProductRefresher.error(this.error) : product = null;
+  const _MetaProductRefresher.product(this.product) : error = null;
+
+  final String? error;
+  final Product? product;
 }

--- a/packages/smooth_app/lib/pages/product/edit_ingredients_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_ingredients_page.dart
@@ -148,12 +148,12 @@ class _EditIngredientsPageState extends State<EditIngredientsPage> {
   Future<void> _updateIngredientsText(String ingredientsText) async {
     widget.product.ingredientsText = ingredientsText;
     final LocalDatabase localDatabase = context.read<LocalDatabase>();
-    final bool savedAndRefreshed = await ProductRefresher().saveAndRefresh(
+    final Product? savedAndRefreshed = await ProductRefresher().saveAndRefresh(
       context: context,
       localDatabase: localDatabase,
       product: widget.product,
     );
-    if (savedAndRefreshed) {
+    if (savedAndRefreshed != null) {
       if (!mounted) {
         return;
       }

--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -10,6 +10,8 @@ import 'package:smooth_app/pages/product/edit_ingredients_page.dart';
 import 'package:smooth_app/pages/product/nutrition_page_loaded.dart';
 import 'package:smooth_app/pages/product/ordered_nutrients_cache.dart';
 import 'package:smooth_app/pages/product/product_image_gallery_view.dart';
+import 'package:smooth_app/pages/product/simple_input_page.dart';
+import 'package:smooth_app/pages/product/simple_input_page_helpers.dart';
 
 /// Page where we can indirectly edit all data about a product.
 class EditProductPage extends StatefulWidget {
@@ -23,6 +25,13 @@ class EditProductPage extends StatefulWidget {
 
 class _EditProductPageState extends State<EditProductPage> {
   int _changes = 0;
+  late Product _product;
+
+  @override
+  void initState() {
+    super.initState();
+    _product = widget.product;
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -30,7 +39,7 @@ class _EditProductPageState extends State<EditProductPage> {
     return Scaffold(
       appBar: AppBar(
         title: AutoSizeText(
-          getProductName(widget.product, appLocalizations),
+          getProductName(_product, appLocalizations),
           maxLines: 2,
         ),
         systemOverlayStyle: const SystemUiOverlayStyle(
@@ -52,9 +61,8 @@ class _EditProductPageState extends State<EditProductPage> {
               title: Text(
                 appLocalizations.edit_product_form_item_barcode,
               ),
-              subtitle: widget.product.barcode == null
-                  ? null
-                  : Text(widget.product.barcode!),
+              subtitle:
+                  _product.barcode == null ? null : Text(_product.barcode!),
             ),
             _ListTitleItem(
               title: appLocalizations.edit_product_form_item_details_title,
@@ -65,7 +73,7 @@ class _EditProductPageState extends State<EditProductPage> {
                   context,
                   MaterialPageRoute<bool>(
                     builder: (BuildContext context) =>
-                        AddBasicDetailsPage(widget.product),
+                        AddBasicDetailsPage(_product),
                   ),
                 );
                 if (refreshed ?? false) {
@@ -78,7 +86,7 @@ class _EditProductPageState extends State<EditProductPage> {
               subtitle: appLocalizations.edit_product_form_item_photos_subtitle,
               onTap: () async {
                 final List<ProductImageData> allProductImagesData =
-                    getAllProductImagesData(widget.product, appLocalizations);
+                    getAllProductImagesData(_product, appLocalizations);
                 final bool? refreshed = await Navigator.push<bool>(
                   context,
                   MaterialPageRoute<bool>(
@@ -86,7 +94,7 @@ class _EditProductPageState extends State<EditProductPage> {
                       productImageData: allProductImagesData.first,
                       allProductImagesData: allProductImagesData,
                       title: allProductImagesData.first.title,
-                      barcode: widget.product.barcode,
+                      barcode: _product.barcode,
                     ),
                   ),
                 );
@@ -106,7 +114,7 @@ class _EditProductPageState extends State<EditProductPage> {
                   context,
                   MaterialPageRoute<bool>(
                     builder: (BuildContext context) => EditIngredientsPage(
-                      product: widget.product,
+                      product: _product,
                     ),
                   ),
                 );
@@ -117,6 +125,26 @@ class _EditProductPageState extends State<EditProductPage> {
             ),
             _ListTitleItem(
               title: appLocalizations.edit_product_form_item_packaging_title,
+            ),
+            _ListTitleItem(
+              title: 'Stores', // TODO(monsieurtanuki): translate
+              onTap: () async {
+                final Product? refreshed = await Navigator.push<Product>(
+                  context,
+                  MaterialPageRoute<Product>(
+                    builder: (BuildContext context) => SimpleInputPage(
+                      SimpleInputPageStoreHelper(
+                        _product,
+                        appLocalizations,
+                      ),
+                    ),
+                  ),
+                );
+                if (refreshed != null) {
+                  _product = refreshed;
+                }
+                return;
+              },
             ),
             _ListTitleItem(
               title:
@@ -136,7 +164,7 @@ class _EditProductPageState extends State<EditProductPage> {
                   context,
                   MaterialPageRoute<bool>(
                     builder: (BuildContext context) => NutritionPageLoaded(
-                      widget.product,
+                      _product,
                       cache.orderedNutrients,
                     ),
                   ),
@@ -145,7 +173,7 @@ class _EditProductPageState extends State<EditProductPage> {
                   _changes++;
                 }
               },
-            )
+            ),
           ],
         ),
       ),

--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -454,12 +454,12 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
     // minimal product: we only want to save the nutrients
     final Product inputProduct = _nutritionContainer.getProduct();
 
-    final bool savedAndRefreshed = await ProductRefresher().saveAndRefresh(
+    final Product? savedAndRefreshed = await ProductRefresher().saveAndRefresh(
       context: context,
       localDatabase: localDatabase,
       product: inputProduct,
     );
-    if (savedAndRefreshed) {
+    if (savedAndRefreshed != null) {
       if (!mounted) {
         return;
       }

--- a/packages/smooth_app/lib/pages/product/simple_input_page.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page.dart
@@ -1,0 +1,161 @@
+import 'package:auto_size_text/auto_size_text.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:provider/provider.dart';
+import 'package:smooth_app/database/local_database.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
+import 'package:smooth_app/helpers/product_cards_helper.dart';
+import 'package:smooth_app/pages/product/common/product_refresher.dart';
+import 'package:smooth_app/pages/product/simple_input_page_helpers.dart';
+
+/// Simple input page: we have a list of labels, we add, we remove, we save.
+class SimpleInputPage extends StatefulWidget {
+  const SimpleInputPage(this.helper) : super();
+
+  final AbstractSimpleInputPageHelper helper;
+
+  @override
+  State<SimpleInputPage> createState() => _SimpleInputPageState();
+}
+
+class _SimpleInputPageState extends State<SimpleInputPage> {
+  final TextEditingController _controller = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData themeData = Theme.of(context);
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final LocalDatabase localDatabase = context.watch<LocalDatabase>();
+    // that's a bit tricky here.
+    // 1. we want to decide if we can go out of this page.
+    // 1a. for this, we return an async bool, according to onWillPop.
+    // 2. but we also want to return the changed Product.
+    return WillPopScope(
+      onWillPop: () async {
+        final Product? changedProduct = widget.helper.getChangedProduct();
+        if (changedProduct == null) {
+          return true;
+        }
+        final bool? pleaseSave = await showDialog<bool>(
+          context: context,
+          builder: (final BuildContext context) => SmoothAlertDialog(
+            body:
+                const Text('You are about to leave this page without saving.'),
+            title: widget.helper.getTitle(),
+            negativeAction: SmoothActionButton(
+              text: 'Ignore',
+              onPressed: () => Navigator.pop(context, false),
+            ),
+            positiveAction: SmoothActionButton(
+              text: 'Save',
+              onPressed: () => Navigator.pop(context, true),
+            ),
+            neutralAction: SmoothActionButton(
+              text: 'Cancel',
+              onPressed: () => Navigator.pop(context, null),
+            ),
+          ),
+        );
+        if (pleaseSave == null) {
+          return false;
+        }
+        if (pleaseSave == false) {
+          return true;
+        }
+        final Product? savedAndRefreshed =
+            await ProductRefresher().saveAndRefresh(
+          context: context,
+          localDatabase: localDatabase,
+          product: changedProduct,
+        );
+        if (savedAndRefreshed == null) {
+          // it failed: we stay on the same page
+          return false;
+        }
+        // tricky part (cf. https://stackoverflow.com/questions/53995673/willpopscope-should-i-use-return-future-valuetrue-after-navigator-pop)
+        // 1. we return true to get out of this page.
+        // 2. we pop the product because the calling page needs it.
+        //ignore: use_build_context_synchronously
+        Navigator.pop(context, savedAndRefreshed);
+        return Future<bool>(() => true);
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          title: AutoSizeText(
+            getProductName(widget.helper.product, appLocalizations),
+            maxLines: 2,
+          ),
+        ),
+        body: Padding(
+          padding: const EdgeInsets.all(SMALL_SPACE),
+          child: ListView(
+            children: <Widget>[
+              Text(
+                widget.helper.getTitle(),
+                style: themeData.textTheme.headline1,
+              ),
+              const SizedBox(height: LARGE_SPACE),
+              Text(widget.helper.getAddTitle()),
+              Row(
+                children: <Widget>[
+                  ElevatedButton(
+                    onPressed: () {
+                      if (widget.helper.addLabel(_controller.text)) {
+                        setState(() => _controller.text = '');
+                      }
+                    },
+                    child: const Icon(Icons.add),
+                  ),
+                  Flexible(
+                    flex: 1, // maximum size, as the other guy has no flex
+                    child: Padding(
+                      padding: const EdgeInsets.all(LARGE_SPACE),
+                      child: TextField(
+                        decoration: InputDecoration(
+                          filled: true,
+                          border: const OutlineInputBorder(
+                            borderRadius: CIRCULAR_BORDER_RADIUS,
+                            borderSide: BorderSide.none,
+                          ),
+                          contentPadding: const EdgeInsets.symmetric(
+                            horizontal: SMALL_SPACE,
+                            vertical: SMALL_SPACE,
+                          ),
+                          hintText: widget.helper.getAddHint(),
+                        ),
+                        controller: _controller,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              Divider(color: themeData.colorScheme.onBackground),
+              Wrap(
+                direction: Axis.horizontal,
+                spacing: LARGE_SPACE,
+                runSpacing: VERY_SMALL_SPACE,
+                children: List<Widget>.generate(
+                  widget.helper.getLabels().length,
+                  (final int index) {
+                    final String label = widget.helper.getLabels()[index];
+                    return ElevatedButton.icon(
+                      icon: const Icon(Icons.clear),
+                      label: Text(label),
+                      onPressed: () async {
+                        if (widget.helper.removeLabel(label)) {
+                          setState(() {});
+                        }
+                      },
+                    );
+                  },
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+
+/// Abstract helper for Simple Input Page.
+///
+/// * we retrieve the initial list of labels.
+/// * we add a label to the list.
+/// * we remove a label from the list.
+abstract class AbstractSimpleInputPageHelper {
+  AbstractSimpleInputPageHelper(
+    this.product,
+    this.appLocalizations,
+  ) {
+    _labels = initLabels();
+  }
+
+  final Product product;
+  final AppLocalizations appLocalizations;
+
+  /// Labels as they were initially then edited by the user.
+  late List<String> _labels;
+
+  /// "Have the labels been changed?"
+  bool _changed = false;
+
+  /// Returns the labels as they were initially in the product.
+  @protected
+  List<String> initLabels();
+
+  /// Returns the current labels to be displayed.
+  List<String> getLabels() => _labels;
+
+  /// Returns true if the label was not in the list and then was added.
+  bool addLabel(String label) {
+    label = label.trim();
+    if (label.isEmpty) {
+      return false;
+    }
+    if (_labels.contains(label)) {
+      return false;
+    }
+    _labels.add(label);
+    _changed = true;
+    return true;
+  }
+
+  /// Returns true if the label was in the list and then was removed.
+  ///
+  /// The things we build the interface, very unlikely to return false,
+  /// as we remove existing items.
+  bool removeLabel(final String label) {
+    if (_labels.remove(label)) {
+      _changed = true;
+      return true;
+    }
+    return false;
+  }
+
+  /// Returns the title on the main "edit product" page.
+  String getTitle();
+
+  /// Returns the title of the "add" paragraph.
+  String getAddTitle();
+
+  /// Returns the hint of the "add" text field.
+  String getAddHint();
+
+  /// Impacts a product in order to take the changes into account.
+  @protected
+  void changeProduct(final Product changedProduct);
+
+  /// Returns null is no change was made, or a Product to be saved on the BE.
+  Product? getChangedProduct() {
+    if (!_changed) {
+      return null;
+    }
+    final Product changedProduct = Product(barcode: product.barcode);
+    changeProduct(changedProduct);
+    return changedProduct;
+  }
+
+  List<String> _splitString(final String? input) {
+    if (input == null) {
+      return <String>[];
+    }
+    final List<String> result = input.split(',');
+    for (int i = 0; i < result.length; i++) {
+      final int pos = result[i].indexOf(':');
+      if (pos == 2) {
+        // we get rid of the language, e.g. 'fr:Sac'
+        result[i] = result[i].substring(pos + 1);
+      }
+    }
+    return result;
+  }
+}
+
+/// Implementation for "Stores" of an [AbstractSimpleInputPageHelper].
+class SimpleInputPageStoreHelper extends AbstractSimpleInputPageHelper {
+  SimpleInputPageStoreHelper(
+    final Product product,
+    final AppLocalizations appLocalizations,
+  ) : super(
+          product,
+          appLocalizations,
+        );
+
+  @override
+  List<String> initLabels() => _splitString(product.stores);
+
+  @override
+  void changeProduct(final Product changedProduct) =>
+      changedProduct.stores = _labels.join(',');
+
+  @override
+  String getTitle() => 'Stores'; // TODO(monsieurtanuki): translate
+
+  @override
+  String getAddTitle() => 'Add a store'; // TODO(monsieurtanuki): translate
+
+  @override
+  String getAddHint() => 'store'; // TODO(monsieurtanuki): translate
+}


### PR DESCRIPTION
New files:
* `simple_input_page.dart`: Simple input page: we have a list of labels, we add, we remove, we save.
* `simple_input_page_helpers.dart`: Helpers for Simple Input Page.

Impacted files:
* `category_picker_page.dart`: refactored
* `edit_ingredients_page.dart`: refactored
* `edit_product_page.dart`: added an "edit store" button; refactored
* `nutrition_page_loaded.dart`: refactored
* `product_query.dart`: added field for stores
* `product_refresher.dart`: now we return the saved and refreshed product instead of a mere `bool`

### What
- This is the first implementation of the new "simple input page".
- In that kind of page, we retrieve a list of labels from the product (in this case, the stores).
- Labels can be added and removed.
- When the end-user Bob exits the page, Bob is being asked to save (or not) the data to the back-end and local database.
- I'm glad to say that it works(I had doubt about just adding "Monoprix").
- Special message for @teolemon (I know you won't like that) - stores were not part of the data we retrieved from the server. As the refresh is not automatic, you have to refresh manually the products (or start from an empty list of stores).

### Screenshot
Added a "Stores" button in the detailed edit page:
![Capture d’écran 2022-06-06 à 20 30 28](https://user-images.githubusercontent.com/11576431/172223473-f7d88e59-6c00-4b46-9574-789a1062ee4f.png)

| landing page | adding... | added |
| --- | --- | --- |
| ![Capture d’écran 2022-06-06 à 20 30 58](https://user-images.githubusercontent.com/11576431/172223553-77eb0ec4-fce8-4f56-b05f-848aadd62427.png) | ![Capture d’écran 2022-06-06 à 20 31 16](https://user-images.githubusercontent.com/11576431/172223600-c5d39733-c1c2-4954-895e-68aee164b223.png) | ![Capture d’écran 2022-06-06 à 20 31 37](https://user-images.githubusercontent.com/11576431/172223697-f6a62b59-3979-4c62-87e2-0e14fb0798ed.png) |

Exiting the page after changes:
![Capture d’écran 2022-06-06 à 20 32 07](https://user-images.githubusercontent.com/11576431/172223820-7e2e1579-9b9a-44f2-a028-b08440400d28.png)


### Part of 
- #2169