### PR TITLE
feat: #2364 - new preferences toggles for ingredients / nutrition expand mode

### DIFF
--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_card.dart
@@ -3,6 +3,8 @@ import 'package:openfoodfacts/model/KnowledgePanel.dart';
 import 'package:openfoodfacts/model/KnowledgePanelElement.dart';
 import 'package:openfoodfacts/model/KnowledgePanels.dart';
 import 'package:openfoodfacts/model/Product.dart';
+import 'package:provider/provider.dart';
+import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_expanded_card.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_group_card.dart';
@@ -20,10 +22,17 @@ class KnowledgePanelCard extends StatelessWidget {
   final KnowledgePanels allPanels;
   final Product product;
 
+  static const String PANEL_NUTRITION_TABLE_ID = 'nutrition_facts_table';
+  static const String PANEL_INGREDIENTS_ID = 'ingredients';
+
+  /// Returns the preferences tag we use for the flag related to that [panelId].
+  static String getExpandFlagTag(final String panelId) => 'expand_$panelId';
+
   @override
   Widget build(BuildContext context) {
-    // If [expanded] = true, render all panel elements (including summary), otherwise just renders panel summary.
-    if (panel.expanded ?? false) {
+    final UserPreferences userPreferences = context.watch<UserPreferences>();
+    if (_isExpandedByUser(panel, allPanels, userPreferences) ||
+        (panel.expanded ?? false)) {
       return KnowledgePanelExpandedCard(
         panel: panel,
         allPanels: allPanels,
@@ -58,5 +67,26 @@ class KnowledgePanelCard extends StatelessWidget {
         },
       ),
     );
+  }
+
+  bool _isExpandedByUser(
+    final KnowledgePanel panel,
+    final KnowledgePanels allPanels,
+    final UserPreferences userPreferences,
+  ) {
+    final List<String> expandedPanelIds = <String>[
+      PANEL_NUTRITION_TABLE_ID,
+      PANEL_INGREDIENTS_ID,
+    ];
+    for (final String panelId in expandedPanelIds) {
+      if (panel.titleElement != null &&
+          panel.titleElement!.title ==
+              allPanels.panelIdToPanelMap[panelId]?.titleElement?.title) {
+        if (userPreferences.getFlag(getExpandFlagTag(panelId)) ?? false) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 }

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1546,6 +1546,16 @@
     "@choose from gallery": {
         "description": "Button label for choosing a photo from gallery"
     },
+    "expand_nutrition_facts": "Expand nutrition facts table",
+    "@expand_nutrition_facts": {
+        "description": "Label for expanding nutrition facts table in application setting"
+    },
+    "expand_nutrition_facts_body": "Keep the nutrition facts table expanded",
+    "expand_ingredients": "Expand ingredients",
+    "@expand_ingredients": {
+        "description": "Label for expanding nutrition facts table in application setting"
+    },
+    "expand_ingredients_body": "Keep the ingredients panel expanded",
     "no_internet_connection": "No internet connection",
     "@no_internet_connection": {
         "description": "Message when there is no internet connection"

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_settings.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_settings.dart
@@ -8,6 +8,7 @@ import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/camera_helper.dart';
+import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_card.dart';
 import 'package:smooth_app/pages/onboarding/country_selector.dart';
 import 'package:smooth_app/pages/preferences/abstract_user_preferences.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_page.dart';
@@ -153,6 +154,16 @@ class _PrivacySettings extends StatelessWidget {
         const _CrashReportingSetting(),
         const UserPreferencesListItemDivider(),
         const _SendAnonymousDataSetting(),
+        _ExpandPanelHelper(
+          title: appLocalizations.expand_nutrition_facts,
+          subtitle: appLocalizations.expand_nutrition_facts_body,
+          panelId: KnowledgePanelCard.PANEL_NUTRITION_TABLE_ID,
+        ),
+        _ExpandPanelHelper(
+          title: appLocalizations.expand_ingredients,
+          subtitle: appLocalizations.expand_ingredients_body,
+          panelId: KnowledgePanelCard.PANEL_INGREDIENTS_ID,
+        ),
       ],
     );
   }
@@ -345,6 +356,31 @@ class _CameraPlayScanSoundSetting extends StatelessWidget {
       onChanged: (final bool value) async {
         await userPreferences.setPlayCameraSound(value);
       },
+    );
+  }
+}
+
+class _ExpandPanelHelper extends StatelessWidget {
+  const _ExpandPanelHelper({
+    required this.title,
+    required this.subtitle,
+    required this.panelId,
+  });
+
+  final String title;
+  final String subtitle;
+  final String panelId;
+
+  @override
+  Widget build(BuildContext context) {
+    final UserPreferences userPreferences = context.watch<UserPreferences>();
+    final String flagTag = KnowledgePanelCard.getExpandFlagTag(panelId);
+    return UserPreferencesSwitchItem(
+      title: title,
+      subtitle: subtitle,
+      value: userPreferences.getFlag(flagTag) ?? false,
+      onChanged: (final bool value) async =>
+          userPreferences.setFlag(flagTag, value),
     );
   }
 }


### PR DESCRIPTION
Impacted files:
* `app_en.arb`: added labels for preferences toggles (ingredients and nutrition)
* `knowledge_panel_card.dart`: now uses the new expand flags to expand the contents (or not)
* `user_preferences_settings.dart`: added 2 preferences toggles (expand ingredients / nutrition)

### What
- Now in the user preferences, we can activate the expand mode of ingredients and nutrition facts on the product page.
- Default mode is "not expanded" for both ingredients and nutrition facts.
- The code is hugely inspired by @cli1005's #2392. I wish I could have kept the original code, but I fell into a `git` rabbit hole that I was not able to escape from, and it was much safer to make a clean copy of the code instead.

### Screenshot
![Capture d’écran 2022-07-20 à 13 34 31](https://user-images.githubusercontent.com/11576431/179972153-e66dfe00-e076-463d-8a19-637e29667ac7.png)

### Fixes bug(s)
- Closes: #2364