### PR TITLE
fix: Ensure the initial loading dialog auto-closes on timeout

### DIFF
--- a/packages/smooth_app/lib/data_models/abstract_onboarding_data.dart
+++ b/packages/smooth_app/lib/data_models/abstract_onboarding_data.dart
@@ -35,13 +35,9 @@ abstract class AbstractOnboardingData<T> {
 
   /// Downloads data and store it locally.
   Future<void> downloadData() async {
-    try {
-      final String string = await downloadDataString();
-      final DaoString daoString = DaoString(_localDatabase);
-      await daoString.put(_getDatabaseKey(), string);
-    } catch (e) {
-      //
-    }
+    final String string = await downloadDataString();
+    final DaoString daoString = DaoString(_localDatabase);
+    await daoString.put(_getDatabaseKey(), string);
   }
 
   /// Converts a string into the expected object, even null.

--- a/packages/smooth_app/lib/data_models/onboarding_data_product.dart
+++ b/packages/smooth_app/lib/data_models/onboarding_data_product.dart
@@ -42,7 +42,7 @@ class OnboardingDataProduct extends AbstractOnboardingData<Product> {
           language: ProductQuery.getLanguage(),
           country: ProductQuery.getCountry(),
         ),
-      );
+      ).timeout(const Duration(seconds: 20));
 
   @override
   String getAssetPath() => assetPath;

--- a/packages/smooth_app/lib/generic_lib/loading_dialog.dart
+++ b/packages/smooth_app/lib/generic_lib/loading_dialog.dart
@@ -99,18 +99,10 @@ class LoadingDialog<T> {
       body: FutureBuilder<T>(
         future: future,
         builder: (BuildContext context, AsyncSnapshot<T> snapshot) {
-          if (snapshot.connectionState == ConnectionState.done) {
-            // Now it's either hasError or successful.
-            // We cannot check hasData because data can be null or void.
-            if (snapshot.hasError) {
-              return ListTile(
-                title: Text(appLocalizations.error_occurred),
-              );
-            }
+          if (snapshot.hasError || snapshot.hasData) {
             _popDialog(context, snapshot.data);
-            // whatever, anyway we've just pop'ed
-            return Container();
           }
+
           return ListTile(
             leading: const CircularProgressIndicator(),
             title: Text(title),


### PR DESCRIPTION
In case of a bad network, the initial loading product dialog was showing forever.
The reason: an empty `try/catch`