### PR TITLE
feat: 3621 - changed icon for null "is packaging complete?" bool

### DIFF
--- a/packages/smooth_app/lib/pages/product/edit_new_packagings.dart
+++ b/packages/smooth_app/lib/pages/product/edit_new_packagings.dart
@@ -98,11 +98,9 @@ class _EditNewPackagingsState extends State<EditNewPackagings> {
         child: ListTile(
           title: Text(appLocalizations.edit_packagings_completed),
           trailing: Icon(
-            _packagingsComplete == null
-                ? Icons.indeterminate_check_box
-                : _packagingsComplete == true
-                    ? Icons.check_box
-                    : Icons.check_box_outline_blank,
+            _packagingsComplete == true
+                ? Icons.check_box
+                : Icons.check_box_outline_blank,
           ),
           onTap: () => setState(
             () {


### PR DESCRIPTION
Impacted file:
* `edit_new_packagings.dart`: changed icon for null "is packaging complete?" bool

### What
- "is packaging complete?" is a `bool?`
- In order to display a `bool?`, we need icons for 3 states (`null`, `true`, `false`). The "indeterminate" icon is a bit peculiar.
- Now we consider that in that case, `null` means `false`
- Therefore, there are only 2 displayed checkboxes - checked (`true`) and unchecked (`false`, `null`).

### Fixes bug(s)
- Closes: #3621