### PR TITLE
fix: Onboarding: consistent bottom padding on iOS

### DIFF
--- a/packages/smooth_app/lib/pages/onboarding/knowledge_panel_page_template.dart
+++ b/packages/smooth_app/lib/pages/onboarding/knowledge_panel_page_template.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -84,6 +86,7 @@ class _KnowledgePanelPageTemplateState
           return Container(
             color: widget.backgroundColor,
             child: SafeArea(
+              bottom: Platform.isAndroid,
               child: Stack(
                 fit: StackFit.expand,
                 children: <Widget>[

--- a/packages/smooth_app/lib/pages/onboarding/next_button.dart
+++ b/packages/smooth_app/lib/pages/onboarding/next_button.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
@@ -45,6 +47,9 @@ class NextButton extends StatelessWidget {
               backgroundColor: Colors.white,
               foregroundColor: Colors.black,
               icon: ConstantIcons.instance.getBackIcon(),
+              iconPadding: Platform.isIOS
+                  ? const EdgeInsetsDirectional.only(end: 2.5)
+                  : EdgeInsets.zero,
             ),
       rightButton: OnboardingBottomButton(
         onPressed: () async {

--- a/packages/smooth_app/lib/pages/onboarding/onboarding_bottom_bar.dart
+++ b/packages/smooth_app/lib/pages/onboarding/onboarding_bottom_bar.dart
@@ -101,12 +101,14 @@ class OnboardingBottomIcon extends StatelessWidget {
     required this.backgroundColor,
     required this.foregroundColor,
     required this.icon,
+    this.iconPadding,
   });
 
   final VoidCallback onPressed;
   final Color backgroundColor;
   final Color foregroundColor;
   final IconData icon;
+  final EdgeInsetsGeometry? iconPadding;
 
   @override
   Widget build(BuildContext context) => ElevatedButton(
@@ -117,6 +119,9 @@ class OnboardingBottomIcon extends StatelessWidget {
           foregroundColor: foregroundColor,
         ),
         onPressed: onPressed,
-        child: Icon(icon),
+        child: Padding(
+          padding: iconPadding ?? EdgeInsets.zero,
+          child: Icon(icon),
+        ),
       );
 }

--- a/packages/smooth_app/lib/pages/onboarding/preferences_page.dart
+++ b/packages/smooth_app/lib/pages/onboarding/preferences_page.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -125,9 +127,10 @@ class _HelperState extends State<_Helper> {
         themeData: Theme.of(context),
       ).getOnboardingContent(),
     );
-    return Container(
+    return ColoredBox(
       color: widget.backgroundColor,
       child: SafeArea(
+        bottom: Platform.isAndroid,
         child: Column(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           crossAxisAlignment: CrossAxisAlignment.start,

--- a/packages/smooth_app/lib/pages/onboarding/reinvention_page.dart
+++ b/packages/smooth_app/lib/pages/onboarding/reinvention_page.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -27,10 +29,11 @@ class ReinventionPage extends StatelessWidget {
     return SmoothScaffold(
       backgroundColor: backgroundColor,
       brightness: Brightness.dark,
-      body: SafeArea(
-        child: Stack(
-          children: <Widget>[
-            Column(
+      body: Stack(
+        children: <Widget>[
+          SafeArea(
+            bottom: false,
+            child: Column(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               crossAxisAlignment: CrossAxisAlignment.center,
               children: <Widget>[
@@ -85,16 +88,19 @@ class ReinventionPage extends StatelessWidget {
                 ),
               ],
             ),
-            const Positioned(
-              bottom: 0,
-              child: NextButton(
+          ),
+          Positioned(
+            bottom: 0,
+            child: SafeArea(
+              bottom: !Platform.isIOS,
+              child: const NextButton(
                 OnboardingPage.REINVENTION,
                 backgroundColor: null,
                 nextKey: Key('nextAfterReinvention'),
               ),
             ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }

--- a/packages/smooth_app/lib/pages/onboarding/scan_example.dart
+++ b/packages/smooth_app/lib/pages/onboarding/scan_example.dart
@@ -23,7 +23,7 @@ class ScanExample extends StatelessWidget {
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
-          Container(),
+          const SizedBox.shrink(),
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: LARGE_SPACE),
             child: Column(


### PR DESCRIPTION
On onboarding, depending on the screen and only on iOS, there is an extra bottom padding.
This should now be fixed.

https://user-images.githubusercontent.com/246838/197335290-49636090-838c-43d3-b3ca-d88c40f8891d.mp4

