### PR TITLE
feat: MLKit as a dependency

### DIFF
--- a/.github/workflows/android-release-to-org-openfoodfacts-scanner.yml
+++ b/.github/workflows/android-release-to-org-openfoodfacts-scanner.yml
@@ -80,6 +80,9 @@ jobs:
       - name: Flutter version    
         run: flutter --version
 
+      - name: Enable MLKit dependency
+        run: ci/enable_mlkit_dependency.sh
+
       - name: Get dependencies
         run: ci/pub_upgrade.sh
 

--- a/.github/workflows/ios-release-to-org-openfoodfacts-scanner.yml
+++ b/.github/workflows/ios-release-to-org-openfoodfacts-scanner.yml
@@ -70,6 +70,9 @@ jobs:
       - name: Flutter version    
         run: flutter --version
 
+      - name: Enable MLKit dependency
+        run: ci/enable_mlkit_dependency.sh
+
       - name: Get dependencies
         run: ci/pub_upgrade.sh
       

--- a/.run/Android (Amazon App Store).run.xml
+++ b/.run/Android (Amazon App Store).run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Android (Amazon App Store)" type="FlutterRunConfigurationType" factoryName="Flutter" folderName="New Folder">
+    <option name="filePath" value="$PROJECT_DIR$/packages/app/lib/entrypoints/android/main_amazon_appstore.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Android (Amazon App Store).run.xml
+++ b/.run/Android (Amazon App Store).run.xml
@@ -1,6 +1,8 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Android (Amazon App Store)" type="FlutterRunConfigurationType" factoryName="Flutter" folderName="Android">
     <option name="filePath" value="$PROJECT_DIR$/packages/app/lib/entrypoints/android/main_amazon_appstore.dart" />
-    <method v="2" />
+    <method v="2">
+      <option name="RunConfigurationTask" enabled="true" run_configuration_name="Enable scanner_zxing dependency" run_configuration_type="ShConfigurationType" />
+    </method>
   </configuration>
 </component>

--- a/.run/Android (Amazon App Store).run.xml
+++ b/.run/Android (Amazon App Store).run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Android (Amazon App Store)" type="FlutterRunConfigurationType" factoryName="Flutter" folderName="New Folder">
+  <configuration default="false" name="Android (Amazon App Store)" type="FlutterRunConfigurationType" factoryName="Flutter" folderName="Android">
     <option name="filePath" value="$PROJECT_DIR$/packages/app/lib/entrypoints/android/main_amazon_appstore.dart" />
     <method v="2" />
   </configuration>

--- a/.run/Android (Fdroid).dart.run.xml
+++ b/.run/Android (Fdroid).dart.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Android (Fdroid).dart" type="FlutterRunConfigurationType" factoryName="Flutter" folderName="New Folder">
+    <option name="filePath" value="$PROJECT_DIR$/packages/app/lib/entrypoints/android/main_fdroid.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Android (Fdroid).dart.run.xml
+++ b/.run/Android (Fdroid).dart.run.xml
@@ -1,6 +1,8 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Android (Fdroid).dart" type="FlutterRunConfigurationType" factoryName="Flutter" folderName="Android">
     <option name="filePath" value="$PROJECT_DIR$/packages/app/lib/entrypoints/android/main_fdroid.dart" />
-    <method v="2" />
+    <method v="2">
+      <option name="RunConfigurationTask" enabled="true" run_configuration_name="Enable scanner_zxing dependency" run_configuration_type="ShConfigurationType" />
+    </method>
   </configuration>
 </component>

--- a/.run/Android (Fdroid).dart.run.xml
+++ b/.run/Android (Fdroid).dart.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Android (Fdroid).dart" type="FlutterRunConfigurationType" factoryName="Flutter" folderName="New Folder">
+  <configuration default="false" name="Android (Fdroid).dart" type="FlutterRunConfigurationType" factoryName="Flutter" folderName="Android">
     <option name="filePath" value="$PROJECT_DIR$/packages/app/lib/entrypoints/android/main_fdroid.dart" />
     <method v="2" />
   </configuration>

--- a/.run/Android (Google Play).dart.run.xml
+++ b/.run/Android (Google Play).dart.run.xml
@@ -1,6 +1,8 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Android (Google Play).dart" type="FlutterRunConfigurationType" factoryName="Flutter" folderName="Android">
     <option name="filePath" value="$PROJECT_DIR$/packages/app/lib/entrypoints/android/main_google_play.dart" />
-    <method v="2" />
+    <method v="2">
+      <option name="RunConfigurationTask" enabled="true" run_configuration_name="Enable scanner_mlkit dependency" run_configuration_type="ShConfigurationType" />
+    </method>
   </configuration>
 </component>

--- a/.run/Android (Google Play).dart.run.xml
+++ b/.run/Android (Google Play).dart.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Android (Google Play).dart" type="FlutterRunConfigurationType" factoryName="Flutter" folderName="New Folder">
+    <option name="filePath" value="$PROJECT_DIR$/packages/app/lib/entrypoints/android/main_google_play.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Android (Google Play).dart.run.xml
+++ b/.run/Android (Google Play).dart.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Android (Google Play).dart" type="FlutterRunConfigurationType" factoryName="Flutter" folderName="New Folder">
+  <configuration default="false" name="Android (Google Play).dart" type="FlutterRunConfigurationType" factoryName="Flutter" folderName="Android">
     <option name="filePath" value="$PROJECT_DIR$/packages/app/lib/entrypoints/android/main_google_play.dart" />
     <method v="2" />
   </configuration>

--- a/.run/Android (Huawei Appgallery).run.xml
+++ b/.run/Android (Huawei Appgallery).run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Android (Huawei Appgallery)" type="FlutterRunConfigurationType" factoryName="Flutter" folderName="New Folder">
+  <configuration default="false" name="Android (Huawei Appgallery)" type="FlutterRunConfigurationType" factoryName="Flutter" folderName="Android">
     <option name="filePath" value="$PROJECT_DIR$/packages/app/lib/entrypoints/android/main_huawei_appgallery.dart" />
     <method v="2" />
   </configuration>

--- a/.run/Android (Huawei Appgallery).run.xml
+++ b/.run/Android (Huawei Appgallery).run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Android (Huawei Appgallery)" type="FlutterRunConfigurationType" factoryName="Flutter" folderName="New Folder">
+    <option name="filePath" value="$PROJECT_DIR$/packages/app/lib/entrypoints/android/main_huawei_appgallery.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Android (Huawei Appgallery).run.xml
+++ b/.run/Android (Huawei Appgallery).run.xml
@@ -1,6 +1,8 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Android (Huawei Appgallery)" type="FlutterRunConfigurationType" factoryName="Flutter" folderName="Android">
     <option name="filePath" value="$PROJECT_DIR$/packages/app/lib/entrypoints/android/main_huawei_appgallery.dart" />
-    <method v="2" />
+    <method v="2">
+      <option name="RunConfigurationTask" enabled="true" run_configuration_name="Enable scanner_zxing dependency" run_configuration_type="ShConfigurationType" />
+    </method>
   </configuration>
 </component>

--- a/.run/Android (Samsung Gallery).dart.run.xml
+++ b/.run/Android (Samsung Gallery).dart.run.xml
@@ -1,6 +1,8 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Android (Samsung Gallery).dart" type="FlutterRunConfigurationType" factoryName="Flutter" folderName="Android">
     <option name="filePath" value="$PROJECT_DIR$/packages/app/lib/entrypoints/android/main_samsung_gallery.dart" />
-    <method v="2" />
+    <method v="2">
+      <option name="RunConfigurationTask" enabled="true" run_configuration_name="Enable scanner_mlkit dependency" run_configuration_type="ShConfigurationType" />
+    </method>
   </configuration>
 </component>

--- a/.run/Android (Samsung Gallery).dart.run.xml
+++ b/.run/Android (Samsung Gallery).dart.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Android (Samsung Gallery).dart" type="FlutterRunConfigurationType" factoryName="Flutter" folderName="New Folder">
+    <option name="filePath" value="$PROJECT_DIR$/packages/app/lib/entrypoints/android/main_samsung_gallery.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Android (Samsung Gallery).dart.run.xml
+++ b/.run/Android (Samsung Gallery).dart.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Android (Samsung Gallery).dart" type="FlutterRunConfigurationType" factoryName="Flutter" folderName="New Folder">
+  <configuration default="false" name="Android (Samsung Gallery).dart" type="FlutterRunConfigurationType" factoryName="Flutter" folderName="Android">
     <option name="filePath" value="$PROJECT_DIR$/packages/app/lib/entrypoints/android/main_samsung_gallery.dart" />
     <method v="2" />
   </configuration>

--- a/.run/Enable scanner_mlkit dependency.run.xml
+++ b/.run/Enable scanner_mlkit dependency.run.xml
@@ -1,0 +1,17 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Enable scanner_mlkit dependency" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="sed -i '' 's|#scanner_mlkit|scanner_mlkit|g' packages/app/pubspec.yaml &amp;&amp; sed -i '' 's|#path:../scanner/mlkit|path:../scanner/mlkit|g' packages/app/pubspec.yaml" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="$PROJECT_DIR$/ci/enable_mlkit_dependency.sh" />
+    <option name="SCRIPT_OPTIONS" value="" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="/bin/zsh" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="true" />
+    <option name="EXECUTE_SCRIPT_FILE" value="true" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Enable scanner_zxing dependency.run.xml
+++ b/.run/Enable scanner_zxing dependency.run.xml
@@ -1,0 +1,17 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Enable scanner_zxing dependency" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="sed -i '' 's|#scanner_mlkit|scanner_mlkit|g' packages/app/pubspec.yaml &amp;&amp; sed -i '' 's|#path:../scanner/mlkit|path:../scanner/mlkit|g' packages/app/pubspec.yaml" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="$PROJECT_DIR$/ci/enable_zxing_dependency.sh" />
+    <option name="SCRIPT_OPTIONS" value="" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="/bin/zsh" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="true" />
+    <option name="EXECUTE_SCRIPT_FILE" value="true" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/iOS app.run.xml
+++ b/.run/iOS app.run.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="iOS app" type="FlutterRunConfigurationType" factoryName="Flutter" folderName="New Folder">
+    <option name="filePath" value="$PROJECT_DIR$/packages/app/lib/entrypoints/ios/main_ios.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/iOS app.run.xml
+++ b/.run/iOS app.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="iOS app" type="FlutterRunConfigurationType" factoryName="Flutter" folderName="New Folder">
+  <configuration default="false" name="iOS app" type="FlutterRunConfigurationType" factoryName="Flutter" folderName="iOS">
     <option name="filePath" value="$PROJECT_DIR$/packages/app/lib/entrypoints/ios/main_ios.dart" />
     <method v="2" />
   </configuration>

--- a/.run/iOS app.run.xml
+++ b/.run/iOS app.run.xml
@@ -1,6 +1,8 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="iOS app" type="FlutterRunConfigurationType" factoryName="Flutter" folderName="iOS">
     <option name="filePath" value="$PROJECT_DIR$/packages/app/lib/entrypoints/ios/main_ios.dart" />
-    <method v="2" />
+    <method v="2">
+      <option name="RunConfigurationTask" enabled="true" run_configuration_name="Enable scanner_mlkit dependency" run_configuration_type="ShConfigurationType" />
+    </method>
   </configuration>
 </component>

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,10 +1,34 @@
 {
-    "configurations": [
-        {
-            "name": "Gooogle Play flavor",
-            "type": "dart",
-            "request": "launch",
-            "program": "packages/app/lib/entrypoints/android/main_google_play.dart"
-        }
-    ]
+  "configurations": [
+    {
+      "name": "Android - Google Play",
+      "type": "dart",
+      "request": "launch",
+      "program": "packages/app/lib/entrypoints/android/main_google_play.dart"
+    },
+    {
+      "name": "iOS",
+      "type": "dart",
+      "request": "launch",
+      "program": "packages/app/lib/entrypoints/ios/main_ios.dart"
+    },
+    {
+      "name": "Android - FDroid",
+      "type": "dart",
+      "request": "launch",
+      "program": "packages/app/lib/entrypoints/android/main_fdroid.dart"
+    },
+    {
+      "name": "Android - Amazon App Store",
+      "type": "dart",
+      "request": "launch",
+      "program": "packages/app/lib/entrypoints/android/main_amazon_appstore.dart"
+    },
+    {
+      "name": "Android - Huawei App Gallery",
+      "type": "dart",
+      "request": "launch",
+      "program": "packages/app/lib/entrypoints/android/main_huawei_appgallery.dart"
+    }
+  ]
 }

--- a/ci/enable_mlkit_dependency.sh
+++ b/ci/enable_mlkit_dependency.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# So that users can run this script from anywhere and it will work as expected.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+REPO_DIR="$(dirname "$SCRIPT_DIR")"
+
+sed -i '' 's|^  #scanner_mlkit|  scanner_mlkit|g' packages/app/pubspec.yaml
+sed -i '' 's|^    #path: ../scanner/mlkit|    path: ../scanner/mlkit|g' packages/app/pubspec.yaml
+sed -i '' 's|^  scanner_zxing|  #scanner_zxing|g' packages/app/pubspec.yaml
+sed -i '' 's|^    path: ../scanner/zxing|    #path: ../scanner/zxing|g' packages/app/pubspec.yaml

--- a/ci/enable_zxing_dependency.sh
+++ b/ci/enable_zxing_dependency.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# So that users can run this script from anywhere and it will work as expected.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+REPO_DIR="$(dirname "$SCRIPT_DIR")"
+
+sed -i '' 's|^  scanner_mlkit|  #scanner_mlkit|g' packages/app/pubspec.yaml
+sed -i '' 's|^    path: ../scanner/mlkit|    #path: ../scanner/mlkit|g' packages/app/pubspec.yaml
+sed -i '' 's|^  #scanner_zxing|  scanner_zxing|g' packages/app/pubspec.yaml
+sed -i '' 's|^    #path: ../scanner/zxing|    path: ../scanner/zxing|g' packages/app/pubspec.yaml

--- a/ci/testing.sh
+++ b/ci/testing.sh
@@ -18,8 +18,16 @@ SHARD="${SHARD:-${1:-test}}"
 
 if [[ "$SHARD" == "test" ]]; then
   echo "Running tests."
+
+  # Ignore scanner/ folder and navigate instead to the sub-folders
   for file in "$REPO_DIR/packages/"*; do
-    if [[ -d $file ]]; then
+    if [[ "$file" == *scanner ]]; then
+      for file in "$file/"*; do
+        if [[ -d $file ]]; then
+          (cd "$file" && flutter test --coverage)
+        fi
+      done
+    elif [[ -d $file ]]; then
       (cd "$file" && flutter test --coverage)
     fi
   done

--- a/packages/app/lib/entrypoints/android/main_amazon_appstore.dart
+++ b/packages/app/lib/entrypoints/android/main_amazon_appstore.dart
@@ -1,8 +1,12 @@
+import 'package:scanner_mlkit/scanner_mlkit.dart';
 import 'package:smooth_app/main.dart';
 
 /// Amazon App Store version with:
 /// - Barcode decoding algorithm: ZXing
 /// - Intent to launch the review
 void main() {
-  launchSmoothApp();
+  launchSmoothApp(
+    // TODO(g123k): Replace this when ZXing is ready
+    scanner: MLKitCameraScanner(),
+  );
 }

--- a/packages/app/lib/entrypoints/android/main_fdroid.dart
+++ b/packages/app/lib/entrypoints/android/main_fdroid.dart
@@ -1,8 +1,12 @@
+import 'package:scanner_mlkit/scanner_mlkit.dart';
 import 'package:smooth_app/main.dart';
 
 /// Fdroid version with:
 /// - Barcode decoding algorithm: ZXing
 /// - Intent to launch the review
 void main() {
-  launchSmoothApp();
+  launchSmoothApp(
+    // TODO(g123k): Replace this when ZXing is ready
+    scanner: MLKitCameraScanner(),
+  );
 }

--- a/packages/app/lib/entrypoints/android/main_google_play.dart
+++ b/packages/app/lib/entrypoints/android/main_google_play.dart
@@ -1,8 +1,11 @@
+import 'package:scanner_mlkit/scanner_mlkit.dart';
 import 'package:smooth_app/main.dart';
 
 /// Google Play version with:
 /// - Barcode decoding algorithm: MLKit
 /// - Google Play app review SDK
 void main() {
-  launchSmoothApp();
+  launchSmoothApp(
+    scanner: MLKitCameraScanner(),
+  );
 }

--- a/packages/app/lib/entrypoints/android/main_huawei_appgallery.dart
+++ b/packages/app/lib/entrypoints/android/main_huawei_appgallery.dart
@@ -1,8 +1,12 @@
+import 'package:scanner_mlkit/scanner_mlkit.dart';
 import 'package:smooth_app/main.dart';
 
 /// Huawei App Gallery version with:
 /// - Barcode decoding algorithm: ZXing
 /// - Intent to launch the review
 void main() {
-  launchSmoothApp();
+  launchSmoothApp(
+    // TODO(g123k): Replace this when ZXing is ready
+    scanner: MLKitCameraScanner(),
+  );
 }

--- a/packages/app/lib/entrypoints/android/main_samsung_gallery.dart
+++ b/packages/app/lib/entrypoints/android/main_samsung_gallery.dart
@@ -1,8 +1,11 @@
+import 'package:scanner_mlkit/scanner_mlkit.dart';
 import 'package:smooth_app/main.dart';
 
 /// Samsung Gallery version with:
 /// - Barcode decoding algorithm: MLKit
 /// - Intent to launch the review
 void main() {
-  launchSmoothApp();
+  launchSmoothApp(
+    scanner: MLKitCameraScanner(),
+  );
 }

--- a/packages/app/lib/entrypoints/ios/main_ios.dart
+++ b/packages/app/lib/entrypoints/ios/main_ios.dart
@@ -1,8 +1,11 @@
+import 'package:scanner_mlkit/scanner_mlkit.dart';
 import 'package:smooth_app/main.dart';
 
 /// App Store/TestFlight version with:
 /// - Barcode decoding algorithm: MLKit
 /// - iOS SDK to open the store
 void main() {
-  launchSmoothApp();
+  launchSmoothApp(
+    scanner: MLKitCameraScanner(),
+  );
 }

--- a/packages/app/pubspec.lock
+++ b/packages/app/pubspec.lock
@@ -366,7 +366,7 @@ packages:
       name: flutter_isolate
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.3"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
@@ -1003,6 +1003,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.27.4"
+  scanner_mlkit:
+    dependency: "direct main"
+    description:
+      path: "../scanner/mlkit"
+      relative: true
+    source: path
+    version: "0.0.1"
+  scanner_shared:
+    dependency: "direct main"
+    description:
+      path: "../scanner/shared"
+      relative: true
+    source: path
+    version: "1.0.0"
   sentry:
     dependency: transitive
     description:

--- a/packages/app/pubspec.yaml
+++ b/packages/app/pubspec.yaml
@@ -16,6 +16,14 @@ dependencies:
   smooth_app:
     path: ../smooth_app
 
+  scanner_shared:
+    path: ../scanner/shared
+
+  # According to the build variant, only one "scanner" implementation must be added when building a release
+  # Call "flutter pub remove xxxx" to remove unused dependencies
+  scanner_mlkit:
+    path: ../scanner/mlkit
+
 dev_dependencies:
   integration_test:
     sdk: flutter

--- a/packages/scanner/mlkit/.gitignore
+++ b/packages/scanner/mlkit/.gitignore
@@ -1,0 +1,30 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+migrate_working_dir/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+# Libraries should not include pubspec.lock, per https://dart.dev/guides/libraries/private-files#pubspeclock.
+/pubspec.lock
+**/doc/api/
+.dart_tool/
+.packages
+build/

--- a/packages/scanner/mlkit/.metadata
+++ b/packages/scanner/mlkit/.metadata
@@ -1,0 +1,10 @@
+# This file tracks properties of this Flutter project.
+# Used by Flutter tool to assess capabilities and perform upgrades etc.
+#
+# This file should be version controlled and should not be manually edited.
+
+version:
+  revision: f1875d570e39de09040c8f79aa13cc56baab8db1
+  channel: stable
+
+project_type: package

--- a/packages/scanner/mlkit/analysis_options.yaml
+++ b/packages/scanner/mlkit/analysis_options.yaml
@@ -1,0 +1,2 @@
+# Shared rules
+include: package:openfoodfacts_flutter_lints/flutter.yaml

--- a/packages/scanner/mlkit/lib/scanner_mlkit.dart
+++ b/packages/scanner/mlkit/lib/scanner_mlkit.dart
@@ -1,0 +1,3 @@
+library scanner_mlkit;
+
+export 'src/mlkit_camera_scanner.dart';

--- a/packages/scanner/mlkit/lib/src/utils/abstract_camera_image_getter.dart
+++ b/packages/scanner/mlkit/lib/src/utils/abstract_camera_image_getter.dart
@@ -1,8 +1,8 @@
 import 'dart:typed_data';
 
-import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
 import 'package:google_mlkit_barcode_scanning/google_mlkit_barcode_scanning.dart';
+import 'package:scanner_shared/scanner_shared.dart';
 
 /// Abstract getter of Camera Image, for barcode scan.
 ///

--- a/packages/scanner/mlkit/lib/src/utils/camera_image_cropper.dart
+++ b/packages/scanner/mlkit/lib/src/utils/camera_image_cropper.dart
@@ -1,9 +1,9 @@
-import 'package:camera/camera.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:google_mlkit_barcode_scanning/google_mlkit_barcode_scanning.dart';
-import 'package:smooth_app/pages/scan/abstract_camera_image_getter.dart';
-import 'package:typed_data/typed_data.dart';
+import 'package:scanner_mlkit/src/utils/abstract_camera_image_getter.dart';
+import 'package:scanner_shared/scanner_shared.dart';
+import 'package:typed_data/typed_buffers.dart';
 
 /// Camera Image Cropper, in order to limit the barcode scan computations.
 ///

--- a/packages/scanner/mlkit/lib/src/utils/camera_image_full_getter.dart
+++ b/packages/scanner/mlkit/lib/src/utils/camera_image_full_getter.dart
@@ -1,8 +1,8 @@
-import 'package:camera/camera.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:google_mlkit_barcode_scanning/google_mlkit_barcode_scanning.dart';
-import 'package:smooth_app/pages/scan/abstract_camera_image_getter.dart';
+import 'package:scanner_mlkit/src/utils/abstract_camera_image_getter.dart';
+import 'package:scanner_shared/scanner_shared.dart';
 
 /// Camera Image helper where we get the full image.
 ///

--- a/packages/scanner/mlkit/pubspec.yaml
+++ b/packages/scanner/mlkit/pubspec.yaml
@@ -1,0 +1,28 @@
+name: scanner_mlkit
+description: MLKit implementation for the scanning feature
+version: 0.0.1
+publish_to: "none"
+
+environment:
+  sdk: ">=2.18.0 <3.0.0"
+  flutter: ">=3.3.2"
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+  scanner_shared:
+    path: ../shared
+
+  flutter_isolate: 2.0.3
+  google_mlkit_barcode_scanning: 0.3.0
+  typed_data: 1.3.1
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: 2.0.1
+  openfoodfacts_flutter_lints:
+    git: https://github.com/openfoodfacts/openfoodfacts_flutter_lints.git
+
+flutter:

--- a/packages/scanner/mlkit/test/scanner_mlkit_test.dart
+++ b/packages/scanner/mlkit/test/scanner_mlkit_test.dart
@@ -1,0 +1,8 @@
+import 'package:flutter_test/flutter_test.dart';
+
+// The CI needs at least one test
+void main() {
+  testWidgets('Fake test', (WidgetTester tester) async {
+    expect(true, true);
+  });
+}

--- a/packages/scanner/shared/.gitignore
+++ b/packages/scanner/shared/.gitignore
@@ -1,0 +1,30 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+migrate_working_dir/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+# Libraries should not include pubspec.lock, per https://dart.dev/guides/libraries/private-files#pubspeclock.
+/pubspec.lock
+**/doc/api/
+.dart_tool/
+.packages
+build/

--- a/packages/scanner/shared/.metadata
+++ b/packages/scanner/shared/.metadata
@@ -1,0 +1,10 @@
+# This file tracks properties of this Flutter project.
+# Used by Flutter tool to assess capabilities and perform upgrades etc.
+#
+# This file should be version controlled and should not be manually edited.
+
+version:
+  revision: eb6d86ee27deecba4a83536aa20f366a6044895c
+  channel: stable
+
+project_type: package

--- a/packages/scanner/shared/analysis_options.yaml
+++ b/packages/scanner/shared/analysis_options.yaml
@@ -1,0 +1,2 @@
+# Shared rules
+include: package:openfoodfacts_flutter_lints/flutter.yaml

--- a/packages/scanner/shared/lib/scanner_shared.dart
+++ b/packages/scanner/shared/lib/scanner_shared.dart
@@ -1,0 +1,6 @@
+library scanner_shared;
+
+export 'src/scanner.dart';
+export 'src/scanner_log.dart';
+export 'src/scanner_mocked.dart';
+export 'src/scanner_modes.dart';

--- a/packages/scanner/shared/lib/src/scanner.dart
+++ b/packages/scanner/shared/lib/src/scanner.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/foundation.dart';
+import 'package:scanner_shared/scanner_shared.dart';
+
+/// Export the [CameraImage] class
+export 'package:camera/camera.dart';
+
+/// Base class for MLKit, ZXing and other scanners
+abstract class CameraScanner with CameraScannerLogMixin {
+  Future<void> onInit({
+    required CameraDescription camera,
+    required DevModeScanMode mode,
+  });
+
+  Future<List<String?>?> processImage(dynamic image) {
+    assert(isInitialized, 'onInit() must be called before _onNewImage()');
+
+    if (image is CameraImage) {
+      return onNewCameraImage(image);
+    } else if (image is String) {
+      return onNewCameraFile(image);
+    } else {
+      throw Exception('Unsupported image type: $image');
+    }
+  }
+
+  @protected
+  Future<List<String?>?> onNewCameraImage(CameraImage image);
+
+  @protected
+  Future<List<String?>?> onNewCameraFile(String path);
+
+  bool get supportCameraImage;
+
+  bool get supportCameraFile;
+
+  bool get isInitialized;
+
+  /// When the device is in low memory mode
+  void onLowMemory() {}
+
+  Future<void> onPause() async {}
+
+  Future<void> onResume() async {}
+
+  @mustCallSuper
+  Future<void> onDispose() async {
+    disposeLogs();
+  }
+
+  @protected
+  Stream<CameraScannerLog> listenToLogs() => controller;
+}

--- a/packages/scanner/shared/lib/src/scanner_log.dart
+++ b/packages/scanner/shared/lib/src/scanner_log.dart
@@ -1,0 +1,34 @@
+import 'dart:async';
+
+mixin CameraScannerLogMixin {
+  final StreamController<CameraScannerLog> _controller =
+      StreamController<CameraScannerLog>.broadcast();
+
+  void addLog(
+          {required String message,
+          dynamic exception,
+          StackTrace? stackTrace}) =>
+      _controller.add(
+        CameraScannerLog(
+          message,
+          exception: exception,
+          stackTrace: stackTrace,
+        ),
+      );
+
+  Stream<CameraScannerLog> get controller => _controller.stream;
+
+  Future<dynamic> disposeLogs() => _controller.close();
+}
+
+class CameraScannerLog {
+  const CameraScannerLog(
+    this.message, {
+    this.exception,
+    this.stackTrace,
+  });
+
+  final String message;
+  final dynamic exception;
+  final StackTrace? stackTrace;
+}

--- a/packages/scanner/shared/lib/src/scanner_mocked.dart
+++ b/packages/scanner/shared/lib/src/scanner_mocked.dart
@@ -1,0 +1,30 @@
+import 'package:scanner_shared/scanner_shared.dart';
+
+/// Empty implementation
+/// (for testing or on non-supported platforms like the desktop)
+class MockedCameraScanner extends CameraScanner {
+  @override
+  Future<void> onInit({
+    required CameraDescription camera,
+    required DevModeScanMode mode,
+  }) async {}
+
+  @override
+  Future<List<String?>?> onNewCameraFile(String path) async {
+    return <String>[];
+  }
+
+  @override
+  Future<List<String?>?> onNewCameraImage(CameraImage image) async {
+    return <String>[];
+  }
+
+  @override
+  bool get supportCameraFile => true;
+
+  @override
+  bool get supportCameraImage => true;
+
+  @override
+  bool get isInitialized => true;
+}

--- a/packages/scanner/shared/lib/src/scanner_modes.dart
+++ b/packages/scanner/shared/lib/src/scanner_modes.dart
@@ -1,0 +1,51 @@
+enum DevModeScanMode {
+  CAMERA_ONLY,
+  PREPROCESS_FULL_IMAGE,
+  PREPROCESS_HALF_IMAGE,
+  SCAN_FULL_IMAGE,
+  SCAN_HALF_IMAGE;
+
+  static DevModeScanMode get defaultScanMode => DevModeScanMode.SCAN_FULL_IMAGE;
+
+  String get label {
+    switch (this) {
+      case DevModeScanMode.CAMERA_ONLY:
+        return 'Only camera stream, no scanning';
+      case DevModeScanMode.PREPROCESS_FULL_IMAGE:
+        return 'Camera stream and full image preprocessing, no scanning';
+      case DevModeScanMode.PREPROCESS_HALF_IMAGE:
+        return 'Camera stream and half image preprocessing, no scanning';
+      case DevModeScanMode.SCAN_FULL_IMAGE:
+        return 'Full image scanning';
+      case DevModeScanMode.SCAN_HALF_IMAGE:
+        return 'Half image scanning';
+    }
+  }
+
+  int get idx {
+    switch (this) {
+      case DevModeScanMode.CAMERA_ONLY:
+        return 4;
+      case DevModeScanMode.PREPROCESS_FULL_IMAGE:
+        return 3;
+      case DevModeScanMode.PREPROCESS_HALF_IMAGE:
+        return 2;
+      case DevModeScanMode.SCAN_FULL_IMAGE:
+        return 0;
+      case DevModeScanMode.SCAN_HALF_IMAGE:
+        return 1;
+    }
+  }
+
+  static DevModeScanMode fromIndex(final int? index) {
+    if (index == null) {
+      return defaultScanMode;
+    }
+    for (final DevModeScanMode scanMode in DevModeScanMode.values) {
+      if (scanMode.index == index) {
+        return scanMode;
+      }
+    }
+    throw Exception('Unknown index $index');
+  }
+}

--- a/packages/scanner/shared/pubspec.yaml
+++ b/packages/scanner/shared/pubspec.yaml
@@ -1,0 +1,33 @@
+name: scanner_shared
+description: Shared interfaces between implementations
+version: 1.0.0
+publish_to: "none"
+
+environment:
+  sdk: '>=2.18.0 <3.0.0'
+  flutter: ">=3.3.2"
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+  # Camera (custom implementation for Android)
+  camera:
+    git:
+      url: "https://github.com/g123k/plugins.git"
+      ref: "smooth_camera"
+      path: "packages/camera/camera"
+  camera_platform_interface:
+    git:
+      url: "https://github.com/g123k/plugins.git"
+      ref: "smooth_camera"
+      path: "packages/camera/camera_platform_interface"
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: 2.0.1
+  openfoodfacts_flutter_lints:
+    git: https://github.com/openfoodfacts/openfoodfacts_flutter_lints.git
+
+flutter:

--- a/packages/scanner/shared/test/shared_test.dart
+++ b/packages/scanner/shared/test/shared_test.dart
@@ -1,0 +1,8 @@
+import 'package:flutter_test/flutter_test.dart';
+
+// The CI needs at least one test
+void main() {
+  testWidgets('Fake test', (WidgetTester tester) async {
+    expect(true, true);
+  });
+}

--- a/packages/smooth_app/integration_test/app_test.dart
+++ b/packages/smooth_app/integration_test/app_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
+import 'package:scanner_shared/scanner_shared.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:smooth_app/main.dart' as app;
 
@@ -52,7 +53,8 @@ void main() {
       await tester.runAsync(() async {
         await _initScreenshot(binding);
 
-        await app.launchSmoothApp(screenshots: true);
+        await app.launchSmoothApp(
+            scanner: MockedCameraScanner(), screenshots: true);
         await tester.pumpAndSettle();
 
         sleep(const Duration(seconds: 30));

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_dev_mode.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_dev_mode.dart
@@ -4,6 +4,7 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:openfoodfacts/model/Attribute.dart';
 import 'package:openfoodfacts/utils/OpenFoodAPIConfiguration.dart';
 import 'package:provider/provider.dart';
+import 'package:scanner_shared/scanner_shared.dart';
 import 'package:smooth_app/data_models/product_list.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/database/dao_product.dart';
@@ -504,30 +505,7 @@ class UserPreferencesDevMode extends AbstractUserPreferences {
   }
 }
 
-enum DevModeScanMode {
-  CAMERA_ONLY,
-  PREPROCESS_FULL_IMAGE,
-  PREPROCESS_HALF_IMAGE,
-  SCAN_FULL_IMAGE,
-  SCAN_HALF_IMAGE;
-
-  static DevModeScanMode get defaultScanMode => DevModeScanMode.SCAN_FULL_IMAGE;
-
-  String get label {
-    switch (this) {
-      case DevModeScanMode.CAMERA_ONLY:
-        return 'Only camera stream, no scanning';
-      case DevModeScanMode.PREPROCESS_FULL_IMAGE:
-        return 'Camera stream and full image preprocessing, no scanning';
-      case DevModeScanMode.PREPROCESS_HALF_IMAGE:
-        return 'Camera stream and half image preprocessing, no scanning';
-      case DevModeScanMode.SCAN_FULL_IMAGE:
-        return 'Full image scanning';
-      case DevModeScanMode.SCAN_HALF_IMAGE:
-        return 'Half image scanning';
-    }
-  }
-
+extension DevModeScanModeExt on DevModeScanMode {
   String localizedLabel(AppLocalizations appLocalizations) {
     switch (this) {
       case DevModeScanMode.CAMERA_ONLY:
@@ -541,32 +519,5 @@ enum DevModeScanMode {
       case DevModeScanMode.SCAN_HALF_IMAGE:
         return appLocalizations.dev_mode_scan_scan_half_image;
     }
-  }
-
-  int get idx {
-    switch (this) {
-      case DevModeScanMode.CAMERA_ONLY:
-        return 4;
-      case DevModeScanMode.PREPROCESS_FULL_IMAGE:
-        return 3;
-      case DevModeScanMode.PREPROCESS_HALF_IMAGE:
-        return 2;
-      case DevModeScanMode.SCAN_FULL_IMAGE:
-        return 0;
-      case DevModeScanMode.SCAN_HALF_IMAGE:
-        return 1;
-    }
-  }
-
-  static DevModeScanMode fromIndex(final int? index) {
-    if (index == null) {
-      return defaultScanMode;
-    }
-    for (final DevModeScanMode scanMode in DevModeScanMode.values) {
-      if (scanMode.index == index) {
-        return scanMode;
-      }
-    }
-    throw Exception('Unknown index $index');
   }
 }

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -133,7 +133,7 @@ packages:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.4.1"
+    version: "8.4.2"
   camera:
     dependency: "direct main"
     description:
@@ -237,7 +237,7 @@ packages:
       name: connectivity_plus_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.3"
   connectivity_plus_web:
     dependency: transitive
     description:
@@ -423,13 +423,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "5.1.0"
-  flutter_isolate:
-    dependency: "direct main"
-    description:
-      name: flutter_isolate
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.3"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
@@ -569,20 +562,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
-  google_mlkit_barcode_scanning:
-    dependency: "direct main"
-    description:
-      name: google_mlkit_barcode_scanning
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.3.0"
-  google_mlkit_commons:
-    dependency: transitive
-    description:
-      name: google_mlkit_commons
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.2.0"
   hive:
     dependency: "direct main"
     description:
@@ -603,7 +582,7 @@ packages:
       name: html
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.15.0"
+    version: "0.15.1"
   http:
     dependency: "direct main"
     description:
@@ -734,7 +713,7 @@ packages:
       name: lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   lists:
     dependency: transitive
     description:
@@ -988,7 +967,7 @@ packages:
       name: permission_handler_apple
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "9.0.6"
+    version: "9.0.7"
   permission_handler_platform_interface:
     dependency: transitive
     description:
@@ -1002,14 +981,14 @@ packages:
       name: permission_handler_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.1"
+    version: "0.1.2"
   petitparser:
     dependency: transitive
     description:
       name: petitparser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.0"
+    version: "5.1.0"
   photo_view:
     dependency: "direct main"
     description:
@@ -1094,13 +1073,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.27.4"
+  scanner_shared:
+    dependency: "direct main"
+    description:
+      path: "../scanner/shared"
+      relative: true
+    source: path
+    version: "1.0.0"
   sentry:
     dependency: transitive
     description:
       name: sentry
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.12.2"
+    version: "6.13.1"
   sentry_flutter:
     dependency: "direct main"
     description:
@@ -1135,7 +1121,7 @@ packages:
       name: share_plus_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.1"
+    version: "3.2.0"
   share_plus_web:
     dependency: transitive
     description:
@@ -1245,7 +1231,7 @@ packages:
       name: sqflite_common
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.0"
+    version: "2.4.0+2"
   stack_trace:
     dependency: transitive
     description:
@@ -1359,7 +1345,7 @@ packages:
       name: url_launcher_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.19"
+    version: "6.0.20"
   url_launcher_ios:
     dependency: transitive
     description:
@@ -1464,7 +1450,7 @@ packages:
       name: workmanager
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.0"
+    version: "0.5.1"
   xdg_directories:
     dependency: transitive
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -55,6 +55,8 @@ dependencies:
       url: "https://github.com/g123k/plugins.git"
       ref: "smooth_camera"
       path: "packages/camera/camera_platform_interface"
+  scanner_shared:
+    path: ../scanner/shared
   task_manager:
     git:
       url: "https://github.com/g123k/flutter_task_manager.git"
@@ -63,14 +65,12 @@ dependencies:
   percent_indicator: 4.2.2
   flutter_email_sender: 5.1.0
   flutter_native_splash: 2.2.3+1
-  google_mlkit_barcode_scanning: 0.3.0
   image: 3.2.0
   image_cropper: 2.0.3
   auto_size_text: 3.0.0
   shared_preferences: 2.0.15
   typed_data: 1.3.1
   intl: 0.17.0
-  flutter_isolate: 2.0.3
   rxdart: 0.27.4
   collection: 1.16.0
   path: ^1.8.2 # careful with 1.8.1 because of https://github.com/flutter/flutter/issues/95478

--- a/packages/smooth_app/test/basic_test.dart
+++ b/packages/smooth_app/test/basic_test.dart
@@ -1,10 +1,10 @@
 import 'package:flutter_test/flutter_test.dart';
-
+import 'package:scanner_shared/scanner_shared.dart';
 import 'package:smooth_app/main.dart';
 
 void main() {
   testWidgets('App Starts', (WidgetTester tester) async {
-    await tester.pumpWidget(const SmoothApp());
+    await tester.pumpWidget(SmoothApp(MockedCameraScanner()));
     expect(find.byType(SmoothApp), findsOneWidget);
   });
 }


### PR DESCRIPTION
MLKit is not embedded anymore in the `smooth_app` package.
We have the following structure :

```
- packages
  -  scanner
    -  shared : Generic classes for scanning purposes and used by `smooth_app`
    -  mlkit : MLKit implementation
```

⚠ In the `app` package, when we generate the different builds via GitHub Actions, we will have to dynamically remove some dependencies, by calling `flutter pub remove [scanner_mlkit]` on ZXing variants.

For debugging purposes, we don't really care about this.


Once this step is merged: creating a ZXing variant allowing FDroid, Huawei AppGallery… builds will (finally) be possible