### PR TITLE
feat: 3207 - now displays a card for product website, if available

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1153,6 +1153,10 @@
     "@edit_product_form_save": {
         "description": "Product edition - Nutrition facts - Save button"
     },
+    "product_field_website_title": "Website",
+    "@product_field_website_title": {
+        "description": "Title of a product field: website"
+    },
     "completed_basic_details_btn_text": "Complete basic details",
     "not_implemented_snackbar_text": "Not implemented yet",
     "category_picker_page_appbar_text": "Categories",

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -1153,6 +1153,10 @@
     "@edit_product_form_save": {
         "description": "Product edition - Nutrition facts - Save button"
     },
+    "product_field_website_title": "Site web",
+    "@product_field_website_title": {
+        "description": "Title of a product field: website"
+    },
     "completed_basic_details_btn_text": "Compléter les informations de base",
     "not_implemented_snackbar_text": "Pas encore disponible",
     "category_picker_page_appbar_text": "Catégories",

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -20,6 +20,8 @@ import 'package:smooth_app/generic_lib/duration_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_back_button.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
+import 'package:smooth_app/helpers/launch_url_helper.dart';
+import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_product_cards.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels_builder.dart';
 import 'package:smooth_app/pages/inherited_data_manager.dart';
@@ -197,6 +199,7 @@ class _ProductPageState extends State<ProductPage> with TraceableClientMixin {
             daoProductList,
           ),
           _buildKnowledgePanelCards(),
+          if (_product.website != null) _buildWebsiteWidget(_product.website!),
           if (context.read<UserPreferences>().getFlag(
                   UserPreferencesDevMode.userPreferencesFlagAdditionalButton) ??
               false)
@@ -208,6 +211,48 @@ class _ProductPageState extends State<ProductPage> with TraceableClientMixin {
       ),
     );
   }
+
+  Widget _buildWebsiteWidget(String website) => InkWell(
+        onTap: () async {
+          if (!website.startsWith('http')) {
+            website = 'http://$website';
+          }
+          LaunchUrlHelper.launchURL(website, false);
+        }, // _product.website!
+        child: buildProductSmoothCard(
+          header: Padding(
+            padding: const EdgeInsets.symmetric(
+              vertical: VERY_SMALL_SPACE,
+              horizontal: SMALL_SPACE,
+            ),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.start,
+              children: <Widget>[
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                    vertical: VERY_SMALL_SPACE,
+                    horizontal: SMALL_SPACE,
+                  ),
+                  child: Text(
+                    AppLocalizations.of(context).product_field_website_title,
+                    style: Theme.of(context).textTheme.headline3,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          body: Padding(
+            padding: const EdgeInsets.only(bottom: SMALL_SPACE),
+            child: Text(
+              website,
+              style: Theme.of(context)
+                  .textTheme
+                  .bodyText2
+                  ?.copyWith(color: Colors.blue),
+            ),
+          ),
+        ),
+      );
 
   Widget _buildKnowledgePanelCards() {
     final List<Widget> knowledgePanelWidgets = <Widget>[];

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -222,33 +222,35 @@ class _ProductPageState extends State<ProductPage> with TraceableClientMixin {
         child: buildProductSmoothCard(
           header: Padding(
             padding: const EdgeInsets.symmetric(
-              vertical: VERY_SMALL_SPACE,
-              horizontal: SMALL_SPACE,
+              vertical: SMALL_SPACE,
+              horizontal: LARGE_SPACE,
             ),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.start,
               children: <Widget>[
-                Padding(
-                  padding: const EdgeInsets.symmetric(
-                    vertical: VERY_SMALL_SPACE,
-                    horizontal: SMALL_SPACE,
-                  ),
-                  child: Text(
-                    AppLocalizations.of(context).product_field_website_title,
-                    style: Theme.of(context).textTheme.headline3,
-                  ),
+                Text(
+                  AppLocalizations.of(context).product_field_website_title,
+                  style: Theme.of(context).textTheme.headline3,
                 ),
               ],
             ),
           ),
           body: Padding(
-            padding: const EdgeInsets.only(bottom: SMALL_SPACE),
-            child: Text(
-              website,
-              style: Theme.of(context)
-                  .textTheme
-                  .bodyText2
-                  ?.copyWith(color: Colors.blue),
+            padding: const EdgeInsets.only(
+              bottom: LARGE_SPACE,
+              left: LARGE_SPACE,
+            ),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  website,
+                  style: Theme.of(context)
+                      .textTheme
+                      .bodyText2
+                      ?.copyWith(color: Colors.blue),
+                ),
+              ],
             ),
           ),
         ),

--- a/packages/smooth_app/lib/query/product_query.dart
+++ b/packages/smooth_app/lib/query/product_query.dart
@@ -151,5 +151,6 @@ abstract class ProductQuery {
         ProductField.COUNTRIES_TAGS_IN_LANGUAGES,
         ProductField.EMB_CODES,
         ProductField.ORIGINS,
+        ProductField.WEBSITE,
       ];
 }


### PR DESCRIPTION
Impacted files:
* `app_en.arb`: added 1 label for "website field title"
* `app_fr.arb`: added 1 label for "website field title"
* `new_product_page.dart`: now displays a card for website, if available
* `product_query.dart`: added "website" product field

### What
- Added the product website to the product page, in READ and CLICK mode. Not on WRITE mode for the moment.

### Screenshot
![Capture d’écran 2022-11-27 à 18 28 51](https://user-images.githubusercontent.com/11576431/204150572-d94f6bd2-e0cf-4775-ab54-a22b7fc5e25d.png)

### Part of 
- #3207
