### PR TITLE
fix: 3535 - padding added to crop tool

### DIFF
--- a/packages/smooth_app/lib/tmp_crop_image/new_crop_page.dart
+++ b/packages/smooth_app/lib/tmp_crop_image/new_crop_page.dart
@@ -120,10 +120,13 @@ class _CropPageState extends State<CropPage> {
                     ],
                   ),
                   Expanded(
-                    child: RotatedCropImage(
-                      controller: _controller,
-                      image: _image,
-                      minimumImageSize: 1,
+                    child: Padding(
+                      padding: const EdgeInsets.all(MINIMUM_TOUCH_SIZE / 2),
+                      child: RotatedCropImage(
+                        controller: _controller,
+                        image: _image,
+                        minimumImageSize: 1,
+                      ),
                     ),
                   ),
                   Wrap(


### PR DESCRIPTION
Impacted file:
* `new_crop_page.dart`: added a `Padding`

### What
- Padding added to crop tool after https://github.com/openfoodfacts/smooth-app/pull/3543#issuecomment-1374805477

### Screenshot
| before | after |
| -- | -- |
| ![Capture d’écran 2023-01-08 à 13 43 13](https://user-images.githubusercontent.com/11576431/211196804-0b51104f-029b-4348-9a62-0354804f9cdc.png) | ![Capture d’écran 2023-01-08 à 13 43 46](https://user-images.githubusercontent.com/11576431/211196810-a69bc60c-1bd1-4ecb-ad8e-941888c244a2.png) |
| ![Capture d’écran 2023-01-08 à 13 44 30](https://user-images.githubusercontent.com/11576431/211196818-49006668-e174-4bc6-82a3-ca83e946a399.png) | ![Capture d’écran 2023-01-08 à 13 44 00](https://user-images.githubusercontent.com/11576431/211196813-3594ec17-588b-4172-aaca-80ec5ec609a8.png) |

### Fixes bug(s)
- Fixes: #3535