### PR TITLE
fix: #3046 - refactored NutritionPage around Nutrient

### DIFF
--- a/packages/app/pubspec.lock
+++ b/packages/app/pubspec.lock
@@ -752,10 +752,10 @@ packages:
   openfoodfacts:
     dependency: transitive
     description:
-      name: openfoodfacts
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.26.0"
+      path: "../../../openfoodfacts-dart"
+      relative: true
+    source: path
+    version: "1.0.0"
   openfoodfacts_flutter_lints:
     dependency: "direct dev"
     description:

--- a/packages/app/pubspec.lock
+++ b/packages/app/pubspec.lock
@@ -752,10 +752,10 @@ packages:
   openfoodfacts:
     dependency: transitive
     description:
-      path: "../../../openfoodfacts-dart"
-      relative: true
-    source: path
-    version: "1.0.0"
+      name: openfoodfacts
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.26.2"
   openfoodfacts_flutter_lints:
     dependency: "direct dev"
     description:

--- a/packages/smooth_app/lib/pages/product/nutrition_add_nutrient_button.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_add_nutrient_button.dart
@@ -9,7 +9,6 @@ import 'package:smooth_app/pages/text_field_helper.dart';
 
 /// Button that opens an "add nutrient" dialog.
 ///
-/// The code was moved here in order to declutter  [NutritionPageLoaded].
 /// The [nutritionContainer] will tell which nutrients can be added, and that's
 /// where the "new" nutrient will eventually be added.
 /// The [refreshParent] will refresh the parent widget when a nutrient is added.

--- a/packages/smooth_app/lib/pages/product/nutrition_add_nutrient_button.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_add_nutrient_button.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:openfoodfacts/model/OrderedNutrient.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
+import 'package:smooth_app/generic_lib/widgets/smooth_text_form_field.dart';
+import 'package:smooth_app/pages/product/nutrition_container.dart';
+import 'package:smooth_app/pages/text_field_helper.dart';
+
+/// Button that opens an "add nutrient" dialog.
+///
+/// The code was moved here in order to declutter  [NutritionPageLoaded].
+/// The [nutritionContainer] will tell which nutrients can be added, and that's
+/// where the "new" nutrient will eventually be added.
+/// The [refreshParent] will refresh the parent widget when a nutrient is added.
+class NutritionAddNutrientButton extends StatelessWidget {
+  const NutritionAddNutrientButton({
+    required this.nutritionContainer,
+    required this.refreshParent,
+  });
+
+  final NutritionContainer nutritionContainer;
+  final VoidCallback refreshParent;
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    return ElevatedButton.icon(
+      onPressed: () async {
+        final List<OrderedNutrient> leftovers = List<OrderedNutrient>.from(
+          nutritionContainer.getLeftoverNutrients(),
+        );
+        leftovers.sort((final OrderedNutrient a, final OrderedNutrient b) =>
+            a.name!.compareTo(b.name!));
+        List<OrderedNutrient> filteredList =
+            List<OrderedNutrient>.from(leftovers);
+        final TextEditingControllerWithInitialValue nutritionTextController =
+            TextEditingControllerWithInitialValue();
+        final OrderedNutrient? selected = await showDialog<OrderedNutrient>(
+          context: context,
+          builder: (BuildContext context) => StatefulBuilder(
+            builder: (
+              BuildContext context,
+              void Function(VoidCallback fn) setState,
+            ) =>
+                SmoothAlertDialog(
+              body: SizedBox(
+                height: MediaQuery.of(context).size.height / 2,
+                width: MediaQuery.of(context).size.width,
+                child: Column(
+                  children: <Widget>[
+                    SmoothTextFormField(
+                      prefixIcon: const Icon(Icons.search),
+                      hintText: appLocalizations.search,
+                      type: TextFieldTypes.PLAIN_TEXT,
+                      controller: nutritionTextController,
+                      onChanged: (String? query) => setState(
+                        () => filteredList = leftovers
+                            .where((OrderedNutrient item) => item.name!
+                                .toLowerCase()
+                                .contains(query!.toLowerCase()))
+                            .toList(),
+                      ),
+                    ),
+                    Expanded(
+                      child: ListView.builder(
+                        itemBuilder: (BuildContext context, int index) {
+                          final OrderedNutrient nutrient = filteredList[index];
+                          return ListTile(
+                            title: Text(nutrient.name!),
+                            onTap: () => Navigator.of(context).pop(nutrient),
+                          );
+                        },
+                        itemCount: filteredList.length,
+                        shrinkWrap: true,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              positiveAction: SmoothActionButton(
+                onPressed: () => Navigator.pop(context),
+                text: appLocalizations.cancel,
+              ),
+            ),
+          ),
+        );
+        if (selected != null) {
+          nutritionContainer.add(selected);
+          refreshParent.call();
+        }
+      },
+      style: ButtonStyle(
+        shape: MaterialStateProperty.all<RoundedRectangleBorder>(
+          const RoundedRectangleBorder(
+            borderRadius: ROUNDED_BORDER_RADIUS,
+            side: BorderSide.none,
+          ),
+        ),
+      ),
+      icon: const Icon(Icons.add),
+      label: Text(appLocalizations.nutrition_page_add_nutrient),
+    );
+  }
+}

--- a/packages/smooth_app/lib/query/product_query.dart
+++ b/packages/smooth_app/lib/query/product_query.dart
@@ -126,6 +126,8 @@ abstract class ProductQuery {
         ProductField.PACKAGING_TEXT_IN_LANGUAGES,
         ProductField.PACKAGING_TEXT_ALL_LANGUAGES,
         ProductField.NO_NUTRITION_DATA,
+        ProductField.NUTRIMENT_DATA_PER,
+        ProductField.NUTRITION_DATA,
         ProductField.NUTRIMENTS,
         ProductField.NUTRIENT_LEVELS,
         ProductField.NUTRIMENT_ENERGY_UNIT,

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -832,7 +832,7 @@ packages:
       name: openfoodfacts
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.26.0"
+    version: "1.26.2"
   openfoodfacts_flutter_lints:
     dependency: "direct dev"
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   latlong2: 0.8.1
   matomo_tracker: 1.5.0
   modal_bottom_sheet: 2.1.2
-  openfoodfacts: 1.26.0
+  openfoodfacts: 1.26.2
   #  openfoodfacts:
   #    path: ../../../openfoodfacts-dart
   package_info_plus: 1.4.3+1

--- a/packages/smooth_app/test/users/registration_login_test.dart
+++ b/packages/smooth_app/test/users/registration_login_test.dart
@@ -40,7 +40,7 @@ void main() {
         User(userId: name, password: 'somerandomnewpassword'),
         queryType: queryType,
       );
-      expect(loginResponse?.successful, isNull);
+      expect(loginResponse?.successful, isFalse);
     });
 
     test('Duplicate Registration', () async {


### PR DESCRIPTION
New file:
* `nutrition_add_nutrient_button.dart`: Button that opens an "add nutrient" dialog.

Impacted files:
* `nutrition_container.dart`: heavy refactoring using `Nutrient` instead of `String` ids
* `nutrition_page_loaded.dart`: now using `Nutrient` instead of `String` ids
* `portion_helper.dart`: now using new `nutriments.getValue` instead of json map trick
* `product_query.dart`: added fields `NUTRIMENT_DATA_PER` and `NUTRITION_DATA`
* `app/pubspec.lock`: wtf
* `smooth_app/pubspec.lock`: wtf
* `pubspec.yaml`: upgraded to `openfoodfacts: 1.26.2`

### What
- In Smoothie we used to be able to edit nutrition values for both 100g and serving.
- But that's not the way things work in the end: the end-user inputs only one of them (one "column"), and the other is computed on the server side using the "serving size" factor (cf. the website interface).
- Therefore, now we only display one column, with a `<Nutrient, double?>` map behind, and only when the user clicks on "Save!" will we say if it's for 100g or for serving - depending on the "per serving?" switch. That fixes the referenced issue.
- We also used to deconstruct the nutrient json map in order to get/set values. We now have a clean approach with the new `Nutrient` class and the related methods in `Nutriments`.

### Fixes bug(s)
- Fixes: #3046