### PR TITLE
fix: #2356 - correct message for "fetch and refresh" dialog

### DIFF
--- a/packages/smooth_app/lib/pages/product/common/product_refresher.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_refresher.dart
@@ -140,7 +140,7 @@ class ProductRefresher {
         await LoadingDialog.run<_MetaProductRefresher>(
       future: _fetchAndRefresh(localDatabase, barcode),
       context: context,
-      title: appLocalizations.nutrition_page_update_running,
+      title: appLocalizations.refreshing_product,
     );
     if (fetchAndRefreshed == null) {
       return false;


### PR DESCRIPTION
"Refreshing product" (en) / "Actualisation du produit" (fr)
instead of
"Updating the product on the server..." (en) / "Mise à jour du produit sur le serveur..." (fr)

Impacted file:
* `product_refresher.dart`: used the adequate localizations for the "fetch and refresh" method

### What
- Same UX, different text for the previously misleading "fetch and refresh" dialog

### Fixes bug(s)
- Fixes: #2356