### PR TITLE
fix: 3504 - different colors for dark/light in structured packagings page

### DIFF
--- a/packages/smooth_app/lib/pages/product/edit_new_packagings.dart
+++ b/packages/smooth_app/lib/pages/product/edit_new_packagings.dart
@@ -312,8 +312,9 @@ class _EditSinglePackagings extends StatelessWidget {
       controllerWeight.text = '${packaging.weightMeasured!}';
     }
     return SmoothCard(
-      color:
-          Colors.grey[300], // TODO(monsieurtanuki): different color? +dark mode
+      color: Theme.of(context).brightness == Brightness.light
+          ? GREY_COLOR
+          : PRIMARY_GREY_COLOR,
       child: Column(
         mainAxisAlignment: MainAxisAlignment.start,
         crossAxisAlignment: CrossAxisAlignment.start,


### PR DESCRIPTION
Impacted file:
* `edit_new_packagings.dart`

### What
- Different colors for dark/light in structured packagings page

### Screenshot
| light | dark |
| -- | -- |
| ![Capture d’écran 2023-01-03 à 18 03 54](https://user-images.githubusercontent.com/11576431/210405184-80b701a2-7407-4677-8c96-e50686d948cc.png) | ![Capture d’écran 2023-01-03 à 18 04 30](https://user-images.githubusercontent.com/11576431/210405274-e161bf5b-129c-41d7-8ff3-a2b8aba5db5f.png) |

### Fixes bug(s)
- Fixes: #3504