### PR TITLE
fix: 3516 - standardized the "do you want to save" dialog?

### DIFF
--- a/packages/smooth_app/lib/pages/product/edit_new_packagings.dart
+++ b/packages/smooth_app/lib/pages/product/edit_new_packagings.dart
@@ -320,7 +320,11 @@ class _EditNewPackagingsState extends State<EditNewPackagings> {
       if (pleaseSave == false) {
         return true;
       }
+      if (!mounted) {
+        return false;
+      }
     }
+
     await BackgroundTaskDetails.addTask(
       changedProduct,
       widget: this,

--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -11,6 +11,7 @@ import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/helpers/text_input_formatters_helper.dart';
 import 'package:smooth_app/pages/product/common/product_refresher.dart';
+import 'package:smooth_app/pages/product/may_exit_page_helper.dart';
 import 'package:smooth_app/pages/product/nutrition_add_nutrient_button.dart';
 import 'package:smooth_app/pages/product/nutrition_container.dart';
 import 'package:smooth_app/pages/product/ordered_nutrients_cache.dart';
@@ -502,36 +503,25 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
     }
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     if (!saving) {
-      final bool? pleaseSave = await showDialog<bool>(
-        context: context,
-        builder: (final BuildContext context) => SmoothAlertDialog(
-          close: true,
-          body: Text(appLocalizations.edit_product_form_item_exit_confirmation),
-          title: appLocalizations.nutrition_page_title,
-          negativeAction: SmoothActionButton(
-            text: appLocalizations.ignore,
-            onPressed: () => Navigator.pop(context, false),
-          ),
-          positiveAction: SmoothActionButton(
-            text: appLocalizations.save,
-            onPressed: () => Navigator.pop(context, true),
-          ),
-        ),
-      );
+      final bool? pleaseSave =
+          await MayExitPageHelper().openSaveBeforeLeavingDialog(context);
       if (pleaseSave == null) {
         return false;
       }
       if (pleaseSave == false) {
         return true;
       }
-    }
-    if (!mounted) {
-      return false;
+      if (!mounted) {
+        return false;
+      }
     }
 
     final Product? changedProduct =
         _getChangedProduct(Product(barcode: widget.product.barcode));
     if (changedProduct == null) {
+      if (!mounted) {
+        return false;
+      }
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           // here I cheat and I reuse the only invalid case.

--- a/packages/smooth_app/lib/pages/product/simple_input_page.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page.dart
@@ -173,7 +173,11 @@ class _SimpleInputPageState extends State<SimpleInputPage> {
       if (pleaseSave == false) {
         return true;
       }
+      if (!mounted) {
+        return false;
+      }
     }
+
     await BackgroundTaskDetails.addTask(
       changedProduct,
       widget: this,

--- a/packages/smooth_app/lib/tmp_crop_image/new_crop_page.dart
+++ b/packages/smooth_app/lib/tmp_crop_image/new_crop_page.dart
@@ -243,6 +243,9 @@ class _CropPageState extends State<CropPage> {
       if (pleaseSave == false) {
         return true;
       }
+      if (!mounted) {
+        return false;
+      }
     }
 
     await _saveFileAndExit();


### PR DESCRIPTION
Impacted files:
* `edit_new_packagings.dart`: minor refactoring
* `new_crop_page.dart`: minor refactoring
* `nutrition_page_loaded.dart`: now using `MayExitPageHelper` as dialog
* `simple_input_page.dart`: minor refactoring

### What
- A good opportunity for minor refactoring, making sure that all (4) similar pages use the same system with `onWillPop` and `_mayExitPage`:
```dart
    if (!saving) {
      final bool? pleaseSave =
          await MayExitPageHelper().openSaveBeforeLeavingDialog(context);
      if (pleaseSave == null) {
        return false;
      }
      if (pleaseSave == false) {
        return true;
      }
      if (!mounted) {
        return false;
      }
    }
```

### Screenshot
![Capture d’écran 2023-01-05 à 08 34 47](https://user-images.githubusercontent.com/11576431/210726279-a78c8adf-bce0-4922-b8c0-5baef8f86ce8.png)

### Fixes bug(s)
- Fixes: #3516