### PR TITLE
feat: Between the screen to take a picture and to crop it, a loading screen is now displayed

### DIFF
--- a/packages/smooth_app/lib/cards/data_cards/image_upload_card.dart
+++ b/packages/smooth_app/lib/cards/data_cards/image_upload_card.dart
@@ -32,7 +32,7 @@ class _ImageUploadCardState extends State<ImageUploadCard> {
 
   Future<void> _getImage() async {
     final File? croppedImageFile =
-        await startImageCropping(context, showoptionDialog: true);
+        await startImageCropping(context, showOptionDialog: true);
 
     if (croppedImageFile != null) {
       if (widget.productImageData.imageField != ImageField.OTHER) {

--- a/packages/smooth_app/lib/pages/image_crop_page.dart
+++ b/packages/smooth_app/lib/pages/image_crop_page.dart
@@ -1,20 +1,30 @@
 import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:image_cropper/image_cropper.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 
-Future<File?> startImageCropping(BuildContext context,
-    {File? existingImage,
-    bool showoptionDialog = false,
-    bool chooseFromGallery = false}) async {
+Future<File?> startImageCropping(
+  BuildContext context, {
+  File? existingImage,
+  bool showOptionDialog = false,
+  bool chooseFromGallery = false,
+  LoadingCallback? beforeScreenVisibleCallback,
+  LoadingCallback? afterScreenVisibleCallback,
+}) async {
   final AppLocalizations appLocalizations = AppLocalizations.of(context);
   late XFile? pickedXFile;
+
+  // Show a loading page on the Flutter side
+  final NavigatorState navigator = Navigator.of(context);
+  await _showScreenBetween(beforeScreenVisibleCallback, navigator);
+
   if (existingImage == null) {
     final ImagePicker picker = ImagePicker();
     // open a dialog to ask the user if they want to take a picture or select one from the gallery
-    if (showoptionDialog) {
+    if (showOptionDialog) {
       pickedXFile = await showDialog<XFile>(
         context: context,
         builder: (BuildContext context) {
@@ -55,7 +65,9 @@ Future<File?> startImageCropping(BuildContext context,
         );
       }
     }
+
     if (pickedXFile == null) {
+      await _hideScreenBetween(afterScreenVisibleCallback, navigator);
       return null;
     }
   }
@@ -83,9 +95,70 @@ Future<File?> startImageCropping(BuildContext context,
       ),
     ],
   );
+
+  await _hideScreenBetween(afterScreenVisibleCallback, navigator);
+
   //attempting to create a file from a null path will throw an exception so return null if that happens
   if (croppedFile == null) {
     return null;
   }
+
   return File(croppedFile.path);
 }
+
+Future<void> _showScreenBetween(
+  LoadingCallback? callback,
+  NavigatorState navigator,
+) {
+  return (callback ??
+          (NavigatorState navigator) async {
+            navigator.push<dynamic>(
+              MaterialPageRoute<dynamic>(
+                settings: _LoadingPage._settings,
+                builder: (_) => const _LoadingPage(),
+              ),
+            );
+          })
+      .call(navigator);
+}
+
+Future<void> _hideScreenBetween(
+  LoadingCallback? callback,
+  NavigatorState navigator,
+) async {
+  return (callback ??
+          (NavigatorState navigator) async {
+            return navigator.popUntil((Route<dynamic> route) {
+              // Remove the screen, only if it's the loading screen
+              if (route.settings == _LoadingPage._settings) {
+                return true;
+              }
+              return false;
+            });
+          })
+      .call(navigator);
+}
+
+/// A screen being displayed once an image is taken, but the cropper is not yet
+/// visible
+class _LoadingPage extends StatelessWidget {
+  const _LoadingPage({
+    Key? key,
+  }) : super(key: key);
+
+  static const RouteSettings _settings = RouteSettings(name: 'loading_page');
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox.expand(
+      child: ColoredBox(
+        color: Colors.black,
+        child: Center(
+          child: CircularProgressIndicator.adaptive(),
+        ),
+      ),
+    );
+  }
+}
+
+typedef LoadingCallback = Future<void> Function(NavigatorState navigator);

--- a/packages/smooth_app/lib/pages/product/edit_ingredients_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_ingredients_page.dart
@@ -93,7 +93,7 @@ class _EditOcrPageState extends State<EditOcrPage> {
     bool isUploaded = true;
     if (isNewImage) {
       final File? croppedImageFile =
-          await startImageCropping(context, showoptionDialog: true);
+          await startImageCropping(context, showOptionDialog: true);
 
       // If the user cancels.
       if (croppedImageFile == null) {

--- a/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
@@ -130,7 +130,7 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView> {
                           if (currentIndex != null) {
                             final File? croppedImageFile =
                                 await startImageCropping(context,
-                                    showoptionDialog: true);
+                                    showOptionDialog: true);
                             if (croppedImageFile != null) {
                               setState(() {
                                 allProductImageProviders[currentIndex] =


### PR DESCRIPTION
Old behavior: see issue #2750 
New behavior: https://user-images.githubusercontent.com/246838/183438012-fb39840c-2bfb-459e-9a3a-b4cd16ba712a.mp4

A black screen is now displayed between the two states, but by providing a callback, we can decide to show something else (just in case)

A typo is also fixed (a missing uppercase)

Will fix #2750
 