### PR TITLE
fix: Move the Sign out button to the last position

### DIFF
--- a/packages/smooth_app/lib/pages/preferences/user_preferences_account.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_account.dart
@@ -296,16 +296,6 @@ class _UserPreferencesPageState extends State<UserPreferencesSection> {
         ),
         const UserPreferencesListItemDivider(),
         _getListTile(
-          appLocalizations.sign_out,
-          () async {
-            if (await _confirmLogout(context) == true) {
-              Navigator.pop(context);
-            }
-          },
-          Icons.clear,
-        ),
-        const UserPreferencesListItemDivider(),
-        _getListTile(
           appLocalizations.account_delete,
           () async {
             final Email email = Email(
@@ -317,6 +307,16 @@ class _UserPreferencesPageState extends State<UserPreferencesSection> {
             await FlutterEmailSender.send(email);
           },
           Icons.delete,
+        ),
+        const UserPreferencesListItemDivider(),
+        _getListTile(
+          appLocalizations.sign_out,
+          () async {
+            if (await _confirmLogout(context) == true) {
+              Navigator.pop(context);
+            }
+          },
+          Icons.clear,
         ),
         const UserPreferencesListItemDivider(),
       ];


### PR DESCRIPTION
### What
- In the profile, the last action should be to Sign out and not Delete an account (the current impl is not logical)

### Screenshot
![Screenshot_1662796996](https://user-images.githubusercontent.com/246838/189474809-1a29ed41-85c8-41ac-bc14-9e59d5a81fb0.png)
