### PR TITLE
feat: #2563 - edit product page - added top barcode display and leading/trailing icons

### DIFF
--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -1,4 +1,5 @@
 import 'package:auto_size_text/auto_size_text.dart';
+import 'package:barcode_widget/barcode_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
@@ -6,6 +7,7 @@ import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/product_image_data.dart';
 import 'package:smooth_app/data_models/up_to_date_product_provider.dart';
 import 'package:smooth_app/database/local_database.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/pages/product/add_basic_details_page.dart';
 import 'package:smooth_app/pages/product/common/product_refresher.dart';
@@ -17,6 +19,7 @@ import 'package:smooth_app/pages/product/ordered_nutrients_cache.dart';
 import 'package:smooth_app/pages/product/product_image_gallery_view.dart';
 import 'package:smooth_app/pages/product/simple_input_page.dart';
 import 'package:smooth_app/pages/product/simple_input_page_helpers.dart';
+import 'package:smooth_app/themes/constant_icons.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
 /// Page where we can indirectly edit all data about a product.
@@ -41,6 +44,7 @@ class _EditProductPageState extends State<EditProductPage> {
   @override
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final Size screenSize = MediaQuery.of(context).size;
 
     final Scaffold scaffold = SmoothScaffold(
         appBar: AppBar(
@@ -51,13 +55,22 @@ class _EditProductPageState extends State<EditProductPage> {
         ),
         body: ListView(
           children: <Widget>[
-            ListTile(
-              title: Text(
-                appLocalizations.edit_product_form_item_barcode,
+            if (_product.barcode != null)
+              BarcodeWidget(
+                padding: EdgeInsets.symmetric(
+                  horizontal: screenSize.width / 4,
+                  vertical: SMALL_SPACE,
+                ),
+                barcode: Barcode.ean13(),
+                data: _product.barcode!,
+                errorBuilder: (final BuildContext context, String? _) =>
+                    ListTile(
+                  title: Text(
+                    appLocalizations.edit_product_form_item_barcode,
+                  ),
+                  subtitle: Text(_product.barcode!),
+                ),
               ),
-              subtitle:
-                  _product.barcode == null ? null : Text(_product.barcode!),
-            ),
             _ListTitleItem(
               title: appLocalizations.edit_product_form_item_details_title,
               subtitle:
@@ -76,6 +89,7 @@ class _EditProductPageState extends State<EditProductPage> {
               },
             ),
             _ListTitleItem(
+              leading: const Icon(Icons.add_a_photo_outlined),
               title: appLocalizations.edit_product_form_item_photos_title,
               subtitle: appLocalizations.edit_product_form_item_photos_subtitle,
               onTap: () async {
@@ -199,6 +213,7 @@ class _EditProductPageState extends State<EditProductPage> {
   Widget _getSimpleListTileItem(final AbstractSimpleInputPageHelper helper) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     return _ListTitleItem(
+      leading: helper.getIcon(),
       title: helper.getTitle(appLocalizations),
       subtitle: helper.getSubtitle(appLocalizations),
       onTap: () async {
@@ -224,24 +239,23 @@ class _ListTitleItem extends StatelessWidget {
     required final this.title,
     this.subtitle,
     this.onTap,
+    this.leading,
     Key? key,
   }) : super(key: key);
 
   final String title;
   final String? subtitle;
   final VoidCallback? onTap;
+  final Widget? leading;
 
   @override
-  Widget build(BuildContext context) {
-    final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    return ListTile(
-      onTap: onTap,
-      title: Text(title),
-      subtitle: subtitle == null ? null : Text(subtitle!),
-      leading: ElevatedButton(
-        onPressed: onTap,
-        child: Text(appLocalizations.edit_product_form_save),
-      ),
-    );
-  }
+  Widget build(BuildContext context) => Card(
+        child: ListTile(
+          onTap: onTap,
+          title: Text(title),
+          subtitle: subtitle == null ? null : Text(subtitle!),
+          leading: leading ?? const Icon(Icons.edit),
+          trailing: Icon(ConstantIcons.instance.getForwardIcon()),
+        ),
+      );
 }

--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -145,6 +145,7 @@ class _EditProductPageState extends State<EditProductPage> {
               },
             ),
             _ListTitleItem(
+              leading: const Icon(Icons.recycling),
               title: appLocalizations.edit_product_form_item_packaging_title,
               onTap: () async {
                 if (!await ProductRefresher().checkIfLoggedIn(context)) {

--- a/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
@@ -127,7 +127,7 @@ class SimpleInputPageStoreHelper extends AbstractSimpleInputPageHelper {
   TagType? getTagType() => null;
 
   @override
-  Widget? getIcon() => const Icon(Icons.shopping_cart_rounded);
+  Widget? getIcon() => const Icon(Icons.shopping_cart);
 }
 
 /// Implementation for "Emb Code" of an [AbstractSimpleInputPageHelper].
@@ -153,6 +153,9 @@ class SimpleInputPageEmbCodeHelper extends AbstractSimpleInputPageHelper {
 
   @override
   TagType? getTagType() => TagType.EMB_CODES;
+
+  @override
+  Widget? getIcon() => const Icon(Icons.factory);
 }
 
 /// Abstraction, for "in language" field, of an [AbstractSimpleInputPageHelper].
@@ -243,7 +246,7 @@ class SimpleInputPageLabelHelper
   TagType? getTagType() => TagType.LABELS;
 
   @override
-  Widget? getIcon() => const Icon(Icons.label);
+  Widget? getIcon() => const Icon(Icons.local_offer);
 }
 
 /// Implementation for "Categories" of an [AbstractSimpleInputPageHelper].
@@ -270,6 +273,9 @@ class SimpleInputPageCategoryHelper
 
   @override
   TagType? getTagType() => TagType.CATEGORIES;
+
+  @override
+  Widget? getIcon() => const Icon(Icons.restaurant);
 }
 
 /// Implementation for "Countries" of an [AbstractSimpleInputPageHelper].

--- a/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
@@ -80,6 +80,9 @@ abstract class AbstractSimpleInputPageHelper {
   /// Returns the tag type for autocomplete suggestions.
   TagType? getTagType();
 
+  /// Returns the icon data for the list tile.
+  Widget? getIcon() => null;
+
   /// Returns null is no change was made, or a Product to be saved on the BE.
   Product? getChangedProduct() {
     if (!_changed) {
@@ -122,6 +125,9 @@ class SimpleInputPageStoreHelper extends AbstractSimpleInputPageHelper {
 
   @override
   TagType? getTagType() => null;
+
+  @override
+  Widget? getIcon() => const Icon(Icons.shopping_cart_rounded);
 }
 
 /// Implementation for "Emb Code" of an [AbstractSimpleInputPageHelper].
@@ -235,6 +241,9 @@ class SimpleInputPageLabelHelper
 
   @override
   TagType? getTagType() => TagType.LABELS;
+
+  @override
+  Widget? getIcon() => const Icon(Icons.label);
 }
 
 /// Implementation for "Categories" of an [AbstractSimpleInputPageHelper].
@@ -291,4 +300,7 @@ class SimpleInputPageCountryHelper
 
   @override
   TagType? getTagType() => TagType.COUNTRIES;
+
+  @override
+  Widget? getIcon() => const Icon(Icons.public);
 }

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -92,6 +92,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.0"
+  barcode:
+    dependency: transitive
+    description:
+      name: barcode
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.2.1"
+  barcode_widget:
+    dependency: "direct main"
+    description:
+      name: barcode_widget
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -991,6 +1005,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.1"
+  qr:
+    dependency: transitive
+    description:
+      name: qr
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.1"
   quiver:
     dependency: transitive
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
 
+  barcode_widget: ^2.0.2
   carousel_slider: ^4.1.1
   cupertino_icons: ^1.0.5
   device_preview: ^1.1.0


### PR DESCRIPTION
Impacted files:
* `edit_product_page.dart`: added barcode display; added leading icon and trailing arrow to items
* `pubspec.lock`: wtf
* `pubspec.yaml`: added package `barcode_widget`
* `simple_input_page_helpers.dart`: added leading icon

### What
- New UI for edit product page.
- Barcode display on top.
- Leading icon for each item (default: "edit").
- Same trailing icon for all items (forward arrow).
- The leading icons are currently not the target ones; to be fine-tuned later according to #2563.

### Screenshot
![Capture d’écran 2022-07-10 à 16 40 27](https://user-images.githubusercontent.com/11576431/178149568-ad51d55f-92d1-4fc8-8094-1bc5d52139ba.png)

### Part of 
- #2563