### PR TITLE
fix: #2009 - product page will always pull down - and refresh

### DIFF
--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -202,7 +202,13 @@ class _ProductPageState extends State<ProductPage> with TraceableClientMixin {
     return RefreshIndicator(
       onRefresh: () => _refreshProduct(context),
       child: ListView(
-        controller: _scrollController,
+        // /!\ Smart Dart
+        // `physics: const AlwaysScrollableScrollPhysics()`
+        // means that we will always scroll, even if it's pointless.
+        // Why do we need to? For the RefreshIndicator, that wouldn't be
+        // triggered on a ListView smaller than the screen
+        // (as there will be no scroll).
+        physics: const AlwaysScrollableScrollPhysics(),
         children: <Widget>[
           Align(
             heightFactor: 0.7,


### PR DESCRIPTION
For the record, tested on `3489940014075` on server `world.openbeautyfacts.org`.

I've also written the explanation behind the trick - perhaps that would make sense to create a wiki about nice tricks:
```dart
// /!\ Smart Dart
// `physics: const AlwaysScrollableScrollPhysics()`
// means that we will always scroll, even if it's pointless.
// Why do we need to? For the RefreshIndicator, that wouldn't be
// triggered on a ListView smaller than the screen
// (as there will be no scroll).
```

Impacted file:
* `new_product_page.dart`: forced the page content to scroll even when not necessary

### What
- Now the product page will always pull down, and therefore refresh the data.

### Fixes bug(s)
- Fixes: #2009