### PR TITLE
fix: iOS camera permission not working

### DIFF
--- a/packages/app/ios/Podfile
+++ b/packages/app/ios/Podfile
@@ -37,8 +37,15 @@ end
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
+
     target.build_configurations.each do |config|
        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '11.0'
+
+       config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= [
+                   '$(inherited)',
+                   'PERMISSION_CAMERA=1',
+                   'PERMISSION_PHOTOS=1',
+                 ]
     end
   end
 end


### PR DESCRIPTION
Hello,

Since the migration to the new architecture, the iOS' camera permission doesn't work.
The previous code called in the Podfile of `smooth_app` is now also called in the `app` module.

Will fix #3161