### PR TITLE
feat: #2337 - additional "power user" product edit page

### DIFF
--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -129,6 +129,16 @@ class _EditProductPageState extends State<EditProductPage> {
                 );
               },
             ),
+            _getMultipleListTileItem(
+              <AbstractSimpleInputPageHelper>[
+                SimpleInputPageLabelHelper(),
+                SimpleInputPageStoreHelper(),
+                SimpleInputPageOriginHelper(),
+                SimpleInputPageEmbCodeHelper(),
+                SimpleInputPageCountryHelper(),
+                SimpleInputPageCategoryHelper(),
+              ],
+            ),
             _getSimpleListTileItem(SimpleInputPageLabelHelper()),
             _ListTitleItem(
               leading: const _SvgIcon('assets/cacheTintable/ingredients.svg'),
@@ -232,6 +242,35 @@ class _EditProductPageState extends State<EditProductPage> {
           MaterialPageRoute<Product>(
             builder: (BuildContext context) => SimpleInputPage(
               helper: helper,
+              product: _product,
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _getMultipleListTileItem(
+    final List<AbstractSimpleInputPageHelper> helpers,
+  ) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final List<String> titles = <String>[];
+    for (final AbstractSimpleInputPageHelper element in helpers) {
+      titles.add(element.getTitle(appLocalizations));
+    }
+    return _ListTitleItem(
+      leading: const Icon(Icons.interests),
+      title: titles.join(', '),
+      subtitle: null,
+      onTap: () async {
+        if (!await ProductRefresher().checkIfLoggedIn(context)) {
+          return;
+        }
+        await Navigator.push<Product>(
+          context,
+          MaterialPageRoute<Product>(
+            builder: (BuildContext context) => SimpleInputPage.multiple(
+              helpers: helpers,
               product: _product,
             ),
           ),

--- a/packages/smooth_app/lib/pages/product/simple_input_page.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page.dart
@@ -6,6 +6,7 @@ import 'package:provider/provider.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
+import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/pages/product/common/product_refresher.dart';
 import 'package:smooth_app/pages/product/simple_input_page_helpers.dart';
@@ -56,8 +57,7 @@ class _SimpleInputPageState extends State<SimpleInputPage> {
           padding: i == 0
               ? EdgeInsets.zero
               : const EdgeInsets.only(top: LARGE_SPACE),
-          child: Card(
-            elevation: 4,
+          child: SmoothCard(
             child: SimpleInputWidget(
               helper: widget.helpers[i],
               product: widget.product,

--- a/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
@@ -83,14 +83,13 @@ abstract class AbstractSimpleInputPageHelper {
   /// Returns the icon data for the list tile.
   Widget? getIcon() => null;
 
-  /// Returns null is no change was made, or a Product to be saved on the BE.
-  Product? getChangedProduct() {
+  /// Returns true if changes were made.
+  bool getChangedProduct(final Product product) {
     if (!_changed) {
-      return null;
+      return false;
     }
-    final Product changedProduct = Product(barcode: product.barcode);
-    changeProduct(changedProduct);
-    return changedProduct;
+    changeProduct(product);
+    return true;
   }
 
   @protected
@@ -103,6 +102,23 @@ abstract class AbstractSimpleInputPageHelper {
       return <String>[];
     }
     return input.split(_separator);
+  }
+
+  /// Adds all the non-already existing items from the controller.
+  ///
+  /// The item separator is the comma.
+  bool addItemsFromController(final TextEditingController controller) {
+    final List<String> input = controller.text.split(',');
+    bool result = false;
+    for (final String item in input) {
+      if (addTerm(item.trim())) {
+        result = true;
+      }
+    }
+    if (result) {
+      controller.text = '';
+    }
+    return result;
   }
 }
 

--- a/packages/smooth_app/lib/pages/product/simple_input_widget.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_widget.dart
@@ -1,0 +1,156 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:openfoodfacts/utils/TagType.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/pages/product/autocomplete.dart';
+import 'package:smooth_app/pages/product/explanation_widget.dart';
+import 'package:smooth_app/pages/product/simple_input_page_helpers.dart';
+import 'package:smooth_app/query/product_query.dart';
+
+/// Simple input widget: we have a list of terms, we add, we remove.
+class SimpleInputWidget extends StatefulWidget {
+  const SimpleInputWidget({
+    required this.helper,
+    required this.product,
+    required this.controller,
+  });
+
+  final AbstractSimpleInputPageHelper helper;
+  final Product product;
+  final TextEditingController controller;
+
+  @override
+  State<SimpleInputWidget> createState() => _SimpleInputWidgetState();
+}
+
+class _SimpleInputWidgetState extends State<SimpleInputWidget> {
+  final FocusNode _focusNode = FocusNode();
+  final Key _autocompleteKey = UniqueKey();
+
+  @override
+  void initState() {
+    super.initState();
+    widget.helper.reInit(widget.product);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData themeData = Theme.of(context);
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        ListTile(
+          leading: widget.helper.getIcon(),
+          title: Text(
+            widget.helper.getTitle(appLocalizations),
+            style: themeData.textTheme.headline3,
+          ),
+        ),
+        ExplanationWidget(widget.helper.getAddExplanations(appLocalizations)),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: <Widget>[
+            Flexible(
+              flex: 1,
+              child: Padding(
+                padding: const EdgeInsets.only(left: LARGE_SPACE),
+                child: RawAutocomplete<String>(
+                  key: _autocompleteKey,
+                  focusNode: _focusNode,
+                  textEditingController: widget.controller,
+                  optionsBuilder: (final TextEditingValue value) async {
+                    final List<String> result = <String>[];
+                    final String input = value.text.trim();
+                    if (input.isEmpty) {
+                      return result;
+                    }
+                    final TagType? tagType = widget.helper.getTagType();
+                    if (tagType == null) {
+                      return result;
+                    }
+                    // TODO(monsieurtanuki): ask off-dart to return Strings instead of dynamic?
+                    final List<dynamic> data =
+                        await OpenFoodAPIClient.getAutocompletedSuggestions(
+                      tagType,
+                      language: ProductQuery.getLanguage()!,
+                      limit: 1000000, // lower max count on the server anyway
+                      input: value.text.trim(),
+                    );
+                    for (final dynamic item in data) {
+                      result.add(item.toString());
+                    }
+                    result.sort();
+                    return result;
+                  },
+                  fieldViewBuilder: (BuildContext context,
+                          TextEditingController textEditingController,
+                          FocusNode focusNode,
+                          VoidCallback onFieldSubmitted) =>
+                      TextField(
+                    controller: textEditingController,
+                    decoration: InputDecoration(
+                      filled: true,
+                      border: const OutlineInputBorder(
+                        borderRadius: CIRCULAR_BORDER_RADIUS,
+                        borderSide: BorderSide.none,
+                      ),
+                      contentPadding: const EdgeInsets.symmetric(
+                        horizontal: SMALL_SPACE,
+                        vertical: SMALL_SPACE,
+                      ),
+                      hintText: widget.helper.getAddHint(appLocalizations),
+                    ),
+                    autofocus: true,
+                    focusNode: focusNode,
+                  ),
+                  optionsViewBuilder: (
+                    BuildContext context,
+                    AutocompleteOnSelected<String> onSelected,
+                    Iterable<String> options,
+                  ) =>
+                      AutocompleteOptions<String>(
+                    displayStringForOption:
+                        RawAutocomplete.defaultStringForOption,
+                    onSelected: onSelected,
+                    options: options,
+                    maxOptionsHeight: MediaQuery.of(context).size.height / 2,
+                  ),
+                ),
+              ),
+            ),
+            IconButton(
+              onPressed: () {
+                if (widget.helper.addItemsFromController(widget.controller)) {
+                  setState(() {});
+                }
+              },
+              icon: const Icon(Icons.add_circle),
+            ),
+          ],
+        ),
+        Divider(color: themeData.colorScheme.onBackground),
+        Column(
+          children: List<Widget>.generate(
+            widget.helper.terms.length,
+            (final int index) {
+              final String term = widget.helper.terms[index];
+              return ListTile(
+                leading: const Icon(Icons.delete),
+                title: Text(term),
+                onTap: () async {
+                  if (widget.helper.removeTerm(term)) {
+                    setState(() {});
+                  }
+                },
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
New file:
* `simple_input_widget.dart`: Simple input widget: we have a list of terms, we add, we remove.

Impacted files
* `edit_product_page.dart`: added an item that includes 6 simple items;
* `simple_input_page.dart`: now manages multiple items; now using new widget `SimpleInputWidget
* `simple_input_page_helpers.dart`: refactored for a better "multiple changes" management

### What
- On the "edit product" page, all items cared about only one product feature (e.g. packaging, nutrition facts, ...)
- Now there's an additional item in the "edit product" page, which makes it possible to change several (simple) features in the same page.

### Screenshot
| dark | light |
| -- | -- |
| ![Capture d’écran 2022-07-18 à 14 41 42](https://user-images.githubusercontent.com/11576431/179513397-4a412950-a652-4d3c-9aac-c9c7633f9a32.png) | ![Capture d’écran 2022-07-18 à 14 43 18](https://user-images.githubusercontent.com/11576431/179513661-3b15dec6-a71f-4f0f-83b0-15861608d69a.png) |
| ![Capture d’écran 2022-07-18 à 14 42 20](https://user-images.githubusercontent.com/11576431/179513513-9ca05527-4c11-4cf8-a62d-6530b56e2370.png) | ![Capture d’écran 2022-07-18 à 14 43 04](https://user-images.githubusercontent.com/11576431/179513626-87650082-d611-450f-838e-dbc78688e8fb.png) |


### Fixes bug(s)
- Closes: #2337