### PR TITLE
feat: #2174 - doomscrolling instead of "download more" button

### DIFF
--- a/packages/smooth_app/ios/Podfile.lock
+++ b/packages/smooth_app/ios/Podfile.lock
@@ -106,13 +106,13 @@ PODS:
   - Realm/Headers (10.28.2)
   - RealmSwift (10.28.2):
     - Realm (= 10.28.2)
-  - Sentry (7.19.0):
-    - Sentry/Core (= 7.19.0)
-  - Sentry/Core (7.19.0)
+  - Sentry (7.22.0):
+    - Sentry/Core (= 7.22.0)
+  - Sentry/Core (7.22.0)
   - sentry_flutter (0.0.1):
     - Flutter
     - FlutterMacOS
-    - Sentry (~> 7.19.0)
+    - Sentry (~> 7.22.0)
   - share_plus (0.0.1):
     - Flutter
   - shared_preferences_ios (0.0.1):
@@ -255,8 +255,8 @@ SPEC CHECKSUMS:
   Protobuf: 818c6a87e44193a77f56b87c6a1c106efda7e062
   Realm: e617c54ad0f566b3d0f6a2abae7010de05f252ac
   RealmSwift: 8a516a8759d80d52ebcec1ff1076f5f5159f98b2
-  Sentry: d6b16e66a0ad0c39a0b76d9a1194e68e78c37ce6
-  sentry_flutter: 609b096af497fa64af7c6c94e792d0780aa472a6
+  Sentry: 30b51086ca9aac23337880152e95538f7e177f7f
+  sentry_flutter: eaca55af5c951f4be6c4b1daddce1744c37d8476
   share_plus: 056a1e8ac890df3e33cb503afffaf1e9b4fbae68
   shared_preferences_ios: 548a61f8053b9b8a49ac19c1ffbc8b92c50d68ad
   sqflite: 6d358c025f5b867b29ed92fc697fd34924e11904


### PR DESCRIPTION
Impacted file:
* `Podfile.lock`: wtf (ios: `pod update Sentry`)
* `product_query_page.dart`

### What
* On product query page, there's no "download more" button anymore
* It's been replaced by the doomscrolling mode:
  * we display the whole list of products, even if we don't know them (not even their barcodes)
  * we trigger automatically the download of the next page, when the first unknown product is asked by the `ListView`
  * when we are loading the next page we don't hide the previous results with a dialog or a progress indicator
* pending questions:
  * maybe we should call the "load next page" method earlier than exactly when we need it, like for first unknown page index - 5?
  * maybe we should display something specific for data being downloaded (the next page) and other unknown data (beyond next page)
* We will probably have to rethink our queries, because of the possible inconsistencies between pages during a long period. Should we query just ALL the barcodes, and let the list download each product one by one if needed? Btw that's not an issue that appeared specifically with that PR. To be continued.

### Screenshot
| When you go beyond the known area | Which smoothly refreshes into |
| -- | -- |
| ![Capture d’écran 2022-08-10 à 18 37 10](https://user-images.githubusercontent.com/11576431/183965206-9892cea1-aaed-4907-af36-70d428523150.png) | ![Capture d’écran 2022-08-10 à 18 37 59](https://user-images.githubusercontent.com/11576431/183965387-6d939024-bff1-472f-87f7-cf99eec972a0.png) |


### Fixes bug(s)
- Closes: #2174