### PR TITLE
fix: Remove the "rubber" library (unused)

### DIFF
--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -45,7 +45,6 @@ dependencies:
   photo_view: ^0.14.0
   uuid: ^3.0.6
   provider: ^6.0.3
-  rubber: ^1.0.1
   sentry_flutter: ^6.5.1 # careful with upgrading cf: https://github.com/openfoodfacts/smooth-app/issues/1300
   sqflite: ^2.0.2+1
   url_launcher: ^6.1.3


### PR DESCRIPTION
I don't know why, but the rubber library is never used in the app.
Removing it