### PR TITLE
feat: Better highlight the selected item in the bottom navigation bar

### DIFF
--- a/packages/smooth_app/lib/themes/smooth_theme.dart
+++ b/packages/smooth_app/lib/themes/smooth_theme.dart
@@ -26,9 +26,14 @@ class SmoothTheme {
       fontFamily: 'PlusJakartaSans',
       colorScheme: myColorScheme,
       bottomNavigationBarTheme: BottomNavigationBarThemeData(
+        selectedIconTheme: const IconThemeData(size: 24.0),
         showSelectedLabels: true,
+        selectedItemColor: brightness == Brightness.dark
+            ? Colors.white
+            : const Color(0xFF341100),
+        selectedLabelStyle: const TextStyle(fontWeight: FontWeight.bold),
         showUnselectedLabels: true,
-        selectedItemColor: myColorScheme.primary,
+        unselectedIconTheme: const IconThemeData(size: 20.0),
       ),
       elevatedButtonTheme: ElevatedButtonThemeData(
         style: ButtonStyle(


### PR DESCRIPTION
Current:
![Screenshot_1658357086](https://user-images.githubusercontent.com/246838/180095370-36d6c75d-cca7-41bd-a586-6e5a99cc31f4.png)
![Screenshot_1658182372](https://user-images.githubusercontent.com/246838/180095645-62f0c965-8566-4b96-a6b1-c7031fcdbc27.png)


With this PR:
![Screenshot_1658356997](https://user-images.githubusercontent.com/246838/180095387-e19fd8bb-f5ab-433d-a9e9-ddbc5eed48fd.png)
![Screenshot_1658356991](https://user-images.githubusercontent.com/246838/180095596-e901e9e1-5f20-444b-9db7-12d0d1350a0c.png)


The selected item is now:
- In brown/white

The unselected item is now:
- A little big smaller (20px for the icon, instead of 24)