### PR TITLE
feat: use gzip to compress the json data for product

### DIFF
--- a/packages/smooth_app/lib/database/dao_product.dart
+++ b/packages/smooth_app/lib/database/dao_product.dart
@@ -129,10 +129,10 @@ class DaoProduct extends AbstractSqlDao implements BulkDeletable {
   String getTableName() => TABLE_PRODUCT;
 
   Product _getProductFromQueryResult(final Map<String, dynamic> row) {
-    /// First we try to uncompress the data (if it's compressed) to get the JSON
-    /// object. If it fails, i.e throws the exception, we use the raw data.
-    /// This is a workaround so that the previous data that might have been stored
-    /// in the database without being compressed is still usable.
+    // First we try to uncompress the data (if it's compressed) to get the JSON
+    // object. If it fails, i.e throws the exception, we use the raw data.
+    // This is a workaround so that the previous data that might have been stored
+    // in the database without being compressed is still usable.
     try {
       final List<int> compressed = row[_TABLE_PRODUCT_COLUMN_JSON] as List<int>;
       final Map<String, dynamic> decodedJson = json


### PR DESCRIPTION
### What
<!-- description of the PR -->
- Used gzip to compress the json before storing to sqf lite
-  Extra care taken to ensure that the `old uncompressed data` is still readable to the end user 
- More details here https://github.com/openfoodfacts/smooth-app/issues/2447#issuecomment-1174622060


### Fixes bug(s)
<!-- change by appropriate issues. -->
#2447 


### Part of 
- https://github.com/orgs/openfoodfacts/projects/33