### PR TITLE
fix: 3663 - packaging number of units and weight as nums

### DIFF
--- a/packages/smooth_app/lib/pages/product/edit_new_packagings.dart
+++ b/packages/smooth_app/lib/pages/product/edit_new_packagings.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:intl/intl.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/background/background_task_details.dart';
@@ -12,6 +13,7 @@ import 'package:smooth_app/pages/image_crop_page.dart';
 import 'package:smooth_app/pages/product/edit_new_packagings_component.dart';
 import 'package:smooth_app/pages/product/edit_new_packagings_helper.dart';
 import 'package:smooth_app/pages/product/may_exit_page_helper.dart';
+import 'package:smooth_app/pages/product/simple_input_number_field.dart';
 import 'package:smooth_app/themes/color_schemes.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
@@ -30,6 +32,8 @@ class EditNewPackagings extends StatefulWidget {
 
 class _EditNewPackagingsState extends State<EditNewPackagings> {
   late final LocalDatabase _localDatabase;
+  late final NumberFormat _decimalNumberFormat;
+  late final NumberFormat _unitNumberFormat;
 
   late bool? _packagingsComplete;
 
@@ -47,7 +51,12 @@ class _EditNewPackagingsState extends State<EditNewPackagings> {
     final bool initiallyExpanded = false,
   }) {
     _helpers.add(
-      EditNewPackagingsHelper.packaging(packaging, initiallyExpanded),
+      EditNewPackagingsHelper.packaging(
+        packaging,
+        initiallyExpanded,
+        decimalNumberFormat: _decimalNumberFormat,
+        unitNumberFormat: _unitNumberFormat,
+      ),
     );
   }
 
@@ -59,6 +68,12 @@ class _EditNewPackagingsState extends State<EditNewPackagings> {
   @override
   void initState() {
     super.initState();
+    _decimalNumberFormat = SimpleInputNumberField.getNumberFormat(
+      decimal: true,
+    );
+    _unitNumberFormat = SimpleInputNumberField.getNumberFormat(
+      decimal: false,
+    );
     _initPackagings();
     _localDatabase = context.read<LocalDatabase>();
     _localDatabase.upToDate.showInterest(widget.product.barcode!);

--- a/packages/smooth_app/lib/pages/product/edit_new_packagings_component.dart
+++ b/packages/smooth_app/lib/pages/product/edit_new_packagings_component.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:intl/intl.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/cards/category_cards/asset_cache_helper.dart';
 import 'package:smooth_app/cards/category_cards/svg_async_asset.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/pages/product/edit_new_packagings_helper.dart';
 import 'package:smooth_app/pages/product/explanation_widget.dart';
-import 'package:smooth_app/pages/product/simple_input_widget.dart';
+import 'package:smooth_app/pages/product/simple_input_number_field.dart';
+import 'package:smooth_app/pages/product/simple_input_text_field.dart';
 
 /// Edit display of a single [ProductPackaging] component.
 class EditNewPackagingsComponent extends StatefulWidget {
@@ -37,22 +39,23 @@ class _EditNewPackagingsComponentState
     final List<Widget> expandedChildren = !widget.helper.expanded
         ? <Widget>[]
         : <Widget>[
-            _EditLine(
-              // TODO(monsieurtanuki): different display for numbers
+            _EditNumberLine(
               title: appLocalizations.edit_packagings_element_field_units,
               controller: widget.helper.controllerUnits,
               // this icon has 2 colors: we need 2 distinct files
               iconName: dark ? 'counter-dark' : 'counter-light',
               iconColor: null,
+              decimal: false,
+              numberFormat: widget.helper.unitNumberFormat,
             ),
-            _EditLine(
+            _EditTextLine(
               title: appLocalizations.edit_packagings_element_field_shape,
               controller: widget.helper.controllerShape,
               tagType: TagType.PACKAGING_SHAPES,
               iconName: 'shape',
               iconColor: iconColor,
             ),
-            _EditLine(
+            _EditTextLine(
               title: appLocalizations.edit_packagings_element_field_material,
               controller: widget.helper.controllerMaterial,
               tagType: TagType.PACKAGING_MATERIALS,
@@ -60,26 +63,27 @@ class _EditNewPackagingsComponentState
               iconColor: iconColor,
               hint: appLocalizations.edit_packagings_element_hint_material,
             ),
-            _EditLine(
+            _EditTextLine(
               title: appLocalizations.edit_packagings_element_field_recycling,
               controller: widget.helper.controllerRecycling,
               tagType: TagType.PACKAGING_RECYCLING,
               iconName: 'recycling',
               iconColor: iconColor,
             ),
-            _EditLine(
+            _EditTextLine(
               title: appLocalizations.edit_packagings_element_field_quantity,
               controller: widget.helper.controllerQuantity,
               iconName: 'quantity',
               iconColor: iconColor,
             ),
-            _EditLine(
-              // TODO(monsieurtanuki): different display for numbers
+            _EditNumberLine(
               title: appLocalizations.edit_packagings_element_field_weight,
               controller: widget.helper.controllerWeight,
               iconName: 'weight',
               iconColor: iconColor,
               hint: appLocalizations.edit_packagings_element_hint_weight,
+              decimal: true,
+              numberFormat: widget.helper.decimalNumberFormat,
             ),
           ];
     return Column(
@@ -111,8 +115,8 @@ class _EditNewPackagingsComponentState
 }
 
 /// Edit display of a single line inside a [ProductPackaging], e.g. its shape.
-class _EditLine extends StatelessWidget {
-  const _EditLine({
+class _EditTextLine extends StatelessWidget {
+  const _EditTextLine({
     required this.title,
     required this.controller,
     required this.iconName,
@@ -147,7 +151,7 @@ class _EditLine extends StatelessWidget {
           LayoutBuilder(
             builder: (_, BoxConstraints constraints) => SizedBox(
               width: constraints.maxWidth,
-              child: SimpleInputWidgetField(
+              child: SimpleInputTextField(
                 focusNode: FocusNode(),
                 autocompleteKey: UniqueKey(),
                 constraints: constraints,
@@ -155,6 +159,68 @@ class _EditLine extends StatelessWidget {
                 hintText: '',
                 controller: controller,
                 withClearButton: true,
+              ),
+            ),
+          ),
+          if (hint != null)
+            Padding(
+              padding: const EdgeInsets.only(bottom: LARGE_SPACE),
+              child: ExplanationWidget(hint!),
+            ),
+        ],
+      );
+}
+
+/// Edit display of a _number_ inside a [ProductPackaging], e.g. its weight.
+class _EditNumberLine extends StatelessWidget {
+  const _EditNumberLine({
+    required this.title,
+    required this.controller,
+    required this.iconName,
+    required this.iconColor,
+    required this.decimal,
+    required this.numberFormat,
+    this.hint,
+  });
+
+  final String title;
+  final TextEditingController controller;
+  final String iconName;
+  final Color? iconColor;
+  final String? hint;
+  final bool decimal;
+  final NumberFormat numberFormat;
+
+  @override
+  Widget build(BuildContext context) => Column(
+        mainAxisAlignment: MainAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          ListTile(
+            leading: SvgAsyncAsset(
+              AssetCacheHelper(
+                <String>['assets/packagings/$iconName.svg'],
+                'no url for packagings/$iconName',
+                color: iconColor,
+                width: MINIMUM_TOUCH_SIZE,
+              ),
+            ),
+            title: Text(title),
+          ),
+          LayoutBuilder(
+            builder: (_, BoxConstraints constraints) => SizedBox(
+              width: constraints.maxWidth,
+              child: SimpleInputNumberField(
+                focusNode: FocusNode(),
+                constraints: constraints,
+                hintText: '',
+                controller: controller,
+                decimal: decimal,
+                withClearButton: true,
+                numberFormat: numberFormat,
+                numberRegExp: SimpleInputNumberField.getNumberRegExp(
+                  decimal: decimal,
+                ),
               ),
             ),
           ),

--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -15,8 +15,8 @@ import 'package:smooth_app/pages/product/may_exit_page_helper.dart';
 import 'package:smooth_app/pages/product/nutrition_add_nutrient_button.dart';
 import 'package:smooth_app/pages/product/nutrition_container.dart';
 import 'package:smooth_app/pages/product/ordered_nutrients_cache.dart';
+import 'package:smooth_app/pages/product/simple_input_number_field.dart';
 import 'package:smooth_app/pages/text_field_helper.dart';
-import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
@@ -83,11 +83,7 @@ class NutritionPageLoaded extends StatefulWidget {
 }
 
 class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
-  // we admit both decimal points
-  // anyway, the keyboard will only show one
-  static final RegExp _decimalRegExp = RegExp(r'[\d,.]');
-
-  late final NumberFormat _numberFormat;
+  late final NumberFormat _decimalNumberFormat;
   late final NutritionContainer _nutritionContainer;
 
   double getColumnSizeFromContext(
@@ -112,7 +108,8 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
       orderedNutrients: widget.orderedNutrients,
       product: _product,
     );
-    _numberFormat = NumberFormat('####0.#####', ProductQuery.getLocaleString());
+    _decimalNumberFormat =
+        SimpleInputNumberField.getNumberFormat(decimal: true);
   }
 
   @override
@@ -255,7 +252,7 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
     if (_controllers[nutrient] == null) {
       final double? value = _nutritionContainer.getValue(nutrient);
       _controllers[nutrient] = TextEditingControllerWithInitialValue(
-        text: value == null ? '' : _numberFormat.format(value),
+        text: value == null ? '' : _decimalNumberFormat.format(value),
       );
     }
     final TextEditingControllerWithInitialValue controller =
@@ -294,15 +291,17 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
             }
           },
           inputFormatters: <TextInputFormatter>[
-            FilteringTextInputFormatter.allow(_decimalRegExp),
-            DecimalSeparatorRewriter(_numberFormat),
+            FilteringTextInputFormatter.allow(
+              SimpleInputNumberField.getNumberRegExp(decimal: true),
+            ),
+            DecimalSeparatorRewriter(_decimalNumberFormat),
           ],
           validator: (String? value) {
             if (value == null || value.trim().isEmpty) {
               return null;
             }
             try {
-              _numberFormat.parse(value);
+              _decimalNumberFormat.parse(value);
               return null;
             } catch (e) {
               return appLocalizations.nutrition_page_invalid_number;
@@ -478,7 +477,7 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
       _nutritionContainer.setNutrientValueText(
         nutrient,
         controller.text,
-        _numberFormat,
+        _decimalNumberFormat,
       );
     }
     if (_servingController != null) {

--- a/packages/smooth_app/lib/pages/product/simple_input_number_field.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_number_field.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:intl/intl.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/helpers/text_input_formatters_helper.dart';
+import 'package:smooth_app/query/product_query.dart';
+
+/// Simple input text field, for numbers.
+class SimpleInputNumberField extends StatelessWidget {
+  const SimpleInputNumberField({
+    required this.focusNode,
+    required this.constraints,
+    required this.hintText,
+    required this.controller,
+    required this.decimal,
+    required this.numberFormat,
+    required this.numberRegExp,
+    this.withClearButton = false,
+  });
+
+  final FocusNode focusNode;
+  final BoxConstraints constraints;
+  final String hintText;
+  final TextEditingController controller;
+  final bool decimal;
+  final NumberFormat numberFormat;
+  final RegExp numberRegExp;
+  final bool withClearButton;
+
+  // we admit both decimal points (anyway, the keyboard will only show one)
+  static RegExp getNumberRegExp({required final bool decimal}) =>
+      decimal ? RegExp(r'[\d,.]') : RegExp(r'\d');
+
+  static NumberFormat getNumberFormat({required final bool decimal}) =>
+      NumberFormat(
+        decimal ? '####0.#####' : '######0',
+        ProductQuery.getLocaleString(),
+      );
+
+  @override
+  Widget build(BuildContext context) => Padding(
+        padding: const EdgeInsets.only(left: LARGE_SPACE),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          mainAxisSize: MainAxisSize.max,
+          children: <Widget>[
+            SizedBox(
+              width: constraints.maxWidth -
+                  LARGE_SPACE -
+                  (withClearButton ? MINIMUM_TOUCH_SIZE : 0),
+              child: TextField(
+                keyboardType: TextInputType.numberWithOptions(
+                  signed: false,
+                  decimal: decimal,
+                ),
+                controller: controller,
+                decoration: InputDecoration(
+                  filled: true,
+                  border: const OutlineInputBorder(
+                    borderRadius: ANGULAR_BORDER_RADIUS,
+                    borderSide: BorderSide.none,
+                  ),
+                  contentPadding: const EdgeInsets.symmetric(
+                    horizontal: SMALL_SPACE,
+                    vertical: SMALL_SPACE,
+                  ),
+                  hintText: hintText,
+                ),
+                autofocus: true,
+                focusNode: focusNode,
+                inputFormatters: <TextInputFormatter>[
+                  FilteringTextInputFormatter.allow(numberRegExp),
+                  DecimalSeparatorRewriter(numberFormat),
+                ],
+              ),
+            ),
+            if (withClearButton)
+              IconButton(
+                icon: const Icon(Icons.clear),
+                onPressed: () => controller.text = '',
+              ),
+          ],
+        ),
+      );
+}

--- a/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/material.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/pages/product/autocomplete.dart';
+import 'package:smooth_app/query/product_query.dart';
+
+/// Simple input text field, with autocompletion.
+class SimpleInputTextField extends StatelessWidget {
+  const SimpleInputTextField({
+    required this.focusNode,
+    required this.autocompleteKey,
+    required this.constraints,
+    required this.tagType,
+    required this.hintText,
+    required this.controller,
+    this.withClearButton = false,
+  });
+
+  final FocusNode focusNode;
+  final Key autocompleteKey;
+  final BoxConstraints constraints;
+  final TagType? tagType;
+  final String hintText;
+  final TextEditingController controller;
+  final bool withClearButton;
+
+  @override
+  Widget build(BuildContext context) => Padding(
+        padding: const EdgeInsets.only(left: LARGE_SPACE),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          mainAxisSize: MainAxisSize.max,
+          children: <Widget>[
+            SizedBox(
+              width: constraints.maxWidth -
+                  LARGE_SPACE -
+                  (withClearButton ? MINIMUM_TOUCH_SIZE : 0),
+              child: RawAutocomplete<String>(
+                key: autocompleteKey,
+                focusNode: focusNode,
+                textEditingController: controller,
+                optionsBuilder: (final TextEditingValue value) async {
+                  final List<String> result = <String>[];
+                  final String input = value.text.trim();
+
+                  if (input.isEmpty) {
+                    return result;
+                  }
+
+                  if (tagType == null) {
+                    return result;
+                  }
+
+                  // TODO(monsieurtanuki): ask off-dart to return Strings instead of dynamic?
+                  final List<dynamic> data =
+                      await OpenFoodAPIClient.getAutocompletedSuggestions(
+                    tagType!,
+                    language: ProductQuery.getLanguage()!,
+                    limit: 1000000, // lower max count on the server anyway
+                    input: value.text.trim(),
+                  );
+                  for (final dynamic item in data) {
+                    result.add(item.toString());
+                  }
+                  result.sort();
+                  return result;
+                },
+                fieldViewBuilder: (BuildContext context,
+                        TextEditingController textEditingController,
+                        FocusNode focusNode,
+                        VoidCallback onFieldSubmitted) =>
+                    TextField(
+                  controller: textEditingController,
+                  decoration: InputDecoration(
+                    filled: true,
+                    border: const OutlineInputBorder(
+                      borderRadius: ANGULAR_BORDER_RADIUS,
+                      borderSide: BorderSide.none,
+                    ),
+                    contentPadding: const EdgeInsets.symmetric(
+                      horizontal: SMALL_SPACE,
+                      vertical: SMALL_SPACE,
+                    ),
+                    hintText: hintText,
+                  ),
+                  autofocus: true,
+                  focusNode: focusNode,
+                ),
+                optionsViewBuilder: (
+                  BuildContext lContext,
+                  AutocompleteOnSelected<String> onSelected,
+                  Iterable<String> options,
+                ) {
+                  final double screenHeight =
+                      MediaQuery.of(context).size.height;
+                  final double keyboardHeight =
+                      MediaQuery.of(lContext).viewInsets.bottom;
+
+                  final double widgetPosition =
+                      (context.findRenderObject() as RenderBox?)
+                              ?.localToGlobal(Offset.zero)
+                              .dy ??
+                          0.0;
+
+                  return AutocompleteOptions<String>(
+                    displayStringForOption:
+                        RawAutocomplete.defaultStringForOption,
+                    onSelected: onSelected,
+                    options: options,
+                    // Width = Row width - horizontal padding
+                    maxOptionsWidth: constraints.maxWidth - (LARGE_SPACE * 2),
+                    maxOptionsHeight: screenHeight -
+                        (keyboardHeight == 0
+                            ? kBottomNavigationBarHeight
+                            : keyboardHeight) -
+                        widgetPosition -
+                        // Vertical padding
+                        (LARGE_SPACE * 2) -
+                        // Height of the TextField
+                        (DefaultTextStyle.of(context).style.fontSize ?? 0) -
+                        // Elevation
+                        4.0,
+                  );
+                },
+              ),
+            ),
+            if (withClearButton)
+              IconButton(
+                icon: const Icon(Icons.clear),
+                onPressed: () => controller.text = '',
+              ),
+          ],
+        ),
+      );
+}

--- a/packages/smooth_app/lib/pages/product/simple_input_widget.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_widget.dart
@@ -2,10 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
-import 'package:smooth_app/pages/product/autocomplete.dart';
 import 'package:smooth_app/pages/product/explanation_widget.dart';
 import 'package:smooth_app/pages/product/simple_input_page_helpers.dart';
-import 'package:smooth_app/query/product_query.dart';
+import 'package:smooth_app/pages/product/simple_input_text_field.dart';
 
 /// Simple input widget: we have a list of terms, we add, we remove.
 class SimpleInputWidget extends StatefulWidget {
@@ -62,7 +61,7 @@ class _SimpleInputWidgetState extends State<SimpleInputWidget> {
               children: <Widget>[
                 Flexible(
                   flex: 1,
-                  child: SimpleInputWidgetField(
+                  child: SimpleInputTextField(
                     autocompleteKey: _autocompleteKey,
                     focusNode: _focusNode,
                     constraints: constraints,
@@ -124,135 +123,4 @@ class _SimpleInputWidgetState extends State<SimpleInputWidget> {
       ],
     );
   }
-}
-
-// TODO(monsieurtanuki): put it in its own file as it's not private anymore.
-class SimpleInputWidgetField extends StatelessWidget {
-  const SimpleInputWidgetField({
-    required this.focusNode,
-    required this.autocompleteKey,
-    required this.constraints,
-    required this.tagType,
-    required this.hintText,
-    required this.controller,
-    this.withClearButton = false,
-  });
-
-  final FocusNode focusNode;
-  final Key autocompleteKey;
-  final BoxConstraints constraints;
-  final TagType? tagType;
-  final String hintText;
-  final TextEditingController controller;
-  final bool withClearButton;
-
-  @override
-  Widget build(BuildContext context) => Padding(
-        padding: const EdgeInsets.only(left: LARGE_SPACE),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          crossAxisAlignment: CrossAxisAlignment.center,
-          mainAxisSize: MainAxisSize.max,
-          children: <Widget>[
-            SizedBox(
-              width: constraints.maxWidth -
-                  LARGE_SPACE -
-                  (withClearButton ? MINIMUM_TOUCH_SIZE : 0),
-              child: RawAutocomplete<String>(
-                key: autocompleteKey,
-                focusNode: focusNode,
-                textEditingController: controller,
-                optionsBuilder: (final TextEditingValue value) async {
-                  final List<String> result = <String>[];
-                  final String input = value.text.trim();
-
-                  if (input.isEmpty) {
-                    return result;
-                  }
-
-                  if (tagType == null) {
-                    return result;
-                  }
-
-                  // TODO(monsieurtanuki): ask off-dart to return Strings instead of dynamic?
-                  final List<dynamic> data =
-                      await OpenFoodAPIClient.getAutocompletedSuggestions(
-                    tagType!,
-                    language: ProductQuery.getLanguage()!,
-                    limit: 1000000, // lower max count on the server anyway
-                    input: value.text.trim(),
-                  );
-                  for (final dynamic item in data) {
-                    result.add(item.toString());
-                  }
-                  result.sort();
-                  return result;
-                },
-                fieldViewBuilder: (BuildContext context,
-                        TextEditingController textEditingController,
-                        FocusNode focusNode,
-                        VoidCallback onFieldSubmitted) =>
-                    TextField(
-                  controller: textEditingController,
-                  decoration: InputDecoration(
-                    filled: true,
-                    border: const OutlineInputBorder(
-                      borderRadius: ANGULAR_BORDER_RADIUS,
-                      borderSide: BorderSide.none,
-                    ),
-                    contentPadding: const EdgeInsets.symmetric(
-                      horizontal: SMALL_SPACE,
-                      vertical: SMALL_SPACE,
-                    ),
-                    hintText: hintText,
-                  ),
-                  autofocus: true,
-                  focusNode: focusNode,
-                ),
-                optionsViewBuilder: (
-                  BuildContext lContext,
-                  AutocompleteOnSelected<String> onSelected,
-                  Iterable<String> options,
-                ) {
-                  final double screenHeight =
-                      MediaQuery.of(context).size.height;
-                  final double keyboardHeight =
-                      MediaQuery.of(lContext).viewInsets.bottom;
-
-                  final double widgetPosition =
-                      (context.findRenderObject() as RenderBox?)
-                              ?.localToGlobal(Offset.zero)
-                              .dy ??
-                          0.0;
-
-                  return AutocompleteOptions<String>(
-                    displayStringForOption:
-                        RawAutocomplete.defaultStringForOption,
-                    onSelected: onSelected,
-                    options: options,
-                    // Width = Row width - horizontal padding
-                    maxOptionsWidth: constraints.maxWidth - (LARGE_SPACE * 2),
-                    maxOptionsHeight: screenHeight -
-                        (keyboardHeight == 0
-                            ? kBottomNavigationBarHeight
-                            : keyboardHeight) -
-                        widgetPosition -
-                        // Vertical padding
-                        (LARGE_SPACE * 2) -
-                        // Height of the TextField
-                        (DefaultTextStyle.of(context).style.fontSize ?? 0) -
-                        // Elevation
-                        4.0,
-                  );
-                },
-              ),
-            ),
-            if (withClearButton)
-              IconButton(
-                icon: const Icon(Icons.clear),
-                onPressed: () => controller.text = '',
-              ),
-          ],
-        ),
-      );
 }


### PR DESCRIPTION
New files:
* `simple_input_number_field.dart`: Simple input text field, for numbers.
* `simple_input_text_field.dart`: Simple input text field, with autocompletion. Used to be in `simple_input_widget.dart`

Impacted files:
* `edit_new_packagings.dart`: minor refactoring
* `edit_new_packagings_component.dart`: now we use a numeric keyboard for number of units and weight
* `edit_new_packagings_helper.dart`: now we format and parse number of units as int? and weight as double?
* `nutrition_page_loaded.dart`: minor refactoring
* `simple_input_widget.dart`: refactored code to new file `simple_input_text_field.dart`

### What
- Now we switch to numeric keyboards for 2 packaging numeric fields (number of units and weight).
- We also format and parse their values according to the query locale.
- We still don't return a message or return `null` if we cannot parse, but it's far more unlikely.
### Screenshot
| number of units | weight in grams |
| -- | -- |
| ![Capture d’écran 2023-02-06 à 13 23 52](https://user-images.githubusercontent.com/11576431/216975081-a2a59034-e9e0-4751-aa6a-ccee447ad1da.png) | ![Capture d’écran 2023-02-06 à 13 22 42](https://user-images.githubusercontent.com/11576431/216975150-a7359790-2d63-4702-9414-7b1ae91c42ec.png) |

### Fixes bug(s)
- Fixes: #3663