### PR TITLE
fix: Barcodes with less than 8 digits should be supported

### DIFF
--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -35,8 +35,6 @@ class EditProductPage extends StatefulWidget {
 }
 
 class _EditProductPageState extends State<EditProductPage> {
-  static const double _barcodeHeight = 120.0;
-
   final ScrollController _controller = ScrollController();
   bool _barcodeVisibleInAppbar = false;
   late Product _product;
@@ -60,8 +58,6 @@ class _EditProductPageState extends State<EditProductPage> {
     context.watch<LocalDatabase>();
     _product = _localDatabase.upToDate.getLocalUpToDate(_initialProduct);
     final ThemeData theme = Theme.of(context);
-    final Brightness brightness = theme.brightness;
-    final Size screenSize = MediaQuery.of(context).size;
 
     return SmoothScaffold(
       appBar: AppBar(
@@ -120,26 +116,7 @@ class _EditProductPageState extends State<EditProductPage> {
           child: ListView(
             controller: _controller,
             children: <Widget>[
-              if (_product.barcode != null)
-                BarcodeWidget(
-                  padding: EdgeInsets.symmetric(
-                    horizontal: screenSize.width / 4,
-                    vertical: SMALL_SPACE,
-                  ),
-                  barcode: _product.barcode!.length <= 8
-                      ? Barcode.ean8()
-                      : Barcode.ean13(),
-                  data: _product.barcode!,
-                  color: brightness == Brightness.dark
-                      ? Colors.white
-                      : Colors.black,
-                  errorBuilder: (final BuildContext context, String? _) => Text(
-                    '${appLocalizations.edit_product_form_item_barcode}\n'
-                    '${_product.barcode}',
-                    textAlign: TextAlign.center,
-                  ),
-                  height: _barcodeHeight,
-                ),
+              if (_product.barcode != null) _ProductBarcode(product: _product),
               _ListTitleItem(
                 title: appLocalizations.edit_product_form_item_details_title,
                 subtitle:
@@ -391,5 +368,40 @@ class _SvgIcon extends StatelessWidget {
       case Brightness.dark:
         return Colors.white;
     }
+  }
+}
+
+/// Barcodes only allowed have a length of 7, 8, 12 or 13 characters
+class _ProductBarcode extends StatelessWidget {
+  _ProductBarcode({required this.product, Key? key})
+      : assert(product.barcode?.isNotEmpty == true),
+        assert(<int>[7, 8, 12, 13].contains(product.barcode!.length)),
+        super(key: key);
+
+  static const double _barcodeHeight = 120.0;
+
+  final Product product;
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final Brightness brightness = Theme.of(context).brightness;
+    final Size screenSize = MediaQuery.of(context).size;
+
+    return BarcodeWidget(
+      padding: EdgeInsets.symmetric(
+        horizontal: screenSize.width / 4,
+        vertical: SMALL_SPACE,
+      ),
+      barcode: product.barcode!.length <= 8 ? Barcode.ean8() : Barcode.ean13(),
+      data: product.barcode!,
+      color: brightness == Brightness.dark ? Colors.white : Colors.black,
+      errorBuilder: (final BuildContext context, String? _) => Text(
+        '${appLocalizations.edit_product_form_item_barcode}\n'
+        '${product.barcode}',
+        textAlign: TextAlign.center,
+      ),
+      height: _barcodeHeight,
+    );
   }
 }

--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -120,24 +120,26 @@ class _EditProductPageState extends State<EditProductPage> {
           child: ListView(
             controller: _controller,
             children: <Widget>[
-              BarcodeWidget(
-                padding: EdgeInsets.symmetric(
-                  horizontal: screenSize.width / 4,
-                  vertical: SMALL_SPACE,
+              if (_product.barcode != null)
+                BarcodeWidget(
+                  padding: EdgeInsets.symmetric(
+                    horizontal: screenSize.width / 4,
+                    vertical: SMALL_SPACE,
+                  ),
+                  barcode: _product.barcode!.length <= 8
+                      ? Barcode.ean8()
+                      : Barcode.ean13(),
+                  data: _product.barcode!,
+                  color: brightness == Brightness.dark
+                      ? Colors.white
+                      : Colors.black,
+                  errorBuilder: (final BuildContext context, String? _) => Text(
+                    '${appLocalizations.edit_product_form_item_barcode}\n'
+                    '${_product.barcode}',
+                    textAlign: TextAlign.center,
+                  ),
+                  height: _barcodeHeight,
                 ),
-                barcode: _product.barcode!.length == 8
-                    ? Barcode.ean8()
-                    : Barcode.ean13(),
-                data: _barcode,
-                color:
-                    brightness == Brightness.dark ? Colors.white : Colors.black,
-                errorBuilder: (final BuildContext context, String? _) => Text(
-                  '${appLocalizations.edit_product_form_item_barcode}\n'
-                  '$_barcode',
-                  textAlign: TextAlign.center,
-                ),
-                height: _barcodeHeight,
-              ),
               _ListTitleItem(
                 title: appLocalizations.edit_product_form_item_details_title,
                 subtitle:

--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -116,7 +116,8 @@ class _EditProductPageState extends State<EditProductPage> {
           child: ListView(
             controller: _controller,
             children: <Widget>[
-              if (_product.barcode != null) _ProductBarcode(product: _product),
+              if (_ProductBarcode.isAValidBarcode(_product.barcode))
+                _ProductBarcode(product: _product),
               _ListTitleItem(
                 title: appLocalizations.edit_product_form_item_details_title,
                 subtitle:
@@ -376,7 +377,7 @@ class _SvgIcon extends StatelessWidget {
 class _ProductBarcode extends StatelessWidget {
   _ProductBarcode({required this.product, Key? key})
       : assert(product.barcode?.isNotEmpty == true),
-        assert(<int>[7, 8, 12, 13].contains(product.barcode!.length)),
+        assert(isAValidBarcode(product.barcode)),
         super(key: key);
 
   static const double _barcodeHeight = 120.0;
@@ -418,4 +419,7 @@ class _ProductBarcode extends StatelessWidget {
         throw Exception('Unknown barcode type!');
     }
   }
+
+  static bool isAValidBarcode(String? barcode) =>
+      barcode != null && <int>[7, 8, 12, 13].contains(barcode.length);
 }

--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -303,7 +303,8 @@ class _EditProductPageState extends State<EditProductPage> {
   }
 
   void _onScrollChanged() {
-    final bool visibleBarcode = _controller.offset > _barcodeHeight;
+    final bool visibleBarcode =
+        _controller.offset > _ProductBarcode._barcodeHeight;
 
     if (visibleBarcode != _barcodeVisibleInAppbar) {
       setState(() {

--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -394,7 +394,7 @@ class _ProductBarcode extends StatelessWidget {
         horizontal: screenSize.width / 4,
         vertical: SMALL_SPACE,
       ),
-      barcode: product.barcode!.length <= 8 ? Barcode.ean8() : Barcode.ean13(),
+      barcode: _barcodeType,
       data: product.barcode!,
       color: brightness == Brightness.dark ? Colors.white : Colors.black,
       errorBuilder: (final BuildContext context, String? _) => Text(
@@ -404,5 +404,18 @@ class _ProductBarcode extends StatelessWidget {
       ),
       height: _barcodeHeight,
     );
+  }
+
+  Barcode get _barcodeType {
+    switch (product.barcode!.length) {
+      case 7:
+      case 8:
+        return Barcode.ean8();
+      case 12:
+      case 13:
+        return Barcode.ean13();
+      default:
+        throw Exception('Unknown barcode type!');
+    }
   }
 }


### PR DESCRIPTION
To fix #3280, barcodes with less than 8 digits, should be considered as so.
Eg: https://fr.openfoodfacts.org/produit/6177449/moelleux-pepites-ma-tatie?rev=16