### PR TITLE
feat: Remove D8 (deprecated on Android)

### DIFF
--- a/packages/smooth_app/android/gradle.properties
+++ b/packages/smooth_app/android/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
-android.enableD8=true
 android.useAndroidX=true
 android.enableJetifier=true


### PR DESCRIPTION
### What
On Android, when running a new build, we have an error related to D8 being deprecated:
`WARNING: The option 'android.enableD8' is deprecated.`

This PR removes this line (to be in line with Flutter's app template).
