### PR TITLE
fix: Ensure all text inputs have coherent cursors + heights

### DIFF
--- a/packages/smooth_app/lib/generic_lib/widgets/smooth_text_form_field.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/smooth_text_form_field.dart
@@ -84,8 +84,7 @@ class _SmoothTextFormFieldState extends State<SmoothTextFormField> {
           },
       onFieldSubmitted: widget.onFieldSubmitted,
       style: TextStyle(fontSize: textSize),
-      cursorHeight:
-          textSize * (DefaultTextStyle.of(context).style.height ?? 1.4),
+      cursorHeight: textSize * (textStyle.height ?? 1.4),
       decoration: InputDecoration(
         //contentPadding: EdgeInsets.only(bottom: textSize),
         prefixIcon: widget.prefixIcon,

--- a/packages/smooth_app/lib/generic_lib/widgets/smooth_text_form_field.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/smooth_text_form_field.dart
@@ -20,6 +20,7 @@ class SmoothTextFormField extends StatefulWidget {
     this.prefixIcon,
     this.textInputType,
     this.onChanged,
+    this.onFieldSubmitted,
     this.autofocus,
   });
 
@@ -34,6 +35,7 @@ class SmoothTextFormField extends StatefulWidget {
   final double? hintTextFontSize;
   final TextInputType? textInputType;
   final void Function(String?)? onChanged;
+  final ValueChanged<String>? onFieldSubmitted;
   final bool? autofocus;
 
   @override
@@ -53,6 +55,9 @@ class _SmoothTextFormFieldState extends State<SmoothTextFormField> {
   Widget build(BuildContext context) {
     final bool enableSuggestions = widget.type == TextFieldTypes.PLAIN_TEXT;
     final bool autocorrect = widget.type == TextFieldTypes.PLAIN_TEXT;
+    final TextStyle textStyle = DefaultTextStyle.of(context).style;
+    final double textSize =
+        widget.hintTextFontSize ?? textStyle.fontSize ?? 20.0;
 
     return TextFormField(
       keyboardType: widget.textInputType,
@@ -77,11 +82,16 @@ class _SmoothTextFormFieldState extends State<SmoothTextFormField> {
               }
             }
           },
+      onFieldSubmitted: widget.onFieldSubmitted,
+      style: TextStyle(fontSize: textSize),
+      cursorHeight:
+          textSize * (DefaultTextStyle.of(context).style.height ?? 1.4),
       decoration: InputDecoration(
+        //contentPadding: EdgeInsets.only(bottom: textSize),
         prefixIcon: widget.prefixIcon,
         filled: true,
         hintStyle: TextStyle(
-          fontSize: widget.hintTextFontSize ?? 20.0,
+          fontSize: textSize,
           overflow: TextOverflow.ellipsis,
         ),
         hintText: widget.hintText,

--- a/packages/smooth_app/lib/generic_lib/widgets/smooth_text_form_field.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/smooth_text_form_field.dart
@@ -86,7 +86,6 @@ class _SmoothTextFormFieldState extends State<SmoothTextFormField> {
       style: TextStyle(fontSize: textSize),
       cursorHeight: textSize * (textStyle.height ?? 1.4),
       decoration: InputDecoration(
-        //contentPadding: EdgeInsets.only(bottom: textSize),
         prefixIcon: widget.prefixIcon,
         filled: true,
         hintStyle: TextStyle(

--- a/packages/smooth_app/lib/pages/user_management/login_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/login_page.dart
@@ -144,6 +144,7 @@ class _LoginPageState extends State<LoginPage> with TraceableClientMixin {
                       //Login
                       SmoothTextFormField(
                         type: TextFieldTypes.PLAIN_TEXT,
+                        textInputType: TextInputType.name,
                         controller: userIdController,
                         hintText: appLocalizations.username_or_email,
                         prefixIcon: const Icon(Icons.person),
@@ -170,6 +171,7 @@ class _LoginPageState extends State<LoginPage> with TraceableClientMixin {
                       //Password
                       SmoothTextFormField(
                         type: TextFieldTypes.PASSWORD,
+                        textInputType: TextInputType.text,
                         controller: passwordController,
                         hintText: appLocalizations.password,
                         prefixIcon: const Icon(Icons.vpn_key),
@@ -185,6 +187,11 @@ class _LoginPageState extends State<LoginPage> with TraceableClientMixin {
                                 .login_page_password_error_empty;
                           }
                           return null;
+                        },
+                        onFieldSubmitted: (String value) {
+                          if (value.isNotEmpty) {
+                            _login(context);
+                          }
                         },
                       ),
 


### PR DESCRIPTION
All inputs that use a `SmoothTextFormField` have:
- A different font size between the hint and the value
- The cursor if often misaligned
- onFieldSubmitted not available to sub widgets

This PR fixes all these issues