### PR TITLE
feat: #2169 - added emb codes and countries

### DIFF
--- a/packages/smooth_app/ios/Podfile.lock
+++ b/packages/smooth_app/ios/Podfile.lock
@@ -104,13 +104,13 @@ PODS:
   - Realm/Headers (10.25.2)
   - RealmSwift (10.25.2):
     - Realm (= 10.25.2)
-  - Sentry (7.11.0):
-    - Sentry/Core (= 7.11.0)
-  - Sentry/Core (7.11.0)
+  - Sentry (7.18.0):
+    - Sentry/Core (= 7.18.0)
+  - Sentry/Core (7.18.0)
   - sentry_flutter (0.0.1):
     - Flutter
     - FlutterMacOS
-    - Sentry (~> 7.11.0)
+    - Sentry (~> 7.18.0)
   - share_plus (0.0.1):
     - Flutter
   - shared_preferences_ios (0.0.1):
@@ -249,8 +249,8 @@ SPEC CHECKSUMS:
   Protobuf: 235750e4696ff59fb07d949a9dbbc92b3c0700fe
   Realm: 978303663d0509166498f423d112e5ee97d4c91b
   RealmSwift: a0c30c1efc49e928a0a6f8fb141bb2629616d79b
-  Sentry: 0c5cd63d714187b4a39c331c1f0eb04ba7868341
-  sentry_flutter: efb3df2c203cd03aad255892a8d628a458656d14
+  Sentry: aff6fb3785973436f0bf25748f6b3bcb3e825e09
+  sentry_flutter: b635e75d735415172e54bf3b72c39ce69882b4ca
   share_plus: 056a1e8ac890df3e33cb503afffaf1e9b4fbae68
   shared_preferences_ios: 548a61f8053b9b8a49ac19c1ffbc8b92c50d68ad
   sqflite: 6d358c025f5b867b29ed92fc697fd34924e11904

--- a/packages/smooth_app/lib/database/product_query.dart
+++ b/packages/smooth_app/lib/database/product_query.dart
@@ -118,6 +118,10 @@ abstract class ProductQuery {
         ProductField.ECOSCORE_GRADE,
         ProductField.ECOSCORE_SCORE,
         ProductField.KNOWLEDGE_PANELS,
+        ProductField.COUNTRIES,
+        ProductField.COUNTRIES_TAGS,
+        ProductField.COUNTRIES_TAGS_IN_LANGUAGES,
+        ProductField.EMB_CODES,
       ];
 
   Future<SearchResult> getSearchResult();

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -945,7 +945,7 @@
     },
     "edit_product_form_item_emb_codes_title": "Traceability codes",
     "@edit_product_form_item_emb_codes_title": {
-        "description": "Product edition - EMB Codes - Title"
+        "description": "Product edition - Traceability codes - Title"
     },
     "edit_product_form_item_emb_codes_hint": "EMB 53062",
     "@edit_product_form_item_emb_codes_hint": {

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -943,7 +943,7 @@
     "@edit_product_form_item_countries_explanations": {
         "description": "Product edition - Countries - explanations"
     },
-    "edit_product_form_item_emb_codes_title": "EMB code",
+    "edit_product_form_item_emb_codes_title": "Traceability codes",
     "@edit_product_form_item_emb_codes_title": {
         "description": "Product edition - EMB Codes - Title"
     },

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -931,6 +931,30 @@
     "@edit_product_form_item_stores_hint": {
         "description": "Product edition - Stores - input textfield hint"
     },
+    "edit_product_form_item_countries_title": "Countries where sold",
+    "@edit_product_form_item_countries_title": {
+        "description": "Product edition - Countries - Title"
+    },
+    "edit_product_form_item_countries_hint": "Spain",
+    "@edit_product_form_item_countries_hint": {
+        "description": "Product edition - Countries - input textfield hint"
+    },
+    "edit_product_form_item_countries_explanations": "Countries where the product is widely available (not including stores specialising in foreign products).",
+    "@edit_product_form_item_countries_explanations": {
+        "description": "Product edition - Countries - explanations"
+    },
+    "edit_product_form_item_emb_codes_title": "EMB code",
+    "@edit_product_form_item_emb_codes_title": {
+        "description": "Product edition - EMB Codes - Title"
+    },
+    "edit_product_form_item_emb_codes_hint": "EMB 53062",
+    "@edit_product_form_item_emb_codes_hint": {
+        "description": "Product edition - EMB Codes - input textfield hint"
+    },
+    "edit_product_form_item_emb_codes_explanations": "In Europe, code in an ellipse with the 2 country initials followed by a number and CE.\nExamples: EMB 53062, FR 62.448.034 CE, 84 R 20, 33 RECOLTANT 522",
+    "@edit_product_form_item_emb_codes_examples": {
+        "description": "Product edition - EMB Codes - explanations"
+    },
     "edit_product_form_item_categories_title": "Categories",
     "@edit_product_form_item_categories_title": {
         "description": "Product edition - Categories - Title"

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -949,7 +949,7 @@
     },
     "edit_product_form_item_emb_codes_hint": "EMB 53062",
     "@edit_product_form_item_emb_codes_hint": {
-        "description": "Product edition - EMB Codes - input textfield hint"
+        "description": "Product edition - Traceability Codes - input textfield hint"
     },
     "edit_product_form_item_emb_codes_explanations": "In Europe, code in an ellipse with the 2 country initials followed by a number and CE.\nExamples: EMB 53062, FR 62.448.034 CE, 84 R 20, 33 RECOLTANT 522",
     "@edit_product_form_item_emb_codes_examples": {

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -947,7 +947,7 @@
     "@edit_product_form_item_emb_codes_title": {
         "description": "Product edition - Traceability codes - Title"
     },
-    "edit_product_form_item_emb_codes_hint": "EMB 53062",
+    "edit_product_form_item_emb_codes_hint": "EMB 53062, FR 62.448.034 CE, 84 R 20, 33 RECOLTANT 522",
     "@edit_product_form_item_emb_codes_hint": {
         "description": "Product edition - Traceability Codes - input textfield hint"
     },

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -931,6 +931,30 @@
     "@edit_product_form_item_stores_hint": {
         "description": "Product edition - Stores - input textfield hint"
     },
+    "edit_product_form_item_countries_title": "Pays de vente",
+    "@edit_product_form_item_countries_title": {
+        "description": "Product edition - Countries - Title"
+    },
+    "edit_product_form_item_countries_hint": "Espagne",
+    "@edit_product_form_item_countries_hint": {
+        "description": "Product edition - Countries - input textfield hint"
+    },
+    "edit_product_form_item_countries_explanations": "Pays dans lesquels le produit est largement distribué (hors magasins spécialisés dans l'import).",
+    "@edit_product_form_item_countries_examples": {
+        "description": "Product edition - Countries - explanations"
+    },
+    "edit_product_form_item_emb_codes_title": "Code de traçabilité",
+    "@edit_product_form_item_emb_codes_title": {
+        "description": "Product edition - EMB Codes - Title"
+    },
+    "edit_product_form_item_emb_codes_hint": "EMB 53062",
+    "@edit_product_form_item_emb_codes_hint": {
+        "description": "Product edition - EMB Codes - input textfield hint"
+    },
+    "edit_product_form_item_emb_codes_explanations": "En Europe, le code est une ellipse contenant les deux initiales du pays suivies par un nombre et CE.\nExemples : EMB 53062, FR 62.448.034 CE, 84 R 20, 33 RECOLTANT 522",
+    "@edit_product_form_item_emb_codes_examples": {
+        "description": "Product edition - EMB Codes - explanations"
+    },
     "edit_product_form_item_categories_title": "Catégories",
     "@edit_product_form_item_categories_title": {
         "description": "Product edition - Categories - Title"

--- a/packages/smooth_app/lib/pages/product/common/product_refresher.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_refresher.dart
@@ -102,6 +102,8 @@ class ProductRefresher {
       final Status status = await OpenFoodAPIClient.saveProduct(
         ProductQuery.getUser(),
         inputProduct,
+        language: ProductQuery.getLanguage(),
+        country: ProductQuery.getCountry(),
       );
       if (status.error != null) {
         return _MetaProductRefresher.error(status.error);

--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -140,6 +140,12 @@ class _EditProductPageState extends State<EditProductPage> {
               SimpleInputPageStoreHelper(_product, appLocalizations),
             ),
             _getSimpleListTileItem(
+              SimpleInputPageEmbCodeHelper(_product, appLocalizations),
+            ),
+            _getSimpleListTileItem(
+              SimpleInputPageCountryHelper(_product, appLocalizations),
+            ),
+            _getSimpleListTileItem(
               SimpleInputPageCategoryHelper(_product, appLocalizations),
             ),
             _ListTitleItem(

--- a/packages/smooth_app/lib/pages/product/simple_input_page.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page.dart
@@ -114,6 +114,8 @@ class _SimpleInputPageState extends State<SimpleInputPage> {
                   ),
                 ],
               ),
+              if (widget.helper.getAddExplanations() != null)
+                Text(widget.helper.getAddExplanations()!),
               Divider(color: themeData.colorScheme.onBackground),
               Wrap(
                 direction: Axis.horizontal,

--- a/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
@@ -27,6 +27,8 @@ abstract class AbstractSimpleInputPageHelper {
   /// "Have the terms been changed?"
   bool _changed = false;
 
+  final String _separator = ',';
+
   /// Returns the terms as they were initially in the product.
   @protected
   List<String> initTerms();
@@ -69,6 +71,9 @@ abstract class AbstractSimpleInputPageHelper {
   /// Returns the hint of the "add" text field.
   String getAddHint();
 
+  /// Returns additional examples about the "add" text field.
+  String? getAddExplanations() => null;
+
   /// Impacts a product in order to take the changes into account.
   @protected
   void changeProduct(final Product changedProduct);
@@ -81,6 +86,18 @@ abstract class AbstractSimpleInputPageHelper {
     final Product changedProduct = Product(barcode: product.barcode);
     changeProduct(changedProduct);
     return changedProduct;
+  }
+
+  @protected
+  List<String> splitString(String? input) {
+    if (input == null) {
+      return <String>[];
+    }
+    input = input.trim();
+    if (input.isEmpty) {
+      return <String>[];
+    }
+    return input.split(_separator);
   }
 }
 
@@ -95,28 +112,45 @@ class SimpleInputPageStoreHelper extends AbstractSimpleInputPageHelper {
         );
 
   @override
-  List<String> initTerms() => _splitString(product.stores);
+  List<String> initTerms() => splitString(product.stores);
 
   @override
   void changeProduct(final Product changedProduct) =>
-      changedProduct.stores = terms.join(', ');
+      changedProduct.stores = terms.join(_separator);
 
   @override
   String getTitle() => appLocalizations.edit_product_form_item_stores_title;
 
   @override
   String getAddHint() => appLocalizations.edit_product_form_item_stores_hint;
+}
 
-  List<String> _splitString(String? input) {
-    if (input == null) {
-      return <String>[];
-    }
-    input = input.trim();
-    if (input.isEmpty) {
-      return <String>[];
-    }
-    return input.split(',');
-  }
+/// Implementation for "Emb Code" of an [AbstractSimpleInputPageHelper].
+class SimpleInputPageEmbCodeHelper extends AbstractSimpleInputPageHelper {
+  SimpleInputPageEmbCodeHelper(
+    final Product product,
+    final AppLocalizations appLocalizations,
+  ) : super(
+          product,
+          appLocalizations,
+        );
+
+  @override
+  List<String> initTerms() => splitString(product.embCodes);
+
+  @override
+  void changeProduct(final Product changedProduct) =>
+      changedProduct.embCodes = terms.join(_separator);
+
+  @override
+  String getTitle() => appLocalizations.edit_product_form_item_emb_codes_title;
+
+  @override
+  String getAddHint() => appLocalizations.edit_product_form_item_emb_codes_hint;
+
+  @override
+  String getAddExplanations() =>
+      appLocalizations.edit_product_form_item_emb_codes_explanations;
 }
 
 /// Abstraction, for "in language" field, of an [AbstractSimpleInputPageHelper].
@@ -175,7 +209,7 @@ abstract class AbstractSimpleInputPageInLanguageHelper
       String? tag = _termToTags[term];
       tag ??= '${_language.code}:$term';
       if (i > 0) {
-        result.write(', ');
+        result.write(_separator);
       }
       result.write(tag);
     }
@@ -244,4 +278,37 @@ class SimpleInputPageCategoryHelper
   @override
   String getAddHint() =>
       appLocalizations.edit_product_form_item_categories_hint;
+}
+
+/// Implementation for "Countries" of an [AbstractSimpleInputPageHelper].
+class SimpleInputPageCountryHelper
+    extends AbstractSimpleInputPageInLanguageHelper {
+  SimpleInputPageCountryHelper(
+    final Product product,
+    final AppLocalizations appLocalizations,
+  ) : super(
+          product,
+          appLocalizations,
+        );
+
+  @override
+  List<String>? getTags() => product.countriesTags;
+
+  @override
+  Map<OpenFoodFactsLanguage, List<String>>? getInLanguages() =>
+      product.countriesTagsInLanguages;
+
+  @override
+  void setValue(final Product changedProduct, final String value) =>
+      changedProduct.countries = value;
+
+  @override
+  String getTitle() => appLocalizations.edit_product_form_item_countries_title;
+
+  @override
+  String getAddHint() => appLocalizations.edit_product_form_item_countries_hint;
+
+  @override
+  String getAddExplanations() =>
+      appLocalizations.edit_product_form_item_countries_explanations;
 }

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -353,6 +353,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.9.3"
+  flutter_lints:
+    dependency: "direct dev"
+    description:
+      name: flutter_lints
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -637,6 +644,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.2"
+  lints:
+    dependency: transitive
+    description:
+      name: lints
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   lists:
     dependency: transitive
     description:
@@ -729,7 +743,7 @@ packages:
       name: openfoodfacts
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.18.2"
+    version: "1.19.0"
   openfoodfacts_flutter_lints:
     dependency: "direct dev"
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
       url: 'https://github.com/M123-dev/matomo-tracker.git'
       ref: 'fix-event-sending'
   modal_bottom_sheet: ^2.0.1
-  openfoodfacts: ^1.18.2
+  openfoodfacts: ^1.19.0
   #  openfoodfacts:
   #    path: ../../../openfoodfacts-dart
   package_info_plus: ^1.4.2
@@ -42,7 +42,7 @@ dependencies:
   photo_view: ^0.14.0
   uuid: ^3.0.6
   provider: ^6.0.3
-  sentry_flutter: ^6.5.1 # careful with upgrading cf: https://github.com/openfoodfacts/smooth-app/issues/1300
+  sentry_flutter: ^6.6.0 # careful with upgrading cf: https://github.com/openfoodfacts/smooth-app/issues/1300
   sqflite: ^2.0.2+1
   url_launcher: ^6.1.3
   visibility_detector: ^0.3.3


### PR DESCRIPTION
Impacted files:
* `app_en.arb`: added emb codes and countries translations
* `app_fr.arb`: added emb codes and countries translations
* `edit_product_page.dart`: added emb codes and countries editors
* `Podfile.lock`: wtf
* `product_query.dart`: added emb codes and countries product fields
* `product_refresher.dart`: now using language and country parameters for `saveProduct`
* `pubspec.lock`: wtf
* `pubspec.yaml`: upgraded versions of off-dart and sentry
* `simple_input_page.dart`: added an optional explanation field
* `simple_input_page_helpers.dart`: added emb codes and countries helpers; added an optional explanation field; refactored

### What
- Added emb codes and countries to product edit page.
- Not 100% sure about the systematic localization (like type in "Belgium" in English, expect "Belgique" in French)

### Screenshots
| French | English |
| -- | -- |
| ![Capture d’écran 2022-06-23 à 11 01 26](https://user-images.githubusercontent.com/11576431/175260880-9d4ef2fa-f7fe-417c-9791-96f03be3aafe.png) | ![Capture d’écran 2022-06-23 à 11 02 27](https://user-images.githubusercontent.com/11576431/175261094-8bdbbb9d-eed1-46cd-ac35-92683a559473.png) |
| ![Capture d’écran 2022-06-23 à 11 05 26](https://user-images.githubusercontent.com/11576431/175261747-dfdbb658-1d63-47be-8cb3-81a3a862bb42.png) | ![Capture d’écran 2022-06-23 à 11 03 42](https://user-images.githubusercontent.com/11576431/175261380-82c507db-ff86-40c2-9c4a-655d7b0777a4.png) |


### Part of 
- #2169
