### PR TITLE
feat: Add an animation to hide the card from the carousel

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/product_title_card.dart
+++ b/packages/smooth_app/lib/cards/product_cards/product_title_card.dart
@@ -1,11 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/model/Product.dart';
-import 'package:provider/provider.dart';
-import 'package:smooth_app/data_models/continuous_scan_model.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/helpers/extension_on_text_helper.dart';
-import 'package:smooth_app/helpers/haptic_feedback_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/pages/product/add_basic_details_page.dart';
 
@@ -15,12 +12,14 @@ class ProductTitleCard extends StatelessWidget {
     this.isSelectable, {
     this.dense = false,
     this.isRemovable = true,
+    this.onRemove,
   });
 
   final Product product;
   final bool dense;
   final bool isSelectable;
   final bool isRemovable;
+  final OnRemoveCallback? onRemove;
 
   @override
   Widget build(BuildContext context) {
@@ -32,16 +31,10 @@ class ProductTitleCard extends StatelessWidget {
     final String quantity = product.quantity ?? '';
 
     if (isRemovable && !isSelectable) {
-      final ContinuousScanModel model = context.watch<ContinuousScanModel>();
       subtitleText = '$brands${quantity == '' ? '' : ', $quantity'}';
       trailingWidget = InkWell(
         customBorder: const CircleBorder(),
-        onTap: () async {
-          await model.removeBarcode(product.barcode!);
-
-          // Vibrate twice
-          SmoothHapticFeedback.confirm();
-        },
+        onTap: () => onRemove?.call(context),
         child: Tooltip(
           message: appLocalizations.product_card_remove_product_tooltip,
           child: const Padding(
@@ -91,3 +84,5 @@ class ProductTitleCard extends StatelessWidget {
     );
   }
 }
+
+typedef OnRemoveCallback = void Function(BuildContext context);

--- a/packages/smooth_app/lib/pages/scan/scan_product_card.dart
+++ b/packages/smooth_app/lib/pages/scan/scan_product_card.dart
@@ -28,7 +28,9 @@ class ScanProductCard extends StatelessWidget {
       },
       child: Hero(
         tag: product.barcode ?? '',
-        child: SummaryCard(product, productPreferences),
+        child: HideableContainer(
+          child: SummaryCard(product, productPreferences),
+        ),
       ),
     );
   }


### PR DESCRIPTION
Hi everyone!

When we remove a card from the carousel, it isn't easy to understand that it worked, as there is no animation.
Furthermore, if we have several cards, it seems that nothing happens at all, as the card will be switched immediately.

By adding a slight animation, the user will better understand what happened.
Here is what I've done (reduce opacity + translation): 

https://user-images.githubusercontent.com/246838/200371952-c1dc0f1e-a1ed-4e11-b6e8-754a08fd9cc4.mp4

