### PR TITLE
fix: Check if user credential still holds

### DIFF
--- a/packages/smooth_app/lib/data_models/user_management_provider.dart
+++ b/packages/smooth_app/lib/data_models/user_management_provider.dart
@@ -105,8 +105,7 @@ class UserManagementProvider with ChangeNotifier {
       }
     } catch (e) {
       // We don't want to crash the app if the login check fails
-      // We might want to log this error in the future
-      Logs.e('Login check failed');
+      // So we do nothing here
     }
   }
   /* Currently not in use, to be used before contributing to something

--- a/packages/smooth_app/lib/data_models/user_management_provider.dart
+++ b/packages/smooth_app/lib/data_models/user_management_provider.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/utils/OpenFoodAPIConfiguration.dart';
 import 'package:smooth_app/database/dao_secured_string.dart';
+import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/services/smooth_services.dart';
 
 class UserManagementProvider with ChangeNotifier {
@@ -82,6 +83,32 @@ class UserManagementProvider with ChangeNotifier {
     notifyListeners();
   }
 
+  /// Check if the user is still logged in and the credentials are still valid
+  /// If not, the user is logged out
+  Future<void> checkUserLoginValidity() async {
+    try {
+      if (ProductQuery.isLoggedIn()) {
+        final User user = ProductQuery.getUser();
+        final bool checkLogin = await OpenFoodAPIClient.login(
+          User(
+            userId: user.userId,
+            password: user.password,
+          ),
+        );
+        if (checkLogin) {
+          // Credentials are still valid so we just return
+          return;
+        } else {
+          // Credentials are not valid anymore so we log out
+          await logout();
+        }
+      }
+    } catch (e) {
+      // We don't want to crash the app if the login check fails
+      // We might want to log this error in the future
+      Logs.e('Login check failed');
+    }
+  }
   /* Currently not in use, to be used before contributing to something
   /// Checks if the saved credentials are still correct
   Future<bool> validateCredentials() async {

--- a/packages/smooth_app/lib/main.dart
+++ b/packages/smooth_app/lib/main.dart
@@ -100,6 +100,7 @@ Future<bool> _init1() async {
     daoString: DaoString(_localDatabase),
   );
   await callbackDispatcher(_localDatabase);
+  await UserManagementProvider().checkUserLoginValidity();
 
   AnalyticsHelper.setCrashReports(_userPreferences.crashReports);
   ProductQuery.setCountry(_userPreferences.userCountryCode);

--- a/packages/smooth_app/lib/main.dart
+++ b/packages/smooth_app/lib/main.dart
@@ -100,7 +100,7 @@ Future<bool> _init1() async {
     daoString: DaoString(_localDatabase),
   );
   await callbackDispatcher(_localDatabase);
-  await UserManagementProvider().checkUserLoginValidity();
+  UserManagementProvider().checkUserLoginValidity();
 
   AnalyticsHelper.setCrashReports(_userPreferences.crashReports);
   ProductQuery.setCountry(_userPreferences.userCountryCode);


### PR DESCRIPTION
### What

-  We check if the user's credentials still hold true
- If not we just log them out, and the providers handle the rest
-  For exception handling, didn't use throw, cuz app might just crash, so just logged it there 
-  If it is causing some merge conflict to occur so we can just wait for it to merge later 



### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes: #3060 


