### PR TITLE
fix: 3620 - bigger touch area for crop, and touchable border

### DIFF
--- a/packages/smooth_app/lib/tmp_crop_image/crop_grid.dart
+++ b/packages/smooth_app/lib/tmp_crop_image/crop_grid.dart
@@ -2,6 +2,11 @@ import 'dart:ui';
 
 import 'package:flutter/material.dart';
 
+/// Crop Grid with invisible border, for better touch detection.
+///
+/// For the record, the border and the corner "triangle" both have the same
+/// "horizontal/vertical" size: [cornerSize]. And it's probably a good practice
+/// to make the touch area the double of that size.
 class CropGrid extends StatelessWidget {
   const CropGrid({
     Key? key,
@@ -13,7 +18,6 @@ class CropGrid extends StatelessWidget {
     required this.scrimColor,
     required this.alwaysShowThirdLines,
     required this.isMoving,
-    required this.onSize,
   }) : super(key: key);
 
   final Rect crop;
@@ -24,7 +28,6 @@ class CropGrid extends StatelessWidget {
   final Color scrimColor;
   final bool alwaysShowThirdLines;
   final bool isMoving;
-  final ValueChanged<Size> onSize;
 
   @override
   Widget build(BuildContext context) => RepaintBoundary(
@@ -39,14 +42,17 @@ class _CropGridPainter extends CustomPainter {
 
   @override
   void paint(Canvas canvas, Size size) {
-    final Rect full = Offset.zero & size;
+    final Rect full = Offset(grid.cornerSize, grid.cornerSize) &
+        Size(
+          size.width - 2 * grid.cornerSize,
+          size.height - 2 * grid.cornerSize,
+        );
     final Rect bounds = Rect.fromLTRB(
       grid.crop.left * full.width,
       grid.crop.top * full.height,
       grid.crop.right * full.width,
       grid.crop.bottom * full.height,
-    );
-    grid.onSize(size);
+    ).translate(grid.cornerSize, grid.cornerSize);
 
     canvas.save();
     canvas.clipRect(bounds, clipOp: ClipOp.difference);

--- a/packages/smooth_app/lib/tmp_crop_image/new_crop_page.dart
+++ b/packages/smooth_app/lib/tmp_crop_image/new_crop_page.dart
@@ -133,13 +133,14 @@ class _CropPageState extends State<CropPage> {
                     ],
                   ),
                   Expanded(
-                    child: Padding(
-                      padding: const EdgeInsets.all(MINIMUM_TOUCH_SIZE / 2),
-                      child: RotatedCropImage(
-                        controller: _controller,
-                        image: _image,
-                        minimumImageSize: 1,
-                      ),
+                    child: RotatedCropImage(
+                      controller: _controller,
+                      image: _image,
+                      minimumImageSize:
+                          MINIMUM_TOUCH_SIZE, // decent visual minimum size
+                      gridCornerSize: MINIMUM_TOUCH_SIZE *
+                          .75, // touch size will be this x 2
+                      alwaysMove: true,
                     ),
                   ),
                   Wrap(


### PR DESCRIPTION
Impacted files:
* `crop_grid.dart`: now we paint with a border
* `new_crop_page.dart`: now the padding is inside the crop tool, in order to make borders touchable
* `rotated_crop_image.dart`: now we include here the border

### What
- The crop tool had a padding. Unfortunately this padding was not touchable, which was problematic for corners (only the 1/4 of the touch area was touchable, the part on top of the image). Now the crop tool includes a border instead of a padding.
- The touch area was enlarged by 50%.

### Fixes bug(s)
- Fixes: #3620