### PR TITLE
fix: #2706 - now we display the "LOG IN!" button only if not logged in

### DIFF
--- a/packages/smooth_app/lib/pages/preferences/abstract_user_preferences.dart
+++ b/packages/smooth_app/lib/pages/preferences/abstract_user_preferences.dart
@@ -106,4 +106,7 @@ abstract class AbstractUserPreferences {
 
   /// Color for the header.
   Color? getHeaderColor() => null;
+
+  /// Additional subtitle, to be displayed outside a [UserPreferencesListTile].
+  Widget? getAdditionalSubtitle() => null;
 }

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_account.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_account.dart
@@ -7,6 +7,7 @@ import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/user_management_provider.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/database/local_database.dart';
+import 'package:smooth_app/generic_lib/buttons/smooth_simple_button.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/helpers/launch_url_helper.dart';
@@ -49,9 +50,11 @@ class UserPreferencesAccount extends AbstractUserPreferences {
   @override
   PreferencePageType? getPreferencePageType() => PreferencePageType.ACCOUNT;
 
+  String? _getUserId() => OpenFoodAPIConfiguration.globalUser?.userId;
+
   @override
   Widget getTitle() {
-    final String? userId = OpenFoodAPIConfiguration.globalUser?.userId;
+    final String? userId = _getUserId();
     final String title;
 
     if (userId == null) {
@@ -118,6 +121,39 @@ class UserPreferencesAccount extends AbstractUserPreferences {
     }
 
     return OpenFoodAPIConfiguration.globalUser != null;
+  }
+
+  @override
+  Widget? getAdditionalSubtitle() {
+    if (_getUserId() != null) {
+      // we are already connected: no "LOGIN" button
+      return null;
+    }
+    final ThemeData theme = Theme.of(context);
+    final Size size = MediaQuery.of(context).size;
+    return Container(
+      margin: EdgeInsets.symmetric(horizontal: size.width / 4),
+      child: SmoothSimpleButton(
+        child: Text(
+          appLocalizations.sign_in,
+          style: theme.textTheme.bodyText2?.copyWith(
+            fontSize: 18.0,
+            fontWeight: FontWeight.bold,
+            color: theme.colorScheme.onPrimary,
+          ),
+        ),
+        onPressed: () async {
+          Navigator.of(
+            context,
+            rootNavigator: true,
+          ).push<dynamic>(
+            MaterialPageRoute<dynamic>(
+              builder: (BuildContext context) => const LoginPage(),
+            ),
+          );
+        },
+      ),
+    );
   }
 }
 

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_page.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_page.dart
@@ -5,7 +5,6 @@ import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/product_preferences.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
-import 'package:smooth_app/generic_lib/buttons/smooth_simple_button.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/pages/preferences/abstract_user_preferences.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_account.dart';
@@ -17,7 +16,6 @@ import 'package:smooth_app/pages/preferences/user_preferences_food.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_settings.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_user_lists.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_widgets.dart';
-import 'package:smooth_app/pages/user_management/login_page.dart';
 import 'package:smooth_app/themes/theme_provider.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
@@ -55,8 +53,6 @@ class _UserPreferencesPageState extends State<UserPreferencesPage>
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final UserPreferences userPreferences = context.watch<UserPreferences>();
-    final ThemeData theme = Theme.of(context);
-    final Size size = MediaQuery.of(context).size;
 
     final String appBarTitle;
     final List<Widget> children = <Widget>[];
@@ -77,38 +73,16 @@ class _UserPreferencesPageState extends State<UserPreferencesPage>
       ];
 
       for (final PreferencePageType type in items) {
-        children.add(
-          getUserPreferences(
-            type: type,
-            userPreferences: userPreferences,
-          ).getOnlyHeader(),
+        final AbstractUserPreferences abstractUserPreferences =
+            getUserPreferences(
+          type: type,
+          userPreferences: userPreferences,
         );
-        if (type == PreferencePageType.ACCOUNT) {
-          children.add(
-            Container(
-              margin: EdgeInsets.symmetric(horizontal: size.width / 4),
-              child: SmoothSimpleButton(
-                child: Text(
-                  appLocalizations.sign_in,
-                  style: theme.textTheme.bodyText2?.copyWith(
-                    fontSize: 18.0,
-                    fontWeight: FontWeight.bold,
-                    color: theme.colorScheme.onPrimary,
-                  ),
-                ),
-                onPressed: () async {
-                  Navigator.of(
-                    context,
-                    rootNavigator: true,
-                  ).push<dynamic>(
-                    MaterialPageRoute<dynamic>(
-                      builder: (BuildContext context) => const LoginPage(),
-                    ),
-                  );
-                },
-              ),
-            ),
-          );
+        children.add(abstractUserPreferences.getOnlyHeader());
+        final Widget? additionalSubtitle =
+            abstractUserPreferences.getAdditionalSubtitle();
+        if (additionalSubtitle != null) {
+          children.add(additionalSubtitle);
         }
       }
       headerAsset = 'assets/preferences/main.svg';


### PR DESCRIPTION
Impacted files:
* `abstract_user_preferences.dart`: added an "additional subtitle" method, returning a `null` widget by default
* `user_preferences_account.dart`: (only) implementation of the "additional subtitle", that displays the "LOG IN!" button, but only if not logged in (that's the issue fix)
* `user_preferences_page.dart`: now we let each item decide if there's an additional subtitle to display beyond the list tile (and its layout constraints)

### What
- The "LOG IN!" button was always displayed on the main preference page.
- Now we display the "LOG IN!" only when not logged in.

### Screenshot
| not logged in | logged in |
| -- | -- |
| ![Capture d’écran 2022-08-02 à 18 29 32](https://user-images.githubusercontent.com/11576431/182425848-a6bdb180-4318-48ca-b788-c9466bae414e.png) | ![Capture d’écran 2022-08-02 à 18 30 58](https://user-images.githubusercontent.com/11576431/182426317-1038dfc1-65c3-48db-a758-46d717ba6227.png) |

### Fixes bug(s)
- Fixes: #2706