### PR TITLE
fix: ean - now we display ean8 (and not just ean13)

### DIFF
--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -62,7 +62,9 @@ class _EditProductPageState extends State<EditProductPage> {
                   horizontal: screenSize.width / 4,
                   vertical: SMALL_SPACE,
                 ),
-                barcode: Barcode.ean13(),
+                barcode: _product.barcode!.length == 8
+                    ? Barcode.ean8()
+                    : Barcode.ean13(),
                 data: _product.barcode!,
                 errorBuilder: (final BuildContext context, String? _) =>
                     ListTile(


### PR DESCRIPTION
Impacted file:
* `edit_product_page.dart`

### What
- To display ean codes in the "edit product" page, we use a package that needs to know the ean format first.
- So far, we assumed that everything was ean13.
- Now we support ean8 too.
- Of course a list of ean types to support would be helpful, with a method to discriminate between them.

### Screenshot
| ean8 | ean13 |
| -- | -- |
| ![Capture d’écran 2022-07-14 à 19 11 15](https://user-images.githubusercontent.com/11576431/179042793-69b47873-2042-428f-8ff0-d0c1fcb22b2d.png) | ![Capture d’écran 2022-07-14 à 19 11 59](https://user-images.githubusercontent.com/11576431/179042941-77160865-2f97-4bf3-97c9-2cf5387566d9.png) |