### PR TITLE
feat: #2574 - added explanations for origins, categories and packaging

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -422,7 +422,7 @@
     "@ingredients_photo": {
         "description": "Button label: For adding a picture of the Ingredients of a product"
     },
-    "packaging_editing_instructions": "",
+    "packaging_editing_instructions": "List all packaging parts separated by a comma or line feed, with their amount (e.g. 1 or 6) type (e.g. bottle, box, can), material (e.g. plastic, metal, aluminium) and if available their size (e.g. 33cl) and recycling instructions.\nExample: 1 glass bottle to recycle, 1 plastic cork to throw away",
     "packaging_editing_error": "Failed to save the packaging.",
     "packaging_editing_image_error": "Failed to get a new packaging image.",
     "packaging_editing_title": "Edit Packaging",
@@ -1017,9 +1017,17 @@
     "@edit_product_form_item_origins_title": {
         "description": "Product edition - Origins - Title"
     },
-    "edit_product_form_item_origins_hint": "Spain, Beef from Argentina, The soy does not come from the European union",
+    "edit_product_form_item_origins_hint": "Spain",
     "@edit_product_form_item_origins_hint": {
         "description": "Product edition - Origins - input textfield hint"
+    },
+    "edit_product_form_item_origins_explainer_1": "Add any indications of origins you can find on the packaging. You need not worry about origins indicated directly in the ingredient list.",
+    "@edit_product_form_item_origins_explainer_1": {
+        "description": "Product edition - Origins - input explainer, part 1"
+    },
+    "edit_product_form_item_origins_explainer_2": "Examples: Beef from Argentina, The soy does not come from the European Union",
+    "@edit_product_form_item_origins_explainer_2": {
+        "description": "Product edition - Origins - input explainer, part 2"
     },
     "edit_product_form_item_countries_title": "Country",
     "@edit_product_form_item_countries_title": {
@@ -1052,6 +1060,18 @@
     "edit_product_form_item_categories_hint": "category",
     "@edit_product_form_item_categories_hint": {
         "description": "Product edition - Categories - input textfield hint"
+    },
+    "edit_product_form_item_categories_explainer_1": "Indicate only the most specific category. Parent categories will be automatically added.",
+    "@edit_product_form_item_categories_explainer_1": {
+        "description": "Product edition - Categories - input explainer, part 1"
+    },
+    "edit_product_form_item_categories_explainer_2": "In case a category is not available in autocomplete, feel free to add it anyway, that will help us improve Open Food Facts in your country.",
+    "@edit_product_form_item_categories_explainer_2": {
+        "description": "Product edition - Categories - input explainer, part 2"
+    },
+    "edit_product_form_item_categories_explainer_3": "Examples: Sardines in olive oil, Orange juice from concentrate",
+    "@edit_product_form_item_categories_explainer_3": {
+        "description": "Product edition - Categories - input explainer, part 3"
     },
     "edit_product_form_item_exit_confirmation": "Do you want to save your changes before leaving this page?",
     "edit_product_form_item_ingredients_title": "Ingredients & Origins",

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -422,7 +422,7 @@
     "@ingredients_photo": {
         "description": "Button label: For adding a picture of the Ingredients of a product"
     },
-    "packaging_editing_instructions": "",
+    "packaging_editing_instructions": "List all packaging parts separated by a comma or line feed, with their amount (e.g. 1 or 6) type (e.g. bottle, box, can), material (e.g. plastic, metal, aluminium) and if available their size (e.g. 33cl) and recycling instructions.\nExample: 1 glass bottle to recycle, 1 plastic cork to throw away",
     "packaging_editing_error": "Échec de l'enregistrement de l'emballage.",
     "packaging_editing_image_error": "Impossible d'obtenir une nouvelle image d'emballage.",
     "packaging_editing_title": "Modifier l'emballage",
@@ -1021,6 +1021,14 @@
     "@edit_product_form_item_origins_hint": {
         "description": "Product edition - Origins - input textfield hint"
     },
+    "edit_product_form_item_origins_explainer_1": "Add any indications of origins you can find on the packaging. You need not worry about origins indicated directly in the ingredient list.",
+    "@edit_product_form_item_origins_explainer_1": {
+        "description": "Product edition - Origins - input explainer, part 1"
+    },
+    "edit_product_form_item_origins_explainer_2": "Examples: Beef from Argentina, The soy does not come from the European Union",
+    "@edit_product_form_item_origins_explainer_2": {
+        "description": "Product edition - Origins - input explainer, part 2"
+    },
     "edit_product_form_item_countries_title": "Pays",
     "@edit_product_form_item_countries_title": {
         "description": "Product edition - Countries - Title"
@@ -1052,6 +1060,18 @@
     "edit_product_form_item_categories_hint": "catégorie",
     "@edit_product_form_item_categories_hint": {
         "description": "Product edition - Categories - input textfield hint"
+    },
+    "edit_product_form_item_categories_explainer_1": "Indicate only the most specific category. Parent categories will be automatically added.",
+    "@edit_product_form_item_categories_explainer_1": {
+        "description": "Product edition - Categories - input explainer, part 1"
+    },
+    "edit_product_form_item_categories_explainer_2": "In case a category is not available in autocomplete, feel free to add it anyway, that will help us improve Open Food Facts in your country.",
+    "@edit_product_form_item_categories_explainer_2": {
+        "description": "Product edition - Categories - input explainer, part 2"
+    },
+    "edit_product_form_item_categories_explainer_3": "Examples: Sardines in olive oil, Orange juice from concentrate",
+    "@edit_product_form_item_categories_explainer_3": {
+        "description": "Product edition - Categories - input explainer, part 3"
     },
     "edit_product_form_item_exit_confirmation": "Souhaitez-vous enregistrer vos modifications avant de quitter cette page ?",
     "edit_product_form_item_ingredients_title": "Ingrédients & Origines",

--- a/packages/smooth_app/lib/pages/product/edit_ingredients_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_ingredients_page.dart
@@ -12,6 +12,7 @@ import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/helpers/picture_capture_helper.dart';
 import 'package:smooth_app/pages/image_crop_page.dart';
 import 'package:smooth_app/pages/product/common/product_refresher.dart';
+import 'package:smooth_app/pages/product/explanation_widget.dart';
 import 'package:smooth_app/pages/product/ocr_helper.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
@@ -312,9 +313,8 @@ class _OcrWidget extends StatelessWidget {
                         onSubmitted: (_) => onSubmitField,
                       ),
                       const SizedBox(height: SMALL_SPACE),
-                      Text(
+                      ExplanationWidget(
                         helper.getInstructions(appLocalizations),
-                        style: Theme.of(context).textTheme.caption,
                       ),
                       const SizedBox(height: MEDIUM_SPACE),
                       SmoothActionButtonsBar(

--- a/packages/smooth_app/lib/pages/product/explanation_widget.dart
+++ b/packages/smooth_app/lib/pages/product/explanation_widget.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+
+/// Widget that displays explanations as a list, with expand/collapse mode.
+class ExplanationWidget extends StatefulWidget {
+  const ExplanationWidget(this.explanations);
+
+  final String? explanations;
+
+  @override
+  State<ExplanationWidget> createState() => _ExplanationWidgetState();
+}
+
+class _ExplanationWidgetState extends State<ExplanationWidget> {
+  bool _expanded = false;
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.explanations == null) {
+      return EMPTY_WIDGET;
+    }
+    if (!_expanded) {
+      return ListTile(
+        title: Text(
+          widget.explanations!,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+        trailing: const Icon(Icons.info_outline),
+        onTap: () => setState(() => _expanded = true),
+      );
+    }
+    final List<Widget> result = <Widget>[];
+    final List<String> split = widget.explanations!.split('\n');
+    bool first = true;
+    for (final String item in split) {
+      if (first) {
+        first = false;
+        result.add(
+          ListTile(
+            title: Text(item),
+            trailing: const Icon(Icons.expand_less),
+            onTap: () => setState(() => _expanded = false),
+          ),
+        );
+      } else {
+        result.add(ListTile(title: Text(item)));
+      }
+    }
+    return Column(children: result);
+  }
+}

--- a/packages/smooth_app/lib/pages/product/ocr_packaging_helper.dart
+++ b/packages/smooth_app/lib/pages/product/ocr_packaging_helper.dart
@@ -1,13 +1,8 @@
 import 'dart:async';
-import 'dart:convert';
 
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:http/http.dart';
 import 'package:openfoodfacts/model/OcrPackagingResult.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
-import 'package:openfoodfacts/utils/OcrField.dart';
-import 'package:openfoodfacts/utils/QueryType.dart';
-import 'package:openfoodfacts/utils/UriHelper.dart';
 import 'package:smooth_app/pages/product/ocr_helper.dart';
 
 /// OCR Helper for packaging.
@@ -54,40 +49,11 @@ class OcrPackagingHelper extends OcrHelper {
 
   @override
   Future<String?> getExtractedText(final Product product) async {
-    final OcrPackagingResult result = await extractPackaging(
+    final OcrPackagingResult result = await OpenFoodAPIClient.extractPackaging(
       getUser(),
       product.barcode!,
       getLanguage(),
     );
     return result.textFromImage;
-  }
-
-  // TODO(monsieurtanuki): move to off-dart
-  static Future<OcrPackagingResult> extractPackaging(
-    User user,
-    String barcode,
-    OpenFoodFactsLanguage language, {
-    OcrField ocrField = OcrField.GOOGLE_CLOUD_VISION,
-    QueryType? queryType,
-  }) async {
-    final Uri uri = UriHelper.getPostUri(
-      path: '/cgi/packaging.pl',
-      queryType: queryType,
-    );
-    final Map<String, String> queryParameters = <String, String>{
-      'code': barcode,
-      'process_image': '1',
-      'id': 'packaging_${language.code}',
-      'ocr_engine': OcrField.GOOGLE_CLOUD_VISION.key
-    };
-    final Response response = await HttpHelper().doPostRequest(
-      uri,
-      queryParameters,
-      user,
-      queryType: queryType,
-    );
-    return OcrPackagingResult.fromJson(
-      json.decode(utf8.decode(response.bodyBytes)) as Map<String, dynamic>,
-    );
   }
 }

--- a/packages/smooth_app/lib/pages/product/simple_input_page.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page.dart
@@ -10,6 +10,7 @@ import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/pages/product/autocomplete.dart';
 import 'package:smooth_app/pages/product/common/product_refresher.dart';
+import 'package:smooth_app/pages/product/explanation_widget.dart';
 import 'package:smooth_app/pages/product/simple_input_page_helpers.dart';
 import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
@@ -66,9 +67,9 @@ class _SimpleInputPageState extends State<SimpleInputPage> {
                       widget.helper.getTitle(appLocalizations),
                       style: themeData.textTheme.headline1,
                     ),
-                    if (widget.helper.getAddExplanations(appLocalizations) !=
-                        null)
-                      Text(widget.helper.getAddExplanations(appLocalizations)!),
+                    ExplanationWidget(
+                      widget.helper.getAddExplanations(appLocalizations),
+                    ),
                     ListTile(
                       onTap: () => _addItemsFromController(),
                       trailing: const Icon(Icons.add_circle),

--- a/packages/smooth_app/lib/pages/product/simple_input_page.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page.dart
@@ -66,8 +66,9 @@ class _SimpleInputPageState extends State<SimpleInputPage> {
                       widget.helper.getTitle(appLocalizations),
                       style: themeData.textTheme.headline1,
                     ),
-                    if (widget.helper.getSubtitle(appLocalizations) != null)
-                      Text(widget.helper.getSubtitle(appLocalizations)!),
+                    if (widget.helper.getAddExplanations(appLocalizations) !=
+                        null)
+                      Text(widget.helper.getAddExplanations(appLocalizations)!),
                     ListTile(
                       onTap: () => _addItemsFromController(),
                       trailing: const Icon(Icons.add_circle),
@@ -137,9 +138,6 @@ class _SimpleInputPageState extends State<SimpleInputPage> {
                         ),
                       ),
                     ),
-                    if (widget.helper.getAddExplanations(appLocalizations) !=
-                        null)
-                      Text(widget.helper.getAddExplanations(appLocalizations)!),
                     Divider(color: themeData.colorScheme.onBackground),
                     Column(
                       children: List<Widget>.generate(

--- a/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
@@ -148,6 +148,12 @@ class SimpleInputPageOriginHelper extends AbstractSimpleInputPageHelper {
       appLocalizations.edit_product_form_item_origins_hint;
 
   @override
+  String? getAddExplanations(final AppLocalizations appLocalizations) =>
+      '${appLocalizations.edit_product_form_item_origins_explainer_1}'
+      '\n'
+      '${appLocalizations.edit_product_form_item_origins_explainer_2}';
+
+  @override
   TagType? getTagType() => null;
 
   @override
@@ -290,6 +296,14 @@ class SimpleInputPageCategoryHelper
   @override
   String getTitle(final AppLocalizations appLocalizations) =>
       appLocalizations.edit_product_form_item_categories_title;
+
+  @override
+  String? getAddExplanations(final AppLocalizations appLocalizations) =>
+      '${appLocalizations.edit_product_form_item_categories_explainer_1}'
+      '\n'
+      '${appLocalizations.edit_product_form_item_categories_explainer_2}'
+      '\n'
+      '${appLocalizations.edit_product_form_item_categories_explainer_3}';
 
   @override
   String getAddHint(final AppLocalizations appLocalizations) =>


### PR DESCRIPTION
Impacted files:
* `app_en.arb`: populated explanation labels for origins, categories and packaging
* `app_fr.arb`: populated explanation labels for origins, categories and packaging
* `ocr_packaging_helper.dart`: unrelated refactoring "en passant"
* `simple_input_page.dart`: replaced subtitle by explanations
* `simple_input_page_helpers.dart`: populated explanations for origins and categories

### What
- Added explanations for origins, categories and packaging

### Screenshot
![Capture d’écran 2022-07-11 à 12 35 48](https://user-images.githubusercontent.com/11576431/178246154-286aa480-56dc-403e-94ad-1bce9d2af248.png)

![Capture d’écran 2022-07-11 à 12 36 59](https://user-images.githubusercontent.com/11576431/178246295-e4126d34-597b-4eb7-9bf6-17d29b8206ef.png)

![Capture d’écran 2022-07-11 à 12 38 07](https://user-images.githubusercontent.com/11576431/178246453-ed45a44b-c900-4e1d-bdb0-fa73f93aa81f.png)

### Fixes bug(s)
- Closes: #2574