### PR TITLE
docs: figma link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@
 - We strive to timebox the core of the meeting (decision making) to 30 minutes, with an optional free discussion/live debugging afterwards.
 - We take comprehensive notes in the Weekly Agenda of agenda item discussions and of decisions taken.
 
+## User interface
+-  [![Figma](https://img.shields.io/badge/figma-%23F24E1E.svg?logo=figma&logoColor=white) Mockups on the current app and future plans to discuss](https://www.figma.com/file/nFMjewFAOa8c4ahtob7CAB/Mobile-App-Design-(Quentin)?node-id=0%3A1&t=SrBuT7gBdhapUerx-0)
+
+
 ## Feature Sprint 
 - We use feature-based sprints, [tracked here](https://github.com/orgs/openfoodfacts/projects/83)
 


### PR DESCRIPTION
### What
docs: figma link in README
Hopefully, this will make the FIGMA board permanently visible, and allow us to make more collaborative design choices.