### PR TITLE
feat: #2513 - product page - moved higher the action bar

### DIFF
--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -227,7 +227,6 @@ class _ProductPageState extends State<ProductPage> with TraceableClientMixin {
               ),
             ),
           ),
-          _buildKnowledgePanelCards(),
           _buildActionBar(appLocalizations),
           if (productListNames.isNotEmpty)
             _buildListWidget(
@@ -235,6 +234,7 @@ class _ProductPageState extends State<ProductPage> with TraceableClientMixin {
               productListNames,
               daoProductList,
             ),
+          _buildKnowledgePanelCards(),
           if (context.read<UserPreferences>().getFlag(
                   UserPreferencesDevMode.userPreferencesFlagAdditionalButton) ??
               false)
@@ -272,7 +272,6 @@ class _ProductPageState extends State<ProductPage> with TraceableClientMixin {
     final bool refreshed = await ProductListUserDialogHelper(daoProductList)
         .showUserListsWithBarcodeDialog(context, widget.product);
     if (refreshed) {
-      _mustScrollToTheEnd = true;
       setState(() {});
     }
   }


### PR DESCRIPTION
Impacted file:
* `new_product_page.dart`: moved higher the action bar

### What
- In the product page, the action bar (list / edit / share) is now between the summary card and the health card. Instead of being down under, mate.
- Might be problematic as each list takes room (cf. screenshots)

### Screenshot
| top | ...scrolling down... |
| -- | -- | 
| ![Capture d’écran 2022-07-18 à 08 02 10](https://user-images.githubusercontent.com/11576431/179452935-d476b313-1dbc-4fb5-aee1-efa954c14271.png) | ![Capture d’écran 2022-07-18 à 08 02 33](https://user-images.githubusercontent.com/11576431/179452974-9c4d1b5e-6daa-461f-bce1-78059b686ab2.png) |

### Fixes bug(s)
- Closes: #2513