### PR TITLE
fix: Carousel - Item not deletable

### DIFF
--- a/packages/smooth_app/lib/pages/scan/scan_product_card.dart
+++ b/packages/smooth_app/lib/pages/scan/scan_product_card.dart
@@ -6,7 +6,9 @@ import 'package:smooth_app/pages/product/new_product_page.dart';
 import 'package:smooth_app/pages/product/summary_card.dart';
 
 class ScanProductCard extends StatelessWidget {
-  const ScanProductCard(this.product);
+  ScanProductCard(this.product)
+      : assert(product.barcode!.isNotEmpty),
+        super(key: Key(product.barcode!));
 
   final Product product;
 


### PR DESCRIPTION
For List based content, we may use Key whenever possible.
Otherwise we have the kind of issue like #2306, where an incorrect card is displayed after a removal

Will fix #2306 