### PR TITLE
feat: Improvements for the decoding process (1/3)

### DIFF
--- a/packages/smooth_app/lib/helpers/collections_helper.dart
+++ b/packages/smooth_app/lib/helpers/collections_helper.dart
@@ -1,4 +1,5 @@
 import 'dart:collection';
+import 'dart:math' as math show max;
 
 import 'package:collection/collection.dart';
 
@@ -14,6 +15,12 @@ class AverageList<T extends num> with ListMixin<T> {
     } else {
       return _elements.average.floor();
     }
+  }
+
+  /// Same as [average], but ensures a minimum value of [minValue] is returned.
+  int averageMin({required int defaultValueIfEmpty, required int minValue}) {
+    final int averageRes = average(defaultValueIfEmpty);
+    return math.max(averageRes, minValue);
   }
 
   @override

--- a/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
@@ -52,7 +52,7 @@ class MLKitScannerPageState extends LifecycleAwareState<MLKitScannerPage>
   /// It's also the minimum window between two decodings
   /// Note: A decoding happens by multiplying a window by [_processingTimeWindows]
   static const int _defaultProcessingTime = 50; // in milliseconds
-  /// In the case where [deviceInLowMemoryMode] is true, this value become the
+  /// In the case where [deviceInLowMemoryMode] is true, this value becomes the
   /// minimum window, which will be multiplied by [_processingTimeWindows]
   static const int _lowMemoryProcessingTime = 500; // in milliseconds
   /// Minimal processing windows between two decodings

--- a/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
@@ -34,7 +34,7 @@ class MLKitScannerPage extends LifecycleAwareStatefulWidget {
 }
 
 class MLKitScannerPageState extends LifecycleAwareState<MLKitScannerPage>
-    with TraceableClientMixin {
+    with TraceableClientMixin, WidgetsBindingObserver {
   /// If the camera is being closed (when [stoppingCamera] == true) and this
   /// Widget is visible again, we add a post frame callback to detect if the
   /// Widget is still visible
@@ -49,7 +49,12 @@ class MLKitScannerPageState extends LifecycleAwareState<MLKitScannerPage>
   /// every [_processingTimeWindows] time windows.
 
   /// Until the first barcode is decoded, this is default timeout
+  /// It's also the minimum window between two decodings
+  /// Note: A decoding happens by multiplying a window by [_processingTimeWindows]
   static const int _defaultProcessingTime = 50; // in milliseconds
+  /// In the case where [deviceInLowMemoryMode] is true, this value become the
+  /// minimum window, which will be multiplied by [_processingTimeWindows]
+  static const int _lowMemoryProcessingTime = 500; // in milliseconds
   /// Minimal processing windows between two decodings
   static const int _processingTimeWindows = 5;
 
@@ -89,6 +94,9 @@ class MLKitScannerPageState extends LifecycleAwareState<MLKitScannerPage>
   /// The next time this tab is visible, we will force relaunching the camera.
   bool pendingResume = false;
 
+  /// If the device is in low memory pressure, lower as possible the decoding
+  bool deviceInLowMemoryMode = false;
+
   @override
   void initState() {
     super.initState();
@@ -97,6 +105,8 @@ class MLKitScannerPageState extends LifecycleAwareState<MLKitScannerPage>
     if (_camera != null) {
       _subject = PublishSubject<CameraImage>();
     }
+
+    WidgetsBinding.instance.addObserver(this);
   }
 
   @override
@@ -257,9 +267,11 @@ class MLKitScannerPageState extends LifecycleAwareState<MLKitScannerPage>
     _subject
         .throttleTime(
           Duration(
-            milliseconds:
-                _averageProcessingTime.average(_defaultProcessingTime) *
-                    _processingTimeWindows,
+            milliseconds: _averageProcessingTime.averageMin(
+                  defaultValueIfEmpty: _processingTime,
+                  minValue: _processingTime,
+                ) *
+                _processingTimeWindows,
           ),
         )
         .asyncMap((CameraImage image) async {
@@ -444,6 +456,9 @@ class MLKitScannerPageState extends LifecycleAwareState<MLKitScannerPage>
     setStateSafe(() {});
   }
 
+  int get _processingTime =>
+      deviceInLowMemoryMode ? _lowMemoryProcessingTime : _defaultProcessingTime;
+
   /// The camera is fully closed at this step.
   /// However, the user may have "reopened" this Widget during this
   /// operation. In this case, [_startLiveFeed] should be called.
@@ -513,11 +528,18 @@ class MLKitScannerPageState extends LifecycleAwareState<MLKitScannerPage>
   }
 
   @override
+  void didHaveMemoryPressure() {
+    deviceInLowMemoryMode = true;
+    Logs.w('The device enters in low memory mode!');
+  }
+
+  @override
   void dispose() {
     // /!\ This call is a Future, which may leads to some issues.
     // This should be handled by [_restartCameraIfNecessary]
     _stopImageStream();
     _disposeSoundManager();
+    WidgetsBinding.instance.removeObserver(this);
     super.dispose();
   }
 


### PR DESCRIPTION
Hi everyone,

I have identified 3 reproducible issues with the camera/scanning.
The idea is to fix and test one after the other to ensure we don't have any regression.

This first PR will:
- Ensure a minimum time between two decodings (50 ms) - notably if the device is too powerful
As a reminder, a decoding is only allowed every `time * 5 = 250ms` (in that case)

- A listener is added to the low memory mode of the phone.
In that case, the time becomes 500 ms, which means a decoding every 2,5 sec (500 * 5).