### PR TITLE
fix: 3581 - descriptions and hints for all packaging components

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1799,31 +1799,59 @@
     "@edit_packagings_element_field_units": {
         "description": "Field label"
     },
+    "edit_packagings_element_hint_units": "Enter the number of packaging units of the same shape and material contained in the product.",
+    "@edit_packagings_element_hint_units": {
+        "description": "Field verbose hint, more like an info than a text field hint"
+    },
     "edit_packagings_element_field_shape": "Shape",
     "@edit_packagings_element_field_shape": {
         "description": "Field label"
+    },
+    "edit_packagings_element_hint_shape": "Enter the shape name listed in the recycling instructions if they are available, or select a shape.",
+    "@edit_packagings_element_hint_shape": {
+        "description": "Field verbose hint, more like an info than a text field hint"
+    },
+    "edit_packagings_element_example_shape": "Bottle",
+    "@edit_packagings_element_example_shape": {
+        "description": "Text field hint"
     },
     "edit_packagings_element_field_material": "Material",
     "@edit_packagings_element_field_material": {
         "description": "Field label"
     },
-    "edit_packagings_element_hint_material": "Sometimes, the materials like ♵ are hidden below the pack, in 3D, on the plastic.",
+    "edit_packagings_element_hint_material": "Enter the specific material if it can be determined (a material code inside a triangle can often be found on packaging parts), or a generic material (for instance plastic or metal) if you are unsure.",
     "@edit_packagings_element_hint_material": {
         "description": "Field verbose hint, more like an info than a text field hint"
+    },
+    "edit_packagings_element_example_material": "Glass",
+    "@edit_packagings_element_example_material": {
+        "description": "Text field hint"
     },
     "edit_packagings_element_field_recycling": "Recycling instruction",
     "@edit_packagings_element_field_recycling": {
         "description": "Field label"
     },
+    "edit_packagings_element_hint_recycling": "Enter recycling instructions only if they are listed on the product.",
+    "@edit_packagings_element_hint_recycling": {
+        "description": "Field verbose hint, more like an info than a text field hint"
+    },
+    "edit_packagings_element_example_recycling": "Recycle",
+    "@edit_packagings_element_example_recycling": {
+        "description": "Text field hint"
+    },
     "edit_packagings_element_field_quantity": "Net quantity of product per unit",
     "@edit_packagings_element_field_quantity": {
         "description": "Field label"
+    },
+    "edit_packagings_element_hint_quantity": "Enter the net weight or net volume and indicate the unit (for example g or ml).",
+    "@edit_packagings_element_hint_quantity": {
+        "description": "Field verbose hint, more like an info than a text field hint"
     },
     "edit_packagings_element_field_weight": "Weight of one empty unit (g)",
     "@edit_packagings_element_field_weight": {
         "description": "Field label"
     },
-    "edit_packagings_element_hint_weight": "For accurate packaging weight measurements, please clean any food residue and then dry any water.",
+    "edit_packagings_element_hint_weight": "Remove any remaining food and wash and dry the packaging part before weighting. If possible, use a scale with 0.1g or 0.01g precision.",
     "@edit_packagings_element_hint_weight": {
         "description": "Field verbose hint, more like an info than a text field hint"
     },

--- a/packages/smooth_app/lib/pages/product/edit_new_packagings.dart
+++ b/packages/smooth_app/lib/pages/product/edit_new_packagings.dart
@@ -405,6 +405,8 @@ class _EditSinglePackagings extends StatelessWidget {
             // this icon has 2 colors: we need 2 distinct files
             iconName: dark ? 'counter-dark' : 'counter-light',
             iconColor: null,
+            description: appLocalizations.edit_packagings_element_hint_units,
+            hintText: '1',
           ),
           _EditLine(
             title: appLocalizations.edit_packagings_element_field_shape,
@@ -412,6 +414,8 @@ class _EditSinglePackagings extends StatelessWidget {
             tagType: TagType.PACKAGING_SHAPES,
             iconName: 'shape',
             iconColor: iconColor,
+            description: appLocalizations.edit_packagings_element_hint_shape,
+            hintText: appLocalizations.edit_packagings_element_example_shape,
           ),
           _EditLine(
             title: appLocalizations.edit_packagings_element_field_material,
@@ -419,7 +423,8 @@ class _EditSinglePackagings extends StatelessWidget {
             tagType: TagType.PACKAGING_MATERIALS,
             iconName: 'material',
             iconColor: iconColor,
-            hint: appLocalizations.edit_packagings_element_hint_material,
+            description: appLocalizations.edit_packagings_element_hint_material,
+            hintText: appLocalizations.edit_packagings_element_example_material,
           ),
           _EditLine(
             title: appLocalizations.edit_packagings_element_field_recycling,
@@ -427,12 +432,18 @@ class _EditSinglePackagings extends StatelessWidget {
             tagType: TagType.PACKAGING_RECYCLING,
             iconName: 'recycling',
             iconColor: iconColor,
+            description:
+                appLocalizations.edit_packagings_element_hint_recycling,
+            hintText:
+                appLocalizations.edit_packagings_element_example_recycling,
           ),
           _EditLine(
             title: appLocalizations.edit_packagings_element_field_quantity,
             controller: controllerQuantity,
             iconName: 'quantity',
             iconColor: iconColor,
+            description: appLocalizations.edit_packagings_element_hint_quantity,
+            hintText: '120g',
           ),
           _EditLine(
             // TODO(monsieurtanuki): different display for numbers
@@ -440,7 +451,8 @@ class _EditSinglePackagings extends StatelessWidget {
             controller: controllerWeight,
             iconName: 'weight',
             iconColor: iconColor,
-            hint: appLocalizations.edit_packagings_element_hint_weight,
+            description: appLocalizations.edit_packagings_element_hint_weight,
+            hintText: '1',
           ),
         ],
       ),
@@ -455,7 +467,8 @@ class _EditLine extends StatelessWidget {
     required this.controller,
     required this.iconName,
     required this.iconColor,
-    this.hint,
+    required this.description,
+    required this.hintText,
     this.tagType,
   });
 
@@ -464,7 +477,8 @@ class _EditLine extends StatelessWidget {
   final TagType? tagType;
   final String iconName;
   final Color? iconColor;
-  final String? hint;
+  final String description;
+  final String hintText;
 
   @override
   Widget build(BuildContext context) => Column(
@@ -490,16 +504,15 @@ class _EditLine extends StatelessWidget {
                 autocompleteKey: UniqueKey(),
                 constraints: constraints,
                 tagType: tagType,
-                hintText: '',
+                hintText: hintText,
                 controller: controller,
               ),
             ),
           ),
-          if (hint != null)
-            Padding(
-              padding: const EdgeInsets.only(bottom: LARGE_SPACE),
-              child: ExplanationWidget(hint!),
-            ),
+          Padding(
+            padding: const EdgeInsets.only(bottom: LARGE_SPACE),
+            child: ExplanationWidget(description),
+          ),
         ],
       );
 }


### PR DESCRIPTION
Impacted files:
* `app_en.arb`: new labels
* `edit_new_packagings.dart`: systematic description and hint for all packaging components

### What
- Just added labels so that all packaging components have a text field hint and a description.

### Screenshot
Screenshots with no values (just text field hints) and expanded descriptions:
| top | bottom |
| -- | -- |
| ![Capture d’écran 2023-01-17 à 17 47 21](https://user-images.githubusercontent.com/11576431/212962326-4019dd45-e7e7-4ab8-9fd9-985d53e5d441.png) | ![Capture d’écran 2023-01-17 à 17 47 57](https://user-images.githubusercontent.com/11576431/212962349-ecfe3e3d-dae0-434c-b8c4-c05465ee7580.png) |

### Fixes bug(s)
- Closes: #3581