### PR TITLE
feat: #2315 - added smoothie fields to user queries and localized

### DIFF
--- a/packages/smooth_app/lib/database/paged_user_product_query.dart
+++ b/packages/smooth_app/lib/database/paged_user_product_query.dart
@@ -33,12 +33,17 @@ abstract class PagedUserProductQuery extends PagedProductQuery {
     final int pageNumber,
     final QueryType? queryType,
   ) async {
+    final List<String> fields = convertFieldsToStrings(
+      ProductQuery.fields,
+      <OpenFoodFactsLanguage>[ProductQuery.getLanguage()!],
+    );
     final Uri uri = UriHelper.getUri(
       path: path,
       queryType: queryType,
       queryParameters: <String, String>{
         'page_size': '$pageSize',
         'page': '$pageNumber',
+        'fields': fields.join(','),
       },
     );
     final Response response = await HttpHelper().doGetRequest(

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1226,6 +1226,22 @@
             }
         }
     },
+    "user_search_contributor_title": "Products I added",
+    "@user_search_contributor_title": {
+        "description": "User search (contributor): list tile title"
+    },
+    "user_search_informer_title": "Products I edited",
+    "@user_search_informer_title": {
+        "description": "User search (informer): list tile title"
+    },
+    "user_search_photographer_title": "Products I photographed",
+    "@user_search_photographer_title": {
+        "description": "User search (photographer): list tile title"
+    },
+    "user_search_to_be_completed_title": "Products that need to be completed",
+    "@user_search_to_be_completed_title": {
+        "description": "User search (to be completed): list tile title"
+    },
     "edit_product_action_retake_picture": "Retake photo",
     "@edit_product_action_retake_picture": {
         "description": "Product edition - FAB actions - retake a picture"

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -1222,6 +1222,22 @@
             }
         }
     },
+    "user_search_contributor_title": "Produits que j'ai ajoutés",
+    "@user_search_contributor_title": {
+        "description": "User search (contributor): list tile title"
+    },
+    "user_search_informer_title": "Produits que j'ai modifiés",
+    "@user_search_informer_title": {
+        "description": "User search (informer): list tile title"
+    },
+    "user_search_photographer_title": "Produits que j'ai photographiés",
+    "@user_search_photographer_title": {
+        "description": "User search (photographer): list tile title"
+    },
+    "user_search_to_be_completed_title": "Produits à compléter",
+    "@user_search_to_be_completed_title": {
+        "description": "User search (to be completed): list tile title"
+    },
     "edit_product_action_retake_picture": "Reprendre une photo",
     "@edit_product_action_retake_picture": {
         "description": "Product edition - FAB actions - retake a picture"

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_account.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_account.dart
@@ -8,6 +8,7 @@ import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/database/contributor_product_query.dart';
 import 'package:smooth_app/database/informer_product_query.dart';
 import 'package:smooth_app/database/local_database.dart';
+import 'package:smooth_app/database/paged_user_product_query.dart';
 import 'package:smooth_app/database/photographer_product_query.dart';
 import 'package:smooth_app/database/to_be_completed_product_query.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
@@ -237,56 +238,40 @@ class _UserPreferencesPageState extends State<UserPreferencesSection> {
       final String userId = OpenFoodAPIConfiguration.globalUser!.userId;
 
       result = <Widget>[
-        ListTile(
-          onTap: () async => ProductQueryPageHelper().openBestChoice(
-            heroTag: 'contributor',
-            name: userId,
-            localDatabase: localDatabase,
-            productQuery: ContributorProductQuery(userId),
-            context: context,
-          ),
-          title:
-              const Text('Products I added'), // TODO(monsieurtanuki): translate
-          leading: const Icon(Icons.add_circle_outline),
+        _buildUserProductQueryTile(
+          productQuery: ContributorProductQuery(userId),
+          title: appLocalizations.user_search_contributor_title,
+          iconData: Icons.add_circle_outline,
+          heroTag: 'contributor',
+          context: context,
+          localDatabase: localDatabase,
         ),
         const UserPreferencesListItemDivider(),
-        ListTile(
-          onTap: () async => ProductQueryPageHelper().openBestChoice(
-            heroTag: 'informer',
-            name: userId,
-            localDatabase: localDatabase,
-            productQuery: InformerProductQuery(userId),
-            context: context,
-          ),
-          title: const Text(
-              'Products I informed?'), // TODO(monsieurtanuki): translate
-          leading: const Icon(Icons.edit),
+        _buildUserProductQueryTile(
+          productQuery: InformerProductQuery(userId),
+          title: appLocalizations.user_search_informer_title,
+          iconData: Icons.edit,
+          heroTag: 'informer',
+          context: context,
+          localDatabase: localDatabase,
         ),
         const UserPreferencesListItemDivider(),
-        ListTile(
-          onTap: () async => ProductQueryPageHelper().openBestChoice(
-            heroTag: 'photographer',
-            name: userId,
-            localDatabase: localDatabase,
-            productQuery: PhotographerProductQuery(userId),
-            context: context,
-          ),
-          title: const Text(
-              'Products I photographed'), // TODO(monsieurtanuki): translate
-          leading: const Icon(Icons.add_a_photo),
+        _buildUserProductQueryTile(
+          productQuery: PhotographerProductQuery(userId),
+          title: appLocalizations.user_search_photographer_title,
+          iconData: Icons.add_a_photo,
+          heroTag: 'photographer',
+          context: context,
+          localDatabase: localDatabase,
         ),
         const UserPreferencesListItemDivider(),
-        ListTile(
-          onTap: () async => ProductQueryPageHelper().openBestChoice(
-            heroTag: 'to_be_completed',
-            name: userId,
-            localDatabase: localDatabase,
-            productQuery: ToBeCompletedProductQuery(userId),
-            context: context,
-          ),
-          title: const Text(
-              'Products that need to be completed'), // TODO(monsieurtanuki): translate
-          leading: const Icon(Icons.more_horiz),
+        _buildUserProductQueryTile(
+          productQuery: ToBeCompletedProductQuery(userId),
+          title: appLocalizations.user_search_to_be_completed_title,
+          iconData: Icons.more_horiz,
+          heroTag: 'to_be_completed',
+          context: context,
+          localDatabase: localDatabase,
         ),
         const UserPreferencesListItemDivider(),
         ListTile(
@@ -362,4 +347,24 @@ class _UserPreferencesPageState extends State<UserPreferencesSection> {
 
     return Column(children: result);
   }
+
+  Widget _buildUserProductQueryTile({
+    required final PagedUserProductQuery productQuery,
+    required final String title,
+    required final IconData iconData,
+    required final String heroTag,
+    required final BuildContext context,
+    required final LocalDatabase localDatabase,
+  }) =>
+      ListTile(
+        onTap: () async => ProductQueryPageHelper().openBestChoice(
+          heroTag: heroTag,
+          name: title,
+          localDatabase: localDatabase,
+          productQuery: productQuery,
+          context: context,
+        ),
+        title: Text(title),
+        leading: Icon(iconData),
+      );
 }

--- a/packages/smooth_app/lib/pages/product/common/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_page.dart
@@ -147,11 +147,7 @@ class _ProductListPageState extends State<ProductListPage>
                 )
               ],
         title: Text(
-          ProductQueryPageHelper.getProductListLabel(
-            productList,
-            context,
-            verbose: false,
-          ),
+          ProductQueryPageHelper.getProductListLabel(productList, context),
           overflow: TextOverflow.fade,
           //style: TextStyle(color: Colors.black),
         ),

--- a/packages/smooth_app/lib/pages/product/common/product_query_page_helper.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_query_page_helper.dart
@@ -71,34 +71,23 @@ class ProductQueryPageHelper {
   }
 
   static String getProductListLabel(
-      final ProductList productList, final BuildContext context,
-      {final bool verbose = true}) {
+    final ProductList productList,
+    final BuildContext context,
+  ) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     switch (productList.listType) {
       case ProductListType.HTTP_SEARCH_KEYWORDS:
-        return '${productList.parameters}'
-            '${verbose ? ' ${appLocalizations.category_search}' : ''}';
       case ProductListType.HTTP_SEARCH_CATEGORY:
-        return '${productList.parameters}'
-            '${verbose ? ' ${appLocalizations.category_search}' : ''}';
       case ProductListType.HTTP_USER_CONTRIBUTOR:
-        return '${productList.parameters}'
-            '${verbose ? ' as a contributor' : ''}'; // TODO(monsieurtanuki): translate
       case ProductListType.HTTP_USER_INFORMER:
-        return '${productList.parameters}'
-            '${verbose ? ' as an informer' : ''}'; // TODO(monsieurtanuki): translate
       case ProductListType.HTTP_USER_PHOTOGRAPHER:
-        return '${productList.parameters}'
-            '${verbose ? ' as a photographer' : ''}'; // TODO(monsieurtanuki): translate
       case ProductListType.HTTP_USER_TO_BE_COMPLETED:
-        return '${productList.parameters}'
-            '${verbose ? ' to be completed' : ''}'; // TODO(monsieurtanuki): translate
+      case ProductListType.USER:
+        return productList.parameters;
       case ProductListType.SCAN_SESSION:
         return appLocalizations.scan;
       case ProductListType.HISTORY:
         return appLocalizations.recently_seen_products;
-      case ProductListType.USER:
-        return productList.parameters;
     }
   }
 }


### PR DESCRIPTION
Impacted files:
* `app_en.arb`: added a title for each of the 4 user queries
* `app_fr.arb`: added a title for each of the 4 user queries
* `paged_user_product_query.dart`: added smoothie fields to user queries
* `product_list_page.dart`: refactored
* `product_query_page_helper.dart`: refactored by removing useless code
* `user_preferences_account.dart`: refactored and translated

### What
- Added smoothie fields to user queries, so that we have all the product data (like scores)
- Localized

### Screenshot
![Capture d’écran 2022-06-20 à 11 10 45](https://user-images.githubusercontent.com/11576431/174567747-743fc0a3-387e-4e21-8e57-191ff929d15f.png)

![Capture d’écran 2022-06-20 à 11 11 06](https://user-images.githubusercontent.com/11576431/174567827-d5e6f9dd-3638-43fb-8565-a8dab67d635c.png)

![Capture d’écran 2022-06-20 à 11 11 28](https://user-images.githubusercontent.com/11576431/174567925-693d8db7-ef95-4400-8ce7-fa4891d022ab.png)

### Fixes bug(s)
- Closes: #2315