### PR TITLE
fix: #2682 - no more trying to display null panels

### DIFF
--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_element_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_element_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:openfoodfacts/model/KnowledgePanel.dart';
 import 'package:openfoodfacts/model/KnowledgePanelElement.dart';
 import 'package:openfoodfacts/model/KnowledgePanels.dart';
 import 'package:openfoodfacts/model/Product.dart';
@@ -41,9 +42,18 @@ class KnowledgePanelElementCard extends StatelessWidget {
           height: knowledgePanelElement.imageElement!.height?.toDouble(),
         );
       case KnowledgePanelElementType.PANEL:
+        final String panelId = knowledgePanelElement.panelElement!.panelId;
+        final KnowledgePanel? panel = allPanels.panelIdToPanelMap[panelId];
+        if (panel == null) {
+          // happened in https://github.com/openfoodfacts/smooth-app/issues/2682
+          // due to some inconsistencies in the data sent by the server
+          Logs.w(
+            'unknown panel "$panelId" for barcode "${product.barcode}"',
+          );
+          return EMPTY_WIDGET;
+        }
         return KnowledgePanelCard(
-          panel: allPanels
-              .panelIdToPanelMap[knowledgePanelElement.panelElement!.panelId]!,
+          panel: panel,
           allPanels: allPanels,
           product: product,
         );


### PR DESCRIPTION
Impacted file:
* `knowledge_panel_element_card.dart`: no more trying to display panels that do not exist

### What
- There may data inconsistencies from the server.
- This PR fixes the assumption that all the references panels actually do exist.
- Instead, we display an empty widget and send a sentry.

### Fixes bug(s)
- Fixes: #2682