### PR TITLE
ci: fix internal args

### DIFF
--- a/.github/workflows/internal-release.yml
+++ b/.github/workflows/internal-release.yml
@@ -73,7 +73,7 @@ jobs:
       BUILD_TYPE: 'appbundle'
       FLAVOR: 'main_google_play'
       SCANNER: 'google_play'
-      APP_REVIEW: ''
+      APP_REVIEW: 'uri_store'
     secrets:
       API_JSON_FILE_DECRYPTKEY: ${{secrets.API_JSON_FILE_DECRYPTKEY }}
       DECRYPT_GPG_KEYSTORE: ${{secrets.DECRYPT_GPG_KEYSTORE }}

--- a/.github/workflows/internal-release.yml
+++ b/.github/workflows/internal-release.yml
@@ -72,7 +72,7 @@ jobs:
       RELEASE_TYPE: 'PLAY'
       BUILD_TYPE: 'appbundle'
       FLAVOR: 'main_google_play'
-      SCANNER: ''
+      SCANNER: 'google_play'
       APP_REVIEW: ''
     secrets:
       API_JSON_FILE_DECRYPTKEY: ${{secrets.API_JSON_FILE_DECRYPTKEY }}

--- a/.github/workflows/internal-release.yml
+++ b/.github/workflows/internal-release.yml
@@ -72,8 +72,8 @@ jobs:
       RELEASE_TYPE: 'PLAY'
       BUILD_TYPE: 'appbundle'
       FLAVOR: 'main_google_play'
-      SCANNER: 'google_play'
-      APP_REVIEW: 'uri_store'
+      SCANNER: 'mlkit'
+      APP_REVIEW: 'google_play'
     secrets:
       API_JSON_FILE_DECRYPTKEY: ${{secrets.API_JSON_FILE_DECRYPTKEY }}
       DECRYPT_GPG_KEYSTORE: ${{secrets.DECRYPT_GPG_KEYSTORE }}

--- a/.github/workflows/internal-release.yml
+++ b/.github/workflows/internal-release.yml
@@ -72,6 +72,8 @@ jobs:
       RELEASE_TYPE: 'PLAY'
       BUILD_TYPE: 'appbundle'
       FLAVOR: 'main_google_play'
+      SCANNER: ''
+      APP_REVIEW: ''
     secrets:
       API_JSON_FILE_DECRYPTKEY: ${{secrets.API_JSON_FILE_DECRYPTKEY }}
       DECRYPT_GPG_KEYSTORE: ${{secrets.DECRYPT_GPG_KEYSTORE }}


### PR DESCRIPTION
### What
- Not sure what I'm doing. @M123-dev , does that look right ?

### Original error
ci: fix internal args
[Invalid workflow file: .github/workflows/internal-release.yml#L66](https://github.com/openfoodfacts/smooth-app/actions/runs/3555215890/workflow)
The workflow is not valid. .github/workflows/internal-release.yml (Line: 66, Col: 11): Input SCANNER is required, but not provided while calling. .github/workflows/internal-release.yml (Line: 66, Col: 11): Input APP_REVIEW is required, but not provided while calling.