### PR TITLE
fix: #2203 - latest off-dart (with the expected fix)

### DIFF
--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -699,7 +699,7 @@ packages:
       name: openfoodfacts
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.18.0"
+    version: "1.18.1"
   package_config:
     dependency: transitive
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
       url: 'https://github.com/M123-dev/matomo-tracker.git'
       ref: 'fix-country'
   modal_bottom_sheet: ^2.0.1
-  openfoodfacts: ^1.18.0
+  openfoodfacts: ^1.18.1
   #  openfoodfacts:
   #    path: ../../../openfoodfacts-dart
   package_info_plus: ^1.4.2


### PR DESCRIPTION
Impacted files:
* `pubspec.lock`: generated
* `pubspec.yaml`: new version 1.18.1 for off-dart

### What
- Latest version of off-dart, which is supposed to be the right fix

### Fixes bug(s)
- Fixes: #2203