### PR TITLE
fix:  loop loading when scanning #2669

### DIFF
--- a/packages/smooth_app/lib/pages/scan/scan_product_card_loader.dart
+++ b/packages/smooth_app/lib/pages/scan/scan_product_card_loader.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/model/Product.dart';
 import 'package:provider/provider.dart';
-import 'package:smooth_app/cards/product_cards/smooth_product_card_loading.dart';
 import 'package:smooth_app/database/dao_product.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/pages/scan/scan_product_card.dart';
@@ -21,9 +20,6 @@ class ScanProductCardLoader extends StatelessWidget {
         final BuildContext context,
         final AsyncSnapshot<Product?> snapshot,
       ) {
-        if (snapshot.connectionState != ConnectionState.done) {
-          return SmoothProductCardLoading(barcode: barcode);
-        }
         if (snapshot.data != null) {
           return ScanProductCard(snapshot.data!);
         }


### PR DESCRIPTION
### What
<!-- description of the PR -->
- Did the research, the bug arrived with this pr #2609 
- IDK why the constructor `ScanProductCardLoader` is always called even when there is no other product in scan range, tried looking into past codes, the code was everywhere the same, so doing this small change fixed the problem
-  The loading indicator is already there, so I guess no need to do extra work here, and this fixed the visual issue now

### Screenshot
https://user-images.githubusercontent.com/57723319/182381141-32ebf7b3-93eb-4630-b5c0-918b7dd9dff7.mp4



### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes: #2669 