### PR TITLE
fix: 3490 - check the Status of picture uploads

### DIFF
--- a/packages/smooth_app/lib/background/background_task_image.dart
+++ b/packages/smooth_app/lib/background/background_task_image.dart
@@ -145,7 +145,12 @@ class BackgroundTaskImage extends AbstractBackgroundTask {
       imageUri: Uri.parse(imagePath),
     );
 
-    // TODO(AshAman999): check returned Status
-    await OpenFoodAPIClient.addProductImage(getUser(), image);
+    final Status status =
+        await OpenFoodAPIClient.addProductImage(getUser(), image);
+    if (status.status == 'status ok') {
+      return;
+    }
+    throw Exception(
+        'Could not upload picture: ${status.status} / ${status.error}');
   }
 }

--- a/packages/smooth_app/lib/background/background_task_manager.dart
+++ b/packages/smooth_app/lib/background/background_task_manager.dart
@@ -1,10 +1,13 @@
+import 'dart:async';
 import 'dart:convert';
 
+import 'package:flutter/rendering.dart';
 import 'package:smooth_app/background/abstract_background_task.dart';
 import 'package:smooth_app/database/dao_instant_string.dart';
 import 'package:smooth_app/database/dao_int.dart';
 import 'package:smooth_app/database/dao_string_list.dart';
 import 'package:smooth_app/database/local_database.dart';
+import 'package:smooth_app/services/smooth_services.dart';
 
 /// Management of background tasks: single thread, block, restart, display.
 class BackgroundTaskManager {
@@ -111,6 +114,8 @@ class BackgroundTaskManager {
         await _runTask(nextTask!);
       }
     } catch (e) {
+      debugPrint('Background task error ($e)');
+      Logs.e('Background task error', ex: e);
       return;
     } finally {
       _justFinished();


### PR DESCRIPTION
Impacted files:
* `background_task_image.dart`: throws an exception if the upload status is not OK
* `background_task_manager.dart`: logs a Sentry error if the executed background task throws an exception

### What
- It won't fix the issue but at least now we log the unsuccessful uploads.

### Part of 
- #3490
