### PR TITLE
feat: 3505 - packagingsComplete toggle and packagings edit bug fixes

### DIFF
--- a/packages/smooth_app/lib/background/background_task_details.dart
+++ b/packages/smooth_app/lib/background/background_task_details.dart
@@ -113,14 +113,15 @@ class BackgroundTaskDetails extends AbstractBackgroundTask {
   /// Uploads the product changes.
   @override
   Future<void> upload() async {
-    if (_product.packagings != null) {
-      // For the moment, we can only save "packagings" with V3,
-      // and V3 can only save "packagings".
+    if (_product.packagings != null || _product.packagingsComplete != null) {
+      // For the moment, some fields can only be saved in V3,
+      // and V3 can only save those fields.
       final ProductResultV3 result =
           await OpenFoodAPIClient.temporarySaveProductV3(
         getUser(),
         _product.barcode!,
         packagings: _product.packagings,
+        packagingsComplete: _product.packagingsComplete,
         language: getLanguage(),
         country: getCountry(),
       );

--- a/packages/smooth_app/lib/data_models/up_to_date_changes.dart
+++ b/packages/smooth_app/lib/data_models/up_to_date_changes.dart
@@ -79,6 +79,9 @@ class UpToDateChanges {
     if (change.packagings != null) {
       initial.packagings = change.packagings;
     }
+    if (change.packagingsComplete != null) {
+      initial.packagingsComplete = change.packagingsComplete;
+    }
     if (change.noNutritionData != null) {
       initial.noNutritionData = change.noNutritionData;
     }

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1778,6 +1778,7 @@
         "description": "Title of the structured packagings page"
     },
     "edit_packagings_element_add": "Add an element",
+    "edit_packagings_completed": "The packaging is complete",
     "@edit_packagings_element_add": {
         "description": "Button label"
     },

--- a/packages/smooth_app/lib/query/product_query.dart
+++ b/packages/smooth_app/lib/query/product_query.dart
@@ -142,6 +142,7 @@ abstract class ProductQuery {
         // ignore: deprecated_member_use
         ProductField.PACKAGING,
         ProductField.PACKAGINGS,
+        ProductField.PACKAGINGS_COMPLETE,
         ProductField.PACKAGING_TAGS,
         ProductField.PACKAGING_TEXT_IN_LANGUAGES,
         ProductField.PACKAGING_TEXT_ALL_LANGUAGES,


### PR DESCRIPTION
Impacted files:
* `app_en.arb`: added a label about "packaging complete"
* `background_task_details.dart`: added field `packagingComplete`
* `edit_new_packagings.dart`: added a `packagingComplete` editor; fixed a bug by populating the controllers at init time and not on demand; now disposes the controllers; aligned the titles
* `product_query.dart`: added field `PACKAGINGS_COMPLETE`
* `up_to_date_changes.dart`: added field `packagingComplete`

### What
- Added the `packagingsComplete` toggle in the new structured packagings page.
- Also fixed a bug about saving the correct packagingS data, with a better management of controllers.

### Screenshot
![Capture d’écran 2023-01-04 à 11 25 53](https://user-images.githubusercontent.com/11576431/210535130-0dc77f5e-a030-4ca1-b0e8-2af511cb5e69.png)

### Fixes bug(s)
- Closes: #3505
- Fixes: #3506