### PR TITLE
fix: Scripts not working on a Linux env

### DIFF
--- a/ci/enable_mlkit_dependency.sh
+++ b/ci/enable_mlkit_dependency.sh
@@ -5,7 +5,12 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 REPO_DIR="$(dirname "$SCRIPT_DIR")"
 
-sed -i '' 's|^  #scanner_mlkit|  scanner_mlkit|g' packages/app/pubspec.yaml
-sed -i '' 's|^    #path: ../scanner/mlkit|    path: ../scanner/mlkit|g' packages/app/pubspec.yaml
-sed -i '' 's|^  scanner_zxing|  #scanner_zxing|g' packages/app/pubspec.yaml
-sed -i '' 's|^    path: ../scanner/zxing|    #path: ../scanner/zxing|g' packages/app/pubspec.yaml
+SEDOPTION=
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  SEDOPTION="-i ''"
+fi
+
+sed $SEDOPTION 's|^  #scanner_mlkit|  scanner_mlkit|g' packages/app/pubspec.yaml
+sed $SEDOPTION 's|^    #path: ../scanner/mlkit|    path: ../scanner/mlkit|g' packages/app/pubspec.yaml
+sed $SEDOPTION 's|^  scanner_zxing|  #scanner_zxing|g' packages/app/pubspec.yaml
+sed $SEDOPTION 's|^    path: ../scanner/zxing|    #path: ../scanner/zxing|g' packages/app/pubspec.yaml

--- a/ci/enable_zxing_dependency.sh
+++ b/ci/enable_zxing_dependency.sh
@@ -5,7 +5,12 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 REPO_DIR="$(dirname "$SCRIPT_DIR")"
 
-sed -i '' 's|^  scanner_mlkit|  #scanner_mlkit|g' packages/app/pubspec.yaml
-sed -i '' 's|^    path: ../scanner/mlkit|    #path: ../scanner/mlkit|g' packages/app/pubspec.yaml
-sed -i '' 's|^  #scanner_zxing|  scanner_zxing|g' packages/app/pubspec.yaml
-sed -i '' 's|^    #path: ../scanner/zxing|    path: ../scanner/zxing|g' packages/app/pubspec.yaml
+SEDOPTION=
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  SEDOPTION="-i ''"
+fi
+
+sed $SEDOPTION 's|^  scanner_mlkit|  #scanner_mlkit|g' packages/app/pubspec.yaml
+sed $SEDOPTION 's|^    path: ../scanner/mlkit|    #path: ../scanner/mlkit|g' packages/app/pubspec.yaml
+sed $SEDOPTION 's|^  #scanner_zxing|  scanner_zxing|g' packages/app/pubspec.yaml
+sed $SEDOPTION 's|^    #path: ../scanner/zxing|    path: ../scanner/zxing|g' packages/app/pubspec.yaml


### PR DESCRIPTION
On Linux environments, the `sed` command doesn't work the same as on Macs.
We simply have to remove the `-i ''` argument