### PR TITLE
fix: 3494 pop dialog navigator properly

### DIFF
--- a/packages/smooth_app/lib/pages/preferences/user_preferences_connect.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_connect.dart
@@ -126,7 +126,7 @@ class UserPreferencesConnect extends AbstractUserPreferences {
                         .no_email_client_available_dialog_content),
                     positiveAction: SmoothActionButton(
                       onPressed: () {
-                        Navigator.of(context).pop();
+                        Navigator.of(context, rootNavigator: true).pop();
                       },
                       text: appLocalizations.okay,
                     ),


### PR DESCRIPTION
Impacted file:
* `user_preferences_connect.dart`

### What
<!-- description of the PR -->
- popping of dialog navigator is now working properly in `connect with us > send us an email` section.
<!-- Changed x to achieve y -->
- settingRootnavigation of context to true (default value will be false) will make the dialog pop off the screen.
<!-- 
Please name your pull request following this scheme: `type: What you did` this allows us to automatically generate the changelog
Following `type`s are allowed:
  - `feat`, for Features
  - `fix`, for Bug Fixes
  - `docs`, for Documentation
  - `ci`, for Automation
  - `refactor`, for code Refactoring
  - `chore`, for Miscellaneous things
-->
### Screenshot
<a href="https://user-images.githubusercontent.com/93595710/210580616-aa2221a7-efd6-48f9-87f1-2219f155fb13.mp4" title="Link Title" height="191" ><img  height="191"  src="{image-url}" alt="Alternate Text" /></a>
<!-- Insert a screenshot to provide visual record of your changes, if visible -->

### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes: #3494 <!-- #1 Note: you can also use Closes: -->

### Part of 
- #525 <!-- Add the most granular issue possible -->
