### PR TITLE
feat: 3594 - expand/collapse for packagings components

### DIFF
--- a/packages/smooth_app/lib/pages/product/edit_new_packagings_component.dart
+++ b/packages/smooth_app/lib/pages/product/edit_new_packagings_component.dart
@@ -1,0 +1,167 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/cards/category_cards/asset_cache_helper.dart';
+import 'package:smooth_app/cards/category_cards/svg_async_asset.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/pages/product/edit_new_packagings_helper.dart';
+import 'package:smooth_app/pages/product/explanation_widget.dart';
+import 'package:smooth_app/pages/product/simple_input_widget.dart';
+
+/// Edit display of a single [ProductPackaging] component.
+class EditNewPackagingsComponent extends StatefulWidget {
+  const EditNewPackagingsComponent({
+    required this.title,
+    required this.deleteCallback,
+    required this.helper,
+  });
+
+  final String title;
+  final VoidCallback deleteCallback;
+  final EditNewPackagingsHelper helper;
+
+  @override
+  State<EditNewPackagingsComponent> createState() =>
+      _EditNewPackagingsComponentState();
+}
+
+class _EditNewPackagingsComponentState
+    extends State<EditNewPackagingsComponent> {
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final bool dark = Theme.of(context).brightness == Brightness.dark;
+    final Color iconColor = dark ? Colors.white : Colors.black;
+    // TODO(monsieurtanuki): the title is not refreshed at each user input
+    final String? title = widget.helper.getTitle();
+    final List<Widget> expandedChildren = !widget.helper.expanded
+        ? <Widget>[]
+        : <Widget>[
+            _EditLine(
+              // TODO(monsieurtanuki): different display for numbers
+              title: appLocalizations.edit_packagings_element_field_units,
+              controller: widget.helper.controllerUnits,
+              // this icon has 2 colors: we need 2 distinct files
+              iconName: dark ? 'counter-dark' : 'counter-light',
+              iconColor: null,
+            ),
+            _EditLine(
+              title: appLocalizations.edit_packagings_element_field_shape,
+              controller: widget.helper.controllerShape,
+              tagType: TagType.PACKAGING_SHAPES,
+              iconName: 'shape',
+              iconColor: iconColor,
+            ),
+            _EditLine(
+              title: appLocalizations.edit_packagings_element_field_material,
+              controller: widget.helper.controllerMaterial,
+              tagType: TagType.PACKAGING_MATERIALS,
+              iconName: 'material',
+              iconColor: iconColor,
+              hint: appLocalizations.edit_packagings_element_hint_material,
+            ),
+            _EditLine(
+              title: appLocalizations.edit_packagings_element_field_recycling,
+              controller: widget.helper.controllerRecycling,
+              tagType: TagType.PACKAGING_RECYCLING,
+              iconName: 'recycling',
+              iconColor: iconColor,
+            ),
+            _EditLine(
+              title: appLocalizations.edit_packagings_element_field_quantity,
+              controller: widget.helper.controllerQuantity,
+              iconName: 'quantity',
+              iconColor: iconColor,
+            ),
+            _EditLine(
+              // TODO(monsieurtanuki): different display for numbers
+              title: appLocalizations.edit_packagings_element_field_weight,
+              controller: widget.helper.controllerWeight,
+              iconName: 'weight',
+              iconColor: iconColor,
+              hint: appLocalizations.edit_packagings_element_hint_weight,
+            ),
+          ];
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        ListTile(
+          leading: Icon(
+            widget.helper.expanded
+                ? Icons.keyboard_arrow_up
+                : Icons.keyboard_arrow_down,
+          ),
+          title: Text(title ?? widget.title),
+          subtitle: title == null ? null : Text(widget.title),
+          trailing: widget.helper.expanded
+              ? IconButton(
+                  icon: const Icon(Icons.delete),
+                  onPressed: widget.deleteCallback,
+                )
+              : null,
+          onTap: () => setState(
+            () => widget.helper.expanded = !widget.helper.expanded,
+          ),
+        ),
+        ...expandedChildren,
+      ],
+    );
+  }
+}
+
+/// Edit display of a single line inside a [ProductPackaging], e.g. its shape.
+class _EditLine extends StatelessWidget {
+  const _EditLine({
+    required this.title,
+    required this.controller,
+    required this.iconName,
+    required this.iconColor,
+    this.hint,
+    this.tagType,
+  });
+
+  final String title;
+  final TextEditingController controller;
+  final TagType? tagType;
+  final String iconName;
+  final Color? iconColor;
+  final String? hint;
+
+  @override
+  Widget build(BuildContext context) => Column(
+        mainAxisAlignment: MainAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          ListTile(
+            leading: SvgAsyncAsset(
+              AssetCacheHelper(
+                <String>['assets/packagings/$iconName.svg'],
+                'no url for packagings/$iconName',
+                color: iconColor,
+                width: MINIMUM_TOUCH_SIZE,
+              ),
+            ),
+            title: Text(title),
+          ),
+          LayoutBuilder(
+            builder: (_, BoxConstraints constraints) => SizedBox(
+              width: constraints.maxWidth,
+              child: SimpleInputWidgetField(
+                focusNode: FocusNode(),
+                autocompleteKey: UniqueKey(),
+                constraints: constraints,
+                tagType: tagType,
+                hintText: '',
+                controller: controller,
+              ),
+            ),
+          ),
+          if (hint != null)
+            Padding(
+              padding: const EdgeInsets.only(bottom: LARGE_SPACE),
+              child: ExplanationWidget(hint!),
+            ),
+        ],
+      );
+}

--- a/packages/smooth_app/lib/pages/product/edit_new_packagings_helper.dart
+++ b/packages/smooth_app/lib/pages/product/edit_new_packagings_helper.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+
+/// Helper about packaging component edition. Useful with controllers.
+class EditNewPackagingsHelper {
+  EditNewPackagingsHelper._({
+    required this.controllerUnits,
+    required this.controllerShape,
+    required this.controllerMaterial,
+    required this.controllerRecycling,
+    required this.controllerQuantity,
+    required this.controllerWeight,
+    required this.expanded,
+  });
+
+  /// Creates all controllers from a packaging.
+  EditNewPackagingsHelper.packaging(
+    final ProductPackaging packaging,
+    final bool initiallyExpanded,
+  ) : this._(
+          controllerUnits: TextEditingController(
+            text: packaging.numberOfUnits == null
+                ? null
+                : '${packaging.numberOfUnits!}',
+          ),
+          controllerShape: TextEditingController(
+            text: packaging.shape?.lcName,
+          ),
+          controllerMaterial: TextEditingController(
+            text: packaging.material?.lcName,
+          ),
+          controllerRecycling: TextEditingController(
+            text: packaging.recycling?.lcName,
+          ),
+          controllerQuantity:
+              TextEditingController(text: packaging.quantityPerUnit),
+          controllerWeight: TextEditingController(
+            text: packaging.weightMeasured == null
+                ? null
+                : '${packaging.weightMeasured!}',
+          ),
+          expanded: initiallyExpanded,
+        );
+
+  final TextEditingController controllerUnits;
+  final TextEditingController controllerShape;
+  final TextEditingController controllerMaterial;
+  final TextEditingController controllerRecycling;
+  final TextEditingController controllerQuantity;
+  final TextEditingController controllerWeight;
+  bool expanded;
+
+  /// Disposes all controllers.
+  void dispose() {
+    controllerUnits.dispose();
+    controllerShape.dispose();
+    controllerMaterial.dispose();
+    controllerRecycling.dispose();
+    controllerQuantity.dispose();
+    controllerWeight.dispose();
+  }
+
+  /// Returns the packaging title from the controllers, or null if empty.
+  String? getTitle() {
+    final List<String> result = <String>[];
+
+    void addIfNotEmpty(final String text) {
+      if (text.isNotEmpty) {
+        result.add(text);
+      }
+    }
+
+    addIfNotEmpty(controllerUnits.text);
+    addIfNotEmpty(controllerShape.text);
+    addIfNotEmpty(controllerMaterial.text);
+    addIfNotEmpty(controllerRecycling.text);
+    addIfNotEmpty(controllerWeight.text);
+    addIfNotEmpty(controllerQuantity.text);
+
+    if (result.isEmpty) {
+      return null;
+    }
+    return result.join(' ');
+  }
+
+  /// Returns the packaging from the controllers.
+  ProductPackaging getPackaging() {
+    final ProductPackaging packaging = ProductPackaging();
+    packaging.shape = _getLocalizedTag(controllerShape);
+    packaging.material = _getLocalizedTag(controllerMaterial);
+    packaging.recycling = _getLocalizedTag(controllerRecycling);
+    packaging.quantityPerUnit = _getString(controllerQuantity);
+    packaging.weightMeasured = double.tryParse(controllerWeight
+        .text); // TODO(monsieurtanuki): handle the "not a number" case
+    packaging.numberOfUnits = int.tryParse(controllerUnits
+        .text); // TODO(monsieurtanuki): handle the "not a number" case
+    return packaging;
+  }
+
+  LocalizedTag? _getLocalizedTag(final TextEditingController controller) {
+    final String text = controller.text;
+    if (text.isEmpty) {
+      return null;
+    }
+    return LocalizedTag()..lcName = text;
+  }
+
+  String? _getString(final TextEditingController controller) {
+    final String text = controller.text;
+    if (text.isEmpty) {
+      return null;
+    }
+    return text;
+  }
+}


### PR DESCRIPTION
New files:
* `edit_new_packagings_component.dart`: Edit display of a single ProductPackaging component.
* `edit_new_packagings_helper.dart`: Helper about packaging component edition. Useful with controllers.

Impacted file:
* `edit_new_packagings.dart`: refactored using new classes `EditNewPackagingsComponent` and `EditNewPackagingsHelper`

### What
- Now there's an expand/collapse feature on the new edit packagings page.
- Existing components are collapsed by default.
- New ("just added") components are expanded by default.
- Some refactoring in this PR, as the main file was getting too big and too confusing.

### Screenshot
New landing page, with all components collapsed:
![Capture d’écran 2023-01-19 à 09 27 59](https://user-images.githubusercontent.com/11576431/213391903-021a7455-6e2d-4142-aaab-99d6a4f78386.png)

### Part of 
- #3594