### PR TITLE
fix: 3606 - much faster "confirm image upload" action

### DIFF
--- a/packages/smooth_app/lib/tmp_crop_image/rotation.dart
+++ b/packages/smooth_app/lib/tmp_crop_image/rotation.dart
@@ -24,6 +24,20 @@ extension RotationExtension on Rotation {
     }
   }
 
+  /// Returns the rotation in degrees cw.
+  int get degrees {
+    switch (this) {
+      case Rotation.noon:
+        return 0;
+      case Rotation.threeOClock:
+        return 90;
+      case Rotation.sixOClock:
+        return 180;
+      case Rotation.nineOClock:
+        return 270;
+    }
+  }
+
   /// Returns the rotation rotated 90 degrees to the right.
   Rotation get rotateRight {
     switch (this) {
@@ -90,6 +104,28 @@ extension RotationExtension on Rotation {
         return Offset(
           noonWidth * (1 - offset01.dy),
           noonHeight * offset01.dx,
+        );
+    }
+  }
+
+  /// Returns the offset as rotated, for the OFF-dart rotation/crop tool.
+  Offset getRotatedOffsetForOff(
+    final Offset offset01,
+    final double noonWidth,
+    final double noonHeight,
+  ) {
+    switch (this) {
+      case Rotation.noon:
+      case Rotation.sixOClock:
+        return Offset(
+          noonWidth * offset01.dx,
+          noonHeight * offset01.dy,
+        );
+      case Rotation.threeOClock:
+      case Rotation.nineOClock:
+        return Offset(
+          noonHeight * offset01.dx,
+          noonWidth * offset01.dy,
         );
     }
   }


### PR DESCRIPTION
Impacted files:
* `background_task_image.dart`: added cropped file, rotation and crop parameters; now we upload the full image and then send the rotation/crop parameters to apply
* `new_crop_page.dart`: now we create two files - the full image, to be sent to the server with rotation/crop parameters, and a small cropped file, for the transient image
* `rotated_crop_controller.dart`: now we can crop into max-sized files
* `rotation.dart`: added helper methods for off-dart rotation/crop tool.

### What
- When we are on the "crop page", the "confirm" action could be slow (several seconds), especially on "canary" devices.
- When we clicked on "confirm", we computed the full cropped image and stored it into a file. That took time.
- And off-dart/server have an API to rotate/crop an image.
- The idea of this PR is to let the server rotate/crop the image - doing so we just have to send the full file and the rotation/crop parameters, and we get rid of the lengthy operations locally.
- Still, we needed a transient version of the cropped file, to be displayed to the user before the file is finally uploaded.
- Therefore, we create a cropped image file - yes, like the one that took time to create. But smaller, as here we limit the size of the cropped image to the max size of the screen. Which is smaller than those crazy 15Mb+ pictures, and which is good enough for the user on a smartphone.

### Fixes bug(s)
- Fixes: #3606