### PR TITLE
fix: Add extra space on the left of the back button - Change the colour of the arrow to be the same as the text

### DIFF
--- a/packages/smooth_app/lib/cards/data_cards/score_card.dart
+++ b/packages/smooth_app/lib/cards/data_cards/score_card.dart
@@ -34,6 +34,7 @@ class ScoreCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final double iconHeight = IconWidgetSizer.getIconSizeFromContext(context);
     final ThemeData themeData = Theme.of(context);
+
     final double opacity = themeData.brightness == Brightness.light
         ? 1
         : SmoothTheme.ADDITIONAL_OPACITY_FOR_DARK;
@@ -73,7 +74,11 @@ class ScoreCard extends StatelessWidget {
                 ),
               ),
             ),
-            if (isClickable) Icon(ConstantIcons.instance.getForwardIcon()),
+            if (isClickable)
+              Icon(
+                ConstantIcons.instance.getForwardIcon(),
+                color: textColor,
+              ),
           ],
         ),
       ),

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -118,28 +118,32 @@ class _ProductPageState extends State<ProductPage> with TraceableClientMixin {
                 },
               ),
             ),
-            SafeArea(
-              child: AnimatedContainer(
-                duration: SmoothAnimationsDuration.short,
-                width: kToolbarHeight,
-                height: kToolbarHeight,
-                decoration: BoxDecoration(
-                  color:
-                      scrollingUp ? themeData.primaryColor : Colors.transparent,
-                  shape: BoxShape.circle,
-                ),
-                child: Offstage(
-                  offstage: !scrollingUp,
-                  child: InkWell(
-                    onTap: () {
-                      Navigator.maybePop(context);
-                    },
-                    child: Tooltip(
-                      message:
-                          MaterialLocalizations.of(context).backButtonTooltip,
-                      child: Icon(
-                        ConstantIcons.instance.getBackIcon(),
-                        color: Colors.white,
+            Padding(
+              padding: const EdgeInsets.only(left: VERY_SMALL_SPACE),
+              child: SafeArea(
+                child: AnimatedContainer(
+                  duration: SmoothAnimationsDuration.short,
+                  width: kToolbarHeight,
+                  height: kToolbarHeight,
+                  decoration: BoxDecoration(
+                    color: scrollingUp
+                        ? themeData.primaryColor
+                        : Colors.transparent,
+                    shape: BoxShape.circle,
+                  ),
+                  child: Offstage(
+                    offstage: !scrollingUp,
+                    child: InkWell(
+                      onTap: () {
+                        Navigator.maybePop(context);
+                      },
+                      child: Tooltip(
+                        message:
+                            MaterialLocalizations.of(context).backButtonTooltip,
+                        child: Icon(
+                          ConstantIcons.instance.getBackIcon(),
+                          color: Colors.white,
+                        ),
                       ),
                     ),
                   ),


### PR DESCRIPTION
### What
<!-- description of the PR -->
- Product edition: small UI fixes issue #2708 

Things that have been completed :- 
- Add extra space on the left of the back button
- Change the colour of the arrow to be the same as the text

Incomplete :- 
- Extend the width of the nutriscore panel

### Screenshot
![Screenshot_2022-08-02-00-10-49-426_org openfoodfacts scanner](https://user-images.githubusercontent.com/75238158/182220738-faaa8724-dabf-48d1-8589-229bffcaf098.jpg)


### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
### Part of 
- #2708 
<!-- please be as granular as possible -->
