### PR TITLE
fix: #2575 - fixed brightness check for app icon

### DIFF
--- a/packages/smooth_app/lib/pages/preferences/user_preferences_faq.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_faq.dart
@@ -94,8 +94,7 @@ class UserPreferencesFaq extends AbstractUserPreferences {
     showDialog<void>(
       context: context,
       builder: (BuildContext context) {
-        final MediaQueryData data = MediaQuery.of(context);
-        final String logo = data.platformBrightness == Brightness.light
+        final String logo = Theme.of(context).brightness == Brightness.light
             ? _iconLightAssetPath
             : _iconDarkAssetPath;
 
@@ -106,7 +105,7 @@ class UserPreferencesFaq extends AbstractUserPreferences {
                 children: <Widget>[
                   SvgPicture.asset(
                     logo,
-                    width: data.size.width * 0.1,
+                    width: MediaQuery.of(context).size.width * 0.1,
                   ),
                   const SizedBox(width: SMALL_SPACE),
                   Expanded(


### PR DESCRIPTION
Impacted file:
* `user_preferences_faq.dart`: fixed brightness check for app icon

### What
- Fixed brightness check for app icon

### Screenshot
| light | dark |
| -- | -- |
| ![Capture d’écran 2022-07-11 à 11 36 06](https://user-images.githubusercontent.com/11576431/178235234-900dc74f-9f67-4a3c-be0a-6a226186a750.png) | ![Capture d’écran 2022-07-11 à 11 36 34](https://user-images.githubusercontent.com/11576431/178235330-ba860d73-d0c4-489b-bfcf-01dff405d0ed.png) |

### Fixes bug(s)
- Fixes: #2575