### PR TITLE
feat: #2573 - Knowledge Panel cells are expanded on detail pages

### DIFF
--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_card.dart
@@ -28,6 +28,7 @@ class KnowledgePanelCard extends StatelessWidget {
         panel: panel,
         allPanels: allPanels,
         product: product,
+        isInitiallyExpanded: false,
       );
     }
 

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_element_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_element_card.dart
@@ -19,11 +19,13 @@ class KnowledgePanelElementCard extends StatelessWidget {
     required this.knowledgePanelElement,
     required this.allPanels,
     required this.product,
+    required this.isInitiallyExpanded,
   });
 
   final KnowledgePanelElement knowledgePanelElement;
   final KnowledgePanels allPanels;
   final Product product;
+  final bool isInitiallyExpanded;
 
   @override
   Widget build(BuildContext context) {
@@ -54,6 +56,7 @@ class KnowledgePanelElementCard extends StatelessWidget {
       case KnowledgePanelElementType.TABLE:
         return KnowledgePanelTableCard(
           tableElement: knowledgePanelElement.tableElement!,
+          isInitiallyExpanded: isInitiallyExpanded,
         );
       case KnowledgePanelElementType.MAP:
         return KnowledgePanelWorldMapCard(knowledgePanelElement.mapElement!);

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_expanded_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_expanded_card.dart
@@ -12,11 +12,13 @@ class KnowledgePanelExpandedCard extends StatelessWidget {
     required this.panel,
     required this.allPanels,
     required this.product,
+    required this.isInitiallyExpanded,
   });
 
   final KnowledgePanel panel;
   final KnowledgePanels allPanels;
   final Product product;
+  final bool isInitiallyExpanded;
 
   @override
   Widget build(BuildContext context) {
@@ -31,6 +33,7 @@ class KnowledgePanelExpandedCard extends StatelessWidget {
             knowledgePanelElement: element,
             allPanels: allPanels,
             product: product,
+            isInitiallyExpanded: isInitiallyExpanded,
           ),
         ),
       );

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_page.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_page.dart
@@ -60,6 +60,7 @@ class _KnowledgePanelPageState extends State<KnowledgePanelPage>
               panel: widget.panel,
               allPanels: widget.allPanels,
               product: widget.product,
+              isInitiallyExpanded: true,
             ),
           ),
         ),

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_table_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_table_card.dart
@@ -58,9 +58,11 @@ class TableCell {
 class KnowledgePanelTableCard extends StatefulWidget {
   const KnowledgePanelTableCard({
     required this.tableElement,
+    required this.isInitiallyExpanded,
   });
 
   final KnowledgePanelTableElement tableElement;
+  final bool isInitiallyExpanded;
 
   @override
   State<KnowledgePanelTableCard> createState() =>
@@ -168,10 +170,12 @@ class _KnowledgePanelTableCardState extends State<KnowledgePanelTableCard> {
             availableWidth / totalMaxColumnWidth * _columnsMaxLength[index++];
         rowWidgets.add(
           TableCellWidget(
-              cell: cell,
-              cellWidth: cellWidth,
-              tableElement: widget.tableElement,
-              rebuildTable: setState),
+            cell: cell,
+            cellWidth: cellWidth,
+            tableElement: widget.tableElement,
+            rebuildTable: setState,
+            isInitiallyExpanded: widget.isInitiallyExpanded,
+          ),
         );
       }
       rowsWidgets.add(rowWidgets);
@@ -249,19 +253,27 @@ class TableCellWidget extends StatefulWidget {
     required this.cellWidth,
     required this.tableElement,
     required this.rebuildTable,
+    required this.isInitiallyExpanded,
   });
 
   final TableCell cell;
   final double cellWidth;
   final KnowledgePanelTableElement tableElement;
   final void Function(VoidCallback fn) rebuildTable;
+  final bool isInitiallyExpanded;
 
   @override
   State<TableCellWidget> createState() => _TableCellWidgetState();
 }
 
 class _TableCellWidgetState extends State<TableCellWidget> {
-  bool _isExpanded = false;
+  late bool _isExpanded;
+
+  @override
+  void initState() {
+    super.initState();
+    _isExpanded = widget.isInitiallyExpanded;
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels_builder.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels_builder.dart
@@ -48,6 +48,7 @@ class KnowledgePanelWidget extends StatelessWidget {
           knowledgePanelElement: knowledgePanelElement,
           allPanels: knowledgePanels,
           product: product,
+          isInitiallyExpanded: false,
         ),
       );
     }


### PR DESCRIPTION
Impacted files:
* `knowledge_panel_card.dart`: no we are not initially expanded! (same as before)
* `knowledge_panel_element_card.dart`: refactored
* `knowledge_panel_expanded_card.dart`: refactored
* `knowledge_panel_page.dart`: yes we are initially expanded!
* `knowledge_panel_table_card.dart`: added an "initially expanded?" parameter to `TableCellWidget`
* `knowledge_panels_builder.dart`: no we are not initially expanded! (same as before)

### What
- The default for KP table cells was "not expanded".
- Now it's a `bool` parameter. Only on detail pages (like "nutrition facts") is the "initially expanded" set to `true`.

### Fixes bug(s)
- Closes: #2573