### PR TITLE
fix: Product page: ensure to reset the carousel position after refreshing

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/product_image_carousel.dart
+++ b/packages/smooth_app/lib/cards/product_cards/product_image_carousel.dart
@@ -10,11 +10,15 @@ class ProductImageCarousel extends StatelessWidget {
   const ProductImageCarousel(
     this.product, {
     required this.height,
+    this.controller,
+    this.onUpload,
     this.alternateImageUrl,
   });
 
   final Product product;
   final double height;
+  final ScrollController? controller;
+  final Function(BuildContext)? onUpload;
   final String? alternateImageUrl;
 
   @override
@@ -38,6 +42,7 @@ class ProductImageCarousel extends StatelessWidget {
       child: ListView.builder(
         // This next line does the trick.
         scrollDirection: Axis.horizontal,
+        controller: controller,
         itemCount: productImagesData.length,
         itemBuilder: (_, int index) {
           final ProductImageData data = productImagesData[index];

--- a/packages/smooth_app/lib/pages/product/common/product_refresher.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_refresher.dart
@@ -75,6 +75,7 @@ class ProductRefresher {
   Future<void> fetchAndRefresh({
     required final String barcode,
     required final State<StatefulWidget> widget,
+    VoidCallback? onSuccessCallback,
   }) async {
     final LocalDatabase localDatabase = widget.context.read<LocalDatabase>();
     final AppLocalizations appLocalizations =
@@ -101,6 +102,8 @@ class ProductRefresher {
         duration: SnackBarDuration.short,
       ),
     );
+
+    onSuccessCallback?.call();
   }
 
   Future<_MetaProductRefresher> _fetchAndRefresh(

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -43,10 +43,13 @@ class ProductPage extends StatefulWidget {
 }
 
 class _ProductPageState extends State<ProductPage> with TraceableClientMixin {
+  final ScrollController _carouselController = ScrollController();
+
   late Product _product;
   late final Product _initialProduct;
   late final LocalDatabase _localDatabase;
   late ProductPreferences _productPreferences;
+
   bool scrollingUp = true;
 
   @override
@@ -126,6 +129,15 @@ class _ProductPageState extends State<ProductPage> with TraceableClientMixin {
     );
   }
 
+  Future<void> _refreshProduct(BuildContext context) async =>
+      ProductRefresher().fetchAndRefresh(
+          barcode: _product.barcode!,
+          widget: this,
+          onSuccessCallback: () {
+            // Reset the carousel to the beginning
+            _carouselController.jumpTo(0.0);
+          });
+
   Future<void> _updateLocalDatabaseWithProductHistory(
     final BuildContext context,
   ) async {
@@ -161,6 +173,8 @@ class _ProductPageState extends State<ProductPage> with TraceableClientMixin {
             child: ProductImageCarousel(
               _product,
               height: 200,
+              controller: _carouselController,
+              onUpload: _refreshProduct,
             ),
           ),
           Padding(


### PR DESCRIPTION
When refreshing the product page, the carousel containing images is not reset to its initial position.
If new images are available (eg: after adding some), we have to scroll to seen them.

New behavior:
https://user-images.githubusercontent.com/246838/201321274-0f798537-9150-4f86-a934-32012fcb0790.mp4

