### PR TITLE
fix: Language code usage

### DIFF
--- a/packages/smooth_app/lib/data_models/product_preferences.dart
+++ b/packages/smooth_app/lib/data_models/product_preferences.dart
@@ -12,6 +12,7 @@ import 'package:openfoodfacts/personalized_search/product_preferences_selection.
 import 'package:smooth_app/data_models/downloadable_string.dart';
 import 'package:smooth_app/database/dao_string.dart';
 import 'package:smooth_app/helpers/app_helper.dart';
+import 'package:smooth_app/query/product_query.dart';
 
 class ProductPreferences extends ProductPreferencesManager with ChangeNotifier {
   ProductPreferences(
@@ -68,11 +69,12 @@ class ProductPreferences extends ProductPreferencesManager with ChangeNotifier {
   }
 
   /// Refreshes the references with network data.
-  Future<void> refresh(final String languageCode) async {
+  Future<void> refresh() async {
+    final String currentLanguageCode = ProductQuery.getLocaleString();
     if (daoString != null) {
       final String? latestLanguage =
           await daoString!.get(_DAO_STRING_KEY_LANGUAGE);
-      if (latestLanguage == null || latestLanguage != languageCode) {
+      if (latestLanguage == null || latestLanguage != currentLanguageCode) {
         // we restart from scratch
         // typical use-case: language change
         _isNetwork = false;
@@ -86,11 +88,11 @@ class ProductPreferences extends ProductPreferencesManager with ChangeNotifier {
       return;
     }
     _isDownloading = true;
-    final bool successful = await _loadFromNetwork(languageCode);
+    final bool successful = await _loadFromNetwork(currentLanguageCode);
     if (successful) {
       _isNetwork = true;
       if (daoString != null) {
-        await daoString!.put(_DAO_STRING_KEY_LANGUAGE, languageCode);
+        await daoString!.put(_DAO_STRING_KEY_LANGUAGE, currentLanguageCode);
       }
       notify();
     }

--- a/packages/smooth_app/lib/data_models/product_preferences.dart
+++ b/packages/smooth_app/lib/data_models/product_preferences.dart
@@ -3,6 +3,7 @@ import 'dart:async' show Future;
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/model/Attribute.dart';
 import 'package:openfoodfacts/model/AttributeGroup.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/personalized_search/available_attribute_groups.dart';
 import 'package:openfoodfacts/personalized_search/available_preference_importances.dart';
 import 'package:openfoodfacts/personalized_search/available_product_preferences.dart';
@@ -70,11 +71,12 @@ class ProductPreferences extends ProductPreferencesManager with ChangeNotifier {
 
   /// Refreshes the references with network data.
   Future<void> refresh() async {
-    final String currentLanguageCode = ProductQuery.getLocaleString();
+    final String currentLocal = ProductQuery.getLocaleString();
+    final String lc = ProductQuery.getLanguage().code;
     if (daoString != null) {
       final String? latestLanguage =
           await daoString!.get(_DAO_STRING_KEY_LANGUAGE);
-      if (latestLanguage == null || latestLanguage != currentLanguageCode) {
+      if (latestLanguage == null || latestLanguage != currentLocal) {
         // we restart from scratch
         // typical use-case: language change
         _isNetwork = false;
@@ -88,11 +90,11 @@ class ProductPreferences extends ProductPreferencesManager with ChangeNotifier {
       return;
     }
     _isDownloading = true;
-    final bool successful = await _loadFromNetwork(currentLanguageCode);
+    final bool successful = await _loadFromNetwork(lc);
     if (successful) {
       _isNetwork = true;
       if (daoString != null) {
-        await daoString!.put(_DAO_STRING_KEY_LANGUAGE, currentLanguageCode);
+        await daoString!.put(_DAO_STRING_KEY_LANGUAGE, currentLocal);
       }
       notify();
     }

--- a/packages/smooth_app/lib/data_models/product_preferences.dart
+++ b/packages/smooth_app/lib/data_models/product_preferences.dart
@@ -71,12 +71,11 @@ class ProductPreferences extends ProductPreferencesManager with ChangeNotifier {
 
   /// Refreshes the references with network data.
   Future<void> refresh() async {
-    final String currentLocal = ProductQuery.getLocaleString();
     final String lc = ProductQuery.getLanguage().code;
     if (daoString != null) {
       final String? latestLanguage =
           await daoString!.get(_DAO_STRING_KEY_LANGUAGE);
-      if (latestLanguage == null || latestLanguage != currentLocal) {
+      if (latestLanguage == null || latestLanguage != lc) {
         // we restart from scratch
         // typical use-case: language change
         _isNetwork = false;
@@ -94,7 +93,7 @@ class ProductPreferences extends ProductPreferencesManager with ChangeNotifier {
     if (successful) {
       _isNetwork = true;
       if (daoString != null) {
-        await daoString!.put(_DAO_STRING_KEY_LANGUAGE, currentLocal);
+        await daoString!.put(_DAO_STRING_KEY_LANGUAGE, lc);
       }
       notify();
     }

--- a/packages/smooth_app/lib/data_models/tagline.dart
+++ b/packages/smooth_app/lib/data_models/tagline.dart
@@ -2,15 +2,17 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:http/http.dart' as http;
+import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/helpers/collections_helper.dart';
+import 'package:smooth_app/query/product_query.dart';
 
 /// A tagline is the text displayed on the homepage
 /// It may contain a link to an external resource
 /// No cache is expected here
 /// API URL: [https://world.openfoodfacts.org/files/tagline-off-ios-v2.json] or
 /// [https://world.openfoodfacts.org/files/tagline-off-android-v2.json]
-Future<TagLineItem?> fetchTagLine(String locale) {
-  assert(locale.isNotEmpty);
+Future<TagLineItem?> fetchTagLine() {
+  final String locale = ProductQuery.getLanguage().code;
 
   return http
       .get(
@@ -23,7 +25,7 @@ Future<TagLineItem?> fetchTagLine(String locale) {
           (http.Response value) => const Utf8Decoder().convert(value.bodyBytes))
       .then((String value) =>
           _TagLine.fromJSON(jsonDecode(value) as List<dynamic>))
-      .then((_TagLine tagLine) => tagLine[locale] ?? tagLine['en'])
+      .then((_TagLine tagLine) => tagLine[locale])
       .catchError((dynamic err) => null);
 }
 

--- a/packages/smooth_app/lib/data_models/tagline.dart
+++ b/packages/smooth_app/lib/data_models/tagline.dart
@@ -25,7 +25,7 @@ Future<TagLineItem?> fetchTagLine() {
           (http.Response value) => const Utf8Decoder().convert(value.bodyBytes))
       .then((String value) =>
           _TagLine.fromJSON(jsonDecode(value) as List<dynamic>))
-      .then((_TagLine tagLine) => tagLine[locale])
+      .then((_TagLine tagLine) => tagLine[locale] ?? tagLine['en'])
       .catchError((dynamic err) => null);
 }
 

--- a/packages/smooth_app/lib/data_models/user_preferences.dart
+++ b/packages/smooth_app/lib/data_models/user_preferences.dart
@@ -167,6 +167,7 @@ class UserPreferences extends ChangeNotifier {
   bool get inAppReviewAlreadyAsked =>
       _sharedPreferences.getBool(_TAG_IN_APP_REVIEW_ALREADY_DISPLAYED) ?? false;
 
+  /// Please use [ProductQuery.setLanguage] as interface
   Future<void> setAppLanguageCode(String? languageCode) async {
     if (languageCode == null) {
       await _sharedPreferences
@@ -178,6 +179,7 @@ class UserPreferences extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Please use [ProductQuery.getLanguage] as interface
   String? get appLanguageCode =>
       getDevModeString(UserPreferencesDevMode.userPreferencesAppLanguageCode);
 

--- a/packages/smooth_app/lib/generic_lib/widgets/language_selector.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/language_selector.dart
@@ -6,6 +6,7 @@ import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_text_form_field.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_languages_list.dart';
+import 'package:smooth_app/query/product_query.dart';
 
 class LanguageSelectorSettings extends StatelessWidget {
   const LanguageSelectorSettings({
@@ -21,8 +22,7 @@ class LanguageSelectorSettings extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // The languages that are supported by flutter widget
-    final String currentLanguageCode = userPreferences.appLanguageCode ??
-        Localizations.localeOf(context).toString();
+    final String currentLanguageCode = ProductQuery.getLocaleString();
     final OpenFoodFactsLanguage language =
         LanguageHelper.fromJson(currentLanguageCode);
     final String nameInEnglish =
@@ -105,8 +105,11 @@ class LanguageSelectorSettings extends StatelessWidget {
                                   overflow: TextOverflow.fade,
                                 ),
                                 onTap: () {
-                                  userPreferences.setAppLanguageCode(
-                                      openFoodFactsLanguage.code);
+                                  ProductQuery.setLanguage(
+                                    context,
+                                    userPreferences,
+                                    languageCode: openFoodFactsLanguage.code,
+                                  );
                                   Navigator.of(context).pop();
                                 },
                               );

--- a/packages/smooth_app/lib/generic_lib/widgets/language_selector.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/language_selector.dart
@@ -22,7 +22,7 @@ class LanguageSelectorSettings extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // The languages that are supported by flutter widget
-    final String currentLanguageCode = ProductQuery.getLocaleString();
+    final String currentLanguageCode = ProductQuery.getLanguage().code;
     final OpenFoodFactsLanguage language =
         LanguageHelper.fromJson(currentLanguageCode);
     final String nameInEnglish =

--- a/packages/smooth_app/lib/main.dart
+++ b/packages/smooth_app/lib/main.dart
@@ -214,8 +214,8 @@ class _SmoothAppState extends State<SmoothApp> {
         OnboardingFlowNavigator.isOnboardingComplete(lastVisitedOnboardingPage);
     themeProvider.setOnboardingComplete(isOnboardingComplete);
 
-    // Still need the value of the UP here, not the ProductQuery as the value is
-    // not available at this time
+    // Still need the value from the UserPreferences here, not the ProductQuery
+    // as the value is not available at this time
     // will refresh each time the language changes
     final String? languageCode =
         context.select((UserPreferences up) => up.appLanguageCode);

--- a/packages/smooth_app/lib/main.dart
+++ b/packages/smooth_app/lib/main.dart
@@ -213,6 +213,10 @@ class _SmoothAppState extends State<SmoothApp> {
     final bool isOnboardingComplete =
         OnboardingFlowNavigator.isOnboardingComplete(lastVisitedOnboardingPage);
     themeProvider.setOnboardingComplete(isOnboardingComplete);
+
+    // Still need the value of the UP here, not the ProductQuery as the value is
+    // at this time
+    // will refresh each time the language changes
     final String? languageCode =
         context.select((UserPreferences up) => up.appLanguageCode);
 
@@ -233,7 +237,7 @@ class _SmoothAppState extends State<SmoothApp> {
         themeProvider,
       ),
       themeMode: themeProvider.currentThemeMode,
-      home: SmoothAppGetLanguage(appWidget),
+      home: SmoothAppGetLanguage(appWidget, _userPreferences),
     );
   }
 
@@ -253,23 +257,18 @@ class _SmoothAppState extends State<SmoothApp> {
 /// Layer needed because we need to know the language. Language isn't available
 /// in the [context] in top level widget ([SmoothApp])
 class SmoothAppGetLanguage extends StatelessWidget {
-  const SmoothAppGetLanguage(this.appWidget);
+  const SmoothAppGetLanguage(this.appWidget, this.up);
 
   final Widget appWidget;
+  final UserPreferences up;
 
   @override
   Widget build(BuildContext context) {
     // TODO(monsieurtanuki): refactor removing the `SmoothAppGetLanguage` layer?
-    // will refresh each time the language changes
-    context.select(
-      (final UserPreferences userPreferences) =>
-          userPreferences.appLanguageCode,
-    );
-    final String languageCode = Localizations.localeOf(context).languageCode;
-    ProductQuery.setLanguage(languageCode);
-    context.read<ProductPreferences>().refresh(languageCode);
+    ProductQuery.setLanguage(context, up);
+    context.read<ProductPreferences>().refresh();
 
-    // The migration requires the language to be set in the app
+    // The migration requires the language to be set in the app!
     _appDataImporter.startMigrationAsync();
 
     return appWidget;

--- a/packages/smooth_app/lib/main.dart
+++ b/packages/smooth_app/lib/main.dart
@@ -215,7 +215,7 @@ class _SmoothAppState extends State<SmoothApp> {
     themeProvider.setOnboardingComplete(isOnboardingComplete);
 
     // Still need the value of the UP here, not the ProductQuery as the value is
-    // at this time
+    // not available at this time
     // will refresh each time the language changes
     final String? languageCode =
         context.select((UserPreferences up) => up.appLanguageCode);
@@ -257,15 +257,15 @@ class _SmoothAppState extends State<SmoothApp> {
 /// Layer needed because we need to know the language. Language isn't available
 /// in the [context] in top level widget ([SmoothApp])
 class SmoothAppGetLanguage extends StatelessWidget {
-  const SmoothAppGetLanguage(this.appWidget, this.up);
+  const SmoothAppGetLanguage(this.appWidget, this.userPreferences);
 
   final Widget appWidget;
-  final UserPreferences up;
+  final UserPreferences userPreferences;
 
   @override
   Widget build(BuildContext context) {
     // TODO(monsieurtanuki): refactor removing the `SmoothAppGetLanguage` layer?
-    ProductQuery.setLanguage(context, up);
+    ProductQuery.setLanguage(context, userPreferences);
     context.read<ProductPreferences>().refresh();
 
     // The migration requires the language to be set in the app!

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_dev_mode.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_dev_mode.dart
@@ -418,7 +418,10 @@ class UserPreferencesDevMode extends AbstractUserPreferences {
         ListTile(
           // Do not translate
           title: const Text('Reset App Language'),
-          onTap: () async => userPreferences.setAppLanguageCode(null),
+          onTap: () async {
+            userPreferences.setAppLanguageCode(null);
+            ProductQuery.setLanguage(context, userPreferences);
+          },
         ),
       ];
 

--- a/packages/smooth_app/lib/query/product_query.dart
+++ b/packages/smooth_app/lib/query/product_query.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:openfoodfacts/model/UserAgent.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/utils/CountryHelper.dart';
@@ -24,7 +25,21 @@ abstract class ProductQuery {
   }
 
   /// Sets the global language for API queries.
-  static void setLanguage(final String languageCode) {
+  static void setLanguage(
+    final BuildContext context,
+    final UserPreferences userPreferences, {
+    String? languageCode,
+  }) {
+    final Locale locale = Localizations.localeOf(context);
+
+    if (languageCode != null) {
+      userPreferences.setAppLanguageCode(languageCode);
+    } else if (userPreferences.appLanguageCode != null) {
+      languageCode = userPreferences.appLanguageCode;
+    } else {
+      languageCode = locale.languageCode;
+    }
+
     final OpenFoodFactsLanguage language =
         LanguageHelper.fromJson(languageCode);
     OpenFoodAPIConfiguration.globalLanguages = <OpenFoodFactsLanguage>[

--- a/packages/smooth_app/lib/query/questions_query.dart
+++ b/packages/smooth_app/lib/query/questions_query.dart
@@ -5,7 +5,7 @@ import 'package:smooth_app/query/product_query.dart';
 class QuestionsQuery {
   Future<List<RobotoffQuestion>> getQuestions() async {
     final User user = OpenFoodAPIConfiguration.globalUser!;
-    final String lc = ProductQuery.getLocaleString();
+    final String lc = ProductQuery.getLanguage().code;
 
     final RobotoffQuestionResult result =
         await OpenFoodAPIClient.getRandomRobotoffQuestion(

--- a/packages/smooth_app/lib/query/questions_query.dart
+++ b/packages/smooth_app/lib/query/questions_query.dart
@@ -1,12 +1,11 @@
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:openfoodfacts/utils/OpenFoodAPIConfiguration.dart';
+import 'package:smooth_app/query/product_query.dart';
 
 class QuestionsQuery {
   Future<List<RobotoffQuestion>> getQuestions() async {
     final User user = OpenFoodAPIConfiguration.globalUser!;
-
-    // TODO(vaiton): Not to sure about this
-    final String lc = OpenFoodAPIConfiguration.globalLanguages![0].code;
+    final String lc = ProductQuery.getLocaleString();
 
     final RobotoffQuestionResult result =
         await OpenFoodAPIClient.getRandomRobotoffQuestion(

--- a/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
+++ b/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
@@ -316,7 +316,7 @@ class _SearchCardTagLineState extends State<_SearchCardTagLine> {
   /// Return a map with keys: [_SearchCardTagLine.DEPRECATED_KEY]<bool> & [_SearchCardTagLine.TAG_LINE_KEY]<TagLineItem?>
   Future<Map<String, dynamic>> _fetchData() async {
     final bool deprecated = await _isApplicationDeprecated();
-    final TagLineItem? item = await fetchTagLine(Platform.localeName);
+    final TagLineItem? item = await fetchTagLine();
 
     return <String, dynamic>{
       _SearchCardTagLine.DEPRECATED_KEY: deprecated,


### PR DESCRIPTION
### What
Fix for #3411

Before we sometimes used the language stored in the preferences, sometimes the locale of the phone which lead to problems for  people with englisch as phone language in other countries. 

Now we have all the languages routes over the ProductPreferences and only in needed places over the UserPreferences
