### PR TITLE
fix: "Dots" not synchronized with the selected image

### DIFF
--- a/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
@@ -64,6 +64,8 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView> {
             element.imageUrl == widget.productImageData.imageUrl),
       ),
     );
+    _currentIndex = _controller.initialPage;
+
     _productImageDataCurrent = widget.productImageData;
     super.initState();
   }


### PR DESCRIPTION
In the gallery view, the dots are not synchronized with the initial position of the selected photo
Will fix #2699 

New behavior (correct):
https://user-images.githubusercontent.com/246838/182121182-bbac4920-52d7-413c-bc95-657483bc213f.mp4


