### PR TITLE
feat: 2484 - now when editing we go to the full image with the cropped area on top

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -478,6 +478,7 @@
         "description": "Button clicking on which confirms the picture of the front of product that user just took."
     },
     "confirm_button_label": "Confirm",
+    "send_image_button_label": "Send image",
     "front_packaging_photo_title": "Front Packaging Photo",
     "ingredients_photo_title": "Ingredients Photo",
     "nutritional_facts_photo_title": "Nutrition Facts Photo",

--- a/packages/smooth_app/lib/pages/product/product_image_viewer.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_viewer.dart
@@ -20,6 +20,7 @@ import 'package:smooth_app/pages/image_crop_page.dart';
 import 'package:smooth_app/pages/product/edit_image_button.dart';
 import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/tmp_crop_image/new_crop_page.dart';
+import 'package:smooth_app/tmp_crop_image/rotation.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
 /// Displays a full-screen image with an "edit" floating button.
@@ -97,155 +98,260 @@ class _ProductImageViewerState extends State<ProductImageViewer> {
             crossAxisAlignment: CrossAxisAlignment.center,
             mainAxisSize: MainAxisSize.max,
             children: <Widget>[
-              Expanded(child: Container()), // would be "take another picture"
               Expanded(
                 child: Padding(
                   padding: const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
-                  child: EditImageButton(
-                    iconData: Icons.image_search,
-                    label: appLocalizations
-                        .edit_photo_select_existing_button_label,
-                    onPressed: () async {
-                      final List<int>? result =
-                          await LoadingDialog.run<List<int>>(
-                        future: OpenFoodAPIClient.getProductImageIds(
-                          _barcode,
-                          user: ProductQuery.getUser(),
-                        ),
-                        context: context,
-                        title: appLocalizations
-                            .edit_photo_select_existing_download_label,
-                      );
-                      if (result == null) {
-                        return;
-                      }
-                      if (!mounted) {
-                        return;
-                      }
-                      if (result.isEmpty) {
-                        await showDialog<void>(
-                          context: context,
-                          builder: (BuildContext context) => SmoothAlertDialog(
-                            body: Text(appLocalizations
-                                .edit_photo_select_existing_downloaded_none),
-                            actionsAxis: Axis.vertical,
-                            positiveAction: SmoothActionButton(
-                              text: appLocalizations.okay,
-                              onPressed: () => Navigator.of(context).pop(),
-                            ),
-                          ),
-                        );
-                        return;
-                      }
-                      await Navigator.push<void>(
-                        context,
-                        MaterialPageRoute<void>(
-                          builder: (BuildContext context) =>
-                              UploadedImageGallery(
-                            barcode: _barcode,
-                            imageIds: result,
-                            imageField: widget.imageField,
-                          ),
-                        ),
-                      );
-                    },
+                  child: _getGalleryButton(appLocalizations),
+                ),
+              ),
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
+                  child: _getCameraImageButton(
+                    appLocalizations,
+                    imageProvider == null,
                   ),
                 ),
               ),
             ],
           ),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            crossAxisAlignment: CrossAxisAlignment.center,
-            mainAxisSize: MainAxisSize.max,
-            children: <Widget>[
-              Expanded(
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
-                  child: (imageProvider == null)
-                      ? Container()
-                      : EditImageButton(
-                          iconData: Icons.do_disturb_on,
-                          label:
-                              appLocalizations.edit_photo_unselect_button_label,
-                          onPressed: () async {
-                            final NavigatorState navigatorState =
-                                Navigator.of(context);
-                            await BackgroundTaskUnselect.addTask(
-                              _barcode,
-                              imageField: widget.imageField,
-                              widget: this,
-                            );
-                            _localDatabase.notifyListeners();
-                            navigatorState.pop();
-                          },
-                        ),
-                ),
-              ),
-              Expanded(
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
-                  child: EditImageButton(
-                    iconData: imageProvider == null ? Icons.add : Icons.edit,
-                    label: imageProvider == null
-                        ? appLocalizations.add
-                        : appLocalizations.edit_photo_button_label,
-                    onPressed: () async => _editImage(),
+          if (imageProvider != null)
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              mainAxisSize: MainAxisSize.max,
+              children: <Widget>[
+                Expanded(
+                  child: Padding(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
+                    child: _getUnselectImageButton(appLocalizations),
                   ),
                 ),
-              ),
-            ],
-          ),
+                Expanded(
+                  child: Padding(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
+                    child: _getEditImageButton(appLocalizations),
+                  ),
+                ),
+              ],
+            ),
         ],
       ),
     );
   }
 
-  Future<void> _editImage() async {
-    // we have no image at all here: we need to create one.
-    if (!TransientFile.isImageAvailable(_imageData, _barcode)) {
-      await confirmAndUploadNewPicture(
+  Widget _getEditImageButton(final AppLocalizations appLocalizations) =>
+      EditImageButton(
+        iconData: Icons.edit,
+        label: appLocalizations.edit_photo_button_label,
+        onPressed: _actionEditImage,
+      );
+
+  Widget _getCameraImageButton(
+    final AppLocalizations appLocalizations,
+    final bool firstPhoto,
+  ) =>
+      EditImageButton(
+        iconData: firstPhoto ? Icons.add : Icons.add_a_photo,
+        label: firstPhoto ? appLocalizations.add : appLocalizations.capture,
+        onPressed: _actionNewImage,
+      );
+
+  Widget _getUnselectImageButton(final AppLocalizations appLocalizations) =>
+      EditImageButton(
+        iconData: Icons.do_disturb_on,
+        label: appLocalizations.edit_photo_unselect_button_label,
+        onPressed: _actionUnselect,
+      );
+
+  Widget _getGalleryButton(final AppLocalizations appLocalizations) =>
+      EditImageButton(
+        iconData: Icons.image_search,
+        label: appLocalizations.edit_photo_select_existing_button_label,
+        onPressed: _actionGallery,
+      );
+
+  // TODO(monsieurtanuki): we should also suggest the existing image gallery
+  Future<File?> _actionNewImage() async => confirmAndUploadNewPicture(
         this,
         imageField: _imageData.imageField,
         barcode: _barcode,
       );
+
+  Future<void> _actionGallery() async {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final List<int>? result = await LoadingDialog.run<List<int>>(
+      future: OpenFoodAPIClient.getProductImageIds(
+        _barcode,
+        user: ProductQuery.getUser(),
+      ),
+      context: context,
+      title: appLocalizations.edit_photo_select_existing_download_label,
+    );
+    if (result == null) {
       return;
     }
+    if (!mounted) {
+      return;
+    }
+    if (result.isEmpty) {
+      await showDialog<void>(
+        context: context,
+        builder: (BuildContext context) => SmoothAlertDialog(
+          body:
+              Text(appLocalizations.edit_photo_select_existing_downloaded_none),
+          actionsAxis: Axis.vertical,
+          positiveAction: SmoothActionButton(
+            text: appLocalizations.okay,
+            onPressed: () => Navigator.of(context).pop(),
+          ),
+        ),
+      );
+      return;
+    }
+    await Navigator.push<void>(
+      context,
+      MaterialPageRoute<void>(
+        builder: (BuildContext context) => UploadedImageGallery(
+          barcode: _barcode,
+          imageIds: result,
+          imageField: widget.imageField,
+        ),
+      ),
+    );
+  }
 
-    // best option: use the transient file.
+  Future<File?> _actionEditImage() async {
+    final NavigatorState navigatorState = Navigator.of(context);
+
+    // best possibility: with the crop parameters
+    // TODO(monsieurtanuki): maybe we should keep the big image locally, in order to avoid the server call?
+    final ProductImage? productImage = _getBestProductImage();
+    if (productImage != null) {
+      final int? imageId = int.tryParse(productImage.imgid!);
+      if (imageId != null) {
+        return _openEditCroppedImage(imageId, productImage);
+      }
+    }
+
+    // alternate option: use the transient file.
     File? imageFile = TransientFile.getImage(
       _imageData.imageField,
       _barcode,
     );
+    if (imageFile != null) {
+      return _openCropPage(navigatorState, imageFile);
+    }
 
     // but if not possible, get the best picture from the server.
-    if (imageFile == null) {
-      final String? imageUrl = _imageData.getImageUrl(ImageSize.ORIGINAL);
-      imageFile = await downloadImageUrl(
-        context,
-        imageUrl,
-        DaoInt(_localDatabase),
-      );
-      if (imageFile == null) {
-        return;
-      }
-    }
-
-    if (!mounted) {
-      return;
-    }
-
-    await Navigator.push<File>(
+    final String? imageUrl = _imageData.getImageUrl(ImageSize.ORIGINAL);
+    imageFile = await downloadImageUrl(
       context,
-      MaterialPageRoute<File>(
-        builder: (BuildContext context) => CropPage(
-          barcode: _barcode,
-          imageField: _imageData.imageField,
-          inputFile: imageFile!,
-          brandNewPicture: false,
+      imageUrl,
+      DaoInt(_localDatabase),
+    );
+    if (imageFile != null) {
+      return _openCropPage(navigatorState, imageFile);
+    }
+
+    return null;
+  }
+
+  Future<void> _actionUnselect() async {
+    final NavigatorState navigatorState = Navigator.of(context);
+    await BackgroundTaskUnselect.addTask(
+      _barcode,
+      imageField: widget.imageField,
+      widget: this,
+    );
+    _localDatabase.notifyListeners();
+    navigatorState.pop();
+  }
+
+  Future<File?> _openCropPage(
+    final NavigatorState navigatorState,
+    final File imageFile, {
+    final int? imageId,
+    final Rect? initialCropRect,
+    final Rotation? initialRotation,
+  }) async =>
+      navigatorState.push<File>(
+        MaterialPageRoute<File>(
+          builder: (BuildContext context) => CropPage(
+            barcode: _product.barcode!,
+            imageField: _imageData.imageField,
+            inputFile: imageFile,
+            imageId: imageId,
+            brandNewPicture: false,
+            initialCropRect: initialCropRect,
+            initialRotation: initialRotation,
+          ),
+          fullscreenDialog: true,
         ),
-        fullscreenDialog: true,
+      );
+
+  Future<File?> _openEditCroppedImage(
+    final int imageId,
+    final ProductImage productImage,
+  ) async {
+    final NavigatorState navigatorState = Navigator.of(context);
+    final LocalDatabase localDatabase = context.read<LocalDatabase>();
+    final File? imageFile = await downloadImageUrl(
+      context,
+      ImageHelper.getUploadedImageUrl(
+        _product.barcode!,
+        imageId,
+        ImageSize.ORIGINAL,
+      ),
+      DaoInt(localDatabase),
+    );
+    if (imageFile == null) {
+      return null;
+    }
+    return _openCropPage(
+      navigatorState,
+      imageFile,
+      imageId: imageId,
+      initialCropRect: _getCropRect(productImage),
+      initialRotation: RotationExtension.fromDegrees(
+        productImage.angle?.degree ?? 0,
       ),
     );
   }
+
+  ProductImage? _getBestProductImage() {
+    if (_product.images == null) {
+      return null;
+    }
+    for (final ProductImage productImage in _product.images!) {
+      if (productImage.field != _imageData.imageField) {
+        continue;
+      }
+      if (productImage.language != ProductQuery.getLanguage()) {
+        continue;
+      }
+      if (productImage.size == ImageSize.ORIGINAL) {
+        if (productImage.imgid != null) {
+          return productImage;
+        }
+      }
+    }
+    return null;
+  }
+
+  /// Returns a crop rect, to be compared with the full image dimensions.
+  Rect? _getCropRect(final ProductImage productImage) =>
+      productImage.x1 == null ||
+              productImage.y1 == null ||
+              productImage.x2 == null ||
+              productImage.y2 == null
+          ? null
+          : Rect.fromLTRB(
+              productImage.x1!.toDouble(),
+              productImage.y1!.toDouble(),
+              productImage.x2!.toDouble(),
+              productImage.y2!.toDouble(),
+            );
 }

--- a/packages/smooth_app/lib/query/product_query.dart
+++ b/packages/smooth_app/lib/query/product_query.dart
@@ -134,6 +134,7 @@ abstract class ProductQuery {
         ProductField.IMAGE_INGREDIENTS_URL,
         ProductField.IMAGE_NUTRITION_URL,
         ProductField.IMAGE_PACKAGING_URL,
+        ProductField.IMAGES,
         ProductField.SELECTED_IMAGE,
         ProductField.QUANTITY,
         ProductField.SERVING_SIZE,

--- a/packages/smooth_app/lib/tmp_crop_image/rotation.dart
+++ b/packages/smooth_app/lib/tmp_crop_image/rotation.dart
@@ -38,6 +38,15 @@ extension RotationExtension on Rotation {
     }
   }
 
+  static Rotation? fromDegrees(final int degrees) {
+    for (final Rotation rotation in Rotation.values) {
+      if (rotation.degrees == degrees) {
+        return rotation;
+      }
+    }
+    return null;
+  }
+
   /// Returns the rotation rotated 90 degrees to the right.
   Rotation get rotateRight {
     switch (this) {

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -811,7 +811,7 @@ packages:
       name: openfoodfacts
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "2.2.1"
   openfoodfacts_flutter_lints:
     dependency: "direct dev"
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   latlong2: 0.8.1
   matomo_tracker: 1.5.0
   modal_bottom_sheet: 2.1.2
-  openfoodfacts: 2.2.0
+  openfoodfacts: 2.2.1
   # openfoodfacts:
   #   path: ../../../openfoodfacts-dart
   package_info_plus: 1.4.3+1


### PR DESCRIPTION
Impacted files:
* `app_en.arb`: added a label for the "send image" button (instead of vague "confirm")
* `background_task_crop.dart`: added a product change where we store the crop parameters
* `background_task_image.dart`: added a fake product change where we remove the crop parameters
* `new_crop_page.dart`: added constructor parameters `initialCropRect` and `initialRotation`; removed the "new photo" button for UI/UX consistency
* `product_image_viewer.dart`: refactored with 2 or 4 buttons and cleaner code
* `product_query.dart`: added `IMAGES` product field
* `pubspec.lock`: wtf
* `pubspec.yaml`: upgraded `openfoodfacts` to `2.2.1` (about `ProductImage`)
* `rotation.dart`: added method `fromDegrees`
* `up_to_date_changes.dart`: added `images` to "overwritable" product fields; now accepts all operation types

### What
- Before, when we edited an image, we edited it as if it was a full image taken by the camera, even if it was cropped.
- Now, we display the full image actually taken by the camera, with the visible cropped area on top.
- Some changes on the buttons too, cf. screenshots.

### Screenshot
| read-only page | crop page |
| -- | -- |
| ![Capture d’écran 2023-01-30 à 19 24 50](https://user-images.githubusercontent.com/11576431/215563069-6c504bf4-fc0b-4157-873c-d4f26fc8ff81.png) | ![Capture d’écran 2023-01-30 à 19 24 29](https://user-images.githubusercontent.com/11576431/215563020-3d298770-1254-47a8-900c-b2b445f0512d.png) |

Read-only page with no previous image:
![Capture d’écran 2023-01-30 à 19 25 07](https://user-images.githubusercontent.com/11576431/215563122-6b9d282a-ad60-4104-a2ce-b4857413c9fa.png)


### Fixes bug(s)
- Closes: #2484

### Part of 
- #766
