### PR TITLE
fix: 3387 - energy and energyKJ confusion fix

### DIFF
--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -253,7 +253,7 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
     final OrderedNutrient orderedNutrient,
     final int position,
   ) {
-    final Nutrient nutrient = orderedNutrient.nutrient!;
+    final Nutrient nutrient = _getNutrient(orderedNutrient);
 
     if (_controllers[nutrient] == null) {
       final double? value = _nutritionContainer.getValue(nutrient);
@@ -329,7 +329,8 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
       _unitLabels[unit] ?? UnitHelper.unitToString(unit)!;
 
   Widget _getUnitCell(final OrderedNutrient orderedNutrient) {
-    final Unit unit = _nutritionContainer.getUnit(orderedNutrient.nutrient!);
+    final Unit unit =
+        _nutritionContainer.getUnit(_getNutrient(orderedNutrient));
     return ElevatedButton(
       onPressed: _nutritionContainer.isEditableWeight(unit)
           ? () => setState(
@@ -549,5 +550,16 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
       widget: this,
     );
     return true;
+  }
+
+  // cf. https://github.com/openfoodfacts/smooth-app/issues/3387
+  Nutrient _getNutrient(final OrderedNutrient orderedNutrient) {
+    if (orderedNutrient.nutrient != null) {
+      return orderedNutrient.nutrient!;
+    }
+    if (orderedNutrient.id == 'energy') {
+      return Nutrient.energyKJ;
+    }
+    throw Exception('unknown nutrient for "${orderedNutrient.id}"');
   }
 }


### PR DESCRIPTION
Impacted file:
* `nutrition_page_loaded.dart`: forces energy as energyKJ

### What
- Depending on the country, the order and the list of nutrients vary.
- There is a bit of confusion as for historical reasons, we have both energy (in KJ) and energyKJ (erm... in KJ) in off, but in off-dart we only have energyKJ (or the other way around)
- At least for Canada, there's no energyKJ, only energy, that should match with energyKJ but does not.
- Should probably be rather fixed in off-dart; here it's only a quick fix for Smoothie.

### Fixes bug(s)
- Fixes: #3387
- Fixes: #3397
- Fixes: #3398
- Fixes SMOOTHIE-1G9
- Fixes SMOOTHIE-1GA