### PR TITLE
feat: 3380 - product refresh 10 minutes after image upload

### DIFF
--- a/packages/smooth_app/lib/background/background_task_details.dart
+++ b/packages/smooth_app/lib/background/background_task_details.dart
@@ -86,11 +86,11 @@ class BackgroundTaskDetails extends AbstractBackgroundTask {
       minimalistProduct,
       uniqueId,
     );
-    await task.addToManager(widget);
+    await task.addToManager(localDatabase, widget: widget);
   }
 
   @override
-  String getSnackBarMessage(final AppLocalizations appLocalizations) =>
+  String? getSnackBarMessage(final AppLocalizations appLocalizations) =>
       appLocalizations.product_task_background_schedule;
 
   /// Returns a new background task about changing a product.

--- a/packages/smooth_app/lib/background/background_task_image.dart
+++ b/packages/smooth_app/lib/background/background_task_image.dart
@@ -7,6 +7,7 @@ import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/background/abstract_background_task.dart';
+import 'package:smooth_app/background/background_task_refresh_later.dart';
 import 'package:smooth_app/data_models/operation_type.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/database/transient_file.dart';
@@ -88,11 +89,11 @@ class BackgroundTaskImage extends AbstractBackgroundTask {
       imageFile,
       uniqueId,
     );
-    await task.addToManager(widget);
+    await task.addToManager(localDatabase, widget: widget);
   }
 
   @override
-  String getSnackBarMessage(final AppLocalizations appLocalizations) =>
+  String? getSnackBarMessage(final AppLocalizations appLocalizations) =>
       appLocalizations.image_upload_queued;
 
   /// Returns a new background task about changing a product.
@@ -123,12 +124,17 @@ class BackgroundTaskImage extends AbstractBackgroundTask {
       );
 
   @override
-  Future<void> postExecute(final LocalDatabase localDatabase) async =>
-      TransientFile.removeImage(
-        ImageFieldExtension.getType(imageField),
-        barcode,
-        localDatabase,
-      );
+  Future<void> postExecute(final LocalDatabase localDatabase) async {
+    TransientFile.removeImage(
+      ImageFieldExtension.getType(imageField),
+      barcode,
+      localDatabase,
+    );
+    await BackgroundTaskRefreshLater.addTask(
+      barcode,
+      localDatabase: localDatabase,
+    );
+  }
 
   /// Uploads the product image.
   @override

--- a/packages/smooth_app/lib/background/background_task_manager.dart
+++ b/packages/smooth_app/lib/background/background_task_manager.dart
@@ -45,7 +45,7 @@ class BackgroundTaskManager {
   }
 
   /// Returns the related task, or null but that is unexpected.
-  Future<AbstractBackgroundTask?> _get(final String taskId) async {
+  AbstractBackgroundTask? _get(final String taskId) {
     try {
       final String? json = DaoInstantString(localDatabase)
           .get(_taskIdToDaoInstantStringKey(taskId));
@@ -102,13 +102,13 @@ class BackgroundTaskManager {
     if (!_canStartNow()) {
       return;
     }
-    String? nextTaskId;
+    AbstractBackgroundTask? nextTask;
     try {
-      while ((nextTaskId = _getNextTaskId()) != null) {
+      while ((nextTask = await _getNextTask()) != null) {
         if (blocked) {
           return;
         }
-        await _runTask(nextTaskId!);
+        await _runTask(nextTask!);
       }
     } catch (e) {
       return;
@@ -118,24 +118,29 @@ class BackgroundTaskManager {
   }
 
   /// Runs a single task. Possible exception.
-  Future<void> _runTask(final String taskId) async {
-    final AbstractBackgroundTask? task = await _get(taskId);
-    if (task == null) {
-      await _remove(taskId);
-      return;
-    }
+  Future<void> _runTask(final AbstractBackgroundTask task) async {
     await task.execute(localDatabase);
     await task.postExecute(localDatabase);
-    await _remove(taskId);
+    await _remove(task.uniqueId);
   }
 
-  /// Returns the next task id
-  String? _getNextTaskId() {
+  /// Returns the next task we can run now.
+  Future<AbstractBackgroundTask?> _getNextTask() async {
     final List<String> list = getAllTaskIds();
     if (list.isEmpty) {
       return null;
     }
-    return list.first;
+    for (final String taskId in list) {
+      final AbstractBackgroundTask? task = _get(taskId);
+      if (task == null) {
+        await _remove(taskId);
+        continue;
+      }
+      if (task.mayRunNow()) {
+        return task;
+      }
+    }
+    return null;
   }
 
   /// Returns all the task ids.

--- a/packages/smooth_app/lib/background/background_task_refresh_later.dart
+++ b/packages/smooth_app/lib/background/background_task_refresh_later.dart
@@ -1,0 +1,121 @@
+import 'dart:convert';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:openfoodfacts/utils/CountryHelper.dart';
+import 'package:smooth_app/background/abstract_background_task.dart';
+import 'package:smooth_app/data_models/operation_type.dart';
+import 'package:smooth_app/database/local_database.dart';
+import 'package:smooth_app/query/product_query.dart';
+
+/// Background task that triggers a product refresh "a bit later".
+///
+/// Typical use-case is after uploading an image. It takes roughly 10 minutes
+/// before Robotoff provides new questions: we should then refresh the product.
+/// cf. https://github.com/openfoodfacts/smooth-app/issues/3380
+class BackgroundTaskRefreshLater extends AbstractBackgroundTask {
+  const BackgroundTaskRefreshLater._({
+    required super.processName,
+    required super.uniqueId,
+    required super.barcode,
+    required super.languageCode,
+    required super.user,
+    required super.country,
+    required this.timestamp,
+  });
+
+  BackgroundTaskRefreshLater._fromJson(Map<String, dynamic> json)
+      : this._(
+          processName: json['processName'] as String,
+          uniqueId: json['uniqueId'] as String,
+          barcode: json['barcode'] as String,
+          languageCode: json['languageCode'] as String,
+          user: json['user'] as String,
+          country: json['country'] as String,
+          timestamp: json['timestamp'] as int,
+        );
+
+  /// Task ID.
+  static const String _PROCESS_NAME = 'PRODUCT_REFRESH_LATER';
+
+  static const OperationType _operationType = OperationType.refreshLater;
+
+  /// Delay in milliseconds.
+  ///
+  /// To be used as a delay between the task creation and its activation.
+  static const int _delay = 10 * 60 * 1000;
+
+  /// Timestamp when the task was created, in millis.
+  final int timestamp;
+
+  @override
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'processName': processName,
+        'uniqueId': uniqueId,
+        'barcode': barcode,
+        'languageCode': languageCode,
+        'user': user,
+        'country': country,
+        'timestamp': timestamp,
+      };
+
+  /// Returns the deserialized background task if possible, or null.
+  static BackgroundTaskRefreshLater? fromJson(final Map<String, dynamic> map) {
+    try {
+      final BackgroundTaskRefreshLater result =
+          BackgroundTaskRefreshLater._fromJson(map);
+      if (result.processName == _PROCESS_NAME) {
+        return result;
+      }
+    } catch (e) {
+      //
+    }
+    return null;
+  }
+
+  /// Here we change nothing, therefore we do nothing.
+  @override
+  Future<void> preExecute(final LocalDatabase localDatabase) async {}
+
+  /// Here we change nothing, therefore we do nothing.
+  @override
+  Future<void> postExecute(final LocalDatabase localDatabase) async {}
+
+  /// Adds the background task about refreshing the product later.
+  static Future<void> addTask(
+    final String barcode, {
+    required final LocalDatabase localDatabase,
+  }) async {
+    final String uniqueId = await _operationType.getNewKey(
+      localDatabase,
+      barcode,
+    );
+    final AbstractBackgroundTask task = _getNewTask(barcode, uniqueId);
+    await task.addToManager(localDatabase);
+  }
+
+  @override
+  String? getSnackBarMessage(final AppLocalizations appLocalizations) => null;
+
+  /// Returns a new background task about refreshing a product later.
+  static BackgroundTaskRefreshLater _getNewTask(
+    final String barcode,
+    final String uniqueId,
+  ) =>
+      BackgroundTaskRefreshLater._(
+        uniqueId: uniqueId,
+        processName: _PROCESS_NAME,
+        barcode: barcode,
+        languageCode: ProductQuery.getLanguage().code,
+        user: jsonEncode(ProductQuery.getUser().toJson()),
+        country: ProductQuery.getCountry()!.iso2Code,
+        timestamp: LocalDatabase.nowInMillis(),
+      );
+
+  /// Here we change nothing, therefore we do nothing.
+  @override
+  Future<void> upload() async {}
+
+  /// Returns true if "enough" time elapsed after the task creation.
+  @override
+  bool mayRunNow() => LocalDatabase.nowInMillis() - timestamp > _delay;
+}

--- a/packages/smooth_app/lib/data_models/operation_type.dart
+++ b/packages/smooth_app/lib/data_models/operation_type.dart
@@ -12,6 +12,7 @@ import 'package:smooth_app/helpers/database_helper.dart';
 /// * possibly, which barcode (not useful yet)
 enum OperationType {
   image('I'),
+  refreshLater('R'),
   details('D');
 
   const OperationType(this.header);

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -8,6 +8,7 @@ import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:provider/provider.dart';
 import 'package:share_plus/share_plus.dart';
+import 'package:smooth_app/background/background_task_manager.dart';
 import 'package:smooth_app/cards/product_cards/product_image_carousel.dart';
 import 'package:smooth_app/data_models/product_list.dart';
 import 'package:smooth_app/data_models/product_preferences.dart';
@@ -81,6 +82,7 @@ class _ProductPageState extends State<ProductPage> with TraceableClientMixin {
 
   @override
   Widget build(BuildContext context) {
+    BackgroundTaskManager(_localDatabase).run(); // no await
     final InheritedDataManagerState inheritedDataManager =
         InheritedDataManager.of(context);
     inheritedDataManager.setCurrentBarcode(_barcode);


### PR DESCRIPTION
New file:
* `background_task_refresh_later.dart`: Background task that triggers a product refresh "a bit later".

Impacted files:
* `abstract_background_task.dart`: added method `mayRunNow`, added the new `BackgroundTaskRefreshLater` class, minor refactoring
* `background_task_details.dart`: minor refactoring
* `background_task_image.dart`: added a "refresh later" task at the end, minor refactoring
* `background_task_manager.dart`: introduced the concept of delayed tasks with new method `mayRunNow`
* `new_product_page.dart`: added a call to background tasks here, as the app's arguably most important page
* `operation_type.dart`: added a new operation type - "refresh later"

### What
- Each time an image is uploaded, we add a task that will refresh the product 10 minutes later.
- With that delay, we assess that Robotoff has enough time to react to the new image with new questions.

### Screenshot
<!-- Insert a screenshot to provide visual record of your changes, if visible -->

### Fixes bug(s)
- Closes: #3380