### PR TITLE
fix: screenshot - different Key for different screens

### DIFF
--- a/packages/smooth_app/integration_test/app_test.dart
+++ b/packages/smooth_app/integration_test/app_test.dart
@@ -56,32 +56,43 @@ void main() {
         await tester.pumpAndSettle();
 
         sleep(const Duration(seconds: 30));
+
+        await _takeScreenshot(
+            tester, binding, 'test-screenshot-onboarding-reinvention');
+        sleep(const Duration(seconds: 10));
+
+        await tester.tap(find.byKey(const Key('nextAfterReinvention')));
+        await tester.pumpAndSettle();
+
         await _takeScreenshot(
             tester, binding, 'test-screenshot-onboarding-home');
         sleep(const Duration(seconds: 10));
 
-        await tester.tap(find.byKey(const Key('next')));
+        await tester.tap(find.byKey(const Key('nextAfterWelcome')));
         await tester.pumpAndSettle();
 
         await _takeScreenshot(
             tester, binding, 'test-screenshot-onboarding-scan');
         sleep(const Duration(seconds: 10));
 
-        await tester.tap(find.byKey(const Key('next')));
+        await tester.tap(find.byKey(const Key('nextAfterScanExample')));
         await tester.pumpAndSettle();
 
         await _takeScreenshot(
             tester, binding, 'test-screenshot-onboarding-health');
         sleep(const Duration(seconds: 10));
 
-        await tester.tap(find.byKey(const Key('next')));
+        await tester.tap(find.byKey(const Key('toolTipPopUp')));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byKey(const Key('nextAfterHealth')));
         await tester.pumpAndSettle();
 
         await _takeScreenshot(
             tester, binding, 'test-screenshot-onboarding-eco');
         sleep(const Duration(seconds: 10));
 
-        await tester.tap(find.byKey(const Key('next')));
+        await tester.tap(find.byKey(const Key('nextAfterEco')));
         await tester.pumpAndSettle();
 
         await _takeScreenshot(

--- a/packages/smooth_app/lib/pages/onboarding/knowledge_panel_page_template.dart
+++ b/packages/smooth_app/lib/pages/onboarding/knowledge_panel_page_template.dart
@@ -21,6 +21,7 @@ class KnowledgePanelPageTemplate extends StatefulWidget {
     required this.localDatabase,
     required this.backgroundColor,
     required this.svgAsset,
+    required this.nextKey,
   });
 
   final String headerTitle;
@@ -32,6 +33,7 @@ class KnowledgePanelPageTemplate extends StatefulWidget {
   final LocalDatabase localDatabase;
   final Color backgroundColor;
   final String svgAsset;
+  final Key nextKey;
 
   @override
   State<KnowledgePanelPageTemplate> createState() =>
@@ -118,6 +120,7 @@ class _KnowledgePanelPageTemplateState
                       NextButton(
                         widget.page,
                         backgroundColor: widget.backgroundColor,
+                        nextKey: widget.nextKey,
                       ),
                     ],
                   ),
@@ -131,6 +134,7 @@ class _KnowledgePanelPageTemplateState
 
   List<Widget> _buildHintPopup() {
     final Widget hintPopup = InkWell(
+      key: const Key('toolTipPopUp'),
       child: Card(
         margin: const EdgeInsets.symmetric(horizontal: 30),
         color: Theme.of(context).hintColor.withOpacity(0.9),

--- a/packages/smooth_app/lib/pages/onboarding/next_button.dart
+++ b/packages/smooth_app/lib/pages/onboarding/next_button.dart
@@ -14,9 +14,11 @@ class NextButton extends StatelessWidget {
   const NextButton(
     this.currentPage, {
     required this.backgroundColor,
-  }) : super(key: const Key('next'));
+    required this.nextKey,
+  });
 
   final OnboardingPage currentPage;
+  final Key nextKey;
 
   /// Color of the background where we put the buttons.
   ///
@@ -57,6 +59,7 @@ class NextButton extends StatelessWidget {
         backgroundColor: Colors.black,
         foregroundColor: Colors.white,
         label: appLocalizations.next_label,
+        nextKey: nextKey,
       ),
       backgroundColor: backgroundColor,
     );

--- a/packages/smooth_app/lib/pages/onboarding/onboarding_bottom_bar.dart
+++ b/packages/smooth_app/lib/pages/onboarding/onboarding_bottom_bar.dart
@@ -7,7 +7,7 @@ class OnboardingBottomBar extends StatelessWidget {
     required this.rightButton,
     required this.backgroundColor,
     this.leftButton,
-  }) : super(key: const Key('next'));
+  });
 
   final Widget rightButton;
   final Widget? leftButton;
@@ -60,6 +60,7 @@ class OnboardingBottomButton extends StatelessWidget {
     required this.backgroundColor,
     required this.foregroundColor,
     required this.label,
+    this.nextKey,
   });
 
   final VoidCallback onPressed;
@@ -67,10 +68,14 @@ class OnboardingBottomButton extends StatelessWidget {
   final Color foregroundColor;
   final String label;
 
+  /// Button Key - typically used during screenshot generation.
+  final Key? nextKey;
+
   @override
   Widget build(BuildContext context) => ConstrainedBox(
         constraints: const BoxConstraints.tightFor(height: MINIMUM_TOUCH_SIZE),
         child: ElevatedButton(
+          key: nextKey,
           onPressed: onPressed,
           style: ButtonStyle(
             backgroundColor: MaterialStateProperty.all(backgroundColor),

--- a/packages/smooth_app/lib/pages/onboarding/preferences_page.dart
+++ b/packages/smooth_app/lib/pages/onboarding/preferences_page.dart
@@ -142,6 +142,7 @@ class _HelperState extends State<_Helper> {
             NextButton(
               OnboardingPage.PREFERENCES_PAGE,
               backgroundColor: widget.backgroundColor,
+              nextKey: const Key('nextAfterPreferences'),
             ),
           ],
         ),

--- a/packages/smooth_app/lib/pages/onboarding/reinvention_page.dart
+++ b/packages/smooth_app/lib/pages/onboarding/reinvention_page.dart
@@ -85,6 +85,7 @@ class ReinventionPage extends StatelessWidget {
               child: NextButton(
                 OnboardingPage.REINVENTION,
                 backgroundColor: null,
+                nextKey: Key('nextAfterReinvention'),
               ),
             ),
           ],

--- a/packages/smooth_app/lib/pages/onboarding/sample_eco_card_page.dart
+++ b/packages/smooth_app/lib/pages/onboarding/sample_eco_card_page.dart
@@ -18,5 +18,6 @@ class SampleEcoCardPage extends StatelessWidget {
         localDatabase: _localDatabase,
         backgroundColor: backgroundColor,
         svgAsset: 'assets/onboarding/eco.svg',
+        nextKey: const Key('nextAfterEco'),
       );
 }

--- a/packages/smooth_app/lib/pages/onboarding/sample_health_card_page.dart
+++ b/packages/smooth_app/lib/pages/onboarding/sample_health_card_page.dart
@@ -18,5 +18,6 @@ class SampleHealthCardPage extends StatelessWidget {
         localDatabase: _localDatabase,
         backgroundColor: backgroundColor,
         svgAsset: 'assets/onboarding/health.svg',
+        nextKey: const Key('nextAfterHealth'),
       );
 }

--- a/packages/smooth_app/lib/pages/onboarding/scan_example.dart
+++ b/packages/smooth_app/lib/pages/onboarding/scan_example.dart
@@ -53,6 +53,7 @@ class ScanExample extends StatelessWidget {
           NextButton(
             OnboardingPage.SCAN_EXAMPLE,
             backgroundColor: backgroundColor,
+            nextKey: const Key('nextAfterScanExample'),
           ),
         ],
       ),

--- a/packages/smooth_app/lib/pages/onboarding/welcome_page.dart
+++ b/packages/smooth_app/lib/pages/onboarding/welcome_page.dart
@@ -103,6 +103,7 @@ class WelcomePage extends StatelessWidget {
           NextButton(
             OnboardingPage.WELCOME,
             backgroundColor: backgroundColor,
+            nextKey: const Key('nextAfterWelcome'),
           ),
         ],
       ),


### PR DESCRIPTION
Impacted files:
* `app_test.dart`: added the "reinvention" page; set different "next" keys; handled tooltip on KP pages
* `knowledge_panel_page_template.dart`: specific "next" keys; added "tooltip" key
* `next_button.dart`: new `nextKey` parameter
* `onboarding_bottom_bar.dart`: added `nextKey` parameter used during screenshot generation
* `preferences_page.dart`: specific "next" key
* `reinvention_page.dart`: specific "next" key
* `sample_eco_card_page.dart`: specific "next" key
* `sample_health_card_page.dart`: specific "next" key
* `scan_example.dart`: specific "next" key
* `welcome_page.dart`: specific "next" key

### What
- Now there's a different `Key` for all screenshot screens: no more ambiguity.

### Screenshots
This is the last screenshot:
![test-screenshot-onboarding-prefs](https://user-images.githubusercontent.com/11576431/185055790-a81d2db1-bd71-4165-b561-ea188add48f2.png)

Little question: should we show the tooltip for the screenshots?
![test-screenshot-onboarding-health](https://user-images.githubusercontent.com/11576431/185055656-cb7ff6b6-6d30-4608-9f2d-ad0386fea8d4.png)

