### PR TITLE
fix: #3188 - colored button for "ignore" in hunger games

### DIFF
--- a/packages/smooth_app/lib/pages/hunger_games/question_answers_options.dart
+++ b/packages/smooth_app/lib/pages/hunger_games/question_answers_options.dart
@@ -3,10 +3,13 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/model/Insight.dart';
 import 'package:openfoodfacts/model/RobotoffQuestion.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/pages/hunger_games/question_card.dart';
 
 const Color _yesBackground = Colors.lightGreen;
 const Color _noBackground = Colors.redAccent;
+const Color _maybeBackground = QuestionCard.robotoffBackground;
 const Color _yesNoTextColor = Colors.white;
+const Color _maybeTextColor = Colors.black;
 
 /// Display of the typical Yes / No / Maybe options for Robotoff
 class QuestionAnswersOptions extends StatelessWidget {
@@ -53,18 +56,14 @@ class QuestionAnswersOptions extends StatelessWidget {
               ),
             ],
           ),
-          const SizedBox(height: SMALL_SPACE),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: <Widget>[
-              _buildAnswerButton(
-                context,
-                insightAnnotation: InsightAnnotation.MAYBE,
-                backgroundColor: const Color(0xFFFFEFB7),
-                contentColor: Colors.black,
-                textButton: true,
-              ),
-            ],
+          SizedBox(
+            width: double.infinity,
+            child: _buildAnswerButton(
+              context,
+              insightAnnotation: InsightAnnotation.MAYBE,
+              backgroundColor: _maybeBackground,
+              contentColor: _maybeTextColor,
+            ),
           ),
         ],
       ),
@@ -76,7 +75,6 @@ class QuestionAnswersOptions extends StatelessWidget {
     required InsightAnnotation insightAnnotation,
     required Color backgroundColor,
     required Color contentColor,
-    bool textButton = false,
     EdgeInsets padding = const EdgeInsets.all(VERY_SMALL_SPACE),
   }) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
@@ -102,16 +100,14 @@ class QuestionAnswersOptions extends StatelessWidget {
       padding: padding,
       child: TextButton.icon(
         onPressed: () => onAnswer(insightAnnotation),
-        style: textButton
-            ? null
-            : ButtonStyle(
-                backgroundColor: MaterialStateProperty.all(backgroundColor),
-                shape: MaterialStateProperty.all(
-                  const RoundedRectangleBorder(
-                    borderRadius: ROUNDED_BORDER_RADIUS,
-                  ),
-                ),
-              ),
+        style: ButtonStyle(
+          backgroundColor: MaterialStateProperty.all(backgroundColor),
+          shape: MaterialStateProperty.all(
+            const RoundedRectangleBorder(
+              borderRadius: ROUNDED_BORDER_RADIUS,
+            ),
+          ),
+        ),
         icon: Icon(
           iconData,
           color: contentColor,

--- a/packages/smooth_app/lib/pages/hunger_games/question_card.dart
+++ b/packages/smooth_app/lib/pages/hunger_games/question_card.dart
@@ -14,6 +14,8 @@ class QuestionCard extends StatelessWidget {
 
   final RobotoffQuestion question;
 
+  static const Color robotoffBackground = Color(0xFFFFEFB7);
+
   @override
   Widget build(BuildContext context) {
     final Future<Product> productFuture = OpenFoodAPIClient.getProduct(
@@ -64,7 +66,7 @@ class QuestionCard extends StatelessWidget {
 
   Widget _buildQuestionText(BuildContext context, RobotoffQuestion question) {
     return Container(
-      color: const Color(0xFFFFEFB7),
+      color: robotoffBackground,
       padding: const EdgeInsets.all(SMALL_SPACE),
       child: Column(
         children: <Widget>[
@@ -99,7 +101,7 @@ class QuestionCard extends StatelessWidget {
   }
 
   Widget _buildQuestionShimmer() => Shimmer.fromColors(
-        baseColor: const Color(0xFFFFEFB7),
+        baseColor: robotoffBackground,
         highlightColor: Colors.white,
         child: Card(
           elevation: 4,


### PR DESCRIPTION
Impacted files:
* `question_answers_options.dart`: now using for "ignore" a button similar to yes/no
* `question_card.dart`: created a shared `Color`

### What
- The "ignore" button had for some reason a different behavior from yes and no. One side effect being that it was not legible in dark mode.
- Now it uses a similar button to yes and no, and looks similar to the website UI too.

### Screenshot
| light | dark |
| -- | -- |
| ![Capture d’écran 2022-10-23 à 11 45 53](https://user-images.githubusercontent.com/11576431/197385470-77de7b01-7968-4546-8c65-106974daf1e1.png) | ![Capture d’écran 2022-10-23 à 11 46 24](https://user-images.githubusercontent.com/11576431/197385476-84f19ba7-d71f-4328-abbe-9a48216bebde.png) |

Website:
![Capture d’écran 2022-10-23 à 11 50 47](https://user-images.githubusercontent.com/11576431/197385503-0f71851a-e081-4981-ba08-219d8c9ed816.png)

### Fixes bug(s)
- Fixes: #3188