### PR TITLE
fix: Edit page not accessible on hebrew

### DIFF
--- a/packages/smooth_app/lib/generic_lib/dialogs/smooth_alert_dialog.dart
+++ b/packages/smooth_app/lib/generic_lib/dialogs/smooth_alert_dialog.dart
@@ -333,7 +333,7 @@ List<Widget>? _buildActions(
   }
 
   if (Directionality.of(context) == TextDirection.rtl) {
-    return actions.reversed.toList(growable: false);
+    return actions.reversed.toList();
   } else {
     return actions;
   }


### PR DESCRIPTION
### What
On languages with RTL layout the edit pages are not accessible, because we add something to the before as not growable declared list
