### PR TITLE
fix: 3570 - background task order is now respected

### DIFF
--- a/packages/smooth_app/lib/background/abstract_background_task.dart
+++ b/packages/smooth_app/lib/background/abstract_background_task.dart
@@ -60,8 +60,17 @@ abstract class AbstractBackgroundTask {
   /// is not even started.
   Future<void> preExecute(final LocalDatabase localDatabase);
 
-  /// Cleans the temporary data changes performed in [preExecute].
-  Future<void> postExecute(final LocalDatabase localDatabase);
+  /// To be executed _after_ the actual run.
+  ///
+  /// Mostly, cleans the temporary data changes performed in [preExecute].
+  /// [success] indicates (if `true`) that so far the operation was a success.
+  /// With that `bool` we're able to deal with 2 cases:
+  /// 1. everything is fine and we may have to do something more than cleaning
+  /// 2. something bad happened and we just need to clear the task
+  Future<void> postExecute(
+    final LocalDatabase localDatabase,
+    final bool success,
+  );
 
   /// Uploads data changes.
   @protected

--- a/packages/smooth_app/lib/background/background_task_details.dart
+++ b/packages/smooth_app/lib/background/background_task_details.dart
@@ -100,7 +100,10 @@ class BackgroundTaskDetails extends AbstractBackgroundTask {
       localDatabase.upToDate.addChange(uniqueId, _product);
 
   @override
-  Future<void> postExecute(final LocalDatabase localDatabase) async =>
+  Future<void> postExecute(
+    final LocalDatabase localDatabase,
+    final bool success,
+  ) async =>
       localDatabase.upToDate.terminate(uniqueId);
 
   /// Adds the background task about changing a product.

--- a/packages/smooth_app/lib/background/background_task_image.dart
+++ b/packages/smooth_app/lib/background/background_task_image.dart
@@ -152,7 +152,10 @@ class BackgroundTaskImage extends AbstractBackgroundTask {
 
   // TODO(monsieurtanuki): we may also need to remove old files that were not removed from some reason
   @override
-  Future<void> postExecute(final LocalDatabase localDatabase) async {
+  Future<void> postExecute(
+    final LocalDatabase localDatabase,
+    final bool success,
+  ) async {
     try {
       File(imagePath).deleteSync();
     } catch (e) {
@@ -164,10 +167,12 @@ class BackgroundTaskImage extends AbstractBackgroundTask {
       localDatabase,
     );
     localDatabase.notifyListeners();
-    await BackgroundTaskRefreshLater.addTask(
-      barcode,
-      localDatabase: localDatabase,
-    );
+    if (success) {
+      await BackgroundTaskRefreshLater.addTask(
+        barcode,
+        localDatabase: localDatabase,
+      );
+    }
   }
 
   /// Uploads the product image.

--- a/packages/smooth_app/lib/background/background_task_refresh_later.dart
+++ b/packages/smooth_app/lib/background/background_task_refresh_later.dart
@@ -83,7 +83,10 @@ class BackgroundTaskRefreshLater extends AbstractBackgroundTask {
 
   /// Here we change nothing, therefore we do nothing.
   @override
-  Future<void> postExecute(final LocalDatabase localDatabase) async {}
+  Future<void> postExecute(
+    final LocalDatabase localDatabase,
+    final bool success,
+  ) async {}
 
   /// Adds the background task about refreshing the product later.
   static Future<void> addTask(

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1837,5 +1837,7 @@
     "background_task_operation_refresh": "refresh delayed after photo upload",
     "background_task_run_started": "started",
     "background_task_run_not_started": "not started yet",
+    "background_task_run_to_be_deleted": "to be deleted",
+    "background_task_question_stop": "Do you want to stop that task ASAP?",
     "feed_back": "Feedback"
 }

--- a/packages/smooth_app/lib/pages/offline_tasks_page.dart
+++ b/packages/smooth_app/lib/pages/offline_tasks_page.dart
@@ -5,6 +5,7 @@ import 'package:smooth_app/background/background_task_manager.dart';
 import 'package:smooth_app/data_models/operation_type.dart';
 import 'package:smooth_app/database/dao_instant_string.dart';
 import 'package:smooth_app/database/local_database.dart';
+import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 
 class OfflineTaskPage extends StatefulWidget {
   const OfflineTaskPage();
@@ -38,6 +39,28 @@ class _OfflineTaskState extends State<OfflineTaskPage> {
                   ),
                 );
                 return ListTile(
+                  onTap: () async {
+                    final bool? stopTask = await showDialog<bool>(
+                      context: context,
+                      builder: (final BuildContext context) =>
+                          SmoothAlertDialog(
+                        body: Text(
+                            appLocalizations.background_task_question_stop),
+                        negativeAction: SmoothActionButton(
+                          text: appLocalizations.no,
+                          onPressed: () => Navigator.of(context).pop(false),
+                        ),
+                        positiveAction: SmoothActionButton(
+                          text: appLocalizations.yes,
+                          onPressed: () => Navigator.of(context).pop(true),
+                        ),
+                      ),
+                    );
+                    if (stopTask == true) {
+                      await BackgroundTaskManager(localDatabase)
+                          .removeTaskAsap(taskId);
+                    }
+                  },
                   title: Text(
                     '${OperationType.getBarcode(taskId)}'
                     ' (${_getOperationLabel(
@@ -46,6 +69,7 @@ class _OfflineTaskState extends State<OfflineTaskPage> {
                     )})',
                   ),
                   subtitle: Text(_getMessage(status, appLocalizations)),
+                  trailing: const Icon(Icons.clear),
                 );
               },
             ),
@@ -79,6 +103,8 @@ class _OfflineTaskState extends State<OfflineTaskPage> {
         return appLocalizations.background_task_run_started;
       case BackgroundTaskManager.taskStatusNoInternet:
         return appLocalizations.background_task_error_no_internet;
+      case BackgroundTaskManager.taskStatusStopAsap:
+        return appLocalizations.background_task_run_to_be_deleted;
     }
     return status!;
   }


### PR DESCRIPTION
Impacted files:
* `app_en.arb`: added a label for the "stop this task ASAP?" question and the corresponding task label
* `background_task_manager.dart`: fixed a bug where the task list was refreshed inappropriately; now it's possible to cancel a task; refactored
* `offline_tasks_page.dart`: now when you click on a task, you can stop it ASAP (for the record that does not mean immediately)

### What
- Now we can cancel a task - not sure how safe it is but it is possible.
- Bug fix: now the task order is respected.
- Let me explain what was fixed
  - The run sets a "start" timestamp, lists all the tasks and runs them one by one.
  - At the end, the run says "I'm done", resets the "start" timestamp and sets the "latest stop" timestamp.
  - When you want a new run, you check the start and stop timestamp first - is there already something running, or when did the latest run stop?
  - The bug was that when checking the timestamps, if ever we saw that it was not OK (e.g. already running), we didn't run anything BUT still we resets the timestamps, like AFTER a SUCCESSFUL run. That was a mess!

### Screenshot
![Capture d’écran 2023-01-17 à 21 48 23](https://user-images.githubusercontent.com/11576431/213010816-20b51446-1cf1-4066-b22d-1cdef534446d.png)

### Part of 
- #3570 (probably fixed; to be tested)
