### PR TITLE
fix: #2553 - upgrade to off-dart 1.24.0 + categories not completed

### DIFF
--- a/packages/smooth_app/lib/helpers/data_importer/product_list_import_export.dart
+++ b/packages/smooth_app/lib/helpers/data_importer/product_list_import_export.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 
+import 'package:openfoodfacts/model/parameter/BarcodeParameter.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
-import 'package:openfoodfacts/utils/ProductListQueryConfiguration.dart';
 import 'package:smooth_app/data_models/product_list.dart';
 import 'package:smooth_app/database/dao_product.dart';
 import 'package:smooth_app/database/dao_product_list.dart';
@@ -67,13 +67,15 @@ class ProductListImportExport {
   Future<List<Product>> _fetchProducts(
     Iterable<String> barcodes,
   ) async {
-    final SearchResult searchResult = await OpenFoodAPIClient.getProductList(
+    final SearchResult searchResult = await OpenFoodAPIClient.searchProducts(
       ProductQuery.getUser(),
-      ProductListQueryConfiguration(
-        barcodes.toList(growable: false),
+      ProductSearchQueryConfiguration(
         fields: ProductQuery.fields,
         language: ProductQuery.getLanguage(),
         country: ProductQuery.getCountry(),
+        parametersList: <Parameter>[
+          BarcodeParameter.list(barcodes.toList(growable: false)),
+        ],
       ),
     );
 

--- a/packages/smooth_app/lib/pages/product/common/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_page.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:matomo_tracker/matomo_tracker.dart';
+import 'package:openfoodfacts/model/parameter/BarcodeParameter.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
-import 'package:openfoodfacts/utils/ProductListQueryConfiguration.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/product_list.dart';
 import 'package:smooth_app/data_models/up_to_date_product_provider.dart';
@@ -360,13 +360,15 @@ class _ProductListPageState extends State<ProductListPage>
     final LocalDatabase localDatabase,
   ) async {
     try {
-      final SearchResult searchResult = await OpenFoodAPIClient.getProductList(
+      final SearchResult searchResult = await OpenFoodAPIClient.searchProducts(
         ProductQuery.getUser(),
-        ProductListQueryConfiguration(
-          barcodes,
+        ProductSearchQueryConfiguration(
           fields: ProductQuery.fields,
           language: ProductQuery.getLanguage(),
           country: ProductQuery.getCountry(),
+          parametersList: <Parameter>[
+            BarcodeParameter.list(barcodes),
+          ],
         ),
       );
       final List<Product>? freshProducts = searchResult.products;

--- a/packages/smooth_app/lib/query/paged_product_query.dart
+++ b/packages/smooth_app/lib/query/paged_product_query.dart
@@ -37,7 +37,8 @@ abstract class PagedProductQuery {
 
   void toTopPage() => _pageNumber = _startPageNumber;
 
-  Future<SearchResult> getSearchResult() async => OpenFoodAPIClient.getProducts(
+  Future<SearchResult> getSearchResult() async =>
+      OpenFoodAPIClient.searchProducts(
         ProductQuery.getUser(),
         getQueryConfiguration(),
         queryType: OpenFoodAPIConfiguration.globalQueryType,

--- a/packages/smooth_app/lib/query/paged_to_be_completed_product_query.dart
+++ b/packages/smooth_app/lib/query/paged_to_be_completed_product_query.dart
@@ -1,5 +1,7 @@
+import 'package:openfoodfacts/model/State.dart';
+import 'package:openfoodfacts/model/parameter/StatesTagsParameter.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/utils/AbstractQueryConfiguration.dart';
-import 'package:openfoodfacts/utils/ToBeCompletedConfiguration.dart';
 import 'package:smooth_app/data_models/product_list.dart';
 import 'package:smooth_app/query/paged_product_query.dart';
 import 'package:smooth_app/query/product_query.dart';
@@ -10,12 +12,20 @@ class PagedToBeCompletedProductQuery extends PagedProductQuery {
 
   @override
   AbstractQueryConfiguration getQueryConfiguration() =>
-      ToBeCompletedQueryConfiguration(
-        pageSize: pageSize,
-        pageNumber: pageNumber,
+      ProductSearchQueryConfiguration(
         language: language,
         country: country,
         fields: ProductQuery.fields,
+        parametersList: <Parameter>[
+          PageSize(size: pageSize),
+          PageNumber(page: pageNumber),
+          StatesTagsParameter(
+            map: <State, bool>{
+              State.CATEGORIES_COMPLETED: false,
+            },
+          ),
+          const SortBy(option: SortOption.EDIT),
+        ],
       );
 
   @override

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -762,7 +762,7 @@ packages:
       name: openfoodfacts
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.23.0"
+    version: "1.24.0"
   openfoodfacts_flutter_lints:
     dependency: "direct dev"
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   latlong2: ^0.8.1
   matomo_tracker: ^1.3.0
   modal_bottom_sheet: ^2.1.0
-  openfoodfacts: ^1.22.0
+  openfoodfacts: ^1.24.0
   #  openfoodfacts:
   #    path: ../../../openfoodfacts-dart
   package_info_plus: ^1.4.2


### PR DESCRIPTION
Impacted files:
* `paged_product_query.dart`: replaced deprecated method from off-dart 1.24.0
* `paged_to_be_completed_product_query.dart`: edited as "CATEGORIES not completed"; replaced deprecated method from off-dart 1.24.0
* `product_list_import_export.dart`: replaced deprecated method from off-dart 1.24.0
* `product_list_page.dart`: replaced deprecated method from off-dart 1.24.0
* `pubspec.lock`: generated
* `pubspec.yaml`: upgrade to off-dart 1.24.0

### What
- Quick fix about the upgrade to off-dart 1.24.0 (deprecated methods)
- Quick fix regarding "all to be completed" product query - now we target "categories not completed"

### Screenshot
| France | World |
| -- | -- |
| ![Capture d’écran 2022-08-16 à 13 42 27](https://user-images.githubusercontent.com/11576431/184871342-f76ae985-57fb-495f-90f8-bd663c7a7a07.png) | ![Capture d’écran 2022-08-16 à 13 42 47](https://user-images.githubusercontent.com/11576431/184871408-1999e95c-788c-45bc-91bf-daa78de5f17e.png) |

### Fixes bug(s)
- Closes: #2553