### PR TITLE
fix: 3490 - now accepting not cropped new pictures

### DIFF
--- a/packages/smooth_app/lib/pages/image_crop_page.dart
+++ b/packages/smooth_app/lib/pages/image_crop_page.dart
@@ -99,6 +99,7 @@ Future<File?> confirmAndUploadNewPicture(
         barcode: barcode,
         imageField: imageField,
         inputFile: File(croppedPhoto.path),
+        brandNewPicture: true,
       ),
       fullscreenDialog: true,
     ),

--- a/packages/smooth_app/lib/pages/product/product_image_viewer.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_viewer.dart
@@ -160,6 +160,7 @@ class _ProductImageViewerState extends State<ProductImageViewer> {
           barcode: _barcode,
           imageField: _imageData.imageField,
           inputFile: imageFile!,
+          brandNewPicture: false,
         ),
         fullscreenDialog: true,
       ),

--- a/packages/smooth_app/lib/tmp_crop_image/new_crop_page.dart
+++ b/packages/smooth_app/lib/tmp_crop_image/new_crop_page.dart
@@ -15,7 +15,7 @@ import 'package:smooth_app/data_models/continuous_scan_model.dart';
 import 'package:smooth_app/database/dao_int.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
-import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
+import 'package:smooth_app/generic_lib/loading_dialog.dart';
 import 'package:smooth_app/helpers/database_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/pages/image_crop_page.dart';
@@ -31,11 +31,15 @@ class CropPage extends StatefulWidget {
     required this.inputFile,
     required this.barcode,
     required this.imageField,
+    required this.brandNewPicture,
   });
 
   final File inputFile;
   final ImageField imageField;
   final String barcode;
+
+  /// Is that a new picture we crop, or an existing picture?
+  final bool brandNewPicture;
 
   @override
   State<CropPage> createState() => _CropPageState();
@@ -178,88 +182,44 @@ class _CropPageState extends State<CropPage> {
   }
 
   Future<bool> _saveFileAndExit() async {
-    late String debug;
-    try {
-      debug = _debugStep('00');
-      final LocalDatabase localDatabase = context.read<LocalDatabase>();
-      debug = _debugStep('01');
-      final DaoInt daoInt = DaoInt(localDatabase);
-      debug = _debugStep('02');
-      final image2.Image? rawImage = await _controller.croppedBitmap();
-      debug = _debugStep('03');
-      if (rawImage == null) {
-        return true;
-      }
-      debug = _debugStep('04');
-      final Uint8List data = Uint8List.fromList(image2.encodeJpg(rawImage));
-      debug = _debugStep('05');
-      final int sequenceNumber =
-          await getNextSequenceNumber(daoInt, _CROP_PAGE_SEQUENCE_KEY);
-
-      debug = _debugStep('06');
-      final Directory tempDirectory = await getTemporaryDirectory();
-      debug = _debugStep('07');
-      final String path = '${tempDirectory.path}/crop_$sequenceNumber.jpeg';
-      debug = _debugStep('08');
-      final File file = File(path);
-      debug = _debugStep('09');
-      await file.writeAsBytes(data);
-      debug = _debugStep('10');
-
-      if (!mounted) {
-        return true;
-      }
-
-      debug = _debugStep('11');
-      await BackgroundTaskImage.addTask(
-        widget.barcode,
-        imageField: widget.imageField,
-        imageFile: file,
-        widget: this,
-      );
-      debug = _debugStep('12');
-      localDatabase.notifyListeners();
-      debug = _debugStep('13');
-      if (!mounted) {
-        return true;
-      }
-      debug = _debugStep('14');
-      final ContinuousScanModel model = context.read<ContinuousScanModel>();
-      debug = _debugStep('15');
-      await model
-          .onCreateProduct(widget.barcode); // TODO(monsieurtanuki): a bit fishy
-      debug = _debugStep('16');
-
-      if (!mounted) {
-        return true;
-      }
-      debug = _debugStep('17');
-      Navigator.of(context).pop<File>(file);
+    final LocalDatabase localDatabase = context.read<LocalDatabase>();
+    final DaoInt daoInt = DaoInt(localDatabase);
+    final image2.Image? rawImage = await _controller.croppedBitmap();
+    if (rawImage == null) {
       return true;
-    } catch (e) {
-      debugPrint('crop exception on debug step $debug: $e');
-      if (mounted) {
-        await showDialog<void>(
-          context: context,
-          builder: (BuildContext context) => SmoothAlertDialog(
-            body: Text('latest debug step $debug and exception $e'),
-            actionsAxis: Axis.vertical,
-            positiveAction: SmoothActionButton(
-              text: 'ok',
-              onPressed: () => Navigator.of(context).pop(),
-            ),
-          ),
-        );
-      }
-      return false;
     }
-  }
+    final Uint8List data = Uint8List.fromList(image2.encodeJpg(rawImage));
+    final int sequenceNumber =
+        await getNextSequenceNumber(daoInt, _CROP_PAGE_SEQUENCE_KEY);
 
-  // TODO(monsieurtanuki): get rid of this somehow when the bug is found
-  // cf. https://github.com/openfoodfacts/smooth-app/issues/3490
-  String _debugStep(final String value) {
-    debugPrint('debug step: $value');
-    return value;
+    final Directory tempDirectory = await getTemporaryDirectory();
+    final String path = '${tempDirectory.path}/crop_$sequenceNumber.jpeg';
+    final File file = File(path);
+    await file.writeAsBytes(data);
+
+    if (!mounted) {
+      return true;
+    }
+
+    await BackgroundTaskImage.addTask(
+      widget.barcode,
+      imageField: widget.imageField,
+      imageFile: file,
+      widget: this,
+    );
+    localDatabase.notifyListeners();
+    if (!mounted) {
+      return true;
+    }
+    final ContinuousScanModel model = context.read<ContinuousScanModel>();
+    await model
+        .onCreateProduct(widget.barcode); // TODO(monsieurtanuki): a bit fishy
+
+    if (!mounted) {
+      return true;
+    }
+    Navigator.of(context).pop<File>(file);
+    return true;
   }
 
   static const String _CROP_PAGE_SEQUENCE_KEY = 'crop_page_sequence';
@@ -271,7 +231,8 @@ class _CropPageState extends State<CropPage> {
   Future<bool> _mayExitPage({required final bool saving}) async {
     if (_controller.value.rotation == Rotation.noon &&
         _controller.value.crop == _initialRect &&
-        _samePicture) {
+        _samePicture &&
+        !widget.brandNewPicture) {
       // nothing has changed, let's leave
       if (saving) {
         Navigator.of(context).pop();
@@ -294,7 +255,18 @@ class _CropPageState extends State<CropPage> {
       }
     }
 
-    return _saveFileAndExit();
+    try {
+      return _saveFileAndExit();
+    } catch (e) {
+      if (mounted) {
+        // not likely to happen, but you never know...
+        await LoadingDialog.error(
+          context: context,
+          title: 'Could not prepare picture with exception $e',
+        );
+      }
+      return false;
+    }
   }
 
   Future<void> _capture() async {


### PR DESCRIPTION
Impacted files:
* `image_crop_page.dart`: told the `CropPage` we're dealing with a brand new picture
* `new_crop_page.dart`: new `bool` parameter `brandNewPicture` used when saving the picture; refactored the debug lines
* `product_image_viewer.dart`: told the `CropPage` we're dealing with an already existing picture

### What
- Dealing differently with brand new and already existing pictures.

### Fixes bug(s)
- Fixes: #3490