### PR TITLE
chore: add launch.json for vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,10 @@
+{
+    "configurations": [
+        {
+            "name": "Gooogle Play flavor",
+            "type": "dart",
+            "request": "launch",
+            "program": "packages/app/lib/entrypoints/android/main_google_play.dart"
+        }
+    ]
+}


### PR DESCRIPTION
Adds a shortcut to launch Flutter from vs code by using the debug panel.
