### PR TITLE
feat: 3507 - full-line text fields

### DIFF
--- a/packages/smooth_app/lib/pages/product/edit_new_packagings.dart
+++ b/packages/smooth_app/lib/pages/product/edit_new_packagings.dart
@@ -452,17 +452,17 @@ class _EditLine extends StatelessWidget {
               ),
             ),
             title: Text(title),
-            trailing: LayoutBuilder(
-              builder: (_, BoxConstraints constraints) => SizedBox(
-                width: constraints.maxWidth * .35,
-                child: SimpleInputWidgetField(
-                  focusNode: FocusNode(),
-                  autocompleteKey: UniqueKey(),
-                  constraints: constraints,
-                  tagType: tagType,
-                  hintText: '',
-                  controller: controller,
-                ),
+          ),
+          LayoutBuilder(
+            builder: (_, BoxConstraints constraints) => SizedBox(
+              width: constraints.maxWidth,
+              child: SimpleInputWidgetField(
+                focusNode: FocusNode(),
+                autocompleteKey: UniqueKey(),
+                constraints: constraints,
+                tagType: tagType,
+                hintText: '',
+                controller: controller,
               ),
             ),
           ),


### PR DESCRIPTION
Impacted file:
* `edit_new_packagings.dart`: full-line text fields

### What
- Structured packagings with full-line text fields

### Screenshot
![Capture d’écran 2023-01-04 à 18 00 22](https://user-images.githubusercontent.com/11576431/210609185-ad7c2eaa-a46c-4d29-b86d-2c95dcf76f15.png)

### Part of 
- #3507
