### PR TITLE
ci: fix: iOS release itc_provider

### DIFF
--- a/packages/app/ios/fastlane/Fastfile
+++ b/packages/app/ios/fastlane/Fastfile
@@ -43,11 +43,12 @@ platform :ios do
     )
   
     # Upload to test flight
-    pilot(
+    upload_to_testflight(
       app_identifier: APP_IDENTIFIER,
       skip_submission: true,
       skip_waiting_for_build_processing: true,
-      ipa: "./Runner.ipa"
+      ipa: "./Runner.ipa",
+      itc_provider: "ZC9CYWD334"
     )
   end
 end


### PR DESCRIPTION
### What
Fixes: #3262 

https://stackoverflow.com/questions/74131575/fastlane-failing-with-error-cannot-obtain-the-content-provider-public-id-pleas
https://docs.fastlane.tools/actions/pilot/#usage