### PR TITLE
fix: new svg asset

### DIFF
--- a/packages/smooth_app/assets/cache/moderate.svg
+++ b/packages/smooth_app/assets/cache/moderate.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0, 0, 2, 2"><circle cx="1" cy="1" r="1" fill="#ffcc01"/></svg>


### PR DESCRIPTION
New file:
* `moderate.svg`

### What
The message was:
* please download https://static.openfoodfacts.org/images/misc/moderate.svg and put it in asset somewhere like [assets/cache/moderate.svg, assets/cacheTintable/moderate.svg]