### PR TITLE
feat: #2572 - added icons for ingredients and nutrition in edit product page

### DIFF
--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -276,28 +276,19 @@ class _SvgIcon extends StatelessWidget {
         assetName,
         height: DEFAULT_ICON_SIZE,
         width: DEFAULT_ICON_SIZE,
-        color: _iconColor(
-          Theme.of(context),
-          ListTileTheme.of(context),
-        ),
+        color: _iconColor(Theme.of(context)),
       );
 
   /// Returns the standard icon color in a [ListTile].
   ///
-  /// Copied from [ListTile], which was not kind enough to make it public.
-  Color? _iconColor(ThemeData theme, ListTileThemeData tileTheme) {
-    final Color? color = tileTheme.iconColor ?? theme.listTileTheme.iconColor;
-    if (color != null) {
-      return color;
-    }
-
+  /// Simplified version from [ListTile], which was anyway not kind enough
+  /// to make it public.
+  Color _iconColor(ThemeData theme) {
     switch (theme.brightness) {
       case Brightness.light:
-        // For the sake of backwards compatibility, the default for unselected
-        // tiles is Colors.black45 rather than colorScheme.onSurface.withAlpha(0x73).
         return Colors.black45;
       case Brightness.dark:
-        return null; // null - use current icon theme color
+        return Colors.white;
     }
   }
 }

--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -2,6 +2,7 @@ import 'package:auto_size_text/auto_size_text.dart';
 import 'package:barcode_widget/barcode_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/product_image_data.dart';
@@ -128,6 +129,7 @@ class _EditProductPageState extends State<EditProductPage> {
             ),
             _getSimpleListTileItem(SimpleInputPageLabelHelper()),
             _ListTitleItem(
+              leading: const _SvgIcon('assets/cacheTintable/ingredients.svg'),
               title: appLocalizations.edit_product_form_item_ingredients_title,
               onTap: () async {
                 if (!await ProductRefresher().checkIfLoggedIn(context)) {
@@ -168,6 +170,7 @@ class _EditProductPageState extends State<EditProductPage> {
             _getSimpleListTileItem(SimpleInputPageCountryHelper()),
             _getSimpleListTileItem(SimpleInputPageCategoryHelper()),
             _ListTitleItem(
+              leading: const _SvgIcon('assets/cacheTintable/scale-balance.svg'),
               title:
                   appLocalizations.edit_product_form_item_nutrition_facts_title,
               subtitle: appLocalizations
@@ -260,4 +263,41 @@ class _ListTitleItem extends StatelessWidget {
           trailing: Icon(ConstantIcons.instance.getForwardIcon()),
         ),
       );
+}
+
+/// SVG that looks like a ListTile icon.
+class _SvgIcon extends StatelessWidget {
+  const _SvgIcon(this.assetName);
+
+  final String assetName;
+
+  @override
+  Widget build(BuildContext context) => SvgPicture.asset(
+        assetName,
+        height: DEFAULT_ICON_SIZE,
+        width: DEFAULT_ICON_SIZE,
+        color: _iconColor(
+          Theme.of(context),
+          ListTileTheme.of(context),
+        ),
+      );
+
+  /// Returns the standard icon color in a [ListTile].
+  ///
+  /// Copied from [ListTile], which was not kind enough to make it public.
+  Color? _iconColor(ThemeData theme, ListTileThemeData tileTheme) {
+    final Color? color = tileTheme.iconColor ?? theme.listTileTheme.iconColor;
+    if (color != null) {
+      return color;
+    }
+
+    switch (theme.brightness) {
+      case Brightness.light:
+        // For the sake of backwards compatibility, the default for unselected
+        // tiles is Colors.black45 rather than colorScheme.onSurface.withAlpha(0x73).
+        return Colors.black45;
+      case Brightness.dark:
+        return null; // null - use current icon theme color
+    }
+  }
 }


### PR DESCRIPTION
Impacted file:
* `edit_product_page.dart`: added svg icons for ingredients and nutrition

### What
- Added icons for ingredients and nutrition in edit product page

### Screenshot
| light | dark |
| -- | -- |
| ![Capture d’écran 2022-07-11 à 11 01 46](https://user-images.githubusercontent.com/11576431/178228225-02dad2b1-8677-423d-bad6-e4caec6a7646.png) | ![Capture d’écran 2022-07-11 à 11 23 47](https://user-images.githubusercontent.com/11576431/178232771-95d3b360-ca4c-430e-979a-0be176b38f27.png) |

### Fixes bug(s)
- Closes: #2572
