### PR TITLE
feat: #3065 - using Robotoff question imageUrl if available

### DIFF
--- a/packages/app/ios/Podfile.lock
+++ b/packages/app/ios/Podfile.lock
@@ -243,7 +243,7 @@ SPEC CHECKSUMS:
   connectivity_plus: 413a8857dd5d9f1c399a39130850d02fe0feaf7e
   data_importer: ab8c74aaf553878170aed03c03626d5820c5cb1f
   device_info_plus: e5c5da33f982a436e103237c0c85f9031142abed
-  Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
+  Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   flutter_email_sender: 02d7443217d8c41483223627972bfdc09f74276b
   flutter_isolate: 0edf5081826d071adf21759d1eb10ff5c24503b5
   flutter_native_splash: 52501b97d1c0a5f898d687f1646226c1f93c56ef

--- a/packages/smooth_app/ios/Podfile.lock
+++ b/packages/smooth_app/ios/Podfile.lock
@@ -243,7 +243,7 @@ SPEC CHECKSUMS:
   connectivity_plus: 413a8857dd5d9f1c399a39130850d02fe0feaf7e
   data_importer: ab8c74aaf553878170aed03c03626d5820c5cb1f
   device_info_plus: e5c5da33f982a436e103237c0c85f9031142abed
-  Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
+  Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   flutter_email_sender: 02d7443217d8c41483223627972bfdc09f74276b
   flutter_isolate: 0edf5081826d071adf21759d1eb10ff5c24503b5
   flutter_native_splash: 52501b97d1c0a5f898d687f1646226c1f93c56ef

--- a/packages/smooth_app/lib/cards/product_cards/product_image_carousel.dart
+++ b/packages/smooth_app/lib/cards/product_cards/product_image_carousel.dart
@@ -1,27 +1,40 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:openfoodfacts/model/Product.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/cards/data_cards/image_upload_card.dart';
 import 'package:smooth_app/data_models/product_image_data.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 
 class ProductImageCarousel extends StatelessWidget {
+  /// Carousel of product images, or of just an [alternateImageUrl].
   const ProductImageCarousel(
     this.product, {
     required this.height,
     this.onUpload,
+    this.alternateImageUrl,
   });
 
   final Product product;
   final double height;
   final Function(BuildContext)? onUpload;
+  final String? alternateImageUrl;
 
   @override
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    final List<ProductImageData> productImagesData =
-        getProductMainImagesData(product, appLocalizations);
-
+    final List<ProductImageData> productImagesData;
+    if (alternateImageUrl != null) {
+      productImagesData = <ProductImageData>[
+        ProductImageData(
+          imageUrl: alternateImageUrl,
+          imageField: ImageField.OTHER,
+          title: '',
+          buttonText: '',
+        ),
+      ];
+    } else {
+      productImagesData = getProductMainImagesData(product, appLocalizations);
+    }
     return SizedBox(
       height: height,
       child: ListView.builder(

--- a/packages/smooth_app/lib/pages/hunger_games/question_card.dart
+++ b/packages/smooth_app/lib/pages/hunger_games/question_card.dart
@@ -41,6 +41,7 @@ class QuestionCard extends StatelessWidget {
                   product,
                   height: screenSize.height / 6,
                   onUpload: (_) {},
+                  alternateImageUrl: question.imageUrl,
                 ),
                 Padding(
                   padding: const EdgeInsets.symmetric(horizontal: SMALL_SPACE),


### PR DESCRIPTION
Impacted files:
* `Podfile.lock` (`app`): wtf
* `Podfile.lock` (`smooth_app`): wtf
* `product_image_carousel.dart`: added optional imageUrl that displays it instead of the standard all pictures
* `question_card.dart`: added Robotoff question imageUrl if available

### What
* In Robotoff questions, there is an optional imageUrl field that we didn't use at all in Smoothie.
* When the field is populated, it is the best field that could help the user answer the question, so it should be displayed with the higher priority (instead of being ignored).
* This PR displays the standard carousel of images when the question imageUrl field is not populated (same as before), or only the question imageUrl field if populated. If needed by the user, all pictures are still available if you click on the single picture.

Open questions:
* Should we display the question imageUrl AND the rest of the images - can be problematic when the imageUrl is the front image, like stuttering (would need deduplicating)
* Should we display a bigger image instead of the carousel?
* Are the question imageUrl always populated?

### Screenshot
| before | after |
| -- | -- |
| ![Capture d’écran 2022-10-19 à 13 25 25](https://user-images.githubusercontent.com/11576431/196678021-b2f37f7f-ad2c-4218-a135-118044903475.png) | ![Capture d’écran 2022-10-19 à 13 24 46](https://user-images.githubusercontent.com/11576431/196677888-b6200833-bd61-4bd3-8435-774df9e19b91.png) |
| ![Capture d’écran 2022-10-19 à 13 21 45](https://user-images.githubusercontent.com/11576431/196677361-e5818cb3-9e4d-41fe-aedc-3248e6bdd064.png) | ![Capture d’écran 2022-10-19 à 13 22 38](https://user-images.githubusercontent.com/11576431/196677474-7ca155fd-cefc-4975-a949-4c41a2a81d1b.png) |

### Fixes bug(s)
- Closes: #3065