### PR TITLE
refactor: uniformized the way to show the nutrition page

### DIFF
--- a/packages/smooth_app/lib/pages/product/add_new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_new_product_page.dart
@@ -11,7 +11,6 @@ import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/pages/image_crop_page.dart';
 import 'package:smooth_app/pages/product/add_basic_details_page.dart';
 import 'package:smooth_app/pages/product/nutrition_page_loaded.dart';
-import 'package:smooth_app/pages/product/ordered_nutrients_cache.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
 const EdgeInsetsGeometry _ROW_PADDING_TOP = EdgeInsetsDirectional.only(
@@ -203,33 +202,11 @@ class _AddNewProductPageState extends State<AddNewProductPage> {
       child: SmoothLargeButtonWithIcon(
         text: AppLocalizations.of(context).nutritional_facts_input_button_label,
         icon: Icons.edit,
-        onPressed: () async {
-          final OrderedNutrientsCache? cache =
-              await OrderedNutrientsCache.getCache(context);
-          if (!mounted) {
-            return;
-          }
-          if (cache == null) {
-            ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(
-                content: Text(
-                    AppLocalizations.of(context).nutrition_cache_loading_error),
-              ),
-            );
-            return;
-          }
-          await Navigator.push<void>(
-            context,
-            MaterialPageRoute<void>(
-              builder: (BuildContext context) => NutritionPageLoaded(
-                Product(barcode: widget.barcode),
-                cache.orderedNutrients,
-                isLoggedInMandatory: false,
-              ),
-              fullscreenDialog: true,
-            ),
-          );
-        },
+        onPressed: () async => NutritionPageLoaded.showNutritionPage(
+          product: Product(barcode: widget.barcode),
+          isLoggedInMandatory: false,
+          widget: this,
+        ),
       ),
     );
   }

--- a/packages/smooth_app/lib/pages/product/add_nutrition_button.dart
+++ b/packages/smooth_app/lib/pages/product/add_nutrition_button.dart
@@ -2,9 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/model/Product.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
-import 'package:smooth_app/pages/product/common/product_refresher.dart';
 import 'package:smooth_app/pages/product/nutrition_page_loaded.dart';
-import 'package:smooth_app/pages/product/ordered_nutrients_cache.dart';
 
 /// "Add nutrition facts" button for user contribution.
 class AddNutritionButton extends StatefulWidget {
@@ -20,28 +18,10 @@ class _AddNutritionButtonState extends State<AddNutritionButton> {
   @override
   Widget build(BuildContext context) => addPanelButton(
         AppLocalizations.of(context).score_add_missing_nutrition_facts,
-        onPressed: () async {
-          if (!await ProductRefresher().checkIfLoggedIn(context)) {
-            return;
-          }
-          final OrderedNutrientsCache? cache =
-              await OrderedNutrientsCache.getCache(context);
-          if (cache == null) {
-            return;
-          }
-          if (!mounted) {
-            return;
-          }
-          await Navigator.push<void>(
-            context,
-            MaterialPageRoute<void>(
-              builder: (BuildContext context) => NutritionPageLoaded(
-                widget.product,
-                cache.orderedNutrients,
-              ),
-              fullscreenDialog: true,
-            ),
-          );
-        },
+        onPressed: () async => NutritionPageLoaded.showNutritionPage(
+          product: widget.product,
+          isLoggedInMandatory: true,
+          widget: this,
+        ),
       );
 }

--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -18,7 +18,6 @@ import 'package:smooth_app/pages/product/edit_ingredients_page.dart';
 import 'package:smooth_app/pages/product/nutrition_page_loaded.dart';
 import 'package:smooth_app/pages/product/ocr_ingredients_helper.dart';
 import 'package:smooth_app/pages/product/ocr_packaging_helper.dart';
-import 'package:smooth_app/pages/product/ordered_nutrients_cache.dart';
 import 'package:smooth_app/pages/product/product_image_gallery_view.dart';
 import 'package:smooth_app/pages/product/simple_input_page.dart';
 import 'package:smooth_app/pages/product/simple_input_page_helpers.dart';
@@ -214,29 +213,11 @@ class _EditProductPageState extends State<EditProductPage> {
                     .edit_product_form_item_nutrition_facts_title,
                 subtitle: appLocalizations
                     .edit_product_form_item_nutrition_facts_subtitle,
-                onTap: () async {
-                  if (!await ProductRefresher().checkIfLoggedIn(context)) {
-                    return;
-                  }
-                  final OrderedNutrientsCache? cache =
-                      await OrderedNutrientsCache.getCache(context);
-                  if (cache == null) {
-                    return;
-                  }
-                  if (!mounted) {
-                    return;
-                  }
-                  await Navigator.push<void>(
-                    context,
-                    MaterialPageRoute<void>(
-                      builder: (BuildContext context) => NutritionPageLoaded(
-                        _product,
-                        cache.orderedNutrients,
-                      ),
-                      fullscreenDialog: true,
-                    ),
-                  );
-                },
+                onTap: () async => NutritionPageLoaded.showNutritionPage(
+                  product: _product,
+                  isLoggedInMandatory: true,
+                  widget: this,
+                ),
               ),
               _getSimpleListTileItem(SimpleInputPageLabelHelper()),
               _ListTitleItem(


### PR DESCRIPTION
Impacted files:
* `add_new_product_page.dart`: now using the new method `showNutritionPage`
* `add_nutrition_button.dart`: now using the new method `showNutritionPage`
* `edit_product_page.dart`: now using the new method `showNutritionPage`
* `nutrition_page_loaded.dart`: new method `showNutritionPage`

### What
- While having a look at #3354 I noticed that some not-easy code was repeating 3 times.
- I've created a method instead.

### Part of 
- #3354
