### PR TITLE
fix: Ensure the auto-suggestion popup is never below the keyboard

### DIFF
--- a/packages/smooth_app/lib/pages/product/simple_input_widget.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_widget.dart
@@ -178,7 +178,7 @@ class _SimpleInputWidgetField extends StatelessWidget {
           final double widgetPosition =
               (context.findRenderObject() as RenderBox?)
                       ?.localToGlobal(Offset.zero)
-                      ?.dy ??
+                      .dy ??
                   0.0;
 
           return AutocompleteOptions<String>(

--- a/packages/smooth_app/lib/pages/product/simple_input_widget.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_widget.dart
@@ -171,8 +171,7 @@ class _SimpleInputWidgetField extends StatelessWidget {
           AutocompleteOnSelected<String> onSelected,
           Iterable<String> options,
         ) {
-          final MediaQueryData mediaQuery = MediaQuery.of(context);
-          final double screenHeight = mediaQuery.size.height;
+          final double screenHeight = MediaQuery.of(context).size.height;
           final double keyboardHeight =
               MediaQuery.of(lContext).viewInsets.bottom;
 

--- a/packages/smooth_app/lib/pages/product/simple_input_widget.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_widget.dart
@@ -167,18 +167,38 @@ class _SimpleInputWidgetField extends StatelessWidget {
           focusNode: focusNode,
         ),
         optionsViewBuilder: (
-          BuildContext context,
+          BuildContext lContext,
           AutocompleteOnSelected<String> onSelected,
           Iterable<String> options,
-        ) =>
-            AutocompleteOptions<String>(
-          displayStringForOption: RawAutocomplete.defaultStringForOption,
-          onSelected: onSelected,
-          options: options,
-          // Width = Row width - horizontal padding
-          maxOptionsWidth: constraints.maxWidth - (LARGE_SPACE * 2),
-          maxOptionsHeight: MediaQuery.of(context).size.height / 2,
-        ),
+        ) {
+          final MediaQueryData mediaQuery = MediaQuery.of(context);
+          final double screenHeight = mediaQuery.size.height;
+          final double keyboardHeight =
+              MediaQuery.of(lContext).viewInsets.bottom;
+
+          final Offset? widgetPosition =
+              (context.findRenderObject() as RenderBox?)
+                  ?.localToGlobal(Offset.zero);
+
+          return AutocompleteOptions<String>(
+            displayStringForOption: RawAutocomplete.defaultStringForOption,
+            onSelected: onSelected,
+            options: options,
+            // Width = Row width - horizontal padding
+            maxOptionsWidth: constraints.maxWidth - (LARGE_SPACE * 2),
+            maxOptionsHeight: screenHeight -
+                (keyboardHeight == 0
+                    ? kBottomNavigationBarHeight
+                    : keyboardHeight) -
+                (widgetPosition?.dy ?? 0.0) -
+                // Vertical padding
+                (LARGE_SPACE * 2) -
+                // Height of the TextField
+                (DefaultTextStyle.of(context).style.fontSize ?? 0) -
+                // Elevation
+                4.0,
+          );
+        },
       ),
     );
   }

--- a/packages/smooth_app/lib/pages/product/simple_input_widget.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_widget.dart
@@ -175,9 +175,11 @@ class _SimpleInputWidgetField extends StatelessWidget {
           final double keyboardHeight =
               MediaQuery.of(lContext).viewInsets.bottom;
 
-          final Offset? widgetPosition =
+          final double widgetPosition =
               (context.findRenderObject() as RenderBox?)
-                  ?.localToGlobal(Offset.zero);
+                      ?.localToGlobal(Offset.zero)
+                      ?.dy ??
+                  0.0;
 
           return AutocompleteOptions<String>(
             displayStringForOption: RawAutocomplete.defaultStringForOption,
@@ -189,7 +191,7 @@ class _SimpleInputWidgetField extends StatelessWidget {
                 (keyboardHeight == 0
                     ? kBottomNavigationBarHeight
                     : keyboardHeight) -
-                (widgetPosition?.dy ?? 0.0) -
+                widgetPosition -
                 // Vertical padding
                 (LARGE_SPACE * 2) -
                 // Height of the TextField


### PR DESCRIPTION
The current computation is based on the screen height, which is totally wrong.
We will not compute it based on the available space.