### PR TITLE
feat: #2204 - new "please sign in" message when the product is about to be edited

### DIFF
--- a/packages/smooth_app/lib/database/product_query.dart
+++ b/packages/smooth_app/lib/database/product_query.dart
@@ -67,6 +67,8 @@ abstract class ProductQuery {
         comment: 'Test user for project smoothie',
       );
 
+  static bool isLoggedIn() => OpenFoodAPIConfiguration.globalUser != null;
+
   /// Sets the query type according to the current [UserPreferences]
   static void setQueryType(final UserPreferences userPreferences) {
     OpenFoodAPIConfiguration.globalQueryType = userPreferences

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -143,6 +143,10 @@
     "@sign_in": {
         "description": "Button label: For sign in"
     },
+    "sign_in_mandatory": "For that feature we need you to sign in.",
+    "@sign_in_mandatory": {
+        "description": "Error message: for some features like product edits you need to be signed in"
+    },
     "sign_out": "Sign out",
     "@sign_out": {
         "description": "Button label: For sign out"

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -143,6 +143,7 @@
     "@sign_in": {
         "description": "Button label: For sign in"
     },
+    "sign_in_mandatory": "Pour cette fonctionnalité nous avons besoin que vous soyez connecté.",
     "sign_out": "Se déconnecter",
     "@sign_out": {
         "description": "Button label: For sign out"

--- a/packages/smooth_app/lib/pages/product/common/product_refresher.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_refresher.dart
@@ -6,21 +6,63 @@ import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/database/product_query.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/generic_lib/loading_dialog.dart';
+import 'package:smooth_app/pages/user_management/login_page.dart';
 
 /// Refreshes a product on the BE then on the local database.
 class ProductRefresher {
+  /// Checks if the user is logged in and opens a "please log in" dialog if not.
+  Future<bool> checkIfLoggedIn(final BuildContext context) async {
+    if (ProductQuery.isLoggedIn()) {
+      return true;
+    }
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    await showDialog<void>(
+      context: context,
+      builder: (BuildContext context) => SmoothAlertDialog(
+        body: Text(appLocalizations.sign_in_mandatory),
+        positiveAction: SmoothActionButton(
+          text: appLocalizations.sign_in,
+          onPressed: () async {
+            Navigator.of(context).pop(); // remove dialog
+            await Navigator.of(
+              context,
+              rootNavigator: true,
+            ).push<dynamic>(
+              MaterialPageRoute<dynamic>(
+                builder: (BuildContext context) => const LoginPage(),
+              ),
+            );
+          },
+        ),
+        neutralAction: SmoothActionButton(
+          text: appLocalizations.cancel,
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+      ),
+    );
+    return false;
+  }
+
   /// Returns a saved and refreshed [Product] if successful, or null.
   Future<Product?> saveAndRefresh({
     required final BuildContext context,
     required final LocalDatabase localDatabase,
     required final Product product,
+    // most of the time, we need the user to be signed in.
+    final bool isLoggedInMandatory = true,
   }) async {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    if (isLoggedInMandatory) {
+      if (!await checkIfLoggedIn(context)) {
+        return null;
+      }
+    }
     final _MetaProductRefresher? savedAndRefreshed =
         await LoadingDialog.run<_MetaProductRefresher>(
       future: _saveAndRefresh(product, localDatabase),
       context: context,
-      title: appLocalizations.nutrition_page_update_running,
+      title: appLocalizations
+          .nutrition_page_update_running, // TODO(monsieurtanuki): title as method parameter
     );
     if (savedAndRefreshed == null) {
       // probably the end user stopped the dialog
@@ -33,7 +75,8 @@ class ProductRefresher {
     await showDialog<void>(
       context: context,
       builder: (BuildContext context) => SmoothAlertDialog(
-        body: Text(appLocalizations.nutrition_page_update_done),
+        body: Text(appLocalizations
+            .nutrition_page_update_done), // TODO(monsieurtanuki): title as method parameter
         positiveAction: SmoothActionButton(
           text: appLocalizations.okay,
           onPressed: () => Navigator.of(context).pop(),

--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -6,6 +6,7 @@ import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/data_models/product_image_data.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/pages/product/add_basic_details_page.dart';
+import 'package:smooth_app/pages/product/common/product_refresher.dart';
 import 'package:smooth_app/pages/product/edit_ingredients_page.dart';
 import 'package:smooth_app/pages/product/nutrition_page_loaded.dart';
 import 'package:smooth_app/pages/product/ordered_nutrients_cache.dart';
@@ -69,6 +70,9 @@ class _EditProductPageState extends State<EditProductPage> {
               subtitle:
                   appLocalizations.edit_product_form_item_details_subtitle,
               onTap: () async {
+                if (!await ProductRefresher().checkIfLoggedIn(context)) {
+                  return;
+                }
                 final bool? refreshed = await Navigator.push<bool>(
                   context,
                   MaterialPageRoute<bool>(
@@ -85,6 +89,9 @@ class _EditProductPageState extends State<EditProductPage> {
               title: appLocalizations.edit_product_form_item_photos_title,
               subtitle: appLocalizations.edit_product_form_item_photos_subtitle,
               onTap: () async {
+                if (!await ProductRefresher().checkIfLoggedIn(context)) {
+                  return;
+                }
                 final List<ProductImageData> allProductImagesData =
                     getAllProductImagesData(_product, appLocalizations);
                 final bool? refreshed = await Navigator.push<bool>(
@@ -109,6 +116,9 @@ class _EditProductPageState extends State<EditProductPage> {
             _ListTitleItem(
               title: appLocalizations.edit_product_form_item_ingredients_title,
               onTap: () async {
+                if (!await ProductRefresher().checkIfLoggedIn(context)) {
+                  return;
+                }
                 final bool? refreshed = await Navigator.push<bool>(
                   context,
                   MaterialPageRoute<bool>(
@@ -137,6 +147,9 @@ class _EditProductPageState extends State<EditProductPage> {
               subtitle: appLocalizations
                   .edit_product_form_item_nutrition_facts_subtitle,
               onTap: () async {
+                if (!await ProductRefresher().checkIfLoggedIn(context)) {
+                  return;
+                }
                 final OrderedNutrientsCache? cache =
                     await OrderedNutrientsCache.getCache(context);
                 if (cache == null) {
@@ -170,6 +183,9 @@ class _EditProductPageState extends State<EditProductPage> {
         title: helper.getTitle(),
         subtitle: helper.getSubtitle(),
         onTap: () async {
+          if (!await ProductRefresher().checkIfLoggedIn(context)) {
+            return;
+          }
           final Product? refreshed = await Navigator.push<Product>(
             context,
             MaterialPageRoute<Product>(


### PR DESCRIPTION
Impacted files:
* `app_en.arb`: new translation for the "please sign in" message
* `app_fr.arb`: new translation for the "please sign in" message
* `edit_product_page.dart`: added calls to new `checkIfLoggedIn` method
* `product_query.dart`: added method `isLoggedIn`
* `product_refresher.dart`: added method `checkIfLoggedIn` and called it in `saveAndRefresh`

### What
- Added a check for most product edit actions, about "is the user logged in?".
- The check is performed before opening the edit data pages.
- The check is also performed just before the call to the server.
- There may be places where the checks are performed and they shouldn't, and vice versa.

### Screenshot
![Capture d’écran 2022-06-08 à 18 24 17](https://user-images.githubusercontent.com/11576431/172668032-ca36b906-3376-4cf2-8695-6f97e4404cff.png)


### Fixes bug(s)
- Closes: #2204
