### PR TITLE
feat: #2169 - new simple input page for "Labels"

### DIFF
--- a/packages/smooth_app/lib/generic_lib/dialogs/smooth_alert_dialog.dart
+++ b/packages/smooth_app/lib/generic_lib/dialogs/smooth_alert_dialog.dart
@@ -24,8 +24,8 @@ class SmoothAlertDialog extends StatelessWidget {
     this.positiveAction,
     this.neutralAction,
     this.negativeAction,
-  })  : close = false,
-        maxHeight = null,
+    this.close = false,
+  })  : maxHeight = null,
         _simpleMode = true;
 
   /// Advanced alert dialog with fancy effects.
@@ -153,7 +153,7 @@ class SmoothAlertDialog extends StatelessWidget {
             Icons.close,
             size: 29.0,
           ),
-          onTap: () => Navigator.of(context, rootNavigator: true).pop('dialog'),
+          onTap: () => Navigator.of(context, rootNavigator: true).pop(),
         ),
       );
     } else {

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -18,6 +18,10 @@
     "skip": "Skip",
     "cancel": "Cancel",
     "@cancel": {},
+    "ignore": "Ignore",
+    "@ignore": {
+        "description": "'Ignore' button. Typical use case in combination with 'OK' and 'Cancel' buttons."
+    },
     "close": "Close",
     "@close": {},
     "no": "No",
@@ -879,6 +883,19 @@
     "@edit_product_form_item_labels_subtitle": {
         "description": "Product edition - Labels - SubTitle"
     },
+    "edit_product_form_item_labels_hint": "label",
+    "@edit_product_form_item_labels_hint": {
+        "description": "Product edition - Labels - input textfield hint"
+    },
+    "edit_product_form_item_stores_title": "Stores",
+    "@edit_product_form_item_stores_title": {
+        "description": "Product edition - Stores - Title"
+    },
+    "edit_product_form_item_stores_hint": "label",
+    "@edit_product_form_item_stores_hint": {
+        "description": "Product edition - Stores - input textfield hint"
+    },
+    "edit_product_form_item_exit_confirmation": "Do you want to save your changes before leaving this page?",
     "edit_product_form_item_ingredients_title": "Ingredients & Origins",
     "@edit_product_form_item_ingredients_title": {
         "description": "Product edition - Ingredients - Title"

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -18,6 +18,10 @@
     "skip": "Ignorer",
     "cancel": "Annuler",
     "@cancel": {},
+    "ignore": "Ignorer",
+    "@ignore": {
+        "description": "'Ignore' button. Typical use case in combination with 'OK' and 'Cancel' buttons."
+    },
     "close": "Fermer",
     "@close": {},
     "no": "Non",
@@ -871,6 +875,19 @@
     "@edit_product_form_item_labels_subtitle": {
         "description": "Product edition - Labels - SubTitle"
     },
+    "edit_product_form_item_labels_hint": "label",
+    "@edit_product_form_item_labels_hint": {
+        "description": "Product edition - Labels - input textfield hint"
+    },
+    "edit_product_form_item_stores_title": "Magasins",
+    "@edit_product_form_item_stores_title": {
+        "description": "Product edition - Stores - Title"
+    },
+    "edit_product_form_item_stores_hint": "magasin",
+    "@edit_product_form_item_stores_hint": {
+        "description": "Product edition - Stores - input textfield hint"
+    },
+    "edit_product_form_item_exit_confirmation": "Voulez-vous sauver vos modifications avant de quitter cette page ?",
     "edit_product_form_item_ingredients_title": "Ingrédients & Origines",
     "@edit_product_form_item_ingredients_title": {
         "description": "Product edition - Ingredients - Title"

--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -103,9 +103,8 @@ class _EditProductPageState extends State<EditProductPage> {
                 }
               },
             ),
-            _ListTitleItem(
-              title: appLocalizations.edit_product_form_item_labels_title,
-              subtitle: appLocalizations.edit_product_form_item_labels_subtitle,
+            _getSimpleListTileItem(
+              SimpleInputPageLabelHelper(_product, appLocalizations),
             ),
             _ListTitleItem(
               title: appLocalizations.edit_product_form_item_ingredients_title,
@@ -126,25 +125,8 @@ class _EditProductPageState extends State<EditProductPage> {
             _ListTitleItem(
               title: appLocalizations.edit_product_form_item_packaging_title,
             ),
-            _ListTitleItem(
-              title: 'Stores', // TODO(monsieurtanuki): translate
-              onTap: () async {
-                final Product? refreshed = await Navigator.push<Product>(
-                  context,
-                  MaterialPageRoute<Product>(
-                    builder: (BuildContext context) => SimpleInputPage(
-                      SimpleInputPageStoreHelper(
-                        _product,
-                        appLocalizations,
-                      ),
-                    ),
-                  ),
-                );
-                if (refreshed != null) {
-                  _product = refreshed;
-                }
-                return;
-              },
+            _getSimpleListTileItem(
+              SimpleInputPageStoreHelper(_product, appLocalizations),
             ),
             _ListTitleItem(
               title:
@@ -179,6 +161,24 @@ class _EditProductPageState extends State<EditProductPage> {
       ),
     );
   }
+
+  Widget _getSimpleListTileItem(final AbstractSimpleInputPageHelper helper) =>
+      _ListTitleItem(
+        title: helper.getTitle(),
+        subtitle: helper.getSubtitle(),
+        onTap: () async {
+          final Product? refreshed = await Navigator.push<Product>(
+            context,
+            MaterialPageRoute<Product>(
+              builder: (BuildContext context) => SimpleInputPage(helper),
+            ),
+          );
+          if (refreshed != null) {
+            _product = refreshed;
+          }
+          setState(() {});
+        },
+      );
 }
 
 class _ListTitleItem extends StatelessWidget {

--- a/packages/smooth_app/lib/pages/product/simple_input_page.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page.dart
@@ -10,7 +10,7 @@ import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/pages/product/common/product_refresher.dart';
 import 'package:smooth_app/pages/product/simple_input_page_helpers.dart';
 
-/// Simple input page: we have a list of labels, we add, we remove, we save.
+/// Simple input page: we have a list of terms, we add, we remove, we save.
 class SimpleInputPage extends StatefulWidget {
   const SimpleInputPage(this.helper) : super();
 
@@ -41,20 +41,17 @@ class _SimpleInputPageState extends State<SimpleInputPage> {
         final bool? pleaseSave = await showDialog<bool>(
           context: context,
           builder: (final BuildContext context) => SmoothAlertDialog(
+            close: true,
             body:
-                const Text('You are about to leave this page without saving.'),
+                Text(appLocalizations.edit_product_form_item_exit_confirmation),
             title: widget.helper.getTitle(),
             negativeAction: SmoothActionButton(
-              text: 'Ignore',
+              text: appLocalizations.ignore,
               onPressed: () => Navigator.pop(context, false),
             ),
             positiveAction: SmoothActionButton(
-              text: 'Save',
+              text: appLocalizations.save,
               onPressed: () => Navigator.pop(context, true),
-            ),
-            neutralAction: SmoothActionButton(
-              text: 'Cancel',
-              onPressed: () => Navigator.pop(context, null),
             ),
           ),
         );
@@ -96,13 +93,13 @@ class _SimpleInputPageState extends State<SimpleInputPage> {
                 widget.helper.getTitle(),
                 style: themeData.textTheme.headline1,
               ),
-              const SizedBox(height: LARGE_SPACE),
-              Text(widget.helper.getAddTitle()),
+              if (widget.helper.getSubtitle() != null)
+                Text(widget.helper.getSubtitle()!),
               Row(
                 children: <Widget>[
                   ElevatedButton(
                     onPressed: () {
-                      if (widget.helper.addLabel(_controller.text)) {
+                      if (widget.helper.addTerm(_controller.text)) {
                         setState(() => _controller.text = '');
                       }
                     },
@@ -137,14 +134,14 @@ class _SimpleInputPageState extends State<SimpleInputPage> {
                 spacing: LARGE_SPACE,
                 runSpacing: VERY_SMALL_SPACE,
                 children: List<Widget>.generate(
-                  widget.helper.getLabels().length,
+                  widget.helper.terms.length,
                   (final int index) {
-                    final String label = widget.helper.getLabels()[index];
+                    final String term = widget.helper.terms[index];
                     return ElevatedButton.icon(
                       icon: const Icon(Icons.clear),
-                      label: Text(label),
+                      label: Text(term),
                       onPressed: () async {
-                        if (widget.helper.removeLabel(label)) {
+                        if (widget.helper.removeTerm(term)) {
                           setState(() {});
                         }
                       },


### PR DESCRIPTION
Impacted files:
* `app_en.arb`: added 5 translations
* `app_fr.arb`: added 5 translations
* `edit_product_page.dart`: added an action for "edit labels"; refactored
* `simple_input_page.dart`: renamed "label" as "term" to avoid confusion; translated; refactored
* `simple_input_page_helpers.dart`: implementation for "labels"; renamed "label" as "term"; translated
* `smooth_alert_dialog.dart`: minor refactoring

### What
- Now we can edit the "Labels" too.

### Screenshot
![Capture d’écran 2022-06-07 à 12 36 47](https://user-images.githubusercontent.com/11576431/172360002-4eef3fab-8b0d-41f4-8a30-cf4294f21743.png)

![Capture d’écran 2022-06-07 à 12 37 07](https://user-images.githubusercontent.com/11576431/172360052-89a1857a-7d24-47e1-a9bf-713b75c7de8a.png)

![Capture d’écran 2022-06-07 à 12 37 30](https://user-images.githubusercontent.com/11576431/172360108-bd4dd706-f83e-4e00-b9af-ae829f795a45.png)



### Part of 
- #2169