### PR TITLE
feat: #2169 - new simple input page for "Categories"

### DIFF
--- a/packages/smooth_app/ios/Podfile.lock
+++ b/packages/smooth_app/ios/Podfile.lock
@@ -1,4 +1,6 @@
 PODS:
+  - audioplayers (0.0.1):
+    - Flutter
   - camera (0.0.1):
     - Flutter
   - data_importer (0.0.1):
@@ -113,6 +115,7 @@ PODS:
     - Flutter
 
 DEPENDENCIES:
+  - audioplayers (from `.symlinks/plugins/audioplayers/ios`)
   - camera (from `.symlinks/plugins/camera/ios`)
   - data_importer (from `.symlinks/plugins/data_importer/ios`)
   - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
@@ -155,6 +158,8 @@ SPEC REPOS:
     - TOCropViewController
 
 EXTERNAL SOURCES:
+  audioplayers:
+    :path: ".symlinks/plugins/audioplayers/ios"
   camera:
     :path: ".symlinks/plugins/camera/ios"
   data_importer:
@@ -195,6 +200,7 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
+  audioplayers: 455322b54050b30ea4b1af7cd9e9d105f74efa8c
   camera: 9993f92f2c793e87b65e35f3a23c70582afb05b1
   data_importer: ab8c74aaf553878170aed03c03626d5820c5cb1f
   device_info_plus: e5c5da33f982a436e103237c0c85f9031142abed

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -891,9 +891,17 @@
     "@edit_product_form_item_stores_title": {
         "description": "Product edition - Stores - Title"
     },
-    "edit_product_form_item_stores_hint": "label",
+    "edit_product_form_item_stores_hint": "store",
     "@edit_product_form_item_stores_hint": {
         "description": "Product edition - Stores - input textfield hint"
+    },
+    "edit_product_form_item_categories_title": "Categories",
+    "@edit_product_form_item_categories_title": {
+        "description": "Product edition - Categories - Title"
+    },
+    "edit_product_form_item_categories_hint": "category",
+    "@edit_product_form_item_categories_hint": {
+        "description": "Product edition - Categories - input textfield hint"
     },
     "edit_product_form_item_exit_confirmation": "Do you want to save your changes before leaving this page?",
     "edit_product_form_item_ingredients_title": "Ingredients & Origins",

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -887,6 +887,14 @@
     "@edit_product_form_item_stores_hint": {
         "description": "Product edition - Stores - input textfield hint"
     },
+    "edit_product_form_item_categories_title": "Catégories",
+    "@edit_product_form_item_categories_title": {
+        "description": "Product edition - Categories - Title"
+    },
+    "edit_product_form_item_categories_hint": "catégorie",
+    "@edit_product_form_item_categories_hint": {
+        "description": "Product edition - Categories - input textfield hint"
+    },
     "edit_product_form_item_exit_confirmation": "Voulez-vous sauver vos modifications avant de quitter cette page ?",
     "edit_product_form_item_ingredients_title": "Ingrédients & Origines",
     "@edit_product_form_item_ingredients_title": {

--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -128,6 +128,9 @@ class _EditProductPageState extends State<EditProductPage> {
             _getSimpleListTileItem(
               SimpleInputPageStoreHelper(_product, appLocalizations),
             ),
+            _getSimpleListTileItem(
+              SimpleInputPageCategoryHelper(_product, appLocalizations),
+            ),
             _ListTitleItem(
               title:
                   appLocalizations.edit_product_form_item_nutrition_facts_title,

--- a/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
@@ -119,9 +119,10 @@ class SimpleInputPageStoreHelper extends AbstractSimpleInputPageHelper {
   }
 }
 
-/// Implementation for "Labels" of an [AbstractSimpleInputPageHelper].
-class SimpleInputPageLabelHelper extends AbstractSimpleInputPageHelper {
-  SimpleInputPageLabelHelper(
+/// Abstraction, for "in language" field, of an [AbstractSimpleInputPageHelper].
+abstract class AbstractSimpleInputPageInLanguageHelper
+    extends AbstractSimpleInputPageHelper {
+  AbstractSimpleInputPageInLanguageHelper(
     final Product product,
     final AppLocalizations appLocalizations,
   ) : super(
@@ -131,15 +132,34 @@ class SimpleInputPageLabelHelper extends AbstractSimpleInputPageHelper {
 
   final Map<String, String> _termToTags = <String, String>{};
 
+  /// Returns the value of the tags list of field for a product.
+  ///
+  /// E.g. `product.categoriesTags`
+  @protected
+  List<String>? getTags();
+
+  /// Returns the value of the translations of a field for a product.
+  ///
+  /// E.g. `product.categoriesTagsInLanguages`
+  @protected
+  Map<OpenFoodFactsLanguage, List<String>>? getInLanguages();
+
+  /// Sets the value of a field for a product.
+  ///
+  /// e.g. `product.categories = value`
+  @protected
+  void setValue(final Product changedProduct, final String value);
+
   @override
   List<String> initTerms() {
-    if (product.labelsTags != null && product.labelsTagsInLanguages != null) {
-      final List<String>? translations =
-          product.labelsTagsInLanguages![_language];
-      if (translations != null &&
-          translations.length == product.labelsTags!.length) {
+    final List<String>? tags = getTags();
+    final Map<OpenFoodFactsLanguage, List<String>>? inLanguages =
+        getInLanguages();
+    if (tags != null && inLanguages != null) {
+      final List<String>? translations = inLanguages[_language];
+      if (translations != null && translations.length == tags.length) {
         for (int i = 0; i < translations.length; i++) {
-          _termToTags[translations[i]] = product.labelsTags![i];
+          _termToTags[translations[i]] = tags[i];
         }
         return List<String>.from(translations);
       }
@@ -159,8 +179,31 @@ class SimpleInputPageLabelHelper extends AbstractSimpleInputPageHelper {
       }
       result.write(tag);
     }
-    changedProduct.labels = result.toString();
+    setValue(changedProduct, result.toString());
   }
+}
+
+/// Implementation for "Labels" of an [AbstractSimpleInputPageHelper].
+class SimpleInputPageLabelHelper
+    extends AbstractSimpleInputPageInLanguageHelper {
+  SimpleInputPageLabelHelper(
+    final Product product,
+    final AppLocalizations appLocalizations,
+  ) : super(
+          product,
+          appLocalizations,
+        );
+
+  @override
+  List<String>? getTags() => product.labelsTags;
+
+  @override
+  Map<OpenFoodFactsLanguage, List<String>>? getInLanguages() =>
+      product.labelsTagsInLanguages;
+
+  @override
+  void setValue(final Product changedProduct, final String value) =>
+      changedProduct.labels = value;
 
   @override
   String getTitle() => appLocalizations.edit_product_form_item_labels_title;
@@ -171,4 +214,34 @@ class SimpleInputPageLabelHelper extends AbstractSimpleInputPageHelper {
 
   @override
   String getAddHint() => appLocalizations.edit_product_form_item_labels_hint;
+}
+
+/// Implementation for "Categories" of an [AbstractSimpleInputPageHelper].
+class SimpleInputPageCategoryHelper
+    extends AbstractSimpleInputPageInLanguageHelper {
+  SimpleInputPageCategoryHelper(
+    final Product product,
+    final AppLocalizations appLocalizations,
+  ) : super(
+          product,
+          appLocalizations,
+        );
+
+  @override
+  List<String>? getTags() => product.categoriesTags;
+
+  @override
+  Map<OpenFoodFactsLanguage, List<String>>? getInLanguages() =>
+      product.categoriesTagsInLanguages;
+
+  @override
+  void setValue(final Product changedProduct, final String value) =>
+      changedProduct.categories = value;
+
+  @override
+  String getTitle() => appLocalizations.edit_product_form_item_categories_title;
+
+  @override
+  String getAddHint() =>
+      appLocalizations.edit_product_form_item_categories_hint;
 }


### PR DESCRIPTION
Impacted files:
* `app_en.arb`: added 2 translations (and fixed 1)
* `app_fr.arb`: added 2 translations
* `edit_product_page.dart`: added an item for "edit categories"
* `Podfile.lock`: wtf
* `simple_input_page_helpers.dart`: implementation for "categories"; refactored with an "in language" abstraction

### What
- Added an "edit categories" button to the "edit product" page
- The dev was quick as it looks like all the "in languages" fields have the same behavior (like "labels" that was coded before)

### Screenshot
![Capture d’écran 2022-06-07 à 18 09 21](https://user-images.githubusercontent.com/11576431/172429518-0f834f47-4668-4b60-9c16-fe4e8af87277.png)

![Capture d’écran 2022-06-07 à 18 09 39](https://user-images.githubusercontent.com/11576431/172429617-7d497123-292c-48c2-9c67-84067a84859f.png)

### Part of 
- #2169