### PR TITLE
feat: better "trapezoid" food preference display

### DIFF
--- a/packages/smooth_app/lib/widgets/attribute_button.dart
+++ b/packages/smooth_app/lib/widgets/attribute_button.dart
@@ -7,6 +7,13 @@ import 'package:smooth_app/data_models/product_preferences.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 
+const List<String> _importanceIds = <String>[
+  PreferenceImportance.ID_NOT_IMPORTANT,
+  PreferenceImportance.ID_IMPORTANT,
+  PreferenceImportance.ID_VERY_IMPORTANT,
+  PreferenceImportance.ID_MANDATORY,
+];
+
 /// Colored button for attribute importance, with corresponding action
 class AttributeButton extends StatelessWidget {
   const AttributeButton(
@@ -17,60 +24,17 @@ class AttributeButton extends StatelessWidget {
   final Attribute attribute;
   final ProductPreferences productPreferences;
 
-  static const List<String> _importanceIds = <String>[
-    PreferenceImportance.ID_NOT_IMPORTANT,
-    PreferenceImportance.ID_IMPORTANT,
-    PreferenceImportance.ID_VERY_IMPORTANT,
-    PreferenceImportance.ID_MANDATORY,
-  ];
-
   @override
   Widget build(BuildContext context) {
     final ThemeData themeData = Theme.of(context);
-    final String currentImportanceId =
+    final String importanceId =
         productPreferences.getImportanceIdForAttributeId(attribute.id!);
+    final int index = productPreferences.getImportanceIndex(importanceId) ?? 0;
     const double horizontalPadding = LARGE_SPACE;
     final double widgetWidth =
         MediaQuery.of(context).size.width - 2 * horizontalPadding;
-    final double importanceWidth = widgetWidth / 4;
     final TextStyle style = themeData.textTheme.headline4!;
     final String? info = attribute.settingNote;
-    final List<Widget> children = <Widget>[];
-    for (final String importanceId in _importanceIds) {
-      children.add(
-        Expanded(
-          child: InkWell(
-            onTap: () async => productPreferences.setImportance(
-              attribute.id!,
-              importanceId,
-            ),
-            child: Container(
-              width: importanceWidth,
-              constraints: const BoxConstraints(minHeight: MINIMUM_TOUCH_SIZE),
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.start,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: <Widget>[
-                  Icon(
-                    currentImportanceId == importanceId
-                        ? Icons.radio_button_checked
-                        : Icons.radio_button_off,
-                    color: themeData.colorScheme.primary,
-                  ),
-                  AutoSizeText(
-                    productPreferences
-                        .getPreferenceImportanceFromImportanceId(importanceId)!
-                        .name!,
-                    maxLines: 2,
-                    textAlign: TextAlign.center,
-                  ),
-                ],
-              ),
-            ),
-          ),
-        ),
-      );
-    }
     return Padding(
       padding: const EdgeInsets.symmetric(
         vertical: SMALL_SPACE,
@@ -104,13 +68,144 @@ class AttributeButton extends StatelessWidget {
                       },
                     ),
           ),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: children,
+          _ButtonRow(
+            width: widgetWidth,
+            productPreferences: productPreferences,
+            attributeId: attribute.id!,
+            selectedIndex: index,
+          ),
+          Center(
+            child: Text(
+              productPreferences
+                  .getPreferenceImportanceFromImportanceId(
+                      _importanceIds[index])!
+                  .name!,
+            ),
           ),
         ],
       ),
     );
   }
+}
+
+/// Row of importance buttons.
+class _ButtonRow extends StatelessWidget {
+  const _ButtonRow({
+    required this.width,
+    required this.selectedIndex,
+    required this.attributeId,
+    required this.productPreferences,
+  });
+
+  /// Row width.
+  final double width;
+
+  /// Current selected index.
+  final int selectedIndex;
+  final String attributeId;
+  final ProductPreferences productPreferences;
+
+  @override
+  Widget build(BuildContext context) {
+    final Color color = Theme.of(context).colorScheme.primary;
+    final int length = _importanceIds.length;
+    const double spaceBetween = VERY_SMALL_SPACE;
+    const double strokeWidth = spaceBetween / 2;
+    final List<Widget> children = <Widget>[];
+    final double trapezoidWidth = width / length - spaceBetween;
+    double abscissaEvolution = 0;
+    for (int i = 0; i < length; i++) {
+      Widget child = SizedBox(
+        width: trapezoidWidth,
+        height: MINIMUM_TOUCH_SIZE,
+        child: CustomPaint(
+          painter: _TrapezoidPainter(
+            empty: selectedIndex < i,
+            color: color,
+            yFactorLeft: abscissaEvolution / width,
+            yFactorRight: (abscissaEvolution + trapezoidWidth) / width,
+            strokeWidth: strokeWidth,
+          ),
+        ),
+      );
+      if (selectedIndex != i) {
+        child = GestureDetector(
+          onTap: () async => productPreferences.setImportance(
+            attributeId,
+            _importanceIds[i],
+          ),
+          child: child,
+        );
+      }
+      children.add(child);
+      children.add(const SizedBox(width: spaceBetween));
+      abscissaEvolution += trapezoidWidth + spaceBetween;
+    }
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: children,
+    );
+  }
+}
+
+/// Paints a trapezoid with parallel vertical and a bottom horizontal lines.
+///
+/// The shape of the trapezoid comes from [yFactorLeft] and [yFactorRight].
+/// Both are values between 0 and 1, to be applied to the height.
+/// E.g. 0 means bottom, 1 means top.
+/// E.g. the same value for both means a rectangle.
+/// E.g. if one value is 0, then it's a right triangle.
+/// E.g. if both values are 0, it's a flat line.
+/// E.g. if both values are 1, it's a rectangle the size of its display box.
+class _TrapezoidPainter extends CustomPainter {
+  _TrapezoidPainter({
+    required this.empty,
+    required this.color,
+    required this.strokeWidth,
+    required this.yFactorLeft,
+    required this.yFactorRight,
+  });
+
+  /// Is this trapezoid empty or full?
+  final bool empty;
+
+  /// Color of the trapezoid.
+  final Color color;
+
+  /// Stroke width.
+  final double strokeWidth;
+
+  /// Value between 0 and 1: y-factor for the left side.
+  final double yFactorLeft;
+
+  /// Value between 0 and 1: y-factor for the right side.
+  final double yFactorRight;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final Paint paint = Paint()
+      ..color = color
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = strokeWidth
+      ..strokeCap = StrokeCap.round;
+
+    final Path path = Path();
+    path.moveTo(0, size.height);
+    path.lineTo(size.width, size.height);
+    path.lineTo(size.width, size.height * (1 - yFactorRight));
+    path.lineTo(0, size.height * (1 - yFactorLeft));
+    path.close();
+    canvas.drawPath(path, paint);
+
+    if (!empty) {
+      final Paint paintFill = Paint()
+        ..color = color
+        ..style = PaintingStyle.fill;
+      canvas.drawPath(path, paintFill);
+    }
+  }
+
+  @override
+  bool shouldRepaint(final CustomPainter oldDelegate) => true;
 }


### PR DESCRIPTION
Impacted file:
* `attribute_button.dart`: now using a "progressive trapezoidal" display for food preferences

### What
- The display of food preferences was lousy, mainly because there's not enough width on a smartphone screen to display all descriptions of importances in the same line ("Not important", "Important", "Very important" and "Mandatory").
- The lack of space forced us to display sometimes labels on 2 lines, but not always...
- The solution was NOT to display all the labels, but just one (we have enough space for that) and with an obviously progressive choice (like a volume controller) instead of just radio buttons.

### Screenshot
| format | light | dark [edit: added] |
| -- | -- | -- |
| current format | ![Capture d’écran 2022-08-12 à 17 52 40](https://user-images.githubusercontent.com/11576431/184394507-040d8f0c-1547-44fd-991e-80013ca945f0.png) | ![Capture d’écran 2022-08-12 à 17 56 22](https://user-images.githubusercontent.com/11576431/184395316-d71c761f-45f2-43d0-afb5-a9fe7580d778.png) |
| [edit: added] other possible format | ![Capture d’écran 2022-08-12 à 18 38 21](https://user-images.githubusercontent.com/11576431/184404234-4c21602e-13b2-43f4-8cca-5d9ac44900d4.png) | ![Capture d’écran 2022-08-12 à 18 37 48](https://user-images.githubusercontent.com/11576431/184404151-756a5d9f-2a00-4b94-9222-ef3b1b4e76bb.png) |