### PR TITLE
fix: #2299 - crash when refreshing just downloaded query product list

### DIFF
--- a/packages/smooth_app/ios/Podfile.lock
+++ b/packages/smooth_app/ios/Podfile.lock
@@ -111,6 +111,8 @@ PODS:
     - Flutter
     - FlutterMacOS
     - Sentry (~> 7.11.0)
+  - share_plus (0.0.1):
+    - Flutter
   - shared_preferences_ios (0.0.1):
     - Flutter
   - sqflite (0.0.2):
@@ -139,6 +141,7 @@ DEPENDENCIES:
   - path_provider_ios (from `.symlinks/plugins/path_provider_ios/ios`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - sentry_flutter (from `.symlinks/plugins/sentry_flutter/ios`)
+  - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - shared_preferences_ios (from `.symlinks/plugins/shared_preferences_ios/ios`)
   - sqflite (from `.symlinks/plugins/sqflite/ios`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
@@ -202,6 +205,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/permission_handler_apple/ios"
   sentry_flutter:
     :path: ".symlinks/plugins/sentry_flutter/ios"
+  share_plus:
+    :path: ".symlinks/plugins/share_plus/ios"
   shared_preferences_ios:
     :path: ".symlinks/plugins/shared_preferences_ios/ios"
   sqflite:
@@ -246,6 +251,7 @@ SPEC CHECKSUMS:
   RealmSwift: a0c30c1efc49e928a0a6f8fb141bb2629616d79b
   Sentry: 0c5cd63d714187b4a39c331c1f0eb04ba7868341
   sentry_flutter: efb3df2c203cd03aad255892a8d628a458656d14
+  share_plus: 056a1e8ac890df3e33cb503afffaf1e9b4fbae68
   shared_preferences_ios: 548a61f8053b9b8a49ac19c1ffbc8b92c50d68ad
   sqflite: 6d358c025f5b867b29ed92fc697fd34924e11904
   TOCropViewController: edfd4f25713d56905ad1e0b9f5be3fbe0f59c863

--- a/packages/smooth_app/lib/pages/product/common/product_query_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_query_page.dart
@@ -425,9 +425,9 @@ class _ProductQueryPageState extends State<ProductQueryPage>
     final ProductListSupplier? refreshSupplier =
         widget.productListSupplier.getRefreshSupplier();
     setState(
-      () {
-        _model = ProductQueryModel(refreshSupplier!);
-      },
+      // How do we refresh a supplier that has no refresher? With itself.
+      () => _model =
+          ProductQueryModel(refreshSupplier ?? widget.productListSupplier),
     );
     return;
   }


### PR DESCRIPTION
Impacted files:
* `Podfile.lock`: wtf
* `product_query_page.dart`

### What
- The reason behind the crash that is described in #2299 is correct.
- How do we refresh a database product query? With its refresher: a server product query.
- How do we refresh a server product query? With itself (it has no refresher). That's where the crash was: we assumed that the refresher was not null.

### Fixes bug(s)
Fixes: #2299
Fixes SMOOTHIE-VJ