### PR TITLE
feat: 3493 - structured packagings +quantity +weight and localized

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1767,5 +1767,46 @@
     "app_rating_dialog_title_enjoying_positive_actions": "Yeah!",
     "not_really": "Not really",
     "app_rating_dialog_title_not_enjoying_app": "I'm so sorry to hear that! Could you tell me what happened?",
+    "edit_packagings_title": "(Beta) Structured packaging",
+    "@edit_packagings_title": {
+        "description": "Title of the structured packagings page"
+    },
+    "edit_packagings_element_add": "Add an element",
+    "@edit_packagings_element_add": {
+        "description": "Button label"
+    },
+    "edit_packagings_element_title": "Element #{index}",
+    "@edit_packagings_element_title": {
+        "description": "Element title",
+        "placeholders": {
+            "index": {
+                "type": "int"
+            }
+        }
+    },
+    "edit_packagings_element_field_units": "Number of units",
+    "@edit_packagings_element_field_units": {
+        "description": "Field label"
+    },
+    "edit_packagings_element_field_shape": "Shape",
+    "@edit_packagings_element_field_shape": {
+        "description": "Field label"
+    },
+    "edit_packagings_element_field_material": "Material",
+    "@edit_packagings_element_field_material": {
+        "description": "Field label"
+    },
+    "edit_packagings_element_field_recycling": "Recycling",
+    "@edit_packagings_element_field_recycling": {
+        "description": "Field label"
+    },
+    "edit_packagings_element_field_quantity": "Quantity per unit",
+    "@edit_packagings_element_field_quantity": {
+        "description": "Field label"
+    },
+    "edit_packagings_element_field_weight": "Weight measured (g)",
+    "@edit_packagings_element_field_weight": {
+        "description": "Field label"
+    },
     "feed_back": "Feedback"
 }

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1777,7 +1777,7 @@
     },
     "edit_packagings_element_title": "Element #{index}",
     "@edit_packagings_element_title": {
-        "description": "Element title",
+        "description": "Element title. Please do not change the index placeholder",
         "placeholders": {
             "index": {
                 "type": "int"

--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -203,10 +203,8 @@ class _EditProductPageState extends State<EditProductPage> {
               ),
               _getSimpleListTileItem(SimpleInputPageLabelHelper()),
               _ListTitleItem(
-                leading: const Icon(
-                    Icons.recycling), // TODO(monsieurtanuki): different logo?
-                title:
-                    '(Beta) Structured packaging', // TODO(monsieurtanuki): localize
+                leading: const Icon(Icons.recycling),
+                title: appLocalizations.edit_packagings_title,
                 onTap: () async {
                   if (!await ProductRefresher().checkIfLoggedIn(context)) {
                     return;


### PR DESCRIPTION
Impacted files:
* `app_en.arb`: added 9 labels for "structured packagings"
* `edit_new_packagings.dart`: added fields quantity and weight for each element; localized; padding around the "add element" button; padding on top of the first element; cleared `hintText`s
* `edit_product_page.dart`: localized the "structured packagings" item title

### What
- 2 new fields (quantity and weight) for the elements of structured packagings.
- Localization, paddings.
- Actually saving to the server.

### Screenshot
| top | bottom |
| -- | -- |
| ![Capture d’écran 2023-01-02 à 19 22 39](https://user-images.githubusercontent.com/11576431/210267391-6ec40aa0-65cd-4e16-a793-a4e7f7440662.png) | ![Capture d’écran 2023-01-02 à 19 24 55](https://user-images.githubusercontent.com/11576431/210267591-8cd37c14-4276-4a44-99a7-2e8736502a87.png) |


### Fixes bug(s)
- Closes: #3493