### PR TITLE
refactor: ProductImageData to contain all image links

### DIFF
--- a/packages/smooth_app/lib/cards/data_cards/image_upload_card.dart
+++ b/packages/smooth_app/lib/cards/data_cards/image_upload_card.dart
@@ -68,10 +68,8 @@ class _ImageUploadCardState extends State<ImageUploadCard> {
     // We can already have an _imageProvider for a file that is going to be uploaded
     // or an imageUrl for a network image
     // or no image yet
-    final String? imageUrl =
-        widget.productImageData.getImageUrl(ImageSize.ORIGINAL);
-    if (imageUrl != null) {
-      _imageProvider = NetworkImage(imageUrl);
+    if (widget.productImageData.imageUrl != null) {
+      _imageProvider = NetworkImage(widget.productImageData.imageUrl!);
     } else {
       if (_imageProvider != null) {
         //Refresh when image has been deselected on server side
@@ -106,11 +104,9 @@ class _ImageUploadCardState extends State<ImageUploadCard> {
           // we need to load the full resolution image
 
           if (_imageFullProvider == null) {
-            final String? imageFullUrl =
-                widget.productImageData.getImageUrl(ImageSize.ORIGINAL);
-            if (imageFullUrl != null) {
-              _imageFullProvider = NetworkImage(imageFullUrl);
-            }
+            final String imageFullUrl =
+                widget.productImageData.imageUrl!.replaceAll('.400.', '.full.');
+            _imageFullProvider = NetworkImage(imageFullUrl);
           }
 
           // TODO(monsieurtanuki): careful, waiting for pop'ed value

--- a/packages/smooth_app/lib/cards/data_cards/image_upload_card.dart
+++ b/packages/smooth_app/lib/cards/data_cards/image_upload_card.dart
@@ -68,8 +68,10 @@ class _ImageUploadCardState extends State<ImageUploadCard> {
     // We can already have an _imageProvider for a file that is going to be uploaded
     // or an imageUrl for a network image
     // or no image yet
-    if (widget.productImageData.imageUrl != null) {
-      _imageProvider = NetworkImage(widget.productImageData.imageUrl!);
+    final String? imageUrl =
+        widget.productImageData.getImageUrl(ImageSize.ORIGINAL);
+    if (imageUrl != null) {
+      _imageProvider = NetworkImage(imageUrl);
     } else {
       if (_imageProvider != null) {
         //Refresh when image has been deselected on server side
@@ -104,9 +106,11 @@ class _ImageUploadCardState extends State<ImageUploadCard> {
           // we need to load the full resolution image
 
           if (_imageFullProvider == null) {
-            final String imageFullUrl =
-                widget.productImageData.imageUrl!.replaceAll('.400.', '.full.');
-            _imageFullProvider = NetworkImage(imageFullUrl);
+            final String? imageFullUrl =
+                widget.productImageData.getImageUrl(ImageSize.ORIGINAL);
+            if (imageFullUrl != null) {
+              _imageFullProvider = NetworkImage(imageFullUrl);
+            }
           }
 
           // TODO(monsieurtanuki): careful, waiting for pop'ed value

--- a/packages/smooth_app/lib/cards/data_cards/image_upload_card.dart
+++ b/packages/smooth_app/lib/cards/data_cards/image_upload_card.dart
@@ -68,10 +68,8 @@ class _ImageUploadCardState extends State<ImageUploadCard> {
     // We can already have an _imageProvider for a file that is going to be uploaded
     // or an imageUrl for a network image
     // or no image yet
-    final String? imageUrl =
-        widget.productImageData.getImageUrl(ImageSize.ORIGINAL);
-    if (imageUrl != null) {
-      _imageProvider = NetworkImage(imageUrl);
+    if (widget.productImageData.imageUrl != null) {
+      _imageProvider = NetworkImage(widget.productImageData.imageUrl!);
     } else {
       if (_imageProvider != null) {
         //Refresh when image has been deselected on server side

--- a/packages/smooth_app/lib/data_models/product_image_data.dart
+++ b/packages/smooth_app/lib/data_models/product_image_data.dart
@@ -8,6 +8,16 @@ class ProductImageData {
     required this.imageDescriptor,
   });
 
+  factory ProductImageData.from(ProductImage image, String barcode) {
+    return ProductImageData(
+      imageField: image.field,
+      // TODO(VaiTon): i18n
+      title: image.imgid ?? '',
+      buttonText: image.imgid ?? '',
+      imageDescriptor: ImageDescriptor.fromImage(barcode, image),
+    );
+  }
+
   final ImageField imageField;
   final String title;
   final String buttonText;

--- a/packages/smooth_app/lib/data_models/product_image_data.dart
+++ b/packages/smooth_app/lib/data_models/product_image_data.dart
@@ -1,15 +1,43 @@
-import 'package:openfoodfacts/model/ProductImage.dart';
+import 'package:collection/collection.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
 
 class ProductImageData {
   const ProductImageData({
     required this.imageField,
     required this.title,
     required this.buttonText,
-    this.imageUrl,
+    required this.imageSizeToUrlMap,
   });
+
+  ProductImageData.from({
+    required this.imageField,
+    required this.title,
+    required this.buttonText,
+    required String? barcode,
+    required Iterable<ProductImage> productImages,
+  }) : imageSizeToUrlMap = _mapProductImages(barcode, productImages);
 
   final ImageField imageField;
   final String title;
   final String buttonText;
-  final String? imageUrl;
+  final Map<ImageSize?, String> imageSizeToUrlMap;
+
+  static Map<ImageSize?, String> _mapProductImages(
+      String? barcode, Iterable<ProductImage> images) {
+    final Map<ImageSize?, String?> map = images
+        .groupListsBy((ProductImage element) => element.size)
+        .map((ImageSize? size, List<ProductImage> images) =>
+            MapEntry<ImageSize?, ProductImage>(size, images.first))
+        .map((ImageSize? size, ProductImage image) {
+      final String? url = image.url ?? ImageHelper.buildUrl(barcode, image);
+      return MapEntry<ImageSize?, String?>(size, url);
+    });
+    map.removeWhere((_, String? image) => image == null);
+    return map.cast();
+  }
+
+  String? getImageUrl(ImageSize preferredSize) {
+    return imageSizeToUrlMap[preferredSize] ??
+        imageSizeToUrlMap.values.firstOrNull;
+  }
 }

--- a/packages/smooth_app/lib/data_models/product_image_data.dart
+++ b/packages/smooth_app/lib/data_models/product_image_data.dart
@@ -22,4 +22,30 @@ class ProductImageData {
   final String title;
   final String buttonText;
   final String? imageUrl;
+
+  /// Convert [imageUrl] to specified [size]
+  String? getImageUrl(ImageSize size) {
+    final String? imageUrl = this.imageUrl;
+    if (imageUrl == null) {
+      return null;
+    }
+
+    const String SEPARATOR = '.';
+
+    final int extensionIndex = imageUrl.lastIndexOf(SEPARATOR);
+    if (extensionIndex < 0) {
+      return null;
+    }
+
+    final int sizeIndex = imageUrl.lastIndexOf(SEPARATOR, extensionIndex - 1);
+    if (sizeIndex < 0) {
+      return null;
+    }
+
+    final String baseUrl = imageUrl.substring(0, sizeIndex + 1);
+    final String number = size.toNumber();
+    final String extension =
+        imageUrl.substring(extensionIndex, imageUrl.length);
+    return baseUrl + number + extension;
+  }
 }

--- a/packages/smooth_app/lib/data_models/product_image_data.dart
+++ b/packages/smooth_app/lib/data_models/product_image_data.dart
@@ -1,15 +1,60 @@
-import 'package:openfoodfacts/model/ProductImage.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
 
 class ProductImageData {
   const ProductImageData({
     required this.imageField,
     required this.title,
     required this.buttonText,
-    this.imageUrl,
+    required this.imageDescriptor,
   });
 
   final ImageField imageField;
   final String title;
   final String buttonText;
-  final String? imageUrl;
+  final ImageDescriptor? imageDescriptor;
+
+  String? getImageUrl(ImageSize size) {
+    return imageDescriptor?.createUrlFor(size);
+  }
+}
+
+class ImageDescriptor {
+  const ImageDescriptor._create(this._baseUrl, this._extension);
+
+  final String _baseUrl;
+  final String _extension;
+  static const String _SEPARATOR = '.';
+
+  static ImageDescriptor? fromUrl(String? imageUrl) {
+    if (imageUrl == null) {
+      return null;
+    }
+
+    final int extensionIndex = imageUrl.lastIndexOf(_SEPARATOR);
+    if (extensionIndex < 0) {
+      return null;
+    }
+
+    final int sizeIndex = imageUrl.lastIndexOf(_SEPARATOR, extensionIndex - 1);
+    if (sizeIndex < 0) {
+      return null;
+    }
+
+    final String baseUrl = imageUrl.substring(0, sizeIndex + 1);
+    final String extension =
+        imageUrl.substring(extensionIndex, imageUrl.length);
+    return ImageDescriptor._create(baseUrl, extension);
+  }
+
+  static ImageDescriptor fromImage(String barcode, ProductImage image) {
+    final String rootUrl = ImageHelper.getProductImageRootUrl(barcode);
+    final String baseUrl =
+        '$rootUrl/${image.field.value}_${image.language.code}.${image.rev}.';
+    return ImageDescriptor._create(baseUrl, '.jpg');
+  }
+
+  String createUrlFor(ImageSize size) {
+    final String number = size.toNumber();
+    return _baseUrl + number + _extension;
+  }
 }

--- a/packages/smooth_app/lib/data_models/product_image_data.dart
+++ b/packages/smooth_app/lib/data_models/product_image_data.dart
@@ -5,7 +5,7 @@ class ProductImageData {
     required this.imageField,
     required this.title,
     required this.buttonText,
-    required this.imageDescriptor,
+    this.imageUrl,
   });
 
   factory ProductImageData.from(ProductImage image, String barcode) {
@@ -14,57 +14,12 @@ class ProductImageData {
       // TODO(VaiTon): i18n
       title: image.imgid ?? '',
       buttonText: image.imgid ?? '',
-      imageDescriptor: ImageDescriptor.fromImage(barcode, image),
+      imageUrl: ImageHelper.buildUrl(barcode, image),
     );
   }
 
   final ImageField imageField;
   final String title;
   final String buttonText;
-  final ImageDescriptor? imageDescriptor;
-
-  String? getImageUrl(ImageSize size) {
-    return imageDescriptor?.createUrlFor(size);
-  }
-}
-
-class ImageDescriptor {
-  const ImageDescriptor._create(this._baseUrl, this._extension);
-
-  final String _baseUrl;
-  final String _extension;
-  static const String _SEPARATOR = '.';
-
-  static ImageDescriptor? fromUrl(String? imageUrl) {
-    if (imageUrl == null) {
-      return null;
-    }
-
-    final int extensionIndex = imageUrl.lastIndexOf(_SEPARATOR);
-    if (extensionIndex < 0) {
-      return null;
-    }
-
-    final int sizeIndex = imageUrl.lastIndexOf(_SEPARATOR, extensionIndex - 1);
-    if (sizeIndex < 0) {
-      return null;
-    }
-
-    final String baseUrl = imageUrl.substring(0, sizeIndex + 1);
-    final String extension =
-        imageUrl.substring(extensionIndex, imageUrl.length);
-    return ImageDescriptor._create(baseUrl, extension);
-  }
-
-  static ImageDescriptor fromImage(String barcode, ProductImage image) {
-    final String rootUrl = ImageHelper.getProductImageRootUrl(barcode);
-    final String baseUrl =
-        '$rootUrl/${image.field.value}_${image.language.code}.${image.rev}.';
-    return ImageDescriptor._create(baseUrl, '.jpg');
-  }
-
-  String createUrlFor(ImageSize size) {
-    final String number = size.toNumber();
-    return _baseUrl + number + _extension;
-  }
+  final String? imageUrl;
 }

--- a/packages/smooth_app/lib/data_models/product_image_data.dart
+++ b/packages/smooth_app/lib/data_models/product_image_data.dart
@@ -1,43 +1,15 @@
-import 'package:collection/collection.dart';
-import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:openfoodfacts/model/ProductImage.dart';
 
 class ProductImageData {
   const ProductImageData({
     required this.imageField,
     required this.title,
     required this.buttonText,
-    required this.imageSizeToUrlMap,
+    this.imageUrl,
   });
-
-  ProductImageData.from({
-    required this.imageField,
-    required this.title,
-    required this.buttonText,
-    required String? barcode,
-    required Iterable<ProductImage> productImages,
-  }) : imageSizeToUrlMap = _mapProductImages(barcode, productImages);
 
   final ImageField imageField;
   final String title;
   final String buttonText;
-  final Map<ImageSize?, String> imageSizeToUrlMap;
-
-  static Map<ImageSize?, String> _mapProductImages(
-      String? barcode, Iterable<ProductImage> images) {
-    final Map<ImageSize?, String?> map = images
-        .groupListsBy((ProductImage element) => element.size)
-        .map((ImageSize? size, List<ProductImage> images) =>
-            MapEntry<ImageSize?, ProductImage>(size, images.first))
-        .map((ImageSize? size, ProductImage image) {
-      final String? url = image.url ?? ImageHelper.buildUrl(barcode, image);
-      return MapEntry<ImageSize?, String?>(size, url);
-    });
-    map.removeWhere((_, String? image) => image == null);
-    return map.cast();
-  }
-
-  String? getImageUrl(ImageSize preferredSize) {
-    return imageSizeToUrlMap[preferredSize] ??
-        imageSizeToUrlMap.values.firstOrNull;
-  }
+  final String? imageUrl;
 }

--- a/packages/smooth_app/lib/data_models/product_image_data.dart
+++ b/packages/smooth_app/lib/data_models/product_image_data.dart
@@ -23,7 +23,8 @@ class ProductImageData {
   final String buttonText;
   final String? imageUrl;
 
-  /// Convert [imageUrl] to specified [size]
+  /// Try to convert [imageUrl] to specified [size].
+  /// Note that url for specified [size] might not exist on API.
   String? getImageUrl(ImageSize size) {
     final String? imageUrl = this.imageUrl;
     if (imageUrl == null) {

--- a/packages/smooth_app/lib/generic_lib/widgets/images/smooth_images_sliver_grid.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/images/smooth_images_sliver_grid.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:openfoodfacts/model/ProductImage.dart';
 import 'package:shimmer/shimmer.dart';
 import 'package:smooth_app/data_models/product_image_data.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
@@ -45,12 +44,11 @@ class SmoothImagesSliverGrid extends SmoothImagesView {
               final MapEntry<ProductImageData, ImageProvider<Object>?> entry =
                   imageList[index];
               final ImageProvider? imageProvider = entry.value;
-              final String? imageUrl = entry.key.getImageUrl(ImageSize.THUMB);
 
-              return imageProvider == null || imageUrl == null
+              return imageProvider == null
                   ? const PictureNotFound()
                   : Hero(
-                      tag: imageUrl,
+                      tag: entry.key.imageUrl!,
                       child: _ImageTile(
                         image: imageProvider,
                         onTap: onTap == null

--- a/packages/smooth_app/lib/generic_lib/widgets/images/smooth_images_sliver_grid.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/images/smooth_images_sliver_grid.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:openfoodfacts/model/ProductImage.dart';
 import 'package:shimmer/shimmer.dart';
 import 'package:smooth_app/data_models/product_image_data.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
@@ -45,7 +44,7 @@ class SmoothImagesSliverGrid extends SmoothImagesView {
               final MapEntry<ProductImageData, ImageProvider<Object>?> entry =
                   imageList[index];
               final ImageProvider? imageProvider = entry.value;
-              final String? imageUrl = entry.key.getImageUrl(ImageSize.THUMB);
+              final String? imageUrl = entry.key.imageUrl;
 
               return imageProvider == null || imageUrl == null
                   ? const PictureNotFound()

--- a/packages/smooth_app/lib/generic_lib/widgets/images/smooth_images_sliver_grid.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/images/smooth_images_sliver_grid.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:openfoodfacts/model/ProductImage.dart';
 import 'package:shimmer/shimmer.dart';
 import 'package:smooth_app/data_models/product_image_data.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
@@ -44,11 +45,12 @@ class SmoothImagesSliverGrid extends SmoothImagesView {
               final MapEntry<ProductImageData, ImageProvider<Object>?> entry =
                   imageList[index];
               final ImageProvider? imageProvider = entry.value;
+              final String? imageUrl = entry.key.getImageUrl(ImageSize.THUMB);
 
-              return imageProvider == null
+              return imageProvider == null || imageUrl == null
                   ? const PictureNotFound()
                   : Hero(
-                      tag: entry.key.imageUrl!,
+                      tag: imageUrl,
                       child: _ImageTile(
                         image: imageProvider,
                         onTap: onTap == null

--- a/packages/smooth_app/lib/helpers/product_cards_helper.dart
+++ b/packages/smooth_app/lib/helpers/product_cards_helper.dart
@@ -1,5 +1,3 @@
-import 'dart:collection';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/model/Attribute.dart';
@@ -116,47 +114,32 @@ List<ProductImageData> getProductMainImagesData(
     <ProductImageData>[
       ProductImageData(
         imageField: ImageField.FRONT,
-        imageSizeToUrlMap:
-            imageUrlToMap(product.imageFrontUrl, product.imageFrontSmallUrl),
+        imageUrl: product.imageFrontUrl,
         title: appLocalizations.product,
         buttonText: appLocalizations.front_photo,
       ),
       ProductImageData(
         imageField: ImageField.INGREDIENTS,
-        imageSizeToUrlMap: imageUrlToMap(
-            product.imageIngredientsUrl, product.imageIngredientsSmallUrl),
+        imageUrl: product.imageIngredientsUrl,
         title: appLocalizations.ingredients,
         buttonText: appLocalizations.ingredients_photo,
       ),
       ProductImageData(
         imageField: ImageField.NUTRITION,
-        imageSizeToUrlMap: imageUrlToMap(
-            product.imageNutritionUrl, product.imageNutritionSmallUrl),
+        imageUrl: product.imageNutritionUrl,
         title: appLocalizations.nutrition,
         buttonText: appLocalizations.nutrition_facts_photo,
       ),
       ProductImageData(
         imageField: ImageField.PACKAGING,
-        imageSizeToUrlMap: imageUrlToMap(
-            product.imagePackagingUrl, product.imagePackagingSmallUrl),
+        imageUrl: product.imagePackagingUrl,
         title: appLocalizations.packaging_information,
         buttonText: appLocalizations.packaging_information_photo,
       ),
       ProductImageData(
         imageField: ImageField.OTHER,
-        imageSizeToUrlMap: {},
+        imageUrl: null,
         title: appLocalizations.more_photos,
         buttonText: appLocalizations.more_photos,
       ),
     ];
-
-Map<ImageSize?, String> imageUrlToMap(String? url, String? smallUrl) {
-  Map<ImageSize?, String> map = HashMap<ImageSize?, String>();
-  if (url != null) {
-    map[ImageSize.DISPLAY] = url;
-  }
-  if (smallUrl != null) {
-    map[ImageSize.SMALL] = smallUrl;
-  }
-  return map;
-}

--- a/packages/smooth_app/lib/helpers/product_cards_helper.dart
+++ b/packages/smooth_app/lib/helpers/product_cards_helper.dart
@@ -114,31 +114,31 @@ List<ProductImageData> getProductMainImagesData(
     <ProductImageData>[
       ProductImageData(
         imageField: ImageField.FRONT,
-        imageDescriptor: ImageDescriptor.fromUrl(product.imageFrontUrl),
+        imageUrl: product.imageFrontUrl,
         title: appLocalizations.product,
         buttonText: appLocalizations.front_photo,
       ),
       ProductImageData(
         imageField: ImageField.INGREDIENTS,
-        imageDescriptor: ImageDescriptor.fromUrl(product.imageIngredientsUrl),
+        imageUrl: product.imageIngredientsUrl,
         title: appLocalizations.ingredients,
         buttonText: appLocalizations.ingredients_photo,
       ),
       ProductImageData(
         imageField: ImageField.NUTRITION,
-        imageDescriptor: ImageDescriptor.fromUrl(product.imageNutritionUrl),
+        imageUrl: product.imageNutritionUrl,
         title: appLocalizations.nutrition,
         buttonText: appLocalizations.nutrition_facts_photo,
       ),
       ProductImageData(
         imageField: ImageField.PACKAGING,
-        imageDescriptor: ImageDescriptor.fromUrl(product.imagePackagingUrl),
+        imageUrl: product.imagePackagingUrl,
         title: appLocalizations.packaging_information,
         buttonText: appLocalizations.packaging_information_photo,
       ),
       ProductImageData(
         imageField: ImageField.OTHER,
-        imageDescriptor: null,
+        imageUrl: null,
         title: appLocalizations.more_photos,
         buttonText: appLocalizations.more_photos,
       ),

--- a/packages/smooth_app/lib/helpers/product_cards_helper.dart
+++ b/packages/smooth_app/lib/helpers/product_cards_helper.dart
@@ -114,31 +114,31 @@ List<ProductImageData> getProductMainImagesData(
     <ProductImageData>[
       ProductImageData(
         imageField: ImageField.FRONT,
-        imageUrl: product.imageFrontUrl,
+        imageDescriptor: ImageDescriptor.fromUrl(product.imageFrontUrl),
         title: appLocalizations.product,
         buttonText: appLocalizations.front_photo,
       ),
       ProductImageData(
         imageField: ImageField.INGREDIENTS,
-        imageUrl: product.imageIngredientsUrl,
+        imageDescriptor: ImageDescriptor.fromUrl(product.imageIngredientsUrl),
         title: appLocalizations.ingredients,
         buttonText: appLocalizations.ingredients_photo,
       ),
       ProductImageData(
         imageField: ImageField.NUTRITION,
-        imageUrl: product.imageNutritionUrl,
+        imageDescriptor: ImageDescriptor.fromUrl(product.imageNutritionUrl),
         title: appLocalizations.nutrition,
         buttonText: appLocalizations.nutrition_facts_photo,
       ),
       ProductImageData(
         imageField: ImageField.PACKAGING,
-        imageUrl: product.imagePackagingUrl,
+        imageDescriptor: ImageDescriptor.fromUrl(product.imagePackagingUrl),
         title: appLocalizations.packaging_information,
         buttonText: appLocalizations.packaging_information_photo,
       ),
       ProductImageData(
         imageField: ImageField.OTHER,
-        imageUrl: null,
+        imageDescriptor: null,
         title: appLocalizations.more_photos,
         buttonText: appLocalizations.more_photos,
       ),

--- a/packages/smooth_app/lib/helpers/product_cards_helper.dart
+++ b/packages/smooth_app/lib/helpers/product_cards_helper.dart
@@ -1,3 +1,5 @@
+import 'dart:collection';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/model/Attribute.dart';
@@ -114,32 +116,47 @@ List<ProductImageData> getProductMainImagesData(
     <ProductImageData>[
       ProductImageData(
         imageField: ImageField.FRONT,
-        imageUrl: product.imageFrontUrl,
+        imageSizeToUrlMap:
+            imageUrlToMap(product.imageFrontUrl, product.imageFrontSmallUrl),
         title: appLocalizations.product,
         buttonText: appLocalizations.front_photo,
       ),
       ProductImageData(
         imageField: ImageField.INGREDIENTS,
-        imageUrl: product.imageIngredientsUrl,
+        imageSizeToUrlMap: imageUrlToMap(
+            product.imageIngredientsUrl, product.imageIngredientsSmallUrl),
         title: appLocalizations.ingredients,
         buttonText: appLocalizations.ingredients_photo,
       ),
       ProductImageData(
         imageField: ImageField.NUTRITION,
-        imageUrl: product.imageNutritionUrl,
+        imageSizeToUrlMap: imageUrlToMap(
+            product.imageNutritionUrl, product.imageNutritionSmallUrl),
         title: appLocalizations.nutrition,
         buttonText: appLocalizations.nutrition_facts_photo,
       ),
       ProductImageData(
         imageField: ImageField.PACKAGING,
-        imageUrl: product.imagePackagingUrl,
+        imageSizeToUrlMap: imageUrlToMap(
+            product.imagePackagingUrl, product.imagePackagingSmallUrl),
         title: appLocalizations.packaging_information,
         buttonText: appLocalizations.packaging_information_photo,
       ),
       ProductImageData(
         imageField: ImageField.OTHER,
-        imageUrl: null,
+        imageSizeToUrlMap: {},
         title: appLocalizations.more_photos,
         buttonText: appLocalizations.more_photos,
       ),
     ];
+
+Map<ImageSize?, String> imageUrlToMap(String? url, String? smallUrl) {
+  Map<ImageSize?, String> map = HashMap<ImageSize?, String>();
+  if (url != null) {
+    map[ImageSize.DISPLAY] = url;
+  }
+  if (smallUrl != null) {
+    map[ImageSize.SMALL] = smallUrl;
+  }
+  return map;
+}

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1698,5 +1698,13 @@
     "word_separator": ", ",
     "@word_separator": {
         "description": "Word separator string. In English, this is a comma followed by a space: ', '"
+    },
+    "image_download_error": "Failed to download image",
+    "@image_download_error": {
+        "description": "Error message, when image download fails"
+    },
+    "image_edit_url_error": "Failed to edit image, image url not set.",
+    "@image_edit_url_error": {
+        "description": "Error message, when editing image fails, due to missing url."
     }
 }

--- a/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
@@ -48,10 +48,8 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView> {
   bool _isRefreshed = false;
   bool _isLoadingMore = true;
 
-  ImageProvider? _provideImage(ProductImageData imageData) {
-    final String? url = imageData.getImageUrl(ImageSize.SMALL);
-    return url == null ? null : NetworkImage(url);
-  }
+  ImageProvider? _provideImage(ProductImageData imageData) =>
+      imageData.imageUrl == null ? null : NetworkImage(imageData.imageUrl!);
 
   @override
   Widget build(BuildContext context) {
@@ -122,10 +120,9 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView> {
                   _buildTitle(appLocalizations.selected_images, theme: theme),
                   SmoothImagesSliverList(
                     imagesData: _selectedImages,
-                    onTap: (ProductImageData data, _) =>
-                        data.getImageUrl(ImageSize.ORIGINAL) != null
-                            ? _openImage(data)
-                            : _newImage(data),
+                    onTap: (ProductImageData data, _) => data.imageUrl != null
+                        ? _openImage(data)
+                        : _newImage(data),
                   ),
                   _buildTitle(appLocalizations.all_images, theme: theme),
                   SmoothImagesSliverGrid(

--- a/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
@@ -48,8 +48,10 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView> {
   bool _isRefreshed = false;
   bool _isLoadingMore = true;
 
-  ImageProvider? _provideImage(ProductImageData imageData) =>
-      imageData.imageUrl == null ? null : NetworkImage(imageData.imageUrl!);
+  ImageProvider? _provideImage(ProductImageData imageData) {
+    final String? url = imageData.getImageUrl(ImageSize.SMALL);
+    return url == null ? null : NetworkImage(url);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -120,9 +122,10 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView> {
                   _buildTitle(appLocalizations.selected_images, theme: theme),
                   SmoothImagesSliverList(
                     imagesData: _selectedImages,
-                    onTap: (ProductImageData data, _) => data.imageUrl != null
-                        ? _openImage(data)
-                        : _newImage(data),
+                    onTap: (ProductImageData data, _) =>
+                        data.getImageUrl(ImageSize.ORIGINAL) != null
+                            ? _openImage(data)
+                            : _newImage(data),
                   ),
                   _buildTitle(appLocalizations.all_images, theme: theme),
                   SmoothImagesSliverGrid(
@@ -263,11 +266,16 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView> {
           .whereNotNull();
 
   /// Created a [ProductImageData] from a [ProductImage]
-  ProductImageData _getProductImageData(ProductImage image) => ProductImageData(
-        imageField: image.field,
-        // TODO(VaiTon): i18n
-        title: image.imgid ?? '',
-        buttonText: image.imgid ?? '',
-        imageUrl: ImageHelper.buildUrl(widget.product.barcode, image),
-      );
+  ProductImageData _getProductImageData(ProductImage image) {
+    final String? barcode = widget.product.barcode;
+    final ImageDescriptor? descriptor =
+        barcode == null ? null : ImageDescriptor.fromImage(barcode, image);
+    return ProductImageData(
+      imageField: image.field,
+      // TODO(VaiTon): i18n
+      title: image.imgid ?? '',
+      buttonText: image.imgid ?? '',
+      imageDescriptor: descriptor,
+    );
+  }
 }

--- a/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
@@ -275,9 +275,6 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView> {
             MapEntry<ImageSize?, ProductImage>(key, value.first));
     return map[ImageSize.DISPLAY] ??
         map[ImageSize.SMALL] ??
-        map[ImageSize.THUMB] ??
-        map[ImageSize.ORIGINAL] ??
-        map[ImageSize.UNKNOWN] ??
-        map[null];
+        map[ImageSize.THUMB];
   }
 }

--- a/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
@@ -230,8 +230,13 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView> {
   }
 
   Future<Iterable<ProductImageData>?> _getProductImages() async {
+    final String? barcode = widget.product.barcode;
+    if (barcode == null) {
+      return null;
+    }
+
     final ProductQueryConfiguration configuration = ProductQueryConfiguration(
-      widget.product.barcode!,
+      barcode,
       fields: <ProductField>[ProductField.IMAGES],
       language: ProductQuery.getLanguage(),
       country: ProductQuery.getCountry(),
@@ -253,7 +258,8 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView> {
       return null;
     }
 
-    return _deduplicateImages(resultProduct.images!).map(_getProductImageData);
+    return _deduplicateImages(resultProduct.images!)
+        .map((ProductImage image) => ProductImageData.from(image, barcode));
   }
 
   /// Groups the list of [ProductImage] by [ProductImage.imgid]
@@ -264,18 +270,4 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView> {
           .values
           .map((List<ProductImage> sameIdImages) => sameIdImages.firstOrNull)
           .whereNotNull();
-
-  /// Created a [ProductImageData] from a [ProductImage]
-  ProductImageData _getProductImageData(ProductImage image) {
-    final String? barcode = widget.product.barcode;
-    final ImageDescriptor? descriptor =
-        barcode == null ? null : ImageDescriptor.fromImage(barcode, image);
-    return ProductImageData(
-      imageField: image.field,
-      // TODO(VaiTon): i18n
-      title: image.imgid ?? '',
-      buttonText: image.imgid ?? '',
-      imageDescriptor: descriptor,
-    );
-  }
 }

--- a/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
@@ -265,6 +265,11 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView> {
       images
           .groupListsBy((ProductImage element) => element.imgid)
           .values
-          .map((List<ProductImage> sameIdImages) => sameIdImages.firstOrNull)
+          .map(_selectProductImage)
           .whereNotNull();
+
+  ProductImage? _selectProductImage(Iterable<ProductImage> images) =>
+      images.firstWhereOrNull(
+          (ProductImage image) => image.size == ImageSize.DISPLAY) ??
+      images.firstOrNull;
 }

--- a/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
@@ -265,11 +265,19 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView> {
       images
           .groupListsBy((ProductImage element) => element.imgid)
           .values
-          .map(_selectProductImage)
+          .map(_findBestProductImage)
           .whereNotNull();
 
-  ProductImage? _selectProductImage(Iterable<ProductImage> images) =>
-      images.firstWhereOrNull(
-          (ProductImage image) => image.size == ImageSize.DISPLAY) ??
-      images.firstOrNull;
+  ProductImage? _findBestProductImage(Iterable<ProductImage> images) {
+    final Map<ImageSize?, ProductImage> map = images
+        .groupListsBy((ProductImage image) => image.size)
+        .map((ImageSize? key, List<ProductImage> value) =>
+            MapEntry<ImageSize?, ProductImage>(key, value.first));
+    return map[ImageSize.DISPLAY] ??
+        map[ImageSize.SMALL] ??
+        map[ImageSize.THUMB] ??
+        map[ImageSize.ORIGINAL] ??
+        map[ImageSize.UNKNOWN] ??
+        map[null];
+  }
 }

--- a/packages/smooth_app/lib/pages/product/product_image_viewer.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_viewer.dart
@@ -92,15 +92,13 @@ class _ProductImageViewerState extends State<ProductImageViewer> {
 
   Future<void> _editImage(final DaoInt daoInt) async {
     final String? imageUrl = imageData.getImageUrl(ImageSize.ORIGINAL);
-    final String? fallbackImageUrl = imageData.imageUrl;
-    if (imageUrl == null || fallbackImageUrl == null) {
+    if (imageUrl == null) {
       return;
     }
 
     final File? imageFile = await LoadingDialog.run<File?>(
       context: context,
-      future:
-          _downloadImageFileWithFallback(daoInt, imageUrl, fallbackImageUrl),
+      future: _downloadImageFile(daoInt, imageUrl),
     );
 
     if (imageFile == null) {
@@ -131,12 +129,6 @@ class _ProductImageViewerState extends State<ProductImageViewer> {
         imageProvider = FileImage(photoUploaded);
       });
     }
-  }
-
-  Future<File?> _downloadImageFileWithFallback(
-      DaoInt daoInt, String url, String fallbackUrl) async {
-    return await _downloadImageFile(daoInt, url) ??
-        await _downloadImageFile(daoInt, fallbackUrl);
   }
 
   static const String _CROP_IMAGE_SEQUENCE_KEY = 'crop_image_sequence';

--- a/packages/smooth_app/lib/pages/product/product_image_viewer.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_viewer.dart
@@ -41,7 +41,7 @@ class _ProductImageViewerState extends State<ProductImageViewer> {
   @override
   void initState() {
     imageData = widget.imageData;
-    imageProvider = NetworkImage(imageData.getImageUrl(ImageSize.DISPLAY)!);
+    imageProvider = NetworkImage(imageData.imageUrl!);
 
     super.initState();
   }

--- a/packages/smooth_app/lib/pages/product/product_image_viewer.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_viewer.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:http/http.dart' as http;
+import 'package:openfoodfacts/model/ProductImage.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:photo_view/photo_view.dart';
 import 'package:provider/provider.dart';
@@ -40,7 +41,7 @@ class _ProductImageViewerState extends State<ProductImageViewer> {
   @override
   void initState() {
     imageData = widget.imageData;
-    imageProvider = NetworkImage(imageData.imageUrl!);
+    imageProvider = NetworkImage(imageData.getImageUrl(ImageSize.DISPLAY)!);
 
     super.initState();
   }
@@ -90,9 +91,14 @@ class _ProductImageViewerState extends State<ProductImageViewer> {
       );
 
   Future<void> _editImage(final DaoInt daoInt) async {
+    final String? imageUrl = imageData.getImageUrl(ImageSize.ORIGINAL);
+    if (imageUrl == null) {
+      return;
+    }
+
     final File? imageFile = await LoadingDialog.run<File>(
       context: context,
-      future: _downloadImageFile(daoInt, imageData.imageUrl!),
+      future: _downloadImageFile(daoInt, imageUrl),
     );
 
     if (imageFile == null) {

--- a/packages/smooth_app/lib/pages/product/product_image_viewer.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_viewer.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:http/http.dart' as http;
-import 'package:openfoodfacts/model/ProductImage.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:photo_view/photo_view.dart';
 import 'package:provider/provider.dart';
@@ -41,7 +40,7 @@ class _ProductImageViewerState extends State<ProductImageViewer> {
   @override
   void initState() {
     imageData = widget.imageData;
-    imageProvider = NetworkImage(imageData.getImageUrl(ImageSize.DISPLAY)!);
+    imageProvider = NetworkImage(imageData.imageUrl!);
 
     super.initState();
   }
@@ -91,14 +90,9 @@ class _ProductImageViewerState extends State<ProductImageViewer> {
       );
 
   Future<void> _editImage(final DaoInt daoInt) async {
-    final String? imageUrl = imageData.getImageUrl(ImageSize.ORIGINAL);
-    if (imageUrl == null) {
-      return;
-    }
-
     final File? imageFile = await LoadingDialog.run<File>(
       context: context,
-      future: _downloadImageFile(daoInt, imageUrl),
+      future: _downloadImageFile(daoInt, imageData.imageUrl!),
     );
 
     if (imageFile == null) {


### PR DESCRIPTION
### What
Improve product image quality for some pages. For example, when full screen image viewer is open (please see issue description).

My idea was to refactor `ProductImageData` to contain a `Map` of all product images for every image size, so you can get specific image quality you want, when you need it.

I'm submitting this as draft for now, since I'm not completely sure if that is the best approach. Open to ideas. Maybe better backend support would be needed.

### Screenshot
[Uploading image.png…]()

### Fixes bug(s)
- Fixes: #2960
