### PR TITLE
chore: fix dep dependency usage

### DIFF
--- a/packages/app/lib/generated_plugin_registrant.dart
+++ b/packages/app/lib/generated_plugin_registrant.dart
@@ -8,7 +8,6 @@
 
 import 'package:audioplayers_web/audioplayers_web.dart';
 import 'package:camera_web/camera_web.dart';
-import 'package:connectivity_plus_web/connectivity_plus_web.dart';
 import 'package:device_info_plus_web/device_info_plus_web.dart';
 import 'package:flutter_native_splash/flutter_native_splash_web.dart';
 import 'package:flutter_secure_storage_web/flutter_secure_storage_web.dart';
@@ -26,7 +25,6 @@ import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 void registerPlugins(Registrar registrar) {
   AudioplayersPlugin.registerWith(registrar);
   CameraPlugin.registerWith(registrar);
-  ConnectivityPlusPlugin.registerWith(registrar);
   DeviceInfoPlusPlugin.registerWith(registrar);
   FlutterNativeSplashWeb.registerWith(registrar);
   FlutterSecureStorageWeb.registerWith(registrar);

--- a/packages/app/linux/flutter/generated_plugin_registrant.cc
+++ b/packages/app/linux/flutter/generated_plugin_registrant.cc
@@ -9,7 +9,6 @@
 #include <audioplayers_linux/audioplayers_linux_plugin.h>
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
 #include <sentry_flutter/sentry_flutter_plugin.h>
-#include <task_manager/task_manager_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
@@ -22,9 +21,6 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) sentry_flutter_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "SentryFlutterPlugin");
   sentry_flutter_plugin_register_with_registrar(sentry_flutter_registrar);
-  g_autoptr(FlPluginRegistrar) task_manager_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "TaskManagerPlugin");
-  task_manager_plugin_register_with_registrar(task_manager_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/packages/app/linux/flutter/generated_plugins.cmake
+++ b/packages/app/linux/flutter/generated_plugins.cmake
@@ -6,7 +6,6 @@ list(APPEND FLUTTER_PLUGIN_LIST
   audioplayers_linux
   flutter_secure_storage_linux
   sentry_flutter
-  task_manager
   url_launcher_linux
 )
 

--- a/packages/app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,7 +6,6 @@ import FlutterMacOS
 import Foundation
 
 import audioplayers_darwin
-import connectivity_plus_macos
 import device_info_plus_macos
 import flutter_secure_storage_macos
 import in_app_review
@@ -16,12 +15,10 @@ import sentry_flutter
 import share_plus_macos
 import shared_preferences_macos
 import sqflite
-import task_manager
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AudioplayersDarwinPlugin.register(with: registry.registrar(forPlugin: "AudioplayersDarwinPlugin"))
-  ConnectivityPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlugin"))
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FlutterSecureStorageMacosPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageMacosPlugin"))
   InAppReviewPlugin.register(with: registry.registrar(forPlugin: "InAppReviewPlugin"))
@@ -31,6 +28,5 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
-  TaskManagerPlugin.register(with: registry.registrar(forPlugin: "TaskManagerPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/packages/app/pubspec.lock
+++ b/packages/app/pubspec.lock
@@ -132,27 +132,23 @@ packages:
     description:
       path: "packages/camera/camera"
       ref: smooth_camera
-      resolved-ref: "3c62b56bb6cc0ae1c9594f417ce6305ea45e214f"
-      url: "https://github.com/g123k/plugins.git"
+      resolved-ref: "2fe0f6e0c7043a9cb855b299315566187827b2a2"
+      url: "https://github.com/openfoodfacts/smooth_app_plugins_fork.git"
     source: git
     version: "0.9.6"
   camera_platform_interface:
     dependency: transitive
     description:
-      path: "packages/camera/camera_platform_interface"
-      ref: smooth_camera
-      resolved-ref: "3c62b56bb6cc0ae1c9594f417ce6305ea45e214f"
-      url: "https://github.com/g123k/plugins.git"
-    source: git
-    version: "2.1.6"
+      name: camera_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.3.1"
   camera_web:
     dependency: transitive
     description:
-      path: "packages/camera/camera_web"
-      ref: smooth_camera
-      resolved-ref: "3c62b56bb6cc0ae1c9594f417ce6305ea45e214f"
-      url: "https://github.com/g123k/plugins.git"
-    source: git
+      name: camera_web
+      url: "https://pub.dartlang.org"
+    source: hosted
     version: "0.2.1+6"
   carousel_slider:
     dependency: transitive
@@ -203,48 +199,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.16.0"
-  connectivity_plus:
-    dependency: transitive
-    description:
-      name: connectivity_plus
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.3.9"
-  connectivity_plus_linux:
-    dependency: transitive
-    description:
-      name: connectivity_plus_linux
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
-  connectivity_plus_macos:
-    dependency: transitive
-    description:
-      name: connectivity_plus_macos
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.2.6"
-  connectivity_plus_platform_interface:
-    dependency: transitive
-    description:
-      name: connectivity_plus_platform_interface
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.2.3"
-  connectivity_plus_web:
-    dependency: transitive
-    description:
-      name: connectivity_plus_web
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.2.5"
-  connectivity_plus_windows:
-    dependency: transitive
-    description:
-      name: connectivity_plus_windows
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.2.2"
   cross_file:
     dependency: transitive
     description:
@@ -287,13 +241,6 @@ packages:
       relative: true
     source: path
     version: "0.0.0"
-  dbus:
-    dependency: transitive
-    description:
-      name: dbus
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.7.8"
   device_frame:
     dependency: transitive
     description:
@@ -455,35 +402,35 @@ packages:
       name: flutter_secure_storage_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   flutter_secure_storage_macos:
     dependency: transitive
     description:
       name: flutter_secure_storage_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   flutter_secure_storage_platform_interface:
     dependency: transitive
     description:
       name: flutter_secure_storage_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   flutter_secure_storage_web:
     dependency: transitive
     description:
       name: flutter_secure_storage_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.1.1"
   flutter_secure_storage_windows:
     dependency: transitive
     description:
       name: flutter_secure_storage_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.3"
   flutter_svg:
     dependency: transitive
     description:
@@ -776,7 +723,7 @@ packages:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   modal_bottom_sheet:
     dependency: transitive
     description:
@@ -791,13 +738,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
-  nm:
-    dependency: transitive
-    description:
-      name: nm
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.5.0"
   openfoodfacts:
     dependency: transitive
     description:
@@ -890,7 +830,7 @@ packages:
       name: path_provider_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.21"
+    version: "2.0.22"
   path_provider_ios:
     dependency: transitive
     description:
@@ -1079,7 +1019,7 @@ packages:
       name: sentry
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.13.1"
+    version: "6.17.0"
   sentry_flutter:
     dependency: transitive
     description:
@@ -1245,7 +1185,7 @@ packages:
       name: stream_transform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
@@ -1267,15 +1207,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.0+3"
-  task_manager:
-    dependency: transitive
-    description:
-      path: "."
-      ref: HEAD
-      resolved-ref: "29e009e760c973359adc99fb86e861dd948daa26"
-      url: "https://github.com/g123k/flutter_task_manager.git"
-    source: git
-    version: "0.0.1"
   term_glyph:
     dependency: transitive
     description:
@@ -1338,7 +1269,7 @@ packages:
       name: url_launcher_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.21"
+    version: "6.0.22"
   url_launcher_ios:
     dependency: transitive
     description:
@@ -1422,7 +1353,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.1.2"
   wkt_parser:
     dependency: transitive
     description:
@@ -1430,13 +1361,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.0"
-  workmanager:
-    dependency: transitive
-    description:
-      name: workmanager
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.5.0"
   xdg_directories:
     dependency: transitive
     description:
@@ -1459,5 +1383,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.17.6 <3.0.0"
+  dart: ">=2.17.0 <3.0.0"
   flutter: ">=3.0.0"

--- a/packages/app/windows/flutter/generated_plugin_registrant.cc
+++ b/packages/app/windows/flutter/generated_plugin_registrant.cc
@@ -7,26 +7,20 @@
 #include "generated_plugin_registrant.h"
 
 #include <audioplayers_windows/audioplayers_windows_plugin.h>
-#include <connectivity_plus_windows/connectivity_plus_windows_plugin.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
 #include <sentry_flutter/sentry_flutter_plugin.h>
-#include <task_manager/task_manager_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   AudioplayersWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("AudioplayersWindowsPlugin"));
-  ConnectivityPlusWindowsPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("ConnectivityPlusWindowsPlugin"));
   FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
   PermissionHandlerWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
   SentryFlutterPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("SentryFlutterPlugin"));
-  TaskManagerPluginCApiRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("TaskManagerPluginCApi"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/packages/app/windows/flutter/generated_plugins.cmake
+++ b/packages/app/windows/flutter/generated_plugins.cmake
@@ -4,11 +4,9 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   audioplayers_windows
-  connectivity_plus_windows
   flutter_secure_storage_windows
   permission_handler_windows
   sentry_flutter
-  task_manager
   url_launcher_windows
 )
 

--- a/packages/scanner/shared/pubspec.yaml
+++ b/packages/scanner/shared/pubspec.yaml
@@ -17,11 +17,6 @@ dependencies:
       url: "https://github.com/openfoodfacts/smooth_app_plugins_fork.git"
       ref: "smooth_camera"
       path: "packages/camera/camera"
-  camera_platform_interface:
-    git:
-      url: "https://github.com/openfoodfacts/smooth_app_plugins_fork.git"
-      ref: "smooth_camera"
-      path: "packages/camera/camera_platform_interface"
 
 dev_dependencies:
   flutter_test:

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -142,31 +142,27 @@ packages:
     source: hosted
     version: "8.4.2"
   camera:
-    dependency: "direct main"
+    dependency: transitive
     description:
       path: "packages/camera/camera"
       ref: smooth_camera
-      resolved-ref: "3c62b56bb6cc0ae1c9594f417ce6305ea45e214f"
-      url: "https://github.com/g123k/plugins.git"
+      resolved-ref: "2fe0f6e0c7043a9cb855b299315566187827b2a2"
+      url: "https://github.com/openfoodfacts/smooth_app_plugins_fork.git"
     source: git
     version: "0.9.6"
   camera_platform_interface:
-    dependency: "direct main"
+    dependency: transitive
     description:
-      path: "packages/camera/camera_platform_interface"
-      ref: smooth_camera
-      resolved-ref: "3c62b56bb6cc0ae1c9594f417ce6305ea45e214f"
-      url: "https://github.com/g123k/plugins.git"
-    source: git
-    version: "2.1.6"
+      name: camera_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.3.1"
   camera_web:
     dependency: transitive
     description:
-      path: "packages/camera/camera_web"
-      ref: smooth_camera
-      resolved-ref: "3c62b56bb6cc0ae1c9594f417ce6305ea45e214f"
-      url: "https://github.com/g123k/plugins.git"
-    source: git
+      name: camera_web
+      url: "https://pub.dartlang.org"
+    source: hosted
     version: "0.2.1+6"
   carousel_slider:
     dependency: "direct main"
@@ -441,35 +437,35 @@ packages:
       name: flutter_secure_storage_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   flutter_secure_storage_macos:
     dependency: transitive
     description:
       name: flutter_secure_storage_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   flutter_secure_storage_platform_interface:
     dependency: transitive
     description:
       name: flutter_secure_storage_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   flutter_secure_storage_web:
     dependency: transitive
     description:
       name: flutter_secure_storage_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.1.1"
   flutter_secure_storage_windows:
     dependency: transitive
     description:
       name: flutter_secure_storage_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.3"
   flutter_svg:
     dependency: "direct main"
     description:
@@ -741,7 +737,7 @@ packages:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   mockito:
     dependency: "direct dev"
     description:
@@ -862,7 +858,7 @@ packages:
       name: path_provider_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.21"
+    version: "2.0.22"
   path_provider_ios:
     dependency: transitive
     description:
@@ -1009,7 +1005,7 @@ packages:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   qr:
     dependency: transitive
     description:
@@ -1044,7 +1040,7 @@ packages:
       name: sentry
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.13.1"
+    version: "6.17.0"
   sentry_flutter:
     dependency: "direct main"
     description:
@@ -1210,7 +1206,7 @@ packages:
       name: stream_transform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
@@ -1294,7 +1290,7 @@ packages:
       name: url_launcher_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.21"
+    version: "6.0.22"
   url_launcher_ios:
     dependency: transitive
     description:
@@ -1385,7 +1381,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.1.2"
   wkt_parser:
     dependency: transitive
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -44,17 +44,6 @@ dependencies:
   url_launcher: 6.1.3
   visibility_detector: 0.3.3
 
-  # Camera (custom implementation for Android)
-  camera:
-    git:
-      url: "https://github.com/openfoodfacts/smooth_app_plugins_fork.git"
-      ref: "smooth_camera"
-      path: "packages/camera/camera"
-  camera_platform_interface:
-    git:
-      url: "https://github.com/openfoodfacts/smooth_app_plugins_fork.git"
-      ref: "smooth_camera"
-      path: "packages/camera/camera_platform_interface"
   scanner_shared:
     path: ../scanner/shared
   app_store_shared:


### PR DESCRIPTION
### What
- `packages/scanner/shared/pubspec.yaml` removed `camera_platform_interface` since `camera` (package above) imports it already
- `packages/smooth_app/pubspec.yaml` removed `camera` and `camera_platform_interface` as both are imported by `/scanner/shared`

### Why
I couldn't run pub get anymore. Do to multiple reaons one of them beeing that we had multiple package imports which had different commit hashes resolved. Tidied up the whole thing while fixing this.