### PR TITLE
fix: 3529 - fixed the too strong link between product data and edit pages

### DIFF
--- a/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
@@ -22,7 +22,7 @@ abstract class AbstractSimpleInputPageHelper extends ChangeNotifier {
   /// Starts from scratch with a new (or refreshed) [Product].
   void reInit(final Product product) {
     this.product = product;
-    _terms = initTerms();
+    _terms = List<String>.from(initTerms());
     _changed = false;
     notifyListeners();
   }
@@ -30,6 +30,9 @@ abstract class AbstractSimpleInputPageHelper extends ChangeNotifier {
   final String _separator = ',';
 
   /// Returns the terms as they were initially in the product.
+  ///
+  /// WARNING: this list must be copied; if not you may alter the product.
+  /// cf. https://github.com/openfoodfacts/smooth-app/issues/3529
   @protected
   List<String> initTerms();
 


### PR DESCRIPTION
Impacted file:
* `simple_input_page_helpers.dart`: copy of the product data

### What
- In the edit pages, we used to take data directly from the product.
- That meant that in some cases the user changed directly the local product object data.
- Now we copy the product data: no change will be reflected on the product if the user decides to "ignore" the changes.

### Fixes bug(s)
- Fixes: #3529