### PR TITLE
fix: #2729 - product query page - simplified top messages and buttons

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1564,11 +1564,11 @@
     "@no_internet_connection": {
         "description": "Message when there is no internet connection"
     },
-    "world_results_label": "Results from the entire world",
+    "world_results_label": "Entire world",
     "@world_results_label": {
-        "description": "Label describing the current source of the results: the entire world"
+        "description": "Label describing the current source of the results: the entire world. Keep it short"
     },
-    "world_results_action": "Search world",
+    "world_results_action": "Extend your search to the world",
     "@world_results_action": {
         "description": "Label for the action button that displays the results from the entire world"
     },

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -1564,11 +1564,11 @@
     "@no_internet_connection": {
         "description": "Message when there is no internet connection"
     },
-    "world_results_label": "Résultats du monde entier",
+    "world_results_label": "Monde entier",
     "@world_results_label": {
-        "description": "Label describing the current source of the results: the entire world"
+        "description": "Label describing the current source of the results: the entire world. Keep it short"
     },
-    "world_results_action": "Monde entier",
+    "world_results_action": "Étendez votre recherche au monde entier",
     "@world_results_action": {
         "description": "Label for the action button that displays the results from the entire world"
     },

--- a/packages/smooth_app/lib/pages/product/common/product_query_page_helper.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_query_page_helper.dart
@@ -25,7 +25,6 @@ class ProductQueryPageHelper {
         builder: (BuildContext context) => ProductQueryPage(
           productListSupplier: supplier,
           name: name,
-          lastUpdate: supplier.timestamp,
         ),
       ),
     );


### PR DESCRIPTION
Impacted files:
* `product_query_page.dart`: now displaying actions as app bar icon buttons (and large buttons for empty results); replaced the banner with a simple card; refactored
* `product_query_page_helper.dart`: minor refactoring

### What
- The product query page had a dismissible `MaterialBanner`, but there was a bug and it sometimes reappeared after being dismissed
- The solution was to remove the `MaterialBanner` altogether: no bug anymore of course ;)
- It was replaced with `AppBar` buttons regarding actions ("world", "refresh"), and with a simple card regarding messages ("988 products")

### Screenshot
| type | country search | world search |
| -- | -- | -- |
| pizza | ![Capture d’écran 2022-08-06 à 08 23 54](https://user-images.githubusercontent.com/11576431/183237155-ece15787-debb-415c-b027-c034e7f55d36.png) | ![Capture d’écran 2022-08-06 à 08 24 42](https://user-images.githubusercontent.com/11576431/183237178-9c6a48c0-2c10-4b63-90b2-02c84509898d.png) |
| [Swedish food](https://www.youtube.com/watch?v=RVsfvbZTBzU) | ![Capture d’écran 2022-08-06 à 08 28 38](https://user-images.githubusercontent.com/11576431/183237336-381551e6-5786-43cc-9799-8e03ac2423c0.png) | ![Capture d’écran 2022-08-06 à 08 29 03](https://user-images.githubusercontent.com/11576431/183237350-94d0b041-dfa6-4b7d-a641-31b6402f8b0b.png) |
| unknown | ![Capture d’écran 2022-08-06 à 08 29 40](https://user-images.githubusercontent.com/11576431/183237367-349417d9-6771-4084-bd7a-1d7b8c1e59b1.png) | ![Capture d’écran 2022-08-06 à 08 29 56](https://user-images.githubusercontent.com/11576431/183237376-e90c92e8-cfb1-4199-a516-3f4a95b69c22.png) |



### Fixes bug(s)
- Fixes: #2729