### PR TITLE
ci: allow to run script

### DIFF
--- a/.github/workflows/android-release-to-org-openfoodfacts-scanner.yml
+++ b/.github/workflows/android-release-to-org-openfoodfacts-scanner.yml
@@ -81,7 +81,7 @@ jobs:
         run: flutter --version
 
       - name: Enable MLKit dependency
-        run: ci/enable_mlkit_dependency.sh
+        run: chmod +x ci/enable_mlkit_dependency.sh && ci/enable_mlkit_dependency.sh
 
       - name: Get dependencies
         run: ci/pub_upgrade.sh

--- a/.github/workflows/ios-release-to-org-openfoodfacts-scanner.yml
+++ b/.github/workflows/ios-release-to-org-openfoodfacts-scanner.yml
@@ -71,7 +71,7 @@ jobs:
         run: flutter --version
 
       - name: Enable MLKit dependency
-        run: ci/enable_mlkit_dependency.sh
+        run: chmod +x ci/enable_mlkit_dependency.sh && ci/enable_mlkit_dependency.sh
 
       - name: Get dependencies
         run: ci/pub_upgrade.sh


### PR DESCRIPTION
### What
The internal release is failing due to 

```
Run ci/enable_mlkit_dependency.sh
/home/runner/work/_temp/0f020cee-f5de-487a-be33-5878c883ff50.sh: line 1: ci/enable_mlkit_dependency.sh: Permission denied
Error: Process completed with exit code 126.
```

This fixes the permissions
