### PR TITLE
fix: Fix for issue 2257

### DIFF
--- a/packages/smooth_app/lib/pages/scan/camera_controller.dart
+++ b/packages/smooth_app/lib/pages/scan/camera_controller.dart
@@ -262,6 +262,7 @@ class SmoothCameraController extends CameraController {
       return super.buildPreview();
     } catch (err) {
       if (err is CameraException && err.code == 'Disposed CameraController') {
+        _updateState(_CameraState.disposed);
         // Just ignore the issue, a new Controller will be created
         // Issue reproducible on iOS
       }

--- a/packages/smooth_app/lib/pages/scan/camera_controller.dart
+++ b/packages/smooth_app/lib/pages/scan/camera_controller.dart
@@ -256,6 +256,20 @@ class SmoothCameraController extends CameraController {
     }
   }
 
+  @override
+  Widget buildPreview() {
+    try {
+      return super.buildPreview();
+    } catch (err) {
+      if (err is CameraException && err.code == 'Disposed CameraController') {
+        // Just ignore the issue, a new Controller will be created
+        // Issue reproducible on iOS
+      }
+
+      return const SizedBox.shrink();
+    }
+  }
+
   bool get isPaused => _state == _CameraState.paused;
 
   bool get isInitialized => !<_CameraState>[


### PR DESCRIPTION
Fix for issue #2257

Basically, if the preview (= Widget) is asked on a _disposed_ controller, the app will show a black screen.
In that case, we just have to wait, as the page will automatically asks for a new one.