### PR TITLE
chore: Bump flutter_isolate dependency

### DIFF
--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -429,7 +429,7 @@ packages:
       name: flutter_isolate
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.3"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -70,7 +70,7 @@ dependencies:
   shared_preferences: 2.0.15
   typed_data: 1.3.1
   intl: 0.17.0
-  flutter_isolate: 2.0.2
+  flutter_isolate: 2.0.3
   rxdart: 0.27.4
   collection: 1.16.0
   path: ^1.8.2 # careful with 1.8.1 because of https://github.com/flutter/flutter/issues/95478


### PR DESCRIPTION
This should fix the issue with the scanner not working in release.

Fix for #3212