### PR TITLE
feat: Increase the number of products imported from "V1" from 500 to 1000

### DIFF
--- a/packages/data_importer/lib/data_importer.dart
+++ b/packages/data_importer/lib/data_importer.dart
@@ -3,7 +3,7 @@ import 'package:data_importer/shared/platform_data_importer.dart';
 import 'package:data_importer_shared/data_importer_shared.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
-/// Data importer from "V1" apps to Smothie ("V2") with:
+/// Data importer from "V1" apps to Smoothie ("V2") with:
 /// - History and user lists
 /// - User credentials (login / password)
 class ApplicationDataImporter {
@@ -14,7 +14,7 @@ class ApplicationDataImporter {
 
   /// Some users may have a long history on the previous app, we limit the
   /// import of last scanned products to this constant
-  static const int MAX_HISTORY_ITEMS = 500;
+  static const int MAX_HISTORY_ITEMS = 1000;
 
   /// The maximum number of times [startImport] can be called automatically
   static const int MAX_NUMBER_RETRIES = 5;


### PR DESCRIPTION
In app store reviews, some users claim they have lost part of their history between the old Android/iOS app and the new one.
It may be a lite late know, since we remove all data, but this PR increases the number of items imported from `500` to `1000`