### PR TITLE
fix: If the latest barcode is removed from the carousel, it should be scannable again

### DIFF
--- a/packages/smooth_app/lib/data_models/continuous_scan_model.dart
+++ b/packages/smooth_app/lib/data_models/continuous_scan_model.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:openfoodfacts/model/Product.dart';
@@ -269,6 +270,11 @@ class ContinuousScanModel with ChangeNotifier {
       false,
     );
     _barcodes.remove(barcode);
+
+    if (barcode == _latestScannedBarcode) {
+      _latestScannedBarcode = null;
+    }
+
     notifyListeners();
   }
 


### PR DESCRIPTION
If I scan a barcode, then remove it, it should be scannable again.
Presently, nothing happens.

Part of https://github.com/openfoodfacts/smooth-app/issues/2741