### PR TITLE
fix: #2561 - fixed value+unit management in nutrient page

### DIFF
--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -378,24 +378,11 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
       );
 
   /// Returns `true` if any value differs between form and container.
-  bool _isEdited() {
-    for (final String key in _controllers.keys) {
-      final TextEditingController controller = _controllers[key]!;
-      if (_nutritionContainer.getValue(key) == null) {
-        if (controller.value.text != '') {
-          return true;
-        }
-      } else if (_numberFormat.format(_nutritionContainer.getValue(key)) !=
-          controller.value.text) {
-        return true;
-      }
-    }
-    if (_nutritionContainer.noNutritionData != _noNutritionData) {
-      return true;
-    }
-    //else form is not edited just return false
-    return false;
-  }
+  bool _isEdited() => _nutritionContainer.isEdited(
+        _controllers,
+        _numberFormat,
+        _noNutritionData,
+      );
 
   Product? _getChangedProduct() {
     if (!_formKey.currentState!.validate()) {
@@ -404,11 +391,15 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
     // We use a separate fresh container here.
     // If something breaks while saving, we won't get a half written object.
     final NutritionContainer output = _getFreshContainer();
+    // we copy the values
     for (final String key in _controllers.keys) {
       final TextEditingController controller = _controllers[key]!;
       output.setControllerText(key, controller.text);
     }
+    // we copy the "with nutrition data true/false"
     output.noNutritionData = _noNutritionData;
+    // we copy the units
+    output.copyUnitsFrom(_nutritionContainer);
     return output.getProduct();
   }
 


### PR DESCRIPTION
Impacted files:
* `nutrition_page_loaded.dart`: little fix - now we consider the page edited also when at least one unit changed.
* `nutrition_container.dart`: fix - now we populate units and we don't convert values when saving to the server; added initial units field for the "were units edited?" check; refactored

### What
- There were errors in the value+unit management in the nutrient page.
- One good reason for those errors is that the server is not very user-friendly with weight data
  - when you _read_ data (value + unit), the value is always in grams and the unit is the unit you should display (e.g. `0.12` and `mg`, which means 0.12 grams to be displayed in mg, therefore as "120 mg"). You have to convert the value from grams into the given unit.
  - when you _write_ data, the server works different way - if you want to say "120 mg" you say `120` and `mg` (more intuitive)
- This PR fixed conversion errors when the unit was not grams.
- Beyond the errors fixes, there's something intrinsically twisted with sodium and salt - it looks like for the server the main value is "salt" and "sodium" is computed, and in the case of the issue product only sodium was indicated. Even if you change the sodium value, the previous salt value takes precedence and overwrite the sodium value.
Should we automatically compute one from the other in the app?

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/2561
