### PR TITLE
fix: #2268 - force a color for tinted icons without color

### DIFF
--- a/packages/smooth_app/lib/cards/category_cards/svg_cache.dart
+++ b/packages/smooth_app/lib/cards/category_cards/svg_cache.dart
@@ -46,9 +46,20 @@ class SvgCache extends AbstractCache {
     if (cachedFilenames.isEmpty) {
       return getDefaultUnknown();
     }
+    Color? forcedColor = color;
+    // cf. https://github.com/openfoodfacts/smooth-app/issues/2268
+    // For tinted icons, when there's no color it's not good, as it will always
+    // be black - not good for dark mode.
+    // Here we detect lazily tinted icons if the URL contains "/icons/"
+    // e.g. https://static.openfoodfacts.org/images/icons/dist/nutrition.svg
+    if (forcedColor == null && iconUrl!.contains('/icons/')) {
+      forcedColor = Theme.of(context).brightness == Brightness.dark
+          ? Colors.white
+          : Colors.black;
+    }
     return SvgPicture.network(
       iconUrl!,
-      color: color,
+      color: forcedColor,
       width: width,
       height: height,
       fit: BoxFit.contain,
@@ -59,7 +70,7 @@ class SvgCache extends AbstractCache {
                 iconUrl!,
                 width: width,
                 height: height,
-                color: color,
+                color: forcedColor,
               ),
             )
           : getCircularProgressIndicator(),


### PR DESCRIPTION
Impacted file:
* `svg_cache.dart`

### What
- Some icons are "tinted": they are black svg icons, and the typical use case is to put a color on top.
- In some cases there was no explicit color specified, which caused the bug #2268, with dark icons on dark backgrounds.
- The fix is to detect when an icon is "tinted", and in that case to apply a decent color (white for dark mode, black for light mode)

### Screenshot
![Capture d’écran 2022-06-14 à 14 08 21](https://user-images.githubusercontent.com/11576431/173573478-3d891d9e-a095-4933-88fa-5fc27ffdae4c.png)


### Fixes bug(s)
- Fixes: #2268