### PR TITLE
fix: #2239 - refresh product preferences and query language

### DIFF
--- a/packages/smooth_app/lib/data_models/product_preferences.dart
+++ b/packages/smooth_app/lib/data_models/product_preferences.dart
@@ -63,6 +63,16 @@ class ProductPreferences extends ProductPreferencesManager with ChangeNotifier {
 
   /// Refreshes the references with network data.
   Future<void> refresh(final String languageCode) async {
+    if (daoString != null) {
+      final String? latestLanguage =
+          await daoString!.get(_DAO_STRING_KEY_LANGUAGE);
+      if (latestLanguage == null || latestLanguage != languageCode) {
+        // we restart from scratch
+        // typical use-case: language change
+        _isNetwork = false;
+        _isDownloading = false;
+      }
+    }
     if (_isNetwork) {
       return;
     }

--- a/packages/smooth_app/lib/main.dart
+++ b/packages/smooth_app/lib/main.dart
@@ -240,6 +240,12 @@ class SmoothAppGetLanguage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // TODO(monsieurtanuki): refactor removing the `SmoothAppGetLanguage` layer?
+    // will refresh each time the language changes
+    context.select(
+      (final UserPreferences userPreferences) =>
+          userPreferences.appLanguageCode,
+    );
     final String languageCode = Localizations.localeOf(context).languageCode;
     ProductQuery.setLanguage(languageCode);
     context.read<ProductPreferences>().refresh(languageCode);

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_dev_mode.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_dev_mode.dart
@@ -312,10 +312,8 @@ class UserPreferencesDevMode extends AbstractUserPreferences {
                 Localizations.localeOf(context).toString(),
             elevation: 16,
             isExpanded: true,
-            onChanged: (String? languageCode) async {
-              await userPreferences.setAppLanguageCode(languageCode);
-              setState(() {});
-            },
+            onChanged: (String? languageCode) async =>
+                userPreferences.setAppLanguageCode(languageCode),
             items: _supportedLanguageCodes.map((Locale locale) {
               final String localeString = locale.toString();
               return DropdownMenuItem<String>(
@@ -328,10 +326,7 @@ class UserPreferencesDevMode extends AbstractUserPreferences {
         ListTile(
           // Do not translate
           title: const Text('Reset App Language'),
-          onTap: () async {
-            await userPreferences.setAppLanguageCode(null);
-            setState(() {});
-          },
+          onTap: () async => userPreferences.setAppLanguageCode(null),
         ),
       ];
 


### PR DESCRIPTION
Impacted files:
* `main.dart`: refresh additional language parameters each time the language changes
* `product_preferences.dart`: making the refresh possible when new language detected
* `user_preferences_dev_mode.dart`: refactoring

### What
- When we changed the app language, the display was localized into the new language but neither the query language nor the preferences were taken into consideration
- I added an extra explicit refresh when the language changes, and made it possible for the preferences to be refreshed

### Fixes bug(s)
- Fixes: #2239