### PR TITLE
fix: Small padding in country/language selection in settings

### DIFF
--- a/packages/smooth_app/lib/generic_lib/widgets/language_selector.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/language_selector.dart
@@ -33,6 +33,7 @@ class LanguageSelectorSettings extends StatelessWidget {
       language,
     );
     return ListTile(
+      contentPadding: EdgeInsets.zero,
       leading: const Icon(Icons.language),
       title: Text(
         '$nameInLanguage ($nameInEnglish)',

--- a/packages/smooth_app/lib/pages/onboarding/country_selector.dart
+++ b/packages/smooth_app/lib/pages/onboarding/country_selector.dart
@@ -144,6 +144,7 @@ class _CountrySelectorState extends State<CountrySelector> {
               borderRadius: BorderRadius.all(Radius.circular(10)),
             ),
             child: ListTile(
+              contentPadding: EdgeInsets.zero,
               leading: const Icon(Icons.public),
               title: Text(
                 _chosenValue.name,

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_settings.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_settings.dart
@@ -122,6 +122,7 @@ class _ApplicationSettings extends StatelessWidget {
             userPreferences: userPreferences,
             appLocalizations: appLocalizations,
           ),
+          minVerticalPadding: MEDIUM_SPACE,
         ),
         const UserPreferencesListItemDivider(),
       ],


### PR DESCRIPTION
### What
<!-- description of the PR -->
- fix: Small padding in country/language selection in settings #2683 

### Screenshot
<!-- Insert a screenshot to provide visual record of your changes, if visible -->
![Screenshot_2022-07-31-18-26-46-591_org openfoodfacts scanner](https://user-images.githubusercontent.com/75238158/182027713-e70b82b6-af13-43de-a014-701869cbf86f.jpg)

### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

### Part of 
- #2683 
<!-- please be as granular as possible -->
