### PR TITLE
fix: 3602 - pending background task back to dev mode; better wording

### DIFF
--- a/packages/smooth_app/ios/Podfile.lock
+++ b/packages/smooth_app/ios/Podfile.lock
@@ -14,6 +14,8 @@ PODS:
     - Flutter
   - flutter_isolate (0.0.1):
     - Flutter
+  - flutter_keyboard_visibility (0.0.1):
+    - Flutter
   - flutter_native_splash (0.0.1):
     - Flutter
   - flutter_secure_storage (3.3.1):
@@ -132,6 +134,7 @@ DEPENDENCIES:
   - Flutter (from `Flutter`)
   - flutter_email_sender (from `.symlinks/plugins/flutter_email_sender/ios`)
   - flutter_isolate (from `.symlinks/plugins/flutter_isolate/ios`)
+  - flutter_keyboard_visibility (from `.symlinks/plugins/flutter_keyboard_visibility/ios`)
   - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
   - google_mlkit_barcode_scanning (from `.symlinks/plugins/google_mlkit_barcode_scanning/ios`)
@@ -186,6 +189,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_email_sender/ios"
   flutter_isolate:
     :path: ".symlinks/plugins/flutter_isolate/ios"
+  flutter_keyboard_visibility:
+    :path: ".symlinks/plugins/flutter_keyboard_visibility/ios"
   flutter_native_splash:
     :path: ".symlinks/plugins/flutter_native_splash/ios"
   flutter_secure_storage:
@@ -229,6 +234,7 @@ SPEC CHECKSUMS:
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
   flutter_email_sender: 02d7443217d8c41483223627972bfdc09f74276b
   flutter_isolate: 0edf5081826d071adf21759d1eb10ff5c24503b5
+  flutter_keyboard_visibility: 0339d06371254c3eb25eeb90ba8d17dca8f9c069
   flutter_native_splash: 52501b97d1c0a5f898d687f1646226c1f93c56ef
   flutter_secure_storage: 7953c38a04c3fdbb00571bcd87d8e3b5ceb9daec
   FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a

--- a/packages/smooth_app/lib/background/background_task_badge.dart
+++ b/packages/smooth_app/lib/background/background_task_badge.dart
@@ -23,7 +23,7 @@ class BackgroundTaskBadge extends StatelessWidget {
         '${tasks.length}',
         style: const TextStyle(color: Colors.white),
       ),
-      position: BadgePosition.topEnd(end: -24),
+      position: BadgePosition.topStart(start: -16),
       child: child,
     );
   }

--- a/packages/smooth_app/lib/pages/offline_tasks_page.dart
+++ b/packages/smooth_app/lib/pages/offline_tasks_page.dart
@@ -88,7 +88,7 @@ class _OfflineTaskState extends State<OfflineTaskPage> {
       case OperationType.image:
         return appLocalizations.background_task_operation_image;
       case OperationType.refreshLater:
-        return appLocalizations.background_task_operation_refresh;
+        return 'Waiting 10 min before refreshing product to get all automatic edits';
     }
   }
 

--- a/packages/smooth_app/lib/pages/page_manager.dart
+++ b/packages/smooth_app/lib/pages/page_manager.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
-import 'package:smooth_app/background/background_task_badge.dart';
 import 'package:smooth_app/pages/inherited_data_manager.dart';
 import 'package:smooth_app/widgets/screen_visibility.dart';
 import 'package:smooth_app/widgets/tab_navigator.dart';
@@ -108,9 +107,7 @@ class PageManagerState extends State<PageManager> {
           currentIndex: _currentPage.index,
           items: <BottomNavigationBarItem>[
             BottomNavigationBarItem(
-              icon: const BackgroundTaskBadge(
-                child: Icon(Icons.account_circle),
-              ),
+              icon: const Icon(Icons.account_circle),
               label: appLocalizations.profile_navbar_label,
             ),
             BottomNavigationBarItem(

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_dev_mode.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_dev_mode.dart
@@ -5,6 +5,7 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:scanner_shared/scanner_shared.dart';
+import 'package:smooth_app/background/background_task_badge.dart';
 import 'package:smooth_app/data_models/continuous_scan_model.dart';
 import 'package:smooth_app/data_models/product_list.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
@@ -14,6 +15,7 @@ import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/helpers/data_importer/product_list_import_export.dart';
 import 'package:smooth_app/helpers/data_importer/smooth_app_data_importer.dart';
 import 'package:smooth_app/pages/offline_data_page.dart';
+import 'package:smooth_app/pages/offline_tasks_page.dart';
 import 'package:smooth_app/pages/onboarding/onboarding_flow_navigator.dart';
 import 'package:smooth_app/pages/preferences/abstract_user_preferences.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_dev_debug_info.dart';
@@ -264,6 +266,19 @@ class UserPreferencesDevMode extends AbstractUserPreferences {
               ),
             );
           },
+        ),
+        ListTile(
+          title: Text(appLocalizations.background_task_title),
+          subtitle: Text(appLocalizations.background_task_subtitle),
+          trailing: const BackgroundTaskBadge(
+            child: Icon(Icons.edit_notifications_outlined),
+          ),
+          onTap: () async => Navigator.push<void>(
+            context,
+            MaterialPageRoute<void>(
+              builder: (BuildContext context) => const OfflineTaskPage(),
+            ),
+          ),
         ),
         ListTile(
           title: Text(

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_page.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_page.dart
@@ -3,12 +3,10 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:provider/provider.dart';
-import 'package:smooth_app/background/background_task_badge.dart';
 import 'package:smooth_app/data_models/product_preferences.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/helpers/app_helper.dart';
-import 'package:smooth_app/pages/offline_tasks_page.dart';
 import 'package:smooth_app/pages/preferences/abstract_user_preferences.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_account.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_connect.dart';
@@ -16,11 +14,9 @@ import 'package:smooth_app/pages/preferences/user_preferences_contribute.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_dev_mode.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_faq.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_food.dart';
-import 'package:smooth_app/pages/preferences/user_preferences_list_tile.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_settings.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_user_lists.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_widgets.dart';
-import 'package:smooth_app/themes/constant_icons.dart';
 import 'package:smooth_app/themes/theme_provider.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
@@ -90,34 +86,6 @@ class _UserPreferencesPageState extends State<UserPreferencesPage>
           children.add(additionalSubtitle);
         }
       }
-
-      children.add(
-        InkWell(
-          onTap: () async => Navigator.push<void>(
-            context,
-            MaterialPageRoute<void>(
-              builder: (BuildContext context) => const OfflineTaskPage(),
-            ),
-          ),
-          child: UserPreferencesListTile(
-            title: Text(
-              appLocalizations.background_task_title,
-              style: Theme.of(context).textTheme.headline2,
-            ),
-            subtitle: Text(appLocalizations.background_task_subtitle),
-            trailing: UserPreferencesListTile.getTintedIcon(
-              ConstantIcons.instance.getForwardIcon(),
-              context,
-            ),
-            leading: BackgroundTaskBadge(
-              child: UserPreferencesListTile.getTintedIcon(
-                Icons.edit_notifications_outlined,
-                context,
-              ),
-            ),
-          ),
-        ),
-      );
 
       headerAsset = 'assets/preferences/main.svg';
       headerColor = const Color(0xFFEBF1FF);


### PR DESCRIPTION
Impacted files:
* `background_task_badge.dart`: slightly modified the position as we're not using it in the same conditions
* `offline_tasks_page.dart`: better wording for "refresh later"
* `page_manager.dart`: remove the badge on "profile" icon about background tasks
* `Podfile.lock`: wtf
* `user_preferences_dev_mode.dart`: put back the access to the pending background task page
* `user_preferences_page.dart`: removed the access to the pending background task page

### What
- The "pending background tasks" page is moved (back) from home preferences to dev mode.
- The "pending background tasks" badge is removed from the bottom profile icon.
- The wording of "refresh later" tasks has been changed.

### Screenshots
| new label | dev mode |
| -- | -- |
| ![Capture d’écran 2023-01-20 à 13 16 37](https://user-images.githubusercontent.com/11576431/213695618-b7a77869-5f49-42e3-a0d2-de871e39fd2d.png) | ![Capture d’écran 2023-01-20 à 13 21 21](https://user-images.githubusercontent.com/11576431/213695621-b4e9e8f3-ec31-40a9-a47e-d6ac92fe06b9.png) |

### Fixes bug(s)
- Closes: #3601
- Closes: #3602