### PR TITLE
fix: The search should force the keyboard to be visible

### DIFF
--- a/packages/smooth_app/lib/pages/scan/search_history_view.dart
+++ b/packages/smooth_app/lib/pages/scan/search_history_view.dart
@@ -6,12 +6,12 @@ import 'package:smooth_app/generic_lib/design_constants.dart';
 
 class SearchHistoryView extends StatefulWidget {
   const SearchHistoryView({
-    this.scrollController,
     this.onTap,
+    this.focusNode,
   });
 
-  final ScrollController? scrollController;
   final void Function(String)? onTap;
+  final FocusNode? focusNode;
 
   @override
   State<SearchHistoryView> createState() => _SearchHistoryViewState();
@@ -35,7 +35,6 @@ class _SearchHistoryViewState extends State<SearchHistoryView> {
   @override
   Widget build(BuildContext context) {
     return ListView.builder(
-      controller: widget.scrollController,
       itemCount: _queries.length,
       itemBuilder: (BuildContext context, int i) =>
           _buildSearchHistoryTile(context, _queries[i]),
@@ -67,7 +66,14 @@ class _SearchHistoryViewState extends State<SearchHistoryView> {
             controller.selection =
                 TextSelection.fromPosition(TextPosition(offset: query.length));
 
-            Focus.maybeOf(context)?.requestFocus();
+            // If the keyboard is hidden, show it.
+            if (WidgetsBinding.instance.window.viewInsets.bottom == 0) {
+              widget.focusNode?.unfocus();
+
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                FocusScope.of(context).requestFocus(widget.focusNode);
+              });
+            }
           },
           child: const Padding(
             padding: EdgeInsets.all(SMALL_SPACE),

--- a/packages/smooth_app/lib/pages/scan/search_page.dart
+++ b/packages/smooth_app/lib/pages/scan/search_page.dart
@@ -175,7 +175,6 @@ class _SearchFieldState extends State<SearchField> {
   void initState() {
     super.initState();
 
-    print(widget.focusNode);
     _focusNode = widget.focusNode ?? FocusNode();
     _focusNode.addListener(_handleFocusChange);
 

--- a/packages/smooth_app/lib/pages/scan/search_page.dart
+++ b/packages/smooth_app/lib/pages/scan/search_page.dart
@@ -121,6 +121,7 @@ class _SearchPageState extends State<SearchPage> {
             ),
             Expanded(
               child: SearchHistoryView(
+                focusNode: _searchFocusNode,
                 onTap: (String query) => _performSearch(
                   context,
                   query,
@@ -174,6 +175,7 @@ class _SearchFieldState extends State<SearchField> {
   void initState() {
     super.initState();
 
+    print(widget.focusNode);
     _focusNode = widget.focusNode ?? FocusNode();
     _focusNode.addListener(_handleFocusChange);
 


### PR DESCRIPTION
When clicking on the "Pen" icon next to an history item, the keyboard should be forced to be visible.
A `ScrollController` is also removed, as no value was passed to the argument.

https://user-images.githubusercontent.com/246838/194860908-36e3663d-fc2f-4fac-be10-863e3e85622e.mp4
