### PR TITLE
fix: added a tintable cached svg asset file

### DIFF
--- a/packages/smooth_app/assets/cacheTintable/off-magnifying-glass.svg
+++ b/packages/smooth_app/assets/cacheTintable/off-magnifying-glass.svg
@@ -1,0 +1,1 @@
+<svg aria-hidden="true" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" class="icon"><path d="M12 4a8 8 0 0 0-8 8 8 8 0 0 0 8 8 8 8 0 0 0 8-8 8 8 0 0 0-8-8zm0 2a6 6 0 0 1 6 6 6 6 0 0 1-6 6 6 6 0 0 1-6-6 6 6 0 0 1 6-6Z"/><path d="m7 22 2 1 1-3-2-1Z"/></svg>


### PR DESCRIPTION
New file:
* `off-magnifying-glass.svg`

### What
- Answer to the following warning message
```
AssetCacheHelper:
please download https://static.openfoodfacts.org/images/icons/dist/off-magnifying-glass.svg
and put it in asset somewhere like
[assets/cacheTintable/off-magnifying-glass.svg, assets/cache/off-magnifying-glass.svg]
```