### PR TITLE
feat: Sign Up form with a "Send" action on the keyboard

### DIFF
--- a/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
@@ -189,7 +189,7 @@ class _SignUpPageState extends State<SignUpPage> with TraceableClientMixin {
                 type: TextFieldTypes.PASSWORD,
                 controller: _password2Controller,
                 focusNode: _password2FocusNode,
-                textInputAction: TextInputAction.next,
+                textInputAction: TextInputAction.send,
                 hintText: appLocalizations.sign_up_page_confirm_password_hint,
                 prefixIcon: const Icon(Icons.vpn_key),
                 autofillHints: const <String>[
@@ -205,6 +205,13 @@ class _SignUpPageState extends State<SignUpPage> with TraceableClientMixin {
                         .sign_up_page_confirm_password_error_invalid;
                   } else {
                     return null;
+                  }
+                },
+                onFieldSubmitted: (String password) {
+                  if (password.isNotEmpty) {
+                    _signUp();
+                  } else {
+                    _formKey.currentState!.validate();
                   }
                 },
               ),


### PR DESCRIPTION
On the Sign Up form, the last element (password confirmation in our case), now have a Submit button on the virtual keyboard.

Will fix #2540