### PR TITLE
feat: Finalizer for MLKitScanDecoder

### DIFF
--- a/packages/smooth_app/lib/pages/scan/mkit_scan_helper.dart
+++ b/packages/smooth_app/lib/pages/scan/mkit_scan_helper.dart
@@ -23,9 +23,8 @@ class MLKitScanDecoder {
   /// Ensures the dispose() method is called if this class is GC'ed.
   static final Finalizer<_MLKitScanDecoderMainIsolate> _finalizer =
       Finalizer<_MLKitScanDecoderMainIsolate>(
-          (_MLKitScanDecoderMainIsolate isolate) {
-    isolate.dispose();
-  });
+    (_MLKitScanDecoderMainIsolate isolate) => isolate.dispose(),
+  );
 
   final DevModeScanMode scanMode;
   final _MLKitScanDecoderMainIsolate _mainIsolate;
@@ -167,8 +166,8 @@ class _MLKitScanDecoderMainIsolate {
 
   bool get isDisposed =>
       _isIsolateInitialized == false &&
-          _completer == null &&
-          _sendPort == null ||
+      _completer == null &&
+      _sendPort == null &&
       _isolate == null;
 }
 


### PR DESCRIPTION
### What
- A `Finalizer` is now used within `MLKitScanDecoder` to ensure the Isolate is well disposed when the class is destroyed

Note: It won't improve the camera or the barcode scanner, but should fix a potential Out Of Memory error.


More info on the Finalizer class:
- https://api.flutter.dev/flutter/dart-core/Finalizer-class.html
- (For French viewers - some kind of autopromo 😅) https://www.youtube.com/watch?v=fD8083_Nigw 
