### PR TITLE
feat: #3449  Make "Start Scanning" Button

### DIFF
--- a/packages/smooth_app/lib/pages/product/common/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_page.dart
@@ -192,39 +192,37 @@ class _ProductListPageState extends State<ProductListPage>
             Text(appLocalizations.compare_products_appbar_subtitle),
       ),
       body: products.isEmpty
-          ? GestureDetector(
-              child: Center(
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: <Widget>[
-                    SvgPicture.asset(
-                      'assets/misc/empty-list.svg',
-                      height: MediaQuery.of(context).size.height * .4,
-                      package: AppHelper.APP_PACKAGE,
-                    ),
-                    const Padding(padding: EdgeInsets.all(VERY_LARGE_SPACE)),
-                    SmoothSimpleButton(
-                      onPressed: () {
-                        InheritedDataManager.of(context)
-                            .resetShowSearchCard(true);
-                      },
-                      child: Text(appLocalizations.product_list_empty_title,
-                          style: theme.textTheme.headlineLarge?.copyWith(
-                            color: theme.colorScheme.onPrimary,
-                          )),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.all(VERY_LARGE_SPACE),
-                      child: Text(
-                        appLocalizations.product_list_empty_message,
-                        textAlign: TextAlign.center,
-                        style: themeData.textTheme.bodyText2?.apply(
-                          color: colorScheme.onBackground,
-                        ),
+          ? Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: <Widget>[
+                  SvgPicture.asset(
+                    'assets/misc/empty-list.svg',
+                    height: MediaQuery.of(context).size.height * .4,
+                    package: AppHelper.APP_PACKAGE,
+                  ),
+                  const Padding(padding: EdgeInsets.all(VERY_LARGE_SPACE)),
+                  SmoothSimpleButton(
+                    onPressed: () {
+                      InheritedDataManager.of(context)
+                          .resetShowSearchCard(true);
+                    },
+                    child: Text(appLocalizations.product_list_empty_title,
+                        style: theme.textTheme.headlineLarge?.copyWith(
+                          color: theme.colorScheme.onPrimary,
+                        )),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.all(VERY_LARGE_SPACE),
+                    child: Text(
+                      appLocalizations.product_list_empty_message,
+                      textAlign: TextAlign.center,
+                      style: themeData.textTheme.bodyText2?.apply(
+                        color: colorScheme.onBackground,
                       ),
-                    )
-                  ],
-                ),
+                    ),
+                  ),
+                ],
               ),
             )
           : WillPopScope(

--- a/packages/smooth_app/lib/pages/product/common/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_page.dart
@@ -202,9 +202,7 @@ class _ProductListPageState extends State<ProductListPage>
                       height: MediaQuery.of(context).size.height * .4,
                       package: AppHelper.APP_PACKAGE,
                     ),
-                    const SizedBox(
-                      height: 20,
-                    ),
+                    const Padding(padding: EdgeInsets.all(VERY_LARGE_SPACE)),
                     SmoothSimpleButton(
                       onPressed: () {
                         InheritedDataManager.of(context)

--- a/packages/smooth_app/lib/pages/product/common/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_page.dart
@@ -8,6 +8,7 @@ import 'package:smooth_app/data_models/product_list.dart';
 import 'package:smooth_app/database/dao_product.dart';
 import 'package:smooth_app/database/dao_product_list.dart';
 import 'package:smooth_app/database/local_database.dart';
+import 'package:smooth_app/generic_lib/buttons/smooth_simple_button.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/generic_lib/duration_constants.dart';
@@ -94,6 +95,9 @@ class _ProductListPageState extends State<ProductListPage>
     }
     final bool enableClear = products.isNotEmpty;
     final bool enableRename = productList.listType == ProductListType.USER;
+
+    final ThemeData theme = Theme.of(context);
+
     return SmoothScaffold(
       floatingActionButton: _selectionMode || products.length <= 1
           ? _CompareProductsButton(
@@ -198,10 +202,18 @@ class _ProductListPageState extends State<ProductListPage>
                       height: MediaQuery.of(context).size.height * .4,
                       package: AppHelper.APP_PACKAGE,
                     ),
-                    Text(
-                      appLocalizations.product_list_empty_title,
-                      style: themeData.textTheme.headlineLarge
-                          ?.apply(color: colorScheme.onBackground),
+                    const SizedBox(
+                      height: 20,
+                    ),
+                    SmoothSimpleButton(
+                      onPressed: () {
+                        InheritedDataManager.of(context)
+                            .resetShowSearchCard(true);
+                      },
+                      child: Text(appLocalizations.product_list_empty_title,
+                          style: theme.textTheme.headlineLarge?.copyWith(
+                            color: theme.colorScheme.onPrimary,
+                          )),
                     ),
                     Padding(
                       padding: const EdgeInsets.all(VERY_LARGE_SPACE),
@@ -216,9 +228,6 @@ class _ProductListPageState extends State<ProductListPage>
                   ],
                 ),
               ),
-              onTap: () {
-                InheritedDataManager.of(context).resetShowSearchCard(true);
-              },
             )
           : WillPopScope(
               onWillPop: _handleUserBacktap,


### PR DESCRIPTION
Files Impacted:
- `product_list_page.dart`

### What
- Converts the simple text widget into a button, so that the ui becomes more intuitive
- Changed sizedBox to PAdding widget as told 
<!-- description of the PR -->

<!-- Changed x to achieve y -->
<!-- 
Please name your pull request following this scheme: `type: What you did` this allows us to automatically generate the changelog
Following `type`s are allowed:
  - `feat`, for Features
  - `fix`, for Bug Fixes
  - `docs`, for Documentation
  - `ci`, for Automation
  - `refactor`, for code Refactoring
  - `chore`, for Miscellaneous things
-->
### Screenshot
<!-- Insert a screenshot to provide visual record of your changes, if visible -->
# dark mode
<img width="191" alt="image" src = "https://user-images.githubusercontent.com/93595710/210568471-065a8b26-d01b-43cb-a5ca-f0aa32dd6f85.png">

# Light mode
<img width="191"  alt="image" src="https://user-images.githubusercontent.com/93595710/210568837-656222bd-171a-487d-a76c-343664c03a7e.png" >

### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes: #3449

### Part of 
- #525 <!-- Add the most granular issue possible -->

BEGIN_COMMIT_OVERRIDE
feat: make "start scanning" a button
END_COMMIT_OVERRIDE
