### PR TITLE
fix: unexpectedKPElement - sentry error but not test fail for new KP elements

### DIFF
--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_element_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_element_card.dart
@@ -10,6 +10,7 @@ import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_card
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_group_card.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_table_card.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_world_map_card.dart';
+import 'package:smooth_app/services/smooth_services.dart';
 
 class KnowledgePanelElementCard extends StatelessWidget {
   const KnowledgePanelElementCard({
@@ -50,6 +51,9 @@ class KnowledgePanelElementCard extends StatelessWidget {
       case KnowledgePanelElementType.MAP:
         return KnowledgePanelWorldMapCard(knowledgePanelElement.mapElement!);
       case KnowledgePanelElementType.UNKNOWN:
+        return EMPTY_WIDGET;
+      default:
+        Logs.e('unexpected element type: ${knowledgePanelElement.elementType}');
         return EMPTY_WIDGET;
     }
   }

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -385,7 +385,7 @@ packages:
       name: flutter_map
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   flutter_native_splash:
     dependency: "direct main"
     description:
@@ -448,7 +448,7 @@ packages:
       name: flutter_svg
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -736,7 +736,7 @@ packages:
       name: modal_bottom_sheet
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.1.0"
   nested:
     dependency: transitive
     description:
@@ -750,7 +750,7 @@ packages:
       name: openfoodfacts
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.19.0"
+    version: "1.20.0"
   openfoodfacts_flutter_lints:
     dependency: "direct dev"
     description:
@@ -1025,7 +1025,7 @@ packages:
       name: share_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.9"
+    version: "4.0.10"
   share_plus_linux:
     dependency: transitive
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -16,8 +16,8 @@ dependencies:
   carousel_slider: ^4.1.1
   cupertino_icons: ^1.0.5
   device_preview: ^1.1.0
-  flutter_svg: ^1.1.0
-  flutter_map: ^1.0.0
+  flutter_svg: ^1.1.1
+  flutter_map: ^1.1.1
   flutter_widget_from_html_core: any
   fwfh_selectable_text: ^0.8.3+1
   flutter_secure_storage: ^5.0.2
@@ -32,8 +32,8 @@ dependencies:
     git:
       url: 'https://github.com/M123-dev/matomo-tracker.git'
       ref: 'fix-event-sending'
-  modal_bottom_sheet: ^2.0.1
-  openfoodfacts: ^1.19.0
+  modal_bottom_sheet: ^2.1.0
+  openfoodfacts: ^1.20.0
   #  openfoodfacts:
   #    path: ../../../openfoodfacts-dart
   package_info_plus: ^1.4.2
@@ -78,7 +78,7 @@ dependencies:
     path: ../data_importer_shared
   data_importer:
     path: ../data_importer
-  share_plus: ^4.0.8
+  share_plus: ^4.0.10
   fimber: ^0.6.6
 
 dev_dependencies:


### PR DESCRIPTION
Impacted files:
* `knowledge_panel_element_card.dart`: sends an error message for unexpected KP elements
* `pubspec.lock`: wtf
* `pubspec.yaml`: upgraded versions, including off-dart to `1.20.0`

### What
- A recent change in off-dart (`1.20.0`) added a new KP element.
- The way we coded the display of KP element in Smoothie, we were very strict and did not allow unexpected elements.
- Therefore, all tests failed each time a new KP element appeared, that was not in the list.
- With this PR, each time we don't know a KP element, we send an error message but do not make the app crash or the test fail.

### Fixes bug(s)
- Fixes: #2430