### PR TITLE
feat: #2503 - language selector now in "App Settings" (for all users)

### DIFF
--- a/packages/smooth_app/lib/generic_lib/widgets/language_selector.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/language_selector.dart
@@ -22,19 +22,24 @@ class LanguageSelectorSettings extends StatelessWidget {
     // The languages that are supported by flutter widget
     final String currentLanguageCode = userPreferences.appLanguageCode ??
         Localizations.localeOf(context).toString();
-    final String nameInLanguage =
+    final OpenFoodFactsLanguage language =
+        LanguageHelper.fromJson(currentLanguageCode);
+    final String nameInEnglish =
         _languages.getLanguageNameInEnglishFromOpenFoodFactsLanguage(
-            LanguageHelper.fromJson(currentLanguageCode));
+      language,
+    );
+    final String nameInLanguage =
+        _languages.getLanguageNameInLanguageFromOpenFoodFactsLanguage(
+      language,
+    );
     return ListTile(
       leading: const Icon(Icons.language),
       title: Text(
-        appLocalizations.choose_app_language,
-      ),
-      subtitle: Text(
-        '$nameInLanguage ($currentLanguageCode)',
+        '$nameInLanguage ($nameInEnglish)',
         softWrap: false,
         overflow: TextOverflow.fade,
       ),
+      trailing: const Icon(Icons.arrow_drop_down),
       onTap: () async {
         final List<OpenFoodFactsLanguage> leftovers =
             _languages.getSupportedLanguagesNameInEnglish();
@@ -69,12 +74,18 @@ class LanguageSelectorSettings extends StatelessWidget {
                                                 item)
                                             .toLowerCase()
                                             .contains(query.toLowerCase()) ||
+                                        _languages
+                                            .getLanguageNameInLanguageFromOpenFoodFactsLanguage(
+                                                item)
+                                            .toLowerCase()
+                                            .contains(query.toLowerCase()) ||
                                         item.code.contains(query))
                                     .toList();
                               },
                             );
                           },
                         ),
+                        // TODO(monsieurtanuki): an optimization would be not to generate all tiles and use something like a ListView.builder instead
                         ...List<ListTile>.generate(
                           filteredList.length,
                           (int index) {

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_dev_mode.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_dev_mode.dart
@@ -9,7 +9,6 @@ import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/database/dao_product_list.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
-import 'package:smooth_app/generic_lib/widgets/language_selector.dart';
 import 'package:smooth_app/helpers/data_importer/product_list_import_export.dart';
 import 'package:smooth_app/helpers/data_importer/smooth_app_data_importer.dart';
 import 'package:smooth_app/pages/onboarding/onboarding_flow_navigator.dart';
@@ -332,10 +331,6 @@ class UserPreferencesDevMode extends AbstractUserPreferences {
             await userPreferences.setExcludedAttributeIds(list);
             setState(() {});
           },
-        ),
-        LanguageSelectorSettings(
-          userPreferences: userPreferences,
-          appLocalizations: appLocalizations,
         ),
         ListTile(
           // Do not translate

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_settings.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_settings.dart
@@ -6,6 +6,7 @@ import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/generic_lib/widgets/language_selector.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/camera_helper.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_card.dart';
@@ -66,6 +67,7 @@ class _ApplicationSettings extends StatelessWidget {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final ThemeProvider themeProvider = context.watch<ThemeProvider>();
     final ThemeData themeData = Theme.of(context);
+    final UserPreferences userPreferences = context.watch<UserPreferences>();
 
     return Column(
       children: <Widget>[
@@ -110,6 +112,17 @@ class _ApplicationSettings extends StatelessWidget {
         ),
         const UserPreferencesListItemDivider(),
         const _CountryPickerSetting(),
+        const UserPreferencesListItemDivider(),
+        ListTile(
+          title: Text(
+            appLocalizations.choose_app_language,
+            style: Theme.of(context).textTheme.headline4,
+          ),
+          subtitle: LanguageSelectorSettings(
+            userPreferences: userPreferences,
+            appLocalizations: appLocalizations,
+          ),
+        ),
         const UserPreferencesListItemDivider(),
       ],
     );


### PR DESCRIPTION
Impacted files:
* `language_selector.dart`: refactored for consistent data and filter
* `user_preferences_dev_mode.dart`: removed the language selector
* `user_preferences_settings.dart`: put the language selector, slightly refactored for UI consistency with country selector

### What
- The language selector was moved from Dev Mode Settings to more user-friendly App Settings

### Screenshot
![Capture d’écran 2022-07-25 à 18 48 24](https://user-images.githubusercontent.com/11576431/180831726-13b7ad47-6795-4b3a-91bf-9e769c75b0c5.png)

### Fixes bug(s)
- Closes: #2503