### PR TITLE
chore: Migrate camera dependency to the one hosted on OFF

### DIFF
--- a/packages/scanner/shared/pubspec.yaml
+++ b/packages/scanner/shared/pubspec.yaml
@@ -14,12 +14,12 @@ dependencies:
   # Camera (custom implementation for Android)
   camera:
     git:
-      url: "https://github.com/g123k/plugins.git"
+      url: "https://github.com/openfoodfacts/smooth_app_plugins_fork.git"
       ref: "smooth_camera"
       path: "packages/camera/camera"
   camera_platform_interface:
     git:
-      url: "https://github.com/g123k/plugins.git"
+      url: "https://github.com/openfoodfacts/smooth_app_plugins_fork.git"
       ref: "smooth_camera"
       path: "packages/camera/camera_platform_interface"
 

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -47,12 +47,12 @@ dependencies:
   # Camera (custom implementation for Android)
   camera:
     git:
-      url: "https://github.com/g123k/plugins.git"
+      url: "https://github.com/openfoodfacts/smooth_app_plugins_fork.git"
       ref: "smooth_camera"
       path: "packages/camera/camera"
   camera_platform_interface:
     git:
-      url: "https://github.com/g123k/plugins.git"
+      url: "https://github.com/openfoodfacts/smooth_app_plugins_fork.git"
       ref: "smooth_camera"
       path: "packages/camera/camera_platform_interface"
   scanner_shared:


### PR DESCRIPTION
The camera fork which was hosted on my personal GitHub' space is now transferred to the OFF org