### PR TITLE
feat: #1136 - handle "action" elements in KP

### DIFF
--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_action_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_action_card.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:openfoodfacts/model/KnowledgePanelElement.dart';
+import 'package:openfoodfacts/model/Product.dart';
+import 'package:smooth_app/generic_lib/smooth_html_widget.dart';
+import 'package:smooth_app/pages/product/add_category_button.dart';
+import 'package:smooth_app/pages/product/add_ingredients_button.dart';
+import 'package:smooth_app/pages/product/add_nutrition_button.dart';
+import 'package:smooth_app/services/smooth_services.dart';
+
+/// "Contribute Actions" for the knowledge panels.
+class KnowledgePanelActionCard extends StatelessWidget {
+  const KnowledgePanelActionCard(this.element, this.product);
+
+  final KnowledgePanelActionElement element;
+  final Product product;
+
+  @override
+  Widget build(BuildContext context) {
+    final List<Widget> actionWidgets = <Widget>[];
+    for (final String action in element.actions) {
+      switch (action) {
+        case KnowledgePanelActionElement.ACTION_ADD_CATEGORIES:
+          actionWidgets.add(AddCategoryButton(product));
+          break;
+        case KnowledgePanelActionElement.ACTION_ADD_INGREDIENTS_TEXT:
+          actionWidgets.add(AddIngredientsButton(product));
+          break;
+        case KnowledgePanelActionElement.ACTION_ADD_NUTRITION_FACTS:
+          actionWidgets.add(AddNutritionButton(product));
+          break;
+        default:
+          Logs.e('unknown knowledge panel action: $action');
+      }
+    }
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        SmoothHtmlWidget(element.html),
+        ...actionWidgets,
+      ],
+    );
+  }
+}

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_card.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:openfoodfacts/model/KnowledgePanel.dart';
 import 'package:openfoodfacts/model/KnowledgePanelElement.dart';
 import 'package:openfoodfacts/model/KnowledgePanels.dart';
+import 'package:openfoodfacts/model/Product.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_expanded_card.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_group_card.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_page.dart';
@@ -11,10 +12,12 @@ class KnowledgePanelCard extends StatelessWidget {
   const KnowledgePanelCard({
     required this.panel,
     required this.allPanels,
+    required this.product,
   });
 
   final KnowledgePanel panel;
   final KnowledgePanels allPanels;
+  final Product product;
 
   @override
   Widget build(BuildContext context) {
@@ -23,6 +26,7 @@ class KnowledgePanelCard extends StatelessWidget {
       return KnowledgePanelExpandedCard(
         panel: panel,
         allPanels: allPanels,
+        product: product,
       );
     }
 
@@ -42,6 +46,7 @@ class KnowledgePanelCard extends StatelessWidget {
               groupElement: group,
               panel: panel,
               allPanels: allPanels,
+              product: product,
             ),
           ),
         );

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_element_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_element_card.dart
@@ -2,10 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/model/KnowledgePanelElement.dart';
 import 'package:openfoodfacts/model/KnowledgePanels.dart';
+import 'package:openfoodfacts/model/Product.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/smooth_html_widget.dart';
 import 'package:smooth_app/helpers/launch_url_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
+import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_action_card.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_card.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_group_card.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_table_card.dart';
@@ -16,10 +18,12 @@ class KnowledgePanelElementCard extends StatelessWidget {
   const KnowledgePanelElementCard({
     required this.knowledgePanelElement,
     required this.allPanels,
+    required this.product,
   });
 
   final KnowledgePanelElement knowledgePanelElement;
   final KnowledgePanels allPanels;
+  final Product product;
 
   @override
   Widget build(BuildContext context) {
@@ -39,11 +43,14 @@ class KnowledgePanelElementCard extends StatelessWidget {
           panel: allPanels
               .panelIdToPanelMap[knowledgePanelElement.panelElement!.panelId]!,
           allPanels: allPanels,
+          product: product,
         );
       case KnowledgePanelElementType.PANEL_GROUP:
         return KnowledgePanelGroupCard(
-            groupElement: knowledgePanelElement.panelGroupElement!,
-            allPanels: allPanels);
+          groupElement: knowledgePanelElement.panelGroupElement!,
+          allPanels: allPanels,
+          product: product,
+        );
       case KnowledgePanelElementType.TABLE:
         return KnowledgePanelTableCard(
           tableElement: knowledgePanelElement.tableElement!,
@@ -52,6 +59,11 @@ class KnowledgePanelElementCard extends StatelessWidget {
         return KnowledgePanelWorldMapCard(knowledgePanelElement.mapElement!);
       case KnowledgePanelElementType.UNKNOWN:
         return EMPTY_WIDGET;
+      case KnowledgePanelElementType.ACTION:
+        return KnowledgePanelActionCard(
+          knowledgePanelElement.actionElement!,
+          product,
+        );
       default:
         Logs.e('unexpected element type: ${knowledgePanelElement.elementType}');
         return EMPTY_WIDGET;

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_expanded_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_expanded_card.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:openfoodfacts/model/KnowledgePanel.dart';
 import 'package:openfoodfacts/model/KnowledgePanelElement.dart';
 import 'package:openfoodfacts/model/KnowledgePanels.dart';
+import 'package:openfoodfacts/model/Product.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_element_card.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_summary_card.dart';
@@ -10,10 +11,12 @@ class KnowledgePanelExpandedCard extends StatelessWidget {
   const KnowledgePanelExpandedCard({
     required this.panel,
     required this.allPanels,
+    required this.product,
   });
 
   final KnowledgePanel panel;
   final KnowledgePanels allPanels;
+  final Product product;
 
   @override
   Widget build(BuildContext context) {
@@ -27,6 +30,7 @@ class KnowledgePanelExpandedCard extends StatelessWidget {
           child: KnowledgePanelElementCard(
             knowledgePanelElement: element,
             allPanels: allPanels,
+            product: product,
           ),
         ),
       );

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_group_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_group_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/model/KnowledgePanelElement.dart';
 import 'package:openfoodfacts/model/KnowledgePanels.dart';
+import 'package:openfoodfacts/model/Product.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_card.dart';
@@ -9,10 +10,12 @@ class KnowledgePanelGroupCard extends StatelessWidget {
   const KnowledgePanelGroupCard({
     required this.groupElement,
     required this.allPanels,
+    required this.product,
   });
 
   final KnowledgePanelPanelGroupElement groupElement;
   final KnowledgePanels allPanels;
+  final Product product;
 
   @override
   Widget build(BuildContext context) {
@@ -35,6 +38,7 @@ class KnowledgePanelGroupCard extends StatelessWidget {
             KnowledgePanelCard(
               panel: allPanels.panelIdToPanelMap[panelId]!,
               allPanels: allPanels,
+              product: product,
             )
         ],
       ),

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_page.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_page.dart
@@ -4,6 +4,7 @@ import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:openfoodfacts/model/KnowledgePanel.dart';
 import 'package:openfoodfacts/model/KnowledgePanelElement.dart';
 import 'package:openfoodfacts/model/KnowledgePanels.dart';
+import 'package:openfoodfacts/model/Product.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
@@ -16,11 +17,13 @@ class KnowledgePanelPage extends StatefulWidget {
   const KnowledgePanelPage({
     required this.panel,
     required this.allPanels,
+    required this.product,
     this.groupElement,
   });
 
   final KnowledgePanel panel;
   final KnowledgePanels allPanels;
+  final Product product;
   final KnowledgePanelPanelGroupElement? groupElement;
 
   @override
@@ -39,7 +42,10 @@ class _KnowledgePanelPageState extends State<KnowledgePanelPage>
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(_title),
+        title: Text(
+          _title,
+          maxLines: 2,
+        ),
       ),
       body: RefreshIndicator(
         onRefresh: () => _refreshProduct(context),
@@ -52,6 +58,7 @@ class _KnowledgePanelPageState extends State<KnowledgePanelPage>
             child: KnowledgePanelExpandedCard(
               panel: widget.panel,
               allPanels: widget.allPanels,
+              product: widget.product,
             ),
           ),
         ),

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels_builder.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels_builder.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/model/KnowledgePanel.dart';
 import 'package:openfoodfacts/model/KnowledgePanelElement.dart';
 import 'package:openfoodfacts/model/KnowledgePanels.dart';
@@ -7,25 +6,24 @@ import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
-import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_element_card.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_dev_mode.dart';
-import 'package:smooth_app/pages/product/edit_ingredients_page.dart';
-import 'package:smooth_app/pages/product/nutrition_page_loaded.dart';
-import 'package:smooth_app/pages/product/ocr_ingredients_helper.dart';
-import 'package:smooth_app/pages/product/ordered_nutrients_cache.dart';
+import 'package:smooth_app/pages/product/add_ingredients_button.dart';
+import 'package:smooth_app/pages/product/add_nutrition_button.dart';
 
 /// "Knowledge Panel" widget.
 class KnowledgePanelWidget extends StatelessWidget {
   const KnowledgePanelWidget({
     required this.panelElement,
     required this.knowledgePanels,
-    this.product,
+    required this.product,
+    required this.onboardingMode,
   });
 
   final KnowledgePanelElement panelElement;
   final KnowledgePanels knowledgePanels;
-  final Product? product;
+  final Product product;
+  final bool onboardingMode;
 
   @override
   Widget build(BuildContext context) {
@@ -49,41 +47,17 @@ class KnowledgePanelWidget extends StatelessWidget {
         KnowledgePanelElementCard(
           knowledgePanelElement: knowledgePanelElement,
           allPanels: knowledgePanels,
+          product: product,
         ),
       );
     }
-    if (product != null) {
+    if (!onboardingMode) {
       if (panelId == 'health_card') {
-        final bool nutritionAddOrUpdate = product!.statesTags
+        final bool nutritionAddOrUpdate = product.statesTags
                 ?.contains('en:nutrition-facts-to-be-completed') ??
             false;
-        final AppLocalizations appLocalizations = AppLocalizations.of(context);
         if (nutritionAddOrUpdate) {
-          children.add(
-            addPanelButton(
-              nutritionAddOrUpdate
-                  ? appLocalizations.score_add_missing_nutrition_facts
-                  : appLocalizations.score_update_nutrition_facts,
-              iconData: nutritionAddOrUpdate ? Icons.add : Icons.edit,
-              onPressed: () async {
-                final OrderedNutrientsCache? cache =
-                    await OrderedNutrientsCache.getCache(context);
-                if (cache == null) {
-                  return;
-                }
-                //ignore: use_build_context_synchronously
-                await Navigator.push<Product>(
-                  context,
-                  MaterialPageRoute<Product>(
-                    builder: (BuildContext context) => NutritionPageLoaded(
-                      product!,
-                      cache.orderedNutrients,
-                    ),
-                  ),
-                );
-              },
-            ),
-          );
+          children.add(AddNutritionButton(product));
         }
 
         final bool needEditIngredients = context
@@ -91,25 +65,12 @@ class KnowledgePanelWidget extends StatelessWidget {
                 .getFlag(UserPreferencesDevMode
                     .userPreferencesFlagEditIngredients) ??
             false;
-        if ((product!.ingredientsText == null ||
-                product!.ingredientsText!.isEmpty) &&
+        if ((product.ingredientsText == null ||
+                product.ingredientsText!.isEmpty) &&
             needEditIngredients) {
           // When the flag is removed, this should be the following:
           // if (product.statesTags?.contains('en:ingredients-to-be-completed') ?? false) {
-          children.add(
-            addPanelButton(
-              appLocalizations.score_add_missing_ingredients,
-              onPressed: () async => Navigator.push<bool>(
-                context,
-                MaterialPageRoute<bool>(
-                  builder: (BuildContext context) => EditOcrPage(
-                    product: product!,
-                    helper: OcrIngredientsHelper(),
-                  ),
-                ),
-              ),
-            ),
-          );
+          children.add(AddIngredientsButton(product));
         }
       }
     }

--- a/packages/smooth_app/lib/pages/onboarding/knowledge_panel_page_template.dart
+++ b/packages/smooth_app/lib/pages/onboarding/knowledge_panel_page_template.dart
@@ -44,6 +44,7 @@ class _KnowledgePanelPageTemplateState
   late KnowledgePanels _knowledgePanels;
   bool _isHintDismissed = false;
   late final AppLocalizations appLocalizations = AppLocalizations.of(context);
+  late final Product _product;
 
   @override
   void initState() {
@@ -52,10 +53,9 @@ class _KnowledgePanelPageTemplateState
   }
 
   Future<void> _init() async {
-    final Product product =
-        await OnboardingDataProduct.forProduct(widget.localDatabase)
-            .getData(rootBundle);
-    _knowledgePanels = product.knowledgePanels!;
+    _product = await OnboardingDataProduct.forProduct(widget.localDatabase)
+        .getData(rootBundle);
+    _knowledgePanels = _product.knowledgePanels!;
   }
 
   @override
@@ -79,6 +79,8 @@ class _KnowledgePanelPageTemplateState
               widget.panelId,
             )!,
             knowledgePanels: _knowledgePanels,
+            product: _product,
+            onboardingMode: true,
           );
           return Container(
             color: widget.backgroundColor,

--- a/packages/smooth_app/lib/pages/product/add_category_button.dart
+++ b/packages/smooth_app/lib/pages/product/add_category_button.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:openfoodfacts/model/Product.dart';
+import 'package:smooth_app/helpers/product_cards_helper.dart';
+import 'package:smooth_app/pages/product/common/product_refresher.dart';
+import 'package:smooth_app/pages/product/simple_input_page.dart';
+import 'package:smooth_app/pages/product/simple_input_page_helpers.dart';
+
+/// "Add category" button for user contribution.
+class AddCategoryButton extends StatelessWidget {
+  const AddCategoryButton(this.product);
+
+  final Product product;
+
+  @override
+  Widget build(BuildContext context) => addPanelButton(
+        AppLocalizations.of(context).score_add_missing_product_category,
+        onPressed: () async {
+          if (!await ProductRefresher().checkIfLoggedIn(context)) {
+            return;
+          }
+          await Navigator.push<Product>(
+            context,
+            MaterialPageRoute<Product>(
+              builder: (BuildContext context) => SimpleInputPage(
+                helper: SimpleInputPageCategoryHelper(),
+                product: product,
+              ),
+            ),
+          );
+        },
+      );
+}

--- a/packages/smooth_app/lib/pages/product/add_ingredients_button.dart
+++ b/packages/smooth_app/lib/pages/product/add_ingredients_button.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:openfoodfacts/model/Product.dart';
+import 'package:smooth_app/helpers/product_cards_helper.dart';
+import 'package:smooth_app/pages/product/common/product_refresher.dart';
+import 'package:smooth_app/pages/product/edit_ingredients_page.dart';
+import 'package:smooth_app/pages/product/ocr_ingredients_helper.dart';
+
+/// "Add ingredients" button for user contribution.
+class AddIngredientsButton extends StatelessWidget {
+  const AddIngredientsButton(this.product);
+
+  final Product product;
+
+  @override
+  Widget build(BuildContext context) => addPanelButton(
+        AppLocalizations.of(context).score_add_missing_ingredients,
+        onPressed: () async {
+          if (!await ProductRefresher().checkIfLoggedIn(context)) {
+            return;
+          }
+          await Navigator.push<bool>(
+            context,
+            MaterialPageRoute<bool>(
+              builder: (BuildContext context) => EditOcrPage(
+                product: product,
+                helper: OcrIngredientsHelper(),
+              ),
+            ),
+          );
+        },
+      );
+}

--- a/packages/smooth_app/lib/pages/product/add_nutrition_button.dart
+++ b/packages/smooth_app/lib/pages/product/add_nutrition_button.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:openfoodfacts/model/Product.dart';
+import 'package:smooth_app/helpers/product_cards_helper.dart';
+import 'package:smooth_app/pages/product/common/product_refresher.dart';
+import 'package:smooth_app/pages/product/nutrition_page_loaded.dart';
+import 'package:smooth_app/pages/product/ordered_nutrients_cache.dart';
+
+/// "Add nutrition facts" button for user contribution.
+class AddNutritionButton extends StatefulWidget {
+  const AddNutritionButton(this.product);
+
+  final Product product;
+
+  @override
+  State<AddNutritionButton> createState() => _AddNutritionButtonState();
+}
+
+class _AddNutritionButtonState extends State<AddNutritionButton> {
+  @override
+  Widget build(BuildContext context) => addPanelButton(
+        AppLocalizations.of(context).score_add_missing_nutrition_facts,
+        onPressed: () async {
+          if (!await ProductRefresher().checkIfLoggedIn(context)) {
+            return;
+          }
+          final OrderedNutrientsCache? cache =
+              await OrderedNutrientsCache.getCache(context);
+          if (cache == null) {
+            return;
+          }
+          if (!mounted) {
+            return;
+          }
+          await Navigator.push<Product>(
+            context,
+            MaterialPageRoute<Product>(
+              builder: (BuildContext context) => NutritionPageLoaded(
+                widget.product,
+                cache.orderedNutrients,
+              ),
+            ),
+          );
+        },
+      );
+}

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -237,6 +237,7 @@ class _ProductPageState extends State<ProductPage> with TraceableClientMixin {
             panelElement: panelElement,
             knowledgePanels: _product.knowledgePanels!,
             product: _product,
+            onboardingMode: false,
           ),
         );
       }

--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -29,10 +29,9 @@ import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_grou
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_page.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_page.dart';
 import 'package:smooth_app/pages/product/add_basic_details_page.dart';
+import 'package:smooth_app/pages/product/add_category_button.dart';
 import 'package:smooth_app/pages/product/common/product_query_page_helper.dart';
 import 'package:smooth_app/pages/product/common/product_refresher.dart';
-import 'package:smooth_app/pages/product/simple_input_page.dart';
-import 'package:smooth_app/pages/product/simple_input_page_helpers.dart';
 import 'package:smooth_app/pages/question_page.dart';
 
 const List<String> _ATTRIBUTE_GROUP_ORDER = <String>[
@@ -296,12 +295,7 @@ class _SummaryCardState extends State<SummaryCard> {
     if (widget.isFullVersion) {
       // Complete category
       if (statesTags.contains('en:categories-to-be-completed')) {
-        summaryCardButtons.add(
-          addPanelButton(
-            localizations.score_add_missing_product_category,
-            onPressed: () async => _addCategories(),
-          ),
-        );
+        summaryCardButtons.add(AddCategoryButton(_product));
       }
 
       // Compare to category
@@ -747,20 +741,6 @@ class _SummaryCardState extends State<SummaryCard> {
           groupElement: group,
           panel: knowledgePanel,
           allPanels: _product.knowledgePanels!,
-        ),
-      ),
-    );
-  }
-
-  Future<void> _addCategories() async {
-    if (!await ProductRefresher().checkIfLoggedIn(context)) {
-      return;
-    }
-    await Navigator.push<Product>(
-      context,
-      MaterialPageRoute<Product>(
-        builder: (BuildContext context) => SimpleInputPage(
-          helper: SimpleInputPageCategoryHelper(),
           product: _product,
         ),
       ),


### PR DESCRIPTION
New files:
* `add_category_button.dart`: "Add category" button for user contribution.
* `add_ingredients_button.dart`: "Add ingredients" button for user contribution.
* `add_nutrition_button.dart`: "Add nutrition facts" button for user contribution.
* `knowledge_panel_action_card.dart`: "Contribute Actions" for the knowledge panels.

Impacted files:
* `knowledge_panel_card.dart`: refactored.
* `knowledge_panel_element_card.dart`: action "actions" element; refactored.
* `knowledge_panel_expanded_card.dart`: refactored.
* `knowledge_panel_group_card.dart`: refactored.
* `knowledge_panel_page.dart`: refactored.
* `knowledge_panel_page_template.dart`: refactored.
* `knowledge_panels_builder.dart`: added an explicit `bool onboardingMode` field; used new classes `AddNutritionButton` and `AddIngredientsButton`; refactored.
* `new_product_page.dart`: refactored.
* `summary_card.dart`: used new class `AddCategoryButton`; refactored.

### What
- The new "action" elements are now handled in the KP sub panels.
- Actually it looks a bit redundant with the product page, but that still makes sense.

### Screenshot
[edit:add] barcode 4006922007543, in English

Impact: the "could you..." text and the buttons:
| nutriscore | ecoscore |
| -- | -- |
| ![Capture d’écran 2022-06-30 à 13 26 41](https://user-images.githubusercontent.com/11576431/176666449-cbbc5b3d-0a54-48d0-9ad1-abc86648fc64.png) | ![Capture d’écran 2022-06-30 à 13 31 23](https://user-images.githubusercontent.com/11576431/176667032-f2a311fa-72c0-4001-ae4c-9a3ed8b34446.png) |

For the record, the product page:
![Capture d’écran 2022-06-30 à 13 32 23](https://user-images.githubusercontent.com/11576431/176667254-b32f7ae8-79b5-4e35-bf82-a5f64cc590d1.png)
![Capture d’écran 2022-06-30 à 13 33 09](https://user-images.githubusercontent.com/11576431/176667378-0149d0bd-345f-463b-9326-206f621005a3.png)



### Fixes bug(s)
- Closes: #1136
