### PR TITLE
feat: Migration to Flutter 3.3.x

### DIFF
--- a/.github/workflows/android-release-to-org-openfoodfacts-scanner.yml
+++ b/.github/workflows/android-release-to-org-openfoodfacts-scanner.yml
@@ -73,9 +73,7 @@ jobs:
         with:
           channel: stable
           cache: true
-          flutter-version: '3.0.5'
-          #cache-key: ${{ inputs.FLUTTER-CACHE-KEY }}
-          cache-key: revert-3.0.5
+          cache-key: ${{ inputs.FLUTTER-CACHE-KEY }}
 
       - name: Flutter version    
         run: flutter --version

--- a/.github/workflows/ios-release-to-org-openfoodfacts-scanner.yml
+++ b/.github/workflows/ios-release-to-org-openfoodfacts-scanner.yml
@@ -65,9 +65,7 @@ jobs:
         with:
           channel: stable
           cache: true
-          flutter-version: '3.0.5'
-          #cache-key: ${{ inputs.FLUTTER-CACHE-KEY }}
-          cache-key: revert-3.0.5
+          cache-key: ${{ inputs.FLUTTER-CACHE-KEY }}
 
       - name: Flutter version    
         run: flutter --version

--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -29,10 +29,8 @@ jobs:
         with:
           channel: stable
           cache: true
-          flutter-version: '3.0.5'
-          #cache-key: flutter-${{ env.FLUTTER_VERSION }}-${{ hashFiles('**/pubspec.lock')}}
-          cache-key: revert-3.0.5
-        
+          cache-key: flutter-${{ env.FLUTTER_VERSION }}-${{ hashFiles('**/pubspec.lock')}}
+
       - run: flutter --version
       
       # Get dependencies.

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -27,9 +27,7 @@ jobs:
         with:
           channel: stable
           cache: true
-          flutter-version: '3.0.5'
-          #cache-key: flutter-${{ env.FLUTTER_VERSION }}-${{ hashFiles('**/pubspec.lock')}}
-          cache-key: revert-3.0.5
+          cache-key: flutter-${{ env.FLUTTER_VERSION }}-${{ hashFiles('**/pubspec.lock')}}
 
       - run: flutter --version
 

--- a/README.md
+++ b/README.md
@@ -7,14 +7,6 @@
 # New Open Food Facts mobile app for Android and iPhone - Codename: "Smooth App"
 [![SmoothApp Post-Submit Tests](https://github.com/openfoodfacts/smooth-app/actions/workflows/postsubmit.yml/badge.svg)](https://github.com/openfoodfacts/smooth-app/actions/workflows/postsubmit.yml)
 
-## Alert!
-
-We are currently using Flutter 3.0.5 as the new 3.3.0 [has some bugs](https://github.com/openfoodfacts/smooth-app/issues/2919).
-
-Running `flutter downgrade 3.0.5` downgrades the version.
-
-------
-
 Latest commit deployed to App Stores: (Released on Sep 6 6:29 PM as Build 731 (3.13.1)) https://github.com/openfoodfacts/smooth-app/compare/v3.8.1...v3.13.1
 
 A new Flutter application by [Open Food Facts](https://github.com/openfoodfacts). You can install it on [Android](https://play.google.com/store/apps/details?id=org.openfoodfacts.scanner) or [iPhone/iPad](https://apps.apple.com/app/open-food-facts/id588797948). Note that a internal development build ([Android](https://play.google.com/apps/internaltest/4699092342921529278) or [iPhone/iPad](https://testflight.apple.com/join/c2tiBHgd) )if you'd like to use the results of your PRs quicker.

--- a/packages/app/pubspec.lock
+++ b/packages/app/pubspec.lock
@@ -1228,12 +1228,12 @@ packages:
     source: hosted
     version: "2.0.0"
   typed_data:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   unicode:
     dependency: transitive
     description:
@@ -1389,5 +1389,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.17.6 <3.0.0"
-  flutter: ">=3.1.0-0"
+  dart: ">=2.18.0 <3.0.0"
+  flutter: ">=3.3.0"

--- a/packages/app/pubspec.yaml
+++ b/packages/app/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: "none"
 
 environment:
   sdk: ">=2.17.0 <3.0.0"
-  flutter: ">=3.0.0"
+  flutter: ">=3.3.2"
 
 dependencies:
   flutter:
@@ -31,7 +31,6 @@ dev_dependencies:
 dependency_overrides:
   path: 1.8.0
   meta: 1.7.0
-  typed_data: 1.3.0
 
 flutter:
   generate: true

--- a/packages/data_importer/pubspec.yaml
+++ b/packages/data_importer/pubspec.yaml
@@ -4,8 +4,8 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <3.0.0"
+  flutter: ">=3.3.2"
 
 dependencies:
   flutter:

--- a/packages/data_importer_shared/pubspec.yaml
+++ b/packages/data_importer_shared/pubspec.yaml
@@ -3,8 +3,8 @@ description: A starting point for Dart libraries or applications.
 publish_to: none
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <3.0.0"
+  flutter: ">=3.3.2"
 
 dev_dependencies:
   flutter_driver:

--- a/packages/smooth_app/lib/cache/files/file_cache_manager_impl.dart
+++ b/packages/smooth_app/lib/cache/files/file_cache_manager_impl.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
 import 'package:path/path.dart';

--- a/packages/smooth_app/lib/pages/onboarding/onboarding_bottom_bar.dart
+++ b/packages/smooth_app/lib/pages/onboarding/onboarding_bottom_bar.dart
@@ -113,8 +113,8 @@ class OnboardingBottomIcon extends StatelessWidget {
         style: ElevatedButton.styleFrom(
           shape: const CircleBorder(),
           padding: const EdgeInsets.all(MEDIUM_SPACE),
-          primary: backgroundColor,
-          onPrimary: foregroundColor,
+          backgroundColor: backgroundColor,
+          foregroundColor: foregroundColor,
         ),
         onPressed: onPressed,
         child: Icon(icon),

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -322,7 +322,7 @@ class _ProductPageState extends State<ProductPage> with TraceableClientMixin {
               shape: const CircleBorder(),
               padding: const EdgeInsets.all(
                   18), // TODO(monsieurtanuki): cf. FloatingActionButton
-              primary: colorScheme.primary,
+              backgroundColor: colorScheme.primary,
             ),
             child: Icon(iconData, color: colorScheme.onPrimary),
           ),

--- a/packages/smooth_app/lib/pages/scan/camera_image_cropper.dart
+++ b/packages/smooth_app/lib/pages/scan/camera_image_cropper.dart
@@ -1,10 +1,9 @@
-import 'dart:typed_data';
-
 import 'package:camera/camera.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:google_mlkit_barcode_scanning/google_mlkit_barcode_scanning.dart';
 import 'package:smooth_app/pages/scan/abstract_camera_image_getter.dart';
-import 'package:typed_data/typed_buffers.dart';
+import 'package:typed_data/typed_data.dart';
 
 /// Camera Image Cropper, in order to limit the barcode scan computations.
 ///

--- a/packages/smooth_app/lib/pages/scan/camera_image_full_getter.dart
+++ b/packages/smooth_app/lib/pages/scan/camera_image_full_getter.dart
@@ -1,5 +1,3 @@
-import 'dart:typed_data';
-
 import 'package:camera/camera.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -1324,7 +1324,7 @@ packages:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   unicode:
     dependency: transitive
     description:
@@ -1487,5 +1487,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.17.6 <3.0.0"
+  dart: ">=2.18.0 <3.0.0"
   flutter: ">=3.1.0-0"

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -4,8 +4,8 @@ version: 0.0.0+734
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=2.18.0 <3.0.0"
+  flutter: ">=3.3.2"
 
 dependencies:
   flutter:
@@ -68,7 +68,7 @@ dependencies:
   image_cropper: 2.0.3
   auto_size_text: 3.0.0
   shared_preferences: 2.0.15
-  typed_data: 1.3.0 # careful with 1.3.1 because of flutter_driver dependence
+  typed_data: 1.3.1
   intl: 0.17.0
   flutter_isolate: 2.0.2
   rxdart: 0.27.4
@@ -103,7 +103,6 @@ dev_dependencies:
 dependency_overrides:
   path: 1.8.0
   meta: 1.7.0
-  typed_data: 1.3.0
 
 # 'flutter pub run flutter_launcher_icons:main' to update
 flutter_icons:

--- a/packages/smooth_app/test/tests_utils/goldens.dart
+++ b/packages/smooth_app/test/tests_utils/goldens.dart
@@ -1,5 +1,4 @@
 import 'dart:developer';
-import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';


### PR DESCRIPTION
- Now that Flutter 3.3.x is stable again, we can upgrade to the latest version.
- It's basically a revert of https://github.com/openfoodfacts/smooth-app/pull/2923
- It will then fix https://github.com/openfoodfacts/smooth-app/issues/2919