### PR TITLE
feat: #2470 - "add" taxonomized field improvements

### DIFF
--- a/packages/smooth_app/lib/pages/product/simple_input_page.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page.dart
@@ -63,12 +63,8 @@ class _SimpleInputPageState extends State<SimpleInputPage> {
                     if (widget.helper.getSubtitle(appLocalizations) != null)
                       Text(widget.helper.getSubtitle(appLocalizations)!),
                     ListTile(
-                      onTap: () {
-                        if (widget.helper.addTerm(_controller.text)) {
-                          setState(() => _controller.text = '');
-                        }
-                      },
-                      leading: const Icon(Icons.add_circle),
+                      onTap: () => _addItemsFromController(),
+                      trailing: const Icon(Icons.add_circle),
                       title: TextField(
                         decoration: InputDecoration(
                           filled: true,
@@ -142,6 +138,7 @@ class _SimpleInputPageState extends State<SimpleInputPage> {
   /// Parameter [saving] tells about the context: are we leaving the page,
   /// or have we clicked on the "save" button?
   Future<bool> _mayExitPage({required final bool saving}) async {
+    _addItemsFromController();
     final Product? changedProduct = widget.helper.getChangedProduct();
     if (changedProduct == null) {
       return true;
@@ -178,5 +175,21 @@ class _SimpleInputPageState extends State<SimpleInputPage> {
       localDatabase: localDatabase,
       product: changedProduct,
     );
+  }
+
+  /// Adds all the non-already existing items from the controller.
+  ///
+  /// The item separator is the comma.
+  void _addItemsFromController() {
+    final List<String> input = _controller.text.split(',');
+    bool result = false;
+    for (final String item in input) {
+      if (widget.helper.addTerm(item.trim())) {
+        result = true;
+      }
+    }
+    if (result) {
+      setState(() => _controller.text = '');
+    }
   }
 }


### PR DESCRIPTION
Impacted file:
* `simple_input_page.dart`: "add" button now trailing; comma separator handled; automatic inclusion of non-committed values

### What
- "add" button was leading - now trailing
- when you click on the "add" button, the input text is considered with a comma separator for multiple items
- when you exit the page, the input text is automatically included - assuming the user has forgotten to click on the "add" button. Another possibility would be to open a dialog: "hey you forgot something!".

### Screenshot
| Typing "a,b,c" | Clicking on "add" (a and b and c were added) |
| -- | -- |
| ![Capture d’écran 2022-07-02 à 19 16 54](https://user-images.githubusercontent.com/11576431/177010123-ee6dc817-4a33-45a4-bbc3-07398da7d40d.png) | ![Capture d’écran 2022-07-02 à 19 17 19](https://user-images.githubusercontent.com/11576431/177010136-7b92b755-2bb3-4dfc-8831-94e5c07ca8af.png) |

| Typing "d,e,f" | Escaping the page (d and e and f were added behind the dialog) |
| -- | -- |
| ![Capture d’écran 2022-07-02 à 19 18 15](https://user-images.githubusercontent.com/11576431/177010157-3bf72c78-19c5-45ef-a8bc-b732c6d59260.png) | ![Capture d’écran 2022-07-02 à 19 19 00](https://user-images.githubusercontent.com/11576431/177010182-088108d9-8eb8-4c03-a7ee-6286a3f6ae1f.png) |



### Fixes bug(s)
- Closes: #2470
