### PR TITLE
ci: Fix postsubmit & iOS release

### DIFF
--- a/.github/workflows/ios-release-to-org-openfoodfacts-scanner.yml
+++ b/.github/workflows/ios-release-to-org-openfoodfacts-scanner.yml
@@ -90,7 +90,7 @@ jobs:
         run: cd ./packages/smooth_app/ios && gem install bundler:1.17.3 && bundle install
 
       - name: Decrypt iOS AuthKey file
-        run: cd ./packages/smooth_app/ios/fastlane/envfiles && ./decrypt_secrets.sh
+        run: cd ./packages/smooth_app/ios/fastlane/envfiles && chmod +x decrypt_secrets.sh && ./decrypt_secrets.sh
         env:
           AUTH_KEY_FILE_DECRYPTKEY: ${{ secrets.AUTH_KEY_FILE_DECRYPTKEY }}
 
@@ -106,7 +106,7 @@ jobs:
           VERSION_CODE: ${{ inputs.VERSION_CODE }}
 
       - name: Build app
-        run: cd ./packages/app && cd ios && pod update Sentry && cd .. && flutter build ios --release --no-codesign -t lib/entrypoints/ios/main_ios.dart
+        run: cd ./packages/smooth_app && cd ios && pod update Sentry && cd .. && flutter build ios --release --no-codesign -t lib/entrypoints/ios/main_ios.dart
         env:
           GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -54,7 +54,7 @@ jobs:
       # Build apk.
       - name: Build APK
         run: flutter build apk --debug -t lib/entrypoints/android/main_google_play.dart
-        working-directory: ./packages/app
+        working-directory: ./packages/smooth_app
 
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
### What
As suspected some (minor) problems with #3555

Postsubmit has the wrong path
iOS release had a wrong path
and the execute permissions for a script for iOS have been resetted
