### PR TITLE
fix: Ensure ripples are drawn above cards

### DIFF
--- a/packages/smooth_app/lib/cards/data_cards/score_card.dart
+++ b/packages/smooth_app/lib/cards/data_cards/score_card.dart
@@ -21,12 +21,14 @@ class ScoreCard extends StatelessWidget {
     required this.cardEvaluation,
     required this.isClickable,
     this.iconUrl,
+    this.margin,
   });
 
   final String? iconUrl;
   final String description;
   final CardEvaluation cardEvaluation;
   final bool isClickable;
+  final EdgeInsetsGeometry? margin;
 
   @override
   Widget build(BuildContext context) {
@@ -42,35 +44,38 @@ class ScoreCard extends StatelessWidget {
         : getTextColor(cardEvaluation).withOpacity(opacity);
     final SvgIconChip? iconChip =
         iconUrl == null ? null : SvgIconChip(iconUrl!, height: iconHeight);
-    return Container(
-      margin: const EdgeInsets.symmetric(vertical: 8.0),
-      padding: const EdgeInsets.all(8.0),
-      decoration: BoxDecoration(
-        color: backgroundColor,
-        borderRadius: ANGULAR_BORDER_RADIUS,
-      ),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: <Widget>[
-          if (iconChip != null)
+
+    return Padding(
+      padding: margin ?? const EdgeInsets.symmetric(vertical: SMALL_SPACE),
+      child: Ink(
+        padding: const EdgeInsets.all(SMALL_SPACE),
+        decoration: BoxDecoration(
+          color: backgroundColor,
+          borderRadius: ANGULAR_BORDER_RADIUS,
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: <Widget>[
+            if (iconChip != null)
+              Expanded(
+                flex: 1,
+                child: Padding(
+                  padding: const EdgeInsets.only(right: 8.0),
+                  child: iconChip,
+                ),
+              ),
             Expanded(
-              flex: 1,
-              child: Padding(
-                padding: const EdgeInsets.only(right: 8.0),
-                child: iconChip,
+              flex: 3,
+              child: Center(
+                child: Text(
+                  description,
+                  style: themeData.textTheme.headline4!.apply(color: textColor),
+                ),
               ),
             ),
-          Expanded(
-            flex: 3,
-            child: Center(
-              child: Text(
-                description,
-                style: themeData.textTheme.headline4!.apply(color: textColor),
-              ),
-            ),
-          ),
-          if (isClickable) Icon(ConstantIcons.instance.getForwardIcon()),
-        ],
+            if (isClickable) Icon(ConstantIcons.instance.getForwardIcon()),
+          ],
+        ),
       ),
     );
   }

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
@@ -58,7 +58,8 @@ class SmoothProductCardFound extends StatelessWidget {
     );
     final ProductCompatibilityHelper helper =
         ProductCompatibilityHelper.product(matchedProduct);
-    return GestureDetector(
+    return InkWell(
+      borderRadius: ROUNDED_BORDER_RADIUS,
       onTap: onTap ??
           () async {
             await Navigator.push<Widget>(
@@ -73,70 +74,79 @@ class SmoothProductCardFound extends StatelessWidget {
       },
       child: Hero(
         tag: heroTag,
-        child: SmoothCard(
-          elevation: elevation,
-          color: backgroundColor,
-          padding: const EdgeInsets.all(VERY_SMALL_SPACE),
-          child: Row(
-            children: <Widget>[
-              SmoothProductImage(
-                product: product,
-                width: screenSize.width * 0.20,
-                height: screenSize.width * 0.20,
-              ),
-              const Padding(padding: EdgeInsets.only(left: VERY_SMALL_SPACE)),
-              Expanded(
-                child: SizedBox(
-                  height: screenSize.width * 0.2,
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: <Widget>[
-                      Text(
-                        getProductName(product, appLocalizations),
-                        overflow: TextOverflow.ellipsis,
-                        style: themeData.textTheme.headline4,
-                      ),
-                      Text(
-                        product.brands ?? appLocalizations.unknownBrand,
-                        overflow: TextOverflow.ellipsis,
-                        style: themeData.textTheme.subtitle1,
-                      ),
-                      Row(
-                        children: <Widget>[
-                          Icon(
-                            Icons.circle,
-                            size: 15,
-                            color: helper.getButtonColor(isDarkMode),
-                          ),
-                          const Padding(
-                              padding: EdgeInsets.only(left: VERY_SMALL_SPACE)),
-                          Expanded(
-                            child: FittedBox(
-                              fit: BoxFit.scaleDown,
-                              alignment: AlignmentDirectional.centerStart,
-                              child: Text(
-                                helper.getSubtitle(appLocalizations),
-                                style: themeData.textTheme.bodyText2!.apply(
-                                    color: helper
-                                        .getButtonForegroundColor(isDarkMode)),
+        child: Ink(
+          decoration: BoxDecoration(
+            borderRadius: ROUNDED_BORDER_RADIUS,
+            color: Theme.of(context).brightness == Brightness.light
+                ? Colors.white
+                : Colors.black,
+          ),
+          child: SmoothCard(
+            elevation: elevation,
+            color: Colors.transparent,
+            padding: const EdgeInsets.all(VERY_SMALL_SPACE),
+            child: Row(
+              children: <Widget>[
+                SmoothProductImage(
+                  product: product,
+                  width: screenSize.width * 0.20,
+                  height: screenSize.width * 0.20,
+                ),
+                const Padding(padding: EdgeInsets.only(left: VERY_SMALL_SPACE)),
+                Expanded(
+                  child: SizedBox(
+                    height: screenSize.width * 0.2,
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        Text(
+                          getProductName(product, appLocalizations),
+                          overflow: TextOverflow.ellipsis,
+                          style: themeData.textTheme.headline4,
+                        ),
+                        Text(
+                          product.brands ?? appLocalizations.unknownBrand,
+                          overflow: TextOverflow.ellipsis,
+                          style: themeData.textTheme.subtitle1,
+                        ),
+                        Row(
+                          children: <Widget>[
+                            Icon(
+                              Icons.circle,
+                              size: 15,
+                              color: helper.getButtonColor(isDarkMode),
+                            ),
+                            const Padding(
+                                padding:
+                                    EdgeInsets.only(left: VERY_SMALL_SPACE)),
+                            Expanded(
+                              child: FittedBox(
+                                fit: BoxFit.scaleDown,
+                                alignment: AlignmentDirectional.centerStart,
+                                child: Text(
+                                  helper.getSubtitle(appLocalizations),
+                                  style: themeData.textTheme.bodyText2!.apply(
+                                      color: helper.getButtonForegroundColor(
+                                          isDarkMode)),
+                                ),
                               ),
                             ),
-                          ),
-                        ],
-                      ),
-                    ],
+                          ],
+                        ),
+                      ],
+                    ),
                   ),
                 ),
-              ),
-              const Padding(padding: EdgeInsets.only(left: VERY_SMALL_SPACE)),
-              Padding(
-                padding: const EdgeInsets.all(VERY_SMALL_SPACE),
-                child: Column(
-                  children: scores,
+                const Padding(padding: EdgeInsets.only(left: VERY_SMALL_SPACE)),
+                Padding(
+                  padding: const EdgeInsets.all(VERY_SMALL_SPACE),
+                  child: Column(
+                    children: scores,
+                  ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_card.dart
@@ -3,6 +3,7 @@ import 'package:openfoodfacts/model/KnowledgePanel.dart';
 import 'package:openfoodfacts/model/KnowledgePanelElement.dart';
 import 'package:openfoodfacts/model/KnowledgePanels.dart';
 import 'package:openfoodfacts/model/Product.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_expanded_card.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_group_card.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_page.dart';
@@ -33,24 +34,29 @@ class KnowledgePanelCard extends StatelessWidget {
     final KnowledgePanelPanelGroupElement? group =
         KnowledgePanelGroupCard.groupElementOf(context);
 
-    return InkWell(
-      child: KnowledgePanelSummaryCard(
-        panel,
-        isClickable: true,
-      ),
-      onTap: () {
-        Navigator.push<Widget>(
-          context,
-          MaterialPageRoute<Widget>(
-            builder: (BuildContext context) => KnowledgePanelPage(
-              groupElement: group,
-              panel: panel,
-              allPanels: allPanels,
-              product: product,
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: SMALL_SPACE),
+      child: InkWell(
+        borderRadius: ANGULAR_BORDER_RADIUS,
+        child: KnowledgePanelSummaryCard(
+          panel,
+          isClickable: true,
+          margin: EdgeInsets.zero,
+        ),
+        onTap: () {
+          Navigator.push<Widget>(
+            context,
+            MaterialPageRoute<Widget>(
+              builder: (BuildContext context) => KnowledgePanelPage(
+                groupElement: group,
+                panel: panel,
+                allPanels: allPanels,
+                product: product,
+              ),
             ),
-          ),
-        );
-      },
+          );
+        },
+      ),
     );
   }
 }

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_summary_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_summary_card.dart
@@ -9,10 +9,12 @@ class KnowledgePanelSummaryCard extends StatelessWidget {
   const KnowledgePanelSummaryCard(
     this.knowledgePanel, {
     required this.isClickable,
+    this.margin,
   });
 
   final KnowledgePanel knowledgePanel;
   final bool isClickable;
+  final EdgeInsets? margin;
 
   @override
   Widget build(BuildContext context) {
@@ -31,6 +33,7 @@ class KnowledgePanelSummaryCard extends StatelessWidget {
                 knowledgePanel.titleElement!,
               ),
               isClickable: isClickable,
+              margin: margin,
             ),
           ],
         );

--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -356,16 +356,21 @@ class _SummaryCardState extends State<SummaryCard> {
     for (final Attribute attribute in scoreAttributes) {
       if (widget.isFullVersion) {
         attributes.add(
-          InkWell(
-            onTap: () async => openFullKnowledgePanel(
-              attribute: attribute,
-            ),
-            child: ScoreCard(
-              iconUrl: attribute.iconUrl,
-              description:
-                  attribute.descriptionShort ?? attribute.description ?? '',
-              cardEvaluation: getCardEvaluationFromAttribute(attribute),
-              isClickable: true,
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: SMALL_SPACE),
+            child: InkWell(
+              borderRadius: ANGULAR_BORDER_RADIUS,
+              onTap: () async => openFullKnowledgePanel(
+                attribute: attribute,
+              ),
+              child: ScoreCard(
+                iconUrl: attribute.iconUrl,
+                description:
+                    attribute.descriptionShort ?? attribute.description ?? '',
+                cardEvaluation: getCardEvaluationFromAttribute(attribute),
+                isClickable: true,
+                margin: EdgeInsets.zero,
+              ),
             ),
           ),
         );


### PR DESCRIPTION
When hovering cards, a Ripple (or InkWell) should be draw above the content, not below.
Here is the new behavior:

https://user-images.githubusercontent.com/246838/177206553-d523ccab-bbde-4ece-982f-041b4a795021.mp4

 