### PR TITLE
feat: 3656 - privacy compliance for cropped new images

### DIFF
--- a/packages/smooth_app/lib/pages/image/uploaded_image_gallery.dart
+++ b/packages/smooth_app/lib/pages/image/uploaded_image_gallery.dart
@@ -76,7 +76,7 @@ class UploadedImageGallery extends StatelessWidget {
                     imageField: imageField,
                     inputFile: imageFile,
                     imageId: imageId,
-                    brandNewPicture: false,
+                    initiallyDifferent: true,
                   ),
                   fullscreenDialog: true,
                 ),

--- a/packages/smooth_app/lib/pages/image_crop_page.dart
+++ b/packages/smooth_app/lib/pages/image_crop_page.dart
@@ -104,7 +104,7 @@ Future<File?> confirmAndUploadNewPicture(
         barcode: barcode,
         imageField: imageField,
         inputFile: File(croppedPhoto.path),
-        brandNewPicture: true,
+        initiallyDifferent: true,
       ),
       fullscreenDialog: true,
     ),

--- a/packages/smooth_app/lib/pages/product/product_image_viewer.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_viewer.dart
@@ -284,7 +284,7 @@ class _ProductImageViewerState extends State<ProductImageViewer> {
             imageField: _imageData.imageField,
             inputFile: imageFile,
             imageId: imageId,
-            brandNewPicture: false,
+            initiallyDifferent: false,
             initialCropRect: initialCropRect,
             initialRotation: initialRotation,
           ),

--- a/packages/smooth_app/lib/tmp_crop_image/new_crop_page.dart
+++ b/packages/smooth_app/lib/tmp_crop_image/new_crop_page.dart
@@ -31,7 +31,7 @@ class CropPage extends StatefulWidget {
     required this.inputFile,
     required this.barcode,
     required this.imageField,
-    required this.brandNewPicture,
+    required this.initiallyDifferent,
     this.imageId,
     this.initialCropRect,
     this.initialRotation,
@@ -43,8 +43,8 @@ class CropPage extends StatefulWidget {
   final ImageField imageField;
   final String barcode;
 
-  /// Is that a new picture we crop, or an existing picture?
-  final bool brandNewPicture;
+  /// Is the full picture initially different from the current selection?
+  final bool initiallyDifferent;
 
   /// Only makes sense when we deal with an "already existing" image.
   final int? imageId;
@@ -346,7 +346,7 @@ class _CropPageState extends State<CropPage> {
   Future<bool> _mayExitPage({required final bool saving}) async {
     if (_controller.value.rotation == _initialRotation &&
         _controller.value.crop == _initialCrop &&
-        !widget.brandNewPicture) {
+        !widget.initiallyDifferent) {
       // nothing has changed, let's leave
       if (saving) {
         Navigator.of(context).pop();


### PR DESCRIPTION
Impacted files:
* `background_task_image.dart`: now we crop here the image before sending it
* `new_crop_page.dart`: now we either let the server crop (old image) or let the background task crop (brand new image)
* `rotated_crop_controller.dart`: refactored adding a static method `getCroppedBitmap`

### What
- There were privacy issues with image cropping, as cropped images were sent as full images with cropped parameters. That meant that areas beyond the crop were still visible, which can be problematic and is not a standard in apps.
- Above that, there are performance issues about cropping locally on "small" smartphones like @alexgarel's.
- @M123-dev suggested that we make a clear difference between brand new pictures (just taken by the users) and "repository" pictures (taken a while ago and allegedly privacy compliant).
- For brand new pictures, we send only the cropped area, and we compute it locally, inside the background task in order to avoid waiting too long after clicking on the "Send!" button.
- For "old" pictures, we let the server crop the already existing image - there's no change in the code in that case.
- An isolate could help with performances for local cropping, if stuttering UI is detected.

### Fixes bug(s)
- Closes: #3656