### PR TITLE
feat: Add the product name or barcode on each sub page

### DIFF
--- a/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
@@ -12,6 +12,7 @@ import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/generic_lib/duration_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_text_form_field.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
+import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
 class AddBasicDetailsPage extends StatefulWidget {
@@ -64,8 +65,12 @@ class _AddBasicDetailsPageState extends State<AddBasicDetailsPage> {
         context.read<UpToDateProductProvider>();
     final DaoProduct daoProduct = DaoProduct(localDatabase);
     return SmoothScaffold(
-      appBar: AppBar(
+      appBar: SmoothAppBar(
         title: Text(appLocalizations.basic_details),
+        subTitle: widget.product.productName != null
+            ? Text(widget.product.productName!,
+                overflow: TextOverflow.ellipsis, maxLines: 1)
+            : null,
       ),
       body: Form(
         key: _formKey,

--- a/packages/smooth_app/lib/pages/product/edit_ingredients_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_ingredients_page.dart
@@ -16,6 +16,7 @@ import 'package:smooth_app/helpers/picture_capture_helper.dart';
 import 'package:smooth_app/pages/image_crop_page.dart';
 import 'package:smooth_app/pages/product/explanation_widget.dart';
 import 'package:smooth_app/pages/product/ocr_helper.dart';
+import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
 /// Editing with OCR a product field and the corresponding image.
@@ -224,8 +225,15 @@ class _EditOcrPageState extends State<EditOcrPage> {
 
     final Scaffold scaffold = SmoothScaffold(
       extendBodyBehindAppBar: true,
-      appBar: AppBar(
+      appBar: SmoothAppBar(
         title: Text(_helper.getTitle(appLocalizations)),
+        subTitle: widget.product.productName != null
+            ? Text(
+                widget.product.productName!,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              )
+            : null,
         backgroundColor: Colors.transparent,
         flexibleSpace: ClipRect(
           child: BackdropFilter(

--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -19,6 +19,7 @@ import 'package:smooth_app/generic_lib/widgets/smooth_text_form_field.dart';
 import 'package:smooth_app/helpers/text_input_formatters_helper.dart';
 import 'package:smooth_app/pages/product/nutrition_container.dart';
 import 'package:smooth_app/query/product_query.dart';
+import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
 /// Actual nutrition page, with data already loaded.
@@ -118,11 +119,18 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
     return WillPopScope(
       onWillPop: () async => _mayExitPage(saving: false),
       child: SmoothScaffold(
-        appBar: AppBar(
+        appBar: SmoothAppBar(
           title: AutoSizeText(
             appLocalizations.nutrition_page_title,
-            maxLines: 2,
+            maxLines: widget.product.productName?.isNotEmpty == true ? 1 : 2,
           ),
+          subTitle: widget.product.productName != null
+              ? Text(
+                  widget.product.productName!,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                )
+              : null,
         ),
         body: Padding(
           padding: const EdgeInsets.symmetric(

--- a/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
@@ -19,6 +19,7 @@ import 'package:smooth_app/pages/image_crop_page.dart';
 import 'package:smooth_app/pages/product/common/product_refresher.dart';
 import 'package:smooth_app/pages/product/product_image_viewer.dart';
 import 'package:smooth_app/query/product_query.dart';
+import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
 /// ProductImageGalleryView is a page that displays a list of product images.
@@ -104,8 +105,15 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView> {
           );
         }
         return SmoothScaffold(
-          appBar: AppBar(
+          appBar: SmoothAppBar(
             title: Text(appLocalizations.edit_product_form_item_photos_title),
+            subTitle: widget.product.productName != null
+                ? Text(
+                    widget.product.productName!,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  )
+                : null,
             leading: SmoothBackButton(
               onPressed: () => Navigator.maybePop(context, _isRefreshed),
             ),

--- a/packages/smooth_app/lib/pages/product/simple_input_page.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page.dart
@@ -15,6 +15,7 @@ import 'package:smooth_app/helpers/collections_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/pages/product/simple_input_page_helpers.dart';
 import 'package:smooth_app/pages/product/simple_input_widget.dart';
+import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
 /// Simple input page: we have a list of terms, we add, we remove, we save.
@@ -89,11 +90,14 @@ class _SimpleInputPageState extends State<SimpleInputPage> {
     return WillPopScope(
       onWillPop: () async => _mayExitPage(saving: false),
       child: SmoothScaffold(
-        appBar: AppBar(
+        appBar: SmoothAppBar(
           title: AutoSizeText(
             getProductName(widget.product, appLocalizations),
-            maxLines: 2,
+            maxLines: widget.product.barcode?.isNotEmpty == true ? 1 : 2,
           ),
+          subTitle: widget.product.barcode != null
+              ? Text(widget.product.barcode!)
+              : null,
         ),
         body: Padding(
           padding: const EdgeInsets.all(SMALL_SPACE),

--- a/packages/smooth_app/lib/widgets/smooth_app_bar.dart
+++ b/packages/smooth_app/lib/widgets/smooth_app_bar.dart
@@ -11,6 +11,7 @@ class SmoothAppBar extends StatelessWidget implements PreferredSizeWidget {
     this.actionModeTitle,
     this.actionModeSubTitle,
     this.title,
+    this.subTitle,
     this.actionModeActions,
     this.actions,
     this.flexibleSpace,
@@ -47,6 +48,7 @@ class SmoothAppBar extends StatelessWidget implements PreferredSizeWidget {
   final Widget? leading;
   final bool automaticallyImplyLeading;
   final Widget? title;
+  final Widget? subTitle;
   final Widget? actionModeTitle;
   final Widget? actionModeSubTitle;
   final List<Widget>? actions;
@@ -100,7 +102,9 @@ class SmoothAppBar extends StatelessWidget implements PreferredSizeWidget {
   Widget _createAppBar() => AppBar(
         leading: leading,
         automaticallyImplyLeading: automaticallyImplyLeading,
-        title: title,
+        title: title != null
+            ? _AppBarTitle(title: title!, subTitle: subTitle)
+            : null,
         actions: actions,
         flexibleSpace: flexibleSpace,
         bottom: bottom,
@@ -136,17 +140,12 @@ class SmoothAppBar extends StatelessWidget implements PreferredSizeWidget {
             },
           ),
           automaticallyImplyLeading: false,
-          title: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              actionModeTitle!,
-              if (actionModeSubTitle != null)
-                DefaultTextStyle(
-                    style: Theme.of(context).textTheme.bodyMedium ??
-                        const TextStyle(),
-                    child: actionModeSubTitle!),
-            ],
-          ),
+          title: actionModeTitle != null
+              ? _AppBarTitle(
+                  title: actionModeTitle!,
+                  subTitle: actionModeSubTitle,
+                )
+              : null,
           actions: actionModeActions,
           flexibleSpace: flexibleSpace,
           bottom: bottom,
@@ -206,6 +205,32 @@ class _ActionModeCloseButton extends StatelessWidget {
           Navigator.maybePop(context);
         }
       },
+    );
+  }
+}
+
+class _AppBarTitle extends StatelessWidget {
+  const _AppBarTitle({
+    required this.title,
+    required this.subTitle,
+    Key? key,
+  }) : super(key: key);
+
+  final Widget title;
+  final Widget? subTitle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        title,
+        if (subTitle != null)
+          DefaultTextStyle(
+            style: Theme.of(context).textTheme.bodyMedium ?? const TextStyle(),
+            child: subTitle!,
+          ),
+      ],
     );
   }
 }


### PR DESCRIPTION
In edit mode, each sub-page should remind the user of the product name and or barcode (in the `AppBar`).
Here is a video: 

https://user-images.githubusercontent.com/246838/195376761-2848fa42-d7eb-460d-9df9-6c539d545fda.mp4

