### PR TITLE
fix: Make the product page action row top aligned solved ✅

### DIFF
--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -277,7 +277,7 @@ class _ProductPageState extends State<ProductPage> with TraceableClientMixin {
         padding: const EdgeInsets.all(SMALL_SPACE),
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceAround,
-          crossAxisAlignment: CrossAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
             _buildActionBarItem(
               Icons.bookmark_border,


### PR DESCRIPTION
### What
<!-- description of the PR -->
- Product page action row top aligned 

### Screenshot
![Simulator Screen Shot - iPhone 13 Pro Max - 2022-07-04 at 16 51 17](https://user-images.githubusercontent.com/107627043/177149783-0b7bec57-4b54-4d37-b430-230eb3745e86.png)
### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://github.com/openfoodfacts/smooth-app/issues/2490#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes: #2490
### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/525
<!-- please be as granular as possible -->
