### PR TITLE
fix: #2681 - share product url

### DIFF
--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:openfoodfacts/model/KnowledgePanelElement.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:provider/provider.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:smooth_app/cards/product_cards/product_image_carousel.dart';
@@ -287,12 +288,9 @@ class _ProductPageState extends State<ProductPage> with TraceableClientMixin {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     // We need to provide a sharePositionOrigin to make the plugin work on ipad
     final RenderBox? box = context.findRenderObject() as RenderBox?;
-    final String url = OpenFoodAPIClient.getProductUri(
-      widget.product.barcode!,
-      replaceSubdomain: true,
-      country: ProductQuery.getCountry(),
-    ).toString();
-
+    final String url = 'https://'
+        '${ProductQuery.getCountry()!.iso2Code}.openfoodfacts.org'
+        '/product/${widget.product.barcode}';
     Share.share(
       appLocalizations.share_product_text(url),
       sharePositionOrigin: box!.localToGlobal(Offset.zero) & box.size,


### PR DESCRIPTION
Impacted file:
* `new_product_page.dart`: fixed the share product url

### What
Lousy quick fix, because there are problems outside of Smoothie:
1. in off-dart, `getProductUri` has no `bool addUserAgentParameters` parameter - the default is `true`, we need `false` in order to remove the numerous url parameters
2. on the server side, https://fr-fr.openfoodfacts.org/product/7300400481588 is redirected as https://fr.openfoodfacts.orgproduct/7300400481588 (which is not a valid url)
3. in off-dart, we cannot specify "I want no language in the URL" in `getProductUri` - if the language is not specified, the default language is used instead

### Screenshot
![Capture d’écran 2022-07-31 à 16 21 56](https://user-images.githubusercontent.com/11576431/182030795-9c1e3964-c091-40bd-85fa-5072b19fd344.png)


### Fixes bug(s)
- Fixes: #2681