### PR TITLE
feat: 3577 - "clear" button for packaging component text fields

### DIFF
--- a/packages/smooth_app/ios/Podfile.lock
+++ b/packages/smooth_app/ios/Podfile.lock
@@ -14,8 +14,6 @@ PODS:
     - Flutter
   - flutter_isolate (0.0.1):
     - Flutter
-  - flutter_keyboard_visibility (0.0.1):
-    - Flutter
   - flutter_native_splash (0.0.1):
     - Flutter
   - flutter_secure_storage (3.3.1):
@@ -134,7 +132,6 @@ DEPENDENCIES:
   - Flutter (from `Flutter`)
   - flutter_email_sender (from `.symlinks/plugins/flutter_email_sender/ios`)
   - flutter_isolate (from `.symlinks/plugins/flutter_isolate/ios`)
-  - flutter_keyboard_visibility (from `.symlinks/plugins/flutter_keyboard_visibility/ios`)
   - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
   - google_mlkit_barcode_scanning (from `.symlinks/plugins/google_mlkit_barcode_scanning/ios`)
@@ -189,8 +186,6 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_email_sender/ios"
   flutter_isolate:
     :path: ".symlinks/plugins/flutter_isolate/ios"
-  flutter_keyboard_visibility:
-    :path: ".symlinks/plugins/flutter_keyboard_visibility/ios"
   flutter_native_splash:
     :path: ".symlinks/plugins/flutter_native_splash/ios"
   flutter_secure_storage:
@@ -234,7 +229,6 @@ SPEC CHECKSUMS:
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
   flutter_email_sender: 02d7443217d8c41483223627972bfdc09f74276b
   flutter_isolate: 0edf5081826d071adf21759d1eb10ff5c24503b5
-  flutter_keyboard_visibility: 0339d06371254c3eb25eeb90ba8d17dca8f9c069
   flutter_native_splash: 52501b97d1c0a5f898d687f1646226c1f93c56ef
   flutter_secure_storage: 7953c38a04c3fdbb00571bcd87d8e3b5ceb9daec
   FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a

--- a/packages/smooth_app/lib/pages/product/edit_new_packagings_component.dart
+++ b/packages/smooth_app/lib/pages/product/edit_new_packagings_component.dart
@@ -154,6 +154,7 @@ class _EditLine extends StatelessWidget {
                 tagType: tagType,
                 hintText: '',
                 controller: controller,
+                withClearButton: true,
               ),
             ),
           ),

--- a/packages/smooth_app/lib/pages/product/simple_input_widget.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_widget.dart
@@ -135,6 +135,7 @@ class SimpleInputWidgetField extends StatelessWidget {
     required this.tagType,
     required this.hintText,
     required this.controller,
+    this.withClearButton = false,
   });
 
   final FocusNode focusNode;
@@ -143,97 +144,115 @@ class SimpleInputWidgetField extends StatelessWidget {
   final TagType? tagType;
   final String hintText;
   final TextEditingController controller;
+  final bool withClearButton;
 
   @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(left: LARGE_SPACE),
-      child: RawAutocomplete<String>(
-        key: autocompleteKey,
-        focusNode: focusNode,
-        textEditingController: controller,
-        optionsBuilder: (final TextEditingValue value) async {
-          final List<String> result = <String>[];
-          final String input = value.text.trim();
+  Widget build(BuildContext context) => Padding(
+        padding: const EdgeInsets.only(left: LARGE_SPACE),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          mainAxisSize: MainAxisSize.max,
+          children: <Widget>[
+            SizedBox(
+              width: constraints.maxWidth -
+                  LARGE_SPACE -
+                  (withClearButton ? MINIMUM_TOUCH_SIZE : 0),
+              child: RawAutocomplete<String>(
+                key: autocompleteKey,
+                focusNode: focusNode,
+                textEditingController: controller,
+                optionsBuilder: (final TextEditingValue value) async {
+                  final List<String> result = <String>[];
+                  final String input = value.text.trim();
 
-          if (input.isEmpty) {
-            return result;
-          }
+                  if (input.isEmpty) {
+                    return result;
+                  }
 
-          if (tagType == null) {
-            return result;
-          }
+                  if (tagType == null) {
+                    return result;
+                  }
 
-          // TODO(monsieurtanuki): ask off-dart to return Strings instead of dynamic?
-          final List<dynamic> data =
-              await OpenFoodAPIClient.getAutocompletedSuggestions(
-            tagType!,
-            language: ProductQuery.getLanguage()!,
-            limit: 1000000, // lower max count on the server anyway
-            input: value.text.trim(),
-          );
-          for (final dynamic item in data) {
-            result.add(item.toString());
-          }
-          result.sort();
-          return result;
-        },
-        fieldViewBuilder: (BuildContext context,
-                TextEditingController textEditingController,
-                FocusNode focusNode,
-                VoidCallback onFieldSubmitted) =>
-            TextField(
-          controller: textEditingController,
-          decoration: InputDecoration(
-            filled: true,
-            border: const OutlineInputBorder(
-              borderRadius: ANGULAR_BORDER_RADIUS,
-              borderSide: BorderSide.none,
+                  // TODO(monsieurtanuki): ask off-dart to return Strings instead of dynamic?
+                  final List<dynamic> data =
+                      await OpenFoodAPIClient.getAutocompletedSuggestions(
+                    tagType!,
+                    language: ProductQuery.getLanguage()!,
+                    limit: 1000000, // lower max count on the server anyway
+                    input: value.text.trim(),
+                  );
+                  for (final dynamic item in data) {
+                    result.add(item.toString());
+                  }
+                  result.sort();
+                  return result;
+                },
+                fieldViewBuilder: (BuildContext context,
+                        TextEditingController textEditingController,
+                        FocusNode focusNode,
+                        VoidCallback onFieldSubmitted) =>
+                    TextField(
+                  controller: textEditingController,
+                  decoration: InputDecoration(
+                    filled: true,
+                    border: const OutlineInputBorder(
+                      borderRadius: ANGULAR_BORDER_RADIUS,
+                      borderSide: BorderSide.none,
+                    ),
+                    contentPadding: const EdgeInsets.symmetric(
+                      horizontal: SMALL_SPACE,
+                      vertical: SMALL_SPACE,
+                    ),
+                    hintText: hintText,
+                  ),
+                  autofocus: true,
+                  focusNode: focusNode,
+                ),
+                optionsViewBuilder: (
+                  BuildContext lContext,
+                  AutocompleteOnSelected<String> onSelected,
+                  Iterable<String> options,
+                ) {
+                  final double screenHeight =
+                      MediaQuery.of(context).size.height;
+                  final double keyboardHeight =
+                      MediaQuery.of(lContext).viewInsets.bottom;
+
+                  final double widgetPosition =
+                      (context.findRenderObject() as RenderBox?)
+                              ?.localToGlobal(Offset.zero)
+                              .dy ??
+                          0.0;
+
+                  return AutocompleteOptions<String>(
+                    displayStringForOption:
+                        RawAutocomplete.defaultStringForOption,
+                    onSelected: onSelected,
+                    options: options,
+                    // Width = Row width - horizontal padding
+                    maxOptionsWidth: constraints.maxWidth - (LARGE_SPACE * 2),
+                    maxOptionsHeight: screenHeight -
+                        (keyboardHeight == 0
+                            ? kBottomNavigationBarHeight
+                            : keyboardHeight) -
+                        widgetPosition -
+                        // Vertical padding
+                        (LARGE_SPACE * 2) -
+                        // Height of the TextField
+                        (DefaultTextStyle.of(context).style.fontSize ?? 0) -
+                        // Elevation
+                        4.0,
+                  );
+                },
+              ),
             ),
-            contentPadding: const EdgeInsets.symmetric(
-              horizontal: SMALL_SPACE,
-              vertical: SMALL_SPACE,
-            ),
-            hintText: hintText,
-          ),
-          autofocus: true,
-          focusNode: focusNode,
+            if (withClearButton)
+              IconButton(
+                icon: const Icon(Icons.clear),
+                onPressed: () => controller.text = '',
+              ),
+          ],
         ),
-        optionsViewBuilder: (
-          BuildContext lContext,
-          AutocompleteOnSelected<String> onSelected,
-          Iterable<String> options,
-        ) {
-          final double screenHeight = MediaQuery.of(context).size.height;
-          final double keyboardHeight =
-              MediaQuery.of(lContext).viewInsets.bottom;
-
-          final double widgetPosition =
-              (context.findRenderObject() as RenderBox?)
-                      ?.localToGlobal(Offset.zero)
-                      .dy ??
-                  0.0;
-
-          return AutocompleteOptions<String>(
-            displayStringForOption: RawAutocomplete.defaultStringForOption,
-            onSelected: onSelected,
-            options: options,
-            // Width = Row width - horizontal padding
-            maxOptionsWidth: constraints.maxWidth - (LARGE_SPACE * 2),
-            maxOptionsHeight: screenHeight -
-                (keyboardHeight == 0
-                    ? kBottomNavigationBarHeight
-                    : keyboardHeight) -
-                widgetPosition -
-                // Vertical padding
-                (LARGE_SPACE * 2) -
-                // Height of the TextField
-                (DefaultTextStyle.of(context).style.fontSize ?? 0) -
-                // Elevation
-                4.0,
-          );
-        },
-      ),
-    );
-  }
+      );
 }


### PR DESCRIPTION
Impacted files:
* `edit_new_packagings_component.dart`: used the new optional "clear" button for autocomplete
* `Podfile.lock`: wtf
* `simple_input_widget.dart`: added an optional "clear" button to autocomplete

### What
- Added an optional "clear" button for autocomplete text fields.
- Used that "clear" button for packaging component text fields.

### Screenshot
| before | after |
| -- | -- |
| ![Capture d’écran 2023-01-21 à 08 07 33](https://user-images.githubusercontent.com/11576431/213848369-902d49f6-229b-457a-a43e-8d316eef39fe.png) | ![Capture d’écran 2023-01-21 à 08 08 05](https://user-images.githubusercontent.com/11576431/213848367-5b52852f-f7f5-4bc4-87f4-a1f99c2d2133.png) |

### Fixes bug(s)
- Closes: #3577