### PR TITLE
feat: 3623 - changed icon for "packaging components"

### DIFF
--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -205,7 +205,7 @@ class _EditProductPageState extends State<EditProductPage> {
               ),
               _getSimpleListTileItem(SimpleInputPageLabelHelper()),
               _ListTitleItem(
-                leading: const Icon(Icons.recycling),
+                leading: const _SvgIcon('assets/cacheTintable/packaging.svg'),
                 title: appLocalizations.edit_packagings_title,
                 onTap: () async {
                   if (!await ProductRefresher().checkIfLoggedIn(context)) {


### PR DESCRIPTION
Impacted file:
* `edit_product_page.dart`: changed icon for "packaging components"

### What
- Changed icon for "packaging components"

### Screenshot
![Capture d’écran 2023-01-23 à 16 57 15](https://user-images.githubusercontent.com/11576431/214086264-0e0eee76-5e50-4573-a759-5b571fe01db4.png)

### Fixes bug(s)
- Closes: #3623