### PR TITLE
feat: #2501 - added "origins" in edit product page

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1017,7 +1017,7 @@
     "@edit_product_form_item_origins_title": {
         "description": "Product edition - Origins - Title"
     },
-    "edit_product_form_item_origins_hint": "Spain",
+    "edit_product_form_item_origins_hint": "Spain, Beef from Argentina, The soy does not come from the European union",
     "@edit_product_form_item_origins_hint": {
         "description": "Product edition - Origins - input textfield hint"
     },

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1013,6 +1013,14 @@
     "@edit_product_form_item_stores_hint": {
         "description": "Product edition - Stores - input textfield hint"
     },
+    "edit_product_form_item_origins_title": "Origins",
+    "@edit_product_form_item_origins_title": {
+        "description": "Product edition - Origins - Title"
+    },
+    "edit_product_form_item_origins_hint": "Spain",
+    "@edit_product_form_item_origins_hint": {
+        "description": "Product edition - Origins - input textfield hint"
+    },
     "edit_product_form_item_countries_title": "Country",
     "@edit_product_form_item_countries_title": {
         "description": "Product edition - Countries - Title"

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -1013,6 +1013,14 @@
     "@edit_product_form_item_stores_hint": {
         "description": "Product edition - Stores - input textfield hint"
     },
+    "edit_product_form_item_origins_title": "Origines",
+    "@edit_product_form_item_origins_title": {
+        "description": "Product edition - Origins - Title"
+    },
+    "edit_product_form_item_origins_hint": "Espagne",
+    "@edit_product_form_item_origins_hint": {
+        "description": "Product edition - Origins - input textfield hint"
+    },
     "edit_product_form_item_countries_title": "Pays",
     "@edit_product_form_item_countries_title": {
         "description": "Product edition - Countries - Title"

--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -163,6 +163,7 @@ class _EditProductPageState extends State<EditProductPage> {
               },
             ),
             _getSimpleListTileItem(SimpleInputPageStoreHelper()),
+            _getSimpleListTileItem(SimpleInputPageOriginHelper()),
             _getSimpleListTileItem(SimpleInputPageEmbCodeHelper()),
             _getSimpleListTileItem(SimpleInputPageCountryHelper()),
             _getSimpleListTileItem(SimpleInputPageCategoryHelper()),

--- a/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
@@ -149,6 +149,9 @@ class SimpleInputPageOriginHelper extends AbstractSimpleInputPageHelper {
 
   @override
   TagType? getTagType() => null;
+
+  @override
+  Widget? getIcon() => const Icon(Icons.travel_explore);
 }
 
 /// Implementation for "Emb Code" of an [AbstractSimpleInputPageHelper].

--- a/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
@@ -130,6 +130,27 @@ class SimpleInputPageStoreHelper extends AbstractSimpleInputPageHelper {
   Widget? getIcon() => const Icon(Icons.shopping_cart);
 }
 
+/// Implementation for "Origins" of an [AbstractSimpleInputPageHelper].
+class SimpleInputPageOriginHelper extends AbstractSimpleInputPageHelper {
+  @override
+  List<String> initTerms() => splitString(product.origins);
+
+  @override
+  void changeProduct(final Product changedProduct) =>
+      changedProduct.origins = terms.join(_separator);
+
+  @override
+  String getTitle(final AppLocalizations appLocalizations) =>
+      appLocalizations.edit_product_form_item_origins_title;
+
+  @override
+  String getAddHint(final AppLocalizations appLocalizations) =>
+      appLocalizations.edit_product_form_item_origins_hint;
+
+  @override
+  TagType? getTagType() => null;
+}
+
 /// Implementation for "Emb Code" of an [AbstractSimpleInputPageHelper].
 class SimpleInputPageEmbCodeHelper extends AbstractSimpleInputPageHelper {
   @override

--- a/packages/smooth_app/lib/query/product_query.dart
+++ b/packages/smooth_app/lib/query/product_query.dart
@@ -145,5 +145,6 @@ abstract class ProductQuery {
         ProductField.COUNTRIES_TAGS,
         ProductField.COUNTRIES_TAGS_IN_LANGUAGES,
         ProductField.EMB_CODES,
+        ProductField.ORIGINS,
       ];
 }

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -764,7 +764,7 @@ packages:
       name: openfoodfacts
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.21.0"
+    version: "1.22.0"
   openfoodfacts_flutter_lints:
     dependency: "direct dev"
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
       url: 'https://github.com/M123-dev/matomo-tracker.git'
       ref: 'fix-event-sending'
   modal_bottom_sheet: ^2.1.0
-  openfoodfacts: ^1.21.0
+  openfoodfacts: ^1.22.0
   #  openfoodfacts:
   #    path: ../../../openfoodfacts-dart
   package_info_plus: ^1.4.2


### PR DESCRIPTION
Impacted files:
* `app_en.arb`: added 2 labels for "origins"
* `app_fr.arb`: added 2 labels for "origins"
* `edit_product_page.dart`: added an item for "origins"
* `product_query.dart`: added field "origins" to the list of the product fields we retrieve
* `pubspec.lock`: wtf
* `pubspec.yaml`: upgraded to `openfoodfacts: ^1.22.0`, which has new product field "origins"
* `simple_input_page_helpers.dart`: implementation for "origins" of a simple input page item

### What
- Added "origins" in edit product page.
- Little problem: as "origins" was not part of the product fields we retrieved, the products currently in the local database don't have this field. Refresh is needed.

### Screenshot
| edit product page | origins |
| -- | -- |
| ![Capture d’écran 2022-07-11 à 08 13 47](https://user-images.githubusercontent.com/11576431/178200119-5d1d8b7e-b93d-4f4b-81be-291408758028.png) | ![Capture d’écran 2022-07-11 à 08 14 25](https://user-images.githubusercontent.com/11576431/178200232-f23d7c7a-7cb9-49b4-8bbd-49ea035d19f9.png) |



### Fixes bug(s)
- Fixes: #2501