### PR TITLE
fix: Placeholder image in case of image not loading

### DIFF
--- a/packages/smooth_app/lib/generic_lib/widgets/smooth_product_image.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/smooth_product_image.dart
@@ -60,6 +60,18 @@ class SmoothProductImage extends StatelessWidget {
                               progress.expectedTotalBytes!,
                         ),
                       ),
+            errorBuilder:
+                (BuildContext context, Object error, StackTrace? stackTrace) =>
+                    SmoothProductImageContainer(
+              width: width,
+              height: height,
+              child: Center(
+                child: SvgPicture.asset(
+                  'assets/product/product_not_found.svg',
+                  fit: BoxFit.cover,
+                ),
+              ),
+            ),
           ),
         );
 }

--- a/packages/smooth_app/lib/generic_lib/widgets/smooth_product_image.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/smooth_product_image.dart
@@ -62,14 +62,10 @@ class SmoothProductImage extends StatelessWidget {
                       ),
             errorBuilder:
                 (BuildContext context, Object error, StackTrace? stackTrace) =>
-                    SmoothProductImageContainer(
-              width: width,
-              height: height,
-              child: Center(
-                child: SvgPicture.asset(
-                  'assets/product/product_not_found.svg',
-                  fit: BoxFit.cover,
-                ),
+                    Center(
+              child: SvgPicture.asset(
+                'assets/product/product_not_found.svg',
+                fit: BoxFit.cover,
               ),
             ),
           ),


### PR DESCRIPTION
### What
<!-- description of the PR -->
- Show placeholder image in case of no internet or error while loading image 

### Screenshot
![image](https://user-images.githubusercontent.com/57723319/187083811-421e59f1-fa56-4068-8105-3b0a45507ee3.png)


### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes: #2851 

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/863