### PR TITLE
feat: #2280 - DaoProduct's just migrated to sqflite

### DIFF
--- a/packages/data_importer/pubspec.yaml
+++ b/packages/data_importer/pubspec.yaml
@@ -14,11 +14,7 @@ dependencies:
   data_importer_shared:
     path: ../data_importer_shared
 
-  # Custom SQLite plugin only with the Android impl
-  sqflite:
-    git:
-      url: 'https://github.com/g123k/sqflite_android_only.git'
-      path: 'sqflite'
+  sqflite: ^2.0.2+1
 
   flutter_secure_storage: ^5.0.2
   path: ^1.8.0

--- a/packages/smooth_app/ios/Podfile.lock
+++ b/packages/smooth_app/ios/Podfile.lock
@@ -16,6 +16,9 @@ PODS:
     - Flutter
   - flutter_secure_storage (3.3.1):
     - Flutter
+  - FMDB (2.7.5):
+    - FMDB/standard (= 2.7.5)
+  - FMDB/standard (2.7.5)
   - google_mlkit_barcode_scanning (0.3.0):
     - Flutter
     - google_mlkit_commons
@@ -110,6 +113,9 @@ PODS:
     - Sentry (~> 7.11.0)
   - shared_preferences_ios (0.0.1):
     - Flutter
+  - sqflite (0.0.2):
+    - Flutter
+    - FMDB (>= 2.7.5)
   - TOCropViewController (2.6.1)
   - url_launcher_ios (0.0.1):
     - Flutter
@@ -134,10 +140,12 @@ DEPENDENCIES:
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - sentry_flutter (from `.symlinks/plugins/sentry_flutter/ios`)
   - shared_preferences_ios (from `.symlinks/plugins/shared_preferences_ios/ios`)
+  - sqflite (from `.symlinks/plugins/sqflite/ios`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
 SPEC REPOS:
   trunk:
+    - FMDB
     - GoogleDataTransport
     - GoogleMLKit
     - GoogleToolboxForMac
@@ -196,6 +204,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/sentry_flutter/ios"
   shared_preferences_ios:
     :path: ".symlinks/plugins/shared_preferences_ios/ios"
+  sqflite:
+    :path: ".symlinks/plugins/sqflite/ios"
   url_launcher_ios:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
 
@@ -208,6 +218,7 @@ SPEC CHECKSUMS:
   flutter_isolate: 0edf5081826d071adf21759d1eb10ff5c24503b5
   flutter_native_splash: 52501b97d1c0a5f898d687f1646226c1f93c56ef
   flutter_secure_storage: 7953c38a04c3fdbb00571bcd87d8e3b5ceb9daec
+  FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a
   google_mlkit_barcode_scanning: 56e88993b6c915ce7134f9d77cb5b2de2fca8cfa
   google_mlkit_commons: e9070f57232c3a3e4bd42fdfa621bb1f4bb3e709
   GoogleDataTransport: 629c20a4d363167143f30ea78320d5a7eb8bd940
@@ -236,6 +247,7 @@ SPEC CHECKSUMS:
   Sentry: 0c5cd63d714187b4a39c331c1f0eb04ba7868341
   sentry_flutter: efb3df2c203cd03aad255892a8d628a458656d14
   shared_preferences_ios: 548a61f8053b9b8a49ac19c1ffbc8b92c50d68ad
+  sqflite: 6d358c025f5b867b29ed92fc697fd34924e11904
   TOCropViewController: edfd4f25713d56905ad1e0b9f5be3fbe0f59c863
   url_launcher_ios: 839c58cdb4279282219f5e248c3321761ff3c4de
 

--- a/packages/smooth_app/lib/database/abstract_sql_dao.dart
+++ b/packages/smooth_app/lib/database/abstract_sql_dao.dart
@@ -1,0 +1,8 @@
+import 'package:smooth_app/database/local_database.dart';
+
+/// DAO abstraction for SQL.
+abstract class AbstractSqlDao {
+  AbstractSqlDao(this.localDatabase);
+
+  final LocalDatabase localDatabase;
+}

--- a/packages/smooth_app/lib/database/bulk_deletable.dart
+++ b/packages/smooth_app/lib/database/bulk_deletable.dart
@@ -1,0 +1,9 @@
+import 'package:smooth_app/database/bulk_insertable.dart';
+
+/// Interface for bulk database deletes.
+///
+/// cf. [BulkManager], [BulkInsertable]
+abstract class BulkDeletable implements BulkInsertable {
+  /// "where" clause for delete in bulk mode
+  String getDeleteWhere(final List<dynamic> deleteWhereArgs);
+}

--- a/packages/smooth_app/lib/database/bulk_insertable.dart
+++ b/packages/smooth_app/lib/database/bulk_insertable.dart
@@ -1,0 +1,12 @@
+import 'package:smooth_app/database/bulk_manager.dart';
+
+/// Interface for bulk database inserts.
+///
+/// cf. [BulkManager]
+abstract class BulkInsertable {
+  /// Insert columns for bulk mode
+  List<String> getInsertColumns();
+
+  /// Table name
+  String getTableName();
+}

--- a/packages/smooth_app/lib/database/bulk_manager.dart
+++ b/packages/smooth_app/lib/database/bulk_manager.dart
@@ -1,0 +1,87 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:smooth_app/database/bulk_deletable.dart';
+import 'package:smooth_app/database/bulk_insertable.dart';
+import 'package:sqflite/sqflite.dart';
+
+/// Manager for bulk database inserts and deletes.
+///
+/// In tests it looked 33% faster to use delete/insert rather than upsert
+/// And of course it's much faster to perform bulk actions
+/// rather than numerous single actions
+/// cf. [BulkInsertable], [BulkDeletable]
+class BulkManager {
+  /// Max number of parameters in a SQFlite query
+  ///
+  /// cf. SQLITE_MAX_VARIABLE_NUMBER, "which defaults to 999"
+  // TODO(monsieurtanuki): find a way to retrieve this number from SQFlite system tables, cf. https://github.com/tekartik/sqflite/issues/663
+  static const int SQLITE_MAX_VARIABLE_NUMBER = 999;
+
+  /// Returns the number of inserted rows by optimized bulk insert
+  Future<int> insert({
+    required final BulkInsertable bulkInsertable,
+    required final List<dynamic> parameters,
+    required final DatabaseExecutor databaseExecutor,
+  }) async {
+    int result = 0;
+    final String tableName = bulkInsertable.getTableName();
+    final List<String> columnNames = bulkInsertable.getInsertColumns();
+    final int numCols = columnNames.length;
+    if (parameters.isEmpty) {
+      return result;
+    }
+    if (columnNames.isEmpty) {
+      throw Exception('There must be at least one column!');
+    }
+    if (parameters.length % numCols != 0) {
+      throw Exception(
+          'Parameter list size (${parameters.length}) cannot be divided by $numCols');
+    }
+    final String variables = '?${',?' * (columnNames.length - 1)}';
+    final int maxSlice = (SQLITE_MAX_VARIABLE_NUMBER ~/ numCols) * numCols;
+    for (int start = 0; start < parameters.length; start += maxSlice) {
+      final int size = min(parameters.length - start, maxSlice);
+      final int insertedRows = size ~/ numCols;
+      final int additionalRecordsNumber = -1 + insertedRows;
+      await databaseExecutor.rawInsert(
+        'insert into $tableName(${columnNames.join(',')}) '
+        'values($variables)${',($variables)' * additionalRecordsNumber}',
+        parameters.sublist(start, start + size),
+      );
+      result += insertedRows;
+    }
+    return result;
+  }
+
+  /// Returns the number of deleted rows by optimized bulk delete
+  Future<int> delete({
+    required final BulkDeletable bulkDeletable,
+    required final List<dynamic> parameters,
+    required final DatabaseExecutor databaseExecutor,
+    final List<dynamic>? additionalParameters,
+  }) async {
+    int result = 0;
+    final String tableName = bulkDeletable.getTableName();
+    if (parameters.isEmpty) {
+      return result;
+    }
+    final int maxSlice =
+        SQLITE_MAX_VARIABLE_NUMBER - (additionalParameters?.length ?? 0);
+    for (int start = 0; start < parameters.length; start += maxSlice) {
+      final int size = min(parameters.length - start, maxSlice);
+      final List<dynamic> currentParameters = <dynamic>[];
+      if (additionalParameters != null && additionalParameters.isNotEmpty) {
+        currentParameters.addAll(additionalParameters);
+      }
+      currentParameters.addAll(parameters.sublist(start, start + size));
+      final int deleted = await databaseExecutor.delete(
+        tableName,
+        where: bulkDeletable.getDeleteWhere(currentParameters),
+        whereArgs: currentParameters,
+      );
+      result += deleted;
+    }
+    return result;
+  }
+}

--- a/packages/smooth_app/lib/database/dao_hive_product.dart
+++ b/packages/smooth_app/lib/database/dao_hive_product.dart
@@ -1,0 +1,76 @@
+import 'dart:async';
+import 'dart:convert';
+import 'package:hive/hive.dart';
+import 'package:openfoodfacts/model/Product.dart';
+import 'package:smooth_app/database/abstract_dao.dart';
+import 'package:smooth_app/database/local_database.dart';
+
+/// Hive type adapter for [Product]
+class _ProductAdapter extends TypeAdapter<Product> {
+  @override
+  final int typeId = 1;
+
+  @override
+  Product read(BinaryReader reader) =>
+      Product.fromJson(jsonDecode(reader.readString()) as Map<String, dynamic>);
+
+  @override
+  void write(BinaryWriter writer, Product obj) =>
+      writer.writeString(jsonEncode(obj.toJson()));
+}
+
+/// Where we store the products as "barcode => product".
+@Deprecated('use [DaoProduct] instead')
+class DaoHiveProduct extends AbstractDao {
+  @Deprecated('use [DaoProduct] instead')
+  DaoHiveProduct(final LocalDatabase localDatabase) : super(localDatabase);
+
+  static const String _hiveBoxName = 'products';
+
+  @override
+  Future<void> init() async => Hive.openLazyBox<Product>(_hiveBoxName);
+
+  @override
+  void registerAdapter() => Hive.registerAdapter(_ProductAdapter());
+
+  LazyBox<Product> _getBox() => Hive.lazyBox<Product>(_hiveBoxName);
+
+  Future<Product?> get(final String barcode) async => _getBox().get(barcode);
+
+  Future<Map<String, Product>> getAll(final List<String> barcodes) async {
+    final LazyBox<Product> box = _getBox();
+    final Map<String, Product> result = <String, Product>{};
+    for (final String barcode in barcodes) {
+      final Product? product = await box.get(barcode);
+      if (product != null) {
+        result[barcode] = product;
+      }
+    }
+    return result;
+  }
+
+  Future<void> put(final Product product) async => putAll(<Product>[product]);
+
+  Future<void> putAll(final Iterable<Product> products) async {
+    final Map<String, Product> upserts = <String, Product>{};
+    for (final Product product in products) {
+      upserts[product.barcode!] = product;
+    }
+    await _getBox().putAll(upserts);
+  }
+
+  Future<List<String>> getAllKeys() async {
+    final LazyBox<Product> box = _getBox();
+    final List<String> result = <String>[];
+    for (final dynamic key in box.keys) {
+      result.add(key.toString());
+    }
+    return result;
+  }
+
+  // Just for the migration
+  Future<void> deleteAll(final List<String> barcodes) async {
+    final LazyBox<Product> box = _getBox();
+    await box.deleteAll(barcodes);
+  }
+}

--- a/packages/smooth_app/lib/database/dao_product.dart
+++ b/packages/smooth_app/lib/database/dao_product.dart
@@ -1,59 +1,133 @@
 import 'dart:async';
 import 'dart:convert';
-import 'package:hive/hive.dart';
 import 'package:openfoodfacts/model/Product.dart';
-import 'package:smooth_app/database/abstract_dao.dart';
+import 'package:smooth_app/database/abstract_sql_dao.dart';
+import 'package:smooth_app/database/bulk_deletable.dart';
+import 'package:smooth_app/database/bulk_manager.dart';
 import 'package:smooth_app/database/local_database.dart';
+import 'package:sqflite/sqflite.dart';
 
-/// Hive type adapter for [Product]
-class _ProductAdapter extends TypeAdapter<Product> {
-  @override
-  final int typeId = 1;
-
-  @override
-  Product read(BinaryReader reader) =>
-      Product.fromJson(jsonDecode(reader.readString()) as Map<String, dynamic>);
-
-  @override
-  void write(BinaryWriter writer, Product obj) =>
-      writer.writeString(jsonEncode(obj.toJson()));
-}
-
-/// Where we store the products as "barcode => product".
-class DaoProduct extends AbstractDao {
+class DaoProduct extends AbstractSqlDao implements BulkDeletable {
   DaoProduct(final LocalDatabase localDatabase) : super(localDatabase);
 
-  static const String _hiveBoxName = 'products';
+  static const String TABLE_PRODUCT = 'product';
+  static const String TABLE_PRODUCT_COLUMN_BARCODE = 'barcode';
+  static const String _TABLE_PRODUCT_COLUMN_JSON = 'encoded_json';
 
-  @override
-  Future<void> init() async => Hive.openLazyBox<Product>(_hiveBoxName);
+  static FutureOr<void> onUpgrade(
+    final Database db,
+    final int oldVersion,
+    final int newVersion,
+  ) async {
+    if (oldVersion < 1) {
+      await db.execute('create table $TABLE_PRODUCT('
+          // cf. https://www.sqlite.org/lang_conflict.html
+          '$TABLE_PRODUCT_COLUMN_BARCODE TEXT PRIMARY KEY on conflict replace'
+          ',$_TABLE_PRODUCT_COLUMN_JSON TEXT NOT NULL'
+          ')');
+    }
+  }
 
-  @override
-  void registerAdapter() => Hive.registerAdapter(_ProductAdapter());
+  Future<Product?> get(final String barcode) async {
+    final Map<String, Product> map = await getAll(<String>[barcode]);
+    return map[barcode];
+  }
 
-  LazyBox<Product> _getBox() => Hive.lazyBox<Product>(_hiveBoxName);
-
-  Future<Product?> get(final String barcode) async => _getBox().get(barcode);
-
-  Future<Map<String, Product>> getAll(final Iterable<String> barcodes) async {
-    final LazyBox<Product> box = _getBox();
+  // TODO(monsieurtanuki): use the max variable threshold BulkManager.SQLITE_MAX_VARIABLE_NUMBER
+  Future<Map<String, Product>> getAll(final List<String> barcodes) async {
     final Map<String, Product> result = <String, Product>{};
-    for (final String barcode in barcodes) {
-      final Product? product = await box.get(barcode);
-      if (product != null) {
-        result[barcode] = product;
-      }
+    if (barcodes.isEmpty) {
+      return result;
+    }
+    final List<Map<String, dynamic>> queryResults =
+        await localDatabase.database.query(
+      TABLE_PRODUCT,
+      columns: <String>[
+        TABLE_PRODUCT_COLUMN_BARCODE,
+        _TABLE_PRODUCT_COLUMN_JSON,
+      ],
+      where:
+          '$TABLE_PRODUCT_COLUMN_BARCODE in(? ${',?' * (barcodes.length - 1)})',
+      whereArgs: barcodes,
+    );
+    if (queryResults.isEmpty) {
+      return result;
+    }
+    for (final Map<String, dynamic> row in queryResults) {
+      result[row[TABLE_PRODUCT_COLUMN_BARCODE] as String] =
+          _getProductFromQueryResult(row);
     }
     return result;
   }
 
   Future<void> put(final Product product) async => putAll(<Product>[product]);
 
-  Future<void> putAll(final Iterable<Product> products) async {
-    final Map<String, Product> upserts = <String, Product>{};
-    for (final Product product in products) {
-      upserts[product.barcode!] = product;
+  /// Replaces products in database
+  Future<void> putAll(final Iterable<Product> products) async =>
+      localDatabase.database.transaction(
+        (final Transaction transaction) async =>
+            _bulkReplaceLoop(transaction, products),
+      );
+
+  Future<List<String>> getAllKeys() async {
+    final List<String> result = <String>[];
+    final List<Map<String, dynamic>> queryResults =
+        await localDatabase.database.query(
+      TABLE_PRODUCT,
+      columns: <String>[
+        TABLE_PRODUCT_COLUMN_BARCODE,
+      ],
+    );
+    if (queryResults.isEmpty) {
+      return result;
     }
-    await _getBox().putAll(upserts);
+    for (final Map<String, dynamic> row in queryResults) {
+      result.add(row[TABLE_PRODUCT_COLUMN_BARCODE] as String);
+    }
+    return result;
+  }
+
+  /// Replaces product data in bulk mode.
+  ///
+  /// Unfortunately it's a replace (=delete if already exists, then insert),
+  /// not an upsert (=insert if possible, or update if already exists).
+  /// "upsert" is not really supported for the moment on sqflite.
+  /// The direct impact is we shouldn't use foreign key constraints on
+  /// `product.barcode`.
+  Future<void> _bulkReplaceLoop(
+    final DatabaseExecutor databaseExecutor,
+    final Iterable<Product> products,
+  ) async {
+    final BulkManager bulkManager = BulkManager();
+    final List<dynamic> insertParameters = <dynamic>[];
+    for (final Product product in products) {
+      insertParameters.add(product.barcode);
+      insertParameters.add(json.encode(product.toJson()));
+    }
+    await bulkManager.insert(
+      bulkInsertable: this,
+      parameters: insertParameters,
+      databaseExecutor: databaseExecutor,
+    );
+  }
+
+  @override
+  List<String> getInsertColumns() => <String>[
+        TABLE_PRODUCT_COLUMN_BARCODE,
+        _TABLE_PRODUCT_COLUMN_JSON,
+      ];
+
+  @override
+  String getDeleteWhere(final List<dynamic> deleteWhereArgs) =>
+      '$TABLE_PRODUCT_COLUMN_BARCODE in (?${',?' * (deleteWhereArgs.length - 1)})';
+
+  @override
+  String getTableName() => TABLE_PRODUCT;
+
+  Product _getProductFromQueryResult(final Map<String, dynamic> row) {
+    final String encodedJson = row[_TABLE_PRODUCT_COLUMN_JSON] as String;
+    final Map<String, dynamic> decodedJson =
+        json.decode(encodedJson) as Map<String, dynamic>;
+    return Product.fromJson(decodedJson);
   }
 }

--- a/packages/smooth_app/lib/database/local_database.dart
+++ b/packages/smooth_app/lib/database/local_database.dart
@@ -1,17 +1,27 @@
 import 'dart:async';
+import 'dart:io';
 
-import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 import 'package:hive_flutter/hive_flutter.dart';
+import 'package:openfoodfacts/model/Product.dart';
+import 'package:path/path.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:smooth_app/database/abstract_dao.dart';
+import 'package:smooth_app/database/dao_hive_product.dart';
 import 'package:smooth_app/database/dao_int.dart';
 import 'package:smooth_app/database/dao_product.dart';
 import 'package:smooth_app/database/dao_product_list.dart';
 import 'package:smooth_app/database/dao_string.dart';
 import 'package:smooth_app/database/dao_string_list.dart';
 import 'package:smooth_app/database/dao_string_list_map.dart';
+import 'package:sqflite/sqflite.dart';
 
 class LocalDatabase extends ChangeNotifier {
-  LocalDatabase._();
+  LocalDatabase._(final Database database) : _database = database;
+
+  final Database _database;
+
+  Database get database => _database;
 
   /// Notify listeners
   /// Comments added only in order to avoid a "warning"
@@ -21,10 +31,29 @@ class LocalDatabase extends ChangeNotifier {
   void notifyListeners() => super.notifyListeners();
 
   static Future<LocalDatabase> getLocalDatabase() async {
+    // sql from there
+    final String databasesRootPath;
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
+      // as suggested in https://pub.dev/documentation/sqflite/latest/sqflite/getDatabasesPath.html
+      final Directory directory = await getLibraryDirectory();
+      databasesRootPath = directory.path;
+    } else {
+      databasesRootPath = await getDatabasesPath();
+    }
+    final String databasePath = join(databasesRootPath, 'smoothie.db');
+    final Database database = await openDatabase(
+      databasePath,
+      version: 1,
+      singleInstance: true,
+      onUpgrade: _onUpgrade,
+    );
+
+    final LocalDatabase localDatabase = LocalDatabase._(database);
+
+    // only hive from there
     await Hive.initFlutter();
-    final LocalDatabase localDatabase = LocalDatabase._();
     final List<AbstractDao> daos = <AbstractDao>[
-      DaoProduct(localDatabase),
+      DaoHiveProduct(localDatabase),
       DaoProductList(localDatabase),
       DaoStringList(localDatabase),
       DaoString(localDatabase),
@@ -37,8 +66,57 @@ class LocalDatabase extends ChangeNotifier {
     for (final AbstractDao dao in daos) {
       await dao.init();
     }
+
+    // Migration here
+    await _migrate(localDatabase);
+
     return localDatabase;
   }
 
+  static Future<void> _migrate(final LocalDatabase localDatabase) async {
+    final DaoHiveProduct daoHiveProduct = DaoHiveProduct(localDatabase);
+    final List<String> barcodesFrom = await daoHiveProduct.getAllKeys();
+    if (barcodesFrom.isEmpty) {
+      // nothing to migrate, or already migrated and cleaned.
+      return;
+    }
+
+    final DaoProduct daoProduct = DaoProduct(localDatabase);
+    final List<String> barcodesAlreadyThere = await daoProduct.getAllKeys();
+
+    final List<String> barcodesToBeCopied = List<String>.from(barcodesFrom);
+    barcodesToBeCopied.removeWhere(
+        (final String barcode) => barcodesAlreadyThere.contains(barcode));
+
+    if (barcodesToBeCopied.isNotEmpty) {
+      final Map<String, Product> copiedProducts =
+          await daoHiveProduct.getAll(barcodesToBeCopied);
+      await daoProduct.putAll(copiedProducts.values);
+      final List<String> barcodesFinallyThere = await daoProduct.getAllKeys();
+      if (barcodesFinallyThere.length !=
+          barcodesAlreadyThere.length + barcodesToBeCopied.length) {
+        // unexpected
+        return;
+      }
+    }
+
+    // cleaning the old product table
+    await daoHiveProduct.deleteAll(barcodesFrom);
+    final List<String> barcodesNoMore = await daoProduct.getAllKeys();
+    if (barcodesNoMore.isNotEmpty) {
+      // unexpected
+    }
+  }
+
   static int nowInMillis() => DateTime.now().millisecondsSinceEpoch;
+
+  /// we don't use onCreate and onUpgrade, we use only onUpgrade instead.
+  /// checked: from scratch, onUpgrade is called with oldVersion = 0.
+  static FutureOr<void> _onUpgrade(
+    final Database db,
+    final int oldVersion,
+    final int newVersion,
+  ) async {
+    await DaoProduct.onUpgrade(db, oldVersion, newVersion);
+  }
 }

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -1088,13 +1088,11 @@ packages:
     source: hosted
     version: "1.8.2"
   sqflite:
-    dependency: transitive
+    dependency: "direct main"
     description:
-      path: sqflite
-      ref: HEAD
-      resolved-ref: "81b305f07755647c90c4c8a1841f030c0dea39b3"
-      url: "https://github.com/g123k/sqflite_android_only.git"
-    source: git
+      name: sqflite
+      url: "https://pub.dartlang.org"
+    source: hosted
     version: "2.0.2+1"
   sqflite_common:
     dependency: transitive

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
   provider: ^6.0.3
   rubber: ^1.0.1
   sentry_flutter: ^6.5.1 # careful with upgrading cf: https://github.com/openfoodfacts/smooth-app/issues/1300
+  sqflite: ^2.0.2+1
   url_launcher: ^6.1.3
   visibility_detector: ^0.3.3
 


### PR DESCRIPTION
New files:
* `abstract_sql_dao.dart`: DAO abstraction for SQL.
* `bulk_deletable.dart`: Interface for bulk database deletes.
* `bulk_insertable.dart`: Interface for bulk database inserts.
* `bulk_manager.dart`: Manager for bulk database inserts and deletes.
* `dao_hive_product.dart`: moved here the code from the previous `hive` version of `DaoProduct`, renamed here `DaoHiveProduct`

Impacted files:
* `dao_product.dart`: `sqflite` version of `DaoProduct`, that is from now on the only one to be used
* `local_database.dart`: added `sqflite` and its one table so far, named `DaoProduct` in order to minimize the changes everywhere else (the old `DaoProduct` being renamed `DaoHiveProduct`); migrated the product data from `hive` to `sqflite`
* `Podfile.lock`: wtf
* `pubspec.lock`: wtf
* `data_importer/pubspec.yaml`: updated the `sqflite` dependency to the same as in `smooth_app`
* `smooth_app/pubspec.yaml`: added a dependency to `sqflite`

### What
- `DaoProduct` now exclusively uses our new `sqflite` database.
- All the product data has been migrated - you should probably restart your app.
- There's no impact in the rest of the code as we use the same class name and the same file name.
- Inspiration was found in the code version just before the previous `sqflite` to `hive` migration, in https://github.com/openfoodfacts/smooth-app/tree/c60fb7fa8888dff276a0ed312d5a56e922b9dd96/packages/smooth_app)

### Fixes bug(s)
- Closes: #2280