### PR TITLE
fix: alternate color between packaging components

### DIFF
--- a/packages/smooth_app/lib/pages/product/edit_new_packagings.dart
+++ b/packages/smooth_app/lib/pages/product/edit_new_packagings.dart
@@ -12,6 +12,7 @@ import 'package:smooth_app/pages/image_crop_page.dart';
 import 'package:smooth_app/pages/product/edit_new_packagings_component.dart';
 import 'package:smooth_app/pages/product/edit_new_packagings_helper.dart';
 import 'package:smooth_app/pages/product/may_exit_page_helper.dart';
+import 'package:smooth_app/themes/color_schemes.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
@@ -81,7 +82,7 @@ class _EditNewPackagingsState extends State<EditNewPackagings> {
       final int deleteIndex = index;
       children.add(
         SmoothCard(
-          color: _getSmoothCardColor(context),
+          color: _getSmoothCardColorAlternate(context, index),
           child: EditNewPackagingsComponent(
             title: appLocalizations.edit_packagings_element_title(index + 1),
             deleteCallback: () =>
@@ -287,3 +288,23 @@ Color _getSmoothCardColor(final BuildContext context) =>
     Theme.of(context).brightness == Brightness.light
         ? GREY_COLOR
         : PRIMARY_GREY_COLOR;
+
+Color _getSmoothCardColorAlternate(final BuildContext context, int index) {
+  final bool lightTheme = Theme.of(context).brightness == Brightness.light;
+  Color cardColor = Colors.white;
+  if (lightTheme) {
+    if (index.isOdd) {
+      cardColor = GREY_COLOR;
+    } else {
+      cardColor = LIGHT_GREY_COLOR;
+    }
+  } else {
+    if (index.isOdd) {
+      cardColor = PRIMARY_GREY_COLOR;
+    } else {
+      cardColor = darkColorScheme.background;
+    }
+  }
+
+  return cardColor;
+}


### PR DESCRIPTION
- files changed
   - `lib/pages/product/edit_new_packagings.dart`

### What
<!-- description of the PR -->
- Alternate the color between packaging components to avoid any potential confusion<!-- Changed x to achieve y -->
<!-- 
Please name your pull request following this scheme: `type: What you did` this allows us to automatically generate the changelog
Following `type`s are allowed:
  - `feat`, for Features
  - `fix`, for Bug Fixes
  - `docs`, for Documentation
  - `ci`, for Automation
  - `refactor`, for code Refactoring
  - `chore`, for Miscellaneous things
-->
### Screenshot
<img src="https://user-images.githubusercontent.com/93595710/214028214-74202175-ad25-432f-8b2b-23793954d9d0.png" height="250">
<img src="https://user-images.githubusercontent.com/93595710/214028441-e09b6f17-b88e-4172-9f95-5043be12e0a6.png" height="250">



### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes: #3580 <!-- #1 Note: you can also use Closes: -->

### Part of 
- #525 <!-- Add the most granular issue possible -->
