### PR TITLE
fix: Black screen with the camera

### DIFF
--- a/packages/smooth_app/lib/pages/scan/camera_controller.dart
+++ b/packages/smooth_app/lib/pages/scan/camera_controller.dart
@@ -193,6 +193,8 @@ class SmoothCameraController extends CameraController {
   Future<void> resumePreviewIfNecessary() async {
     if (!isPauseResumePreviewSupported) {
       throw UnimplementedError('This feature is not supported!');
+    } else if (_state.isDisposedOrBeing) {
+      throw const DisposedControllerException();
     } else if (_state == _CameraState.beingPaused) {
       // The pause process can sometimes be too long, in that case, we just for
       // it to be finished
@@ -210,6 +212,10 @@ class SmoothCameraController extends CameraController {
   @protected
   @override
   Future<void> resumePreview() async {
+    if (_state.isDisposedOrBeing) {
+      throw const DisposedControllerException();
+    }
+
     _updateState(_CameraState.beingResumed);
     await super.resumePreview();
     await _resumeFlash();
@@ -370,5 +376,12 @@ enum _CameraState {
   resumed,
   stopped,
   isBeingDisposed,
-  disposed,
+  disposed;
+
+  bool get isDisposedOrBeing =>
+      this == _CameraState.isBeingDisposed || this == _CameraState.disposed;
+}
+
+class DisposedControllerException implements Exception {
+  const DisposedControllerException();
 }

--- a/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart
@@ -425,6 +425,9 @@ class MLKitScannerPageState extends LifecycleAwareState<MLKitScannerPage>
       } on CameraException catch (_) {
         // Dart Controller is OK, but native part is KO
         return _stopImageStream();
+      } on DisposedControllerException catch (_) {
+        // Dart Controller is OK, but native part is KO
+        return _stopImageStream();
       }
     }
     stoppingCamera = false;


### PR DESCRIPTION
In some cases, the camera may be black (reproducible on Android & iOS).
The only way I've found to reproduce the issue is the first time the app is launched, when approving the permission on the onboarding.

Basically, the camera controller is disposed and at the same time, the app tries to resume the preview.
To fix this behavior, we simply close / cancel all controllers and restart them properly.