### PR TITLE
fix: 3447 fab appearing in start scanning page

### DIFF
--- a/packages/smooth_app/lib/pages/product/common/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_page.dart
@@ -95,7 +95,7 @@ class _ProductListPageState extends State<ProductListPage>
     final bool enableClear = products.isNotEmpty;
     final bool enableRename = productList.listType == ProductListType.USER;
     return SmoothScaffold(
-      floatingActionButton: _selectionMode
+      floatingActionButton: _selectionMode || products.length <= 1
           ? _CompareProductsButton(
               selectedBarcodes: _selectedBarcodes,
               barcodes: products,


### PR DESCRIPTION
Impacted file:
* `product_list_page.dart`

### What
<!-- description of the PR -->
- Issue was floating button was appearing on "start scanning" page where it should not. The issue was fixed now by adding a check i.e when there is less than 1 product the button won't appear

<!-- Changed x to achieve y -->
<!-- 
Please name your pull request following this scheme: `type: What you did` this allows us to automatically generate the changelog
Following `type`s are allowed:
  - `feat`, for Features
  - `fix`, for Bug Fixes
  - `docs`, for Documentation
  - `ci`, for Automation
  - `refactor`, for code Refactoring
  - `chore`, for Miscellaneous things
-->
### Screenshot
- When there is one product no compare button is visible
<img height="250" src="https://user-images.githubusercontent.com/93595710/211183927-ac48140e-9c35-4bfa-9a06-46514560eda9.png">

- The compare button wont be visible is "Start scanning" page
<img height="250" src="https://user-images.githubusercontent.com/93595710/211183993-9a0403d5-4aee-4c50-86cb-973f38d9bc6a.png">

- When more than one product is present the compare button works as expected !

https://user-images.githubusercontent.com/93595710/211184168-4c018b95-6296-4c32-b085-8354037fbb44.mp4

<!-- Insert a screenshot to provide visual record of your changes, if visible -->

### Fixes bug(s)

<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes: https://github.com/openfoodfacts/smooth-app/issues/3447#issuecomment-1374720521<!-- #1 Note: you can also use Closes: -->

### Part of 
- #3447
