### PR TITLE
fix: #3038 - applied (colored) style for CupertinoPicker

### DIFF
--- a/packages/smooth_app/lib/pages/product/portion_calculator.dart
+++ b/packages/smooth_app/lib/pages/product/portion_calculator.dart
@@ -63,7 +63,10 @@ class _PortionCalculatorState extends State<PortionCalculator> {
                     _grams = _fromIndexToGrams(index),
                 childCount: _fromGramsToIndex(_maxGrams) + 1,
                 itemBuilder: (final BuildContext context, final int index) =>
-                    Text('${_fromIndexToGrams(index)}'),
+                    Text(
+                  '${_fromIndexToGrams(index)}',
+                  style: Theme.of(context).textTheme.bodyMedium,
+                ),
               ),
             ),
             Text(UnitHelper.unitToString(Unit.G)!),


### PR DESCRIPTION
Impacted file:
* `portion_calculator.dart`: applied (colored) style for `CupertinoPicker`

### What
- There was no specified color / style for the text used in the portion calculator's `CupertinoPicker`
- As a consequence, the grams were written in black, even in dark mode
- Now we use a style, therefore a color, and the portion calculator works in both dark and light modes

### Screenshots
| dark | light |
| -- | -- |
| ![Capture d’écran 2022-09-19 à 15 12 16](https://user-images.githubusercontent.com/11576431/191025203-abd4695d-e401-435c-86da-9b2a11555ad1.png) | ![Capture d’écran 2022-09-19 à 15 12 40](https://user-images.githubusercontent.com/11576431/191025271-933bc2f7-f07e-4d4a-a406-02452ed080ce.png) |

### Fixes bug(s)
- Fixes: #3038