### PR TITLE
ci: Fix github actions

### DIFF
--- a/.github/workflows/internal-release.yml
+++ b/.github/workflows/internal-release.yml
@@ -10,7 +10,7 @@ jobs:
     concurrency: 
       group: release
       cancel-in-progress: true
-    if: "!contains(github.event.commits[0].message, 'chore(develop): release') && github.owner == openfoodfacts" 
+    if: "!contains(github.event.commits[0].message, 'chore(develop): release') && github.owner == 'openfoodfacts'"
     runs-on: ubuntu-latest
     outputs:
       VERSION_NAME: ${{ steps.set_output.outputs.VERSION_NAME }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release-please:
     runs-on: ubuntu-latest
-    if: github.owner == openfoodfacts
+    if: github.owner == 'openfoodfacts'
     outputs:
       release_created: ${{ steps.release_please.outputs.release_created }}
       major: ${{ steps.release_please.outputs.major }}

--- a/.github/workflows/update-assets.yml
+++ b/.github/workflows/update-assets.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   update-assets:
-    if: github.owner == openfoodfacts
+    if: github.owner == 'openfoodfacts'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
### What

Learned about the next exception to the norm in github actions due to the update-assets workflow

`Unrecognized named-value: 'openfoodfacts'`
![](https://media.tenor.com/aDhtD8yQLMQAAAAC/mcdonalds-im-lovin-it.gif)


> When you use expressions in an if conditional, you may omit the expression syntax (${{ }}) because GitHub automatically evaluates the if conditional as an expression. For more information, see "[Expressions](https://docs.github.com/en/actions/learn-github-actions/expressions)."

So I have to explicitly have to mark it as string. 
