### PR TITLE
fix: svgAsset - additional svg assets

### DIFF
--- a/packages/smooth_app/assets/cache/high.svg
+++ b/packages/smooth_app/assets/cache/high.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0, 0, 2, 2"><circle cx="1" cy="1" r="1" fill="#f00000"/></svg>

--- a/packages/smooth_app/assets/cache/low.svg
+++ b/packages/smooth_app/assets/cache/low.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0, 0, 2, 2"><circle cx="1" cy="1" r="1" fill="#60f000"/></svg>


### PR DESCRIPTION
New files:
* `high.svg`
* `low.svg`

Fix for the following sentry messages:
* please download https://static.openfoodfacts.org/images/misc/low.svg and put it in asset somewhere like [assets/cache/low.svg, assets/cacheTintable/low.svg]
* please download https://static.openfoodfacts.org/images/misc/high.svg and put it in asset somewhere like [assets/cache/high.svg, assets/cacheTintable/high.svg]

### What
- As usual, new svg files from the server, which calls for new svg asset files in Smoothie for a faster/offline app.