### PR TITLE
feat: use modals for navigating to editing screens

### DIFF
--- a/packages/smooth_app/lib/pages/product/add_category_button.dart
+++ b/packages/smooth_app/lib/pages/product/add_category_button.dart
@@ -26,6 +26,7 @@ class AddCategoryButton extends StatelessWidget {
                 helper: SimpleInputPageCategoryHelper(),
                 product: product,
               ),
+              fullscreenDialog: true,
             ),
           );
         },

--- a/packages/smooth_app/lib/pages/product/add_new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_new_product_page.dart
@@ -276,6 +276,7 @@ class _AddNewProductPageState extends State<AddNewProductPage> {
                 Product(barcode: widget.barcode),
                 cache.orderedNutrients,
               ),
+              fullscreenDialog: true,
             ),
           );
 

--- a/packages/smooth_app/lib/pages/product/add_nutrition_button.dart
+++ b/packages/smooth_app/lib/pages/product/add_nutrition_button.dart
@@ -39,6 +39,7 @@ class _AddNutritionButtonState extends State<AddNutritionButton> {
                 widget.product,
                 cache.orderedNutrients,
               ),
+              fullscreenDialog: true,
             ),
           );
         },

--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -146,6 +146,7 @@ class _EditProductPageState extends State<EditProductPage> {
                         context,
                         MaterialPageRoute<Product>(
                           builder: (_) => AddBasicDetailsPage(_product),
+                          fullscreenDialog: true,
                         ),
                       );
                     },
@@ -171,6 +172,7 @@ class _EditProductPageState extends State<EditProductPage> {
                             title: allProductImagesData.first.title,
                             barcode: _product.barcode,
                           ),
+                          fullscreenDialog: true,
                         ),
                       );
 
@@ -217,6 +219,7 @@ class _EditProductPageState extends State<EditProductPage> {
                             product: _product,
                             helper: OcrIngredientsHelper(),
                           ),
+                          fullscreenDialog: true,
                         ),
                       );
                     },
@@ -270,6 +273,7 @@ class _EditProductPageState extends State<EditProductPage> {
                             product: _product,
                             helper: OcrPackagingHelper(),
                           ),
+                          fullscreenDialog: true,
                         ),
                       );
                     },
@@ -353,6 +357,7 @@ class _EditProductPageState extends State<EditProductPage> {
               helpers: helpers,
               product: _product,
             ),
+            fullscreenDialog: true,
           ),
         );
       },

--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -249,6 +249,7 @@ class _EditProductPageState extends State<EditProductPage> {
                             _product,
                             cache.orderedNutrients,
                           ),
+                          fullscreenDialog: true,
                         ),
                       );
                     },
@@ -303,6 +304,7 @@ class _EditProductPageState extends State<EditProductPage> {
               helper: helper,
               product: _product,
             ),
+            fullscreenDialog: true,
           ),
         );
       },

--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -629,6 +629,7 @@ class _SummaryCardState extends State<SummaryCard> {
                       questions: questions,
                       updateProductUponAnswers: _updateProductUponAnswers,
                     ),
+                    fullscreenDialog: true,
                   ),
                 );
               },


### PR DESCRIPTION
### What
- Present editing screens as modals on iOS to make it natural to disable back navigation gesture

### Fixes issues
- Fixes: #2796

### Potential future improvements

Modals in iOS are always presented on top of bottom tab bars. I found a way to do this fairly easily by using the root navigator instead of the top navigator. The problem was that it started generating this warning about duplicate hero tags: `There are multiple heroes that share the same tag within a subtree`. I couldn't figure out why this was the case and haven't worked with Hero's or nested navigators much so left it as is.

For future reference, this change enabled modals to cover the entire screen (including bottom tab bar):

Replace
```dart
await Navigator.push<Product>(context, <route>, fullscreenDialog: true)
```
with
```dart
await Navigator.of(context, rootNavigator: true).push<Product>(<route>, fullscreenDialog: true)
```

