### PR TITLE
fix: 3445 - correct check if nutriments are populated

### DIFF
--- a/packages/smooth_app/lib/pages/product/add_new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_new_product_page.dart
@@ -50,8 +50,7 @@ class _AddNewProductPageState extends State<AddNewProductPage> {
 
   final ProductList _history = ProductList.history();
 
-  //likely broken: see https://github.com/openfoodfacts/smooth-app/issues/3445
-  bool get _nutritionFactsAdded => _product.nutriments != null;
+  bool get _nutritionFactsAdded => _product.nutriments?.isEmpty() == false;
   bool get _basicDetailsAdded =>
       AddBasicDetailsPage.isProductBasicValid(_product);
 


### PR DESCRIPTION
Impacted file:
* `add_new_product_page.dart`: correct check if nutriments are populated

### What
- Now we check if `nutriments` is null _or empty_.

### Fixes bug(s)
- Fixes: #3445