### PR TITLE
feat: 3207 - edit page for website product field

### DIFF
--- a/packages/smooth_app/lib/data_models/up_to_date_changes.dart
+++ b/packages/smooth_app/lib/data_models/up_to_date_changes.dart
@@ -15,22 +15,6 @@ class UpToDateChanges {
 
   OperationType get taskActionable => OperationType.details;
 
-  /// Returns a minimalist [Product] with successive changes on top.
-  Product prepareChangesForServer(
-    final String barcode,
-    final Iterable<TransientOperation> sortedOperations,
-  ) {
-    final Product initial = Product(barcode: barcode);
-    for (final TransientOperation transientOperation in sortedOperations) {
-      if (initial.barcode != transientOperation.product.barcode) {
-        // very unlikely
-        continue;
-      }
-      _overwrite(initial, transientOperation.product);
-    }
-    return initial;
-  }
-
   /// Returns all the actions related to a barcode, sorted by id.
   Iterable<TransientOperation> getSortedOperations(final String barcode) {
     final List<TransientOperation> result = <TransientOperation>[];
@@ -149,6 +133,9 @@ class UpToDateChanges {
     }
     if (change.imagePackagingSmallUrl != null) {
       initial.imagePackagingSmallUrl = change.imagePackagingSmallUrl;
+    }
+    if (change.website != null) {
+      initial.website = change.website;
     }
     return initial;
   }

--- a/packages/smooth_app/lib/data_models/up_to_date_product_provider.dart
+++ b/packages/smooth_app/lib/data_models/up_to_date_product_provider.dart
@@ -110,13 +110,8 @@ class UpToDateProductProvider {
         jsonDecode(jsonEncode(source.toJson())) as Map<String, dynamic>,
       );
 
-  /// Returns the key of a new minimalist local change added to pending ones.
-  ///
-  /// To make it clearer:
-  /// * the method creates a new minimalist change
-  /// * that change has a (new) key
-  /// * after creating the change, the method returns the key
-  Future<String> addChange(
+  /// Adds a minimalist local change to pending ones.
+  Future<void> addChange(
     final String key,
     final Product minimalistProduct,
   ) async {
@@ -124,19 +119,12 @@ class UpToDateProductProvider {
     await _changes.add(key, minimalistProduct);
     _timestamps[barcode] = LocalDatabase.nowInMillis();
     localDatabase.notifyListeners();
-    return key;
   }
 
   /// Returns the local pending change ids related to a [barcode].
   Iterable<TransientOperation>? getSortedChangeOperations(
           final String barcode) =>
       _changes.getSortedOperations(barcode);
-
-  Product prepareChangesForServer(
-    final String barcode,
-    final Iterable<TransientOperation> sortedOperations,
-  ) =>
-      _changes.prepareChangesForServer(barcode, sortedOperations);
 
   /// Closes a single operation, successful or failed.
   void terminate(final String operationKey) {

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1037,7 +1037,15 @@
     },
     "edit_product_form_item_details_subtitle": "Product name, brand, quantity",
     "@edit_product_form_item_details_subtitle": {
-        "description": "Product edition - Basic Details - Title"
+        "description": "Product edition - Basic Details - Subtitle"
+    },
+    "edit_product_form_item_other_details_title": "Additional details",
+    "@edit_product_form_item_other_details_title": {
+        "description": "Product edition - Other Details - Title"
+    },
+    "edit_product_form_item_other_details_subtitle": "Website, ...",
+    "@edit_product_form_item_other_details_subtitle": {
+        "description": "Product edition - Other Details - Subtitle"
     },
     "edit_product_form_item_photos_title": "Photos",
     "@edit_product_form_item_photos_title": {

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -1037,7 +1037,15 @@
     },
     "edit_product_form_item_details_subtitle": "Nom du produit, marque, quantité",
     "@edit_product_form_item_details_subtitle": {
-        "description": "Product edition - Basic Details - Title"
+        "description": "Product edition - Basic Details - Subtitle"
+    },
+    "edit_product_form_item_other_details_title": "Informations complémentaires",
+    "@edit_product_form_item_other_details_title": {
+        "description": "Product edition - Other Details - Title"
+    },
+    "edit_product_form_item_other_details_subtitle": "Site web, ...",
+    "@edit_product_form_item_other_details_subtitle": {
+        "description": "Product edition - Other Details - Subtitle"
     },
     "edit_product_form_item_photos_title": "Photos",
     "@edit_product_form_item_photos_title": {

--- a/packages/smooth_app/lib/pages/product/add_other_details_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_other_details_page.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/background/background_task_details.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
+import 'package:smooth_app/generic_lib/widgets/smooth_text_form_field.dart';
+import 'package:smooth_app/widgets/smooth_app_bar.dart';
+import 'package:smooth_app/widgets/smooth_scaffold.dart';
+
+/// Input of a product's less significant details, like website.
+class AddOtherDetailsPage extends StatefulWidget {
+  const AddOtherDetailsPage(
+    this.product,
+  );
+
+  final Product product;
+
+  @override
+  State<AddOtherDetailsPage> createState() => _AddOtherDetailsPageState();
+}
+
+class _AddOtherDetailsPageState extends State<AddOtherDetailsPage> {
+  final TextEditingController _websiteController = TextEditingController();
+
+  final double _heightSpace = LARGE_SPACE;
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+  late Product _product;
+  late AppLocalizations appLocalizations = AppLocalizations.of(context);
+
+  bool _initDone = false;
+
+  void _initializeProduct() {
+    if (_initDone) {
+      return;
+    }
+    _initDone = true;
+    _product = widget.product;
+    _websiteController.text = _product.website ?? '';
+  }
+
+  /// Returns a [Product] with the values from the text fields.
+  Product _getMinimalistProduct() => Product()
+    ..barcode = _product.barcode
+    ..website = _websiteController.text;
+
+  @override
+  Widget build(BuildContext context) {
+    _initializeProduct();
+    final Size size = MediaQuery.of(context).size;
+    return SmoothScaffold(
+      appBar: SmoothAppBar(
+        title:
+            Text(appLocalizations.edit_product_form_item_other_details_title),
+        subTitle: widget.product.productName != null
+            ? Text(widget.product.productName!,
+                overflow: TextOverflow.ellipsis, maxLines: 1)
+            : null,
+      ),
+      body: Form(
+        key: _formKey,
+        child: ListView(
+          children: <Widget>[
+            SizedBox(height: _heightSpace),
+            Padding(
+              padding: EdgeInsets.symmetric(horizontal: size.width * 0.05),
+              child: Column(
+                children: <Widget>[
+                  Text(
+                    appLocalizations.barcode_barcode(_product.barcode!),
+                    style: Theme.of(context).textTheme.bodyText2?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
+                  ),
+                  SizedBox(height: _heightSpace),
+                  SmoothTextFormField(
+                    controller: _websiteController,
+                    type: TextFieldTypes.PLAIN_TEXT,
+                    hintText: appLocalizations.product_field_website_title,
+                  ),
+                  SizedBox(height: _heightSpace),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: LARGE_SPACE,
+              ),
+              child: SmoothActionButtonsBar(
+                negativeAction: SmoothActionButton(
+                  text: appLocalizations.cancel,
+                  onPressed: () => Navigator.pop(context),
+                ),
+                positiveAction: SmoothActionButton(
+                  text: appLocalizations.save,
+                  onPressed: () async {
+                    if (!_formKey.currentState!.validate()) {
+                      return;
+                    }
+                    await BackgroundTaskDetails.addTask(
+                      _getMinimalistProduct(),
+                      widget: this,
+                    );
+                    if (!mounted) {
+                      return;
+                    }
+                    Navigator.pop(context);
+                  },
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -13,6 +13,7 @@ import 'package:smooth_app/generic_lib/widgets/smooth_list_tile_card.dart';
 import 'package:smooth_app/helpers/app_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/pages/product/add_basic_details_page.dart';
+import 'package:smooth_app/pages/product/add_other_details_page.dart';
 import 'package:smooth_app/pages/product/common/product_refresher.dart';
 import 'package:smooth_app/pages/product/edit_ingredients_page.dart';
 import 'package:smooth_app/pages/product/nutrition_page_loaded.dart';
@@ -223,6 +224,24 @@ class _EditProductPageState extends State<EditProductPage> {
               _getSimpleListTileItem(SimpleInputPageOriginHelper()),
               _getSimpleListTileItem(SimpleInputPageEmbCodeHelper()),
               _getSimpleListTileItem(SimpleInputPageCountryHelper()),
+              _ListTitleItem(
+                title:
+                    appLocalizations.edit_product_form_item_other_details_title,
+                subtitle: appLocalizations
+                    .edit_product_form_item_other_details_subtitle,
+                onTap: () async {
+                  if (!await ProductRefresher().checkIfLoggedIn(context)) {
+                    return;
+                  }
+                  await Navigator.push<void>(
+                    context,
+                    MaterialPageRoute<void>(
+                      builder: (_) => AddOtherDetailsPage(_product),
+                      fullscreenDialog: true,
+                    ),
+                  );
+                },
+              ),
             ],
           ),
         ),

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -199,7 +199,8 @@ class _ProductPageState extends State<ProductPage> with TraceableClientMixin {
             daoProductList,
           ),
           _buildKnowledgePanelCards(),
-          if (_product.website != null) _buildWebsiteWidget(_product.website!),
+          if (_product.website != null && _product.website!.trim().isNotEmpty)
+            _buildWebsiteWidget(_product.website!.trim()),
           if (context.read<UserPreferences>().getFlag(
                   UserPreferencesDevMode.userPreferencesFlagAdditionalButton) ??
               false)


### PR DESCRIPTION
New file:
* `add_other_details_page.dart`: Input of a product's less significant details, like website.

Impacted files:
* `app_en.arb`: added 2 labels in order to describe the click to new page `AddOtherDetailsPage`
* `app_fr.arb`: added 2 labels in order to describe the click to new page `AddOtherDetailsPage`
* `edit_product_page.dart`: added a call to new page `AddOtherDetailsPage` for website input
* `new_product_page.dart`: minor bug fix
* `up_to_date_changes.dart`: added the `website` field to the copy; unrelated code simplification
* `up_to_date_product_provider.dart`: unrelated code simplification

### What
- Now we can edit the website product field, in a new page dedicated to "additional details"

### Screenshot
| new item at the bottom | new page |
| -- | -- |
| ![Capture d’écran 2022-11-28 à 14 51 27](https://user-images.githubusercontent.com/11576431/204294192-2efd00c2-3b43-4924-a96d-263b318888bc.png) | ![Capture d’écran 2022-11-28 à 14 51 42](https://user-images.githubusercontent.com/11576431/204294251-b269c9e6-acd9-4849-be02-9dc744175ca3.png) |

### Fixes bug(s)
- Closes: #3207