### PR TITLE
fix: Barcode color in product edition page

### DIFF
--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -56,6 +56,8 @@ class _EditProductPageState extends State<EditProductPage> {
         if (refreshedProduct != null) {
           _product = refreshedProduct;
         }
+        final Brightness brightness = Theme.of(context).brightness;
+
         return SmoothScaffold(
           appBar: AppBar(
             title: AutoSizeText(
@@ -76,6 +78,9 @@ class _EditProductPageState extends State<EditProductPage> {
                     barcode: _product.barcode!.length == 8
                         ? Barcode.ean8()
                         : Barcode.ean13(),
+                    color: brightness == Brightness.dark
+                        ? Colors.white
+                        : Colors.black,
                     data: _product.barcode!,
                     errorBuilder: (final BuildContext context, String? _) =>
                         ListTile(


### PR DESCRIPTION
In dark mode, the barcode should be white and black in light in the product edition page.

Will fix #2701 

New behavior:
![Screenshot_1659347435](https://user-images.githubusercontent.com/246838/182122815-dd01dc07-7416-40c4-9dfc-048e3c8b6c5a.png)

