### PR TITLE
feat: #2248 - user agent distinction between scan and barcode search

### DIFF
--- a/packages/smooth_app/lib/data_models/continuous_scan_model.dart
+++ b/packages/smooth_app/lib/data_models/continuous_scan_model.dart
@@ -181,6 +181,7 @@ class ContinuousScanModel with ChangeNotifier {
       BarcodeProductQuery(
         barcode: barcode,
         daoProduct: _daoProduct,
+        isScanned: true,
       ).getFetchedProduct();
 
   Future<void> _loadBarcode(

--- a/packages/smooth_app/lib/database/barcode_product_query.dart
+++ b/packages/smooth_app/lib/database/barcode_product_query.dart
@@ -9,10 +9,12 @@ class BarcodeProductQuery {
   BarcodeProductQuery({
     required this.barcode,
     required this.daoProduct,
+    required this.isScanned,
   });
 
   final String barcode;
   final DaoProduct daoProduct;
+  final bool isScanned;
 
   Future<FetchedProduct> getFetchedProduct() async {
     final ProductQueryConfiguration configuration = ProductQueryConfiguration(
@@ -24,10 +26,13 @@ class BarcodeProductQuery {
 
     final ProductResult result;
     try {
+      ProductQuery.setUserAgentComment(isScanned ? 'scan' : 'search');
       result = await OpenFoodAPIClient.getProduct(configuration);
     } catch (e) {
+      ProductQuery.setUserAgentComment('');
       return FetchedProduct.error(FetchedProductStatus.internetError);
     }
+    ProductQuery.setUserAgentComment('');
 
     if (result.status == 1) {
       final Product? product = result.product;

--- a/packages/smooth_app/lib/database/product_query.dart
+++ b/packages/smooth_app/lib/database/product_query.dart
@@ -1,3 +1,4 @@
+import 'package:openfoodfacts/model/UserAgent.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:openfoodfacts/utils/OpenFoodAPIConfiguration.dart';
@@ -41,6 +42,23 @@ abstract class ProductQuery {
   static String getLocaleString() => '${getLanguage()!.code}'
       '_'
       '${getCountry()!.iso2Code.toUpperCase()}';
+
+  /// Sets a comment for the user agent.
+  ///
+  /// cf. https://github.com/openfoodfacts/smooth-app/issues/2248
+  static void setUserAgentComment(final String comment) {
+    final UserAgent? previous = OpenFoodAPIConfiguration.userAgent;
+    if (previous == null) {
+      return;
+    }
+    OpenFoodAPIConfiguration.userAgent = UserAgent(
+      name: previous.name,
+      version: previous.version,
+      system: previous.system,
+      url: previous.url,
+      comment: comment,
+    );
+  }
 
   static const String _UUID_NAME = 'UUID_NAME_REV_1';
 

--- a/packages/smooth_app/lib/pages/product/common/product_dialog_helper.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_dialog_helper.dart
@@ -37,6 +37,7 @@ class ProductDialogHelper {
           future: BarcodeProductQuery(
             barcode: barcode,
             daoProduct: DaoProduct(localDatabase),
+            isScanned: false,
           ).getFetchedProduct(),
           title: refresh
               ? AppLocalizations.of(context).refreshing_product


### PR DESCRIPTION
Impacted files:
* `barcode_product_query.dart`: new parameter `isScanned` to distinguish scan and barcode search via the user agent comment field
* `continuous_scan_model.dart`: "this IS a scan"
* `product_dialog_helper.dart`: "this is NOT a scan"
* `product_query.dart`: new method to set the user agent comment field

### What
- Barcode scan and barcode search use the same search URL.
- We were asked to distinguish them via the user agent.
- The user agent comment will be different, and will be either 'scan' or 'search'.

### Fixes bug(s)
- Closes: #2248