### PR TITLE
fix: Better product_query_page (Search)

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
@@ -58,99 +58,106 @@ class SmoothProductCardFound extends StatelessWidget {
     );
     final ProductCompatibilityHelper helper =
         ProductCompatibilityHelper.product(matchedProduct);
-    return InkWell(
-      borderRadius: ROUNDED_BORDER_RADIUS,
-      onTap: onTap ??
-          () async {
-            await Navigator.push<void>(
-              context,
-              MaterialPageRoute<void>(
-                builder: (BuildContext context) => ProductPage(product),
-              ),
-            );
-          },
-      onLongPress: () {
-        onLongPress?.call();
-      },
-      child: Hero(
-        tag: heroTag,
-        child: Ink(
-          decoration: BoxDecoration(
-            borderRadius: ROUNDED_BORDER_RADIUS,
-            color:
-                backgroundColor ?? (isDarkMode ? Colors.black : Colors.white),
-          ),
-          child: SmoothCard(
-            elevation: elevation,
-            color: Colors.transparent,
-            padding: const EdgeInsets.all(VERY_SMALL_SPACE),
-            child: Row(
-              children: <Widget>[
-                SmoothMainProductImage(
-                  product: product,
-                  width: screenSize.width * 0.20,
-                  height: screenSize.width * 0.20,
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: MEDIUM_SPACE,
+        vertical: SMALL_SPACE,
+      ),
+      child: InkWell(
+        borderRadius: ROUNDED_BORDER_RADIUS,
+        onTap: onTap ??
+            () async {
+              await Navigator.push<void>(
+                context,
+                MaterialPageRoute<void>(
+                  builder: (BuildContext context) => ProductPage(product),
                 ),
-                const Padding(
-                    padding:
-                        EdgeInsetsDirectional.only(start: VERY_SMALL_SPACE)),
-                Expanded(
-                  child: SizedBox(
-                    height: screenSize.width * 0.2,
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: <Widget>[
-                        Text(
-                          getProductName(product, appLocalizations),
-                          overflow: TextOverflow.ellipsis,
-                          style: themeData.textTheme.headline4,
-                        ),
-                        Text(
-                          product.brands ?? appLocalizations.unknownBrand,
-                          overflow: TextOverflow.ellipsis,
-                          style: themeData.textTheme.subtitle1,
-                        ),
-                        Row(
-                          children: <Widget>[
-                            Icon(
-                              Icons.circle,
-                              size: 15,
-                              color: helper.getButtonColor(isDarkMode),
-                            ),
-                            const Padding(
-                              padding: EdgeInsetsDirectional.only(
-                                  start: VERY_SMALL_SPACE),
-                            ),
-                            Expanded(
-                              child: FittedBox(
-                                fit: BoxFit.scaleDown,
-                                alignment: AlignmentDirectional.centerStart,
-                                child: Text(
-                                  helper.getSubtitle(appLocalizations),
-                                  style: themeData.textTheme.bodyText2!.apply(
-                                    color: helper
-                                        .getButtonForegroundColor(isDarkMode),
+              );
+            },
+        onLongPress: () {
+          onLongPress?.call();
+        },
+        child: Hero(
+          tag: heroTag,
+          child: Ink(
+            decoration: BoxDecoration(
+              borderRadius: ROUNDED_BORDER_RADIUS,
+              color:
+                  backgroundColor ?? (isDarkMode ? Colors.black : Colors.white),
+            ),
+            child: SmoothCard(
+              elevation: elevation,
+              color: Colors.transparent,
+              padding: const EdgeInsets.all(VERY_SMALL_SPACE),
+              child: Row(
+                children: <Widget>[
+                  SmoothMainProductImage(
+                    product: product,
+                    width: screenSize.width * 0.20,
+                    height: screenSize.width * 0.20,
+                  ),
+                  const Padding(
+                      padding:
+                          EdgeInsetsDirectional.only(start: VERY_SMALL_SPACE)),
+                  Expanded(
+                    child: SizedBox(
+                      height: screenSize.width * 0.2,
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: <Widget>[
+                          Text(
+                            getProductName(product, appLocalizations),
+                            overflow: TextOverflow.ellipsis,
+                            style: themeData.textTheme.headline4,
+                          ),
+                          Text(
+                            product.brands ?? appLocalizations.unknownBrand,
+                            overflow: TextOverflow.ellipsis,
+                            style: themeData.textTheme.subtitle1,
+                          ),
+                          Row(
+                            children: <Widget>[
+                              Icon(
+                                Icons.circle,
+                                size: 15,
+                                color: helper.getButtonColor(isDarkMode),
+                              ),
+                              const Padding(
+                                padding: EdgeInsetsDirectional.only(
+                                    start: VERY_SMALL_SPACE),
+                              ),
+                              Expanded(
+                                child: FittedBox(
+                                  fit: BoxFit.scaleDown,
+                                  alignment: AlignmentDirectional.centerStart,
+                                  child: Text(
+                                    helper.getSubtitle(appLocalizations),
+                                    style: themeData.textTheme.bodyText2!.apply(
+                                      color: helper
+                                          .getButtonForegroundColor(isDarkMode),
+                                    ),
                                   ),
                                 ),
                               ),
-                            ),
-                          ],
-                        ),
-                      ],
+                            ],
+                          ),
+                        ],
+                      ),
                     ),
                   ),
-                ),
-                const Padding(
-                  padding: EdgeInsetsDirectional.only(start: VERY_SMALL_SPACE),
-                ),
-                Padding(
-                  padding: const EdgeInsets.all(VERY_SMALL_SPACE),
-                  child: Column(
-                    children: scores,
+                  const Padding(
+                    padding:
+                        EdgeInsetsDirectional.only(start: VERY_SMALL_SPACE),
                   ),
-                ),
-              ],
+                  Padding(
+                    padding: const EdgeInsets.all(VERY_SMALL_SPACE),
+                    child: Column(
+                      children: scores,
+                    ),
+                  ),
+                ],
+              ),
             ),
           ),
         ),

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_template.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_template.dart
@@ -42,62 +42,60 @@ class SmoothProductCardTemplate extends StatelessWidget {
       width: svgWidth,
       color: itemColor,
     );
-    return Padding(
+    return Container(
       padding: const EdgeInsets.symmetric(
         horizontal: MEDIUM_SPACE,
         vertical: SMALL_SPACE,
       ),
-      child: Container(
-        decoration: BoxDecoration(
-          borderRadius: ROUNDED_BORDER_RADIUS,
-          color: backgroundColor,
-        ),
-        child: SmoothCard(
-          elevation: SmoothProductCardFound.elevation,
-          color: Colors.transparent,
-          padding: const EdgeInsets.all(VERY_SMALL_SPACE),
-          child: Row(
-            children: <Widget>[
-              SmoothImage(
-                width: screenSize.width * 0.20,
-                height: screenSize.width * 0.20,
-                color: itemColor,
-              ),
-              const Padding(padding: EdgeInsets.only(left: VERY_SMALL_SPACE)),
-              Expanded(
-                child: SizedBox(
-                  height: screenSize.width * 0.2,
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    children: <Widget>[
-                      if (barcode == null) textWidget else Text(barcode!),
-                      if (message == null) textWidget,
-                      if (message == null) textWidget,
-                      if (message != null) AutoSizeText(message!, maxLines: 3),
-                    ],
-                  ),
+      decoration: BoxDecoration(
+        borderRadius: ROUNDED_BORDER_RADIUS,
+        color: backgroundColor,
+      ),
+      child: SmoothCard(
+        elevation: SmoothProductCardFound.elevation,
+        color: Colors.transparent,
+        padding: const EdgeInsets.all(VERY_SMALL_SPACE),
+        child: Row(
+          children: <Widget>[
+            SmoothImage(
+              width: screenSize.width * 0.20,
+              height: screenSize.width * 0.20,
+              color: itemColor,
+            ),
+            const Padding(padding: EdgeInsets.only(left: VERY_SMALL_SPACE)),
+            Expanded(
+              child: SizedBox(
+                height: screenSize.width * 0.2,
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: <Widget>[
+                    if (barcode == null) textWidget else Text(barcode!),
+                    if (message == null) textWidget,
+                    if (message == null) textWidget,
+                    if (message != null) AutoSizeText(message!, maxLines: 3),
+                  ],
                 ),
               ),
-              const Padding(padding: EdgeInsets.only(left: VERY_SMALL_SPACE)),
-              Padding(
-                padding: const EdgeInsets.all(VERY_SMALL_SPACE),
-                child: actionButton == null
-                    ? Column(
-                        children: <Widget>[
-                          svgWidget,
-                          Container(height: iconSize * .2),
-                          svgWidget,
-                        ],
-                      )
-                    : SizedBox(
-                        width: svgWidth,
-                        height: iconSize * (.9 * 2 + .2),
-                        child: actionButton,
-                      ),
-              ),
-            ],
-          ),
+            ),
+            const Padding(padding: EdgeInsets.only(left: VERY_SMALL_SPACE)),
+            Padding(
+              padding: const EdgeInsets.all(VERY_SMALL_SPACE),
+              child: actionButton == null
+                  ? Column(
+                      children: <Widget>[
+                        svgWidget,
+                        Container(height: iconSize * .2),
+                        svgWidget,
+                      ],
+                    )
+                  : SizedBox(
+                      width: svgWidth,
+                      height: iconSize * (.9 * 2 + .2),
+                      child: actionButton,
+                    ),
+            ),
+          ],
         ),
       ),
     );

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_template.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_template.dart
@@ -20,6 +20,8 @@ class SmoothProductCardTemplate extends StatelessWidget {
   final String? barcode;
   final Widget? actionButton;
 
+  // TODO(m123): Animate
+
   @override
   Widget build(BuildContext context) {
     final Size screenSize = MediaQuery.of(context).size;
@@ -40,56 +42,62 @@ class SmoothProductCardTemplate extends StatelessWidget {
       width: svgWidth,
       color: itemColor,
     );
-    return Container(
-      decoration: BoxDecoration(
-        borderRadius: ROUNDED_BORDER_RADIUS,
-        color: backgroundColor,
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: MEDIUM_SPACE,
+        vertical: SMALL_SPACE,
       ),
-      child: SmoothCard(
-        elevation: SmoothProductCardFound.elevation,
-        color: Colors.transparent,
-        padding: const EdgeInsets.all(VERY_SMALL_SPACE),
-        child: Row(
-          children: <Widget>[
-            SmoothImage(
-              width: screenSize.width * 0.20,
-              height: screenSize.width * 0.20,
-              color: itemColor,
-            ),
-            const Padding(padding: EdgeInsets.only(left: VERY_SMALL_SPACE)),
-            Expanded(
-              child: SizedBox(
-                height: screenSize.width * 0.2,
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: <Widget>[
-                    if (barcode == null) textWidget else Text(barcode!),
-                    if (message == null) textWidget,
-                    if (message == null) textWidget,
-                    if (message != null) AutoSizeText(message!, maxLines: 3),
-                  ],
+      child: Container(
+        decoration: BoxDecoration(
+          borderRadius: ROUNDED_BORDER_RADIUS,
+          color: backgroundColor,
+        ),
+        child: SmoothCard(
+          elevation: SmoothProductCardFound.elevation,
+          color: Colors.transparent,
+          padding: const EdgeInsets.all(VERY_SMALL_SPACE),
+          child: Row(
+            children: <Widget>[
+              SmoothImage(
+                width: screenSize.width * 0.20,
+                height: screenSize.width * 0.20,
+                color: itemColor,
+              ),
+              const Padding(padding: EdgeInsets.only(left: VERY_SMALL_SPACE)),
+              Expanded(
+                child: SizedBox(
+                  height: screenSize.width * 0.2,
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: <Widget>[
+                      if (barcode == null) textWidget else Text(barcode!),
+                      if (message == null) textWidget,
+                      if (message == null) textWidget,
+                      if (message != null) AutoSizeText(message!, maxLines: 3),
+                    ],
+                  ),
                 ),
               ),
-            ),
-            const Padding(padding: EdgeInsets.only(left: VERY_SMALL_SPACE)),
-            Padding(
-              padding: const EdgeInsets.all(VERY_SMALL_SPACE),
-              child: actionButton == null
-                  ? Column(
-                      children: <Widget>[
-                        svgWidget,
-                        Container(height: iconSize * .2),
-                        svgWidget,
-                      ],
-                    )
-                  : SizedBox(
-                      width: svgWidth,
-                      height: iconSize * (.9 * 2 + .2),
-                      child: actionButton,
-                    ),
-            ),
-          ],
+              const Padding(padding: EdgeInsets.only(left: VERY_SMALL_SPACE)),
+              Padding(
+                padding: const EdgeInsets.all(VERY_SMALL_SPACE),
+                child: actionButton == null
+                    ? Column(
+                        children: <Widget>[
+                          svgWidget,
+                          Container(height: iconSize * .2),
+                          svgWidget,
+                        ],
+                      )
+                    : SizedBox(
+                        width: svgWidth,
+                        height: iconSize * (.9 * 2 + .2),
+                        child: actionButton,
+                      ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/packages/smooth_app/lib/data_models/product_query_model.dart
+++ b/packages/smooth_app/lib/data_models/product_query_model.dart
@@ -19,7 +19,8 @@ class ProductQueryModel with ChangeNotifier {
   late LoadingStatus _loadingStatus;
   String? _loadingError;
   List<String> displayBarcodes = <String>[];
-  bool isNotEmpty() => displayBarcodes.isNotEmpty;
+
+  bool isEmpty() => displayBarcodes.isEmpty;
 
   String? get loadingError => _loadingError;
   LoadingStatus get loadingStatus => _loadingStatus;

--- a/packages/smooth_app/lib/pages/personalized_ranking_page.dart
+++ b/packages/smooth_app/lib/pages/personalized_ranking_page.dart
@@ -196,18 +196,12 @@ class _PersonalizedRankingPageState extends State<PersonalizedRankingPage>
             ),
           );
         },
-        child: Padding(
-          padding: const EdgeInsets.symmetric(
-            horizontal: MEDIUM_SPACE,
-            vertical: SMALL_SPACE,
-          ),
-          child: ProductListItemSimple(
-            barcode: matchedProduct.barcode,
-            backgroundColor:
-                ProductCompatibilityHelper.status(matchedProduct.status)
-                    .getHeaderBackgroundColor(darkMode)
-                    .withAlpha(_backgroundAlpha),
-          ),
+        child: ProductListItemSimple(
+          barcode: matchedProduct.barcode,
+          backgroundColor:
+              ProductCompatibilityHelper.status(matchedProduct.status)
+                  .getHeaderBackgroundColor(darkMode)
+                  .withAlpha(_backgroundAlpha),
         ),
       );
 }

--- a/packages/smooth_app/lib/pages/product/common/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_page.dart
@@ -275,9 +275,8 @@ class _ProductListPageState extends State<ProductListPage>
     final Widget child = InkWell(
       onTap: _selectionMode ? onTap : null,
       child: Container(
-        padding: EdgeInsets.symmetric(
-          horizontal: _selectionMode ? 0 : MEDIUM_SPACE,
-          vertical: SMALL_SPACE,
+        padding: EdgeInsets.only(
+          left: _selectionMode ? SMALL_SPACE : 0,
         ),
         child: Row(
           children: <Widget>[


### PR DESCRIPTION
### What
We had some reports about search on Slack which are fixed here:

1. The template cards had no padding (I unified the padding across the cards now)
2. When you were scrolling to far into the templates the empty list card appeard

And I further fixed:

4. You landed on a blank screen if refreshing while scrolling down
5. To many rebuilds while scrolling, we don't need to rebuild on every scroll (?), but only when the scroll to top button appears or dissapears

### Screen recording 

<details>
  <summary>Click me</summary>

https://user-images.githubusercontent.com/39344769/193820025-4f9acb65-7cab-49aa-b66a-f49e2e559055.mp4





</details>


### Design

I'm honestly really open about the design, 
- maybe just 3 animated cards are enouph
- the single (not animated) template card could be confusing
- maybe just a loading indicator
- maybe a text "Loading more products..."

Open for suggestions
