### PR TITLE
fix: Scanner - Not being reinitialized in low memory mode

### DIFF
--- a/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
@@ -239,16 +239,6 @@ class MLKitScannerPageState extends LifecycleAwareState<MLKitScannerPage>
 
     stoppingCamera = false;
 
-    // If the controller is initialized update the UI.
-    _barcodeDecoder ??= MLKitScanDecoder(
-      camera: _camera!,
-      scanMode: DevModeScanMode.fromIndex(
-        _userPreferences.getDevModeIndex(
-          UserPreferencesDevMode.userPreferencesEnumScanMode,
-        ),
-      ),
-    );
-
     CameraHelper.initController(
       SmoothCameraController(
         _userPreferences,
@@ -274,8 +264,19 @@ class MLKitScannerPageState extends LifecycleAwareState<MLKitScannerPage>
           final DateTime start = DateTime.now();
 
           try {
-            final List<String?>? res =
-                await _barcodeDecoder?.processImage(image);
+            // If the decoder is not initialized yet…
+            _barcodeDecoder ??= MLKitScanDecoder(
+              camera: _camera!,
+              scanMode: DevModeScanMode.fromIndex(
+                _userPreferences.getDevModeIndex(
+                  UserPreferencesDevMode.userPreferencesEnumScanMode,
+                ),
+              ),
+            );
+
+            final List<String?>? res = await _barcodeDecoder
+                ?.processImage(image)
+                .timeout(const Duration(seconds: 5));
 
             _averageProcessingTime.add(
               DateTime.now().difference(start).inMilliseconds,


### PR DESCRIPTION

### What
- When returning to the camera's page, the decoder may be disposed (in low memory mode, for example).
- When a new image is sent by the camera, we now re-initialize the controller if necessary.
- A timeout is also set for decoding a barcode. 
  - In that case, the current image will be ignored and the next one will ensure all the system is fully functional (isolates, decoder…)

This will fix #2929

### Part of
- #526 