### PR TITLE
fix: #3266 - centered world map

### DIFF
--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_world_map_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_world_map_card.dart
@@ -30,6 +30,14 @@ class KnowledgePanelWorldMapCard extends StatelessWidget {
             ),
             zoom: 6.0,
           ),
+          layers: <LayerOptions>[
+            TileLayerOptions(
+              urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+            ),
+            MarkerLayerOptions(
+              markers: getMarkers(mapElement.pointers),
+            ),
+          ],
           nonRotatedChildren: <Widget>[
             AttributionWidget(
               attributionBuilder: (BuildContext context) {
@@ -64,18 +72,6 @@ class KnowledgePanelWorldMapCard extends StatelessWidget {
                 );
               },
             )
-          ],
-          children: <Widget>[
-            FlutterMap(
-              options: MapOptions(),
-              layers: <LayerOptions>[
-                TileLayerOptions(
-                  urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-                  userAgentPackageName: 'world.openfoodfacts.org',
-                ),
-                MarkerLayerOptions(markers: getMarkers(mapElement.pointers))
-              ],
-            ),
           ],
         ),
       ),


### PR DESCRIPTION
### What
- When switching from/to flutter 3.3 we forgot some parameters for the map.
- I must say I haven't tested the code.

### Fixes bug(s)
- Fixes: #3266