### PR TITLE
feat: Smooth Dialog with an axis for buttons

### DIFF
--- a/packages/smooth_app/lib/generic_lib/dialogs/smooth_alert_dialog.dart
+++ b/packages/smooth_app/lib/generic_lib/dialogs/smooth_alert_dialog.dart
@@ -21,7 +21,7 @@ class SmoothAlertDialog extends StatelessWidget {
     required this.body,
     this.positiveAction,
     this.negativeAction,
-    this.actionsAxis = Axis.horizontal,
+    this.actionsAxis,
     this.close = false,
   });
 

--- a/packages/smooth_app/lib/pages/product/common/product_refresher.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_refresher.dart
@@ -22,6 +22,7 @@ class ProductRefresher {
       context: context,
       builder: (BuildContext context) => SmoothAlertDialog(
         body: Text(appLocalizations.sign_in_mandatory),
+        actionsAxis: Axis.vertical,
         positiveAction: SmoothActionButton(
           text: appLocalizations.sign_in,
           onPressed: () async {


### PR DESCRIPTION
In some dialogs, using a horizontal axis for the two buttons is not a good idea, as the content may be shrunk:
![Screenshot_1657652612](https://user-images.githubusercontent.com/246838/178577130-eabff41d-ba02-411c-826e-6b8cef7e9cda.png)

This PR introduces the ability to pass an axis and thus have the button on a vertical axis:
![Screenshot_1657653755](https://user-images.githubusercontent.com/246838/178577192-29915de1-1bec-4d59-911d-76c6d044b084.png)

