### PR TITLE
fix: #3018 - storing the pending changes

### DIFF
--- a/packages/app/ios/Podfile.lock
+++ b/packages/app/ios/Podfile.lock
@@ -243,7 +243,7 @@ SPEC CHECKSUMS:
   connectivity_plus: 413a8857dd5d9f1c399a39130850d02fe0feaf7e
   data_importer: ab8c74aaf553878170aed03c03626d5820c5cb1f
   device_info_plus: e5c5da33f982a436e103237c0c85f9031142abed
-  Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
+  Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
   flutter_email_sender: 02d7443217d8c41483223627972bfdc09f74276b
   flutter_isolate: 0edf5081826d071adf21759d1eb10ff5c24503b5
   flutter_native_splash: 52501b97d1c0a5f898d687f1646226c1f93c56ef

--- a/packages/smooth_app/lib/database/dao_transient_operation.dart
+++ b/packages/smooth_app/lib/database/dao_transient_operation.dart
@@ -1,0 +1,102 @@
+import 'dart:async';
+import 'dart:convert';
+import 'package:hive/hive.dart';
+import 'package:openfoodfacts/model/Product.dart';
+import 'package:smooth_app/database/abstract_dao.dart';
+import 'package:smooth_app/database/local_database.dart';
+
+/// Transient operation: a minimalist [product] with a [key].
+///
+/// The [key] has nothing to do with the barcode, it's an operation key.
+/// Typically, the [key] may include:
+/// * a type ("it's a detail change")
+/// * a sequential id (in order to sort operations)
+class TransientOperation {
+  const TransientOperation(this.key, this.product);
+
+  final String key;
+  final Product product;
+
+  @override
+  String toString() => 'TransientOperation($key})';
+}
+
+/// Hive type adapter for [Product]
+class _ProductAdapter extends TypeAdapter<Product> {
+  @override
+  final int typeId = 2;
+
+  @override
+  Product read(BinaryReader reader) =>
+      Product.fromJson(jsonDecode(reader.readString()) as Map<String, dynamic>);
+
+  @override
+  void write(BinaryWriter writer, Product obj) =>
+      writer.writeString(jsonEncode(obj.toJson()));
+}
+
+/// Where we store products for transient operations.
+///
+/// Use [DaoProduct] instead if you want to enrich the local product database.
+///
+/// This class is only for transient operations.
+/// For instance, when you submit a change, we store the changes here,
+/// while async'ly saving them on the server. This way we can take into account
+/// those changes in the app before they are actually saved on the server. And
+/// typically, when we got an ACK from the server, we can remove that change
+/// from the pending changes.
+///
+/// It is open to different uses, therefore the key is just a stupid String.
+/// Of course, to make those different uses compatible, the key should be
+/// properly designed, e.g. with all keys starting with `'USECASEx;'`
+///
+/// This is not a Lazy database, because:
+/// * it's supposed to be little anyway, so we can load it at startup
+/// * the way we use it may sometimes require instant access (no `await`)
+class DaoTransientOperation extends AbstractDao {
+  DaoTransientOperation(final LocalDatabase localDatabase)
+      : super(localDatabase);
+
+  static const String _hiveBoxName = 'transientOperations';
+
+  @override
+  Future<void> init() async => Hive.openBox<Product>(_hiveBoxName);
+
+  @override
+  void registerAdapter() => Hive.registerAdapter(_ProductAdapter());
+
+  Box<Product> _getBox() => Hive.box<Product>(_hiveBoxName);
+
+  Product? get(final String key) => _getBox().get(key);
+
+  Future<void> put(final String key, final Product product) =>
+      _getBox().put(key, product);
+
+  Future<void> delete(final String key) async => _getBox().delete(key);
+
+  List<String> getAllKeys() {
+    final Box<Product> box = _getBox();
+    final List<String> result = <String>[];
+    for (final dynamic key in box.keys) {
+      result.add(key.toString());
+    }
+    return result;
+  }
+
+  Iterable<TransientOperation> getAll(final String barcode) {
+    final Box<Product> box = _getBox();
+    final List<TransientOperation> result = <TransientOperation>[];
+    for (final dynamic key in box.keys) {
+      final Product? product = box.get(key);
+      if (product == null) {
+        // very unlikely
+        continue;
+      }
+      if (product.barcode != barcode) {
+        continue;
+      }
+      result.add(TransientOperation(key.toString(), product));
+    }
+    return result;
+  }
+}

--- a/packages/smooth_app/lib/database/local_database.dart
+++ b/packages/smooth_app/lib/database/local_database.dart
@@ -15,6 +15,7 @@ import 'package:smooth_app/database/dao_product_migration.dart';
 import 'package:smooth_app/database/dao_string.dart';
 import 'package:smooth_app/database/dao_string_list.dart';
 import 'package:smooth_app/database/dao_string_list_map.dart';
+import 'package:smooth_app/database/dao_transient_operation.dart';
 import 'package:smooth_app/database/dao_unzipped_product.dart';
 import 'package:sqflite/sqflite.dart';
 
@@ -66,6 +67,7 @@ class LocalDatabase extends ChangeNotifier {
       DaoString(localDatabase),
       DaoInt(localDatabase),
       DaoStringListMap(localDatabase),
+      DaoTransientOperation(localDatabase),
     ];
     for (final AbstractDao dao in daos) {
       dao.registerAdapter();

--- a/packages/smooth_app/lib/pages/product/common/product_refresher.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_refresher.dart
@@ -70,8 +70,6 @@ class ProductRefresher {
       await LoadingDialog.error(context: widget.context);
       return;
     }
-    localDatabase.upToDate
-        .setLatestDownloadedProduct(fetchAndRefreshed.product!);
     ScaffoldMessenger.of(widget.context).showSnackBar(
       SnackBar(
         content: Text(appLocalizations.product_refreshed),
@@ -96,6 +94,7 @@ class ProductRefresher {
       );
       if (result.product != null) {
         await DaoProduct(localDatabase).put(result.product!);
+        localDatabase.upToDate.setLatestDownloadedProduct(result.product!);
         localDatabase.notifyListeners();
         return _MetaProductRefresher.product(result.product);
       }

--- a/packages/smooth_app/lib/query/barcode_product_query.dart
+++ b/packages/smooth_app/lib/query/barcode_product_query.dart
@@ -42,6 +42,7 @@ class BarcodeProductQuery {
       final Product? product = result.product;
       if (product != null) {
         await daoProduct.put(product);
+        daoProduct.localDatabase.upToDate.setLatestDownloadedProduct(product);
         return FetchedProduct(product);
       }
     }

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.3.0"
+    version: "3.1.11"
   args:
     dependency: transitive
     description:
@@ -35,7 +35,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.9.0"
+    version: "2.8.2"
   audioplayers:
     dependency: "direct main"
     description:
@@ -174,7 +174,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.0"
+  charcode:
+    dependency: transitive
+    description:
+      name: charcode
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -195,7 +202,7 @@ packages:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.0"
   code_builder:
     dependency: transitive
     description:
@@ -272,7 +279,7 @@ packages:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.1"
   csslib:
     dependency: transitive
     description:
@@ -377,7 +384,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.0"
   ffi:
     dependency: transitive
     description:
@@ -741,14 +748,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.11"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.5"
+    version: "0.1.4"
   matomo_tracker:
     dependency: "direct main"
     description:
@@ -1217,7 +1224,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.0"
+    version: "1.8.2"
   sqflite:
     dependency: "direct main"
     description:
@@ -1259,14 +1266,14 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.0"
   sync_http:
     dependency: transitive
     description:
       name: sync_http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.1"
+    version: "0.3.0"
   synchronized:
     dependency: transitive
     description:
@@ -1289,14 +1296,14 @@ packages:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.9"
   tuple:
     dependency: transitive
     description:
@@ -1415,7 +1422,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "9.0.0"
+    version: "8.2.2"
   watcher:
     dependency: transitive
     description:


### PR DESCRIPTION
New file:
* `dao_transient_operation.dart`: Transient operation: a minimalist product with a key.

Impacted files:
* `barcode_product_query.dart`: minor refactoring
* `local_database.dart`: added reference to new class `DaoTransientOperation`
* `Podfile.lock`: wtf
* `product_refresher.dart`: minor refactoring
* `pubspec.lock`: wtf

### What
- Here, the main change is the new class `DaoTransientOperation`, where we will store "minimalist" products
   - when we add a background task, the first thing we will do is to store the minimalist product there
   - until the background task is completed, this is where we'll find the pending changes, to be used by the app, that will show the product as stored as the downloaded product, with those pending changes on top
   - when the background task is completed we download the latest version of the product - at this moment we can remove the corresponding minimalist products as they are integrated into the latest downloaded version

### Part of 
- #3018
