### PR TITLE
feat: Move to Sentry breadcrumbs

### DIFF
--- a/packages/smooth_app/lib/services/logs/fimber/trees/sentry_fimber_tree.dart
+++ b/packages/smooth_app/lib/services/logs/fimber/trees/sentry_fimber_tree.dart
@@ -24,9 +24,12 @@ class SentryFimberTree extends BaseFimberTree {
         hint: tag,
       );
     } else {
-      Sentry.captureMessage(
-        message,
-        level: _convertLevel(level),
+      Sentry.addBreadcrumb(
+        Breadcrumb(
+          message: message,
+          timestamp: DateTime.now(),
+          level: _convertLevel(level),
+        ),
         hint: tag,
       );
     }

--- a/packages/smooth_app/lib/services/logs/logs_fimber_impl.dart
+++ b/packages/smooth_app/lib/services/logs/logs_fimber_impl.dart
@@ -12,7 +12,7 @@ import 'package:smooth_app/services/logs/smooth_log_levels.dart';
 import 'package:smooth_app/services/logs/smooth_logs_service.dart';
 
 /// On debug builds: device logs + file (all levels)
-/// On release builds : device logs (only errors), sentry (all levels) and
+/// On release builds : device logs (only errors), Sentry (all levels) and
 /// file (only errors & info)
 class FimberLogImpl implements AppLogService {
   // Link to a file tree impl (required for exporting logs)


### PR DESCRIPTION
The documentation for Sentry is not really detailed, with comments like `captureMessage => "capture a message"` 🤨
It seems that a message for Sentry is similar to an exception. 

Instead, what we want to do is only to provide information for a given bug. In that case, we should use `breadcrumbs`.
The change is really simple in the code, but should prevent all the spam we have.

Should fix #2413