### PR TITLE
chore: MLKit Page renamed

### DIFF
--- a/packages/smooth_app/lib/pages/preferences/user_preferences_dev_mode.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_dev_mode.dart
@@ -20,7 +20,7 @@ import 'package:smooth_app/pages/onboarding/onboarding_flow_navigator.dart';
 import 'package:smooth_app/pages/preferences/abstract_user_preferences.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_dialog_editor.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_page.dart';
-import 'package:smooth_app/pages/scan/ml_kit_scan_page.dart';
+import 'package:smooth_app/pages/scan/camera_scan_page.dart';
 import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/query/products_preload_helper.dart';
 

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_dev_mode.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_dev_mode.dart
@@ -475,7 +475,7 @@ class UserPreferencesDevMode extends AbstractUserPreferences {
   }
 
   Future<void> _changeCameraPostFrameCallbackDuration() async {
-    const int minValue = MLKitScannerPageState.postFrameCallbackStandardDelay;
+    const int minValue = CameraScannerPageState.postFrameCallbackStandardDelay;
     final int initialValue = userPreferences.getDevModeIndex(
           userPreferencesCameraPostFrameDuration,
         ) ??

--- a/packages/smooth_app/lib/pages/scan/camera_scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/camera_scan_page.dart
@@ -26,16 +26,18 @@ import 'package:smooth_app/services/smooth_services.dart';
 import 'package:smooth_app/widgets/lifecycle_aware_widget.dart';
 import 'package:smooth_app/widgets/screen_visibility.dart';
 
-class MLKitScannerPage extends LifecycleAwareStatefulWidget {
-  const MLKitScannerPage({
+/// A page showing the camera feed and using a [CameraScanner] to decode
+/// barcodes. Depending on the store/platform, it can be MLKit or ZXing.
+class CameraScannerPage extends LifecycleAwareStatefulWidget {
+  const CameraScannerPage({
     super.key,
   });
 
   @override
-  MLKitScannerPageState createState() => MLKitScannerPageState();
+  CameraScannerPageState createState() => CameraScannerPageState();
 }
 
-class MLKitScannerPageState extends LifecycleAwareState<MLKitScannerPage>
+class CameraScannerPageState extends LifecycleAwareState<CameraScannerPage>
     with TraceableClientMixin, WidgetsBindingObserver {
   /// If the camera is being closed (when [stoppingCamera] == true) and this
   /// Widget is visible again, we add a post frame callback to detect if the
@@ -518,7 +520,7 @@ class MLKitScannerPageState extends LifecycleAwareState<MLKitScannerPage>
       _userPreferences.getDevModeIndex(
         UserPreferencesDevMode.userPreferencesCameraPostFrameDuration,
       ) ??
-      MLKitScannerPageState.postFrameCallbackStandardDelay;
+      CameraScannerPageState.postFrameCallbackStandardDelay;
 
   /// Only initialize the "beep" player when needed
   /// (at least one camera available + settings set to ON)

--- a/packages/smooth_app/lib/pages/scan/scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/scan_page.dart
@@ -9,7 +9,7 @@ import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/helpers/camera_helper.dart';
 import 'package:smooth_app/helpers/permission_helper.dart';
-import 'package:smooth_app/pages/scan/ml_kit_scan_page.dart';
+import 'package:smooth_app/pages/scan/camera_scan_page.dart';
 import 'package:smooth_app/pages/scan/scan_visor.dart';
 import 'package:smooth_app/pages/scan/scanner_overlay.dart';
 import 'package:smooth_app/widgets/smooth_product_carousel.dart';

--- a/packages/smooth_app/lib/pages/scan/scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/scan_page.dart
@@ -65,7 +65,7 @@ class _ScanPageBackgroundWidget extends StatelessWidget {
     return Consumer<PermissionListener>(
       builder: (BuildContext context, PermissionListener listener, _) {
         if (listener.value.isGranted) {
-          return const MLKitScannerPage();
+          return const CameraScannerPage();
         } else {
           return const SizedBox();
         }


### PR DESCRIPTION
Hi everyone,

The `smooth_app` package is totally independent from the barcode scanner algorithm (MLKit / ZXing), that's why calling the page `MLKitScannerPage` is now irrelevant.