### PR TITLE
fix: 3249 - refresh of product after each Robotoff answer

### DIFF
--- a/packages/smooth_app/lib/background/abstract_background_task.dart
+++ b/packages/smooth_app/lib/background/abstract_background_task.dart
@@ -5,8 +5,8 @@ import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:smooth_app/background/background_task_details.dart';
 import 'package:smooth_app/background/background_task_image.dart';
-import 'package:smooth_app/database/dao_product.dart';
 import 'package:smooth_app/database/local_database.dart';
+import 'package:smooth_app/pages/product/common/product_refresher.dart';
 import 'package:smooth_app/query/product_query.dart';
 import 'package:task_manager/task_manager.dart';
 
@@ -67,26 +67,11 @@ abstract class AbstractBackgroundTask {
   User getUser() => User.fromJson(jsonDecode(user) as Map<String, dynamic>);
 
   /// Downloads the whole product, updates locally.
-  Future<void> _downloadAndRefresh(final LocalDatabase localDatabase) async {
-    final DaoProduct daoProduct = DaoProduct(localDatabase);
-    final ProductQueryConfiguration configuration = ProductQueryConfiguration(
-      barcode,
-      fields: ProductQuery.fields,
-      language: getLanguage(),
-      country: getCountry(),
-    );
-
-    final ProductResult queryResult =
-        await OpenFoodAPIClient.getProduct(configuration);
-    if (queryResult.status == AbstractBackgroundTask.SUCCESS_CODE) {
-      final Product? product = queryResult.product;
-      if (product != null) {
-        await daoProduct.put(product);
-        localDatabase.upToDate.setLatestDownloadedProduct(product);
-        localDatabase.notifyListeners();
-      }
-    }
-  }
+  Future<void> _downloadAndRefresh(final LocalDatabase localDatabase) async =>
+      ProductRefresher().silentFetchAndRefresh(
+        barcode: barcode,
+        localDatabase: localDatabase,
+      );
 
   /// Generates a unique id for the background task.
   ///

--- a/packages/smooth_app/lib/data_models/onboarding_data_product.dart
+++ b/packages/smooth_app/lib/data_models/onboarding_data_product.dart
@@ -5,13 +5,12 @@ import 'package:smooth_app/data_models/abstract_onboarding_data.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/duration_constants.dart';
 import 'package:smooth_app/helpers/app_helper.dart';
-import 'package:smooth_app/query/product_query.dart';
+import 'package:smooth_app/pages/product/common/product_refresher.dart';
 
 /// Helper around a product we download, store and reuse at onboarding.
 class OnboardingDataProduct extends AbstractOnboardingData<Product> {
   OnboardingDataProduct(
     final LocalDatabase localDatabase,
-    this.fields,
     this.assetPath,
   ) : super(localDatabase);
 
@@ -21,11 +20,9 @@ class OnboardingDataProduct extends AbstractOnboardingData<Product> {
   OnboardingDataProduct.forProduct(final LocalDatabase localDatabase)
       : this(
           localDatabase,
-          ProductQuery.fields,
           AppHelper.getAssetPath('assets/onboarding/sample_product_data.json'),
         );
 
-  final List<ProductField> fields;
   final String assetPath;
 
   @override
@@ -38,11 +35,8 @@ class OnboardingDataProduct extends AbstractOnboardingData<Product> {
   @override
   Future<String> downloadDataString() async =>
       OpenFoodAPIClient.getProductString(
-        ProductQueryConfiguration(
+        ProductRefresher().getBarcodeQueryConfiguration(
           AbstractOnboardingData.barcode,
-          fields: fields,
-          language: ProductQuery.getLanguage(),
-          country: ProductQuery.getCountry(),
         ),
       ).timeout(SnackBarDuration.long);
 

--- a/packages/smooth_app/lib/pages/hunger_games/question_card.dart
+++ b/packages/smooth_app/lib/pages/hunger_games/question_card.dart
@@ -1,66 +1,83 @@
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:provider/provider.dart';
 import 'package:shimmer/shimmer.dart';
 import 'package:smooth_app/cards/product_cards/product_image_carousel.dart';
 import 'package:smooth_app/cards/product_cards/product_title_card.dart';
+import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/pages/product/common/product_refresher.dart';
 
 /// Display of a Robotoff question text.
 class QuestionCard extends StatelessWidget {
   const QuestionCard(
     this.question, {
-    Key? key,
-  }) : super(key: key);
+    this.initialProduct,
+    super.key,
+  });
 
   final RobotoffQuestion question;
+  final Product? initialProduct;
 
   static const Color robotoffBackground = Color(0xFFFFEFB7);
 
   @override
   Widget build(BuildContext context) {
-    final Future<Product> productFuture = OpenFoodAPIClient.getProduct(
-      ProductQueryConfiguration(question.barcode!),
-    ).then((ProductResult result) => result.product!);
+    final Future<Product?> productFuture =
+        ProductRefresher().silentFetchAndRefresh(
+      barcode: question.barcode!,
+      localDatabase: context.read<LocalDatabase>(),
+    );
 
     final Size screenSize = MediaQuery.of(context).size;
 
-    return FutureBuilder<Product>(
-        future: productFuture,
-        builder: (BuildContext context, AsyncSnapshot<Product> snapshot) {
-          if (!snapshot.hasData) {
-            return _buildQuestionShimmer();
-          }
-          final Product product = snapshot.data!;
-          return Card(
-            elevation: 4,
-            clipBehavior: Clip.antiAlias,
-            shape: const RoundedRectangleBorder(
-              borderRadius: ROUNDED_BORDER_RADIUS,
-            ),
-            child: Column(
-              children: <Widget>[
-                ProductImageCarousel(
-                  product,
-                  height: screenSize.height / 6,
-                  alternateImageUrl: question.imageUrl,
+    return FutureBuilder<Product?>(
+      future: productFuture,
+      builder: (
+        BuildContext context,
+        AsyncSnapshot<Product?> snapshot,
+      ) {
+        Product? product;
+        if (snapshot.connectionState == ConnectionState.done) {
+          product = snapshot.data;
+          // TODO(monsieurtanuki): do something aggressive if product is null here and we don't have a fallback value - like an error widget
+        }
+        // fallback version
+        product ??= initialProduct;
+        if (product == null) {
+          return _buildQuestionShimmer();
+        }
+        return Card(
+          elevation: 4,
+          clipBehavior: Clip.antiAlias,
+          shape: const RoundedRectangleBorder(
+            borderRadius: ROUNDED_BORDER_RADIUS,
+          ),
+          child: Column(
+            children: <Widget>[
+              ProductImageCarousel(
+                product,
+                height: screenSize.height / 6,
+                alternateImageUrl: question.imageUrl,
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
+                child: Column(
+                  children: <Widget>[
+                    ProductTitleCard(
+                      product,
+                      true,
+                      dense: true,
+                    ),
+                  ],
                 ),
-                Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
-                  child: Column(
-                    children: <Widget>[
-                      ProductTitleCard(
-                        product,
-                        true,
-                        dense: true,
-                      ),
-                    ],
-                  ),
-                ),
-                _buildQuestionText(context, question),
-              ],
-            ),
-          );
-        });
+              ),
+              _buildQuestionText(context, question),
+            ],
+          ),
+        );
+      },
+    );
   }
 
   Widget _buildQuestionText(BuildContext context, RobotoffQuestion question) {

--- a/packages/smooth_app/lib/pages/hunger_games/question_page.dart
+++ b/packages/smooth_app/lib/pages/hunger_games/question_page.dart
@@ -12,6 +12,7 @@ import 'package:smooth_app/helpers/robotoff_insight_helper.dart';
 import 'package:smooth_app/pages/hunger_games/congrats.dart';
 import 'package:smooth_app/pages/hunger_games/question_answers_options.dart';
 import 'package:smooth_app/pages/hunger_games/question_card.dart';
+import 'package:smooth_app/pages/product/common/product_refresher.dart';
 import 'package:smooth_app/query/product_questions_query.dart';
 import 'package:smooth_app/query/questions_query.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
@@ -42,11 +43,13 @@ class _QuestionPageState extends State<QuestionPage>
 
   late Future<List<RobotoffQuestion>> questions;
   int _currentQuestionIndex = 0;
+  late LocalDatabase _localDatabase;
 
   @override
   void initState() {
     super.initState();
 
+    _localDatabase = context.read<LocalDatabase>();
     final List<RobotoffQuestion>? widgetQuestions = widget.questions;
 
     if (widgetQuestions != null) {
@@ -174,10 +177,13 @@ class _QuestionPageState extends State<QuestionPage>
 
     return Column(
       children: <Widget>[
-        QuestionCard(question),
+        QuestionCard(
+          question,
+          initialProduct: widget.product,
+        ),
         QuestionAnswersOptions(
           question,
-          onAnswer: (InsightAnnotation answer) => trySave(
+          onAnswer: (InsightAnnotation answer) => _trySave(
             question,
             answer,
             appLocalizations,
@@ -187,7 +193,7 @@ class _QuestionPageState extends State<QuestionPage>
     );
   }
 
-  Future<void> trySave(
+  Future<void> _trySave(
     RobotoffQuestion question,
     InsightAnnotation insightAnnotation,
     AppLocalizations appLocalizations,
@@ -228,21 +234,18 @@ class _QuestionPageState extends State<QuestionPage>
     await LoadingDialog.run<Status>(
       context: context,
       title: appLocalizations.saving_answer,
-      // TODO(monsieurtanuki): remove that line when fixed in [off-dart #451](https://github.com/openfoodfacts/openfoodfacts-dart/pull/451)
-      future: OpenFoodAPIClient.postInsightAnnotation(
-        insightId,
-        insightAnnotation,
-        deviceId: OpenFoodAPIConfiguration.uuid,
-        user: OpenFoodAPIConfiguration.globalUser,
+      future: _saveAnswerQuery(
+        insightId: insightId,
+        insightAnnotation: insightAnnotation,
+        barcode: barcode,
       ),
     );
     if (barcode != null && insightId != null) {
       if (!mounted) {
         return;
       }
-      final LocalDatabase localDatabase = context.read<LocalDatabase>();
       final RobotoffInsightHelper robotoffInsightHelper =
-          RobotoffInsightHelper(localDatabase);
+          RobotoffInsightHelper(_localDatabase);
       await robotoffInsightHelper.cacheInsightAnnotationVoted(
         barcode,
         insightId,
@@ -254,4 +257,27 @@ class _QuestionPageState extends State<QuestionPage>
       product != null
           ? ProductQuestionsQuery(product.barcode!).getQuestions()
           : QuestionsQuery().getQuestions();
+
+  /// Saves the Robotoff answer and refreshes the product locally if relevant.
+  Future<Status> _saveAnswerQuery({
+    required String? barcode,
+    required String? insightId,
+    required InsightAnnotation insightAnnotation,
+  }) async {
+    final Status status = await OpenFoodAPIClient.postInsightAnnotation(
+      insightId,
+      insightAnnotation,
+      deviceId: OpenFoodAPIConfiguration.uuid,
+      user: OpenFoodAPIConfiguration.globalUser,
+    );
+    // TODO(monsieurtanuki): optim - do not ask QuestionCard to constantly refresh the product if we deal with several times the same product
+    if (widget.product != null) {
+      // here we have a special interest in that product being up-to-date
+      await ProductRefresher().silentFetchAndRefresh(
+        barcode: widget.product!.barcode!,
+        localDatabase: _localDatabase,
+      );
+    }
+    return status;
+  }
 }

--- a/packages/smooth_app/lib/pages/product/common/product_refresher.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_refresher.dart
@@ -46,7 +46,32 @@ class ProductRefresher {
     return false;
   }
 
+  /// Returns the standard configuration for barcode product query.
+  ProductQueryConfiguration getBarcodeQueryConfiguration(
+    final String barcode,
+  ) =>
+      ProductQueryConfiguration(
+        barcode,
+        fields: ProductQuery.fields,
+        language: ProductQuery.getLanguage(),
+        country: ProductQuery.getCountry(),
+      );
+
   /// Fetches the product from the server and refreshes the local database.
+  ///
+  /// Silent version.
+  Future<Product?> silentFetchAndRefresh({
+    required final String barcode,
+    required final LocalDatabase localDatabase,
+  }) async {
+    final _MetaProductRefresher meta =
+        await _fetchAndRefresh(localDatabase, barcode);
+    return meta.product;
+  }
+
+  /// Fetches the product from the server and refreshes the local database.
+  ///
+  /// With a waiting dialog.
   Future<void> fetchAndRefresh({
     required final String barcode,
     required final State<StatefulWidget> widget,
@@ -83,14 +108,8 @@ class ProductRefresher {
     final String barcode,
   ) async {
     try {
-      final ProductQueryConfiguration configuration = ProductQueryConfiguration(
-        barcode,
-        fields: ProductQuery.fields,
-        language: ProductQuery.getLanguage(),
-        country: ProductQuery.getCountry(),
-      );
       final ProductResult result = await OpenFoodAPIClient.getProduct(
-        configuration,
+        getBarcodeQueryConfiguration(barcode),
       );
       if (result.product != null) {
         await DaoProduct(localDatabase).put(result.product!);

--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -30,7 +30,6 @@ import 'package:smooth_app/pages/preferences/user_preferences_page.dart';
 import 'package:smooth_app/pages/product/add_basic_details_page.dart';
 import 'package:smooth_app/pages/product/add_category_button.dart';
 import 'package:smooth_app/pages/product/common/product_query_page_helper.dart';
-import 'package:smooth_app/pages/product/common/product_refresher.dart';
 import 'package:smooth_app/query/category_product_query.dart';
 import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/query/product_questions_query.dart';
@@ -703,15 +702,6 @@ class _SummaryCardState extends State<SummaryCard> {
     }
     _annotationVoted =
         await robotoffInsightHelper.areQuestionsAlreadyVoted(questions);
-    // Reload the product as it may have been updated because of the
-    // new answers.
-    if (!mounted) {
-      return;
-    }
-    await ProductRefresher().fetchAndRefresh(
-      widget: this,
-      barcode: _product.barcode!,
-    );
   }
 
   Future<List<RobotoffQuestion>?> _loadProductQuestions() async {

--- a/packages/smooth_app/lib/query/barcode_product_query.dart
+++ b/packages/smooth_app/lib/query/barcode_product_query.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
 
 import 'package:openfoodfacts/openfoodfacts.dart';
-import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:smooth_app/data_models/fetched_product.dart';
 import 'package:smooth_app/database/dao_product.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
+import 'package:smooth_app/pages/product/common/product_refresher.dart';
 import 'package:smooth_app/query/product_query.dart';
 
 class BarcodeProductQuery {
@@ -19,36 +19,19 @@ class BarcodeProductQuery {
   final bool isScanned;
 
   Future<FetchedProduct> getFetchedProduct() async {
-    final OpenFoodFactsLanguage? language = ProductQuery.getLanguage();
-    final OpenFoodFactsCountry? country = ProductQuery.getCountry();
-    final ProductQueryConfiguration configuration = ProductQueryConfiguration(
-      barcode,
-      fields: ProductQuery.fields,
-      language: language,
-      country: country,
-    );
-
-    final ProductResult result;
     try {
       ProductQuery.setUserAgentComment(isScanned ? 'scan' : 'search');
-      result = await OpenFoodAPIClient.getProduct(configuration);
-    } catch (e) {
-      ProductQuery.setUserAgentComment('');
-      return FetchedProduct.error(FetchedProductStatus.internetError);
-    }
-    ProductQuery.setUserAgentComment('');
-
-    if (result.status == 1) {
-      final Product? product = result.product;
+      final Product? product = await ProductRefresher().silentFetchAndRefresh(
+        barcode: barcode,
+        localDatabase: daoProduct.localDatabase,
+      );
       if (product != null) {
-        await daoProduct.put(product);
-        daoProduct.localDatabase.upToDate.setLatestDownloadedProduct(product);
         return FetchedProduct(product);
       }
-    }
-    if (barcode.trim().isNotEmpty &&
-        (result.barcode == null || result.barcode!.isEmpty)) {
-      return FetchedProduct.error(FetchedProductStatus.codeInvalid);
+    } catch (e) {
+      return FetchedProduct.error(FetchedProductStatus.internetError);
+    } finally {
+      ProductQuery.setUserAgentComment('');
     }
 
     if (isScanned) {


### PR DESCRIPTION
Impacted files:
* `abstract_background_task.dart`: now uses a new `ProductRefresher` method for query execution
* `barcode_product_query.dart`: now uses a new `ProductRefresher` method for query execution
* `onboarding_data_product.dart`: now uses a new `ProductRefresher` method for query configuration
* `product_refresher.dart`: created methods for standard query configuration and execution
* `question_card.dart`: added a fallback product; now uses a new `ProductRefresher` method for query execution
* `question_page.dart`: added a fallback product to the `QuestionCard`; now refreshes the product locally after each answer
* `summary_card.dart`: removed an unnecessary product refresh with loading dialog

### What
- Now we refresh the product after each Robotoff answer.
- That's invisible for the user (no additional dialog) as it's part of the "saving your answer" dialog/query.
- The Robotoff page is now displayed immediately. There used to be a visible product refresh before. Now the refresh is invisible, and we display the input (out of date?) product as a fallback during the refresh.
- All those fixes and optimizations only make sense on a "product robotoff session". For Hunger Games (where we don't know the product beforehand) no big change.
- That was an opportunity for refactoring: now the calls to off-dart `getProduct` methods are mainly performed by `ProductRefresher`, for consistency.
- This PR goes with 2 new `TODO`s:
  - what should we do in Robotoff page if we cannot download a product and have no fallback - for the moment (it was the case before) we have a sort of forever loop (cf. `QuestionCard`)
  - we refresh the product after an answer and before a new question - there's room for optimization there, we could avoid one call (cf. `QuestionPage`)
- This PR goes with different UI/UX suggestions:
  - especially in Hunger Games, we could have "instant answers" - a bit like what we do for background tasks, we could not `await` saving the results (we still would have to download the next product)
  - in Robotoff questions there is one (or many) pictures, and if you click on it you go to the picture list page, and then you have to click on "your" picture to go to an "edit picture" page. It should be faster (directly to the single picture page) and with no edit feature. cf. #3332
  - Generally speaking, the Robotoff UI could be improved, for instance by improving the initial `CircularProgressIndicator` (with a "Next question is being loaded..." dialog for instance?)

### Fixes bug(s)
- Fixes: #3249