### PR TITLE
fix: smoothAlertDialog - uniformization of AlertDialog into SmoothAlertDialog

### DIFF
--- a/packages/smooth_app/lib/pages/preferences/user_preferences_dev_mode.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_dev_mode.dart
@@ -9,6 +9,7 @@ import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/database/dao_product_list.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/database/product_query.dart';
+import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/helpers/data_importer/product_list_import_export.dart';
 import 'package:smooth_app/helpers/data_importer/smooth_app_data_importer.dart';
 import 'package:smooth_app/pages/onboarding/onboarding_flow_navigator.dart';
@@ -195,25 +196,20 @@ class UserPreferencesDevMode extends AbstractUserPreferences {
                 ),
               );
             }
-            showDialog<void>(
+            await showDialog<void>(
               context: context,
-              builder: (BuildContext context) => AlertDialog(
-                title: Text(
-                  appLocalizations.dev_preferences_export_history_dialog_title,
-                ),
-                content: SizedBox(
+              builder: (BuildContext context) => SmoothAlertDialog(
+                title: appLocalizations
+                    .dev_preferences_export_history_dialog_title,
+                body: SizedBox(
                   height: 400,
                   width: 300,
                   child: ListView(children: children),
                 ),
-                actions: <Widget>[
-                  ElevatedButton(
-                    child: Text(
-                      appLocalizations.dev_preferences_button_positive,
-                    ),
-                    onPressed: () => Navigator.pop(context),
-                  ),
-                ],
+                positiveAction: SmoothActionButton(
+                  text: appLocalizations.okay,
+                  onPressed: () => Navigator.pop(context),
+                ),
               ),
             );
           },
@@ -259,11 +255,9 @@ class UserPreferencesDevMode extends AbstractUserPreferences {
           onTap: () async {
             final DevModeScanMode? scanMode = await showDialog<DevModeScanMode>(
               context: context,
-              builder: (BuildContext context) => AlertDialog(
-                title: Text(
-                  appLocalizations.dev_mode_scan_mode_dialog_title,
-                ),
-                content: SizedBox(
+              builder: (BuildContext context) => SmoothAlertDialog(
+                title: appLocalizations.dev_mode_scan_mode_dialog_title,
+                body: SizedBox(
                   height: 400,
                   width: 300,
                   child: ListView.builder(
@@ -278,14 +272,10 @@ class UserPreferencesDevMode extends AbstractUserPreferences {
                     },
                   ),
                 ),
-                actions: <Widget>[
-                  ElevatedButton(
-                    child: Text(
-                      appLocalizations.dev_preferences_button_negative,
-                    ),
-                    onPressed: () => Navigator.pop(context),
-                  ),
-                ],
+                negativeAction: SmoothActionButton(
+                  text: appLocalizations.dev_preferences_button_negative,
+                  onPressed: () => Navigator.pop(context),
+                ),
               ),
             );
             if (scanMode != null) {
@@ -384,25 +374,17 @@ class UserPreferencesDevMode extends AbstractUserPreferences {
             OpenFoodAPIConfiguration.uriTestHost;
     final bool? result = await showDialog<bool>(
       context: context,
-      builder: (final BuildContext context) => AlertDialog(
-        title: Text(
-          appLocalizations.dev_preferences_test_environment_dialog_title,
+      builder: (final BuildContext context) => SmoothAlertDialog(
+        title: appLocalizations.dev_preferences_test_environment_dialog_title,
+        body: TextField(controller: _textFieldController),
+        negativeAction: SmoothActionButton(
+          text: appLocalizations.cancel,
+          onPressed: () => Navigator.pop(context, false),
         ),
-        content: TextField(controller: _textFieldController),
-        actions: <Widget>[
-          TextButton(
-            child: Text(
-              appLocalizations.dev_preferences_button_negative,
-            ),
-            onPressed: () => Navigator.pop(context, false),
-          ),
-          ElevatedButton(
-            child: Text(
-              appLocalizations.dev_preferences_button_positive,
-            ),
-            onPressed: () => Navigator.pop(context, true),
-          ),
-        ],
+        positiveAction: SmoothActionButton(
+          text: appLocalizations.okay,
+          onPressed: () => Navigator.pop(context, true),
+        ),
       ),
     );
     if (result == true) {

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_food.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_food.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/product_preferences.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/pages/preferences/abstract_user_preferences.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_attribute_group.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_page.dart';
@@ -62,7 +63,7 @@ class UserPreferencesFood extends AbstractUserPreferences {
       ListTile(
         leading: const Icon(Icons.rotate_left),
         title: Text(appLocalizations.reset_food_prefs),
-        onTap: () => _confirmReset(context),
+        onTap: () async => _confirmReset(),
       ),
     ];
     result.addAll(_getOnboardingBody());
@@ -79,31 +80,25 @@ class UserPreferencesFood extends AbstractUserPreferences {
     return result;
   }
 
-  void _confirmReset(BuildContext context) {
-    final AppLocalizations localizations = AppLocalizations.of(context);
-    showDialog<void>(
+  Future<void> _confirmReset() async {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    await showDialog<void>(
       context: context,
-      builder: (BuildContext context) {
-        return AlertDialog(
-          title: Text(localizations.confirmResetPreferences),
-          actions: <Widget>[
-            TextButton(
-              child: Text(localizations.yes),
-              onPressed: () async {
-                await context.read<ProductPreferences>().resetImportances();
-                //ignore: use_build_context_synchronously
-                Navigator.pop(context);
-              },
-            ),
-            TextButton(
-              child: Text(localizations.no),
-              onPressed: () {
-                Navigator.pop(context);
-              },
-            )
-          ],
-        );
-      },
+      builder: (BuildContext context) => SmoothAlertDialog(
+        body: Text(appLocalizations.confirmResetPreferences),
+        positiveAction: SmoothActionButton(
+          text: appLocalizations.yes,
+          onPressed: () async {
+            await context.read<ProductPreferences>().resetImportances();
+            //ignore: use_build_context_synchronously
+            Navigator.pop(context);
+          },
+        ),
+        negativeAction: SmoothActionButton(
+          text: appLocalizations.no,
+          onPressed: () => Navigator.pop(context),
+        ),
+      ),
     );
   }
 

--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -11,6 +11,7 @@ import 'package:provider/provider.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/database/product_query.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/helpers/text_input_formatters_helper.dart';
 import 'package:smooth_app/pages/product/common/product_refresher.dart';
@@ -90,6 +91,8 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
     }
 
     return WillPopScope(
+      //return a boolean to decide whether to return to previous page or not
+      onWillPop: () => _showCancelPopup(localizations),
       child: Scaffold(
         appBar: AppBar(
           title: AutoSizeText(
@@ -118,8 +121,6 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
           ),
         ),
       ),
-      //return a boolean to decide whether to return to previous page or not
-      onWillPop: () => _showCancelPopup(localizations),
     );
   }
 
@@ -301,9 +302,9 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
                 return StatefulBuilder(
                   builder: (BuildContext context,
                       void Function(VoidCallback fn) setState) {
-                    return AlertDialog(
-                      title: Text(appLocalizations.nutrition_page_add_nutrient),
-                      content: Column(
+                    return SmoothAlertDialog.advanced(
+                      title: appLocalizations.nutrition_page_add_nutrient,
+                      body: Column(
                         children: <Widget>[
                           TextField(
                             decoration: InputDecoration(
@@ -340,12 +341,10 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
                           ),
                         ],
                       ),
-                      actions: <Widget>[
-                        ElevatedButton(
-                          onPressed: () => Navigator.pop(context),
-                          child: Text(appLocalizations.cancel),
-                        ),
-                      ],
+                      negativeAction: SmoothActionButton(
+                        onPressed: () => Navigator.pop(context),
+                        text: appLocalizations.cancel,
+                      ),
                     );
                   },
                 );
@@ -366,7 +365,7 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
         label: Text(appLocalizations.nutrition_page_add_nutrient),
       );
 
-  Future<bool> _showCancelPopup(AppLocalizations localizations) async {
+  Future<bool> _showCancelPopup(final AppLocalizations appLocalizations) async {
     //if no changes made then returns true to the onWillPop
     // allowing it to let the user return back to previous screen
     if (!_isEdited()) {
@@ -374,26 +373,21 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
     }
     return await showDialog<bool>(
           context: context,
-          builder: (BuildContext context) => AlertDialog(
-            shape: const RoundedRectangleBorder(
-              borderRadius: ROUNDED_BORDER_RADIUS,
+          builder: (BuildContext context) => SmoothAlertDialog(
+            title: appLocalizations.general_confirmation,
+            body: Text(appLocalizations.nutrition_page_close_confirmation),
+            negativeAction: SmoothActionButton(
+              text: appLocalizations.cancel,
+              // returns false to onWillPop after the alert dialog is closed with cancel button
+              //blocking return to the previous screen
+              onPressed: () => Navigator.pop(context),
             ),
-            title: Text(localizations.general_confirmation),
-            content: Text(localizations.nutrition_page_close_confirmation),
-            actions: <TextButton>[
-              TextButton(
-                child: Text(localizations.cancel.toUpperCase()),
-                // returns false to onWillPop after the alert dialog is closed with cancel button
-                //blocking return to the previous screen
-                onPressed: () => Navigator.pop(context),
-              ),
-              TextButton(
-                child: Text(localizations.okay.toUpperCase()),
-                // returns true to onWillPop after the alert dialog is closed with close button
-                //letting return to the previous screen
-                onPressed: () => Navigator.pop(context, _product),
-              ),
-            ],
+            positiveAction: SmoothActionButton(
+              text: appLocalizations.okay,
+              // returns true to onWillPop after the alert dialog is closed with close button
+              //letting return to the previous screen
+              onPressed: () => Navigator.pop(context, true),
+            ),
           ),
         ) ??
         // in case alert dialog is closed, a false is return
@@ -411,26 +405,24 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
   }
 
   Future<void> _showSavePopup(
-      AppLocalizations localizations, LocalDatabase localDatabase) async {
+    final AppLocalizations appLocalizations,
+    final LocalDatabase localDatabase,
+  ) async {
     final bool shouldSave = await showDialog<bool>(
-            context: context,
-            builder: (BuildContext context) => AlertDialog(
-                  title: Text(localizations.general_confirmation),
-                  content: Text(localizations.save_confirmation),
-                  shape: const RoundedRectangleBorder(
-                    borderRadius: ROUNDED_BORDER_RADIUS,
-                  ),
-                  actions: <TextButton>[
-                    TextButton(
-                      child: Text(localizations.cancel.toUpperCase()),
-                      onPressed: () => Navigator.pop(context, false),
-                    ),
-                    TextButton(
-                      child: Text(localizations.save.toUpperCase()),
-                      onPressed: () => Navigator.pop(context, true),
-                    ),
-                  ],
-                )) ??
+          context: context,
+          builder: (BuildContext context) => SmoothAlertDialog(
+            title: appLocalizations.general_confirmation,
+            body: Text(appLocalizations.save_confirmation),
+            negativeAction: SmoothActionButton(
+              text: appLocalizations.cancel,
+              onPressed: () => Navigator.pop(context, false),
+            ),
+            positiveAction: SmoothActionButton(
+              text: appLocalizations.save.toUpperCase(),
+              onPressed: () => Navigator.pop(context, true),
+            ),
+          ),
+        ) ??
         false;
 
     if (shouldSave) {
@@ -445,16 +437,11 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
     }
     // minimal product: we only want to save the nutrients
     final Product inputProduct = _nutritionContainer.getProduct();
-
-    final Product? savedAndRefreshed = await ProductRefresher().saveAndRefresh(
+    await ProductRefresher().saveAndRefresh(
       context: context,
       localDatabase: localDatabase,
       product: inputProduct,
     );
-    if (!mounted) {
-      return;
-    }
-    Navigator.of(context).pop(savedAndRefreshed);
   }
 
   bool _isEdited() {

--- a/packages/smooth_app/lib/pages/product_list_user_dialog_helper.dart
+++ b/packages/smooth_app/lib/pages/product_list_user_dialog_helper.dart
@@ -3,6 +3,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/data_models/product_list.dart';
 import 'package:smooth_app/database/dao_product_list.dart';
+import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_text_form_field.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 
@@ -17,15 +18,14 @@ class ProductListUserDialogHelper {
     final BuildContext context,
   ) async {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
-
     final TextEditingController textEditingController = TextEditingController();
     final GlobalKey<FormState> formKey = GlobalKey<FormState>();
 
     final String? title = await showDialog<String>(
       context: context,
-      builder: (final BuildContext context) => AlertDialog(
-        title: Text(appLocalizations.user_list_dialog_new_title),
-        content: Form(
+      builder: (final BuildContext context) => SmoothAlertDialog(
+        title: appLocalizations.user_list_dialog_new_title,
+        body: Form(
           key: formKey,
           child: SmoothTextFormField(
             type: TextFieldTypes.PLAIN_TEXT,
@@ -45,21 +45,19 @@ class ProductListUserDialogHelper {
             },
           ),
         ),
-        actions: <Widget>[
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: Text(appLocalizations.cancel),
-          ),
-          ElevatedButton(
-            onPressed: () {
-              if (!formKey.currentState!.validate()) {
-                return;
-              }
-              Navigator.pop(context, textEditingController.text);
-            },
-            child: Text(appLocalizations.okay),
-          ),
-        ],
+        neutralAction: SmoothActionButton(
+          onPressed: () => Navigator.pop(context),
+          text: appLocalizations.cancel,
+        ),
+        positiveAction: SmoothActionButton(
+          onPressed: () {
+            if (!formKey.currentState!.validate()) {
+              return;
+            }
+            Navigator.pop(context, textEditingController.text);
+          },
+          text: appLocalizations.okay,
+        ),
       ),
     );
     if (title == null) {
@@ -88,9 +86,9 @@ class ProductListUserDialogHelper {
       builder: (final BuildContext context) => StatefulBuilder(
         builder:
             (BuildContext context, void Function(VoidCallback fn) setState) =>
-                AlertDialog(
-          title: Text(getProductName(product, appLocalizations)),
-          content: StatefulBuilder(
+                SmoothAlertDialog(
+          title: getProductName(product, appLocalizations),
+          body: StatefulBuilder(
             builder: (BuildContext context,
                 void Function(VoidCallback fn) setState) {
               final List<Widget> children = <Widget>[];
@@ -117,28 +115,26 @@ class ProductListUserDialogHelper {
               );
             },
           ),
-          actions: <Widget>[
-            TextButton(
-              onPressed: () => Navigator.pop(context),
-              child: Text(appLocalizations.cancel),
-            ),
-            ElevatedButton(
-              onPressed: () async {
-                final ProductList? productList =
-                    await showCreateUserListDialog(context);
-                if (productList != null) {
-                  all.clear();
-                  all.addAll(daoProductList.getUserLists());
-                  setState(() => addedLists = true);
-                }
-              },
-              child: Text(appLocalizations.user_list_button_new),
-            ),
-            ElevatedButton(
-              onPressed: () => Navigator.pop(context, true),
-              child: Text(appLocalizations.okay),
-            ),
-          ],
+          negativeAction: SmoothActionButton(
+            onPressed: () => Navigator.pop(context),
+            text: appLocalizations.cancel,
+          ),
+          neutralAction: SmoothActionButton(
+            onPressed: () async {
+              final ProductList? productList =
+                  await showCreateUserListDialog(context);
+              if (productList != null) {
+                all.clear();
+                all.addAll(daoProductList.getUserLists());
+                setState(() => addedLists = true);
+              }
+            },
+            text: appLocalizations.user_list_button_new,
+          ),
+          positiveAction: SmoothActionButton(
+            onPressed: () => Navigator.pop(context, true),
+            text: appLocalizations.okay,
+          ),
         ),
       ),
     );
@@ -174,9 +170,9 @@ class ProductListUserDialogHelper {
     textEditingController.text = initialName;
     final String? newName = await showDialog<String>(
       context: context,
-      builder: (final BuildContext context) => AlertDialog(
-        title: Text(appLocalizations.user_list_dialog_rename_title),
-        content: Form(
+      builder: (final BuildContext context) => SmoothAlertDialog(
+        title: appLocalizations.user_list_dialog_rename_title,
+        body: Form(
           key: formKey,
           child: SmoothTextFormField(
             type: TextFieldTypes.PLAIN_TEXT,
@@ -198,21 +194,19 @@ class ProductListUserDialogHelper {
             },
           ),
         ),
-        actions: <Widget>[
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: Text(appLocalizations.cancel),
-          ),
-          ElevatedButton(
-            onPressed: () {
-              if (!formKey.currentState!.validate()) {
-                return;
-              }
-              Navigator.pop(context, textEditingController.text);
-            },
-            child: Text(appLocalizations.okay),
-          ),
-        ],
+        negativeAction: SmoothActionButton(
+          onPressed: () => Navigator.pop(context),
+          text: appLocalizations.cancel,
+        ),
+        positiveAction: SmoothActionButton(
+          onPressed: () {
+            if (!formKey.currentState!.validate()) {
+              return;
+            }
+            Navigator.pop(context, textEditingController.text);
+          },
+          text: appLocalizations.okay,
+        ),
       ),
     );
     if (newName == null) {
@@ -230,21 +224,19 @@ class ProductListUserDialogHelper {
 
     final bool? deleted = await showDialog<bool>(
       context: context,
-      builder: (final BuildContext context) => AlertDialog(
-        title: const Text('Delete list?'),
-        content: Text(productList.parameters),
-        actions: <Widget>[
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: Text(appLocalizations.cancel),
-          ),
-          ElevatedButton(
-            onPressed: () {
-              Navigator.pop(context, true);
-            },
-            child: Text(appLocalizations.okay),
-          ),
-        ],
+      builder: (final BuildContext context) => SmoothAlertDialog(
+        title: 'Delete list?',
+        body: Text(productList.parameters),
+        negativeAction: SmoothActionButton(
+          onPressed: () => Navigator.pop(context),
+          text: appLocalizations.cancel,
+        ),
+        positiveAction: SmoothActionButton(
+          onPressed: () {
+            Navigator.pop(context, true);
+          },
+          text: appLocalizations.okay,
+        ),
       ),
     );
     if (deleted == null) {

--- a/packages/smooth_app/lib/smooth_category_picker_example.dart
+++ b/packages/smooth_app/lib/smooth_category_picker_example.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/utils/LanguageHelper.dart';
+import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_category_picker.dart';
 
 void main() {
@@ -135,8 +136,8 @@ class _ExampleAppState extends State<ExampleApp> {
           .pop(name.isNotEmpty ? FruitCategory(Fruit(name)) : null);
     }
 
-    return AlertDialog(
-      content: TextField(
+    return SmoothAlertDialog(
+      body: TextField(
         autofocus: true,
         controller: controller,
         decoration: const InputDecoration(
@@ -144,16 +145,14 @@ class _ExampleAppState extends State<ExampleApp> {
         ),
         onSubmitted: addCategory,
       ),
-      actions: <Widget>[
-        TextButton(
-          child: const Text('OK'),
-          onPressed: () => addCategory(controller.text),
-        ),
-        TextButton(
-          child: const Text('Cancel'),
-          onPressed: () => Navigator.of(context).pop(),
-        ),
-      ],
+      positiveAction: SmoothActionButton(
+        text: 'OK',
+        onPressed: () => addCategory(controller.text),
+      ),
+      negativeAction: SmoothActionButton(
+        text: 'Cancel',
+        onPressed: () => Navigator.of(context).pop(),
+      ),
     );
   }
 


### PR DESCRIPTION
...and related fixes

Impacted files:
* `nutrition_page_loaded.dart`: 3 more dialogs now as `SmoothAlertDialog`
* `product_list_user_dialog_helper.dart`: 4 more dialogs now as `SmoothAlertDialog`
* `smooth_category_picker_example.dart`: 1 more dialog now as `SmoothAlertDialog`
* `user_preferences_dev_mode.dart`: 3 more dialogs now as `SmoothAlertDialog`
* `user_preferences_food.dart`: 1 more dialog now as `SmoothAlertDialog`

### What
- I encountered bugs when trying to add a product to a list (from the product page) - for some reason the fix by @bhattabhi013 in #1690 does not work anymore.
- And then I saw that more generally some pages were still using `AlertDialog` instead of `SmoothAlertDialog`.
- That's why I switched those `AlertDialog`s into `SmoothAlertDialog`s, for code consistency.
- As a side effect it apparently solved my bug, but still, the product list dialog does not look well (if you have too many product lists, you go too far, if you use `SmoothAlertDialog.advanced` you have a full screen even with no product lists)