### PR TITLE
feat: New scan algorithm for Android devices

### DIFF
--- a/packages/smooth_app/ios/Podfile.lock
+++ b/packages/smooth_app/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - audioplayers (0.0.1):
+  - audioplayers_darwin (0.0.1):
     - Flutter
   - camera (0.0.1):
     - Flutter
@@ -115,7 +115,7 @@ PODS:
     - Flutter
 
 DEPENDENCIES:
-  - audioplayers (from `.symlinks/plugins/audioplayers/ios`)
+  - audioplayers_darwin (from `.symlinks/plugins/audioplayers_darwin/ios`)
   - camera (from `.symlinks/plugins/camera/ios`)
   - data_importer (from `.symlinks/plugins/data_importer/ios`)
   - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
@@ -158,8 +158,8 @@ SPEC REPOS:
     - TOCropViewController
 
 EXTERNAL SOURCES:
-  audioplayers:
-    :path: ".symlinks/plugins/audioplayers/ios"
+  audioplayers_darwin:
+    :path: ".symlinks/plugins/audioplayers_darwin/ios"
   camera:
     :path: ".symlinks/plugins/camera/ios"
   data_importer:
@@ -200,7 +200,7 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
-  audioplayers: 455322b54050b30ea4b1af7cd9e9d105f74efa8c
+  audioplayers_darwin: 387322cb364026a1782298c982693b1b6aa9fa1b
   camera: 9993f92f2c793e87b65e35f3a23c70582afb05b1
   data_importer: ab8c74aaf553878170aed03c03626d5820c5cb1f
   device_info_plus: e5c5da33f982a436e103237c0c85f9031142abed
@@ -241,4 +241,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: e1ffd3daa5042cd516081f94f61b857c0deb822d
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.11.3

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_error.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_error.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/continuous_scan_model.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
@@ -27,6 +28,13 @@ class SmoothProductCardError extends StatelessWidget {
         mainAxisSize: MainAxisSize.max,
         mainAxisAlignment: MainAxisAlignment.center,
         children: <Widget>[
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: SvgPicture.asset(
+              'assets/misc/error.svg',
+              width: MINIMUM_TOUCH_SIZE * 2,
+            ),
+          ),
           Row(
             mainAxisSize: MainAxisSize.max,
             mainAxisAlignment: MainAxisAlignment.center,

--- a/packages/smooth_app/lib/data_models/user_preferences.dart
+++ b/packages/smooth_app/lib/data_models/user_preferences.dart
@@ -4,6 +4,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:smooth_app/data_models/product_preferences.dart';
 import 'package:smooth_app/pages/onboarding/onboarding_flow_navigator.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_dev_mode.dart';
+import 'package:smooth_app/pages/scan/camera_controller.dart';
 
 class UserPreferences extends ChangeNotifier {
   UserPreferences._shared(final SharedPreferences sharedPreferences)
@@ -26,11 +27,21 @@ class UserPreferences extends ChangeNotifier {
   static const String _TAG_DEV_MODE = 'devMode';
   static const String _TAG_CRASH_REPORTS = 'crash_reports';
   static const String _TAG_EXCLUDED_ATTRIBUTE_IDS = 'excluded_attributes';
+
+  /// Camera preferences
+  // Detect if a first successful scan was achieved (condition to show the
+  // tagline)
   static const String _TAG_IS_FIRST_SCAN = 'is_first_scan';
+  // Which preset to use
   static const String _TAG_SCAN_CAMERA_RESOLUTION_PRESET =
       'camera_resolution_preset';
+  // Use the flash/torch with the camera
   static const String _TAG_USE_FLASH_WITH_CAMERA = 'enable_flash_with_camera';
+  // Play sound when decoding a barcode
   static const String _TAG_PLAY_CAMERA_SCAN_SOUND = 'camera_scan_sound';
+  // Which algorithm to use with the camera (Android only)
+  static const String _TAG_CAMERA_FOCUS_POINT_ALGORITHM =
+      'camera_focus_point_algorithm';
 
   /// Attribute group that is not collapsed
   static const String _TAG_ACTIVE_ATTRIBUTE_GROUP = 'activeAttributeGroup';
@@ -136,14 +147,6 @@ class UserPreferences extends ChangeNotifier {
   bool? getFlag(final String key) =>
       _sharedPreferences.getBool(_getFlagTag(key));
 
-  bool get useFlashWithCamera =>
-      _sharedPreferences.getBool(_TAG_USE_FLASH_WITH_CAMERA) ?? false;
-
-  Future<void> setUseFlashWithCamera(final bool useFlash) async {
-    await _sharedPreferences.setBool(_TAG_USE_FLASH_WITH_CAMERA, useFlash);
-    notifyListeners();
-  }
-
   List<String> getExcludedAttributeIds() =>
       _sharedPreferences.getStringList(_TAG_EXCLUDED_ATTRIBUTE_IDS) ??
       <String>[];
@@ -153,8 +156,13 @@ class UserPreferences extends ChangeNotifier {
     notifyListeners();
   }
 
-  bool get useVeryHighResolutionPreset =>
-      _sharedPreferences.getBool(_TAG_SCAN_CAMERA_RESOLUTION_PRESET) ?? false;
+  bool get useFlashWithCamera =>
+      _sharedPreferences.getBool(_TAG_USE_FLASH_WITH_CAMERA) ?? false;
+
+  Future<void> setUseFlashWithCamera(final bool useFlash) async {
+    await _sharedPreferences.setBool(_TAG_USE_FLASH_WITH_CAMERA, useFlash);
+    notifyListeners();
+  }
 
   Future<void> setUseVeryHighResolutionPreset(bool enableFeature) async {
     await _sharedPreferences.setBool(
@@ -162,13 +170,27 @@ class UserPreferences extends ChangeNotifier {
     notifyListeners();
   }
 
-  bool get playCameraSound =>
-      _sharedPreferences.getBool(_TAG_PLAY_CAMERA_SCAN_SOUND) ?? false;
+  bool get useVeryHighResolutionPreset =>
+      _sharedPreferences.getBool(_TAG_SCAN_CAMERA_RESOLUTION_PRESET) ?? false;
 
   Future<void> setPlayCameraSound(bool playSound) async {
     await _sharedPreferences.setBool(_TAG_PLAY_CAMERA_SCAN_SOUND, playSound);
     notifyListeners();
   }
+
+  bool get playCameraSound =>
+      _sharedPreferences.getBool(_TAG_PLAY_CAMERA_SCAN_SOUND) ?? false;
+
+  Future<void> setCameraFocusAlgorithm(
+      CameraFocusPointAlgorithm algorithm) async {
+    await _sharedPreferences.setInt(
+        _TAG_CAMERA_FOCUS_POINT_ALGORITHM, algorithm.index);
+    notifyListeners();
+  }
+
+  CameraFocusPointAlgorithm get cameraFocusPointAlgorithm =>
+      CameraFocusPointAlgorithm.values[
+          _sharedPreferences.getInt(_TAG_CAMERA_FOCUS_POINT_ALGORITHM) ?? 0];
 
   Future<void> setDevMode(final int value) async {
     await _sharedPreferences.setInt(_TAG_DEV_MODE, value);

--- a/packages/smooth_app/lib/generic_lib/widgets/smooth_error_card.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/smooth_error_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:smooth_app/generic_lib/buttons/smooth_simple_button.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
@@ -115,18 +116,22 @@ class _SmoothErrorCardState extends State<SmoothErrorCard> {
   }
 
   Widget _getTitle() {
-    return Align(
-      alignment: AlignmentDirectional.centerStart,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
-        child: Text(
-          _appLocalizations.there_was_an_error,
-          style: const TextStyle(
-            fontSize: 24.0,
-            fontWeight: FontWeight.bold,
-          ),
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
+      child: Text(
+        _appLocalizations.there_was_an_error,
+        style: const TextStyle(
+          fontSize: 24.0,
+          fontWeight: FontWeight.bold,
         ),
       ),
+    );
+  }
+
+  Widget _getErrorSvg() {
+    return SvgPicture.asset(
+      'assets/misc/error.svg',
+      width: MINIMUM_TOUCH_SIZE * 2,
     );
   }
 
@@ -139,6 +144,7 @@ class _SmoothErrorCardState extends State<SmoothErrorCard> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: <Widget>[
+            _getErrorSvg(),
             _getTitle(),
             _getBody(),
           ],

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -793,7 +793,13 @@
             }
         }
     },
-    "camera_high_resolution_preset_toggle_title": "Camera high performance mode",
+    "settings_app_app": "Application",
+    "settings_app_data": "Privacy & monitoring",
+    "settings_app_camera": "Camera",
+    "@camera_settings_title": {
+        "description": "Name of the camera section in the settings"
+    },
+    "camera_high_resolution_preset_toggle_title": "High performance mode",
     "@camera_high_resolution_preset_toggle_title": {
         "description": "Title for the Camera high resolution toggle"
     },
@@ -801,6 +807,28 @@
     "@camera_high_resolution_preset_toggle_subtitle": {
         "description": "SubTitle for the Camera high resolution toggle"
     },
+    "camera_focus_point_algorithm_title": "Focus mode",
+    "@camera_focus_point_algorithm_title": {
+        "description": "Title for the Camera focus mode (Android only)"
+    },
+    "camera_focus_point_algorithm_subtitle": "Current mode: {mode}\n{reason}",
+    "@camera_focus_point_algorithm_subtitle": {
+        "description": "SubTitle for the Camera focus mode (Android only)",
+        "placeholders": {
+                    "mode": {
+                        "type": "String"
+                    },
+                    "reason": {
+                        "type": "String"
+                    }
+                }
+    },
+    "camera_focus_point_algorithm_value_auto_label": "Auto",
+    "camera_focus_point_algorithm_value_auto_description": "Let the system choose automatically between fast and safe modes.",
+    "camera_focus_point_algorithm_value_new_algorithm_label": "Fast mode",
+    "camera_focus_point_algorithm_value_new_algorithm_description": "A mode recommended to recent devices.",
+    "camera_focus_point_algorithm_value_old_algorithm_label": "Safe mode",
+    "camera_focus_point_algorithm_value_old_algorithm_description": "If fast mode doesn't work, this should resolve your focus issues.",
     "camera_play_sound_title": "Play a sound on scan",
     "@camera_play_sound_title": {
         "description": "Title for the Camera play sound toggle"

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_settings.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_settings.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:matomo_tracker/matomo_tracker.dart';
@@ -9,6 +11,7 @@ import 'package:smooth_app/pages/onboarding/country_selector.dart';
 import 'package:smooth_app/pages/preferences/abstract_user_preferences.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_page.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_widgets.dart';
+import 'package:smooth_app/pages/scan/camera_controller.dart';
 import 'package:smooth_app/themes/theme_provider.dart';
 
 /// Collapsed/expanded display of settings for the preferences page.
@@ -44,7 +47,29 @@ class UserPreferencesSettings extends AbstractUserPreferences {
   IconData getLeadingIconData() => Icons.handyman;
 
   @override
-  List<Widget> getBody() => <Widget>[
+  List<Widget> getBody() => const <Widget>[
+        _ApplicationSettings(),
+        UserPreferencesListItemDivider(),
+        _CameraSettings(),
+        UserPreferencesListItemDivider(),
+        _PrivacySettings(),
+      ];
+}
+
+class _ApplicationSettings extends StatelessWidget {
+  const _ApplicationSettings({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final ThemeProvider themeProvider = context.watch<ThemeProvider>();
+    final ThemeData themeData = Theme.of(context);
+
+    return Column(
+      children: <Widget>[
+        UserPreferencesTitle(
+          label: appLocalizations.settings_app_app,
+        ),
         Padding(
           padding: const EdgeInsets.symmetric(
             horizontal: LARGE_SPACE,
@@ -84,14 +109,9 @@ class UserPreferencesSettings extends AbstractUserPreferences {
         const UserPreferencesListItemDivider(),
         const _CountryPickerSetting(),
         const UserPreferencesListItemDivider(),
-        const _CameraHighResolutionPresetSetting(),
-        const UserPreferencesListItemDivider(),
-        const _CameraPlayScanSoundSetting(),
-        const UserPreferencesListItemDivider(),
-        const _CrashReportingSetting(),
-        const UserPreferencesListItemDivider(),
-        const _SendAnonymousDataSetting(),
-      ];
+      ],
+    );
+  }
 }
 
 class _CountryPickerSetting extends StatelessWidget {
@@ -112,6 +132,27 @@ class _CountryPickerSetting extends StatelessWidget {
         textStyle: Theme.of(context).textTheme.bodyText2,
       ),
       minVerticalPadding: MEDIUM_SPACE,
+    );
+  }
+}
+
+class _PrivacySettings extends StatelessWidget {
+  const _PrivacySettings({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        UserPreferencesTitle(
+          label: appLocalizations.settings_app_data,
+        ),
+        const _CrashReportingSetting(),
+        const UserPreferencesListItemDivider(),
+        const _SendAnonymousDataSetting(),
+      ],
     );
   }
 }
@@ -161,6 +202,32 @@ class _CrashReportingSetting extends StatelessWidget {
   }
 }
 
+class _CameraSettings extends StatelessWidget {
+  const _CameraSettings({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        UserPreferencesTitle(
+          label: appLocalizations.settings_app_camera,
+        ),
+        const _CameraHighResolutionPresetSetting(),
+        const UserPreferencesListItemDivider(),
+        const _CameraPlayScanSoundSetting(),
+        const UserPreferencesListItemDivider(),
+        if (Platform.isAndroid) ...const <Widget>[
+          _CameraFocusModeSetting(),
+          UserPreferencesListItemDivider(),
+        ],
+      ],
+    );
+  }
+}
+
 class _CameraHighResolutionPresetSetting extends StatelessWidget {
   const _CameraHighResolutionPresetSetting({Key? key}) : super(key: key);
 
@@ -177,6 +244,84 @@ class _CameraHighResolutionPresetSetting extends StatelessWidget {
         await userPreferences.setUseVeryHighResolutionPreset(value);
       },
     );
+  }
+}
+
+class _CameraFocusModeSetting extends StatelessWidget {
+  const _CameraFocusModeSetting({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final UserPreferences userPreferences = context.watch<UserPreferences>();
+
+    return UserPreferencesMultipleChoicesItem<CameraFocusPointAlgorithm>(
+      title: appLocalizations.camera_focus_point_algorithm_title,
+      subtitle: appLocalizations.camera_focus_point_algorithm_subtitle(
+        getReadableMode(
+          appLocalizations,
+          userPreferences.cameraFocusPointAlgorithm,
+        ),
+        getReadableDescription(
+          appLocalizations,
+          userPreferences.cameraFocusPointAlgorithm,
+        ),
+      ),
+      values: CameraFocusPointAlgorithm.values,
+      descriptions: getDescriptions(appLocalizations),
+      labels: getLabels(appLocalizations),
+      currentValue: userPreferences.cameraFocusPointAlgorithm,
+      onChanged: (final CameraFocusPointAlgorithm value) async {
+        await userPreferences.setCameraFocusAlgorithm(value);
+      },
+    );
+  }
+
+  String getReadableMode(
+    AppLocalizations appLocalizations,
+    CameraFocusPointAlgorithm cameraFocusPointAlgorithm,
+  ) {
+    switch (cameraFocusPointAlgorithm) {
+      case CameraFocusPointAlgorithm.newAlgorithm:
+        return appLocalizations
+            .camera_focus_point_algorithm_value_new_algorithm_label;
+      case CameraFocusPointAlgorithm.oldAlgorithm:
+        return appLocalizations
+            .camera_focus_point_algorithm_value_old_algorithm_label;
+      case CameraFocusPointAlgorithm.auto:
+      default:
+        return appLocalizations.camera_focus_point_algorithm_value_auto_label;
+    }
+  }
+
+  String getReadableDescription(
+    AppLocalizations appLocalizations,
+    CameraFocusPointAlgorithm cameraFocusPointAlgorithm,
+  ) {
+    switch (cameraFocusPointAlgorithm) {
+      case CameraFocusPointAlgorithm.newAlgorithm:
+        return appLocalizations
+            .camera_focus_point_algorithm_value_new_algorithm_description;
+      case CameraFocusPointAlgorithm.oldAlgorithm:
+        return appLocalizations
+            .camera_focus_point_algorithm_value_old_algorithm_description;
+      case CameraFocusPointAlgorithm.auto:
+      default:
+        return appLocalizations
+            .camera_focus_point_algorithm_value_auto_description;
+    }
+  }
+
+  Iterable<String> getLabels(AppLocalizations appLocalizations) {
+    return CameraFocusPointAlgorithm.values.map((CameraFocusPointAlgorithm e) {
+      return getReadableMode(appLocalizations, e);
+    });
+  }
+
+  Iterable<String> getDescriptions(AppLocalizations appLocalizations) {
+    return CameraFocusPointAlgorithm.values.map((CameraFocusPointAlgorithm e) {
+      return getReadableDescription(appLocalizations, e);
+    });
   }
 }
 

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_widgets.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_widgets.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 
 /// A dashed line
 class UserPreferencesListItemDivider extends StatelessWidget {
@@ -93,6 +95,149 @@ class UserPreferencesSwitchItem extends StatelessWidget {
       value: value,
       onChanged: onChanged,
       isThreeLine: true,
+    );
+  }
+}
+
+/// A preference allowing to choose between a list of items.
+/// Before clicking on an item, the selected value is displayed via its [title]
+/// and [subtitle]
+///
+/// [labels] contains all the visible labels for the user in the dialog
+/// For each item, a [descriptions] can be provided (displayed below [labels])
+/// [values] are of type [T] and are returned according to the selected value
+/// A [currentValue] can be provided to auto-select a value
+class UserPreferencesMultipleChoicesItem<T> extends StatelessWidget {
+  const UserPreferencesMultipleChoicesItem({
+    required this.title,
+    required this.subtitle,
+    required this.labels,
+    required this.values,
+    required this.currentValue,
+    required this.onChanged,
+    this.descriptions,
+    this.dialogHeight,
+    Key? key,
+  })  : assert(labels.length > 0),
+        assert(values.length == labels.length),
+        assert(descriptions == null || descriptions.length == labels.length),
+        assert(dialogHeight == null || dialogHeight > 0.0),
+        super(key: key);
+
+  final String title;
+  final String subtitle;
+  final Iterable<String> labels;
+  final Iterable<String>? descriptions;
+  final Iterable<T> values;
+  final T? currentValue;
+  final ValueChanged<T>? onChanged;
+  final double? dialogHeight;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      title: Padding(
+        padding: const EdgeInsets.only(
+          top: SMALL_SPACE,
+          bottom: SMALL_SPACE,
+        ),
+        child: Text(title, style: Theme.of(context).textTheme.headline4),
+      ),
+      subtitle: Padding(
+        padding: const EdgeInsets.only(
+          bottom: SMALL_SPACE,
+        ),
+        child: Text(
+          subtitle,
+          style: const TextStyle(height: 1.5),
+        ),
+      ),
+      onTap: () async {
+        final T? res = await showDialog<T>(
+            context: context,
+            builder: (BuildContext context) {
+              final AppLocalizations appLocalizations =
+                  AppLocalizations.of(context);
+
+              return SmoothAlertDialog(
+                title: title,
+                body: SizedBox(
+                  height: dialogHeight ?? 250.0,
+                  child: Scrollbar(
+                    child: ListView.builder(
+                        itemCount: labels.length,
+                        itemBuilder: (BuildContext context, int position) {
+                          final bool selected =
+                              currentValue == values.elementAt(position);
+                          final Color? selectedColor =
+                              selected ? Theme.of(context).primaryColor : null;
+
+                          return ColoredBox(
+                            color: selectedColor?.withOpacity(0.1) ??
+                                Colors.transparent,
+                            child: ListTile(
+                              title: Text(
+                                labels.elementAt(position),
+                                style: Theme.of(context).textTheme.headline4,
+                              ),
+                              subtitle: descriptions != null
+                                  ? Text(descriptions!.elementAt(position))
+                                  : null,
+                              contentPadding: const EdgeInsets.symmetric(
+                                horizontal: 16.0,
+                                vertical: 5.0,
+                              ),
+                              onTap: () {
+                                Navigator.of(context)
+                                    .pop(values.elementAt(position));
+                              },
+                            ),
+                          );
+                        }),
+                  ),
+                ),
+                negativeAction: SmoothActionButton(
+                  text: appLocalizations.cancel,
+                  onPressed: () => Navigator.of(context).pop(),
+                ),
+              );
+            });
+
+        if (res != null) {
+          onChanged?.call(res);
+        }
+      },
+      isThreeLine: true,
+    );
+  }
+}
+
+class UserPreferencesTitle extends StatelessWidget {
+  const UserPreferencesTitle({required this.label, Key? key})
+      : assert(label.length > 0),
+        super(key: key);
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      child: Padding(
+        padding: const EdgeInsets.only(
+          top: SMALL_SPACE,
+          bottom: MEDIUM_SPACE,
+          // Horizontal = same as ListTile
+          left: 16.0,
+          right: 16.0,
+        ),
+        child: Text(
+          label,
+          style: Theme.of(context).textTheme.headline3?.copyWith(
+                height: 2.5,
+              ),
+        ),
+      ),
     );
   }
 }

--- a/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
@@ -104,6 +104,10 @@ class MLKitScannerPageState extends LifecycleAwareState<MLKitScannerPage>
     // Relaunch the feed after a hot reload
     if (_controller == null) {
       _startLiveFeed();
+    } else {
+      _controller!.updateFocusPointAlgorithm(
+        _userPreferences.cameraFocusPointAlgorithm,
+      );
     }
   }
 
@@ -275,7 +279,10 @@ class MLKitScannerPageState extends LifecycleAwareState<MLKitScannerPage>
       // If the Widget tree isn't ready, wait for the first frame
       if (!point.precise) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
-          _controller?.setFocusPoint(_focusPoint.offset);
+          _controller?.setFocusPointTo(
+            _focusPoint.offset,
+            _userPreferences.cameraFocusPointAlgorithm,
+          );
         });
       }
     } on CameraException catch (e) {

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -131,24 +131,28 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/camera/camera"
-      ref: camera_fix_debug
-      resolved-ref: "001de4ef6dc1f806aa6c0a794413a3441bc9da65"
+      ref: smooth_camera
+      resolved-ref: "5935f7ab6e661f59b2abfad27a012aecd19a6f0c"
       url: "https://github.com/g123k/plugins.git"
     source: git
     version: "0.9.6"
   camera_platform_interface:
     dependency: "direct main"
     description:
-      name: camera_platform_interface
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.2.0"
+      path: "packages/camera/camera_platform_interface"
+      ref: smooth_camera
+      resolved-ref: "5935f7ab6e661f59b2abfad27a012aecd19a6f0c"
+      url: "https://github.com/g123k/plugins.git"
+    source: git
+    version: "2.1.6"
   camera_web:
     dependency: transitive
     description:
-      name: camera_web
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "packages/camera/camera_web"
+      ref: smooth_camera
+      resolved-ref: "5935f7ab6e661f59b2abfad27a012aecd19a6f0c"
+      url: "https://github.com/g123k/plugins.git"
+    source: git
     version: "0.2.1+6"
   carousel_slider:
     dependency: "direct main"

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -49,13 +49,19 @@ dependencies:
   sentry_flutter: ^6.5.1 # careful with upgrading cf: https://github.com/openfoodfacts/smooth-app/issues/1300
   url_launcher: ^6.1.3
   visibility_detector: ^0.3.3
-  # Until the PR is merged, we have a fork of the camera plugin: https://github.com/openfoodfacts/smooth-app/issues/1892
+
+  # Camera (custom implementation for Android)
   camera:
     git:
       url: 'https://github.com/g123k/plugins.git'
-      ref: 'camera_fix_debug'
+      ref: 'smooth_camera'
       path: 'packages/camera/camera'
-  camera_platform_interface: any
+  camera_platform_interface:
+    git:
+      url: 'https://github.com/g123k/plugins.git'
+      ref: 'smooth_camera'
+      path: 'packages/camera/camera_platform_interface'
+      
   audioplayers: ^1.0.0
   percent_indicator: ^4.2.2
   mailto: ^2.0.0


### PR DESCRIPTION
Some Android devices (mainly Samsung & < Android 12) have sometimes some difficulties to obtain the focus.

A new algorithm is available in the native code of our fork of the camera package.

The app will now be able to choose between the two from the settings.
I have also revamped a little bit the Settings by adding some titles:
![1](https://user-images.githubusercontent.com/246838/173403261-f79b6d70-4cbf-4ed1-9e92-eccae3551b9e.png)
![2](https://user-images.githubusercontent.com/246838/173403308-f4e2431e-da21-4860-b98c-2cf32118929d.png)

Will fix #2251 
