### PR TITLE
fix: #2469 - additional small space before action buttons for KP

### DIFF
--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_action_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_action_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/model/KnowledgePanelElement.dart';
 import 'package:openfoodfacts/model/Product.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/smooth_html_widget.dart';
 import 'package:smooth_app/pages/product/add_category_button.dart';
 import 'package:smooth_app/pages/product/add_ingredients_button.dart';
@@ -37,6 +38,7 @@ class KnowledgePanelActionCard extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
         SmoothHtmlWidget(element.html),
+        const SizedBox(height: SMALL_SPACE),
         ...actionWidgets,
       ],
     );


### PR DESCRIPTION
Impacted file:
* `knowledge_panel_action_card.dart`: additional small space before action buttons

### What
- additional small space before action buttons for KP

### Screenshot
| after | before |
| -- | -- |
| ![Capture d’écran 2022-07-02 à 18 36 50](https://user-images.githubusercontent.com/11576431/177008947-bd60d06e-186f-4eb8-b4ff-1aa87314989b.png) | ![Capture d’écran 2022-07-02 à 18 37 15](https://user-images.githubusercontent.com/11576431/177008956-bfca2ea7-ca0a-411b-8ec8-4ba2bd6be8d1.png) |

### Fixes bug(s)
- Fixes: #2469