### PR TITLE
fix: #2305 - cleaner layout for onboarding (preferences + kp)

### DIFF
--- a/packages/smooth_app/lib/pages/onboarding/knowledge_panel_page_template.dart
+++ b/packages/smooth_app/lib/pages/onboarding/knowledge_panel_page_template.dart
@@ -85,41 +85,40 @@ class _KnowledgePanelPageTemplateState
               child: Stack(
                 fit: StackFit.expand,
                 children: <Widget>[
-                  ListView(
-                    // bottom padding is very large because [NextButton] is stacked on top of the page.
-                    padding: const EdgeInsets.only(
-                      top: LARGE_SPACE,
-                      right: LARGE_SPACE,
-                      left: LARGE_SPACE,
-                      bottom: VERY_LARGE_SPACE * 5,
-                    ),
-                    shrinkWrap: true,
+                  Column(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    crossAxisAlignment: CrossAxisAlignment.start,
                     children: <Widget>[
-                      SvgPicture.asset(
-                        widget.svgAsset,
-                        height: MediaQuery.of(context).size.height * .25,
-                      ),
-                      Padding(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: LARGE_SPACE,
+                      Flexible(
+                        flex: 1,
+                        child: ListView(
+                          children: <Widget>[
+                            SvgPicture.asset(
+                              widget.svgAsset,
+                              height: MediaQuery.of(context).size.height * .25,
+                            ),
+                            Padding(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: LARGE_SPACE,
+                              ),
+                              child: Text(
+                                widget.headerTitle,
+                                style:
+                                    Theme.of(context).textTheme.displayMedium,
+                              ),
+                            ),
+                            KnowledgePanelProductCards(
+                                <Widget>[knowledgePanelWidget]),
+                          ],
                         ),
-                        child: Text(
-                          widget.headerTitle,
-                          style: Theme.of(context).textTheme.displayMedium,
-                        ),
                       ),
-                      KnowledgePanelProductCards(
-                          <Widget>[knowledgePanelWidget]),
+                      NextButton(
+                        widget.page,
+                        backgroundColor: widget.backgroundColor,
+                      ),
                     ],
                   ),
                   ..._buildHintPopup(),
-                  Positioned(
-                    bottom: 0,
-                    child: NextButton(
-                      widget.page,
-                      backgroundColor: widget.backgroundColor,
-                    ),
-                  ),
                 ],
               ),
             ),

--- a/packages/smooth_app/lib/pages/onboarding/preferences_page.dart
+++ b/packages/smooth_app/lib/pages/onboarding/preferences_page.dart
@@ -126,21 +126,22 @@ class _HelperState extends State<_Helper> {
     return Container(
       color: widget.backgroundColor,
       child: SafeArea(
-        child: Stack(
-          fit: StackFit.expand,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
-            ListView.builder(
-              padding: const EdgeInsets.only(top: LARGE_SPACE),
-              itemCount: pageData.length,
-              itemBuilder: (BuildContext context, int position) =>
-                  pageData[position],
-            ),
-            Positioned(
-              bottom: 0,
-              child: NextButton(
-                OnboardingPage.PREFERENCES_PAGE,
-                backgroundColor: widget.backgroundColor,
+            Flexible(
+              flex: 1,
+              child: ListView.builder(
+                padding: const EdgeInsets.only(top: LARGE_SPACE),
+                itemCount: pageData.length,
+                itemBuilder: (BuildContext context, int position) =>
+                    pageData[position],
               ),
+            ),
+            NextButton(
+              OnboardingPage.PREFERENCES_PAGE,
+              backgroundColor: widget.backgroundColor,
             ),
           ],
         ),


### PR DESCRIPTION
Impacted files:
* `knowledge_panel_page_template.dart`: cleaner layout with spaceBetween and flexible
* `preferences_page.dart`: cleaner layout with spaceBetween and flexible

### What
- The new layouts let `flutter` deal with alignment and sizes.

### Screenshot
![Capture d’écran 2022-06-17 à 13 27 48](https://user-images.githubusercontent.com/11576431/174289803-7060b11b-44b9-4580-9aae-b716def2a33a.png)


### Fixes bug(s)
- Fixes: #2305