### PR TITLE
fix: Sticky headers in search dialogs

### DIFF
--- a/packages/smooth_app/lib/generic_lib/widgets/language_selector.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/language_selector.dart
@@ -50,13 +50,16 @@ class LanguageSelectorSettings extends StatelessWidget {
                     .getLanguageNameInEnglishFromOpenFoodFactsLanguage(b)));
         List<OpenFoodFactsLanguage> filteredList = leftovers;
         await showDialog<void>(
-            context: context,
-            builder: (BuildContext context) {
-              return StatefulBuilder(
-                builder: (BuildContext context,
-                    void Function(VoidCallback fn) setState) {
-                  return SmoothAlertDialog(
-                    body: Column(
+          context: context,
+          builder: (BuildContext context) {
+            return StatefulBuilder(
+              builder: (BuildContext context,
+                  void Function(VoidCallback fn) setState) {
+                return SmoothAlertDialog(
+                  body: SizedBox(
+                    height: MediaQuery.of(context).size.height / 2,
+                    width: MediaQuery.of(context).size.width,
+                    child: Column(
                       children: <Widget>[
                         TextField(
                           decoration: InputDecoration(
@@ -85,39 +88,43 @@ class LanguageSelectorSettings extends StatelessWidget {
                             );
                           },
                         ),
-                        // TODO(monsieurtanuki): an optimization would be not to generate all tiles and use something like a ListView.builder instead
-                        ...List<ListTile>.generate(
-                          filteredList.length,
-                          (int index) {
-                            final OpenFoodFactsLanguage openFoodFactsLanguage =
-                                filteredList[index];
-                            final String nameInLanguage = _languages
-                                .getLanguageNameInLanguageFromOpenFoodFactsLanguage(
-                                    openFoodFactsLanguage);
-                            return ListTile(
-                              title: Text(
-                                '$nameInLanguage (${_languages.getLanguageNameInEnglishFromOpenFoodFactsLanguage(openFoodFactsLanguage)})',
-                                softWrap: false,
-                                overflow: TextOverflow.fade,
-                              ),
-                              onTap: () {
-                                userPreferences.setAppLanguageCode(
-                                    openFoodFactsLanguage.code);
-                                Navigator.of(context).pop();
-                              },
-                            );
-                          },
+                        Expanded(
+                          child: ListView.builder(
+                            itemBuilder: (BuildContext context, int index) {
+                              final OpenFoodFactsLanguage
+                                  openFoodFactsLanguage = filteredList[index];
+                              final String nameInLanguage = _languages
+                                  .getLanguageNameInLanguageFromOpenFoodFactsLanguage(
+                                      openFoodFactsLanguage);
+                              return ListTile(
+                                title: Text(
+                                  '$nameInLanguage (${_languages.getLanguageNameInEnglishFromOpenFoodFactsLanguage(openFoodFactsLanguage)})',
+                                  softWrap: false,
+                                  overflow: TextOverflow.fade,
+                                ),
+                                onTap: () {
+                                  userPreferences.setAppLanguageCode(
+                                      openFoodFactsLanguage.code);
+                                  Navigator.of(context).pop();
+                                },
+                              );
+                            },
+                            itemCount: filteredList.length,
+                            shrinkWrap: true,
+                          ),
                         ),
                       ],
                     ),
-                    positiveAction: SmoothActionButton(
-                      onPressed: () => Navigator.pop(context),
-                      text: appLocalizations.cancel,
-                    ),
-                  );
-                },
-              );
-            });
+                  ),
+                  positiveAction: SmoothActionButton(
+                    onPressed: () => Navigator.pop(context),
+                    text: appLocalizations.cancel,
+                  ),
+                );
+              },
+            );
+          },
+        );
       },
     );
   }

--- a/packages/smooth_app/lib/pages/onboarding/country_selector.dart
+++ b/packages/smooth_app/lib/pages/onboarding/country_selector.dart
@@ -73,56 +73,64 @@ class _CountrySelectorState extends State<CountrySelector> {
                   builder: (BuildContext context,
                       void Function(VoidCallback fn) setState) {
                     return SmoothAlertDialog(
-                      body: Column(
-                        children: <Widget>[
-                          SmoothTextFormField(
-                            type: TextFieldTypes.PLAIN_TEXT,
-                            prefixIcon: const Icon(Icons.search),
-                            controller: countryController,
-                            onChanged: (String? query) {
-                              setState(
-                                () {
-                                  filteredList = _countryList
-                                      .where(
-                                        (Country item) =>
-                                            item.name.toLowerCase().contains(
-                                                  query!.toLowerCase(),
-                                                ) |
-                                            item.countryCode
-                                                .toLowerCase()
-                                                .contains(
-                                                  query.toLowerCase(),
-                                                ),
-                                      )
-                                      .toList(growable: false);
+                      body: SizedBox(
+                        height: MediaQuery.of(context).size.height / 2,
+                        width: MediaQuery.of(context).size.width,
+                        child: Column(
+                          children: <Widget>[
+                            SmoothTextFormField(
+                              type: TextFieldTypes.PLAIN_TEXT,
+                              prefixIcon: const Icon(Icons.search),
+                              controller: countryController,
+                              onChanged: (String? query) {
+                                setState(
+                                  () {
+                                    filteredList = _countryList
+                                        .where(
+                                          (Country item) =>
+                                              item.name.toLowerCase().contains(
+                                                    query!.toLowerCase(),
+                                                  ) |
+                                              item.countryCode
+                                                  .toLowerCase()
+                                                  .contains(
+                                                    query.toLowerCase(),
+                                                  ),
+                                        )
+                                        .toList(growable: false);
+                                  },
+                                );
+                              },
+                              hintText: appLocalizations.search,
+                            ),
+                            Expanded(
+                              child: ListView.builder(
+                                itemBuilder: (BuildContext context, int index) {
+                                  final Country country = filteredList[index];
+                                  final bool isSelected =
+                                      country == _chosenValue;
+                                  return ListTile(
+                                    shape: const RoundedRectangleBorder(
+                                      borderRadius: ANGULAR_BORDER_RADIUS,
+                                    ),
+                                    title: Text(
+                                      country.name,
+                                      style: TextStyle(
+                                        fontWeight:
+                                            isSelected ? FontWeight.bold : null,
+                                      ),
+                                    ),
+                                    onTap: () {
+                                      Navigator.of(context).pop(country);
+                                    },
+                                  );
                                 },
-                              );
-                            },
-                            hintText: appLocalizations.search,
-                          ),
-                          ...List<ListTile>.generate(
-                            filteredList.length,
-                            (final int index) {
-                              final Country country = filteredList[index];
-                              final bool isSelected = country == _chosenValue;
-                              return ListTile(
-                                shape: const RoundedRectangleBorder(
-                                  borderRadius: ANGULAR_BORDER_RADIUS,
-                                ),
-                                title: Text(
-                                  country.name,
-                                  style: TextStyle(
-                                    fontWeight:
-                                        isSelected ? FontWeight.bold : null,
-                                  ),
-                                ),
-                                onTap: () {
-                                  Navigator.of(context).pop(country);
-                                },
-                              );
-                            },
-                          ),
-                        ],
+                                itemCount: filteredList.length,
+                                shrinkWrap: true,
+                              ),
+                            )
+                          ],
+                        ),
                       ),
                       positiveAction: SmoothActionButton(
                         onPressed: () => Navigator.pop(context),

--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -385,40 +385,47 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
                     return SmoothAlertDialog(
                       close: true,
                       title: appLocalizations.nutrition_page_add_nutrient,
-                      body: Column(
-                        children: <Widget>[
-                          TextField(
-                            decoration: InputDecoration(
-                              prefixIcon: const Icon(Icons.search),
-                              enabledBorder: const UnderlineInputBorder(),
-                              labelText: appLocalizations.search,
+                      body: SizedBox(
+                        height: MediaQuery.of(context).size.height / 2,
+                        width: MediaQuery.of(context).size.width,
+                        child: Column(
+                          children: <Widget>[
+                            TextField(
+                              decoration: InputDecoration(
+                                prefixIcon: const Icon(Icons.search),
+                                enabledBorder: const UnderlineInputBorder(),
+                                labelText: appLocalizations.search,
+                              ),
+                              onChanged: (String query) {
+                                setState(
+                                  () {
+                                    filteredList = leftovers
+                                        .where((OrderedNutrient item) => item
+                                            .name!
+                                            .toLowerCase()
+                                            .contains(query.toLowerCase()))
+                                        .toList();
+                                  },
+                                );
+                              },
                             ),
-                            onChanged: (String query) {
-                              setState(
-                                () {
-                                  filteredList = leftovers
-                                      .where((OrderedNutrient item) => item
-                                          .name!
-                                          .toLowerCase()
-                                          .contains(query.toLowerCase()))
-                                      .toList();
+                            Expanded(
+                              child: ListView.builder(
+                                itemBuilder: (BuildContext context, int index) {
+                                  final OrderedNutrient nutrient =
+                                      filteredList[index];
+                                  return ListTile(
+                                    title: Text(nutrient.name!),
+                                    onTap: () =>
+                                        Navigator.of(context).pop(nutrient),
+                                  );
                                 },
-                              );
-                            },
-                          ),
-                          ...List<ListTile>.generate(
-                            filteredList.length,
-                            (int index) {
-                              final OrderedNutrient nutrient =
-                                  filteredList[index];
-                              return ListTile(
-                                title: Text(nutrient.name!),
-                                onTap: () =>
-                                    Navigator.of(context).pop(nutrient),
-                              );
-                            },
-                          ),
-                        ],
+                                itemCount: filteredList.length,
+                                shrinkWrap: true,
+                              ),
+                            ),
+                          ],
+                        ),
                       ),
                       negativeAction: SmoothActionButton(
                         onPressed: () => Navigator.pop(context),


### PR DESCRIPTION
### What
<!-- description of the PR -->
 Sticky headers text search field in
-  nutrient screen, 
 - country and 
 - language selector as well

### Screenshot

https://user-images.githubusercontent.com/57723319/191064012-07fdab4a-665b-4df7-a848-a19f4c6e571a.mp4



### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes: #3037 
### Part of 

