### PR TITLE
fix: 3534 - upgraded off-dart for user-agent fix

### DIFF
--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -804,7 +804,7 @@ packages:
       name: openfoodfacts
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.2"
   openfoodfacts_flutter_lints:
     dependency: "direct dev"
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   latlong2: 0.8.1
   matomo_tracker: 1.5.0
   modal_bottom_sheet: 2.1.2
-  openfoodfacts: 2.0.0
+  openfoodfacts: 2.1.2
   #  openfoodfacts:
   #    path: ../../../openfoodfacts-dart
   package_info_plus: 1.4.3+1


### PR DESCRIPTION
Impacted files:
* `pubspec.lock`: wtf
* `pubspec.yaml`: upgraded off-dart to 2.1.2 for user-agent fix

### What
- Upgrade to off-dart 2.1.2 and its fix of `User-Agent` spelling.

### Slightly related screenshot
![Capture d’écran 2023-01-09 à 19 44 40](https://user-images.githubusercontent.com/11576431/211384006-4fc802a4-7e73-42fe-a2bb-99cc9fbc1be2.png)

### Part of 
- #3534
