### PR TITLE
fix: unable to load 'sample_product_data.json'

### DIFF
--- a/packages/smooth_app/lib/helpers/app_helper.dart
+++ b/packages/smooth_app/lib/helpers/app_helper.dart
@@ -6,6 +6,8 @@ class AppHelper {
   static String getAssetPath(String asset) {
     if (asset.startsWith('/')) {
       asset = asset.substring(0);
+    } else if (asset.startsWith('packages/')) {
+      return asset;
     }
 
     assert(asset.isNotEmpty);

--- a/packages/smooth_app/lib/helpers/app_helper.dart
+++ b/packages/smooth_app/lib/helpers/app_helper.dart
@@ -5,7 +5,7 @@ class AppHelper {
 
   static String getAssetPath(String asset) {
     if (asset.startsWith('/')) {
-      asset = asset.substring(0);
+      asset = asset.substring(1);
     } else if (asset.startsWith('packages/')) {
       return asset;
     }


### PR DESCRIPTION
It seems there is a regression when loading the default JSON file for the onboarding.

The app provides an asset path starting with `packages/…` and we (I actually) force it to concatenate with another string with `packages/...` resulting in a path like: `packages/smooth_app/packages/smooth_app/linktoasset`.

This PR simply checks if the string provided starts with `package` and in that case won't concatenate it.