### PR TITLE
fix: AutocompleteWidget: Scrollbar + dividers + correct width

### DIFF
--- a/packages/smooth_app/lib/pages/product/autocomplete.dart
+++ b/packages/smooth_app/lib/pages/product/autocomplete.dart
@@ -20,7 +20,6 @@ class AutocompleteOptions<T extends Object> extends StatelessWidget {
         super(key: key);
 
   final AutocompleteOptionToString<T> displayStringForOption;
-
   final AutocompleteOnSelected<T> onSelected;
 
   final Iterable<T> options;
@@ -29,6 +28,8 @@ class AutocompleteOptions<T extends Object> extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final int highlightedOption = AutocompleteHighlightedOption.of(context);
+
     return Align(
       alignment: AlignmentDirectional.topStart,
       child: Material(
@@ -46,25 +47,13 @@ class AutocompleteOptions<T extends Object> extends StatelessWidget {
               itemCount: options.length,
               itemBuilder: (BuildContext context, int index) {
                 final T option = options.elementAt(index);
-                return InkWell(
-                  onTap: () {
-                    onSelected(option);
-                  },
-                  child: Builder(builder: (BuildContext context) {
-                    final bool highlight =
-                        AutocompleteHighlightedOption.of(context) == index;
-                    if (highlight) {
-                      SchedulerBinding.instance
-                          .addPostFrameCallback((Duration timeStamp) {
-                        Scrollable.ensureVisible(context, alignment: 0.5);
-                      });
-                    }
-                    return Container(
-                      color: highlight ? Theme.of(context).focusColor : null,
-                      padding: const EdgeInsets.all(LARGE_SPACE),
-                      child: Text(displayStringForOption(option)),
-                    );
-                  }),
+
+                return _AutocompleteOptionsItem<T>(
+                  key: Key(index.toString()),
+                  option: option,
+                  highlight: highlightedOption == index,
+                  onSelected: onSelected,
+                  displayStringForOption: displayStringForOption,
                 );
               },
               separatorBuilder: (_, __) => const Divider(
@@ -72,6 +61,43 @@ class AutocompleteOptions<T extends Object> extends StatelessWidget {
               ),
             ),
           ),
+        ),
+      ),
+    );
+  }
+}
+
+class _AutocompleteOptionsItem<T extends Object> extends StatelessWidget {
+  const _AutocompleteOptionsItem({
+    required this.option,
+    required this.highlight,
+    required this.displayStringForOption,
+    required this.onSelected,
+    Key? key,
+  }) : super(key: key);
+
+  final T option;
+  final bool highlight;
+  final AutocompleteOptionToString<T> displayStringForOption;
+  final AutocompleteOnSelected<T> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    if (highlight) {
+      SchedulerBinding.instance.addPostFrameCallback((Duration timeStamp) {
+        Scrollable.ensureVisible(context, alignment: 0.5);
+      });
+    }
+
+    return InkWell(
+      onTap: () {
+        onSelected(option);
+      },
+      child: Container(
+        color: highlight ? Theme.of(context).focusColor : null,
+        padding: const EdgeInsets.all(LARGE_SPACE),
+        child: Text(
+          displayStringForOption(option),
         ),
       ),
     );

--- a/packages/smooth_app/lib/pages/product/autocomplete.dart
+++ b/packages/smooth_app/lib/pages/product/autocomplete.dart
@@ -14,13 +14,17 @@ class AutocompleteOptions<T extends Object> extends StatelessWidget {
     required this.onSelected,
     required this.options,
     required this.maxOptionsHeight,
-  }) : super(key: key);
+    required this.maxOptionsWidth,
+  })  : assert(maxOptionsHeight >= 0),
+        assert(maxOptionsWidth >= 0),
+        super(key: key);
 
   final AutocompleteOptionToString<T> displayStringForOption;
 
   final AutocompleteOnSelected<T> onSelected;
 
   final Iterable<T> options;
+  final double maxOptionsWidth;
   final double maxOptionsHeight;
 
   @override
@@ -30,34 +34,43 @@ class AutocompleteOptions<T extends Object> extends StatelessWidget {
       child: Material(
         elevation: 4.0,
         child: ConstrainedBox(
-          constraints: BoxConstraints(maxHeight: maxOptionsHeight),
-          child: ListView.builder(
-            padding: EdgeInsets.zero,
-            shrinkWrap: true,
-            itemCount: options.length,
-            itemBuilder: (BuildContext context, int index) {
-              final T option = options.elementAt(index);
-              return InkWell(
-                onTap: () {
-                  onSelected(option);
-                },
-                child: Builder(builder: (BuildContext context) {
-                  final bool highlight =
-                      AutocompleteHighlightedOption.of(context) == index;
-                  if (highlight) {
-                    SchedulerBinding.instance
-                        .addPostFrameCallback((Duration timeStamp) {
-                      Scrollable.ensureVisible(context, alignment: 0.5);
-                    });
-                  }
-                  return Container(
-                    color: highlight ? Theme.of(context).focusColor : null,
-                    padding: const EdgeInsets.all(LARGE_SPACE),
-                    child: Text(displayStringForOption(option)),
-                  );
-                }),
-              );
-            },
+          constraints: BoxConstraints(
+            maxHeight: maxOptionsHeight,
+            maxWidth: maxOptionsWidth,
+            minWidth: 100.0,
+          ),
+          child: Scrollbar(
+            child: ListView.separated(
+              padding: EdgeInsets.zero,
+              shrinkWrap: true,
+              itemCount: options.length,
+              itemBuilder: (BuildContext context, int index) {
+                final T option = options.elementAt(index);
+                return InkWell(
+                  onTap: () {
+                    onSelected(option);
+                  },
+                  child: Builder(builder: (BuildContext context) {
+                    final bool highlight =
+                        AutocompleteHighlightedOption.of(context) == index;
+                    if (highlight) {
+                      SchedulerBinding.instance
+                          .addPostFrameCallback((Duration timeStamp) {
+                        Scrollable.ensureVisible(context, alignment: 0.5);
+                      });
+                    }
+                    return Container(
+                      color: highlight ? Theme.of(context).focusColor : null,
+                      padding: const EdgeInsets.all(LARGE_SPACE),
+                      child: Text(displayStringForOption(option)),
+                    );
+                  }),
+                );
+              },
+              separatorBuilder: (_, __) => const Divider(
+                height: 1.0,
+              ),
+            ),
           ),
         ),
       ),

--- a/packages/smooth_app/lib/pages/product/simple_input_widget.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_widget.dart
@@ -50,87 +50,97 @@ class _SimpleInputWidgetState extends State<SimpleInputWidget> {
           ),
         ),
         ExplanationWidget(widget.helper.getAddExplanations(appLocalizations)),
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: <Widget>[
-            Flexible(
-              flex: 1,
-              child: Padding(
-                padding: const EdgeInsets.only(left: LARGE_SPACE),
-                child: RawAutocomplete<String>(
-                  key: _autocompleteKey,
-                  focusNode: _focusNode,
-                  textEditingController: widget.controller,
-                  optionsBuilder: (final TextEditingValue value) async {
-                    final List<String> result = <String>[];
-                    final String input = value.text.trim();
-                    if (input.isEmpty) {
-                      return result;
-                    }
-                    final TagType? tagType = widget.helper.getTagType();
-                    if (tagType == null) {
-                      return result;
-                    }
-                    // TODO(monsieurtanuki): ask off-dart to return Strings instead of dynamic?
-                    final List<dynamic> data =
-                        await OpenFoodAPIClient.getAutocompletedSuggestions(
-                      tagType,
-                      language: ProductQuery.getLanguage()!,
-                      limit: 1000000, // lower max count on the server anyway
-                      input: value.text.trim(),
-                    );
-                    for (final dynamic item in data) {
-                      result.add(item.toString());
-                    }
-                    result.sort();
-                    return result;
-                  },
-                  fieldViewBuilder: (BuildContext context,
-                          TextEditingController textEditingController,
-                          FocusNode focusNode,
-                          VoidCallback onFieldSubmitted) =>
-                      TextField(
-                    controller: textEditingController,
-                    decoration: InputDecoration(
-                      filled: true,
-                      border: const OutlineInputBorder(
-                        borderRadius: CIRCULAR_BORDER_RADIUS,
-                        borderSide: BorderSide.none,
+        LayoutBuilder(
+          builder: (_, BoxConstraints constraints) {
+            return Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: <Widget>[
+                Flexible(
+                  flex: 1,
+                  child: Padding(
+                    padding: const EdgeInsets.only(left: LARGE_SPACE),
+                    child: RawAutocomplete<String>(
+                      key: _autocompleteKey,
+                      focusNode: _focusNode,
+                      textEditingController: widget.controller,
+                      optionsBuilder: (final TextEditingValue value) async {
+                        final List<String> result = <String>[];
+                        final String input = value.text.trim();
+                        if (input.isEmpty) {
+                          return result;
+                        }
+                        final TagType? tagType = widget.helper.getTagType();
+                        if (tagType == null) {
+                          return result;
+                        }
+                        // TODO(monsieurtanuki): ask off-dart to return Strings instead of dynamic?
+                        final List<dynamic> data =
+                            await OpenFoodAPIClient.getAutocompletedSuggestions(
+                          tagType,
+                          language: ProductQuery.getLanguage()!,
+                          limit:
+                              1000000, // lower max count on the server anyway
+                          input: value.text.trim(),
+                        );
+                        for (final dynamic item in data) {
+                          result.add(item.toString());
+                        }
+                        result.sort();
+                        return result;
+                      },
+                      fieldViewBuilder: (BuildContext context,
+                              TextEditingController textEditingController,
+                              FocusNode focusNode,
+                              VoidCallback onFieldSubmitted) =>
+                          TextField(
+                        controller: textEditingController,
+                        decoration: InputDecoration(
+                          filled: true,
+                          border: const OutlineInputBorder(
+                            borderRadius: CIRCULAR_BORDER_RADIUS,
+                            borderSide: BorderSide.none,
+                          ),
+                          contentPadding: const EdgeInsets.symmetric(
+                            horizontal: SMALL_SPACE,
+                            vertical: SMALL_SPACE,
+                          ),
+                          hintText: widget.helper.getAddHint(appLocalizations),
+                        ),
+                        autofocus: true,
+                        focusNode: focusNode,
                       ),
-                      contentPadding: const EdgeInsets.symmetric(
-                        horizontal: SMALL_SPACE,
-                        vertical: SMALL_SPACE,
+                      optionsViewBuilder: (
+                        BuildContext context,
+                        AutocompleteOnSelected<String> onSelected,
+                        Iterable<String> options,
+                      ) =>
+                          AutocompleteOptions<String>(
+                        displayStringForOption:
+                            RawAutocomplete.defaultStringForOption,
+                        onSelected: onSelected,
+                        options: options,
+                        // Width = Row width - horizontal padding
+                        maxOptionsWidth:
+                            constraints.maxWidth - (LARGE_SPACE * 2),
+                        maxOptionsHeight:
+                            MediaQuery.of(context).size.height / 2,
                       ),
-                      hintText: widget.helper.getAddHint(appLocalizations),
                     ),
-                    autofocus: true,
-                    focusNode: focusNode,
-                  ),
-                  optionsViewBuilder: (
-                    BuildContext context,
-                    AutocompleteOnSelected<String> onSelected,
-                    Iterable<String> options,
-                  ) =>
-                      AutocompleteOptions<String>(
-                    displayStringForOption:
-                        RawAutocomplete.defaultStringForOption,
-                    onSelected: onSelected,
-                    options: options,
-                    maxOptionsHeight: MediaQuery.of(context).size.height / 2,
                   ),
                 ),
-              ),
-            ),
-            IconButton(
-              onPressed: () {
-                if (widget.helper.addItemsFromController(widget.controller)) {
-                  setState(() {});
-                }
-              },
-              icon: const Icon(Icons.add_circle),
-            ),
-          ],
+                IconButton(
+                  onPressed: () {
+                    if (widget.helper
+                        .addItemsFromController(widget.controller)) {
+                      setState(() {});
+                    }
+                  },
+                  icon: const Icon(Icons.add_circle),
+                ),
+              ],
+            );
+          },
         ),
         Divider(color: themeData.colorScheme.onBackground),
         Column(


### PR DESCRIPTION
On product edition pages, when there are fields with suggestions, the list can be improved by:
- Adding some dividers
- Adding a scrollbar
- Ensuring the content fits the screen width

Previous UI:
![Screenshot_1659347776](https://user-images.githubusercontent.com/246838/182128604-cc2cd67f-1638-4e20-a9c5-5a93169d9f06.png)

New UI:
![Screenshot_1659349478](https://user-images.githubusercontent.com/246838/182128586-e8ab1a7b-7633-4d3f-a48b-417a4f1f8ddc.png)

Will fix #2703

