### PR TITLE
feat: 3332 - crop page title now reflects image field

### DIFF
--- a/packages/smooth_app/lib/cards/data_cards/image_upload_card.dart
+++ b/packages/smooth_app/lib/cards/data_cards/image_upload_card.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/product_image_data.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/database/transient_file.dart';
+import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/pages/image_crop_page.dart';
 import 'package:smooth_app/pages/product/product_image_gallery_view.dart';
 
@@ -45,7 +46,12 @@ class _ImageUploadCardState extends State<ImageUploadCard> {
           imageField: widget.productImageData.imageField,
         ),
         icon: const Icon(Icons.add_a_photo),
-        label: Text(widget.productImageData.buttonText),
+        label: Text(
+          getProductImageButtonText(
+            appLocalizations,
+            widget.productImageData.imageField,
+          ),
+        ),
       );
     }
     return GestureDetector(

--- a/packages/smooth_app/lib/cards/product_cards/product_image_carousel.dart
+++ b/packages/smooth_app/lib/cards/product_cards/product_image_carousel.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/cards/data_cards/image_upload_card.dart';
 import 'package:smooth_app/data_models/product_image_data.dart';
@@ -23,19 +22,16 @@ class ProductImageCarousel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final List<ProductImageData> productImagesData;
     if (alternateImageUrl != null) {
       productImagesData = <ProductImageData>[
         ProductImageData(
           imageUrl: alternateImageUrl,
           imageField: ImageField.OTHER,
-          title: '',
-          buttonText: '',
         ),
       ];
     } else {
-      productImagesData = getProductMainImagesData(product, appLocalizations);
+      productImagesData = getProductMainImagesData(product);
     }
     return SizedBox(
       height: height,

--- a/packages/smooth_app/lib/data_models/product_image_data.dart
+++ b/packages/smooth_app/lib/data_models/product_image_data.dart
@@ -3,24 +3,17 @@ import 'package:openfoodfacts/openfoodfacts.dart';
 class ProductImageData {
   const ProductImageData({
     required this.imageField,
-    required this.title,
-    required this.buttonText,
     this.imageUrl,
   });
 
   factory ProductImageData.from(ProductImage image, String barcode) {
     return ProductImageData(
       imageField: image.field,
-      // TODO(VaiTon): i18n
-      title: image.imgid ?? '',
-      buttonText: image.imgid ?? '',
       imageUrl: ImageHelper.buildUrl(barcode, image),
     );
   }
 
   final ImageField imageField;
-  final String title;
-  final String buttonText;
   final String? imageUrl;
 
   /// Try to convert [imageUrl] to specified [size].

--- a/packages/smooth_app/lib/generic_lib/widgets/images/smooth_images_sliver_list.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/images/smooth_images_sliver_list.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:smooth_app/data_models/product_image_data.dart';
 import 'package:smooth_app/generic_lib/loading_sliver.dart';
 import 'package:smooth_app/generic_lib/widgets/images/smooth_images_view.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_list_tile_card.dart';
+import 'package:smooth_app/helpers/product_cards_helper.dart';
 
 /// Displays a [SliverList] by using [SmoothListTileCard] for showing images
 /// passed via [imagesData].
@@ -18,6 +20,7 @@ class SmoothImagesSliverList extends SmoothImagesView {
 
   @override
   Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final ThemeData themeData = Theme.of(context);
     final List<MapEntry<ProductImageData, ImageProvider?>> imageList =
         imagesData.entries.toList();
@@ -31,7 +34,10 @@ class SmoothImagesSliverList extends SmoothImagesView {
         childBuilder: (_, int index) => SmoothListTileCard.image(
           imageProvider: imageList[index].value,
           title: Text(
-            imageList[index].key.title,
+            getProductImageTitle(
+              appLocalizations,
+              imageList[index].key.imageField,
+            ),
             style: themeData.textTheme.headline4,
           ),
           onTap: onTap == null

--- a/packages/smooth_app/lib/generic_lib/widgets/smooth_product_image.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/smooth_product_image.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/database/local_database.dart';
@@ -23,11 +22,7 @@ class SmoothMainProductImage extends StatelessWidget {
   Widget build(BuildContext context) {
     context.watch<LocalDatabase>();
     final ImageProvider? imageProvider = TransientFile.getImageProvider(
-      getProductImageData(
-        product,
-        AppLocalizations.of(context),
-        ImageField.FRONT,
-      ),
+      getProductImageData(product, ImageField.FRONT),
       product.barcode!,
     );
 

--- a/packages/smooth_app/lib/helpers/product_cards_helper.dart
+++ b/packages/smooth_app/lib/helpers/product_cards_helper.dart
@@ -108,33 +108,24 @@ Widget addPanelButton(
     );
 
 List<ProductImageData> getProductMainImagesData(
-  Product product,
-  AppLocalizations appLocalizations, {
+  Product product, {
   final bool includeOther = true,
 }) =>
     <ProductImageData>[
-      getProductImageData(product, appLocalizations, ImageField.FRONT),
-      getProductImageData(product, appLocalizations, ImageField.INGREDIENTS),
-      getProductImageData(product, appLocalizations, ImageField.NUTRITION),
-      getProductImageData(product, appLocalizations, ImageField.PACKAGING),
-      if (includeOther)
-        getProductImageData(product, appLocalizations, ImageField.OTHER),
+      getProductImageData(product, ImageField.FRONT),
+      getProductImageData(product, ImageField.INGREDIENTS),
+      getProductImageData(product, ImageField.NUTRITION),
+      getProductImageData(product, ImageField.PACKAGING),
+      if (includeOther) getProductImageData(product, ImageField.OTHER),
     ];
 
 ProductImageData getProductImageData(
   final Product product,
-  final AppLocalizations? appLocalizations,
   final ImageField imageField,
 ) =>
     ProductImageData(
       imageField: imageField,
       imageUrl: getProductImageUrl(product, imageField),
-      title: appLocalizations == null
-          ? ''
-          : getProductImageTitle(appLocalizations, imageField),
-      buttonText: appLocalizations == null
-          ? ''
-          : getProductImageButtonText(appLocalizations, imageField),
     );
 
 String? getProductImageUrl(
@@ -155,6 +146,7 @@ String? getProductImageUrl(
   }
 }
 
+/// Returns a compact description of the image field.
 String getProductImageTitle(
   final AppLocalizations appLocalizations,
   final ImageField imageField,
@@ -170,6 +162,25 @@ String getProductImageTitle(
       return appLocalizations.packaging_information;
     case ImageField.OTHER:
       return appLocalizations.more_photos;
+  }
+}
+
+/// Returns a verbose description of the image field.
+String getImagePageTitle(
+  final AppLocalizations appLocalizations,
+  final ImageField imageField,
+) {
+  switch (imageField) {
+    case ImageField.FRONT:
+      return appLocalizations.front_packaging_photo_title;
+    case ImageField.INGREDIENTS:
+      return appLocalizations.ingredients_photo_title;
+    case ImageField.NUTRITION:
+      return appLocalizations.nutritional_facts_photo_title;
+    case ImageField.PACKAGING:
+      return appLocalizations.recycling_photo_title;
+    case ImageField.OTHER:
+      return appLocalizations.other_interesting_photo_title;
   }
 }
 

--- a/packages/smooth_app/lib/pages/crop_helper.dart
+++ b/packages/smooth_app/lib/pages/crop_helper.dart
@@ -22,8 +22,9 @@ abstract class CropHelper {
   /// Returns the path of the image file after the crop operation.
   Future<String?> getCroppedPath(
     final BuildContext context,
-    final String inputPath,
-  );
+    final String inputPath, {
+    final String? pageTitle,
+  });
 }
 
 /// New version of the image cropper.
@@ -31,12 +32,16 @@ class _NewCropHelper extends CropHelper {
   @override
   Future<String?> getCroppedPath(
     final BuildContext context,
-    final String inputPath,
-  ) async =>
+    final String inputPath, {
+    final String? pageTitle,
+  }) async =>
       Navigator.push<String>(
         context,
         MaterialPageRoute<String>(
-          builder: (BuildContext context) => CropPage(File(inputPath)),
+          builder: (BuildContext context) => CropPage(
+            File(inputPath),
+            title: pageTitle,
+          ),
           fullscreenDialog: true,
         ),
       );
@@ -47,8 +52,9 @@ class _OldCropHelper extends CropHelper {
   @override
   Future<String?> getCroppedPath(
     final BuildContext context,
-    final String inputPath,
-  ) async =>
+    final String inputPath, {
+    final String? pageTitle,
+  }) async =>
       (await ImageCropper().cropImage(
         sourcePath: inputPath,
         aspectRatioPresets: <CropAspectRatioPreset>[
@@ -62,7 +68,8 @@ class _OldCropHelper extends CropHelper {
           AndroidUiSettings(
             initAspectRatio: CropAspectRatioPreset.original,
             lockAspectRatio: false,
-            toolbarTitle: AppLocalizations.of(context).product_edit_photo_title,
+            toolbarTitle: pageTitle ??
+                AppLocalizations.of(context).product_edit_photo_title,
             // They all need to be the same for dark/light mode as we can't change
             // the background color and the action bar color
             statusBarColor: Colors.black,

--- a/packages/smooth_app/lib/pages/image_crop_page.dart
+++ b/packages/smooth_app/lib/pages/image_crop_page.dart
@@ -8,6 +8,7 @@ import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/helpers/camera_helper.dart';
+import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/pages/crop_helper.dart';
 import 'package:smooth_app/pages/product/confirm_and_upload_picture.dart';
 
@@ -85,7 +86,7 @@ Future<File?> confirmAndUploadNewPicture(
   required final ImageField imageField,
   required final String barcode,
 }) async {
-  final File? croppedPhoto = await startNewImageCropping(widget);
+  final File? croppedPhoto = await startNewImageCropping(widget, imageField);
   if (croppedPhoto == null) {
     return null;
   }
@@ -107,19 +108,22 @@ Future<File?> confirmAndUploadNewPicture(
 /// Crops an image picked from the gallery or camera.
 Future<File?> startNewImageCropping(
   final State<StatefulWidget> widget,
+  final ImageField imageField,
 ) async =>
-    _startImageCropping(widget);
+    _startImageCropping(widget, imageField);
 
 /// Crops an existing image.
 Future<File?> startExistingImageCropping(
   final State<StatefulWidget> widget,
+  final ImageField imageField,
   final File? existingImage,
 ) async =>
-    _startImageCropping(widget, existingImage: existingImage);
+    _startImageCropping(widget, imageField, existingImage: existingImage);
 
 /// Crops an image, either existing or picked from the gallery or camera.
 Future<File?> _startImageCropping(
-  final State<StatefulWidget> widget, {
+  final State<StatefulWidget> widget,
+  final ImageField imageField, {
   final File? existingImage,
 }) async {
   // Show a loading page on the Flutter side
@@ -148,6 +152,10 @@ Future<File?> _startImageCropping(
   final String? croppedPath = await cropHelper.getCroppedPath(
     widget.context,
     sourceImagePath,
+    pageTitle: getImagePageTitle(
+      AppLocalizations.of(widget.context),
+      imageField,
+    ),
   );
 
   await _hideScreenBetween(navigator);

--- a/packages/smooth_app/lib/pages/product/confirm_and_upload_picture.dart
+++ b/packages/smooth_app/lib/pages/product/confirm_and_upload_picture.dart
@@ -8,6 +8,7 @@ import 'package:smooth_app/background/background_task_image.dart';
 import 'package:smooth_app/data_models/continuous_scan_model.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/pages/image_crop_page.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
@@ -51,7 +52,7 @@ class _ConfirmAndUploadPictureState extends State<ConfirmAndUploadPicture> {
     return SmoothScaffold(
       backgroundColor: Colors.black,
       appBar: AppBar(
-        title: Text(_getAppBarTitle(appLocalizations, widget.imageField)),
+        title: Text(getImagePageTitle(appLocalizations, widget.imageField)),
       ),
       body: Stack(
         children: <Widget>[
@@ -74,8 +75,10 @@ class _ConfirmAndUploadPictureState extends State<ConfirmAndUploadPicture> {
                       iconData: Icons.camera_alt,
                       label: appLocalizations.capture,
                       onPressed: () async {
-                        final File? retakenPhoto =
-                            await startNewImageCropping(this);
+                        final File? retakenPhoto = await startNewImageCropping(
+                          this,
+                          widget.imageField,
+                        );
                         if (retakenPhoto == null) {
                           return;
                         }
@@ -90,7 +93,11 @@ class _ConfirmAndUploadPictureState extends State<ConfirmAndUploadPicture> {
                       label: appLocalizations.edit_photo_button_label,
                       onPressed: () async {
                         final File? croppedPhoto =
-                            await startExistingImageCropping(this, photo);
+                            await startExistingImageCropping(
+                          this,
+                          widget.imageField,
+                          photo,
+                        );
                         if (croppedPhoto == null) {
                           return;
                         }
@@ -124,24 +131,6 @@ class _ConfirmAndUploadPictureState extends State<ConfirmAndUploadPicture> {
         ],
       ),
     );
-  }
-
-  String _getAppBarTitle(
-    final AppLocalizations appLocalizations,
-    final ImageField imageField,
-  ) {
-    switch (imageField) {
-      case ImageField.FRONT:
-        return appLocalizations.front_packaging_photo_title;
-      case ImageField.INGREDIENTS:
-        return appLocalizations.ingredients_photo_title;
-      case ImageField.NUTRITION:
-        return appLocalizations.nutritional_facts_photo_title;
-      case ImageField.PACKAGING:
-        return appLocalizations.recycling_photo_title;
-      case ImageField.OTHER:
-        return appLocalizations.other_interesting_photo_title;
-    }
   }
 
   Future<void> _uploadCapturedPicture({

--- a/packages/smooth_app/lib/pages/product/edit_ingredients_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_ingredients_page.dart
@@ -109,11 +109,8 @@ class _EditOcrPageState extends State<EditOcrPage> {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     context.watch<LocalDatabase>();
     _product = _localDatabase.upToDate.getLocalUpToDate(_initialProduct);
-    final ProductImageData productImageData = getProductImageData(
-      _product,
-      appLocalizations,
-      _helper.getImageField(),
-    );
+    final ProductImageData productImageData =
+        getProductImageData(_product, _helper.getImageField());
 
     return SmoothScaffold(
       extendBodyBehindAppBar: true,

--- a/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
@@ -61,11 +61,7 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView> {
     context.watch<LocalDatabase>();
     _product = _localDatabase.upToDate.getLocalUpToDate(_initialProduct);
     final List<ProductImageData> allProductImagesData =
-        getProductMainImagesData(
-      _product,
-      appLocalizations,
-      includeOther: false,
-    );
+        getProductMainImagesData(_product, includeOther: false);
     _selectedImages = Map<ProductImageData, ImageProvider?>.fromIterables(
       allProductImagesData,
       allProductImagesData.map(_provideImage),

--- a/packages/smooth_app/lib/pages/product/product_image_swipeable_view.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_swipeable_view.dart
@@ -65,11 +65,7 @@ class _ProductImageSwipeableViewState extends State<ProductImageSwipeableView> {
     context.watch<LocalDatabase>();
     _product = _localDatabase.upToDate.getLocalUpToDate(_initialProduct);
     final List<ProductImageData> allProductImagesData =
-        getProductMainImagesData(
-      _product,
-      appLocalizations,
-      includeOther: false,
-    );
+        getProductMainImagesData(_product, includeOther: false);
     _selectedImages = Map<ProductImageData, ImageProvider?>.fromIterables(
       allProductImagesData,
       allProductImagesData.map(_provideImage),
@@ -82,11 +78,10 @@ class _ProductImageSwipeableViewState extends State<ProductImageSwipeableView> {
         elevation: 0,
         title: ValueListenableBuilder<int>(
           valueListenable: _currentImageDataIndex,
-          builder: (_, int index, __) {
-            return Text(
-              _imageDataList[index].title,
-            );
-          },
+          builder: (_, int index, __) => Text(getImagePageTitle(
+            appLocalizations,
+            _imageDataList[index].imageField,
+          )),
         ),
         leading: SmoothBackButton(
           iconColor: Colors.white,

--- a/packages/smooth_app/lib/pages/product/product_image_viewer.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_viewer.dart
@@ -61,11 +61,7 @@ class _ProductImageViewerState extends State<ProductImageViewer> {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     context.watch<LocalDatabase>();
     _product = _localDatabase.upToDate.getLocalUpToDate(_initialProduct);
-    _imageData = getProductImageData(
-      _product,
-      appLocalizations,
-      widget.imageField,
-    );
+    _imageData = getProductImageData(_product, widget.imageField);
     final ImageProvider? imageProvider = TransientFile.getImageProvider(
       _imageData,
       _barcode,

--- a/packages/smooth_app/lib/tmp_crop_image/new_crop_page.dart
+++ b/packages/smooth_app/lib/tmp_crop_image/new_crop_page.dart
@@ -62,8 +62,10 @@ class _CropPageState extends State<CropPage> {
   Widget build(final BuildContext context) => Scaffold(
         appBar: AppBar(
           title: Text(
-            widget.title ??
-                AppLocalizations.of(context).product_edit_photo_title,
+            AppLocalizations.of(context).product_edit_photo_title +
+                (widget.title == null ? '' : '\n${widget.title}'),
+            maxLines: 2,
+            overflow: TextOverflow.fade,
           ),
         ),
         backgroundColor: Colors.black,

--- a/packages/smooth_app/lib/tmp_crop_image/new_crop_page.dart
+++ b/packages/smooth_app/lib/tmp_crop_image/new_crop_page.dart
@@ -17,9 +17,13 @@ import 'package:smooth_app/tmp_crop_image/rotated_crop_image.dart';
 
 /// Page dedicated to image cropping. Pops the resulting file path if relevant.
 class CropPage extends StatefulWidget {
-  const CropPage(this.inputFile);
+  const CropPage(
+    this.inputFile, {
+    this.title,
+  });
 
   final File inputFile;
+  final String? title;
 
   @override
   State<CropPage> createState() => _CropPageState();
@@ -57,7 +61,10 @@ class _CropPageState extends State<CropPage> {
   @override
   Widget build(final BuildContext context) => Scaffold(
         appBar: AppBar(
-          title: Text(AppLocalizations.of(context).product_edit_photo_title),
+          title: Text(
+            widget.title ??
+                AppLocalizations.of(context).product_edit_photo_title,
+          ),
         ),
         backgroundColor: Colors.black,
         body: _image == null


### PR DESCRIPTION
Impacted files:
* `confirm_and_upload_picture.dart`: minor refactoring
* `crop_helper.dart`: added a `pageTitle` parameter
* `edit_ingredients_page.dart`: minor refactoring
* `image_crop_page.dart`: added `imageField` parameters, so that we can compute the correct label on crop page
* `image_upload_card.dart`: now we explicitly use `getProductImageButtonText` as label
* `new_crop_page.dart`: added a page title parameter
* `product_cards_helper.dart`: new label method `getImagePageTitle`; minor refactoring
* `product_image_carousel.dart`: minor refactoring
* `product_image_data.dart`: removed label fields - now we have more flexibility, computing labels from `imageField` with `product_cards_helper.dart` methods
* `product_image_gallery_view.dart`: minor refactoring
* `product_image_swipeable_view.dart`: now we explicitly use `getImagePageTitle` as label
* `product_image_viewer.dart`: minor refactoring
* `smooth_images_sliver_list.dart`: now we explicitly use `getProductImageTitle` as label
* `smooth_product_image.dart`: minor refactoring

### What
- Very first step of #3332: the crop page title now reflects the image field (instead of a mere "Edit image")
- That was a good opportunity to refactor actually, by removing "labels" from `ProductImageData` that were not really useful

### Screenshot
![Capture d’écran 2022-11-27 à 11 50 27](https://user-images.githubusercontent.com/11576431/204131360-bb0c14dc-d5fd-48f3-a059-c49124445fd7.png)

### Part of 
- #3332
