### PR TITLE
fix: make textfield more visible in darkmode

### DIFF
--- a/packages/smooth_app/lib/pages/product/edit_ingredients_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_ingredients_page.dart
@@ -304,8 +304,10 @@ class _OcrWidget extends StatelessWidget {
                       TextField(
                         enabled: !updatingText,
                         controller: controller,
-                        decoration: const InputDecoration(
-                          enabledBorder: OutlineInputBorder(
+                        decoration: InputDecoration(
+                          fillColor: Colors.white.withOpacity(0.2),
+                          filled: true,
+                          enabledBorder: const OutlineInputBorder(
                             borderRadius: ANGULAR_BORDER_RADIUS,
                           ),
                         ),


### PR DESCRIPTION
### What
<!-- description of the PR -->
- Changed the background color of the texfield to white with 0.5 opacity, won't have any effect in light mode as the backgrround is already white 

### Screenshot
![image](https://user-images.githubusercontent.com/57723319/177045125-043b631f-0a3f-48f7-ba42-fe78fb5e143b.png)

### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes: #2473 
