### PR TITLE
feat: Instant refresh views

### DIFF
--- a/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
@@ -5,6 +5,7 @@ import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/cards/product_cards/product_image_carousel.dart';
+import 'package:smooth_app/data_models/up_to_date_product_provider.dart';
 import 'package:smooth_app/database/dao_product.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
@@ -56,6 +57,8 @@ class _AddBasicDetailsPageState extends State<AddBasicDetailsPage> {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final Size size = MediaQuery.of(context).size;
     final LocalDatabase localDatabase = context.read<LocalDatabase>();
+    final UpToDateProductProvider provider =
+        context.read<UpToDateProductProvider>();
     return SmoothScaffold(
       appBar: AppBar(
         title: Text(appLocalizations.basic_details),
@@ -170,18 +173,21 @@ class _AddBasicDetailsPageState extends State<AddBasicDetailsPage> {
                     //And if it is not, we create a new product with the fields of the _product
                     // and we insert it in the database. (Giving the user an immediate feedback)
                     if (product == null) {
-                      daoProduct.put(Product(
+                      final Product newProduct = Product(
                         barcode: _product.barcode,
                         productName: _productNameController.text,
                         brands: _brandNameController.text,
                         quantity: _weightController.text,
                         lang: ProductQuery.getLanguage(),
-                      ));
+                      );
+                      daoProduct.put(newProduct);
+                      provider.set(newProduct);
                     } else {
                       product.productName = _productNameController.text;
                       product.brands = _brandNameController.text;
                       product.quantity = _weightController.text;
                       daoProduct.put(product);
+                      provider.set(product);
                     }
                     localDatabase.notifyListeners();
                     if (!mounted) {

--- a/packages/smooth_app/lib/pages/product/edit_ingredients_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_ingredients_page.dart
@@ -58,13 +58,7 @@ class _EditOcrPageState extends State<EditOcrPage> {
     setState(() => _updatingText = true);
     final UpToDateProductProvider provider =
         context.read<UpToDateProductProvider>();
-    try {
-      await _updateText(_controller.text, provider);
-    } catch (error) {
-      final AppLocalizations appLocalizations = AppLocalizations.of(context);
-      _showError(_helper.getError(appLocalizations));
-    }
-
+    await _updateText(_controller.text, provider);
     setState(() => _updatingText = false);
   }
 

--- a/packages/smooth_app/lib/pages/product/edit_ingredients_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_ingredients_page.dart
@@ -56,9 +56,10 @@ class _EditOcrPageState extends State<EditOcrPage> {
 
   Future<void> _onSubmitField() async {
     setState(() => _updatingText = true);
-
+    final UpToDateProductProvider provider =
+        context.read<UpToDateProductProvider>();
     try {
-      await _updateText(_controller.text);
+      await _updateText(_controller.text, provider);
     } catch (error) {
       final AppLocalizations appLocalizations = AppLocalizations.of(context);
       _showError(_helper.getError(appLocalizations));
@@ -129,7 +130,8 @@ class _EditOcrPageState extends State<EditOcrPage> {
     }
   }
 
-  Future<bool> _updateText(final String text) async {
+  Future<bool> _updateText(
+      final String text, UpToDateProductProvider provider) async {
     final Product minimalistProduct =
         _helper.getMinimalistProduct(_product, text);
     final String uniqueId =
@@ -163,8 +165,10 @@ class _EditOcrPageState extends State<EditOcrPage> {
     if (localProduct != null) {
       localProduct.ingredientsText = minimalistProduct.ingredientsText;
       await daoProduct.put(localProduct);
+      provider.set(localProduct);
     } else {
       await daoProduct.put(minimalistProduct);
+      provider.set(minimalistProduct);
     }
 
     localDatabase.notifyListeners();

--- a/packages/smooth_app/lib/pages/product/nutrition_container.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_container.dart
@@ -95,13 +95,14 @@ class NutritionContainer {
         (!_added.contains(nutrientId));
   }
 
-  /// Returns a [Product] with only nutrients data.
-  Product getProduct() => Product(
-        barcode: _barcode,
-        noNutritionData: noNutritionData,
-        nutriments: _getNutriments(),
-        servingSize: _servingSize,
-      );
+  /// Returns a [Product] with changed nutrients data.
+  Product getProduct(Product product) {
+    product.barcode = _barcode;
+    product.noNutritionData = noNutritionData;
+    product.nutriments = _getNutriments();
+    product.servingSize = _servingSize;
+    return product;
+  }
 
   void copyUnitsFrom(final NutritionContainer other) =>
       _units.addAll(other._units);

--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -11,6 +11,7 @@ import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:openfoodfacts/utils/UnitHelper.dart';
 import 'package:provider/provider.dart';
+import 'package:smooth_app/data_models/up_to_date_product_provider.dart';
 import 'package:smooth_app/database/dao_product.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
@@ -495,6 +496,8 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
     }
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final LocalDatabase localDatabase = context.read<LocalDatabase>();
+    final UpToDateProductProvider provider =
+        context.read<UpToDateProductProvider>();
     if (!saving) {
       final bool? pleaseSave = await showDialog<bool>(
         context: context,
@@ -562,6 +565,14 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
       product.servingSize = changedProduct.servingSize;
       product.nutriments = changedProduct.nutriments;
       await daoProduct.put(product);
+      provider.set(product);
+    } else {
+      final Product newProduct = Product(
+        servingSize: changedProduct.servingSize,
+        nutriments: changedProduct.nutriments,
+      );
+      await daoProduct.put(newProduct);
+      provider.set(newProduct);
     }
     localDatabase.notifyListeners();
     if (mounted) {

--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -562,12 +562,15 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
     //And if it is not, we create a new product with the fields of the _product
     // and we insert it in the database. (Giving the user an immediate feedback)
     if (product != null) {
+      product.noNutritionData = changedProduct.noNutritionData;
       product.servingSize = changedProduct.servingSize;
       product.nutriments = changedProduct.nutriments;
       await daoProduct.put(product);
       provider.set(product);
     } else {
       final Product newProduct = Product(
+        barcode: _product.barcode,
+        noNutritionData: changedProduct.noNutritionData,
         servingSize: changedProduct.servingSize,
         nutriments: changedProduct.nutriments,
       );

--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -70,7 +70,7 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
   void initState() {
     super.initState();
     _product = widget.product;
-    _nutritionContainer = _getFreshContainer();
+    _nutritionContainer = _getFreshContainer(widget.product);
     _numberFormat = NumberFormat('####0.#####', ProductQuery.getLocaleString());
     _noNutritionData = _product.noNutritionData ?? false;
   }
@@ -455,13 +455,13 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
         _noNutritionData,
       );
 
-  Product? _getChangedProduct() {
+  Product? _getChangedProduct(Product product) {
     if (!_formKey.currentState!.validate()) {
       return null;
     }
     // We use a separate fresh container here.
     // If something breaks while saving, we won't get a half written object.
-    final NutritionContainer output = _getFreshContainer();
+    final NutritionContainer output = _getFreshContainer(product);
     // we copy the values
     for (final String key in _controllers.keys) {
       final TextEditingController controller = _controllers[key]!;
@@ -471,12 +471,12 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
     output.noNutritionData = _noNutritionData;
     // we copy the units
     output.copyUnitsFrom(_nutritionContainer);
-    return output.getProduct();
+    return output.getProduct(product);
   }
 
-  NutritionContainer _getFreshContainer() => NutritionContainer(
+  NutritionContainer _getFreshContainer(Product product) => NutritionContainer(
         orderedNutrients: widget.orderedNutrients,
-        product: _product,
+        product: product,
       );
 
   /// Exits the page if the [flag] is `true`.
@@ -498,6 +498,7 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
     final LocalDatabase localDatabase = context.read<LocalDatabase>();
     final UpToDateProductProvider provider =
         context.read<UpToDateProductProvider>();
+    final DaoProduct daoProduct = DaoProduct(localDatabase);
     if (!saving) {
       final bool? pleaseSave = await showDialog<bool>(
         context: context,
@@ -522,7 +523,16 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
         return true;
       }
     }
-    final Product? changedProduct = _getChangedProduct();
+
+    final Product? changedProduct =
+        _getChangedProduct(Product(barcode: widget.product.barcode));
+    Product? cachedProduct = await daoProduct.get(
+      _product.barcode!,
+    );
+    if (cachedProduct != null) {
+      cachedProduct = _getChangedProduct(_product);
+    }
+
     if (changedProduct == null) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -553,30 +563,9 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
         uniqueId: uniqueId,
       ),
     );
-    final DaoProduct daoProduct = DaoProduct(localDatabase);
-    final Product? product = await daoProduct.get(
-      _product.barcode!,
-    );
-    // We go and chek in the local database if the product is
-    // already in the database. If it is, we update the fields of the product.
-    //And if it is not, we create a new product with the fields of the _product
-    // and we insert it in the database. (Giving the user an immediate feedback)
-    if (product != null) {
-      product.noNutritionData = changedProduct.noNutritionData;
-      product.servingSize = changedProduct.servingSize;
-      product.nutriments = changedProduct.nutriments;
-      await daoProduct.put(product);
-      provider.set(product);
-    } else {
-      final Product newProduct = Product(
-        barcode: _product.barcode,
-        noNutritionData: changedProduct.noNutritionData,
-        servingSize: changedProduct.servingSize,
-        nutriments: changedProduct.nutriments,
-      );
-      await daoProduct.put(newProduct);
-      provider.set(newProduct);
-    }
+    final Product upToDateProduct = cachedProduct ?? changedProduct;
+    await daoProduct.put(upToDateProduct);
+    provider.set(upToDateProduct);
     localDatabase.notifyListeners();
     if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(

--- a/packages/smooth_app/lib/pages/product/ocr_ingredients_helper.dart
+++ b/packages/smooth_app/lib/pages/product/ocr_ingredients_helper.dart
@@ -9,11 +9,10 @@ class OcrIngredientsHelper extends OcrHelper {
   String getText(final Product product) => product.ingredientsText ?? '';
 
   @override
-  Product getMinimalistProduct(final Product product, final String text) =>
-      Product(
-        barcode: product.barcode,
-        ingredientsText: text,
-      );
+  Product getMinimalistProduct(final Product product, final String text) {
+    product.ingredientsText = text;
+    return product;
+  }
 
   @override
   String? getImageUrl(final Product product) => product.imageIngredientsUrl;

--- a/packages/smooth_app/lib/pages/product/ocr_packaging_helper.dart
+++ b/packages/smooth_app/lib/pages/product/ocr_packaging_helper.dart
@@ -11,11 +11,10 @@ class OcrPackagingHelper extends OcrHelper {
   String getText(final Product product) => product.packaging ?? '';
 
   @override
-  Product getMinimalistProduct(final Product product, final String text) =>
-      Product(
-        barcode: product.barcode,
-        packaging: text,
-      );
+  Product getMinimalistProduct(Product product, final String text) {
+    product.packaging = text;
+    return product;
+  }
 
   @override
   String? getImageUrl(final Product product) => product.imagePackagingUrl;

--- a/packages/smooth_app/lib/pages/product/simple_input_page.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page.dart
@@ -227,17 +227,9 @@ class _SimpleInputPageState extends State<SimpleInputPage> {
       ),
     );
 
-    // We go and chek in the local database if the product is
-    // already in the database. If it is, we update the fields of the product.
-    //And if it is not, we create a new product with the fields of the changed product.
-    // and we insert it in the database. (Giving the user an immediate feedback)
-    if (cachedProduct == null) {
-      daoProduct.put(changedProduct);
-      provider.set(changedProduct);
-    } else {
-      daoProduct.put(cachedProduct);
-      provider.set(cachedProduct);
-    }
+    final Product upToDateProduct = cachedProduct ?? changedProduct;
+    await daoProduct.put(upToDateProduct);
+    provider.set(upToDateProduct);
     localDatabase.notifyListeners();
     if (!mounted) {
       return false;

--- a/packages/smooth_app/lib/pages/product/simple_input_page.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page.dart
@@ -144,7 +144,7 @@ class _SimpleInputPageState extends State<SimpleInputPage> {
     }
   }
 
-  /// Merge the changes from [newProduct] into [product].
+  /// Merge the changes from [newProduct] into [productInCache].
   Product _mergeProducts(Product productInCache, Product newProduct) {
     // We take the json representation of both products
     final Map<String, dynamic> newProductMap = newProduct.toJson();

--- a/packages/smooth_app/lib/pages/product/simple_input_page.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page.dart
@@ -150,7 +150,7 @@ class _SimpleInputPageState extends State<SimpleInputPage> {
     final Map<String, dynamic> newProductMap = newProduct.toJson();
     final Map<String, dynamic> productInCacheMap = productInCache.toJson();
     for (final String key in newProductMap.keys) {
-      if (newProductMap[key] != null && newProductMap[key] != '') {
+      if (newProductMap[key] != null) {
         productInCacheMap[key] = newProductMap[key];
       }
     }
@@ -159,8 +159,7 @@ class _SimpleInputPageState extends State<SimpleInputPage> {
     final String encodedJson = jsonEncode(productInCacheMap);
     final Map<String, dynamic> decodedJson =
         json.decode(encodedJson) as Map<String, dynamic>;
-    productInCache = Product.fromJson(decodedJson);
-    return productInCache;
+    return Product.fromJson(decodedJson);
   }
 
   /// Returns `true` if we should really exit the page.


### PR DESCRIPTION
### What
Instantly update views on product edit 
<!-- description of the PR -->
## Steps
-  Go to the edit page of any product
-  Edit the basic details like name, brand name, etc ...
-  go back to the previous screen, then again to the same edit page
-  the changes have not been updated 

#### This pr would fix those problems 
- would immediately change the product state in the edit screen
-  works even when offline 
-  Immediate response compared to what was earlier after the offline pr merge

### Screen Recording


https://user-images.githubusercontent.com/57723319/188330807-ce4ea172-ea3d-4af3-9699-6ccac6c2abb1.mp4


### Part of 
- https://github.com/orgs/openfoodfacts/projects/33