### PR TITLE
fix: #2774 - moved items in EditProductPage

### DIFF
--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -176,7 +176,6 @@ class _EditProductPageState extends State<EditProductPage> {
                     SimpleInputPageCategoryHelper(),
                   ],
                 ),
-                _getSimpleListTileItem(SimpleInputPageLabelHelper()),
                 _ListTitleItem(
                   leading:
                       const _SvgIcon('assets/cacheTintable/ingredients.svg'),
@@ -197,29 +196,6 @@ class _EditProductPageState extends State<EditProductPage> {
                     );
                   },
                 ),
-                _ListTitleItem(
-                  leading: const Icon(Icons.recycling),
-                  title:
-                      appLocalizations.edit_product_form_item_packaging_title,
-                  onTap: () async {
-                    if (!await ProductRefresher().checkIfLoggedIn(context)) {
-                      return;
-                    }
-                    await Navigator.push<Product?>(
-                      context,
-                      MaterialPageRoute<Product>(
-                        builder: (BuildContext context) => EditOcrPage(
-                          product: _product,
-                          helper: OcrPackagingHelper(),
-                        ),
-                      ),
-                    );
-                  },
-                ),
-                _getSimpleListTileItem(SimpleInputPageStoreHelper()),
-                _getSimpleListTileItem(SimpleInputPageOriginHelper()),
-                _getSimpleListTileItem(SimpleInputPageEmbCodeHelper()),
-                _getSimpleListTileItem(SimpleInputPageCountryHelper()),
                 _getSimpleListTileItem(SimpleInputPageCategoryHelper()),
                 _ListTitleItem(
                   leading:
@@ -251,6 +227,30 @@ class _EditProductPageState extends State<EditProductPage> {
                     );
                   },
                 ),
+                _getSimpleListTileItem(SimpleInputPageLabelHelper()),
+                _ListTitleItem(
+                  leading: const Icon(Icons.recycling),
+                  title:
+                      appLocalizations.edit_product_form_item_packaging_title,
+                  onTap: () async {
+                    if (!await ProductRefresher().checkIfLoggedIn(context)) {
+                      return;
+                    }
+                    await Navigator.push<Product?>(
+                      context,
+                      MaterialPageRoute<Product>(
+                        builder: (BuildContext context) => EditOcrPage(
+                          product: _product,
+                          helper: OcrPackagingHelper(),
+                        ),
+                      ),
+                    );
+                  },
+                ),
+                _getSimpleListTileItem(SimpleInputPageStoreHelper()),
+                _getSimpleListTileItem(SimpleInputPageOriginHelper()),
+                _getSimpleListTileItem(SimpleInputPageEmbCodeHelper()),
+                _getSimpleListTileItem(SimpleInputPageCountryHelper()),
               ],
             ),
           ),


### PR DESCRIPTION
Impacted file:
 * `edit_product_page.dart`: moved up ingredients, categories and nutrition

### What
- In EditProductPage, moved up ingredients, categories and nutrition

### Screenshot
![Capture d’écran 2022-08-11 à 18 56 30](https://user-images.githubusercontent.com/11576431/184190835-984cb9e9-5c07-4310-abfc-6dd29a4de813.png)

### Fixes bug(s)
- Fixes: #2774