### PR TITLE
refactor: #920 - when relevant, switched to "Navigator.push<void>"

### DIFF
--- a/packages/smooth_app/lib/cards/data_cards/image_upload_card.dart
+++ b/packages/smooth_app/lib/cards/data_cards/image_upload_card.dart
@@ -127,6 +127,7 @@ class _ImageUploadCardState extends State<ImageUploadCard> {
             _imageFullProvider = NetworkImage(imageFullUrl);
           }
 
+          // TODO(monsieurtanuki): careful, waiting for pop'ed value
           final bool? refreshed = await Navigator.push<bool>(
             context,
             MaterialPageRoute<bool>(

--- a/packages/smooth_app/lib/cards/product_cards/product_title_card.dart
+++ b/packages/smooth_app/lib/cards/product_cards/product_title_card.dart
@@ -52,9 +52,9 @@ class ProductTitleCard extends StatelessWidget {
         onTap: (getProductName(product, appLocalizations) ==
                 appLocalizations.unknownProductName)
             ? () async {
-                await Navigator.push<Product?>(
+                await Navigator.push<void>(
                   context,
-                  MaterialPageRoute<Product>(
+                  MaterialPageRoute<void>(
                     builder: (BuildContext context) =>
                         AddBasicDetailsPage(product),
                   ),

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
@@ -62,9 +62,9 @@ class SmoothProductCardFound extends StatelessWidget {
       borderRadius: ROUNDED_BORDER_RADIUS,
       onTap: onTap ??
           () async {
-            await Navigator.push<Widget>(
+            await Navigator.push<void>(
               context,
-              MaterialPageRoute<Widget>(
+              MaterialPageRoute<void>(
                 builder: (BuildContext context) => ProductPage(product),
               ),
             );

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_not_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_not_found.dart
@@ -59,6 +59,7 @@ class SmoothProductCardNotFound extends StatelessWidget {
                   icon: Icons.add,
                   padding: const EdgeInsets.symmetric(vertical: LARGE_SPACE),
                   onPressed: () async {
+                    // TODO(monsieurtanuki): careful, waiting for pop'ed value
                     final String? result = await Navigator.push<String>(
                       context,
                       MaterialPageRoute<String>(

--- a/packages/smooth_app/lib/pages/product/add_category_button.dart
+++ b/packages/smooth_app/lib/pages/product/add_category_button.dart
@@ -19,9 +19,9 @@ class AddCategoryButton extends StatelessWidget {
           if (!await ProductRefresher().checkIfLoggedIn(context)) {
             return;
           }
-          await Navigator.push<Product>(
+          await Navigator.push<void>(
             context,
-            MaterialPageRoute<Product>(
+            MaterialPageRoute<void>(
               builder: (BuildContext context) => SimpleInputPage(
                 helper: SimpleInputPageCategoryHelper(),
                 product: product,

--- a/packages/smooth_app/lib/pages/product/add_ingredients_button.dart
+++ b/packages/smooth_app/lib/pages/product/add_ingredients_button.dart
@@ -19,9 +19,9 @@ class AddIngredientsButton extends StatelessWidget {
           if (!await ProductRefresher().checkIfLoggedIn(context)) {
             return;
           }
-          await Navigator.push<bool>(
+          await Navigator.push<void>(
             context,
-            MaterialPageRoute<bool>(
+            MaterialPageRoute<void>(
               builder: (BuildContext context) => EditOcrPage(
                 product: product,
                 helper: OcrIngredientsHelper(),

--- a/packages/smooth_app/lib/pages/product/add_new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_new_product_page.dart
@@ -140,6 +140,7 @@ class _AddNewProductPageState extends State<AddNewProductPage> {
           }
           // Photo can change in the ConfirmAndUploadPicture widget, the user
           // may choose to retake the image.
+          // TODO(monsieurtanuki): careful, waiting for pop'ed value
           //ignore: use_build_context_synchronously
           final File? finalPhoto = await Navigator.push<File?>(
             context,
@@ -269,6 +270,7 @@ class _AddNewProductPageState extends State<AddNewProductPage> {
           if (!mounted) {
             return;
           }
+          // TODO(monsieurtanuki): careful, waiting for pop'ed value
           final Product? result = await Navigator.push<Product?>(
             context,
             MaterialPageRoute<Product>(
@@ -319,6 +321,8 @@ class _AddNewProductPageState extends State<AddNewProductPage> {
         text: AppLocalizations.of(context).completed_basic_details_btn_text,
         icon: Icons.edit,
         onPressed: () async {
+          // TODO(monsieurtanuki): probably wrong as AddBasicDetailsPage pops nothing
+          // TODO(monsieurtanuki): careful, waiting for pop'ed value
           final Product? result = await Navigator.push<Product?>(
             context,
             MaterialPageRoute<Product>(

--- a/packages/smooth_app/lib/pages/product/add_nutrition_button.dart
+++ b/packages/smooth_app/lib/pages/product/add_nutrition_button.dart
@@ -32,9 +32,9 @@ class _AddNutritionButtonState extends State<AddNutritionButton> {
           if (!mounted) {
             return;
           }
-          await Navigator.push<Product>(
+          await Navigator.push<void>(
             context,
-            MaterialPageRoute<Product>(
+            MaterialPageRoute<void>(
               builder: (BuildContext context) => NutritionPageLoaded(
                 widget.product,
                 cache.orderedNutrients,

--- a/packages/smooth_app/lib/pages/product/common/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_page.dart
@@ -412,9 +412,9 @@ class _ProductListPageState extends State<ProductListPage>
                     if (!mounted) {
                       return;
                     }
-                    await Navigator.push<Widget>(
+                    await Navigator.push<void>(
                       context,
-                      MaterialPageRoute<Widget>(
+                      MaterialPageRoute<void>(
                         builder: (BuildContext context) =>
                             PersonalizedRankingPage(
                           barcodes: list,

--- a/packages/smooth_app/lib/pages/product/edit_ingredients_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_ingredients_page.dart
@@ -335,7 +335,7 @@ class _OcrWidget extends StatelessWidget {
                           onPressed: () async {
                             await onSubmitField();
                             //ignore: use_build_context_synchronously
-                            Navigator.pop(context, product);
+                            Navigator.pop(context);
                           },
                         ),
                       ),

--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -142,9 +142,9 @@ class _EditProductPageState extends State<EditProductPage> {
                       if (!await ProductRefresher().checkIfLoggedIn(context)) {
                         return;
                       }
-                      await Navigator.push<Product?>(
+                      await Navigator.push<void>(
                         context,
-                        MaterialPageRoute<Product>(
+                        MaterialPageRoute<void>(
                           builder: (_) => AddBasicDetailsPage(_product),
                         ),
                       );
@@ -161,6 +161,7 @@ class _EditProductPageState extends State<EditProductPage> {
                       }
                       final List<ProductImageData> allProductImagesData =
                           getAllProductImagesData(_product, appLocalizations);
+                      // TODO(monsieurtanuki): careful, waiting for pop'ed value
                       final bool? refreshed = await Navigator.push<bool>(
                         context,
                         MaterialPageRoute<bool>(
@@ -210,9 +211,9 @@ class _EditProductPageState extends State<EditProductPage> {
                       if (!await ProductRefresher().checkIfLoggedIn(context)) {
                         return;
                       }
-                      await Navigator.push<Product?>(
+                      await Navigator.push<void>(
                         context,
-                        MaterialPageRoute<Product>(
+                        MaterialPageRoute<void>(
                           builder: (BuildContext context) => EditOcrPage(
                             product: _product,
                             helper: OcrIngredientsHelper(),
@@ -241,9 +242,9 @@ class _EditProductPageState extends State<EditProductPage> {
                       if (!mounted) {
                         return;
                       }
-                      await Navigator.push<Product?>(
+                      await Navigator.push<void>(
                         context,
-                        MaterialPageRoute<Product>(
+                        MaterialPageRoute<void>(
                           builder: (BuildContext context) =>
                               NutritionPageLoaded(
                             _product,
@@ -262,9 +263,9 @@ class _EditProductPageState extends State<EditProductPage> {
                       if (!await ProductRefresher().checkIfLoggedIn(context)) {
                         return;
                       }
-                      await Navigator.push<Product?>(
+                      await Navigator.push<void>(
                         context,
-                        MaterialPageRoute<Product>(
+                        MaterialPageRoute<void>(
                           builder: (BuildContext context) => EditOcrPage(
                             product: _product,
                             helper: OcrPackagingHelper(),
@@ -296,9 +297,9 @@ class _EditProductPageState extends State<EditProductPage> {
         if (!await ProductRefresher().checkIfLoggedIn(context)) {
           return;
         }
-        await Navigator.push<Product>(
+        await Navigator.push<void>(
           context,
-          MaterialPageRoute<Product>(
+          MaterialPageRoute<void>(
             builder: (BuildContext context) => SimpleInputPage(
               helper: helper,
               product: _product,
@@ -344,9 +345,9 @@ class _EditProductPageState extends State<EditProductPage> {
         if (!await ProductRefresher().checkIfLoggedIn(context)) {
           return;
         }
-        await Navigator.push<Product>(
+        await Navigator.push<void>(
           context,
-          MaterialPageRoute<Product>(
+          MaterialPageRoute<void>(
             builder: (BuildContext context) => SimpleInputPage.multiple(
               helpers: helpers,
               product: _product,

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -300,9 +300,9 @@ class _ProductPageState extends State<ProductPage> with TraceableClientMixin {
             _buildActionBarItem(
               Icons.edit,
               appLocalizations.edit_product_label,
-              () async => Navigator.push<bool>(
+              () async => Navigator.push<void>(
                 context,
-                MaterialPageRoute<bool>(
+                MaterialPageRoute<void>(
                   builder: (BuildContext context) => EditProductPage(_product),
                 ),
               ),

--- a/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
@@ -331,6 +331,7 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView> {
           return;
         }
 
+        // TODO(monsieurtanuki): careful, waiting for pop'ed value
         // ignore: use_build_context_synchronously
         final File? photoUploaded = await Navigator.push<File?>(
           context,

--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -321,9 +321,9 @@ class _SummaryCardState extends State<SummaryCard> {
           addPanelButton(
             localizations.completed_basic_details_btn_text,
             onPressed: () async {
-              await Navigator.push<Product?>(
+              await Navigator.push<void>(
                 context,
-                MaterialPageRoute<Product>(
+                MaterialPageRoute<void>(
                   builder: (BuildContext context) =>
                       AddBasicDetailsPage(_product),
                 ),
@@ -433,9 +433,9 @@ class _SummaryCardState extends State<SummaryCard> {
           InkWell(
             borderRadius: const BorderRadius.only(topRight: ROUNDED_RADIUS),
             onTap: widget.isSettingClickable
-                ? () async => Navigator.push<Widget>(
+                ? () async => Navigator.push<void>(
                       context,
-                      MaterialPageRoute<Widget>(
+                      MaterialPageRoute<void>(
                         builder: (BuildContext context) =>
                             const UserPreferencesPage(
                           type: PreferencePageType.FOOD,
@@ -621,9 +621,9 @@ class _SummaryCardState extends State<SummaryCard> {
           if (questions.isNotEmpty && !_annotationVoted) {
             return InkWell(
               onTap: () async {
-                await Navigator.push<Widget>(
+                await Navigator.push<void>(
                   context,
-                  MaterialPageRoute<Widget>(
+                  MaterialPageRoute<void>(
                     builder: (BuildContext context) => QuestionPage(
                       product: _product,
                       questions: questions,
@@ -740,9 +740,9 @@ class _SummaryCardState extends State<SummaryCard> {
     final KnowledgePanelPanelGroupElement? group =
         KnowledgePanelGroupCard.groupElementOf(context);
 
-    Navigator.push<Widget>(
+    Navigator.push<void>(
       context,
-      MaterialPageRoute<Widget>(
+      MaterialPageRoute<void>(
         builder: (BuildContext context) => KnowledgePanelPage(
           groupElement: group,
           panel: knowledgePanel,

--- a/packages/smooth_app/lib/pages/question_page.dart
+++ b/packages/smooth_app/lib/pages/question_page.dart
@@ -424,9 +424,9 @@ class CongratsWidget extends StatelessWidget {
                         action: SmoothActionButton(
                           text: appLocalizations.sign_in,
                           onPressed: () async {
-                            await Navigator.push<Widget>(
+                            await Navigator.push<void>(
                               context,
-                              MaterialPageRoute<Widget>(
+                              MaterialPageRoute<void>(
                                 builder: (_) => const LoginPage(),
                               ),
                             );

--- a/packages/smooth_app/lib/pages/scan/scan_header.dart
+++ b/packages/smooth_app/lib/pages/scan/scan_header.dart
@@ -72,9 +72,9 @@ class _ScanHeaderState extends State<ScanHeader> {
                       if (!mounted) {
                         return;
                       }
-                      await Navigator.push<Widget>(
+                      await Navigator.push<void>(
                         context,
-                        MaterialPageRoute<Widget>(
+                        MaterialPageRoute<void>(
                           builder: (BuildContext context) =>
                               PersonalizedRankingPage(
                             barcodes: model.productList.barcodes,

--- a/packages/smooth_app/lib/pages/scan/scan_product_card.dart
+++ b/packages/smooth_app/lib/pages/scan/scan_product_card.dart
@@ -34,9 +34,9 @@ class ScanProductCard extends StatelessWidget {
   }
 
   Future<void> _openProductPage(BuildContext context) async {
-    await Navigator.push<Widget>(
+    await Navigator.push<void>(
       context,
-      MaterialPageRoute<Widget>(
+      MaterialPageRoute<void>(
         builder: (BuildContext context) => ProductPage(product),
       ),
     );

--- a/packages/smooth_app/lib/pages/user_management/login_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/login_page.dart
@@ -250,7 +250,7 @@ class _LoginPageState extends State<LoginPage> with TraceableClientMixin {
                         onPressed: () {
                           Navigator.push(
                             context,
-                            MaterialPageRoute<Widget>(
+                            MaterialPageRoute<void>(
                               builder: (BuildContext context) =>
                                   const ForgotPasswordPage(),
                             ),
@@ -274,6 +274,8 @@ class _LoginPageState extends State<LoginPage> with TraceableClientMixin {
                         height: size.height * 0.06,
                         child: OutlinedButton(
                           onPressed: () async {
+                            // TODO(monsieurtanuki): we probably don't need the returned value and could check the "logged in?" question differently
+                            // TODO(monsieurtanuki): careful, waiting for pop'ed value
                             final bool? registered = await Navigator.push<bool>(
                               context,
                               MaterialPageRoute<bool>(


### PR DESCRIPTION
Impacted files:
* `add_category_button.dart`: now `push<void>` (no expected returned value, no pop'ed value from `SimpleInputPage`)
* `add_ingredients_button.dart`: now `push<void>` (no expected returned value, no pop'ed value from `EditOcrPage`)
* `add_new_product_page.dart`: added `TODO`s about problematic returned values
* `add_nutrition_button.dart`: now `push<void>` (no expected returned value, no pop'ed value from `NutritionPageLoaded`)
* `edit_ingredients_page.dart`: now `pop`ing nothing, as nobody cares about the value
* `edit_product_page.dart`: now `push<void>` (no expected returned value, no pop'ed value from `AddBasicDetailsPage`, `EditOcrPage`, `NutritionPageLoaded`, `SimpleInputPage`); added a `TODO` about a problematic returned value
* `image_upload_card.dart`: added a `TODO` about a problematic returned value
* `login_page.dart`: added a `TODO` about a problematic returned value
* `new_product_page.dart` now `push<void>` (no expected returned value, no pop'ed value from `EditProductPage`)
* `product_image_gallery_view.dart`: added a `TODO` about a problematic returned value
* `product_list_page.dart`: now `push<void>` (no expected returned value, no pop'ed value from `PersonalizedRankingPage`)
* `product_title_card.dart`: now `push<void>` (no expected returned value, no pop'ed value from `AddBasicDetailsPage`)
* `question_page.dart`: now `push<void>` (no expected returned value, no pop'ed value from `LoginPage`)
* `scan_header.dart`: now `push<void>` (no expected returned value, no pop'ed value from `PersonalizedRankingPage`)
* `scan_product_card.dart`: now `push<void>` (no expected returned value, no pop'ed value from `ProductPage`)
* `smooth_product_card_found.dart`: now `push<void>` (no expected returned value, no pop'ed value from `ProductPage`)
* `smooth_product_card_not_found.dart`: added a `TODO` about a problematic returned value
* `summary_card.dart`: now `push<void>` (no expected returned value, no pop'ed value from `AddBasicDetailsPage`, `UserPreferencesPage`, `QuestionPage`, `KnowledgePanelPage)

### What
- We could not migrate to Navigator 2.0 / deep-linking because it looked like many times, we were not only opening pages but waiting for a returned value. And that is a deal breaker, unless flutter merges a specific PR (cf. https://github.com/openfoodfacts/smooth-app/issues/920#issuecomment-1217008636)
- This PR is about cleaning the code to detect where we actually need a returned value, and where we check a returned value for historical reasons but we don't have to anymore.
- That way we can focus on the cases where we do need a returned value. What should we do then? Probably change the "pages" into "dialogs", for which it's normal to return a value.
- There are now 8 cases in 6 files where it looks like we need a returned value. In 2 cases we probably could rewrite easily the code so that we don't.

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/920
- https://github.com/openfoodfacts/smooth-app/issues/1313
