### PR TITLE
feat: Disable camera pause/resume preview on iOS

### DIFF
--- a/packages/smooth_app/lib/pages/scan/camera_controller.dart
+++ b/packages/smooth_app/lib/pages/scan/camera_controller.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:camera/camera.dart';
 import 'package:camera_platform_interface/camera_platform_interface.dart';
@@ -7,6 +8,9 @@ import 'package:flutter/services.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
 
 /// A lifecycle-aware [CameraController]
+/// On Android it supports pause/resume feed
+/// On iOS, pausing the feed will dispose the controller instead, as the camera
+/// indicator stays on
 class SmoothCameraController extends CameraController {
   SmoothCameraController(
     this.preferences,
@@ -79,6 +83,10 @@ class SmoothCameraController extends CameraController {
 
   @override
   Future<void> pausePreview() async {
+    if (!isPauseResumePreviewSupported) {
+      throw UnimplementedError('This feature is not supported!');
+    }
+
     if (_isInitialized) {
       await _pauseFlash();
       await super.pausePreview();
@@ -87,6 +95,10 @@ class SmoothCameraController extends CameraController {
   }
 
   Future<void> resumePreviewIfNecessary() async {
+    if (!isPauseResumePreviewSupported) {
+      throw UnimplementedError('This feature is not supported!');
+    }
+
     if (_isPaused) {
       return resumePreview();
     }
@@ -152,6 +164,8 @@ class SmoothCameraController extends CameraController {
   bool get isInitialized => _isInitialized;
 
   bool get isBeingInitialized => _isBeingInitialized;
+
+  bool get isPauseResumePreviewSupported => !Platform.isIOS;
 }
 
 extension CameraValueExtension on CameraValue {


### PR DESCRIPTION
Hi everyone,

On iOS, pausing/resuming the preview will keep the [camera indicator](https://www.the-sun.com/wp-content/uploads/sites/6/2020/10/iphone-camera.jpg) on top of the screen.
This PR will instead disable the camera once it's invisible, which may cause some black screens during a few milliseconds.

New behavior:
https://user-images.githubusercontent.com/246838/172611975-2b2d54de-e7ab-4712-bdc5-85a9bbb43597.mp4

Will fix #2193
