### PR TITLE
fix: make links clickable again

### DIFF
--- a/packages/smooth_app/lib/helpers/launch_url_helper.dart
+++ b/packages/smooth_app/lib/helpers/launch_url_helper.dart
@@ -19,15 +19,15 @@ class LaunchUrlHelper {
 
     AnalyticsHelper.trackOpenLink(url: url);
 
-    if (await canLaunchUrl(Uri.parse(url))) {
+    try {
       await launchUrl(
         Uri.parse(url),
         mode: Platform.isAndroid
             ? LaunchMode.externalApplication
             : LaunchMode.platformDefault,
       );
-    } else {
-      throw 'Could not launch $url';
+    } catch (e) {
+      throw 'Could not launch $url,Error: $e';
     }
   }
 


### PR DESCRIPTION
### What
<!-- description of the PR -->
- Changed the canLaunchUrl to a try-catch block https://cutt.ly/4B2AMZl
- There is another way to change the XML files, but this seemed more cleaner to me 

### Screenshot
<!-- Insert a screenshot to provide a visual record of your changes, if visible -->


https://user-images.githubusercontent.com/57723319/197031959-1ac5548d-a24f-4890-a131-e15593c17c80.mp4



### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes: #3163 

