### PR TITLE
fix: Layout issue with product title card

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/product_title_card.dart
+++ b/packages/smooth_app/lib/cards/product_cards/product_title_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/model/Product.dart';
+import 'package:provider/provider.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/helpers/extension_on_text_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
@@ -23,16 +24,128 @@ class ProductTitleCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    return Provider<Product>.value(
+      value: product,
+      child: Align(
+        alignment: AlignmentDirectional.topStart,
+        child: InkWell(
+          onTap: _hasProductName
+              ? () async {
+                  await Navigator.push<Product?>(
+                    context,
+                    MaterialPageRoute<Product>(
+                      builder: (BuildContext context) =>
+                          AddBasicDetailsPage(product),
+                    ),
+                  );
+                }
+              : null,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Expanded(
+                    child: _ProductTitleCardName(
+                      selectable: isSelectable,
+                    ),
+                  ),
+                  Expanded(
+                    child: _ProductTitleCardTrailing(
+                      removable: isRemovable,
+                      selectable: isSelectable,
+                      onRemove: onRemove,
+                    ),
+                  )
+                ],
+              ),
+              _ProductTitleCardBrand(
+                removable: isRemovable,
+                selectable: isSelectable,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  bool get _hasProductName => product.productName != null;
+}
+
+class _ProductTitleCardName extends StatelessWidget {
+  const _ProductTitleCardName({
+    required this.selectable,
+  });
+
+  final bool selectable;
+
+  @override
+  Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    final ThemeData themeData = Theme.of(context);
-    final String subtitleText;
-    final Widget trailingWidget;
-    final String brands = getProductBrands(product, appLocalizations);
+    final Product product = context.read<Product>();
+
+    return Text(
+      getProductName(product, appLocalizations),
+      style: Theme.of(context).textTheme.headline4,
+      textAlign: TextAlign.start,
+    ).selectable(isSelectable: selectable);
+  }
+}
+
+class _ProductTitleCardBrand extends StatelessWidget {
+  const _ProductTitleCardBrand({
+    required this.selectable,
+    required this.removable,
+  });
+
+  final bool selectable;
+  final bool removable;
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final Product product = context.read<Product>();
+
+    final String brands = product.brands ?? appLocalizations.unknownBrand;
     final String quantity = product.quantity ?? '';
 
-    if (isRemovable && !isSelectable) {
+    final String subtitleText;
+
+    if (removable && !selectable) {
       subtitleText = '$brands${quantity == '' ? '' : ', $quantity'}';
-      trailingWidget = InkWell(
+    } else {
+      subtitleText = brands;
+    }
+
+    return Text(
+      subtitleText,
+      style: Theme.of(context).textTheme.bodyText2,
+      textAlign: TextAlign.start,
+    ).selectable(isSelectable: selectable);
+  }
+}
+
+class _ProductTitleCardTrailing extends StatelessWidget {
+  const _ProductTitleCardTrailing({
+    required this.selectable,
+    required this.removable,
+    required this.onRemove,
+  });
+
+  final bool selectable;
+  final bool removable;
+  final OnRemoveCallback? onRemove;
+
+  @override
+  Widget build(BuildContext context) {
+    final Product product = context.read<Product>();
+
+    if (removable && !selectable) {
+      final AppLocalizations appLocalizations = AppLocalizations.of(context);
+
+      return InkWell(
         customBorder: const CircleBorder(),
         onTap: () => onRemove?.call(context),
         child: Tooltip(
@@ -47,41 +160,12 @@ class ProductTitleCard extends StatelessWidget {
         ),
       );
     } else {
-      subtitleText = brands;
-      trailingWidget = Text(
-        quantity,
-        style: themeData.textTheme.headline3,
-      ).selectable(isSelectable: isSelectable);
+      return Text(
+        product.quantity ?? '',
+        style: Theme.of(context).textTheme.headline3,
+        textAlign: TextAlign.end,
+      ).selectable(isSelectable: selectable);
     }
-    return Align(
-      alignment: AlignmentDirectional.topStart,
-      child: InkWell(
-        onTap: (getProductName(product, appLocalizations) ==
-                appLocalizations.unknownProductName)
-            ? () async {
-                await Navigator.push<void>(
-                  context,
-                  MaterialPageRoute<void>(
-                    builder: (BuildContext context) =>
-                        AddBasicDetailsPage(product),
-                  ),
-                );
-              }
-            : null,
-        child: ListTile(
-          dense: dense,
-          contentPadding: EdgeInsets.zero,
-          title: Text(
-            getProductName(product, appLocalizations),
-            style: themeData.textTheme.headline4,
-          ).selectable(isSelectable: isSelectable),
-          subtitle: Text(
-            subtitleText,
-          ).selectable(isSelectable: isSelectable),
-          trailing: trailingWidget,
-        ),
-      ),
-    );
   }
 }
 

--- a/packages/smooth_app/lib/helpers/extension_on_text_helper.dart
+++ b/packages/smooth_app/lib/helpers/extension_on_text_helper.dart
@@ -6,6 +6,11 @@ extension Selectable on Text {
         ? SelectableText(
             data!,
             style: style,
+            strutStyle: strutStyle,
+            textDirection: textDirection,
+            textScaleFactor: textScaleFactor,
+            textAlign: textAlign,
+            maxLines: maxLines,
             toolbarOptions: const ToolbarOptions(
               copy: true,
               selectAll: true,
@@ -14,6 +19,11 @@ extension Selectable on Text {
         : Text(
             data!,
             style: style,
+            strutStyle: strutStyle,
+            textDirection: textDirection,
+            textScaleFactor: textScaleFactor,
+            textAlign: textAlign,
+            maxLines: maxLines,
           );
   }
 }


### PR DESCRIPTION
Fixed UI:
![Screenshot_1657174966](https://user-images.githubusercontent.com/246838/177706381-98630818-ed20-45a7-8043-828952f7ce53.png)

My PR not only consists of fixing the layout issue mentioned in #2488, but also:
- Splits the three items of the title Card into three different Widgets (a bad behavior that we should fix in the app)
- Adds some missing attributes to the `SelectableText` Widget