### PR TITLE
fix: fixed package versions

### DIFF
--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -42,7 +42,7 @@ packages:
       name: audioplayers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.0"
   audioplayers_android:
     dependency: transitive
     description:
@@ -335,42 +335,42 @@ packages:
       name: device_info_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.2"
+    version: "4.0.1"
   device_info_plus_linux:
     dependency: transitive
     description:
       name: device_info_plus_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "2.1.1"
   device_info_plus_macos:
     dependency: transitive
     description:
       name: device_info_plus_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "2.2.3"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
       name: device_info_plus_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "2.6.1"
   device_info_plus_web:
     dependency: transitive
     description:
       name: device_info_plus_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "2.1.0"
   device_info_plus_windows:
     dependency: transitive
     description:
       name: device_info_plus_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.0"
+    version: "3.0.3"
   device_preview:
     dependency: "direct main"
     description:
@@ -469,7 +469,7 @@ packages:
       name: flutter_native_splash
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.8"
+    version: "2.2.3+1"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -483,7 +483,7 @@ packages:
       name: flutter_secure_storage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.1.2"
+    version: "5.0.2"
   flutter_secure_storage_linux:
     dependency: transitive
     description:
@@ -617,7 +617,7 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.5"
+    version: "0.13.4"
   http_parser:
     dependency: transitive
     description:
@@ -804,7 +804,7 @@ packages:
       name: mockito
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.3.0"
+    version: "5.2.0"
   modal_bottom_sheet:
     dependency: "direct main"
     description:
@@ -855,7 +855,7 @@ packages:
       name: package_info_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.3+1"
+    version: "1.4.3"
   package_info_plus_linux:
     dependency: transitive
     description:
@@ -1093,7 +1093,7 @@ packages:
       name: rxdart
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.27.5"
+    version: "0.27.4"
   sentry:
     dependency: transitive
     description:
@@ -1114,7 +1114,7 @@ packages:
       name: share_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.10+1"
+    version: "4.0.10"
   share_plus_linux:
     dependency: transitive
     description:
@@ -1238,7 +1238,7 @@ packages:
       name: sqflite
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3+1"
+    version: "2.0.2+1"
   sqflite_common:
     dependency: transitive
     description:
@@ -1352,7 +1352,7 @@ packages:
       name: url_launcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.5"
+    version: "6.1.3"
   url_launcher_android:
     dependency: transitive
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -13,36 +13,36 @@ dependencies:
   flutter_localizations:
     sdk: flutter
 
-  barcode_widget: ^2.0.3
-  carousel_slider: ^4.1.1
-  cupertino_icons: ^1.0.5
-  device_preview: ^1.1.0
-  flutter_svg: ^1.1.4
-  flutter_map: ^1.1.1
+  barcode_widget: 2.0.3
+  carousel_slider: 4.1.1
+  cupertino_icons: 1.0.5
+  device_preview: 1.1.0
+  flutter_svg: 1.1.4
+  flutter_map: 1.1.1
   flutter_widget_from_html_core: any
-  fwfh_selectable_text: ^0.8.3+1
-  flutter_secure_storage: ^5.0.2
-  hive: ^2.2.2
-  hive_flutter: ^1.1.0
-  http: ^0.13.4
-  image_picker: ^0.8.5+3
+  fwfh_selectable_text: 0.8.3+1
+  flutter_secure_storage: 5.0.2
+  hive: 2.2.3
+  hive_flutter: 1.1.0
+  http: 0.13.4
+  image_picker: 0.8.5+3
   iso_countries: 2.1.0
-  latlong2: ^0.8.1
-  matomo_tracker: ^1.3.0
-  modal_bottom_sheet: ^2.1.0
-  openfoodfacts: ^1.24.0
+  latlong2: 0.8.1
+  matomo_tracker: 1.3.0
+  modal_bottom_sheet: 2.1.0
+  openfoodfacts: 1.24.0
   #  openfoodfacts:
   #    path: ../../../openfoodfacts-dart
-  package_info_plus: ^1.4.2
-  device_info_plus: ^4.0.1
-  permission_handler: ^9.2.0
-  photo_view: ^0.14.0
-  uuid: ^3.0.6
-  provider: ^6.0.3
-  sentry_flutter: ^6.9.1 # careful with upgrading cf: https://github.com/openfoodfacts/smooth-app/issues/1300
-  sqflite: ^2.0.2+1
-  url_launcher: ^6.1.3
-  visibility_detector: ^0.3.3
+  package_info_plus: 1.4.3
+  device_info_plus: 4.0.1
+  permission_handler: 9.2.0
+  photo_view: 0.14.0
+  uuid: 3.0.6
+  provider: 6.0.3
+  sentry_flutter: 6.9.1 # careful with upgrading cf: https://github.com/openfoodfacts/smooth-app/issues/1300
+  sqflite: 2.0.2+1
+  url_launcher: 6.1.3
+  visibility_detector: 0.3.3
 
   # Camera (custom implementation for Android)
   camera:
@@ -59,41 +59,41 @@ dependencies:
     git:
       url: "https://github.com/g123k/flutter_task_manager.git"
 
-  audioplayers: ^1.0.0
-  percent_indicator: ^4.2.2
-  flutter_email_sender: ^5.1.0
-  flutter_native_splash: ^2.2.3+1
+  audioplayers: 1.0.0
+  percent_indicator: 4.2.2
+  flutter_email_sender: 5.1.0
+  flutter_native_splash: 2.2.3+1
   google_mlkit_barcode_scanning: 0.3.0
-  image_cropper: ^2.0.3
-  auto_size_text: ^3.0.0
-  shared_preferences: ^2.0.15
-  typed_data: ^1.3.0 # careful with 1.3.1 because of flutter_driver dependence
-  intl: ^0.17.0
-  flutter_isolate: ^2.0.2
-  rxdart: ^0.27.4
-  collection: ^1.16.0
-  path: ^1.8.2 # careful with 1.8.1 because of https://github.com/flutter/flutter/issues/95478
-  path_provider: ^2.0.11
+  image_cropper: 2.0.3
+  auto_size_text: 3.0.0
+  shared_preferences: 2.0.15
+  typed_data: 1.3.0 # careful with 1.3.1 because of flutter_driver dependence
+  intl: 0.17.0
+  flutter_isolate: 2.0.2
+  rxdart: 0.27.4
+  collection: 1.16.0
+  path: 1.8.2 # careful with 1.8.1 because of https://github.com/flutter/flutter/issues/95478
+  path_provider: 2.0.11
   data_importer_shared:
     path: ../data_importer_shared
   data_importer:
     path: ../data_importer
-  share_plus: ^4.0.10
-  fimber: ^0.6.6
-  shimmer: ^2.0.0
+  share_plus: 4.0.10
+  fimber: 0.6.6
+  shimmer: 2.0.0
 
 dev_dependencies:
   integration_test:
     sdk: flutter
   flutter_driver:
     sdk: flutter
-  flutter_launcher_icons: ^0.10.0
+  flutter_launcher_icons: 0.10.0
   flutter_test:
     sdk: flutter
-  mockito: ^5.2.0
-  path_provider_platform_interface: ^2.0.4
-  plugin_platform_interface: ^2.1.2
-  flutter_lints: ^2.0.1
+  mockito: 5.2.0
+  path_provider_platform_interface: 2.0.4
+  plugin_platform_interface: 2.1.2
+  flutter_lints: 2.0.1
   openfoodfacts_flutter_lints:
     git: https://github.com/openfoodfacts/openfoodfacts_flutter_lints.git
 


### PR DESCRIPTION
### What
- After the downgrade to flutter 3.0.5 (from 3.3.0), we're trying to use fixed versions of packages (in short, removing the starting `^` in the `pubspec.yaml` version entries)
- That is supposed to limit the impact of external package evolutions - currently we need stability in order to code our own bugs without the risk of being attacked by the others' ;)
- That's more a test than a lasting recommendation.
- Fun fact: `flutter pub outdated` still recommends new packages, even if we specify fixed version numbers (and implicitly state that we're not interested in new stuff)

### Part of 
- #2919