### PR TITLE
fix: 3417 The tagline blinks in the app language, then goes back to English

### DIFF
--- a/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
+++ b/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
@@ -260,6 +260,7 @@ class _SearchCardTagLine extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    TagLineItem? tagline;
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: VERY_SMALL_SPACE),
       child: DefaultTextStyle.merge(
@@ -279,17 +280,26 @@ class _SearchCardTagLine extends StatelessWidget {
               future: _fetchData(),
               builder: (BuildContext context,
                   AsyncSnapshot<Map<String, dynamic>> data) {
-                if (data.data == null || !data.hasData) {
+                if (data.connectionState == ConnectionState.done) {
+                  if (data.hasData) {
+                    if (data.data![TAG_LINE_KEY] != null) {
+                      tagline = data.data![TAG_LINE_KEY] as TagLineItem;
+                      return _SearchCardTagLineText(
+                        tagLine: tagline!,
+                      );
+                    }
+                    if (data.data![DEPRECATED_KEY] as bool) {
+                      return const _SearchCardTagLineDeprecatedAppText();
+                    }
+                  }
                   return const _SearchCardTagLineDefaultText();
                 }
 
-                if (data.data![DEPRECATED_KEY] as bool) {
-                  return const _SearchCardTagLineDeprecatedAppText();
-                }
-
-                if (data.data![TAG_LINE_KEY] != null) {
+                ///This is to avoid blinking issue caused, Due to [ConnectionState.done] followed by [ConnectionState.waiting]
+                ///When [Consumer] refreshes the [FutureBuilder] causing [_fetchData()] to be called again.
+                if (tagline != null) {
                   return _SearchCardTagLineText(
-                    tagLine: data.data![TAG_LINE_KEY] as TagLineItem,
+                    tagLine: tagline!,
                   );
                 }
                 return const _SearchCardTagLineDefaultText();

--- a/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
+++ b/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
@@ -279,9 +279,7 @@ class _SearchCardTagLine extends StatelessWidget {
               future: _fetchData(),
               builder: (BuildContext context,
                   AsyncSnapshot<Map<String, dynamic>> data) {
-                if (data.connectionState != ConnectionState.done ||
-                    data.data == null ||
-                    !data.hasData) {
+                if (data.data == null || !data.hasData) {
                   return const _SearchCardTagLineDefaultText();
                 }
 


### PR DESCRIPTION
### What
<!-- description of the PR -->
- #3417 
- When tried debugging, I found that there is flag for checking if `snapshot.connectionState == ConnectionState.done`, During lifecycle changes when it's in state `ConnectionState.waiting` it displays default tagline text, Even though snapshot has data.
<!-- 
Please name your pull request following this scheme: `type: What you did` this allows us to automatically generate the changelog
Following `type`s are allowed:
  - `feat`, for Features
  - `fix`, for Bug Fixes
  - `docs`, for Documentation
  - `ci`, for Automation
  - `refactor`, for code Refactoring
  - `chore`, for Miscellaneous things
-->

### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes: #3417 

