### PR TITLE
fix: A fix for Controller disposed error

### DIFF
--- a/packages/scanner/shared/lib/src/scanner_log.dart
+++ b/packages/scanner/shared/lib/src/scanner_log.dart
@@ -5,9 +5,8 @@ mixin CameraScannerLogMixin {
       StreamController<CameraScannerLog>.broadcast();
 
   void addLog(
-          {required String message,
-          dynamic exception,
-          StackTrace? stackTrace}) =>
+      {required String message, dynamic exception, StackTrace? stackTrace}) {
+    if (!_controller.isClosed) {
       _controller.add(
         CameraScannerLog(
           message,
@@ -15,6 +14,8 @@ mixin CameraScannerLogMixin {
           stackTrace: stackTrace,
         ),
       );
+    }
+  }
 
   Stream<CameraScannerLog> get controller => _controller.stream;
 


### PR DESCRIPTION
Hi,

In the logs, we sometimes see something like this:

```
E/flutter ( 9644): [ERROR:flutter/lib/ui/ui_dart_state.cc(198)] Unhandled Exception: Bad state: Cannot add new events after calling close
E/flutter ( 9644): #0      _BroadcastStreamController.add (dart:async/broadcast_stream_controller.dart:243)
E/flutter ( 9644): #1      CameraScannerLogMixin.addLog (package:scanner_shared/src/scanner_log.dart:11)
E/flutter ( 9644): #2      MLKitCameraScanner.onDispose (package:scanner_mlkit/src/mlkit_camera_scanner.dart:80)
E/flutter ( 9644): #3      MLKitScannerPageState._stopImageStream (package:smooth_app/pages/scan/ml_kit_scan_page.dart:457)
E/flutter ( 9644): <asynchronous suspension>
```

This PR ensures the controller is opened before sending anything into it.