### PR TITLE
fix: SmoothListTileCard: onTap callback passed twice

### DIFF
--- a/packages/smooth_app/lib/generic_lib/widgets/smooth_list_tile_card.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/smooth_list_tile_card.dart
@@ -95,7 +95,6 @@ class SmoothListTileCard extends StatelessWidget {
           child: Padding(
             padding: const EdgeInsets.all(VERY_SMALL_SPACE),
             child: ListTile(
-              onTap: onTap,
               title: title,
               subtitle: subtitle,
               leading: leading,


### PR DESCRIPTION
### What
- The `SmoothListTileCard` Widget pass twice the callback to handle click events
- This will fix the visual issue (the ripple don't having rounded corners)