### PR TITLE
refactor: integrating off-dart 1.30.1

### DIFF
--- a/packages/app/ios/Podfile.lock
+++ b/packages/app/ios/Podfile.lock
@@ -58,9 +58,6 @@ PODS:
   - GoogleUtilitiesComponents (1.1.0):
     - GoogleUtilities/Logger
   - GTMSessionFetcher/Core (1.7.2)
-  - image_cropper (0.0.4):
-    - Flutter
-    - TOCropViewController (~> 2.6.1)
   - image_picker_ios (0.0.1):
     - Flutter
   - in_app_review (0.2.0):
@@ -122,8 +119,9 @@ PODS:
   - sqflite (0.0.2):
     - Flutter
     - FMDB (>= 2.7.5)
-  - TOCropViewController (2.6.1)
   - url_launcher_ios (0.0.1):
+    - Flutter
+  - webview_flutter_wkwebview (0.0.1):
     - Flutter
 
 DEPENDENCIES:
@@ -138,7 +136,6 @@ DEPENDENCIES:
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
   - google_mlkit_barcode_scanning (from `.symlinks/plugins/google_mlkit_barcode_scanning/ios`)
   - google_mlkit_commons (from `.symlinks/plugins/google_mlkit_commons/ios`)
-  - image_cropper (from `.symlinks/plugins/image_cropper/ios`)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
   - in_app_review (from `.symlinks/plugins/in_app_review/ios`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
@@ -151,6 +148,7 @@ DEPENDENCIES:
   - shared_preferences_ios (from `.symlinks/plugins/shared_preferences_ios/ios`)
   - sqflite (from `.symlinks/plugins/sqflite/ios`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
+  - webview_flutter_wkwebview (from `.symlinks/plugins/webview_flutter_wkwebview/ios`)
 
 SPEC REPOS:
   trunk:
@@ -172,7 +170,6 @@ SPEC REPOS:
     - Realm
     - RealmSwift
     - Sentry
-    - TOCropViewController
 
 EXTERNAL SOURCES:
   audioplayers_darwin:
@@ -197,8 +194,6 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/google_mlkit_barcode_scanning/ios"
   google_mlkit_commons:
     :path: ".symlinks/plugins/google_mlkit_commons/ios"
-  image_cropper:
-    :path: ".symlinks/plugins/image_cropper/ios"
   image_picker_ios:
     :path: ".symlinks/plugins/image_picker_ios/ios"
   in_app_review:
@@ -223,6 +218,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/sqflite/ios"
   url_launcher_ios:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
+  webview_flutter_wkwebview:
+    :path: ".symlinks/plugins/webview_flutter_wkwebview/ios"
 
 SPEC CHECKSUMS:
   audioplayers_darwin: 387322cb364026a1782298c982693b1b6aa9fa1b
@@ -243,7 +240,6 @@ SPEC CHECKSUMS:
   GoogleUtilities: 1d20a6ad97ef46f67bbdec158ce00563a671ebb7
   GoogleUtilitiesComponents: 679b2c881db3b615a2777504623df6122dd20afe
   GTMSessionFetcher: 5595ec75acf5be50814f81e9189490412bad82ba
-  image_cropper: 60c2789d1f1a78c873235d4319ca0c34a69f2d98
   image_picker_ios: b786a5dcf033a8336a657191401bfdf12017dabb
   in_app_review: 4a97249f7a2f539a0f294c2d9196b7fe35e49541
   integration_test: a1e7d09bd98eca2fc37aefd79d4f41ad37bdbbe5
@@ -266,8 +262,8 @@ SPEC CHECKSUMS:
   share_plus: 056a1e8ac890df3e33cb503afffaf1e9b4fbae68
   shared_preferences_ios: 548a61f8053b9b8a49ac19c1ffbc8b92c50d68ad
   sqflite: 6d358c025f5b867b29ed92fc697fd34924e11904
-  TOCropViewController: edfd4f25713d56905ad1e0b9f5be3fbe0f59c863
   url_launcher_ios: 839c58cdb4279282219f5e248c3321761ff3c4de
+  webview_flutter_wkwebview: b7e70ef1ddded7e69c796c7390ee74180182971f
 
 PODFILE CHECKSUM: aa97d8b016d7264ad0a1ef5c44765133ae787bc4
 

--- a/packages/app/pubspec.lock
+++ b/packages/app/pubspec.lock
@@ -727,7 +727,7 @@ packages:
       name: openfoodfacts
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.27.1"
+    version: "1.30.1"
   openfoodfacts_flutter_lints:
     dependency: "direct dev"
     description:

--- a/packages/smooth_app/lib/background/background_task_details.dart
+++ b/packages/smooth_app/lib/background/background_task_details.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
-import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/background/abstract_background_task.dart';
 import 'package:smooth_app/data_models/operation_type.dart';
@@ -105,7 +104,7 @@ class BackgroundTaskDetails extends AbstractBackgroundTask {
         languageCode: ProductQuery.getLanguage().code,
         inputMap: jsonEncode(minimalistProduct.toJson()),
         user: jsonEncode(ProductQuery.getUser().toJson()),
-        country: ProductQuery.getCountry()!.iso2Code,
+        country: ProductQuery.getCountry()!.offTag,
       );
 
   Product get _product =>

--- a/packages/smooth_app/lib/background/background_task_image.dart
+++ b/packages/smooth_app/lib/background/background_task_image.dart
@@ -4,7 +4,6 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
-import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/background/abstract_background_task.dart';
 import 'package:smooth_app/background/background_task_refresh_later.dart';
@@ -107,17 +106,17 @@ class BackgroundTaskImage extends AbstractBackgroundTask {
         uniqueId: uniqueId,
         barcode: barcode,
         processName: _PROCESS_NAME,
-        imageField: imageField.value,
+        imageField: imageField.offTag,
         imagePath: imageFile.path,
         languageCode: ProductQuery.getLanguage().code,
         user: jsonEncode(ProductQuery.getUser().toJson()),
-        country: ProductQuery.getCountry()!.iso2Code,
+        country: ProductQuery.getCountry()!.offTag,
       );
 
   @override
   Future<void> preExecute(final LocalDatabase localDatabase) async =>
       TransientFile.putImage(
-        ImageFieldExtension.getType(imageField),
+        ImageField.fromOffTag(imageField)!,
         barcode,
         localDatabase,
         File(imagePath),
@@ -126,7 +125,7 @@ class BackgroundTaskImage extends AbstractBackgroundTask {
   @override
   Future<void> postExecute(final LocalDatabase localDatabase) async {
     TransientFile.removeImage(
-      ImageFieldExtension.getType(imageField),
+      ImageField.fromOffTag(imageField)!,
       barcode,
       localDatabase,
     );
@@ -142,7 +141,7 @@ class BackgroundTaskImage extends AbstractBackgroundTask {
     final SendImage image = SendImage(
       lang: getLanguage(),
       barcode: barcode,
-      imageField: ImageFieldExtension.getType(imageField),
+      imageField: ImageField.fromOffTag(imageField)!,
       imageUri: Uri.parse(imagePath),
     );
 

--- a/packages/smooth_app/lib/background/background_task_refresh_later.dart
+++ b/packages/smooth_app/lib/background/background_task_refresh_later.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
-import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:smooth_app/background/abstract_background_task.dart';
 import 'package:smooth_app/data_models/operation_type.dart';
 import 'package:smooth_app/database/local_database.dart';
@@ -107,7 +106,7 @@ class BackgroundTaskRefreshLater extends AbstractBackgroundTask {
         barcode: barcode,
         languageCode: ProductQuery.getLanguage().code,
         user: jsonEncode(ProductQuery.getUser().toJson()),
-        country: ProductQuery.getCountry()!.iso2Code,
+        country: ProductQuery.getCountry()!.offTag,
         timestamp: LocalDatabase.nowInMillis(),
       );
 

--- a/packages/smooth_app/lib/data_models/product_image_data.dart
+++ b/packages/smooth_app/lib/data_models/product_image_data.dart
@@ -37,7 +37,7 @@ class ProductImageData {
     }
 
     final String baseUrl = imageUrl.substring(0, sizeIndex + 1);
-    final String number = size.toNumber();
+    final String number = size.number;
     final String extension =
         imageUrl.substring(extensionIndex, imageUrl.length);
     return baseUrl + number + extension;

--- a/packages/smooth_app/lib/data_models/product_list.dart
+++ b/packages/smooth_app/lib/data_models/product_list.dart
@@ -268,7 +268,7 @@ class ProductList {
             ',$pageSize'
             ',$pageNumber'
             ',${language?.code ?? ''}'
-            ',${country?.iso2Code ?? ''}';
+            ',${country?.offTag ?? ''}';
     }
   }
 }

--- a/packages/smooth_app/lib/data_models/up_to_date_changes.dart
+++ b/packages/smooth_app/lib/data_models/up_to_date_changes.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use
+
 import 'package:openfoodfacts/model/Product.dart';
 import 'package:smooth_app/data_models/operation_type.dart';
 import 'package:smooth_app/database/dao_transient_operation.dart';

--- a/packages/smooth_app/lib/helpers/data_importer/product_list_import_export.dart
+++ b/packages/smooth_app/lib/helpers/data_importer/product_list_import_export.dart
@@ -76,6 +76,7 @@ class ProductListImportExport {
         parametersList: <Parameter>[
           BarcodeParameter.list(barcodes.toList(growable: false)),
         ],
+        version: ProductQuery.productQueryVersion,
       ),
     );
 

--- a/packages/smooth_app/lib/pages/offline_data_page.dart
+++ b/packages/smooth_app/lib/pages/offline_data_page.dart
@@ -54,6 +54,7 @@ Future<int> updateLocalDatabaseFromServer(BuildContext context) async {
     parametersList: <Parameter>[
       BarcodeParameter.list(productsWithoutKnowledgePanel),
     ],
+    version: ProductQuery.productQueryVersion,
   );
 
   final SearchResult result = await OpenFoodAPIClient.searchProducts(
@@ -75,6 +76,7 @@ Future<int> updateLocalDatabaseFromServer(BuildContext context) async {
     parametersList: <Parameter>[
       BarcodeParameter.list(completeProducts),
     ],
+    version: ProductQuery.productQueryVersion,
   );
 
   final SearchResult resultForFullProducts =

--- a/packages/smooth_app/lib/pages/onboarding/country_selector.dart
+++ b/packages/smooth_app/lib/pages/onboarding/country_selector.dart
@@ -189,7 +189,7 @@ class _CountrySelectorState extends State<CountrySelector> {
         <String, OpenFoodFactsCountry>{};
     final Map<String, Country> localizedIsoCodeToCountry = <String, Country>{};
     for (final OpenFoodFactsCountry c in OpenFoodFactsCountry.values) {
-      oFFIsoCodeToCountry[c.iso2Code.toLowerCase()] = c;
+      oFFIsoCodeToCountry[c.offTag.toLowerCase()] = c;
     }
     for (final Country c in localizedCountries) {
       localizedIsoCodeToCountry.putIfAbsent(

--- a/packages/smooth_app/lib/pages/product/common/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_page.dart
@@ -396,6 +396,7 @@ class _ProductListPageState extends State<ProductListPage>
           parametersList: <Parameter>[
             BarcodeParameter.list(barcodes),
           ],
+          version: ProductQuery.productQueryVersion,
         ),
       );
       final List<Product>? freshProducts = searchResult.products;

--- a/packages/smooth_app/lib/pages/product/common/product_query_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_query_page.dart
@@ -378,8 +378,7 @@ class _ProductQueryPageState extends State<ProductQueryPage>
     final List<Country> localizedCountries =
         await IsoCountries.iso_countries_for_locale(locale);
     for (final Country country in localizedCountries) {
-      if (country.countryCode.toLowerCase() ==
-          _country!.iso2Code.toLowerCase()) {
+      if (country.countryCode.toLowerCase() == _country!.offTag.toLowerCase()) {
         return country.name;
       }
     }

--- a/packages/smooth_app/lib/pages/product/common/product_refresher.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_refresher.dart
@@ -9,6 +9,7 @@ import 'package:smooth_app/generic_lib/duration_constants.dart';
 import 'package:smooth_app/generic_lib/loading_dialog.dart';
 import 'package:smooth_app/pages/user_management/login_page.dart';
 import 'package:smooth_app/query/product_query.dart';
+import 'package:smooth_app/services/smooth_services.dart';
 
 /// Refreshes a product on the BE then on the local database.
 class ProductRefresher {
@@ -55,6 +56,7 @@ class ProductRefresher {
         fields: ProductQuery.fields,
         language: ProductQuery.getLanguage(),
         country: ProductQuery.getCountry(),
+        version: ProductQuery.productQueryVersion,
       );
 
   /// Fetches the product from the server and refreshes the local database.
@@ -111,6 +113,7 @@ class ProductRefresher {
     final String barcode,
   ) async {
     try {
+      // ignore: deprecated_member_use
       final ProductResult result = await OpenFoodAPIClient.getProduct(
         getBarcodeQueryConfiguration(barcode),
       );
@@ -122,7 +125,7 @@ class ProductRefresher {
       }
       return const _MetaProductRefresher.error(null);
     } catch (e) {
-      // TODO(monsieurtanuki): add call to Logs
+      Logs.e('Refresh from server error', ex: e);
       return _MetaProductRefresher.error(e.toString());
     }
   }

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -5,7 +5,6 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:openfoodfacts/model/KnowledgePanelElement.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
-import 'package:openfoodfacts/utils/CountryHelper.dart';
 import 'package:provider/provider.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:smooth_app/background/background_task_manager.dart';
@@ -290,7 +289,7 @@ class _ProductPageState extends State<ProductPage> with TraceableClientMixin {
     // We need to provide a sharePositionOrigin to make the plugin work on ipad
     final RenderBox? box = context.findRenderObject() as RenderBox?;
     final String url = 'https://'
-        '${ProductQuery.getCountry()!.iso2Code}.openfoodfacts.org'
+        '${ProductQuery.getCountry()!.offTag}.openfoodfacts.org'
         '/product/$_barcode';
     Share.share(
       appLocalizations.share_product_text(url),

--- a/packages/smooth_app/lib/pages/product/ocr_packaging_helper.dart
+++ b/packages/smooth_app/lib/pages/product/ocr_packaging_helper.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use
+
 import 'dart:async';
 
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';

--- a/packages/smooth_app/lib/pages/product/ordered_nutrients_cache.dart
+++ b/packages/smooth_app/lib/pages/product/ordered_nutrients_cache.dart
@@ -77,7 +77,7 @@ class OrderedNutrientsCache {
     final OpenFoodFactsCountry country = ProductQuery.getCountry()!;
     final OpenFoodFactsLanguage language = ProductQuery.getLanguage()!;
     return 'nutrients.pl'
-        '/${country.iso2Code}'
+        '/${country.offTag}'
         '/${language.code}'
         '/${OpenFoodAPIConfiguration.globalQueryType}';
   }

--- a/packages/smooth_app/lib/query/paged_search_product_query.dart
+++ b/packages/smooth_app/lib/query/paged_search_product_query.dart
@@ -20,5 +20,6 @@ abstract class PagedSearchProductQuery extends PagedProductQuery {
         ],
         language: language,
         country: country,
+        version: ProductQuery.productQueryVersion,
       );
 }

--- a/packages/smooth_app/lib/query/paged_to_be_completed_product_query.dart
+++ b/packages/smooth_app/lib/query/paged_to_be_completed_product_query.dart
@@ -26,6 +26,7 @@ class PagedToBeCompletedProductQuery extends PagedProductQuery {
           ),
           const SortBy(option: SortOption.EDIT),
         ],
+        version: ProductQuery.productQueryVersion,
       );
 
   @override

--- a/packages/smooth_app/lib/query/product_query.dart
+++ b/packages/smooth_app/lib/query/product_query.dart
@@ -13,6 +13,8 @@ import 'package:uuid/uuid.dart';
 
 // ignore: avoid_classes_with_only_static_members
 abstract class ProductQuery {
+  static const ProductQueryVersion productQueryVersion = ProductQueryVersion.v2;
+
   static OpenFoodFactsCountry? _country;
 
   /// Returns the global language for API queries.
@@ -61,7 +63,7 @@ abstract class ProductQuery {
   /// Returns the global locale string (e.g. 'pt_BR')
   static String getLocaleString() => '${getLanguage()!.code}'
       '_'
-      '${getCountry()!.iso2Code.toUpperCase()}';
+      '${getCountry()!.offTag.toUpperCase()}';
 
   /// Sets a comment for the user agent.
   ///
@@ -141,6 +143,7 @@ abstract class ProductQuery {
         ProductField.SERVING_SIZE,
         ProductField.STORES,
         ProductField.PACKAGING_QUANTITY,
+        // ignore: deprecated_member_use
         ProductField.PACKAGING,
         ProductField.PACKAGING_TAGS,
         ProductField.PACKAGING_TEXT_IN_LANGUAGES,

--- a/packages/smooth_app/lib/query/products_preload_helper.dart
+++ b/packages/smooth_app/lib/query/products_preload_helper.dart
@@ -26,6 +26,7 @@ class PreloadDataHelper {
         ],
         language: ProductQuery.getLanguage(),
         country: ProductQuery.getCountry(),
+        version: ProductQuery.productQueryVersion,
       );
       final SearchResult searchResult = await OpenFoodAPIClient.searchProducts(
         ProductQuery.getUser(),

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -748,7 +748,7 @@ packages:
       name: openfoodfacts
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.27.1"
+    version: "1.30.1"
   openfoodfacts_flutter_lints:
     dependency: "direct dev"
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   latlong2: 0.8.1
   matomo_tracker: 1.5.0
   modal_bottom_sheet: 2.1.2
-  openfoodfacts: 1.27.1
+  openfoodfacts: 1.30.1
   #  openfoodfacts:
   #    path: ../../../openfoodfacts-dart
   package_info_plus: 1.4.3+1
@@ -70,7 +70,7 @@ dependencies:
   intl: 0.17.0
   rxdart: 0.27.4
   collection: 1.16.0
-  path: ^1.8.2 # careful with 1.8.1 because of https://github.com/flutter/flutter/issues/95478
+  path: ^1.8.3
   path_provider: 2.0.11
   data_importer_shared:
     path: ../data_importer_shared


### PR DESCRIPTION
Impacted files:
* `background_task_details.dart`: minor refactoring
* `background_task_image.dart`: minor refactoring
* `background_task_refresh_later.dart`: minor refactoring
* `country_selector.dart`: minor refactoring
* `new_product_page.dart`: minor refactoring
* `ocr_packaging_helper.dart`: minor refactoring
* `offline_data_page.dart`: now using an explicit api version
* `ordered_nutrients_cache.dart`: minor refactoring
* `paged_search_product_query.dart`: now using an explicit api version
* `paged_to_be_completed_product_query.dart`: now using an explicit api version
* `Podfile.lock`: wtf
* `product_image_data.dart`: minor refactoring
* `product_list.dart`: minor refactoring
* `product_list_import_export.dart`: now using an explicit api version
* `product_list_page.dart`: now using an explicit api version
* `product_query.dart`: explicit api version
* `product_query_page.dart`: minor refactoring
* `product_refresher.dart`: now using an explicit api version
* `products_preload_helper.dart`: now using an explicit api version
* `app/pubspec.lock`: wtf
* `smooth_app/pubspec.lock`: wtf
* `pubspec.yaml`: upgraded off-dart version to 1.30.1
* `up_to_date_changes.dart`: minor refactoring

### What
- Upgraded to off-dart 1.30.1
- Mainly it was about
  - field "packaging" that got deprecated
  - field "offTag" that replaced custom tags
  - setting a specific api version (v2)
- We cannot set v3 yet because of a pending bug (cf. https://github.com/openfoodfacts/openfoodfacts-dart/issues/617#issuecomment-1365356459). Meanwhile, we'll have to tap dance if we want to use the new packagings instead of the old packaging.
- Perhaps we should make `api_version` mandatory in off-dart 2.0.0, for more clarity.