### PR TITLE
fix: Camera ignore turn flash off exception

### DIFF
--- a/packages/smooth_app/lib/pages/scan/camera_controller.dart
+++ b/packages/smooth_app/lib/pages/scan/camera_controller.dart
@@ -80,7 +80,12 @@ class SmoothCameraController extends CameraController {
   @override
   Future<void> pausePreview() async {
     if (_isInitialized) {
-      await _pauseFlash();
+      try {
+        await _pauseFlash();
+      } catch (exception) {
+        // Camera already disposed
+      }
+
       await super.pausePreview();
       _isPaused = true;
     }

--- a/packages/smooth_app/lib/pages/scan/camera_controller.dart
+++ b/packages/smooth_app/lib/pages/scan/camera_controller.dart
@@ -86,7 +86,12 @@ class SmoothCameraController extends CameraController {
         // Camera already disposed
       }
 
-      await super.pausePreview();
+      try {
+        await super.pausePreview();
+      } catch (exception) {
+        // Camera already disposed
+      }
+
       _isPaused = true;
     }
   }

--- a/packages/smooth_app/lib/pages/scan/mkit_scan_helper.dart
+++ b/packages/smooth_app/lib/pages/scan/mkit_scan_helper.dart
@@ -227,12 +227,17 @@ class _MLKitScanDecoderIsolate {
 
     final CameraImage image = CameraImage.fromPlatformData(message);
     final InputImage cropImage = _cropImage(image);
+    final double imageHeight =
+        cropImage.inputImageData?.size.longestSide ?? double.infinity;
 
     final List<Barcode> barcodes =
         await _barcodeScanner.processImage(cropImage);
 
     port.send(
       barcodes
+          // Only accepts barcodes on half-top of the image
+          .where((Barcode barcode) =>
+              (barcode.boundingBox?.top ?? 0.0) <= imageHeight * 0.5)
           .map((Barcode barcode) => _changeBarcodeType(barcode))
           .where((String? barcode) => barcode?.isNotEmpty == true)
           .cast<String>()


### PR DESCRIPTION
Hi everyone,

When the preview is paused, I force the flash to be turned off.
But if the native part is quicker than the Dart side (camera closed for example), it will trigger an exception.

Instead, we just ignore the error


```
I/Camera  (12140): open | onClosed
I/Camera  (12140): CameraCaptureSession onClosed
I/Camera  (12140): refreshPreviewCaptureSession: captureSession not yet initialized, skipping preview capture session refresh.
E/flutter (12140): [ERROR:flutter/lib/ui/ui_dart_state.cc(198)] Unhandled Exception: CameraException(setFlashModeFailed, Could not set flash mode.)
E/flutter (12140): #0      CameraController.setFlashMode (package:camera/src/camera_controller.dart:642:7)
E/flutter (12140): <asynchronous suspension>
E/flutter (12140): #1      SmoothCameraController.pausePreview (package:smooth_app/pages/scan/camera_controller.dart:83:7)
E/flutter (12140): <asynchronous suspension>
E/flutter (12140): #2      MLKitScannerPageState._stopImageStream (package:smooth_app/pages/scan/ml_kit_scan_page.dart:365:5)
E/flutter (12140): <asynchronous suspension>
E/flutter (12140): 
```