### PR TITLE
feat: #2001 - consistency for left/right button positions during onboarding

### DIFF
--- a/packages/smooth_app/lib/pages/onboarding/consent_analytics_page.dart
+++ b/packages/smooth_app/lib/pages/onboarding/consent_analytics_page.dart
@@ -123,10 +123,10 @@ class ConsentAnalytics extends StatelessWidget {
       OnboardingBottomButton(
         onPressed: () async => _analyticsLogic(
           isAccepted,
-          context.watch<UserPreferences>(),
-          context.watch<LocalDatabase>(),
+          context.read<UserPreferences>(),
+          context.read<LocalDatabase>(),
           context,
-          context.watch<ThemeProvider>(),
+          context.read<ThemeProvider>(),
         ),
         backgroundColor: backgroundColor,
         foregroundColor: foregroundColor,

--- a/packages/smooth_app/lib/pages/onboarding/consent_analytics_page.dart
+++ b/packages/smooth_app/lib/pages/onboarding/consent_analytics_page.dart
@@ -8,6 +8,7 @@ import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
+import 'package:smooth_app/pages/onboarding/onboarding_bottom_bar.dart';
 import 'package:smooth_app/pages/onboarding/onboarding_flow_navigator.dart';
 import 'package:smooth_app/themes/theme_provider.dart';
 
@@ -68,7 +69,23 @@ class ConsentAnalytics extends StatelessWidget {
               ],
             ),
           ),
-          _buildBottomAppBar(context, appLocalizations),
+          OnboardingBottomBar(
+            leftButton: _buildButton(
+              context,
+              appLocalizations.refuse_button_label,
+              false,
+              const Color(0xFFA08D84),
+              Colors.white,
+            ),
+            rightButton: _buildButton(
+              context,
+              appLocalizations.authorize_button_label,
+              true,
+              Colors.white,
+              Colors.black,
+            ),
+            backgroundColor: backgroundColor,
+          ),
         ],
       ),
     );
@@ -96,88 +113,23 @@ class ConsentAnalytics extends StatelessWidget {
     );
   }
 
-  Widget _buildBottomAppBar(
-    final BuildContext context,
-    final AppLocalizations appLocalizations,
-  ) {
-    final Size screenSize = MediaQuery.of(context).size;
-    // Side padding is 8% of total width.
-    final double sidePadding = screenSize.width * .08;
-    return Column(
-      children: <Widget>[
-        Container(
-          height: SMALL_SPACE,
-          width: screenSize.width,
-          color: LIGHT_GREY_COLOR,
-        ),
-        Container(
-          padding: EdgeInsets.symmetric(
-            vertical: VERY_LARGE_SPACE,
-            horizontal: sidePadding,
-          ),
-          width: screenSize.width,
-          color: backgroundColor,
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: <Widget>[
-              _buildButton(
-                context,
-                appLocalizations.refuse_button_label,
-                false,
-                const Color(0xFFA08D84),
-                Colors.white,
-              ),
-              _buildButton(
-                context,
-                appLocalizations.authorize_button_label,
-                true,
-                Colors.white,
-                Colors.black,
-              ),
-            ],
-          ),
-        ),
-      ],
-    );
-  }
-
   Widget _buildButton(
-    BuildContext context,
-    String label,
-    bool isAccepted,
+    final BuildContext context,
+    final String label,
+    final bool isAccepted,
     final Color backgroundColor,
     final Color foregroundColor,
-  ) {
-    final LocalDatabase localDatabase = context.watch<LocalDatabase>();
-    final UserPreferences userPreferences = context.watch<UserPreferences>();
-    final ThemeProvider themeProvider = context.watch<ThemeProvider>();
-    return ConstrainedBox(
-      constraints: const BoxConstraints.tightFor(height: MINIMUM_TARGET_SIZE),
-      child: ElevatedButton(
+  ) =>
+      OnboardingBottomButton(
         onPressed: () async => _analyticsLogic(
           isAccepted,
-          userPreferences,
-          localDatabase,
+          context.watch<UserPreferences>(),
+          context.watch<LocalDatabase>(),
           context,
-          themeProvider,
+          context.watch<ThemeProvider>(),
         ),
-        style: ButtonStyle(
-          backgroundColor: MaterialStateProperty.all(backgroundColor),
-          shape: MaterialStateProperty.all<RoundedRectangleBorder>(
-            RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(40),
-            ),
-          ),
-        ),
-        child: Text(
-          label,
-          style: Theme.of(context)
-              .textTheme
-              .headline3
-              ?.copyWith(color: foregroundColor),
-        ),
-      ),
-    );
-  }
+        backgroundColor: backgroundColor,
+        foregroundColor: foregroundColor,
+        label: label,
+      );
 }

--- a/packages/smooth_app/lib/pages/onboarding/next_button.dart
+++ b/packages/smooth_app/lib/pages/onboarding/next_button.dart
@@ -4,7 +4,7 @@ import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/onboarding_loader.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/database/local_database.dart';
-import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/pages/onboarding/onboarding_bottom_bar.dart';
 import 'package:smooth_app/pages/onboarding/onboarding_flow_navigator.dart';
 import 'package:smooth_app/themes/constant_icons.dart';
 
@@ -25,88 +25,40 @@ class NextButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final Size screenSize = MediaQuery.of(context).size;
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final UserPreferences userPreferences = context.watch<UserPreferences>();
     final LocalDatabase localDatabase = context.watch<LocalDatabase>();
-    // Side padding is 8% of total width.
-    final double sidePadding = screenSize.width * .08;
     final OnboardingFlowNavigator navigator =
         OnboardingFlowNavigator(userPreferences);
     final OnboardingPage previousPage =
         OnboardingFlowNavigator.getPrevPage(currentPage);
-    final bool hasPrevious = previousPage != OnboardingPage.NOT_STARTED;
-    return Column(
-      children: <Widget>[
-        Container(
-          height: SMALL_SPACE,
-          width: screenSize.width,
-          color: backgroundColor == null ? null : LIGHT_GREY_COLOR,
-        ),
-        Container(
-          padding: EdgeInsets.symmetric(
-            vertical: VERY_LARGE_SPACE,
-            horizontal: sidePadding,
-          ),
-          width: screenSize.width,
-          color: backgroundColor,
-          child: Row(
-            mainAxisAlignment: hasPrevious
-                ? MainAxisAlignment.spaceBetween
-                : MainAxisAlignment.end,
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: <Widget>[
-              if (hasPrevious)
-                Padding(
-                  padding: const EdgeInsets.only(right: LARGE_SPACE),
-                  child: ElevatedButton(
-                    style: ElevatedButton.styleFrom(
-                      shape: const CircleBorder(),
-                      padding: const EdgeInsets.all(12),
-                      primary: Colors.white,
-                      onPrimary: Colors.black,
-                    ),
-                    onPressed: () => navigator.navigateToPage(
-                      context,
-                      previousPage,
-                    ),
-                    child: Icon(ConstantIcons.instance.getBackIcon()),
-                  ),
-                ),
-              ConstrainedBox(
-                constraints:
-                    const BoxConstraints.tightFor(height: MINIMUM_TARGET_SIZE),
-                child: ElevatedButton(
-                  onPressed: () async {
-                    await OnboardingLoader(localDatabase)
-                        .runAtNextTime(currentPage, context);
-                    //ignore: use_build_context_synchronously
-                    navigator.navigateToPage(
-                      context,
-                      OnboardingFlowNavigator.getNextPage(currentPage),
-                    );
-                  },
-                  style: ButtonStyle(
-                    backgroundColor: MaterialStateProperty.all(Colors.black),
-                    shape: MaterialStateProperty.all<RoundedRectangleBorder>(
-                      RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(40),
-                      ),
-                    ),
-                  ),
-                  child: Text(
-                    appLocalizations.next_label,
-                    style: Theme.of(context)
-                        .textTheme
-                        .headline3
-                        ?.copyWith(color: Colors.white),
-                  ),
-                ),
+    return OnboardingBottomBar(
+      leftButton: previousPage == OnboardingPage.NOT_STARTED
+          ? null
+          : OnboardingBottomIcon(
+              onPressed: () => navigator.navigateToPage(
+                context,
+                previousPage,
               ),
-            ],
-          ),
-        ),
-      ],
+              backgroundColor: Colors.white,
+              foregroundColor: Colors.black,
+              icon: ConstantIcons.instance.getBackIcon(),
+            ),
+      rightButton: OnboardingBottomButton(
+        onPressed: () async {
+          await OnboardingLoader(localDatabase)
+              .runAtNextTime(currentPage, context);
+          //ignore: use_build_context_synchronously
+          navigator.navigateToPage(
+            context,
+            OnboardingFlowNavigator.getNextPage(currentPage),
+          );
+        },
+        backgroundColor: Colors.black,
+        foregroundColor: Colors.white,
+        label: appLocalizations.next_label,
+      ),
+      backgroundColor: backgroundColor,
     );
   }
 }

--- a/packages/smooth_app/lib/pages/onboarding/next_button.dart
+++ b/packages/smooth_app/lib/pages/onboarding/next_button.dart
@@ -35,6 +35,7 @@ class NextButton extends StatelessWidget {
         OnboardingFlowNavigator(userPreferences);
     final OnboardingPage previousPage =
         OnboardingFlowNavigator.getPrevPage(currentPage);
+    final bool hasPrevious = previousPage != OnboardingPage.NOT_STARTED;
     return Column(
       children: <Widget>[
         Container(
@@ -50,10 +51,12 @@ class NextButton extends StatelessWidget {
           width: screenSize.width,
           color: backgroundColor,
           child: Row(
-            mainAxisAlignment: MainAxisAlignment.center,
+            mainAxisAlignment: hasPrevious
+                ? MainAxisAlignment.spaceBetween
+                : MainAxisAlignment.end,
             crossAxisAlignment: CrossAxisAlignment.center,
             children: <Widget>[
-              if (previousPage != OnboardingPage.NOT_STARTED)
+              if (hasPrevious)
                 Padding(
                   padding: const EdgeInsets.only(right: LARGE_SPACE),
                   child: ElevatedButton(

--- a/packages/smooth_app/lib/pages/onboarding/onboarding_bottom_bar.dart
+++ b/packages/smooth_app/lib/pages/onboarding/onboarding_bottom_bar.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+
+/// Bottom Bar during onboarding. Typical use case: previous/next buttons.
+class OnboardingBottomBar extends StatelessWidget {
+  const OnboardingBottomBar({
+    required this.rightButton,
+    required this.backgroundColor,
+    this.leftButton,
+  }) : super(key: const Key('next'));
+
+  final Widget rightButton;
+  final Widget? leftButton;
+
+  /// Color of the background where we put the buttons.
+  ///
+  /// If null, transparent background and no visible divider.
+  final Color? backgroundColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final Size screenSize = MediaQuery.of(context).size;
+    // Side padding is 8% of total width.
+    final double sidePadding = screenSize.width * .08;
+    final bool hasPrevious = leftButton != null;
+    return Column(
+      children: <Widget>[
+        Container(
+          height: SMALL_SPACE,
+          width: screenSize.width,
+          color: backgroundColor == null ? null : LIGHT_GREY_COLOR,
+        ),
+        Container(
+          padding: EdgeInsets.symmetric(
+            vertical: VERY_LARGE_SPACE,
+            horizontal: sidePadding,
+          ),
+          width: screenSize.width,
+          color: backgroundColor,
+          child: Row(
+            mainAxisAlignment: hasPrevious
+                ? MainAxisAlignment.spaceBetween
+                : MainAxisAlignment.end,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: <Widget>[
+              if (leftButton != null) leftButton!,
+              rightButton,
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Onboarding Bottom Button, e.g. "next" or "previous".
+class OnboardingBottomButton extends StatelessWidget {
+  const OnboardingBottomButton({
+    required this.onPressed,
+    required this.backgroundColor,
+    required this.foregroundColor,
+    required this.label,
+  });
+
+  final VoidCallback onPressed;
+  final Color backgroundColor;
+  final Color foregroundColor;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) => ConstrainedBox(
+        constraints: const BoxConstraints.tightFor(height: MINIMUM_TARGET_SIZE),
+        child: ElevatedButton(
+          onPressed: onPressed,
+          style: ButtonStyle(
+            backgroundColor: MaterialStateProperty.all(backgroundColor),
+            shape: MaterialStateProperty.all<RoundedRectangleBorder>(
+              RoundedRectangleBorder(borderRadius: BorderRadius.circular(40)),
+            ),
+          ),
+          child: Text(
+            label,
+            style: Theme.of(context).textTheme.headline3?.copyWith(
+                  color: foregroundColor,
+                ),
+          ),
+        ),
+      );
+}
+
+/// Onboarding Bottom Icon, e.g. arrow for "next" or "previous".
+class OnboardingBottomIcon extends StatelessWidget {
+  const OnboardingBottomIcon({
+    required this.onPressed,
+    required this.backgroundColor,
+    required this.foregroundColor,
+    required this.icon,
+  });
+
+  final VoidCallback onPressed;
+  final Color backgroundColor;
+  final Color foregroundColor;
+  final IconData icon;
+
+  @override
+  Widget build(BuildContext context) => ElevatedButton(
+        style: ElevatedButton.styleFrom(
+          shape: const CircleBorder(),
+          padding: const EdgeInsets.all(12),
+          primary: backgroundColor,
+          onPrimary: foregroundColor,
+        ),
+        onPressed: onPressed,
+        child: Icon(icon),
+      );
+}


### PR DESCRIPTION
Impacted file:
* `next_button.dart`: changed the left/right button positions

### What
- Now we have a clear algo: either just one to the right, or one left + one right

### Screenshot

![Capture d’écran 2022-06-09 à 14 27 26](https://user-images.githubusercontent.com/11576431/172846737-a52ecfaf-7772-474d-92e7-c53e9d7dbda8.png)
![Capture d’écran 2022-06-09 à 14 27 38](https://user-images.githubusercontent.com/11576431/172846775-58d139c0-3227-4ba9-bffc-2b86337f7832.png)
![Capture d’écran 2022-06-09 à 14 28 49](https://user-images.githubusercontent.com/11576431/172846991-1202c500-6a5b-4106-b214-d8443e5eef12.png)

### Part of 
- #2001