### PR TITLE
fix: The permission workflow for the camera should now be OK

### DIFF
--- a/packages/smooth_app/lib/helpers/permission_helper.dart
+++ b/packages/smooth_app/lib/helpers/permission_helper.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:smooth_app/helpers/camera_helper.dart';
@@ -35,8 +37,11 @@ class PermissionListener extends ValueNotifier<DevicePermission> {
         DevicePermissionStatus.checking,
       );
 
-      _onNewPermissionStatus(await permission.request());
+      _status = _DevicePermissionStatus.asked;
+      await _requestPermission();
     }
+
+    _status = _DevicePermissionStatus.answered;
   }
 
   Future<void> askPermission(
@@ -49,23 +54,29 @@ class PermissionListener extends ValueNotifier<DevicePermission> {
 
     _status = _DevicePermissionStatus.asked;
 
+    // On non-Android platforms, this call will always return false
     final bool showRationale = await permission.shouldShowRequestRationale;
 
-    if (showRationale) {
-      _onNewPermissionStatus(await permission.request());
-    } else {
+    // Directly ask for the permission on Android (first time) and iOS
+    if (showRationale || !Platform.isAndroid) {
+      await _requestPermission();
+    }
+
+    if (!value.isGranted) {
       final bool? shouldOpenSettings = await onRationaleNotAvailable.call();
 
       if (shouldOpenSettings == true) {
         await openAppSettings();
-        await checkPermission();
+        await _requestPermission();
       }
     }
 
     _status = _DevicePermissionStatus.answered;
   }
 
-  void _onNewPermissionStatus(PermissionStatus status) {
+  Future<void> _requestPermission() async {
+    final PermissionStatus status = await permission.request();
+
     value = DevicePermission._fromPermissionStatus(
       permission,
       status,

--- a/packages/smooth_app/lib/pages/scan/scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/scan_page.dart
@@ -2,7 +2,6 @@ import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:permission_handler/permission_handler.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/continuous_scan_model.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
@@ -49,15 +48,10 @@ class _ScanPageState extends State<ScanPage> {
 
     return SmoothScaffold(
       brightness: Brightness.light,
-      body: ChangeNotifierProvider<PermissionListener>(
-        create: (_) => PermissionListener(
-          permission: Permission.camera,
-        ),
-        child: ScannerOverlay(
-          backgroundChild: const _ScanPageBackgroundWidget(),
-          foregroundChild: const _ScanPageForegroundWidget(),
-          topChild: const _ScanPageTopWidget(),
-        ),
+      body: ScannerOverlay(
+        backgroundChild: const _ScanPageBackgroundWidget(),
+        foregroundChild: const _ScanPageForegroundWidget(),
+        topChild: const _ScanPageTopWidget(),
       ),
     );
   }


### PR DESCRIPTION
Hi everyone,

I have fixed many issues on this PR, but the main change is that it should work far better on iOS.
Basically:
- The `PermissionListener` was created twice -> singleton
- `shouldShowRequestRationale` always returns false on iOS, so the code now takes care of this
- (Really) ensure only one permission request can be asked at a given time

This PR will participate to improve #2741 
