### PR TITLE
fix: 3018 - immediate local and server refresh for details (temporary)

### DIFF
--- a/packages/smooth_app/lib/background/abstract_background_task.dart
+++ b/packages/smooth_app/lib/background/abstract_background_task.dart
@@ -82,6 +82,7 @@ abstract class AbstractBackgroundTask {
       final Product? product = queryResult.product;
       if (product != null) {
         await daoProduct.put(product);
+        localDatabase.upToDate.setLatestDownloadedProduct(product);
         localDatabase.notifyListeners();
       }
     }

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_not_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_not_found.dart
@@ -11,7 +11,7 @@ class SmoothProductCardNotFound extends StatelessWidget {
     this.callback,
   }) : assert(barcode.isNotEmpty);
 
-  final Future<void> Function(String?)? callback;
+  final Future<void> Function()? callback;
   final String barcode;
 
   @override
@@ -58,16 +58,15 @@ class SmoothProductCardNotFound extends StatelessWidget {
               icon: Icons.add,
               padding: const EdgeInsets.symmetric(vertical: LARGE_SPACE),
               onPressed: () async {
-                // TODO(monsieurtanuki): careful, waiting for pop'ed value
-                final String? result = await Navigator.push<String>(
+                await Navigator.push<void>(
                   context,
-                  MaterialPageRoute<String>(
+                  MaterialPageRoute<void>(
                     builder: (BuildContext context) =>
                         AddNewProductPage(barcode),
                   ),
                 );
                 if (callback != null) {
-                  await callback!(result);
+                  await callback!();
                 }
               },
             ),

--- a/packages/smooth_app/lib/data_models/operation_type.dart
+++ b/packages/smooth_app/lib/data_models/operation_type.dart
@@ -1,0 +1,50 @@
+import 'package:smooth_app/database/dao_int.dart';
+import 'package:smooth_app/database/dao_transient_operation.dart';
+import 'package:smooth_app/database/local_database.dart';
+import 'package:smooth_app/helpers/database_helper.dart';
+
+/// Type of a transient operation.
+///
+/// We need a type to discriminate between operations (cf. [getNewKey]).
+/// When we are in a collection of operations, the keys will helper us know
+/// * which type (cf. [matches])
+/// * which order (cf. [getSequentialId], [sort])
+/// * possibly, which barcode (not useful yet)
+enum OperationType {
+  image('I'),
+  details('D');
+
+  const OperationType(this.header);
+
+  final String header;
+
+  static const String _transientHeaderSeparator = ';';
+
+  static const String _uniqueSequenceKey = 'OperationType';
+
+  Future<String> getNewKey(
+    final LocalDatabase localDatabase,
+    final String barcode,
+  ) async {
+    final int sequentialId =
+        await getNextSequenceNumber(DaoInt(localDatabase), _uniqueSequenceKey);
+    return '$header'
+        '$_transientHeaderSeparator$sequentialId'
+        '$_transientHeaderSeparator$barcode';
+  }
+
+  bool matches(final TransientOperation action) =>
+      action.key.startsWith('$header$_transientHeaderSeparator');
+
+  static int getSequentialId(final TransientOperation operation) {
+    final List<String> keyItems =
+        operation.key.split(_transientHeaderSeparator);
+    return int.parse(keyItems[1]);
+  }
+
+  static int sort(
+    final TransientOperation operationA,
+    final TransientOperation operationB,
+  ) =>
+      getSequentialId(operationA).compareTo(getSequentialId(operationB));
+}

--- a/packages/smooth_app/lib/data_models/up_to_date_changes.dart
+++ b/packages/smooth_app/lib/data_models/up_to_date_changes.dart
@@ -1,0 +1,161 @@
+import 'package:openfoodfacts/model/Product.dart';
+import 'package:smooth_app/data_models/operation_type.dart';
+import 'package:smooth_app/database/dao_transient_operation.dart';
+import 'package:smooth_app/database/local_database.dart';
+
+/// Sequence of minimalist product changes.
+class UpToDateChanges {
+  UpToDateChanges(this.localDatabase)
+      : _daoTransientProduct = DaoTransientOperation(localDatabase);
+
+  final LocalDatabase localDatabase;
+
+  /// For a barcode, map of the actions (pending and done).
+  final DaoTransientOperation _daoTransientProduct;
+
+  OperationType get taskActionable => OperationType.details;
+
+  /// Returns a minimalist [Product] with successive changes on top.
+  Product prepareChangesForServer(
+    final String barcode,
+    final Iterable<TransientOperation> sortedOperations,
+  ) {
+    final Product initial = Product(barcode: barcode);
+    for (final TransientOperation transientOperation in sortedOperations) {
+      if (initial.barcode != transientOperation.product.barcode) {
+        // very unlikely
+        continue;
+      }
+      _overwrite(initial, transientOperation.product);
+    }
+    return initial;
+  }
+
+  /// Returns all the actions related to a barcode, sorted by id.
+  Iterable<TransientOperation> getSortedOperations(final String barcode) {
+    final List<TransientOperation> result = <TransientOperation>[];
+    for (final TransientOperation transientProduct
+        in _daoTransientProduct.getAll(barcode)) {
+      if (taskActionable.matches(transientProduct)) {
+        result.add(transientProduct);
+      }
+    }
+    result.sort(OperationType.sort);
+    return result;
+  }
+
+  Product getUpToDateProduct(Product product) {
+    final String barcode = product.barcode!;
+    final Iterable<TransientOperation> sortedOperations =
+        getSortedOperations(barcode);
+    for (final TransientOperation operation in sortedOperations) {
+      final Product minimalistProduct = operation.product;
+      product = _overwrite(product, minimalistProduct);
+    }
+    return product;
+  }
+
+  Future<String> add(final Product product) async {
+    final String key = await taskActionable.getNewKey(
+      localDatabase,
+      product.barcode!,
+    );
+    _daoTransientProduct.put(key, product);
+    return key;
+  }
+
+  /// Returns true if some actions have not been terminated.
+  bool hasNotTerminatedOperations(final String barcode) {
+    final Iterable<TransientOperation> actions = getSortedOperations(barcode);
+    return actions.isNotEmpty;
+  }
+
+  /// Terminates a single operation.
+  void terminate(final String operationKey) =>
+      _daoTransientProduct.delete(operationKey);
+
+  /// Overwrite the [initial] product with the non-null fields of [change].
+  ///
+  /// Currently limited to the fields modified by
+  /// * [BackgroundTaskDetails]
+  /// * [BackgroundTaskImage]
+  // TODO(monsieurtanuki): refactor this "à la copyWith" or something like that
+  Product _overwrite(final Product initial, final Product change) {
+    if (change.productName != null) {
+      initial.productName = change.productName;
+    }
+    if (change.quantity != null) {
+      initial.quantity = change.quantity;
+    }
+    if (change.brands != null) {
+      initial.brands = change.brands;
+    }
+    if (change.ingredientsText != null) {
+      initial.ingredientsText = change.ingredientsText;
+    }
+    if (change.packaging != null) {
+      initial.packaging = change.packaging;
+    }
+    if (change.noNutritionData != null) {
+      initial.noNutritionData = change.noNutritionData;
+    }
+    if (change.nutriments != null) {
+      initial.nutriments = change.nutriments;
+    }
+    if (change.servingSize != null) {
+      initial.servingSize = change.servingSize;
+    }
+    if (change.stores != null) {
+      initial.stores = change.stores;
+    }
+    if (change.origins != null) {
+      initial.origins = change.origins;
+    }
+    if (change.embCodes != null) {
+      initial.embCodes = change.embCodes;
+    }
+    if (change.labels != null) {
+      initial.labels = change.labels;
+    }
+    if (change.labelsTagsInLanguages != null) {
+      initial.labelsTagsInLanguages = change.labelsTagsInLanguages;
+    }
+    if (change.categories != null) {
+      initial.categories = change.categories;
+    }
+    if (change.categoriesTagsInLanguages != null) {
+      initial.categoriesTagsInLanguages = change.categoriesTagsInLanguages;
+    }
+    if (change.countries != null) {
+      initial.countries = change.countries;
+    }
+    if (change.countriesTagsInLanguages != null) {
+      initial.countriesTagsInLanguages = change.countriesTagsInLanguages;
+    }
+    if (change.imageFrontUrl != null) {
+      initial.imageFrontUrl = change.imageFrontUrl;
+    }
+    if (change.imageFrontSmallUrl != null) {
+      initial.imageFrontSmallUrl = change.imageFrontSmallUrl;
+    }
+    if (change.imageIngredientsUrl != null) {
+      initial.imageIngredientsUrl = change.imageIngredientsUrl;
+    }
+    if (change.imageIngredientsSmallUrl != null) {
+      initial.imageIngredientsSmallUrl = change.imageIngredientsSmallUrl;
+    }
+    if (change.imageNutritionUrl != null) {
+      initial.imageNutritionUrl = change.imageNutritionUrl;
+    }
+    if (change.imageNutritionSmallUrl != null) {
+      initial.imageNutritionSmallUrl = change.imageNutritionSmallUrl;
+    }
+    if (change.imagePackagingUrl != null) {
+      initial.imagePackagingUrl = change.imagePackagingUrl;
+    }
+    if (change.imagePackagingSmallUrl != null) {
+      initial.imagePackagingSmallUrl = change.imagePackagingSmallUrl;
+    }
+    return initial;
+  }
+}

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_page.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_page.dart
@@ -35,19 +35,20 @@ class _KnowledgePanelPageState extends State<KnowledgePanelPage>
   String get traceName => 'Opened full knowledge panel page';
 
   late Product _product;
+  late final Product _initialProduct;
   late final LocalDatabase _localDatabase;
 
   @override
   void initState() {
     super.initState();
-    _product = widget.product;
+    _initialProduct = widget.product;
     _localDatabase = context.read<LocalDatabase>();
-    _localDatabase.upToDate.showInterest(_product.barcode!);
+    _localDatabase.upToDate.showInterest(_initialProduct.barcode!);
   }
 
   @override
   void dispose() {
-    _localDatabase.upToDate.loseInterest(_product.barcode!);
+    _localDatabase.upToDate.loseInterest(_initialProduct.barcode!);
     super.dispose();
   }
 
@@ -62,11 +63,8 @@ class _KnowledgePanelPageState extends State<KnowledgePanelPage>
 
   @override
   Widget build(BuildContext context) {
-    final LocalDatabase localDatabase = context.watch<LocalDatabase>();
-    final Product? refreshedProduct = localDatabase.upToDate.get(_product);
-    if (refreshedProduct != null) {
-      _product = refreshedProduct;
-    }
+    context.watch<LocalDatabase>();
+    _product = _localDatabase.upToDate.getLocalUpToDate(_initialProduct);
     return SmoothScaffold(
       appBar: AppBar(
         title: Text(

--- a/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
@@ -1,19 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
-import 'package:provider/provider.dart';
 import 'package:smooth_app/background/background_task_details.dart';
 import 'package:smooth_app/cards/product_cards/product_image_carousel.dart';
-import 'package:smooth_app/database/dao_product.dart';
-import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
-import 'package:smooth_app/generic_lib/duration_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_text_form_field.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
+/// Input of a product's basic details, like name, quantity and brands.
 class AddBasicDetailsPage extends StatefulWidget {
   const AddBasicDetailsPage(
     this.product, {
@@ -22,6 +19,15 @@ class AddBasicDetailsPage extends StatefulWidget {
 
   final Product product;
   final bool isLoggedInMandatory;
+
+  /// Returns true if the [field] is valid (= not empty).
+  static bool _isProductFieldValid(final String? field) =>
+      field != null && field.trim().isNotEmpty;
+
+  /// Returns true if the [product] basic details are valid (= not empty).
+  static bool isProductBasicValid(final Product product) =>
+      _isProductFieldValid(product.productName) &&
+      _isProductFieldValid(product.brands);
 
   @override
   State<AddBasicDetailsPage> createState() => _AddBasicDetailsPageState();
@@ -37,30 +43,33 @@ class _AddBasicDetailsPageState extends State<AddBasicDetailsPage> {
   late Product _product;
   late AppLocalizations appLocalizations = AppLocalizations.of(context);
 
+  bool _initDone = false;
+
   void _initializeProduct() {
+    if (_initDone) {
+      return;
+    }
+    _initDone = true;
     _product = widget.product;
     _productNameController.text = _product.productName ?? '';
     _weightController.text = _product.quantity ?? '';
     _brandNameController.text = _formatProductBrands(_product.brands);
   }
 
-  /// Sets a [Product] with the values from the text fields.
-  void _setChangedProduct(Product product) {
-    product.productName = _productNameController.text;
-    product.quantity = _weightController.text;
-    product.brands = _formatProductBrands(_brandNameController.text);
-  }
+  /// Returns a [Product] with the values from the text fields.
+  Product _getMinimalistProduct() => Product()
+    ..barcode = _product.barcode
+    ..productName = _productNameController.text
+    ..quantity = _weightController.text
+    ..brands = _formatProductBrands(_brandNameController.text);
 
-  String _formatProductBrands(String? text) {
-    return text == null ? '' : formatProductBrands(text, appLocalizations);
-  }
+  String _formatProductBrands(String? text) =>
+      text == null ? '' : formatProductBrands(text, appLocalizations);
 
   @override
   Widget build(BuildContext context) {
     _initializeProduct();
     final Size size = MediaQuery.of(context).size;
-    final LocalDatabase localDatabase = context.watch<LocalDatabase>();
-    final DaoProduct daoProduct = DaoProduct(localDatabase);
     return SmoothScaffold(
       appBar: SmoothAppBar(
         title: Text(appLocalizations.basic_details),
@@ -82,53 +91,52 @@ class _AddBasicDetailsPageState extends State<AddBasicDetailsPage> {
               ),
             ),
             SizedBox(height: _heightSpace),
-            if (_product.barcode != null)
-              Padding(
-                padding: EdgeInsets.symmetric(horizontal: size.width * 0.05),
-                child: Column(
-                  children: <Widget>[
-                    Text(
-                      appLocalizations.barcode_barcode(_product.barcode!),
-                      style: Theme.of(context).textTheme.bodyText2?.copyWith(
-                            fontWeight: FontWeight.bold,
-                          ),
-                    ),
-                    SizedBox(height: _heightSpace),
-                    SmoothTextFormField(
-                      controller: _productNameController,
-                      type: TextFieldTypes.PLAIN_TEXT,
-                      hintText: appLocalizations.product_name,
-                      validator: (String? value) {
-                        if (value == null || value.isEmpty) {
-                          return appLocalizations
-                              .add_basic_details_product_name_error;
-                        }
-                        return null;
-                      },
-                    ),
-                    SizedBox(height: _heightSpace),
-                    SmoothTextFormField(
-                      controller: _brandNameController,
-                      type: TextFieldTypes.PLAIN_TEXT,
-                      hintText: appLocalizations.brand_name,
-                      validator: (String? value) {
-                        if (value == null || value.isEmpty) {
-                          return appLocalizations
-                              .add_basic_details_brand_name_error;
-                        }
-                        return null;
-                      },
-                    ),
-                    SizedBox(height: _heightSpace),
-                    SmoothTextFormField(
-                      controller: _weightController,
-                      type: TextFieldTypes.PLAIN_TEXT,
-                      hintText: appLocalizations.quantity,
-                    ),
-                    SizedBox(height: _heightSpace),
-                  ],
-                ),
+            Padding(
+              padding: EdgeInsets.symmetric(horizontal: size.width * 0.05),
+              child: Column(
+                children: <Widget>[
+                  Text(
+                    appLocalizations.barcode_barcode(_product.barcode!),
+                    style: Theme.of(context).textTheme.bodyText2?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
+                  ),
+                  SizedBox(height: _heightSpace),
+                  SmoothTextFormField(
+                    controller: _productNameController,
+                    type: TextFieldTypes.PLAIN_TEXT,
+                    hintText: appLocalizations.product_name,
+                    validator: (String? value) {
+                      if (!AddBasicDetailsPage._isProductFieldValid(value)) {
+                        return appLocalizations
+                            .add_basic_details_product_name_error;
+                      }
+                      return null;
+                    },
+                  ),
+                  SizedBox(height: _heightSpace),
+                  SmoothTextFormField(
+                    controller: _brandNameController,
+                    type: TextFieldTypes.PLAIN_TEXT,
+                    hintText: appLocalizations.brand_name,
+                    validator: (String? value) {
+                      if (!AddBasicDetailsPage._isProductFieldValid(value)) {
+                        return appLocalizations
+                            .add_basic_details_brand_name_error;
+                      }
+                      return null;
+                    },
+                  ),
+                  SizedBox(height: _heightSpace),
+                  SmoothTextFormField(
+                    controller: _weightController,
+                    type: TextFieldTypes.PLAIN_TEXT,
+                    hintText: appLocalizations.quantity,
+                  ),
+                  SizedBox(height: _heightSpace),
+                ],
               ),
+            ),
             Padding(
               padding: const EdgeInsets.symmetric(
                 horizontal: LARGE_SPACE,
@@ -144,36 +152,14 @@ class _AddBasicDetailsPageState extends State<AddBasicDetailsPage> {
                     if (!_formKey.currentState!.validate()) {
                       return;
                     }
-                    final Product inputProduct = Product(
-                      barcode: _product.barcode,
-                    );
-                    _setChangedProduct(inputProduct);
-                    final Product? cachedProduct =
-                        await daoProduct.get(_product.barcode!);
-                    if (cachedProduct != null) {
-                      _setChangedProduct(cachedProduct);
-                    }
                     await BackgroundTaskDetails.addTask(
-                      inputProduct,
-                      productEditTask: ProductEditTask.basic,
+                      _getMinimalistProduct(),
                       widget: this,
                     );
-                    final Product upToDateProduct =
-                        cachedProduct ?? inputProduct;
-                    await daoProduct.put(upToDateProduct);
-                    localDatabase.upToDate.set(upToDateProduct);
                     if (!mounted) {
                       return;
                     }
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(
-                        content: Text(
-                          appLocalizations.basic_details_add_success,
-                        ),
-                        duration: SnackBarDuration.medium,
-                      ),
-                    );
-                    Navigator.pop(context, upToDateProduct);
+                    Navigator.pop(context);
                   },
                 ),
               ),

--- a/packages/smooth_app/lib/pages/product/add_new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_new_product_page.dart
@@ -42,14 +42,18 @@ class _AddNewProductPageState extends State<AddNewProductPage> {
   final Map<ImageField, List<File>> _uploadedImages =
       <ImageField, List<File>>{};
 
+  late Product _product;
+  late final Product _initialProduct;
   late final LocalDatabase _localDatabase;
 
-  bool _nutritionFactsAdded = false;
-  bool _basicDetailsAdded = false;
+  bool get _nutritionFactsAdded => _product.nutriments != null;
+  bool get _basicDetailsAdded =>
+      AddBasicDetailsPage.isProductBasicValid(_product);
 
   @override
   void initState() {
     super.initState();
+    _initialProduct = Product(barcode: widget.barcode);
     _localDatabase = context.read<LocalDatabase>();
     _localDatabase.upToDate.showInterest(widget.barcode);
   }
@@ -63,13 +67,9 @@ class _AddNewProductPageState extends State<AddNewProductPage> {
   @override
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    final LocalDatabase localDatabase = context.watch<LocalDatabase>();
+    context.watch<LocalDatabase>();
     final ThemeData themeData = Theme.of(context);
-    Product product = Product(barcode: widget.barcode);
-    final Product? refreshedProduct = localDatabase.upToDate.get(product);
-    if (refreshedProduct != null) {
-      product = refreshedProduct;
-    }
+    _product = _localDatabase.upToDate.getLocalUpToDate(_initialProduct);
     return SmoothScaffold(
       appBar: AppBar(
           title: Text(appLocalizations.new_product),
@@ -79,29 +79,23 @@ class _AddNewProductPageState extends State<AddNewProductPage> {
           if (_basicDetailsAdded ||
               _nutritionFactsAdded ||
               _uploadedImages.isNotEmpty) {
-            final LocalDatabase localDatabase = context.read<LocalDatabase>();
-            final DaoProduct daoProduct = DaoProduct(localDatabase);
+            // Tricky situation: we've launched background tasks,
+            // but is at least one of them completed?
+            final DaoProduct daoProduct = DaoProduct(_localDatabase);
             final Product? localProduct = await daoProduct.get(widget.barcode);
+            // No background task was completed yet: we create a dummy product,
+            // so that the pending changes can go on top of something.
             if (localProduct == null) {
-              product = Product(
-                barcode: widget.barcode,
-              );
-              daoProduct.put(product);
-              localDatabase.notifyListeners();
+              await daoProduct.put(_initialProduct);
+              _localDatabase.upToDate
+                  .setLatestDownloadedProduct(_initialProduct);
+              _localDatabase.notifyListeners();
             }
-            localDatabase.upToDate.set(product);
-            if (mounted) {
-              await Navigator.maybePop(
-                context,
-                widget.barcode,
-              );
-            }
-          } else {
-            await Navigator.maybePop(
-              context,
-              null,
-            );
           }
+          if (!mounted) {
+            return;
+          }
+          await Navigator.maybePop(context);
         },
         label: Text(appLocalizations.finish),
         icon: const Icon(Icons.done),
@@ -122,7 +116,7 @@ class _AddNewProductPageState extends State<AddNewProductPage> {
                     .apply(color: themeData.colorScheme.onBackground),
               ),
               ..._buildImageCaptureRows(context),
-              _buildNutritionInputButton(product),
+              _buildNutritionInputButton(),
               _buildaddInputDetailsButton()
             ],
           ),
@@ -183,7 +177,7 @@ class _AddNewProductPageState extends State<AddNewProductPage> {
             MaterialPageRoute<File?>(
               builder: (BuildContext context) => ConfirmAndUploadPicture(
                 barcode: widget.barcode,
-                imageType: imageType,
+                imageField: imageType,
                 initialPhoto: initialPhoto,
               ),
             ),
@@ -225,9 +219,9 @@ class _AddNewProductPageState extends State<AddNewProductPage> {
     return (_uploadedImages[imageType] ?? <File>[]).isNotEmpty;
   }
 
-  Widget _buildNutritionInputButton(Product product) {
+  Widget _buildNutritionInputButton() {
     // if the nutrition image is null, ie no image , we return nothing
-    if (product.imageNutritionUrl == null) {
+    if (_product.imageNutritionUrl == null) {
       return const SizedBox();
     }
     if (_nutritionFactsAdded) {
@@ -243,27 +237,21 @@ class _AddNewProductPageState extends State<AddNewProductPage> {
         onPressed: () async {
           final OrderedNutrientsCache? cache =
               await OrderedNutrientsCache.getCache(context);
-          if (cache == null) {
-            if (!mounted) {
-              return;
-            }
-            final SnackBar snackBar = SnackBar(
-              content: Text(
-                  AppLocalizations.of(context).nutrition_cache_loading_error),
-            );
-            if (!mounted) {
-              return;
-            }
-            ScaffoldMessenger.of(context).showSnackBar(snackBar);
-            return;
-          }
           if (!mounted) {
             return;
           }
-          // TODO(monsieurtanuki): careful, waiting for pop'ed value
-          final Product? result = await Navigator.push<Product?>(
+          if (cache == null) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text(
+                    AppLocalizations.of(context).nutrition_cache_loading_error),
+              ),
+            );
+            return;
+          }
+          await Navigator.push<void>(
             context,
-            MaterialPageRoute<Product>(
+            MaterialPageRoute<void>(
               builder: (BuildContext context) => NutritionPageLoaded(
                 Product(barcode: widget.barcode),
                 cache.orderedNutrients,
@@ -272,10 +260,6 @@ class _AddNewProductPageState extends State<AddNewProductPage> {
               fullscreenDialog: true,
             ),
           );
-
-          setState(() {
-            _nutritionFactsAdded = result != null;
-          });
         },
       ),
     );
@@ -292,22 +276,15 @@ class _AddNewProductPageState extends State<AddNewProductPage> {
       child: SmoothLargeButtonWithIcon(
         text: AppLocalizations.of(context).completed_basic_details_btn_text,
         icon: Icons.edit,
-        onPressed: () async {
-          // TODO(monsieurtanuki): probably wrong as AddBasicDetailsPage pops nothing
-          // TODO(monsieurtanuki): careful, waiting for pop'ed value
-          final Product? result = await Navigator.push<Product?>(
-            context,
-            MaterialPageRoute<Product>(
-              builder: (BuildContext context) => AddBasicDetailsPage(
-                Product(barcode: widget.barcode),
-                isLoggedInMandatory: false,
-              ),
+        onPressed: () async => Navigator.push<void>(
+          context,
+          MaterialPageRoute<void>(
+            builder: (BuildContext context) => AddBasicDetailsPage(
+              Product(barcode: widget.barcode),
+              isLoggedInMandatory: false,
             ),
-          );
-          setState(() {
-            _basicDetailsAdded = result != null;
-          });
-        },
+          ),
+        ),
       ),
     );
   }

--- a/packages/smooth_app/lib/pages/product/add_new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_new_product_page.dart
@@ -177,7 +177,7 @@ class _AddNewProductPageState extends State<AddNewProductPage> {
             MaterialPageRoute<File?>(
               builder: (BuildContext context) => ConfirmAndUploadPicture(
                 barcode: widget.barcode,
-                imageField: imageType,
+                imageType: imageType,
                 initialPhoto: initialPhoto,
               ),
             ),

--- a/packages/smooth_app/lib/pages/product/common/product_dialog_helper.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_dialog_helper.dart
@@ -56,9 +56,9 @@ class ProductDialogHelper {
             ),
             positiveAction: SmoothActionButton(
               text: AppLocalizations.of(context).contribute,
-              onPressed: () => Navigator.push<bool?>(
+              onPressed: () => Navigator.push<void>(
                 context,
-                MaterialPageRoute<bool?>(
+                MaterialPageRoute<void>(
                   builder: (BuildContext context) => AddNewProductPage(barcode),
                 ),
               ),

--- a/packages/smooth_app/lib/pages/product/common/product_list_item_simple.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_item_simple.dart
@@ -53,10 +53,8 @@ class _ProductListItemSimpleState extends State<ProductListItemSimple> {
           final AppLocalizations appLocalizations =
               AppLocalizations.of(context);
           context.watch<ProductModel>();
-          final LocalDatabase localDatabase = context.watch<LocalDatabase>();
-          _model.setRefreshedProduct(
-            localDatabase.upToDate.getFromBarcode(widget.barcode),
-          );
+          context.watch<LocalDatabase>();
+          _model.setLocalUpToDate();
           switch (_model.loadingStatus) {
             case LoadingStatus.LOADING:
               return SmoothProductCardTemplate(

--- a/packages/smooth_app/lib/pages/product/edit_ingredients_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_ingredients_page.dart
@@ -6,7 +6,6 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/background/background_task_details.dart';
-import 'package:smooth_app/database/dao_product.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
@@ -37,20 +36,23 @@ class EditOcrPage extends StatefulWidget {
 class _EditOcrPageState extends State<EditOcrPage> {
   final TextEditingController _controller = TextEditingController();
   ImageProvider? _imageProvider;
+  // TODO(monsieurtanuki): probably not relevant as relying on background task
   bool _updatingImage = false;
+  // TODO(monsieurtanuki): probably not relevant as relying on background task
   bool _updatingText = false;
   late Product _product;
+  late final Product _initialProduct;
   late final LocalDatabase _localDatabase;
   late OcrHelper _helper;
 
   @override
   void initState() {
     super.initState();
-    _product = widget.product;
+    _initialProduct = widget.product;
     _localDatabase = context.read<LocalDatabase>();
-    _localDatabase.upToDate.showInterest(_product.barcode!);
+    _localDatabase.upToDate.showInterest(_initialProduct.barcode!);
     _helper = widget.helper;
-    _controller.text = _helper.getText(_product);
+    _controller.text = _helper.getText(_initialProduct);
   }
 
   @override
@@ -129,32 +131,17 @@ class _EditOcrPageState extends State<EditOcrPage> {
   Future<void> _updateText(
     final String text,
     final ImageField imageField,
-  ) async {
-    final LocalDatabase localDatabase = context.read<LocalDatabase>();
-    final DaoProduct daoProduct = DaoProduct(localDatabase);
-    Product changedProduct = Product(barcode: _product.barcode);
-    Product? cachedProduct = await daoProduct.get(_product.barcode!);
-    if (cachedProduct != null) {
-      cachedProduct = _helper.getMinimalistProduct(cachedProduct, text);
-    }
-    changedProduct = _helper.getMinimalistProduct(changedProduct, text);
-    await BackgroundTaskDetails.addTask(
-      changedProduct,
-      productEditTask:
-          _helper.getImageField().value == ImageField.PACKAGING.value
-              ? ProductEditTask.packaging
-              : ProductEditTask.ingredient,
-      widget: this,
-    );
-    final Product upToDateProduct = cachedProduct ?? changedProduct;
-    await daoProduct.put(upToDateProduct);
-    localDatabase.upToDate.set(upToDateProduct);
-  }
+  ) async =>
+      BackgroundTaskDetails.addTask(
+        _helper.getMinimalistProduct(Product(barcode: _product.barcode), text),
+        widget: this,
+      );
 
   @override
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    final LocalDatabase localDatabase = context.watch<LocalDatabase>();
+    context.watch<LocalDatabase>();
+    _product = _localDatabase.upToDate.getLocalUpToDate(_initialProduct);
     final Size size = MediaQuery.of(context).size;
     final List<Widget> children = <Widget>[];
 
@@ -219,13 +206,13 @@ class _EditOcrPageState extends State<EditOcrPage> {
       );
     }
 
-    final Scaffold scaffold = SmoothScaffold(
+    return SmoothScaffold(
       extendBodyBehindAppBar: true,
       appBar: SmoothAppBar(
         title: Text(_helper.getTitle(appLocalizations)),
-        subTitle: widget.product.productName != null
+        subTitle: _product.productName != null
             ? Text(
-                widget.product.productName!,
+                _product.productName!,
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
               )
@@ -244,11 +231,6 @@ class _EditOcrPageState extends State<EditOcrPage> {
         children: children,
       ),
     );
-    final Product? refreshedProduct = localDatabase.upToDate.get(_product);
-    if (refreshedProduct != null) {
-      _product = refreshedProduct;
-    }
-    return scaffold;
   }
 
   Widget _buildZoomableImage(ImageProvider imageSource) {

--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -39,25 +39,25 @@ class _EditProductPageState extends State<EditProductPage> {
   final ScrollController _controller = ScrollController();
   bool _barcodeVisibleInAppbar = false;
   late Product _product;
+  late final Product _initialProduct;
   late final LocalDatabase _localDatabase;
+
+  String get _barcode => _initialProduct.barcode!;
 
   @override
   void initState() {
     super.initState();
-    _product = widget.product;
+    _initialProduct = widget.product;
     _localDatabase = context.read<LocalDatabase>();
-    _localDatabase.upToDate.showInterest(_product.barcode!);
+    _localDatabase.upToDate.showInterest(_barcode);
     _controller.addListener(_onScrollChanged);
   }
 
   @override
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    final LocalDatabase localDatabase = context.watch<LocalDatabase>();
-    final Product? refreshedProduct = localDatabase.upToDate.get(_product);
-    if (refreshedProduct != null) {
-      _product = refreshedProduct;
-    }
+    context.watch<LocalDatabase>();
+    _product = _localDatabase.upToDate.getLocalUpToDate(_initialProduct);
     final ThemeData theme = Theme.of(context);
     final Brightness brightness = theme.brightness;
     final Size screenSize = MediaQuery.of(context).size;
@@ -77,12 +77,12 @@ class _EditProductPageState extends State<EditProductPage> {
               style: theme.primaryTextTheme.headline6
                   ?.copyWith(fontWeight: FontWeight.w500),
             ),
-            if (_product.barcode?.isNotEmpty == true)
+            if (_barcode.isNotEmpty)
               AnimatedContainer(
                 duration: const Duration(milliseconds: 250),
                 height: _barcodeVisibleInAppbar ? 13.0 : 0.0,
                 child: Text(
-                  _product.barcode!,
+                  _barcode,
                   style: theme.textTheme.subtitle1?.copyWith(
                     fontWeight: FontWeight.normal,
                   ),
@@ -96,13 +96,12 @@ class _EditProductPageState extends State<EditProductPage> {
             tooltip: appLocalizations.clipboard_barcode_copy,
             onPressed: () {
               Clipboard.setData(
-                ClipboardData(text: _product.barcode),
+                ClipboardData(text: _barcode),
               );
               ScaffoldMessenger.of(context).showSnackBar(
                 SnackBar(
                   content: Text(
-                    appLocalizations
-                        .clipboard_barcode_copied(_product.barcode!),
+                    appLocalizations.clipboard_barcode_copied(_barcode),
                   ),
                 ),
               );
@@ -112,33 +111,31 @@ class _EditProductPageState extends State<EditProductPage> {
       ),
       body: RefreshIndicator(
         onRefresh: () async => ProductRefresher().fetchAndRefresh(
-          barcode: _product.barcode!,
+          barcode: _barcode,
           widget: this,
         ),
         child: Scrollbar(
           child: ListView(
             controller: _controller,
             children: <Widget>[
-              if (_product.barcode != null)
-                BarcodeWidget(
-                  padding: EdgeInsets.symmetric(
-                    horizontal: screenSize.width / 4,
-                    vertical: SMALL_SPACE,
-                  ),
-                  barcode: _product.barcode!.length == 8
-                      ? Barcode.ean8()
-                      : Barcode.ean13(),
-                  data: _product.barcode!,
-                  color: brightness == Brightness.dark
-                      ? Colors.white
-                      : Colors.black,
-                  errorBuilder: (final BuildContext context, String? _) => Text(
-                    '${appLocalizations.edit_product_form_item_barcode}\n'
-                    '${_product.barcode}',
-                    textAlign: TextAlign.center,
-                  ),
-                  height: _barcodeHeight,
+              BarcodeWidget(
+                padding: EdgeInsets.symmetric(
+                  horizontal: screenSize.width / 4,
+                  vertical: SMALL_SPACE,
                 ),
+                barcode: _product.barcode!.length == 8
+                    ? Barcode.ean8()
+                    : Barcode.ean13(),
+                data: _barcode,
+                color:
+                    brightness == Brightness.dark ? Colors.white : Colors.black,
+                errorBuilder: (final BuildContext context, String? _) => Text(
+                  '${appLocalizations.edit_product_form_item_barcode}\n'
+                  '$_barcode',
+                  textAlign: TextAlign.center,
+                ),
+                height: _barcodeHeight,
+              ),
               _ListTitleItem(
                 title: appLocalizations.edit_product_form_item_details_title,
                 subtitle:
@@ -165,29 +162,15 @@ class _EditProductPageState extends State<EditProductPage> {
                   if (!await ProductRefresher().checkIfLoggedIn(context)) {
                     return;
                   }
-                  // TODO(monsieurtanuki): careful, waiting for pop'ed value
-                  final bool? refreshed = await Navigator.push<bool>(
+                  await Navigator.push<void>(
                     context,
-                    MaterialPageRoute<bool>(
+                    MaterialPageRoute<void>(
                       builder: (BuildContext context) =>
                           ProductImageGalleryView(
                         product: _product,
                       ),
                       fullscreenDialog: true,
                     ),
-                  );
-
-                  // TODO(monsieurtanuki): do the refresh uptream with a new ProductRefresher method
-                  if (refreshed != true) {
-                    return;
-                  }
-                  //Refetch product if needed for new urls, since no product in ProductImageGalleryView
-                  if (!mounted) {
-                    return;
-                  }
-                  await ProductRefresher().fetchAndRefresh(
-                    widget: this,
-                    barcode: _product.barcode!,
                   );
                 },
               ),
@@ -352,7 +335,7 @@ class _EditProductPageState extends State<EditProductPage> {
   void dispose() {
     _controller.removeListener(_onScrollChanged);
     _controller.dispose();
-    _localDatabase.upToDate.loseInterest(_product.barcode!);
+    _localDatabase.upToDate.loseInterest(_barcode);
     super.dispose();
   }
 }

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -44,10 +44,9 @@ class ProductPage extends StatefulWidget {
 
 class _ProductPageState extends State<ProductPage> with TraceableClientMixin {
   late Product _product;
+  late final Product _initialProduct;
   late final LocalDatabase _localDatabase;
   late ProductPreferences _productPreferences;
-  late ScrollController _scrollController;
-  bool _mustScrollToTheEnd = false;
   bool scrollingUp = true;
 
   @override
@@ -56,13 +55,14 @@ class _ProductPageState extends State<ProductPage> with TraceableClientMixin {
   @override
   String get traceTitle => 'product_page';
 
+  String get _barcode => _initialProduct.barcode!;
+
   @override
   void initState() {
     super.initState();
-    _product = widget.product;
+    _initialProduct = widget.product;
     _localDatabase = context.read<LocalDatabase>();
-    _localDatabase.upToDate.showInterest(_product.barcode!);
-    _scrollController = ScrollController();
+    _localDatabase.upToDate.showInterest(_barcode);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _updateLocalDatabaseWithProductHistory(context);
     });
@@ -70,7 +70,7 @@ class _ProductPageState extends State<ProductPage> with TraceableClientMixin {
 
   @override
   void dispose() {
-    _localDatabase.upToDate.loseInterest(_product.barcode!);
+    _localDatabase.upToDate.loseInterest(_barcode);
     super.dispose();
   }
 
@@ -78,19 +78,11 @@ class _ProductPageState extends State<ProductPage> with TraceableClientMixin {
   Widget build(BuildContext context) {
     final InheritedDataManagerState inheritedDataManager =
         InheritedDataManager.of(context);
-    inheritedDataManager.setCurrentBarcode(_product.barcode ?? '');
+    inheritedDataManager.setCurrentBarcode(_barcode);
     final ThemeData themeData = Theme.of(context);
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (_mustScrollToTheEnd) {
-        _scrollToTheEnd();
-      }
-    });
     _productPreferences = context.watch<ProductPreferences>();
-    final LocalDatabase localDatabase = context.watch<LocalDatabase>();
-    final Product? refreshedProduct = localDatabase.upToDate.get(_product);
-    if (refreshedProduct != null) {
-      _product = refreshedProduct;
-    }
+    context.watch<LocalDatabase>();
+    _product = _localDatabase.upToDate.getLocalUpToDate(_initialProduct);
 
     return SmoothScaffold(
       contentBehindStatusBar: true,
@@ -134,18 +126,9 @@ class _ProductPageState extends State<ProductPage> with TraceableClientMixin {
     );
   }
 
-  void _scrollToTheEnd() {
-    _scrollController.animateTo(
-      _scrollController.position.maxScrollExtent,
-      curve: Curves.easeOut,
-      duration: SmoothAnimationsDuration.long,
-    );
-    _mustScrollToTheEnd = false;
-  }
-
   Future<void> _refreshProduct(BuildContext context) async =>
       ProductRefresher().fetchAndRefresh(
-        barcode: _product.barcode!,
+        barcode: _barcode,
         widget: this,
       );
 
@@ -155,7 +138,7 @@ class _ProductPageState extends State<ProductPage> with TraceableClientMixin {
     final LocalDatabase localDatabase = context.read<LocalDatabase>();
     await DaoProductList(localDatabase).push(
       ProductList.history(),
-      _product.barcode!,
+      _barcode,
     );
     localDatabase.notifyListeners();
   }
@@ -189,7 +172,7 @@ class _ProductPageState extends State<ProductPage> with TraceableClientMixin {
               horizontal: SMALL_SPACE,
             ),
             child: Hero(
-              tag: _product.barcode ?? '',
+              tag: _barcode,
               child: SummaryCard(
                 _product,
                 _productPreferences,
@@ -247,14 +230,14 @@ class _ProductPageState extends State<ProductPage> with TraceableClientMixin {
   Future<void> _shareProduct() async {
     AnalyticsHelper.trackEvent(
       AnalyticsEvent.shareProduct,
-      barcode: widget.product.barcode,
+      barcode: _barcode,
     );
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     // We need to provide a sharePositionOrigin to make the plugin work on ipad
     final RenderBox? box = context.findRenderObject() as RenderBox?;
     final String url = 'https://'
         '${ProductQuery.getCountry()!.iso2Code}.openfoodfacts.org'
-        '/product/${widget.product.barcode}';
+        '/product/$_barcode';
     Share.share(
       appLocalizations.share_product_text(url),
       sharePositionOrigin: box!.localToGlobal(Offset.zero) & box.size,
@@ -325,7 +308,7 @@ class _ProductPageState extends State<ProductPage> with TraceableClientMixin {
     final DaoProductList daoProductList,
   ) =>
       FutureBuilder<List<String>>(
-        future: daoProductList.getUserLists(withBarcode: _product.barcode),
+        future: daoProductList.getUserLists(withBarcode: _barcode),
         builder: (
           final BuildContext context,
           final AsyncSnapshot<List<String>> snapshot,

--- a/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
+++ b/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
@@ -154,10 +154,8 @@ class _SmoothProductCarouselState extends State<SmoothProductCarousel> {
       case ScannedProductState.NOT_FOUND:
         return SmoothProductCardNotFound(
           barcode: barcode,
-          callback: (String? barcodeLoaded) async {
-            if (barcodeLoaded != null) {
-              await _model.refresh();
-            }
+          callback: () async {
+            await _model.refresh();
             setState(() {});
           },
         );


### PR DESCRIPTION
New files:
* `operation_type.dart`: Type of a transient operation.
* `up_to_date_changes.dart`: Sequence of minimalist product changes.

Impacted files:
* `abstract_background_task.dart`: minor refactoring
* `add_basic_details_page.dart`: refactored call to `AddTask`
* `add_new_product_page.dart`: now refreshed by detail tasks
* `background_task_details.dart`: temporary version - we run the task only once and rollback the change if it failed
* `edit_ingredients_page.dart`: now refreshed by detail tasks
* `edit_product_page.dart`: refactored; now refreshed by detail tasks
* `knowledge_panel_page.dart`: now refreshed by detail tasks
* `new_product_page.dart`: now refreshed by detail tasks
* `nutrition_page_loaded.dart`: refactored call to `AddTask`
* `product_dialog_helper.dart`: minor refactoring
* `product_list_item_simple.dart`: refactored
* `product_model.dart`: refactored
* `simple_input_page.dart`: refactored call to `AddTask`
* `simple_input_page_helpers.dart`: refactored the "language" helpers in order to get server refresh AND local refresh
* `smooth_product_card_not_found.dart`: minor refactoring
* `smooth_product_carousel.dart`: minor refactoring
* `summary_card.dart`: now refreshed by detail tasks
* `up_to_date_product_provider.dart`: added an `UpToDateChanges` field

### What
- This is a temporary version of #3018.
- In this version, only the _detail_ changes (as opposed to _image upload_) are impacted
   - each time the user changes the data and presses OK, the whole app will immediately be refreshed with that change, and the server will be called asynchronously (without `await`ing for it)
   - if the server succeeds, a fresh product is downloaded, the local minimalist change is removed and the whole app is refreshed with the new product
   - if the server fails to answer, the local change is rolled back and the whole app is refreshed without that change
   - That's the main limit of this PR, we're in "I'm lucky" mode: here we expect the server to be available and we try only once.
- The next steps will include
   - coding the same "instant refresh/async server action" for image uploads
   - managing parallel changes, on the same fields or on different fields
   - real background tasks (not just once, not just when the server is up or the connection is available)

### Part of 
- #3018