### PR TITLE
fix: #2221 - set the "disabled" background color in the theme

### DIFF
--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -199,23 +199,12 @@ class _ListTitleItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    final ColorScheme colorScheme = Theme.of(context).colorScheme;
     return ListTile(
       onTap: onTap,
       title: Text(title),
       subtitle: subtitle == null ? null : Text(subtitle!),
       leading: ElevatedButton(
         onPressed: onTap,
-        style: ButtonStyle(
-          backgroundColor: MaterialStateProperty.resolveWith<Color?>(
-            (Set<MaterialState> states) {
-              if (states.contains(MaterialState.disabled)) {
-                return Colors.grey;
-              }
-              return colorScheme.primary;
-            },
-          ),
-        ),
         child: Text(appLocalizations.edit_product_form_save),
       ),
     );

--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -204,7 +204,6 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
       _unitLabels[unit] ?? UnitHelper.unitToString(unit)!;
 
   Widget _getUnitCell(final OrderedNutrient orderedNutrient) {
-    final ColorScheme colorScheme = Theme.of(context).colorScheme;
     final Unit unit = _nutritionContainer.getUnit(orderedNutrient.id);
     return ElevatedButton(
       onPressed: NutritionContainer.isEditableWeight(orderedNutrient)
@@ -212,16 +211,6 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
                 () => _nutritionContainer.setNextWeightUnit(orderedNutrient),
               )
           : null,
-      style: ButtonStyle(
-        backgroundColor: MaterialStateProperty.resolveWith<Color?>(
-          (Set<MaterialState> states) {
-            if (states.contains(MaterialState.disabled)) {
-              return Colors.grey;
-            }
-            return colorScheme.primary;
-          },
-        ),
-      ),
       child: Text(
         _getUnitLabel(unit),
         style: const TextStyle(fontWeight: FontWeight.bold),

--- a/packages/smooth_app/lib/themes/smooth_theme.dart
+++ b/packages/smooth_app/lib/themes/smooth_theme.dart
@@ -28,6 +28,16 @@ class SmoothTheme {
         showUnselectedLabels: false,
         selectedItemColor: myColorScheme.primary,
       ),
+      elevatedButtonTheme: ElevatedButtonThemeData(
+        style: ButtonStyle(
+          backgroundColor: MaterialStateProperty.resolveWith<Color?>(
+            (Set<MaterialState> states) =>
+                states.contains(MaterialState.disabled)
+                    ? Colors.grey
+                    : myColorScheme.primary,
+          ),
+        ),
+      ),
       floatingActionButtonTheme: FloatingActionButtonThemeData(
           backgroundColor: myColorScheme.primary,
           foregroundColor: myColorScheme.onPrimary),


### PR DESCRIPTION
Impacted files:
* `edit_product_page.dart`: removed the explicit "disabled" background color
* `nutrition_page_loaded.dart`: removed the explicit "disabled" background color
* `smooth_theme.dart`: set the "disabled" background color in the theme

### What
- A disabled `ElevatedButton` was not visible in dark mode.
- Now we set the "disabled" background color in the theme.

### Screenshot
| light | dark |
| --- | --- |
| ![Capture d’écran 2022-06-08 à 18 48 35](https://user-images.githubusercontent.com/11576431/172672357-c4f1c6d5-145c-4480-8551-664b967a9878.png) | ![Capture d’écran 2022-06-08 à 18 49 01](https://user-images.githubusercontent.com/11576431/172672439-d1025a22-c502-4164-839d-508c36b2e4ac.png) |


### Fixes bug(s)
- Fixes: #2221