### PR TITLE
fix: text alignment in attribute chips

### DIFF
--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -539,7 +539,7 @@ class _SummaryCardState extends State<SummaryCard> {
             ),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.start,
-              crossAxisAlignment: CrossAxisAlignment.start,
+              crossAxisAlignment: CrossAxisAlignment.center,
               children: <Widget>[
                 attributeIcon,
                 Expanded(child: Text(attributeDisplayTitle)),


### PR DESCRIPTION
| Before | After |
|---|---|
| ![immagine](https://user-images.githubusercontent.com/12072630/184516103-8bbda9bc-669f-4b6a-a80c-b88aff88553c.png) | ![immagine](https://user-images.githubusercontent.com/12072630/184516112-57835bd7-91af-464e-88a8-5c938de186f3.png) |