### PR TITLE
feat: Mark the app as not optimized for tablets

### DIFF
--- a/packages/app/android/app/src/main/AndroidManifest.xml
+++ b/packages/app/android/app/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
                 android:theme="@style/LaunchTheme"
                 android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
                 android:hardwareAccelerated="true"
+                android:resizeableActivity="false"
                 android:windowSoftInputMode="adjustResize">
             <!-- Specifies an Android theme to apply to this Activity as soon as
                  the Android process has started. This theme is visible to the user

--- a/packages/smooth_app/android/app/src/main/AndroidManifest.xml
+++ b/packages/smooth_app/android/app/src/main/AndroidManifest.xml
@@ -34,6 +34,7 @@
                 android:screenOrientation="portrait"
                 android:theme="@style/LaunchTheme"
                 android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
+                android:resizeableActivity="false"
                 android:hardwareAccelerated="true"
                 android:windowSoftInputMode="adjustResize">
             <!-- Specifies an Android theme to apply to this Activity as soon as


### PR DESCRIPTION
To have a better rendering on Android tablets, scaling the smartphone's UI will be better.
My little change will allow the app to be run in "letter box" mode: https://developer.android.com/guide/practices/enhanced-letterboxing