### PR TITLE
fix: #1314 switch to scanner from empty list

### DIFF
--- a/packages/smooth_app/lib/pages/page_manager.dart
+++ b/packages/smooth_app/lib/pages/page_manager.dart
@@ -52,6 +52,17 @@ class PageManagerState extends State<PageManager> {
   }
 
   @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final InheritedDataManagerState inheritedDataManager =
+        InheritedDataManager.of(context);
+    if (inheritedDataManager.showSearchCard &&
+        _currentPage != BottomNavigationTab.Scan) {
+      _currentPage = BottomNavigationTab.Scan;
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     _tabs = <Widget>[

--- a/packages/smooth_app/lib/pages/page_manager.dart
+++ b/packages/smooth_app/lib/pages/page_manager.dart
@@ -59,6 +59,7 @@ class PageManagerState extends State<PageManager> {
     if (inheritedDataManager.showSearchCard &&
         _currentPage != BottomNavigationTab.Scan) {
       _currentPage = BottomNavigationTab.Scan;
+      _selectTab(_currentPage, 1);
     }
   }
 

--- a/packages/smooth_app/lib/pages/product/common/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_page.dart
@@ -20,6 +20,7 @@ import 'package:smooth_app/pages/personalized_ranking_page.dart';
 import 'package:smooth_app/pages/product/common/product_list_item_simple.dart';
 import 'package:smooth_app/pages/product/common/product_query_page_helper.dart';
 import 'package:smooth_app/pages/product_list_user_dialog_helper.dart';
+import 'package:smooth_app/pages/scan/inherited_data_manager.dart';
 
 class ProductListPage extends StatefulWidget {
   const ProductListPage(this.productList);
@@ -162,29 +163,34 @@ class _ProductListPageState extends State<ProductListPage>
         ),
       ),
       body: products.isEmpty
-          ? Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: <Widget>[
-                SvgPicture.asset(
-                  'assets/misc/empty-list.svg',
-                  height: MediaQuery.of(context).size.height * .4,
-                ),
-                Text(
-                  appLocalizations.product_list_empty_title,
-                  style: themeData.textTheme.headlineLarge
-                      ?.apply(color: colorScheme.onBackground),
-                ),
-                Padding(
-                  padding: const EdgeInsets.all(VERY_LARGE_SPACE),
-                  child: Text(
-                    appLocalizations.product_list_empty_message,
-                    textAlign: TextAlign.center,
-                    style: themeData.textTheme.bodyText2?.apply(
-                      color: colorScheme.onBackground,
-                    ),
+          ? GestureDetector(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: <Widget>[
+                  SvgPicture.asset(
+                    'assets/misc/empty-list.svg',
+                    height: MediaQuery.of(context).size.height * .4,
                   ),
-                )
-              ],
+                  Text(
+                    appLocalizations.product_list_empty_title,
+                    style: themeData.textTheme.headlineLarge
+                        ?.apply(color: colorScheme.onBackground),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.all(VERY_LARGE_SPACE),
+                    child: Text(
+                      appLocalizations.product_list_empty_message,
+                      textAlign: TextAlign.center,
+                      style: themeData.textTheme.bodyText2?.apply(
+                        color: colorScheme.onBackground,
+                      ),
+                    ),
+                  )
+                ],
+              ),
+              onTap: () {
+                InheritedDataManager.of(context).resetShowSearchCard(true);
+              },
             )
           : RefreshIndicator(
               //if it is in selectmode then refresh indicator is not shown


### PR DESCRIPTION
### What
<!-- description of the PR -->
Switch to barcode scanner when clicking on empty history screen or empty lists

### Screenshot
https://user-images.githubusercontent.com/87010739/174814794-a175112c-d159-4076-a8be-60ae3aaf0342.MP4
<!-- Insert a screenshot to provide visual record of your changes, if visible -->

### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes: #1314

