### PR TITLE
feat: Add checkmarks on 'add new product' screen

### DIFF
--- a/packages/smooth_app/lib/pages/product/add_new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_new_product_page.dart
@@ -233,31 +233,7 @@ class _AddNewProductPageState extends State<AddNewProductPage> {
       return const SizedBox();
     }
     if (_nutritionFactsAdded) {
-      return Padding(
-        padding: _ROW_PADDING_TOP,
-        child: Row(
-          mainAxisSize: MainAxisSize.max,
-          mainAxisAlignment: MainAxisAlignment.start,
-          children: <Widget>[
-            SizedBox(
-              width: 50.0,
-              child: Icon(
-                Icons.check,
-                color: Theme.of(context)
-                    .bottomNavigationBarTheme
-                    .selectedItemColor,
-              ),
-            ),
-            Expanded(
-              child: Center(
-                child: Text(
-                    AppLocalizations.of(context).nutritional_facts_added,
-                    style: Theme.of(context).textTheme.bodyText1),
-              ),
-            ),
-          ],
-        ),
-      );
+      return _buildInfoAddedRow(AppLocalizations.of(context).nutritional_facts_added);
     }
 
     return Padding(

--- a/packages/smooth_app/lib/pages/product/add_new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_new_product_page.dart
@@ -335,24 +335,25 @@ class _AddNewProductPageState extends State<AddNewProductPage> {
     if (_basicDetailsAdded) {
       final ThemeData themeData = Theme.of(context);
       return Padding(
-          padding: _ROW_PADDING_TOP,
+          padding: const EdgeInsetsDirectional.only(
+            top: VERY_LARGE_SPACE,
+            // Add start padding, so text is centrally alligned with other texts
+            start: 50,
+          ),
           child: Row(
             mainAxisSize: MainAxisSize.max,
             mainAxisAlignment: MainAxisAlignment.start,
             children: <Widget>[
-              SizedBox(
-                width: 50.0,
-                child: Icon(
-                  Icons.check,
-                  color: themeData.bottomNavigationBarTheme.selectedItemColor,
-                ),
-              ),
               Expanded(
                 child: Center(
                   child: Text(
                       AppLocalizations.of(context).basic_details_add_success,
                       style: Theme.of(context).textTheme.bodyText1),
                 ),
+              ),
+              Icon(
+                Icons.check_box,
+                color: themeData.bottomNavigationBarTheme.selectedItemColor,
               ),
             ],
           ));

--- a/packages/smooth_app/lib/pages/product/add_new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_new_product_page.dart
@@ -201,34 +201,9 @@ class _AddNewProductPageState extends State<AddNewProductPage> {
 
   Widget _buildImageUploadedRow(
       BuildContext context, ImageField imageType, File image) {
-    final ThemeData themeData = Theme.of(context);
-    return Padding(
-      padding: _ROW_PADDING_TOP,
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: <Widget>[
-          SizedBox(
-            height: 50,
-            width: 50,
-            child: ClipRRect(
-              borderRadius: ROUNDED_BORDER_RADIUS,
-              child: Image.file(image, fit: BoxFit.cover),
-            ),
-          ),
-          Expanded(
-            child: Center(
-              child: Text(
-                _getAddPhotoButtonText(context, imageType),
-                style: themeData.textTheme.bodyText1,
-              ),
-            ),
-          ),
-          Icon(
-            Icons.check_box,
-            color: themeData.bottomNavigationBarTheme.selectedItemColor,
-          )
-        ],
-      ),
+    return _buildInfoAddedRow(
+      _getAddPhotoButtonText(context, imageType),
+      imgStart: image
     );
   }
 
@@ -333,30 +308,7 @@ class _AddNewProductPageState extends State<AddNewProductPage> {
 
   Widget _buildaddInputDetailsButton() {
     if (_basicDetailsAdded) {
-      final ThemeData themeData = Theme.of(context);
-      return Padding(
-          padding: const EdgeInsetsDirectional.only(
-            top: VERY_LARGE_SPACE,
-            // Add start padding, so text is centrally alligned with other texts
-            start: 50,
-          ),
-          child: Row(
-            mainAxisSize: MainAxisSize.max,
-            mainAxisAlignment: MainAxisAlignment.start,
-            children: <Widget>[
-              Expanded(
-                child: Center(
-                  child: Text(
-                      AppLocalizations.of(context).basic_details_add_success,
-                      style: Theme.of(context).textTheme.bodyText1),
-                ),
-              ),
-              Icon(
-                Icons.check_box,
-                color: themeData.bottomNavigationBarTheme.selectedItemColor,
-              ),
-            ],
-          ));
+      return _buildInfoAddedRow(AppLocalizations.of(context).basic_details_add_success);
     }
 
     return Padding(
@@ -380,6 +332,35 @@ class _AddNewProductPageState extends State<AddNewProductPage> {
             _basicDetailsAdded = result != null;
           });
         },
+      ),
+    );
+  }
+
+  Widget _buildInfoAddedRow(String text, { File? imgStart }) {
+    final ThemeData themeData = Theme.of(context);
+    return Padding(
+      padding: _ROW_PADDING_TOP,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          SizedBox(
+            height: 50,
+            width: 50,
+            child: ClipRRect(
+              borderRadius: ROUNDED_BORDER_RADIUS,
+              child: imgStart == null ? null : Image.file(imgStart, fit: BoxFit.cover),
+            ),
+          ),
+          Expanded(
+            child: Center(
+              child: Text(text, style: themeData.textTheme.bodyText1),
+            ),
+          ),
+          Icon(
+            Icons.check_box,
+            color: themeData.bottomNavigationBarTheme.selectedItemColor,
+          )
+        ],
       ),
     );
   }

--- a/packages/smooth_app/lib/pages/product/add_new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_new_product_page.dart
@@ -335,7 +335,7 @@ class _AddNewProductPageState extends State<AddNewProductPage> {
             ),
           ),
           Icon(
-            Icons.check_box,
+            Icons.check,
             color: themeData.bottomNavigationBarTheme.selectedItemColor,
           )
         ],

--- a/packages/smooth_app/lib/pages/product/add_new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_new_product_page.dart
@@ -201,8 +201,10 @@ class _AddNewProductPageState extends State<AddNewProductPage> {
 
   Widget _buildImageUploadedRow(
       BuildContext context, ImageField imageType, File image) {
-    return _buildInfoAddedRow(_getAddPhotoButtonText(context, imageType),
-        imgStart: image);
+    return _InfoAddedRow(
+      text: _getAddPhotoButtonText(context, imageType),
+      imgStart: image,
+    );
   }
 
   String _getAddPhotoButtonText(BuildContext context, ImageField imageType) {
@@ -231,8 +233,8 @@ class _AddNewProductPageState extends State<AddNewProductPage> {
       return const SizedBox();
     }
     if (_nutritionFactsAdded) {
-      return _buildInfoAddedRow(
-          AppLocalizations.of(context).nutritional_facts_added);
+      return _InfoAddedRow(
+          text: AppLocalizations.of(context).nutritional_facts_added);
     }
 
     return Padding(
@@ -283,8 +285,8 @@ class _AddNewProductPageState extends State<AddNewProductPage> {
 
   Widget _buildaddInputDetailsButton() {
     if (_basicDetailsAdded) {
-      return _buildInfoAddedRow(
-          AppLocalizations.of(context).basic_details_add_success);
+      return _InfoAddedRow(
+          text: AppLocalizations.of(context).basic_details_add_success);
     }
 
     return Padding(
@@ -311,35 +313,42 @@ class _AddNewProductPageState extends State<AddNewProductPage> {
       ),
     );
   }
+}
 
-  Widget _buildInfoAddedRow(String text, {File? imgStart}) {
+class _InfoAddedRow extends StatelessWidget {
+  const _InfoAddedRow({required this.text, this.imgStart});
+
+  final String text;
+  final File? imgStart;
+
+  @override
+  Widget build(BuildContext context) {
     final ThemeData themeData = Theme.of(context);
     return Padding(
-      padding: _ROW_PADDING_TOP,
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: <Widget>[
-          SizedBox(
-            height: 50,
-            width: 50,
-            child: ClipRRect(
-              borderRadius: ROUNDED_BORDER_RADIUS,
-              child: imgStart == null
-                  ? null
-                  : Image.file(imgStart, fit: BoxFit.cover),
+        padding: _ROW_PADDING_TOP,
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            SizedBox(
+              height: 50,
+              width: 50,
+              child: ClipRRect(
+                borderRadius: ROUNDED_BORDER_RADIUS,
+                child: imgStart == null
+                    ? null
+                    : Image.file(imgStart!, fit: BoxFit.cover),
+              ),
             ),
-          ),
-          Expanded(
-            child: Center(
-              child: Text(text, style: themeData.textTheme.bodyText1),
+            Expanded(
+              child: Center(
+                child: Text(text, style: themeData.textTheme.bodyText1),
+              ),
             ),
-          ),
-          Icon(
-            Icons.check,
-            color: themeData.bottomNavigationBarTheme.selectedItemColor,
-          )
-        ],
-      ),
-    );
+            Icon(
+              Icons.check,
+              color: themeData.bottomNavigationBarTheme.selectedItemColor,
+            )
+          ],
+        ));
   }
 }

--- a/packages/smooth_app/lib/pages/product/add_new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_new_product_page.dart
@@ -201,10 +201,8 @@ class _AddNewProductPageState extends State<AddNewProductPage> {
 
   Widget _buildImageUploadedRow(
       BuildContext context, ImageField imageType, File image) {
-    return _buildInfoAddedRow(
-      _getAddPhotoButtonText(context, imageType),
-      imgStart: image
-    );
+    return _buildInfoAddedRow(_getAddPhotoButtonText(context, imageType),
+        imgStart: image);
   }
 
   String _getAddPhotoButtonText(BuildContext context, ImageField imageType) {
@@ -233,7 +231,8 @@ class _AddNewProductPageState extends State<AddNewProductPage> {
       return const SizedBox();
     }
     if (_nutritionFactsAdded) {
-      return _buildInfoAddedRow(AppLocalizations.of(context).nutritional_facts_added);
+      return _buildInfoAddedRow(
+          AppLocalizations.of(context).nutritional_facts_added);
     }
 
     return Padding(
@@ -284,7 +283,8 @@ class _AddNewProductPageState extends State<AddNewProductPage> {
 
   Widget _buildaddInputDetailsButton() {
     if (_basicDetailsAdded) {
-      return _buildInfoAddedRow(AppLocalizations.of(context).basic_details_add_success);
+      return _buildInfoAddedRow(
+          AppLocalizations.of(context).basic_details_add_success);
     }
 
     return Padding(
@@ -312,7 +312,7 @@ class _AddNewProductPageState extends State<AddNewProductPage> {
     );
   }
 
-  Widget _buildInfoAddedRow(String text, { File? imgStart }) {
+  Widget _buildInfoAddedRow(String text, {File? imgStart}) {
     final ThemeData themeData = Theme.of(context);
     return Padding(
       padding: _ROW_PADDING_TOP,
@@ -324,7 +324,9 @@ class _AddNewProductPageState extends State<AddNewProductPage> {
             width: 50,
             child: ClipRRect(
               borderRadius: ROUNDED_BORDER_RADIUS,
-              child: imgStart == null ? null : Image.file(imgStart, fit: BoxFit.cover),
+              child: imgStart == null
+                  ? null
+                  : Image.file(imgStart, fit: BoxFit.cover),
             ),
           ),
           Expanded(


### PR DESCRIPTION
### What
- Add checkmarks on the right side of the screen, after information has been added.

### Screenshot
<img src="https://user-images.githubusercontent.com/5972966/193415691-29e144b8-1131-498a-8e46-25e03fa61f7d.png" height="400px">

### Fixes bug(s)

- Closes: #2974
- Closes: #2975
- Closes: #2976
