### PR TITLE
feat: Alternative mode for camera (Android only feature)

### DIFF
--- a/packages/smooth_app/lib/data_models/user_preferences.dart
+++ b/packages/smooth_app/lib/data_models/user_preferences.dart
@@ -35,6 +35,10 @@ class UserPreferences extends ChangeNotifier {
   // Use the flash/torch with the camera
   static const String _TAG_USE_FLASH_WITH_CAMERA = 'enable_flash_with_camera';
 
+  // Alternative mode for the camera (file based implementation on Android)
+  static const String _TAG_CAMERA_USE_ALTERNATIVE_MODE =
+      'camera_alternative_mode';
+
   // Play sound when decoding a barcode
   static const String _TAG_PLAY_CAMERA_SCAN_SOUND = 'camera_scan_sound';
 
@@ -156,6 +160,18 @@ class UserPreferences extends ChangeNotifier {
 
   Future<void> setUseFlashWithCamera(final bool useFlash) async {
     await _sharedPreferences.setBool(_TAG_USE_FLASH_WITH_CAMERA, useFlash);
+    notifyListeners();
+  }
+
+  bool? get useAlternativeCameraMode =>
+      _sharedPreferences.getBool(_TAG_CAMERA_USE_ALTERNATIVE_MODE);
+
+  Future<void> setUseAlternativeCameraMode(final bool alternativeMode) async {
+    await _sharedPreferences.setBool(
+      _TAG_CAMERA_USE_ALTERNATIVE_MODE,
+      alternativeMode,
+    );
+
     notifyListeners();
   }
 

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -933,6 +933,31 @@
     "@camera_play_sound_subtitle": {
         "description": "SubTitle for the Camera play sound toggle"
     },
+    "camera_alternative_mode_title": "Alternative mode for the scanner",
+    "@camera_alternative_mode_title": {
+        "description": "Title for the Alternative mode for the camera/scanner"
+    },
+    "camera_alternative_mode_subtitle": "If your device is unable to scan barcodes, please try this mode. If it works well, please communicate us your device name: {device}, in order to make this mode the default one for your device.",
+    "@camera_alternative_mode_subtitle": {
+        "description": "SubTitle for the Alternative mode for the camera/scanner",
+        "placeholders": {
+            "device": {
+                "type": "String"
+            }
+        }
+    },
+    "camera_alternative_mode_confirm_dialog_title": "Scanner mode changed!",
+    "@camera_alternative_mode_confirm_dialog_title": {
+        "description": "Title for the dialog explaining the alternative mode has changed"
+    },
+    "camera_alternative_mode_confirm_dialog_body": "The new mode will only be used after stopping, then relaunching the app!",
+    "@camera_alternative_mode_confirm_dialog_body": {
+        "description": "Content for the dialog explaining the alternative mode has changed = restart the app"
+    },
+    "camera_alternative_mode_confirm_dialog_button": "Duly noted!",
+    "@camera_alternative_mode_confirm_dialog_button": {
+        "description": "Button for the dialog to confirm the user has understood"
+    },
     "crash_reporting_toggle_title": "Crash reporting",
     "@crash_reporting_toggle_title": {
         "description": "Title for the Crash reporting toggle"

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_settings.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_settings.dart
@@ -312,7 +312,7 @@ class _CameraAlternativeModeSetting extends StatelessWidget {
 
     showDialog<void>(
         context: context,
-        builder: (_) {
+        builder: (BuildContext subContext) {
           return SmoothAlertDialog(
             title:
                 appLocalizations.camera_alternative_mode_confirm_dialog_title,
@@ -322,7 +322,7 @@ class _CameraAlternativeModeSetting extends StatelessWidget {
             positiveAction: SmoothActionButton(
               text: appLocalizations
                   .camera_alternative_mode_confirm_dialog_button,
-              onPressed: () => Navigator.pop(context),
+              onPressed: () => Navigator.pop(subContext),
             ),
           );
         });

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_settings.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_settings.dart
@@ -299,7 +299,7 @@ class _CameraAlternativeModeSetting extends StatelessWidget {
               .camera_alternative_mode_subtitle(snapshot.data![1] as String),
           value: enabled,
           onChanged: (final bool value) {
-            showWarningAfterChange(context);
+            _showWarningAfterChange(context);
             userPreferences.setUseAlternativeCameraMode(value);
           },
         );
@@ -307,7 +307,7 @@ class _CameraAlternativeModeSetting extends StatelessWidget {
     );
   }
 
-  void showWarningAfterChange(BuildContext context) {
+  void _showWarningAfterChange(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
 
     showDialog<void>(

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_settings.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_settings.dart
@@ -4,6 +4,7 @@ import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/generic_lib/widgets/language_selector.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/camera_helper.dart';
@@ -12,6 +13,7 @@ import 'package:smooth_app/pages/onboarding/country_selector.dart';
 import 'package:smooth_app/pages/preferences/abstract_user_preferences.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_page.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_widgets.dart';
+import 'package:smooth_app/pages/scan/alternative_camera_mode.dart';
 import 'package:smooth_app/themes/theme_provider.dart';
 
 /// Collapsed/expanded display of settings for the preferences page.
@@ -241,6 +243,10 @@ class _CameraSettings extends StatelessWidget {
         UserPreferencesTitle(
           label: appLocalizations.settings_app_camera,
         ),
+        if (AlternativeCameraMode.isSupported) ...<Widget>[
+          const _CameraAlternativeModeSetting(),
+          const UserPreferencesListItemDivider(),
+        ],
         const _CameraPlayScanSoundSetting(),
       ],
     );
@@ -263,6 +269,63 @@ class _CameraPlayScanSoundSetting extends StatelessWidget {
         await userPreferences.setPlayCameraSound(value);
       },
     );
+  }
+}
+
+class _CameraAlternativeModeSetting extends StatelessWidget {
+  const _CameraAlternativeModeSetting({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final UserPreferences userPreferences = context.watch<UserPreferences>();
+
+    return FutureBuilder<List<Object>>(
+      future: Future.wait<Object>(<Future<Object>>[
+        AlternativeCameraMode.isAWhitelistedDevice,
+        AlternativeCameraMode.getDeviceName()
+      ]),
+      builder: (BuildContext context, AsyncSnapshot<List<Object>> snapshot) {
+        if (!snapshot.hasData) {
+          return const SizedBox.shrink();
+        }
+
+        final bool enabled = userPreferences.useAlternativeCameraMode ??
+            snapshot.data![0] as bool;
+
+        return UserPreferencesSwitchItem(
+          title: appLocalizations.camera_alternative_mode_title,
+          subtitle: appLocalizations
+              .camera_alternative_mode_subtitle(snapshot.data![1] as String),
+          value: enabled,
+          onChanged: (final bool value) {
+            showWarningAfterChange(context);
+            userPreferences.setUseAlternativeCameraMode(value);
+          },
+        );
+      },
+    );
+  }
+
+  void showWarningAfterChange(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+
+    showDialog<void>(
+        context: context,
+        builder: (_) {
+          return SmoothAlertDialog(
+            title:
+                appLocalizations.camera_alternative_mode_confirm_dialog_title,
+            body: Text(
+              appLocalizations.camera_alternative_mode_confirm_dialog_body,
+            ),
+            positiveAction: SmoothActionButton(
+              text: appLocalizations
+                  .camera_alternative_mode_confirm_dialog_button,
+              onPressed: () => Navigator.pop(context),
+            ),
+          );
+        });
   }
 }
 

--- a/packages/smooth_app/lib/pages/scan/alternative_camera_mode.dart
+++ b/packages/smooth_app/lib/pages/scan/alternative_camera_mode.dart
@@ -1,0 +1,40 @@
+import 'dart:io';
+
+import 'package:device_info_plus/device_info_plus.dart';
+
+/// File based camera implementation (only on Android)
+class AlternativeCameraMode {
+  const AlternativeCameraMode._();
+
+  static final Iterable<String> _whitelistedBrands = <String>{
+    'OnePlus',
+  };
+  static final Iterable<String> _whitelistedModels = <String>{
+    'CPH2409', // OnePlus Nord CE 2 Lite 5G
+  };
+
+  static bool get isSupported => Platform.isAndroid;
+
+  /// Detects if the current device is whitelisted for the "alternative" mode
+  static Future<bool> get isAWhitelistedDevice async {
+    if (!isSupported) {
+      return false;
+    }
+
+    return DeviceInfoPlugin().androidInfo.then(
+          (AndroidDeviceInfo info) =>
+              _whitelistedBrands.contains(info.brand) ||
+              _whitelistedModels.contains(info.model),
+        );
+  }
+
+  static Future<String> getDeviceName() {
+    if (!isSupported) {
+      throw UnsupportedError('Not supported on this platform');
+    }
+
+    return DeviceInfoPlugin().androidInfo.then(
+          (AndroidDeviceInfo info) => '${info.brand} / ${info.model}',
+        );
+  }
+}

--- a/packages/smooth_app/lib/pages/scan/mkit_scan_helper.dart
+++ b/packages/smooth_app/lib/pages/scan/mkit_scan_helper.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 import 'dart:isolate';
 
 import 'package:camera/camera.dart';
@@ -24,12 +25,14 @@ class MLKitScanDecoder {
   final _MLKitScanDecoderMainIsolate _mainIsolate;
 
   /// Extract barcodes from an image
+  /// An image may be a [CameraImage] or a [String] file path.
   ///
   /// A null result is sent when the [scanMode] is unsupported or if a current
   /// decoding is already in progress
   /// Otherwise a list of decoded barcoded is returned
   /// Note: This list may be empty if no barcode is detected
-  Future<List<String>?> processImage(CameraImage image) async {
+  Future<List<String>?> processImage(dynamic image) async {
+    // TODO(g123k): Not implemented
     switch (scanMode) {
       case DevModeScanMode.CAMERA_ONLY:
       case DevModeScanMode.PREPROCESS_FULL_IMAGE:
@@ -40,7 +43,9 @@ class MLKitScanDecoder {
       // OK -> continue
     }
 
-    return _mainIsolate.decode(image);
+    final decode = await _mainIsolate.decode(image);
+    print('DECODED: $decode');
+    return decode;
   }
 
   Future<void> dispose() async {
@@ -77,11 +82,20 @@ class _MLKitScanDecoderMainIsolate {
         _isIsolateInitialized = true;
 
         if (_queuedImage != null && _completer != null) {
-          _sendPort!.send(_queuedImage!.export());
+          if (_queuedImage is CameraImage) {
+            _sendPort!.send((_queuedImage as CameraImage).export());
+          } else if (_queuedImage is String) {
+            _sendPort!.send(_CameraFileUtils.export(_queuedImage as String));
+          }
+
           _queuedImage = null;
         }
       } else if (message is List) {
         _completer?.complete(message as List<String>);
+        _completer = null;
+      } else {
+        // TODO REMOVE
+        _completer?.complete(<String>[message.runtimeType.toString()]);
         _completer = null;
       }
     });
@@ -112,11 +126,11 @@ class _MLKitScanDecoderMainIsolate {
   /// When the Isolate is started, we have to wait until [_isIsolateInitialized]
   /// is [true]. This variable temporary contains the image waiting to be
   /// decoded.
-  CameraImage? _queuedImage;
+  dynamic _queuedImage;
 
-  /// Decodes barcodes from a [CameraImage]
+  /// Decodes barcodes from an image
   /// A null result will be sent until the Isolate isn't ready
-  Future<List<String>?> decode(CameraImage image) async {
+  Future<List<String>?> decode(dynamic image) async {
     // If a decoding process is running -> ignore new requests
     if (_completer != null) {
       return null;
@@ -132,7 +146,12 @@ class _MLKitScanDecoderMainIsolate {
       _queuedImage = image;
       return _completer!.future;
     } else if (_isIsolateInitialized) {
-      _sendPort?.send(image.export());
+      if (image is CameraImage) {
+        _sendPort?.send(image.export());
+      } else if (image is String) {
+        _sendPort?.send(_CameraFileUtils.export(image));
+      }
+
       return _completer!.future;
     }
 
@@ -227,24 +246,47 @@ class _MLKitScanDecoderIsolate {
       return;
     }
 
-    final CameraImage image = CameraImage.fromPlatformData(message);
-    final InputImage cropImage = _cropImage(image);
-    final double imageHeight =
-        cropImage.inputImageData?.size.longestSide ?? double.infinity;
+    Iterable<Barcode>? barcodes;
+    if (_CameraFileUtils.containsKey(message)) {
+      final String path = _CameraFileUtils.import(message);
+      final File file = File(path);
 
-    final List<Barcode> barcodes =
-        await _barcodeScanner.processImage(cropImage);
+      if (file.existsSync() && file.lengthSync() > 0) {
+        try {
+          barcodes = await _barcodeScanner.processImage(
+            InputImage.fromFilePath(path),
+          );
+        } catch (ignored) {
+          // The native code may fail if the file is invalid
+        }
 
-    port.send(
-      barcodes
-          // Only accepts barcodes on half-top of the image
-          .where((Barcode barcode) =>
-              (barcode.boundingBox?.top ?? 0.0) <= imageHeight * 0.5)
-          .map((Barcode barcode) => _changeBarcodeType(barcode))
-          .where((String? barcode) => barcode?.isNotEmpty == true)
-          .cast<String>()
-          .toList(growable: false),
-    );
+        // Not mandatory as the native part also removes the file
+        File(path).delete();
+      }
+    } else {
+      final CameraImage image = CameraImage.fromPlatformData(message);
+      final InputImage cropImage = _cropImage(image);
+      final double imageHeight =
+          cropImage.inputImageData?.size.longestSide ?? double.infinity;
+
+      final List<Barcode> list = await _barcodeScanner.processImage(cropImage);
+
+      // With files, we don't know the imageHeight
+      barcodes = list.where((Barcode barcode) =>
+          (barcode.boundingBox?.top ?? 0.0) <= imageHeight * 0.5);
+    }
+
+    if (barcodes == null || barcodes.isEmpty) {
+      port.send(<String>['']);
+    } else {
+      port.send(
+        barcodes
+            .map((Barcode barcode) => _changeBarcodeType(barcode))
+            .where((String? barcode) => barcode?.isNotEmpty == true)
+            .cast<String>()
+            .toList(growable: false),
+      );
+    }
   }
 
   static String? _changeBarcodeType(Barcode barcode) {
@@ -333,4 +375,15 @@ class _CameraDescriptionUtils {
       sensorOrientation: map[_sensorOrientationKey] as int,
     );
   }
+}
+
+class _CameraFileUtils {
+  const _CameraFileUtils._();
+
+  static Map<String, dynamic> export(String file) =>
+      <String, dynamic>{'file': file};
+
+  static String import(Map<dynamic, dynamic> map) => map['file'] as String;
+
+  static bool containsKey(Map<dynamic, dynamic> map) => map.containsKey('file');
 }

--- a/packages/smooth_app/lib/pages/scan/mkit_scan_helper.dart
+++ b/packages/smooth_app/lib/pages/scan/mkit_scan_helper.dart
@@ -43,9 +43,7 @@ class MLKitScanDecoder {
       // OK -> continue
     }
 
-    final decode = await _mainIsolate.decode(image);
-    print('DECODED: $decode');
-    return decode;
+    return _mainIsolate.decode(image);
   }
 
   Future<void> dispose() async {
@@ -92,10 +90,6 @@ class _MLKitScanDecoderMainIsolate {
         }
       } else if (message is List) {
         _completer?.complete(message as List<String>);
-        _completer = null;
-      } else {
-        // TODO REMOVE
-        _completer?.complete(<String>[message.runtimeType.toString()]);
         _completer = null;
       }
     });

--- a/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
@@ -331,10 +331,7 @@ class MLKitScannerPageState extends LifecycleAwareState<MLKitScannerPage>
   }
 
   Future<void> _onNewBarcodeDetected(List<String> barcodes) async {
-    print('BARCODES $barcodes');
-
     for (final String barcode in barcodes) {
-      print('HERE $barcode');
       if (await _model.onScan(barcode)) {
         // Both are Future methods, but it doesn't matter to wait here
         HapticFeedback.lightImpact();

--- a/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
@@ -67,7 +67,7 @@ class MLKitScannerPageState extends LifecycleAwareState<MLKitScannerPage>
   AudioPlayer? _musicPlayer;
 
   /// Subject notifying when a new image is available
-  PublishSubject<CameraImage> _subject = PublishSubject<CameraImage>();
+  PublishSubject<dynamic> _subject = PublishSubject<dynamic>();
 
   /// Stream calling the barcode detection
   StreamSubscription<List<String>?>? _streamSubscription;
@@ -103,7 +103,7 @@ class MLKitScannerPageState extends LifecycleAwareState<MLKitScannerPage>
     _camera = CameraHelper.findBestCamera();
 
     if (_camera != null) {
-      _subject = PublishSubject<CameraImage>();
+      _subject = PublishSubject<dynamic>();
     }
 
     WidgetsBinding.instance.addObserver(this);
@@ -260,7 +260,7 @@ class MLKitScannerPageState extends LifecycleAwareState<MLKitScannerPage>
                 _processingTimeWindows,
           ),
         )
-        .asyncMap((CameraImage image) async {
+        .asyncMap((dynamic image) async {
           final DateTime start = DateTime.now();
 
           try {
@@ -282,12 +282,18 @@ class MLKitScannerPageState extends LifecycleAwareState<MLKitScannerPage>
               DateTime.now().difference(start).inMilliseconds,
             );
 
-            return res;
+            return res ?? <String>[];
           } catch (err) {
             // Isolate is stopped
             return <String>[];
           }
         })
+        // Remove list with empty strings
+        .map(
+          (List<String?> res) => res
+              .where((String? e) => e != null && e.trim().isNotEmpty)
+              .toList(growable: false),
+        )
         .where(
           (List<String?>? barcodes) => barcodes?.isNotEmpty == true,
         )
@@ -301,7 +307,7 @@ class MLKitScannerPageState extends LifecycleAwareState<MLKitScannerPage>
         focusMode: FocusMode.auto,
         focusPoint: point.offset,
         deviceOrientation: DeviceOrientation.portraitUp,
-        onAvailable: (CameraImage image) => _subject.add(image),
+        onAvailable: (dynamic image) => _subject.add(image),
       );
 
       // If the Widget tree isn't ready, wait for the first frame
@@ -325,7 +331,10 @@ class MLKitScannerPageState extends LifecycleAwareState<MLKitScannerPage>
   }
 
   Future<void> _onNewBarcodeDetected(List<String> barcodes) async {
+    print('BARCODES $barcodes');
+
     for (final String barcode in barcodes) {
+      print('HERE $barcode');
       if (await _model.onScan(barcode)) {
         // Both are Future methods, but it doesn't matter to wait here
         HapticFeedback.lightImpact();

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -139,7 +139,7 @@ packages:
     description:
       path: "packages/camera/camera"
       ref: smooth_camera
-      resolved-ref: b285b3c4c9a60dbec46105992d6cd255a1178f0a
+      resolved-ref: "8bf329e07f74f341fae7e08c968da0a949459912"
       url: "https://github.com/g123k/plugins.git"
     source: git
     version: "0.9.6"

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -139,7 +139,7 @@ packages:
     description:
       path: "packages/camera/camera"
       ref: smooth_camera
-      resolved-ref: "873afe5cc5077e431ec29d7c31a34cc48e34b850"
+      resolved-ref: b285b3c4c9a60dbec46105992d6cd255a1178f0a
       url: "https://github.com/g123k/plugins.git"
     source: git
     version: "0.9.6"
@@ -148,7 +148,7 @@ packages:
     description:
       path: "packages/camera/camera_platform_interface"
       ref: smooth_camera
-      resolved-ref: "873afe5cc5077e431ec29d7c31a34cc48e34b850"
+      resolved-ref: b285b3c4c9a60dbec46105992d6cd255a1178f0a
       url: "https://github.com/g123k/plugins.git"
     source: git
     version: "2.1.6"
@@ -157,7 +157,7 @@ packages:
     description:
       path: "packages/camera/camera_web"
       ref: smooth_camera
-      resolved-ref: "873afe5cc5077e431ec29d7c31a34cc48e34b850"
+      resolved-ref: b285b3c4c9a60dbec46105992d6cd255a1178f0a
       url: "https://github.com/g123k/plugins.git"
     source: git
     version: "0.2.1+6"

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "46.0.0"
+    version: "47.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.6.0"
+    version: "4.7.0"
   archive:
     dependency: transitive
     description:
@@ -139,7 +139,7 @@ packages:
     description:
       path: "packages/camera/camera"
       ref: smooth_camera
-      resolved-ref: a21ae5f359ea46a657814812478fd138c4de52f6
+      resolved-ref: "873afe5cc5077e431ec29d7c31a34cc48e34b850"
       url: "https://github.com/g123k/plugins.git"
     source: git
     version: "0.9.6"
@@ -148,7 +148,7 @@ packages:
     description:
       path: "packages/camera/camera_platform_interface"
       ref: smooth_camera
-      resolved-ref: a21ae5f359ea46a657814812478fd138c4de52f6
+      resolved-ref: "873afe5cc5077e431ec29d7c31a34cc48e34b850"
       url: "https://github.com/g123k/plugins.git"
     source: git
     version: "2.1.6"
@@ -157,7 +157,7 @@ packages:
     description:
       path: "packages/camera/camera_web"
       ref: smooth_camera
-      resolved-ref: a21ae5f359ea46a657814812478fd138c4de52f6
+      resolved-ref: "873afe5cc5077e431ec29d7c31a34cc48e34b850"
       url: "https://github.com/g123k/plugins.git"
     source: git
     version: "0.2.1+6"
@@ -666,7 +666,7 @@ packages:
       name: image_picker_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.5+2"
+    version: "0.8.5+3"
   image_picker_for_web:
     dependency: transitive
     description:
@@ -680,7 +680,7 @@ packages:
       name: image_picker_ios
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.5+6"
+    version: "0.8.6"
   image_picker_platform_interface:
     dependency: transitive
     description:
@@ -890,7 +890,7 @@ packages:
       name: package_info_plus_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   path:
     dependency: "direct main"
     description:
@@ -960,7 +960,7 @@ packages:
       name: path_provider_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   percent_indicator:
     dependency: "direct main"
     description:
@@ -1163,7 +1163,7 @@ packages:
       name: shared_preferences_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.12"
+    version: "2.0.13"
   shared_preferences_ios:
     dependency: transitive
     description:
@@ -1287,7 +1287,7 @@ packages:
       name: synchronized
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0+2"
+    version: "3.0.0+3"
   task_manager:
     dependency: "direct main"
     description:
@@ -1359,7 +1359,7 @@ packages:
       name: url_launcher_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.17"
+    version: "6.0.18"
   url_launcher_ios:
     dependency: transitive
     description:

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -139,7 +139,7 @@ packages:
     description:
       path: "packages/camera/camera"
       ref: smooth_camera
-      resolved-ref: "8bf329e07f74f341fae7e08c968da0a949459912"
+      resolved-ref: "40497e4fc74a8512634e04c3c9d6a8c3a50284c0"
       url: "https://github.com/g123k/plugins.git"
     source: git
     version: "0.9.6"
@@ -148,7 +148,7 @@ packages:
     description:
       path: "packages/camera/camera_platform_interface"
       ref: smooth_camera
-      resolved-ref: b285b3c4c9a60dbec46105992d6cd255a1178f0a
+      resolved-ref: "40497e4fc74a8512634e04c3c9d6a8c3a50284c0"
       url: "https://github.com/g123k/plugins.git"
     source: git
     version: "2.1.6"
@@ -157,7 +157,7 @@ packages:
     description:
       path: "packages/camera/camera_web"
       ref: smooth_camera
-      resolved-ref: b285b3c4c9a60dbec46105992d6cd255a1178f0a
+      resolved-ref: "40497e4fc74a8512634e04c3c9d6a8c3a50284c0"
       url: "https://github.com/g123k/plugins.git"
     source: git
     version: "0.2.1+6"


### PR DESCRIPTION
### What
The MLKit plugin doesn't work on some devices with a byte array, but is OK when passing a file instead.
The native plugin (camera) is able to both provide a byte array or a file only on Android (as iOS seems OK).

The PR allows switching between the two modes.

Here is the screenshot of the new setting (only visible on Android)
![1](https://user-images.githubusercontent.com/246838/188747408-5bb0fb2a-e0ec-4e25-b559-af7f107d0308.png)

![2](https://user-images.githubusercontent.com/246838/188747489-1be9a549-c7ed-4cfb-982d-5716d44d3657.png)


Some notes:
- The focus should now be a bit quicker than before (my last PR was a bit too conservative)
- For the "normal mode", the native part only sends one image every 100 ms (some devices like the Pixel 6 Pro was able to send 3 images during this time). It should lower memory usage.

Related to #2741 
