### PR TITLE
ci: Show flavour in about this app and sentry

### DIFF
--- a/packages/app/lib/entrypoints/android/main_fdroid.dart
+++ b/packages/app/lib/entrypoints/android/main_fdroid.dart
@@ -13,5 +13,6 @@ void main() {
         'https://f-droid.org/fr/packages/openfoodfacts.github.scrachx.openfood/',
       ),
     ),
+    appFlavour: 'zxing-uri',
   );
 }

--- a/packages/app/lib/entrypoints/android/main_google_play.dart
+++ b/packages/app/lib/entrypoints/android/main_google_play.dart
@@ -9,5 +9,6 @@ void main() {
   launchSmoothApp(
     scanner: MLKitCameraScanner(),
     appStore: GooglePlayStore(),
+    appFlavour: 'ml-play',
   );
 }

--- a/packages/app/lib/entrypoints/ios/main_ios.dart
+++ b/packages/app/lib/entrypoints/ios/main_ios.dart
@@ -9,5 +9,6 @@ void main() {
   launchSmoothApp(
     scanner: MLKitCameraScanner(),
     appStore: AppleAppStore('588797948'),
+    appFlavour: 'ml-ios',
   );
 }

--- a/packages/smooth_app/integration_test/app_test.dart
+++ b/packages/smooth_app/integration_test/app_test.dart
@@ -58,6 +58,7 @@ void main() {
         await app.launchSmoothApp(
           scanner: MockedCameraScanner(),
           appStore: const MockedAppStore(),
+          appFlavour: 'test-runner',
           screenshots: true,
         );
         await tester.pumpAndSettle();

--- a/packages/smooth_app/lib/helpers/analytics_helper.dart
+++ b/packages/smooth_app/lib/helpers/analytics_helper.dart
@@ -5,6 +5,7 @@ import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:openfoodfacts/utils/OpenFoodAPIConfiguration.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
+import 'package:smooth_app/main.dart';
 
 /// Category for Matomo Events
 enum AnalyticsCategory {
@@ -55,7 +56,9 @@ class AnalyticsHelper {
 
   static String latestSearch = '';
 
-  static Future<void> initSentry({Function()? appRunner}) async {
+  static Future<void> initSentry({
+    required Function()? appRunner,
+  }) async {
     final PackageInfo packageInfo = await PackageInfo.fromPlatform();
 
     await SentryFlutter.init(
@@ -67,6 +70,7 @@ class AnalyticsHelper {
         // To set a uniform sample rate
         options.tracesSampleRate = 1.0;
         options.beforeSend = _beforeSend;
+        options.environment = flavour;
       },
       appRunner: appRunner,
     );

--- a/packages/smooth_app/lib/main.dart
+++ b/packages/smooth_app/lib/main.dart
@@ -33,10 +33,12 @@ import 'package:smooth_app/themes/theme_provider.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
 late bool _screenshots;
+late String flavour;
 
 Future<void> launchSmoothApp({
   required CameraScanner scanner,
   required AppStore appStore,
+  required String appFlavour,
   final bool screenshots = false,
 }) async {
   _screenshots = screenshots;
@@ -49,10 +51,11 @@ Future<void> launchSmoothApp({
       WidgetsFlutterBinding.ensureInitialized();
   FlutterNativeSplash.preserve(widgetsBinding: widgetsBinding);
 
+  flavour = appFlavour;
+
   if (kReleaseMode) {
     await AnalyticsHelper.initSentry(
-      appRunner: () => runApp(SmoothApp(scanner, appStore)),
-    );
+        appRunner: () => runApp(SmoothApp(scanner, appStore)));
   } else {
     runApp(
       DevicePreview(

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_faq.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_faq.dart
@@ -7,6 +7,7 @@ import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/helpers/app_helper.dart';
 import 'package:smooth_app/helpers/launch_url_helper.dart';
+import 'package:smooth_app/main.dart';
 import 'package:smooth_app/pages/preferences/abstract_user_preferences.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_list_tile.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_page.dart';
@@ -121,7 +122,7 @@ class UserPreferencesFaq extends AbstractUserPreferences {
                           ),
                         ),
                         Text(
-                          '${packageInfo.version}+${packageInfo.buildNumber}',
+                          '${packageInfo.version}+${packageInfo.buildNumber}-$flavour',
                           style: themeData.textTheme.subtitle2,
                         )
                       ],


### PR DESCRIPTION
### What
Something we didn't need until know. But we will certainly need it in the future https://github.com/openfoodfacts/smooth-app/issues/3427

Now we show the app flavour in the "about this app" section as well as sending it to sentry.

Why a global variable?

The value won't change after the build and I put it in the main.dart because I didn't know where else to put. A single dedicated file seems again too much. If we  later find anything to pair it with why not?

