### PR TITLE
fix: Ensure the permission request is only asked once

### DIFF
--- a/packages/smooth_app/lib/helpers/permission_helper.dart
+++ b/packages/smooth_app/lib/helpers/permission_helper.dart
@@ -7,12 +7,19 @@ class PermissionListener extends ValueNotifier<DevicePermission> {
   PermissionListener({
     required this.permission,
   })  : _status = _DevicePermissionStatus.initial,
-        super(DevicePermission._initial(permission)) {
-    checkPermission();
-  }
+        super(DevicePermission._initial(permission));
 
   final Permission permission;
   _DevicePermissionStatus _status = _DevicePermissionStatus.initial;
+
+  @override
+  void addListener(VoidCallback listener) {
+    super.addListener(listener);
+
+    if (_status == _DevicePermissionStatus.initial) {
+      checkPermission();
+    }
+  }
 
   Future<void> checkPermission() async {
     /// If a device doesn't have a camera, let's pretend the permission is

--- a/packages/smooth_app/lib/main.dart
+++ b/packages/smooth_app/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:openfoodfacts/personalized_search/product_preferences_selection.dart';
+import 'package:permission_handler/permission_handler.dart';
 import 'package:provider/provider.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:smooth_app/data_models/continuous_scan_model.dart';
@@ -22,6 +23,7 @@ import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/camera_helper.dart';
 import 'package:smooth_app/helpers/data_importer/smooth_app_data_importer.dart';
 import 'package:smooth_app/helpers/network_config.dart';
+import 'package:smooth_app/helpers/permission_helper.dart';
 import 'package:smooth_app/pages/onboarding/onboarding_flow_navigator.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
 import 'package:smooth_app/themes/theme_provider.dart';
@@ -77,6 +79,8 @@ late ProductPreferences _productPreferences;
 late LocalDatabase _localDatabase;
 late ThemeProvider _themeProvider;
 final ContinuousScanModel _continuousScanModel = ContinuousScanModel();
+final PermissionListener _permissionListener =
+    PermissionListener(permission: Permission.camera);
 final UpToDateProductProvider _upToDateProductProvider =
     UpToDateProductProvider();
 bool _init1done = false;
@@ -182,6 +186,7 @@ class _SmoothAppState extends State<SmoothApp> {
             provide<ContinuousScanModel>(_continuousScanModel),
             provide<SmoothAppDataImporter>(_appDataImporter),
             provide<UpToDateProductProvider>(_upToDateProductProvider),
+            provide<PermissionListener>(_permissionListener)
           ],
           builder: _buildApp,
         );

--- a/packages/smooth_app/lib/pages/scan/scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/scan_page.dart
@@ -3,7 +3,6 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:permission_handler/permission_handler.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/continuous_scan_model.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
@@ -50,15 +49,10 @@ class _ScanPageState extends State<ScanPage> {
     return AnnotatedRegion<SystemUiOverlayStyle>(
       value: SystemUiOverlayStyle.light,
       child: Scaffold(
-        body: ChangeNotifierProvider<PermissionListener>(
-          create: (_) => PermissionListener(
-            permission: Permission.camera,
-          ),
-          child: ScannerOverlay(
-            backgroundChild: const _ScanPageBackgroundWidget(),
-            foregroundChild: const _ScanPageForegroundWidget(),
-            topChild: const _ScanPageTopWidget(),
-          ),
+        body: ScannerOverlay(
+          backgroundChild: const _ScanPageBackgroundWidget(),
+          foregroundChild: const _ScanPageForegroundWidget(),
+          topChild: const _ScanPageTopWidget(),
         ),
       ),
     );

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -353,6 +353,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.9.3"
+  flutter_lints:
+    dependency: "direct dev"
+    description:
+      name: flutter_lints
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -637,6 +644,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.2"
+  lints:
+    dependency: transitive
+    description:
+      name: lints
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   lists:
     dependency: transitive
     description:
@@ -729,13 +743,13 @@ packages:
       name: openfoodfacts
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.18.2"
+    version: "1.19.0"
   openfoodfacts_flutter_lints:
     dependency: "direct dev"
     description:
       path: "."
       ref: HEAD
-      resolved-ref: d4ebb93e19ef8398171c841975038818a43f61cc
+      resolved-ref: "7d31d5cf5bd2cef6b8d06233d98da5047f721df3"
       url: "https://github.com/openfoodfacts/openfoodfacts_flutter_lints.git"
     source: git
     version: "1.0.0"
@@ -1226,7 +1240,7 @@ packages:
       name: url_launcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.3"
+    version: "6.1.4"
   url_launcher_android:
     dependency: transitive
     description:


### PR DESCRIPTION
Hi everyone,

It looked like my fix was not enough.
When the popup shows to ask for the permission, we leave the Flutter app.
In that case, the PermissionListener (ValueNotifier) was disposed.

That's why this listener is now on top of the app.


Furthermore, to prevent an initial test for nothing, we only check if the permission was requested when a listener is added = when the scan page is visible