### PR TITLE
feat: 3526 - add OTHER picture from product gallery

### DIFF
--- a/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
@@ -79,6 +79,15 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView> {
           onPressed: () => Navigator.maybePop(context),
         ),
       ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () async => confirmAndUploadNewPicture(
+          this,
+          imageField: ImageField.OTHER,
+          barcode: _barcode,
+        ),
+        label: Text(appLocalizations.add_photo_button_label),
+        icon: const Icon(Icons.add_a_photo),
+      ),
       body: RefreshIndicator(
         onRefresh: () async => ProductRefresher().fetchAndRefresh(
           barcode: _barcode,
@@ -88,9 +97,12 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView> {
           child: CustomScrollView(
             slivers: <Widget>[
               _buildTitle(
+                // TODO(monsieurtanuki): put the title in the app bar instead, as in the other pages
                 appLocalizations.edit_product_form_item_photos_title,
                 theme: theme,
               ),
+              // TODO(monsieurtanuki): that's ridiculous, we only have 4 items to display, use a ListView instead, easier to maintain
+              // TODO(monsieurtanuki): we should even display 4 pics in the whole page instead of just tiny pics
               SmoothImagesSliverList(
                 imagesData: _selectedImages,
                 onTap: (


### PR DESCRIPTION
Impacted file:
* `product_image_gallery_view.dart`: added a FAB in order to add an OTHER picture

### What
- Added a FAB in the product picture gallery in order to add an OTHER picture.
- Still find it frustrating to add a picture that I will never see again, but that's another story.
- I cannot quite visualize how to add that button in the recycling pages without them getting too obscure. @manon-corneille suggestions are welcome!

### Screenshot
| gallery | crop page |
| -- | -- |
| ![Capture d’écran 2023-01-06 à 19 41 19](https://user-images.githubusercontent.com/11576431/211077559-5e6d89ed-61f1-43cf-8159-8b3c9919ca6f.png) | ![Capture d’écran 2023-01-06 à 19 41 49](https://user-images.githubusercontent.com/11576431/211077660-8b87c4cb-fab5-440d-a885-1d33b47094ab.png) |

Yes it's the same waterfall as in "Ingredients" but that's a coincidence.

### Part of 
- #3526
