### PR TITLE
feat: #2447 - gzipped product column - 6 times smaller database!

### DIFF
--- a/packages/smooth_app/lib/database/dao_hive_product.dart
+++ b/packages/smooth_app/lib/database/dao_hive_product.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:hive/hive.dart';
 import 'package:openfoodfacts/model/Product.dart';
 import 'package:smooth_app/database/abstract_dao.dart';
+import 'package:smooth_app/database/dao_product_migration.dart';
 import 'package:smooth_app/database/local_database.dart';
 
 /// Hive type adapter for [Product]
@@ -22,7 +23,7 @@ class _ProductAdapter extends TypeAdapter<Product> {
 // TODO(monsieurtanuki): remove when old enough (today is 2022-06-16)
 /// Where we store the products as "barcode => product".
 @Deprecated('use [DaoProduct] instead')
-class DaoHiveProduct extends AbstractDao {
+class DaoHiveProduct extends AbstractDao implements DaoProductMigrationSource {
   @Deprecated('use [DaoProduct] instead')
   DaoHiveProduct(final LocalDatabase localDatabase) : super(localDatabase);
 
@@ -38,6 +39,7 @@ class DaoHiveProduct extends AbstractDao {
 
   Future<Product?> get(final String barcode) async => _getBox().get(barcode);
 
+  @override
   Future<Map<String, Product>> getAll(final List<String> barcodes) async {
     final LazyBox<Product> box = _getBox();
     final Map<String, Product> result = <String, Product>{};
@@ -60,6 +62,7 @@ class DaoHiveProduct extends AbstractDao {
     await _getBox().putAll(upserts);
   }
 
+  @override
   Future<List<String>> getAllKeys() async {
     final LazyBox<Product> box = _getBox();
     final List<String> result = <String>[];
@@ -70,6 +73,7 @@ class DaoHiveProduct extends AbstractDao {
   }
 
   // Just for the migration
+  @override
   Future<void> deleteAll(final List<String> barcodes) async {
     final LazyBox<Product> box = _getBox();
     await box.deleteAll(barcodes);

--- a/packages/smooth_app/lib/database/dao_product_migration.dart
+++ b/packages/smooth_app/lib/database/dao_product_migration.dart
@@ -1,0 +1,55 @@
+import 'package:openfoodfacts/model/Product.dart';
+
+/// Helper around product data migration.
+abstract class DaoProductMigration {
+  Future<List<String>> getAllKeys();
+
+  /// Migrates product data from a [source] to a [destination].
+  ///
+  /// Will empty the source in the end if successful.
+  static Future<void> migrate({
+    required final DaoProductMigrationSource source,
+    required final DaoProductMigrationDestination destination,
+  }) async {
+    final List<String> barcodesFrom = await source.getAllKeys();
+    if (barcodesFrom.isEmpty) {
+      // nothing to migrate, or already migrated and cleaned.
+      return;
+    }
+
+    final List<String> barcodesAlreadyThere = await destination.getAllKeys();
+
+    final List<String> barcodesToBeCopied = List<String>.from(barcodesFrom);
+    barcodesToBeCopied.removeWhere(
+        (final String barcode) => barcodesAlreadyThere.contains(barcode));
+
+    if (barcodesToBeCopied.isNotEmpty) {
+      final Map<String, Product> copiedProducts =
+          await source.getAll(barcodesToBeCopied);
+      await destination.putAll(copiedProducts.values);
+      final List<String> barcodesFinallyThere = await destination.getAllKeys();
+      if (barcodesFinallyThere.length !=
+          barcodesAlreadyThere.length + barcodesToBeCopied.length) {
+        throw Exception('Unexpected difference between counts');
+      }
+    }
+
+    // cleaning the old product table
+    await source.deleteAll(barcodesFrom);
+    final List<String> barcodesNoMore = await source.getAllKeys();
+    if (barcodesNoMore.isNotEmpty) {
+      throw Exception('Unexpected not empty source');
+    }
+  }
+}
+
+/// Source of a dao product migration.
+abstract class DaoProductMigrationSource implements DaoProductMigration {
+  Future<Map<String, Product>> getAll(final List<String> barcodes);
+  Future<void> deleteAll(final List<String> barcodes);
+}
+
+/// Destination of a dao product migration.
+abstract class DaoProductMigrationDestination implements DaoProductMigration {
+  Future<void> putAll(final Iterable<Product> products);
+}

--- a/packages/smooth_app/lib/database/dao_unzipped_product.dart
+++ b/packages/smooth_app/lib/database/dao_unzipped_product.dart
@@ -1,9 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 import 'dart:math';
-import 'dart:typed_data';
-import 'package:flutter/rendering.dart';
 import 'package:openfoodfacts/model/Product.dart';
 import 'package:smooth_app/database/abstract_sql_dao.dart';
 import 'package:smooth_app/database/bulk_deletable.dart';
@@ -12,27 +9,30 @@ import 'package:smooth_app/database/dao_product_migration.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:sqflite/sqflite.dart';
 
-class DaoProduct extends AbstractSqlDao
-    implements BulkDeletable, DaoProductMigrationDestination {
-  DaoProduct(final LocalDatabase localDatabase) : super(localDatabase);
+// TODO(monsieurtanuki): remove when old enough (today is 2022-07-07)
+@Deprecated('use [DaoProduct] instead')
+class DaoUnzippedProduct extends AbstractSqlDao
+    implements
+        BulkDeletable,
+        DaoProductMigrationSource,
+        DaoProductMigrationDestination {
+  @Deprecated('use [DaoProduct] instead')
+  DaoUnzippedProduct(final LocalDatabase localDatabase) : super(localDatabase);
 
-  static const String _TABLE_PRODUCT = 'gzipped_product';
+  static const String _TABLE_PRODUCT = 'product';
   static const String _TABLE_PRODUCT_COLUMN_BARCODE = 'barcode';
-  static const String _TABLE_PRODUCT_COLUMN_GZIPPED_JSON =
-      'encoded_gzipped_json';
-  static const String _TABLE_PRODUCT_COLUMN_LAST_UPDATE = 'last_update';
+  static const String _TABLE_PRODUCT_COLUMN_JSON = 'encoded_json';
 
   static FutureOr<void> onUpgrade(
     final Database db,
     final int oldVersion,
     final int newVersion,
   ) async {
-    if (oldVersion < 2) {
+    if (oldVersion < 1) {
       await db.execute('create table $_TABLE_PRODUCT('
           // cf. https://www.sqlite.org/lang_conflict.html
           '$_TABLE_PRODUCT_COLUMN_BARCODE TEXT PRIMARY KEY on conflict replace'
-          ',$_TABLE_PRODUCT_COLUMN_GZIPPED_JSON BLOB NOT NULL'
-          ',$_TABLE_PRODUCT_COLUMN_LAST_UPDATE INT NOT NULL'
+          ',$_TABLE_PRODUCT_COLUMN_JSON TEXT NOT NULL'
           ')');
     }
   }
@@ -42,6 +42,7 @@ class DaoProduct extends AbstractSqlDao
     return map[barcode];
   }
 
+  @override
   Future<Map<String, Product>> getAll(final List<String> barcodes) async {
     final Map<String, Product> result = <String, Product>{};
     if (barcodes.isEmpty) {
@@ -59,8 +60,7 @@ class DaoProduct extends AbstractSqlDao
         _TABLE_PRODUCT,
         columns: <String>[
           _TABLE_PRODUCT_COLUMN_BARCODE,
-          _TABLE_PRODUCT_COLUMN_GZIPPED_JSON,
-          _TABLE_PRODUCT_COLUMN_LAST_UPDATE,
+          _TABLE_PRODUCT_COLUMN_JSON,
         ],
         where: '$_TABLE_PRODUCT_COLUMN_BARCODE in(? ${',?' * (size - 1)})',
         whereArgs: barcodes.sublist(start, start + size),
@@ -113,17 +113,11 @@ class DaoProduct extends AbstractSqlDao
     final DatabaseExecutor databaseExecutor,
     final Iterable<Product> products,
   ) async {
-    final int lastUpdate = LocalDatabase.nowInMillis();
     final BulkManager bulkManager = BulkManager();
     final List<dynamic> insertParameters = <dynamic>[];
     for (final Product product in products) {
       insertParameters.add(product.barcode);
-      insertParameters.add(
-        Uint8List.fromList(
-          gzip.encode(utf8.encode(jsonEncode(product.toJson()))),
-        ),
-      );
-      insertParameters.add(lastUpdate);
+      insertParameters.add(json.encode(product.toJson()));
     }
     await bulkManager.insert(
       bulkInsertable: this,
@@ -135,8 +129,7 @@ class DaoProduct extends AbstractSqlDao
   @override
   List<String> getInsertColumns() => <String>[
         _TABLE_PRODUCT_COLUMN_BARCODE,
-        _TABLE_PRODUCT_COLUMN_GZIPPED_JSON,
-        _TABLE_PRODUCT_COLUMN_LAST_UPDATE,
+        _TABLE_PRODUCT_COLUMN_JSON,
       ];
 
   @override
@@ -147,50 +140,21 @@ class DaoProduct extends AbstractSqlDao
   String getTableName() => _TABLE_PRODUCT;
 
   Product _getProductFromQueryResult(final Map<String, dynamic> row) {
-    final Uint8List compressed =
-        row[_TABLE_PRODUCT_COLUMN_GZIPPED_JSON] as Uint8List;
-    final String encodedJson = utf8.decode(gzip.decode(compressed.toList()));
+    final String encodedJson = row[_TABLE_PRODUCT_COLUMN_JSON] as String;
     final Map<String, dynamic> decodedJson =
         json.decode(encodedJson) as Map<String, dynamic>;
     return Product.fromJson(decodedJson);
   }
 
-  /// For developers with stats in mind only.
-  Future<void> printStats({final bool verbose = false}) async {
-    final List<String> barcodes = await getAllKeys();
-    debugPrint('number of barcodes: ${barcodes.length}');
-    final Map<String, Product> map = await getAll(barcodes);
-    int jsonLength = 0;
-    for (final Product product in map.values) {
-      jsonLength += utf8.encode(jsonEncode(product.toJson())).length;
-    }
-    debugPrint('json length: $jsonLength');
-    final int gzippedLength = Sqflite.firstIntValue(
-      await localDatabase.database.rawQuery(
-        'select sum(length($_TABLE_PRODUCT_COLUMN_GZIPPED_JSON))'
-        ' from $_TABLE_PRODUCT',
+  @override
+  Future<void> deleteAll(final List<String> barcodes) async {
+    final BulkManager bulkManager = BulkManager();
+    localDatabase.database.transaction(
+      (final Transaction transaction) async => bulkManager.delete(
+        bulkDeletable: this,
+        parameters: barcodes,
+        databaseExecutor: transaction,
       ),
-    )!;
-    debugPrint('gzipped length: $gzippedLength');
-    if (!verbose) {
-      return;
-    }
-    final List<Map<String, dynamic>> queryResults =
-        await localDatabase.database.rawQuery(
-      'select'
-      ' $_TABLE_PRODUCT_COLUMN_BARCODE'
-      ', length($_TABLE_PRODUCT_COLUMN_GZIPPED_JSON) as mylength'
-      ' from $_TABLE_PRODUCT',
     );
-    debugPrint('Product by product');
-    debugPrint('barcode;gzipped;string;factor');
-    for (final Map<String, dynamic> row in queryResults) {
-      final String barcode = row[_TABLE_PRODUCT_COLUMN_BARCODE] as String;
-      final int asString =
-          utf8.encode(jsonEncode(map[barcode]!.toJson())).length;
-      final int asZipped = row['mylength'] as int;
-      final double factor = (asString * 1.0) / asZipped;
-      debugPrint('$barcode;$asZipped;$asString;$factor');
-    }
   }
 }


### PR DESCRIPTION
New files:
* `dao_product_migration.dart`: Helpers around product data migration.
* `dao_unzipped_product.dart`: used to be `DaoProduct` - the old not zipped version; fixed `getAll` for big lists

Impacted files:
* `dao_hive_product.dart`: minor refactoring as `DaoProductMigrationSource`
* `dao_product.dart`: new table with zipped BLOB column as product and last update timestamp
* `local_database.dart`: now it's version 2 of sql database (new zipped product table); migration from old unzipped to new zipped product table; refactored around `DaoProductMigration`

### What
- Based on @AshAman999's #2524.
- No we store the product data in a gzipped BLOB field, in order to save space. We also maintain a "database last update" timestamp for each product.
- On the 251 products I had on my app, with the gzip operation we go from 44Kb to 7Kb per product, which is a factor similar to what was already found.
- We are talking about an old and a new product table, with automatic migration included. If the migration is successful the old table is emptied.

### Fixes bug(s)
- Closes: #2447