### PR TITLE
fix: 3533 - using a not temporary directory for images to be uploaded

### DIFF
--- a/packages/smooth_app/lib/background/background_task_image.dart
+++ b/packages/smooth_app/lib/background/background_task_image.dart
@@ -122,13 +122,20 @@ class BackgroundTaskImage extends AbstractBackgroundTask {
         File(imagePath),
       );
 
+  // TODO(monsieurtanuki): we may also need to remove old files that were not removed from some reason
   @override
   Future<void> postExecute(final LocalDatabase localDatabase) async {
+    try {
+      File(imagePath).deleteSync();
+    } catch (e) {
+      // not likely, but let's not spoil the task for that either.
+    }
     TransientFile.removeImage(
       ImageField.fromOffTag(imageField)!,
       barcode,
       localDatabase,
     );
+    localDatabase.notifyListeners();
     await BackgroundTaskRefreshLater.addTask(
       barcode,
       localDatabase: localDatabase,

--- a/packages/smooth_app/lib/database/transient_file.dart
+++ b/packages/smooth_app/lib/database/transient_file.dart
@@ -24,22 +24,12 @@ class TransientFile {
   }
 
   /// Removes the current transient image for [imageField] and [barcode].
-  ///
-  /// It will also delete the actual local file.
   static void removeImage(
     final ImageField imageField,
     final String barcode,
     final LocalDatabase localDatabase,
-  ) {
-    final String key = _getImageKey(imageField, barcode);
-    final String? path = _transientFiles[key];
-    if (path == null) {
-      return;
-    }
-    _transientFiles.remove(key);
-    File(path).deleteSync();
-    localDatabase.notifyListeners();
-  }
+  ) =>
+      _transientFiles.remove(_getImageKey(imageField, barcode));
 
   /// Returns the transient image for [imageField] and [barcode].
   static File? getImage(

--- a/packages/smooth_app/lib/tmp_crop_image/new_crop_page.dart
+++ b/packages/smooth_app/lib/tmp_crop_image/new_crop_page.dart
@@ -192,7 +192,7 @@ class _CropPageState extends State<CropPage> {
     final int sequenceNumber =
         await getNextSequenceNumber(daoInt, _CROP_PAGE_SEQUENCE_KEY);
 
-    final Directory tempDirectory = await getTemporaryDirectory();
+    final Directory tempDirectory = await getApplicationSupportDirectory();
     final String path = '${tempDirectory.path}/crop_$sequenceNumber.jpeg';
     final File file = File(path);
     await file.writeAsBytes(data);


### PR DESCRIPTION
Impacted files:
* `background_task_image.dart`: explicitly deleting the file at the end of the task.
* `new_crop_page.dart`: changed the directory to a "not temporary" one
* `transient_file.dart`: finally only dealing with removing transient files, not the actual OS file

### What
- Could not reproduce the bug, but the bug was about the image file not being there.
- Could the file have been deleted automatically by the OS?
- Anyway, as we're dealing with not instant tasks, we will be better off with a non temporary directory for images to be uploaded.

### Fixes bug(s)
- Fixes: #3533