### PR TITLE
ci: Finalize new pipeline 

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,8 +1,4 @@
 📦 Existing
-App Store Release(TestFlight): 
- Process: deliver the IOS version onto TestFlight [.github/release.yml](https://github.com/openfoodfacts/smooth-app/blob/develop/.github/release.yml)
- Event: Push on [release/*]
-
 
 Crowdin Action：
  Process: Dump sources and download translations from Crowdin [.github/crowdin.yml](https://github.com/openfoodfacts/smooth-app/blob/develop/.github/crowdin.yml)
@@ -14,16 +10,14 @@ Labeler:
  Event: Creation PR
 
 
-Google Play Release:
- Process: deliver Android version onto Google Play [.github/release.yml](https://github.com/openfoodfacts/smooth-app/blob/develop/.github/release.yml)
- Event: Push on [release/*]
-
-
 Github Pages Deploy Action:
  Process: Deploy auto-generated APIs document in GitHub Pages https://openfoodfacts.github.io/smooth-app/
  Event: Push onto [develop]
 
 
-Release please:
- Process: Update version.txt and CHANGELOG.md by setting release-type=simple
- Event: Push onto [develop]
+Release:
+ The release process is triggered by release please (by merging a generated "chore(develop): release x.x.x" pull request).
+ This triggers the release to the Play- and App-Store using [Fastlane](https://fastlane.tools/).
+ [Release please](https://github.com/openfoodfacts/smooth-app/blob/develop/.github/release-please.yml)
+ [Android release](https://github.com/openfoodfacts/smooth-app/blob/develop/.github/android-release-to-org-openfoodfacts-scanner.yml)
+ [iOS please](https://github.com/openfoodfacts/smooth-app/blob/develop/.github/ios-release-to-org-openfoodfacts-scanner.yml)

--- a/.github/workflows/android-release-to-org-openfoodfacts-scanner.yml
+++ b/.github/workflows/android-release-to-org-openfoodfacts-scanner.yml
@@ -88,14 +88,13 @@ jobs:
          SIGN_KEY_ALIAS: ${{ secrets.SIGN_KEY_ALIAS }}
          SIGN_KEY_PASSWORD: ${{ secrets.SIGN_KEY_PASSWORD }}
 
- #     - name: Release AAB
- #       uses: maierj/fastlane-action@v2.2.1
- #       with:
- #         lane: closed_beta
- #         subdirectory: packages/smooth_app/android
- #       env:
- #        SIGN_STORE_PATH: ./../fastlane/envfiles/keystore.jks
- #        SIGN_STORE_PASSWORD: ${{ secrets.SIGN_STORE_PASSWORD }}
- #        SIGN_KEY_ALIAS: ${{ secrets.SIGN_KEY_ALIAS }}
- #        SIGN_KEY_PASSWORD: ${{ secrets.SIGN_KEY_PASSWORD }}
-
+      - name: Release AAB
+        uses: maierj/fastlane-action@v2.2.1
+        with:
+          lane: closed_beta
+          subdirectory: packages/smooth_app/android
+        env:
+         SIGN_STORE_PATH: ./../fastlane/envfiles/keystore.jks
+         SIGN_STORE_PASSWORD: ${{ secrets.SIGN_STORE_PASSWORD }}
+         SIGN_KEY_ALIAS: ${{ secrets.SIGN_KEY_ALIAS }}
+         SIGN_KEY_PASSWORD: ${{ secrets.SIGN_KEY_PASSWORD }}

--- a/.github/workflows/ios-release-to-org-openfoodfacts-scanner.yml
+++ b/.github/workflows/ios-release-to-org-openfoodfacts-scanner.yml
@@ -112,20 +112,20 @@ jobs:
       - name: cat Podfile
         run: cd ./packages/smooth_app/ios && cat Podfile
  
-#      - name: Release ipa
-#        run: cd ./packages/smooth_app/ios && bundle exec fastlane beta
-#        env:
-#          GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-#          FASTLANE_USER: ${{ secrets.FASTLANE_USER }}
-#          FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: ${{ secrets.FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD }}
-#          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
-#          MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
-#          MATCH_KEYCHAIN_PASSWORD: ${{ secrets.MATCH_KEYCHAIN_PASSWORD }}
-#          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
-#          PILOT_APPLE_ID: ${{ secrets.PILOT_APPLE_ID }}
-#          SPACESHIP_CONNECT_API_ISSUER_ID: ${{ secrets.SPACESHIP_CONNECT_API_ISSUER_ID }}
-#          SPACESHIP_CONNECT_API_KEY_ID: ${{ secrets.SPACESHIP_CONNECT_API_KEY_ID }}
-#          SPACESHIP_CONNECT_API_KEY_FILEPATH: ./fastlane/envfiles/AuthKey_KDAUTTM76R.p8
-#          CI_RELEASE: true
+      - name: Release ipa
+        run: cd ./packages/smooth_app/ios && bundle exec fastlane beta
+        env:
+          GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          FASTLANE_USER: ${{ secrets.FASTLANE_USER }}
+          FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: ${{ secrets.FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD }}
+          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+          MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
+          MATCH_KEYCHAIN_PASSWORD: ${{ secrets.MATCH_KEYCHAIN_PASSWORD }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          PILOT_APPLE_ID: ${{ secrets.PILOT_APPLE_ID }}
+          SPACESHIP_CONNECT_API_ISSUER_ID: ${{ secrets.SPACESHIP_CONNECT_API_ISSUER_ID }}
+          SPACESHIP_CONNECT_API_KEY_ID: ${{ secrets.SPACESHIP_CONNECT_API_KEY_ID }}
+          SPACESHIP_CONNECT_API_KEY_FILEPATH: ./fastlane/envfiles/AuthKey_KDAUTTM76R.p8
+          CI_RELEASE: true
 


### PR DESCRIPTION
### What
- This activates the new release pipeline which is more modular, namely to pass arguments so that the same workflow can later be used for multiple flavours/store listings.
- https://github.com/openfoodfacts/smooth-app/actions/runs/2898324719
![grafik](https://user-images.githubusercontent.com/39344769/185790184-877ea93e-e4bb-4e04-bd0d-48cd4c1d5f90.png)
#### Related to
https://github.com/openfoodfacts/smooth-app/pull/2811
https://github.com/openfoodfacts/smooth-app/pull/2812
https://github.com/openfoodfacts/smooth-app/pull/2813
https://github.com/openfoodfacts/smooth-app/pull/2814
https://github.com/openfoodfacts/smooth-app/pull/2816
https://github.com/openfoodfacts/smooth-app/pull/2817
https://github.com/openfoodfacts/smooth-app/pull/2818
https://github.com/openfoodfacts/smooth-app/pull/2819
https://github.com/openfoodfacts/smooth-app/pull/2820
https://github.com/openfoodfacts/smooth-app/pull/2821
https://github.com/openfoodfacts/smooth-app/pull/2822
https://github.com/openfoodfacts/smooth-app/pull/2823
https://github.com/openfoodfacts/smooth-app/issues/2771
https://github.com/openfoodfacts/smooth-app/pull/2286
https://github.com/openfoodfacts/smooth-app/issues/1882