### PR TITLE
fix: String of only whitespaces considered as name

### DIFF
--- a/packages/smooth_app/lib/pages/product_list_user_dialog_helper.dart
+++ b/packages/smooth_app/lib/pages/product_list_user_dialog_helper.dart
@@ -35,6 +35,7 @@ class ProductListUserDialogHelper {
               autofocus: true,
               textInputAction: TextInputAction.done,
               validator: (String? value) {
+                value = value?.trim();
                 if (value == null || value.isEmpty) {
                   return appLocalizations.user_list_name_error_empty;
                 }
@@ -47,7 +48,7 @@ class ProductListUserDialogHelper {
                 if (!formKey.currentState!.validate()) {
                   return;
                 }
-                Navigator.pop(context, textEditingController.text);
+                Navigator.pop(context, textEditingController.text.trim());
               },
             ),
           ),
@@ -61,7 +62,7 @@ class ProductListUserDialogHelper {
               if (!formKey.currentState!.validate()) {
                 return;
               }
-              Navigator.pop(context, textEditingController.text);
+              Navigator.pop(context, textEditingController.text.trim());
             },
             text: appLocalizations.create,
           ),


### PR DESCRIPTION
- Impacted Files
   - `packages/smooth_app/lib/pages/product_list_user_dialog_helper.dart`
### What
<!-- description of the PR -->
- The input form for adding a new list was allowing names with only whitespaces.
- Input string will remove leading and trailing spaces in the list item name and then adds to the list if it's validated
- Event though if there is leading or trailing spaces will be there  it will be removed before adding to the list !
<!-- 
Please name your pull request following this scheme: `type: What you did` this allows us to automatically generate the changelog
Following `type`s are allowed:
  - `feat`, for Features
  - `fix`, for Bug Fixes
  - `docs`, for Documentation
  - `ci`, for Automation
  - `refactor`, for code Refactoring
  - `chore`, for Miscellaneous things
-->

### Screenshot
<!-- Insert a screenshot to provide visual record of your changes, if visible -->
[whitespaceTrim.webm](https://user-images.githubusercontent.com/93595710/213190804-b193e785-a5b3-4e5f-8a16-be6a0aee1aac.webm)


### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes: #3574 <!-- #1 Note: you can also use Closes: -->

### Part of 
- #525 <!-- Add the most granular issue possible -->
