### PR TITLE
fix: hunger games link added

### DIFF
--- a/packages/smooth_app/lib/pages/preferences/user_preferences_contribute.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_contribute.dart
@@ -86,6 +86,13 @@ class UserPreferencesContribute extends AbstractUserPreferences {
           () => _contributors(),
           Icons.emoji_people,
         ),
+        _getListTile(
+          'Hunger Games',
+          () => _hungerGames(),
+          Icons.games,
+          icon:
+              UserPreferencesListTile.getTintedIcon(Icons.open_in_new, context),
+        ),
       ];
 
   Future<void> _contribute() => showDialog<void>(
@@ -290,6 +297,11 @@ class UserPreferencesContribute extends AbstractUserPreferences {
             actionsOrder: SmoothButtonsBarOrder.numerical,
           );
         },
+      );
+
+  Future<void> _hungerGames() async => LaunchUrlHelper.launchURL(
+        'https://hunger.openfoodfacts.org/',
+        false,
       );
 
   Widget _getListTile(


### PR DESCRIPTION
### What
<!-- description of the PR -->
- fix: added link of Hunger Games in contribute section #3064 .

### Screenshot
![Screenshot_2022-09-27-19-36-08-129_org openfoodfacts scanner](https://user-images.githubusercontent.com/75238158/192552223-6dc7298c-a706-41c2-99b0-97fc24fb1d51.jpg)


### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->


### Part of 
- #3064 
