### PR TITLE
fix: #2387 - centered layout for empty product page

### DIFF
--- a/packages/smooth_app/lib/pages/product/common/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_page.dart
@@ -160,29 +160,31 @@ class _ProductListPageState extends State<ProductListPage>
       ),
       body: products.isEmpty
           ? GestureDetector(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: <Widget>[
-                  SvgPicture.asset(
-                    'assets/misc/empty-list.svg',
-                    height: MediaQuery.of(context).size.height * .4,
-                  ),
-                  Text(
-                    appLocalizations.product_list_empty_title,
-                    style: themeData.textTheme.headlineLarge
-                        ?.apply(color: colorScheme.onBackground),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.all(VERY_LARGE_SPACE),
-                    child: Text(
-                      appLocalizations.product_list_empty_message,
-                      textAlign: TextAlign.center,
-                      style: themeData.textTheme.bodyText2?.apply(
-                        color: colorScheme.onBackground,
-                      ),
+              child: Center(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: <Widget>[
+                    SvgPicture.asset(
+                      'assets/misc/empty-list.svg',
+                      height: MediaQuery.of(context).size.height * .4,
                     ),
-                  )
-                ],
+                    Text(
+                      appLocalizations.product_list_empty_title,
+                      style: themeData.textTheme.headlineLarge
+                          ?.apply(color: colorScheme.onBackground),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.all(VERY_LARGE_SPACE),
+                      child: Text(
+                        appLocalizations.product_list_empty_message,
+                        textAlign: TextAlign.center,
+                        style: themeData.textTheme.bodyText2?.apply(
+                          color: colorScheme.onBackground,
+                        ),
+                      ),
+                    )
+                  ],
+                ),
               ),
               onTap: () {
                 InheritedDataManager.of(context).resetShowSearchCard(true);


### PR DESCRIPTION
Impacted file:
* `product_list_page.dart`: centered the "empty" layout.

### What
- Centered layout for empty product page

### Screenshot
![Capture d’écran 2022-06-27 à 09 40 25](https://user-images.githubusercontent.com/11576431/175886196-60229237-16c5-4738-b859-6f8509ba7918.png)

### Fixes bug(s)
- Fixes: #2387