### PR TITLE
feat: Ensure user's lists are not considered as a regular search

### DIFF
--- a/packages/smooth_app/lib/pages/preferences/user_preferences_account.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_account.dart
@@ -407,6 +407,7 @@ class _UserPreferencesPageState extends State<UserPreferencesSection> {
           localDatabase: localDatabase,
           productQuery: productQuery,
           context: context,
+          editableAppBarTitle: false,
         ),
         iconData,
         type: type,

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_contribute.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_contribute.dart
@@ -137,6 +137,7 @@ class UserPreferencesContribute extends AbstractUserPreferences {
                   productQuery: PagedToBeCompletedProductQuery(),
                   // the other "context"s being popped
                   context: this.context,
+                  editableAppBarTitle: false,
                 );
               },
             ),

--- a/packages/smooth_app/lib/pages/product/common/product_query_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_query_page.dart
@@ -31,10 +31,12 @@ class ProductQueryPage extends StatefulWidget {
   const ProductQueryPage({
     required this.productListSupplier,
     required this.name,
+    required this.editableAppBarTitle,
   });
 
   final ProductListSupplier productListSupplier;
   final String name;
+  final bool editableAppBarTitle;
 
   @override
   State<ProductQueryPage> createState() => _ProductQueryPageState();
@@ -199,7 +201,10 @@ class _ProductQueryPageState extends State<ProductQueryPage>
           elevation: 2,
           automaticallyImplyLeading: false,
           leading: const SmoothBackButton(),
-          title: _AppBarTitle(name: widget.name),
+          title: _AppBarTitle(
+            name: widget.name,
+            editableAppBarTitle: widget.editableAppBarTitle,
+          ),
           actions: _getAppBarButtons(),
         ),
         body: RefreshIndicator(
@@ -485,7 +490,10 @@ class _EmptyScreen extends StatelessWidget {
       appBar: AppBar(
         backgroundColor: Theme.of(context).scaffoldBackgroundColor,
         leading: const SmoothBackButton(),
-        title: _AppBarTitle(name: name),
+        title: _AppBarTitle(
+          name: name,
+          editableAppBarTitle: false,
+        ),
         actions: actions,
       ),
       body: Center(child: emptiness),
@@ -496,27 +504,35 @@ class _EmptyScreen extends StatelessWidget {
 class _AppBarTitle extends StatelessWidget {
   const _AppBarTitle({
     required this.name,
+    required this.editableAppBarTitle,
     Key? key,
   }) : super(key: key);
 
   final String name;
+  final bool editableAppBarTitle;
 
   @override
   Widget build(BuildContext context) {
-    final AppLocalizations appLocalizations = AppLocalizations.of(context);
-
-    return GestureDetector(
-      onTap: () {
-        Navigator.of(context).pop(ProductQueryPageResult.editProductQuery);
-      },
-      child: Tooltip(
-        message: appLocalizations.tap_to_edit_search,
-        child: AutoSizeText(
-          name,
-          maxLines: 2,
-        ),
-      ),
+    final Widget child = AutoSizeText(
+      name,
+      maxLines: 2,
     );
+
+    if (editableAppBarTitle) {
+      final AppLocalizations appLocalizations = AppLocalizations.of(context);
+
+      return GestureDetector(
+        onTap: () {
+          Navigator.of(context).pop(ProductQueryPageResult.editProductQuery);
+        },
+        child: Tooltip(
+          message: appLocalizations.tap_to_edit_search,
+          child: child,
+        ),
+      );
+    } else {
+      return child;
+    }
   }
 }
 

--- a/packages/smooth_app/lib/pages/product/common/product_query_page_helper.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_query_page_helper.dart
@@ -14,6 +14,7 @@ class ProductQueryPageHelper {
     required final LocalDatabase localDatabase,
     required final String name,
     required final BuildContext context,
+    bool editableAppBarTitle = true,
     EditProductQueryCallback? editQueryCallback,
   }) async {
     final ProductListSupplier supplier =
@@ -29,6 +30,7 @@ class ProductQueryPageHelper {
         builder: (BuildContext context) => ProductQueryPage(
           productListSupplier: supplier,
           name: name,
+          editableAppBarTitle: editableAppBarTitle,
         ),
       ),
     );


### PR DESCRIPTION
Hi everyone,

When the user searches for something, he can tap on the title to edit it.
But this same screen is also used for "Products I added, edited…" and in that case, the search is not editable.

This PR disables this feature in that particular case.