### PR TITLE
fix: Added unique id to API Request header.

### DIFF
--- a/packages/smooth_app/lib/helpers/network_config.dart
+++ b/packages/smooth_app/lib/helpers/network_config.dart
@@ -5,11 +5,22 @@ import 'package:flutter/services.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:smooth_app/helpers/app_helper.dart';
+import 'package:uuid/uuid.dart';
 
 /// Initializes both the user agent && the SSL certificate
 Future<void> setupAppNetworkConfig() async {
   await _initUserAgent();
   return _importSSLCertificate();
+}
+
+String _getUuidId() {
+  if (OpenFoodAPIConfiguration.uuid != null) {
+    return OpenFoodAPIConfiguration.uuid!;
+  }
+
+  const Uuid uuid = Uuid();
+  OpenFoodAPIConfiguration.uuid = uuid.v4();
+  return OpenFoodAPIConfiguration.uuid!;
 }
 
 Future<void> _initUserAgent() async {
@@ -19,10 +30,12 @@ Future<void> _initUserAgent() async {
   final String version = '${packageInfo.version}+${packageInfo.buildNumber}';
   final String system =
       '${Platform.operatingSystem}+${Platform.operatingSystemVersion}';
+  final String id = _getUuidId();
   final String comment = _getAppInfoComment(
     name: name,
     version: version,
     system: system,
+    id: id,
   );
   OpenFoodAPIConfiguration.userAgent = UserAgent(
       name: name,
@@ -39,6 +52,8 @@ String _getAppInfoComment({
   String version = '',
   bool withSystem = true,
   String system = '',
+  bool withId = true,
+  String id = '',
 }) {
   String appInfo = '';
   const String infoDelimiter = ' - ';
@@ -53,6 +68,10 @@ String _getAppInfoComment({
   if (withSystem) {
     appInfo += infoDelimiter;
     appInfo += system;
+  }
+  if (withId) {
+    appInfo += infoDelimiter;
+    appInfo += id;
   }
   return appInfo;
 }


### PR DESCRIPTION
### What
Added a Unique Id to each app installation.

The issue:
<a href="https://world.openfoodfacts.org/product/12354654777563/test-carrefour#:~:text=Last%20edit%20of%20product%20page%20on%20February%204%2C%202023%20at%201%3A39%3A19%20PM%20CET%20by%20smoothie%2Dapp.">Data Source</a> should show who updated something.
![image](https://user-images.githubusercontent.com/33085535/216943659-8075e054-32e5-47a4-b9a1-7ab8812dfb70.png)


<h3>So far I have come to 2/3 ways to do this.</h3>
<ul>
 <li>
<b>App Side</b><br/>
The app has a global user and is used when an anonymous user edits the product.
Ref: <a href="https://github.com/openfoodfacts/smooth-app/blob/c9935da9b6a7b75ffca64f85ce5bf7dc9e81964e/packages/smooth_app/lib/query/product_query.dart#L105">smoothie-app</a>
We can create an account on Open Food Facts using UUID for each app installation as a global user (I don't know if it's the right way).
</li>
<li>
<b>Server Side</b></br>
If we store the comments that come with the API Request header.
And show them if the user is a 'smoothie-app'. <br/>Ref to the Server Side Template:
<a href="https://github.com/openfoodfacts/openfoodfacts-server/blob/aa9404dcfd1b62d7adb587577cc85cdc5b002c29/templates/web/pages/product/product_page.tt.html#L303">here</a> And the <a href="https://github.com/openfoodfacts/openfoodfacts-server/blob/a67350e081b96613526ec8c111c1c12df9f06dc7/lib/ProductOpener/Display.pm#L8023">View</a>
</li>
<li>Maybe Someone else can suggest something.</li>
</ul>

<i>Sorry, I was not able to test if the server-side receives the comments, I tried building the server-side docker container 3 times, twice in Windows 11, and once in Debian 11. I was getting lots of errors</i>.

### Part of
#1351 
#3644 
