### PR TITLE
fix: Improvements for logs

### DIFF
--- a/packages/smooth_app/lib/services/logs/fimber/trees/file_fimber_tree.dart
+++ b/packages/smooth_app/lib/services/logs/fimber/trees/file_fimber_tree.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:fimber/fimber.dart';
+import 'package:intl/intl.dart';
 import 'package:smooth_app/services/logs/fimber/trees/base_fimber_tree.dart';
 import 'package:smooth_app/services/logs/smooth_log_levels.dart';
 
@@ -15,6 +16,7 @@ class FileFimberTree extends BaseFimberTree {
   }
 
   static final int _maxFileSize = DataSize(megabytes: 5).realSize;
+  final DateFormat _dateFormat = DateFormat('yyyy-MM-dd HH:mm:ss');
   final File outputFile;
 
   /// Generates the following String:
@@ -32,6 +34,7 @@ class FileFimberTree extends BaseFimberTree {
     final StringBuffer buffer = StringBuffer(level);
 
     if (tag != null) {
+      buffer.write(' ${_dateFormat.format(DateTime.now())}');
       buffer.write(' $tag');
     }
 

--- a/packages/smooth_app/lib/services/logs/logs_fimber_impl.dart
+++ b/packages/smooth_app/lib/services/logs/logs_fimber_impl.dart
@@ -47,6 +47,8 @@ class FimberLogImpl implements AppLogService {
     }
 
     Fimber.plantTree(_fileTree);
+
+    log(LogLevel.info, 'New app session started');
   }
 
   Future<File> get _fileName => _filesDirectory
@@ -67,7 +69,7 @@ class FimberLogImpl implements AppLogService {
     Fimber.log(
       _getFimberLogLevel(level),
       message,
-      tag: tag ?? _generateTag(),
+      tag: tag ?? _defaultTag,
       ex: ex,
       stacktrace: stacktrace,
     );
@@ -75,38 +77,66 @@ class FimberLogImpl implements AppLogService {
 
   @override
   void d(String message, {String? tag, dynamic ex, StackTrace? stacktrace}) {
-    Fimber.log('D', message,
-        tag: tag ?? _generateTag(), ex: ex, stacktrace: stacktrace);
+    Fimber.log(
+      'D',
+      message,
+      tag: tag ?? _defaultTag,
+      ex: ex,
+      stacktrace: stacktrace,
+    );
   }
 
   @override
   void e(String message, {String? tag, dynamic ex, StackTrace? stacktrace}) {
     Fimber.log('E', message,
-        tag: tag ?? _generateTag(), ex: ex, stacktrace: stacktrace);
+        tag: tag ?? _defaultTag, ex: ex, stacktrace: stacktrace);
   }
 
   @override
   void i(String message, {String? tag, dynamic ex, StackTrace? stacktrace}) {
-    Fimber.log('I', message,
-        tag: tag ?? _generateTag(), ex: ex, stacktrace: stacktrace);
+    Fimber.log(
+      'I',
+      message,
+      tag: tag ?? _defaultTag,
+      ex: ex,
+      stacktrace: stacktrace,
+    );
   }
 
   @override
   void v(String message, {String? tag, dynamic ex, StackTrace? stacktrace}) {
-    Fimber.log('V', message,
-        tag: tag ?? _generateTag(), ex: ex, stacktrace: stacktrace);
+    Fimber.log(
+      'V',
+      message,
+      tag: tag ?? _defaultTag,
+      ex: ex,
+      stacktrace: stacktrace,
+    );
   }
 
   @override
   void w(String message, {String? tag, dynamic ex, StackTrace? stacktrace}) {
-    Fimber.log('W', message,
-        tag: tag ?? _generateTag(), ex: ex, stacktrace: stacktrace);
+    Fimber.log(
+      'W',
+      message,
+      tag: tag ?? _defaultTag,
+      ex: ex,
+      stacktrace: stacktrace,
+    );
   }
 
   String _getFimberLogLevel(LogLevel level) => level.fimberLevel;
 
-  String _generateTag() {
-    return StackTrace.current.toString().split('\n')[4].split('.')[0];
+  String get _defaultTag {
+    final String tag =
+        StackTrace.current.toString().split('\n')[4].split('.')[0];
+
+    // Some tags looks like "#1    some text" -> we only use "some text"
+    if (tag.startsWith('#')) {
+      return tag.substring(tag.indexOf(' '));
+    } else {
+      return tag;
+    }
   }
 
   @override

--- a/packages/smooth_app/lib/services/logs/smooth_log_levels.dart
+++ b/packages/smooth_app/lib/services/logs/smooth_log_levels.dart
@@ -14,8 +14,10 @@ class LogLevels {
     LogLevel.verbose,
     LogLevel.warning
   ];
+
   static const List<LogLevel> prodLogLevels = <LogLevel>[
     LogLevel.error,
-    LogLevel.info
+    LogLevel.info,
+    LogLevel.debug,
   ];
 }


### PR DESCRIPTION
To fix #2541, but also to improve logs in general, here are a few changes

- Ensure a log is generated every time the app is launched (info level)
- On release builds, the default levels should include "info"
- On file output (or `FileTree`), no timestamp is currently printed -> adding one by default will help us debugging
- If the generated tag is incorrect (something like "# 1        some text") -> "some text" is extracted