### PR TITLE
fix: #3231 - removed an embedded scrolling in product list page

### DIFF
--- a/packages/smooth_app/lib/pages/product/common/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_page.dart
@@ -191,65 +191,62 @@ class _ProductListPageState extends State<ProductListPage>
           )
         ],
       ),
-      body: SingleChildScrollView(
-        child: products.isEmpty
-            ? GestureDetector(
-                child: Center(
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: <Widget>[
-                      SvgPicture.asset(
-                        'assets/misc/empty-list.svg',
-                        height: MediaQuery.of(context).size.height * .4,
-                        package: AppHelper.APP_PACKAGE,
-                      ),
-                      Text(
-                        appLocalizations.product_list_empty_title,
-                        style: themeData.textTheme.headlineLarge
-                            ?.apply(color: colorScheme.onBackground),
-                      ),
-                      Padding(
-                        padding: const EdgeInsets.all(VERY_LARGE_SPACE),
-                        child: Text(
-                          appLocalizations.product_list_empty_message,
-                          textAlign: TextAlign.center,
-                          style: themeData.textTheme.bodyText2?.apply(
-                            color: colorScheme.onBackground,
-                          ),
+      body: products.isEmpty
+          ? GestureDetector(
+              child: Center(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: <Widget>[
+                    SvgPicture.asset(
+                      'assets/misc/empty-list.svg',
+                      height: MediaQuery.of(context).size.height * .4,
+                      package: AppHelper.APP_PACKAGE,
+                    ),
+                    Text(
+                      appLocalizations.product_list_empty_title,
+                      style: themeData.textTheme.headlineLarge
+                          ?.apply(color: colorScheme.onBackground),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.all(VERY_LARGE_SPACE),
+                      child: Text(
+                        appLocalizations.product_list_empty_message,
+                        textAlign: TextAlign.center,
+                        style: themeData.textTheme.bodyText2?.apply(
+                          color: colorScheme.onBackground,
                         ),
-                      )
-                    ],
-                  ),
+                      ),
+                    )
+                  ],
                 ),
-                onTap: () {
-                  InheritedDataManager.of(context).resetShowSearchCard(true);
-                },
-              )
-            : WillPopScope(
-                onWillPop: _handleUserBacktap,
-                child: RefreshIndicator(
-                  //if it is in selectmode then refresh indicator is not shown
-                  notificationPredicate:
-                      _selectionMode ? (_) => false : (_) => true,
-                  onRefresh: () async => _refreshListProducts(
+              ),
+              onTap: () {
+                InheritedDataManager.of(context).resetShowSearchCard(true);
+              },
+            )
+          : WillPopScope(
+              onWillPop: _handleUserBacktap,
+              child: RefreshIndicator(
+                //if it is in selectmode then refresh indicator is not shown
+                notificationPredicate:
+                    _selectionMode ? (_) => false : (_) => true,
+                onRefresh: () async => _refreshListProducts(
+                  products,
+                  localDatabase,
+                  appLocalizations,
+                ),
+                child: ListView.builder(
+                  itemCount: products.length,
+                  itemBuilder: (BuildContext context, int index) => _buildItem(
+                    dismissible,
                     products,
+                    index,
                     localDatabase,
                     appLocalizations,
                   ),
-                  child: ListView.builder(
-                    itemCount: products.length,
-                    itemBuilder: (BuildContext context, int index) =>
-                        _buildItem(
-                      dismissible,
-                      products,
-                      index,
-                      localDatabase,
-                      appLocalizations,
-                    ),
-                  ),
                 ),
               ),
-      ),
+            ),
     );
   }
 


### PR DESCRIPTION
Impacted file:
* `product_list_page.dart`: removed another embedded scrolling

### What
- Not sure if it's 100% related with #3231, but with my latest "background" PR I introduced a bug where the product list page looked always empty (the display crashed in the logs and displayed nothing) (and not even a "this is an empty page" message).
- The reason was that there were too many embedded scrollings - in those cases flutter doesn't know how to compute the widget heights and crashes.