### PR TITLE
fix: update app image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img height='175' src="https://static.openfoodfacts.org/images/misc/mobileapp/new_openfoodfacts_app_en_light_3_screenshots.png" align="left" hspace="1" vspace="1">
+<img height="100" src="https://static.openfoodfacts.org/images/logos/off-logo-horizontal-light.svg">
 
 # Open Food Facts - Codename: "Smooth App"
 [![SmoothApp Post-Submit Tests](https://github.com/openfoodfacts/smooth-app/actions/workflows/postsubmit.yml/badge.svg)](https://github.com/openfoodfacts/smooth-app/actions/workflows/postsubmit.yml)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-<img height="100" src="https://static.openfoodfacts.org/images/logos/off-logo-horizontal-light.svg">
+<picture>
+  <source srcset="https://static.openfoodfacts.org/images/logos/off-logo-horizontal-dark.svg" media="(prefers-color-scheme: dark)">
+  <img height="100" src="https://static.openfoodfacts.org/images/logos/off-logo-horizontal-light.svg">
+</picture>
 
 # Open Food Facts - Codename: "Smooth App"
 [![SmoothApp Post-Submit Tests](https://github.com/openfoodfacts/smooth-app/actions/workflows/postsubmit.yml/badge.svg)](https://github.com/openfoodfacts/smooth-app/actions/workflows/postsubmit.yml)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 <picture>
-  <source srcset="https://static.openfoodfacts.org/images/logos/off-logo-horizontal-dark.svg" media="(prefers-color-scheme: dark)">
+  <source media="(prefers-color-scheme: dark)" srcset="https://static.openfoodfacts.org/images/logos/off-logo-horizontal-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://static.openfoodfacts.org/images/logos/off-logo-horizontal-light.svg">
   <img height="100" src="https://static.openfoodfacts.org/images/logos/off-logo-horizontal-light.svg">
 </picture>
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img height='175' src="https://en.blog.openfoodfacts.org/images/EXE_LOGO_OFF_RVB_Plan_de_travail_1_copie_0_t.jpg" align="left" hspace="1" vspace="1">
+<img height='175' src="https://static.openfoodfacts.org/images/misc/mobileapp/new_openfoodfacts_app_en_light_3_screenshots.png" align="left" hspace="1" vspace="1">
 
 # Open Food Facts - Codename: "Smooth App"
 [![SmoothApp Post-Submit Tests](https://github.com/openfoodfacts/smooth-app/actions/workflows/postsubmit.yml/badge.svg)](https://github.com/openfoodfacts/smooth-app/actions/workflows/postsubmit.yml)


### PR DESCRIPTION
We migrated our blog to a new platform, which broke some URLs, including the image we used in the README file.

fixes #2279