### PR TITLE
feat: format sign_up_errors to normal texts instead of HTML format

### DIFF
--- a/packages/smooth_app/lib/generic_lib/loading_dialog.dart
+++ b/packages/smooth_app/lib/generic_lib/loading_dialog.dart
@@ -50,10 +50,13 @@ class LoadingDialog<T> {
                   width: MINIMUM_TOUCH_SIZE * 2,
                   package: AppHelper.APP_PACKAGE,
                 ),
-                Text(
-                  title ??
-                      appLocalizations.loading_dialog_default_error_message,
-                  textAlign: TextAlign.center,
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: MEDIUM_SPACE),
+                  child: Text(
+                    title ??
+                        appLocalizations.loading_dialog_default_error_message,
+                    textAlign: TextAlign.center,
+                  ),
                 ),
               ],
             ),

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -214,7 +214,7 @@
     "sign_up_page_username_hint": "Username: Publicly visible",
     "sign_up_page_username_error_empty": "Please enter a username",
     "sign_up_page_username_error_invalid": "Please enter a valid username",
-    "sign_up_page_username_description": "Username cannot contains spaces, caps or special characters",
+    "sign_up_page_username_description": "Username cannot contains spaces, caps or special characters.",
     "sign_up_page_username_length_invalid": "Username cannot exceed {value} characters",
     "@sign_up_page_username_length_invalid": {
         "placeholders": {
@@ -253,6 +253,9 @@
     "sign_up_page_producer_hint": "Producer/brand",
     "sign_up_page_producer_error_empty": "Please enter a producer or a brand name",
     "sign_up_page_subscribe_checkbox": "I'd like to subscribe to the Open Food Facts newsletter (You can unsubscribe from it at any time)",
+    "sign_up_page_user_name_already_used": "The user name already exists, please choose another username.",
+    "sign_up_page_email_already_exists": "already exists, login to the account or try with another email.",
+    "sign_up_page_provide_valid_email": "Please provide a valid email adress.",
     "@Settings": {},
     "settingsTitle": "Settings",
     "@settingsTitle": {

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -255,7 +255,7 @@
     "sign_up_page_subscribe_checkbox": "I'd like to subscribe to the Open Food Facts newsletter (You can unsubscribe from it at any time)",
     "sign_up_page_user_name_already_used": "The user name already exists, please choose another username.",
     "sign_up_page_email_already_exists": "already exists, login to the account or try with another email.",
-    "sign_up_page_provide_valid_email": "Please provide a valid email adress.",
+    "sign_up_page_provide_valid_email": "Please provide a valid email address.",
     "@Settings": {},
     "settingsTitle": "Settings",
     "@settingsTitle": {

--- a/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
@@ -315,6 +315,7 @@ class _SignUpPageState extends State<SignUpPage> with TraceableClientMixin {
   }
 
   Future<void> _signUp() async {
+    final AppLocalizations appLocalisations = AppLocalizations.of(context);
     _disagreed = !_agree;
     setState(() {});
     if (!_formKey.currentState!.validate() || _disagreed) {
@@ -333,34 +334,47 @@ class _SignUpPageState extends State<SignUpPage> with TraceableClientMixin {
         newsletter: _subscribe,
         orgName: _foodProducer ? _brandController.trimmedText : null,
       ),
-      title: AppLocalizations.of(context).sign_up_page_action_doing_it,
+      title: appLocalisations.sign_up_page_action_doing_it,
     );
     if (status == null) {
       // probably the end user stopped the dialog
       return;
     }
     if (status.error != null) {
-      // ignore: use_build_context_synchronously
-      await LoadingDialog.error(context: context, title: status.error);
+      String? errorMessage;
 
       // Highlight the field with the error
       if (status.statusErrors?.isNotEmpty == true) {
         if (status.statusErrors!
             .contains(SignUpStatusError.EMAIL_ALREADY_USED)) {
           _emailFocusNode.requestFocus();
+          errorMessage =
+              '${_emailController.trimmedText} ${appLocalisations.sign_up_page_email_already_exists}';
         } else if (status.statusErrors!
-            .contains(SignUpStatusError.INCORRECT_EMAIL)) {
+                .contains(SignUpStatusError.INCORRECT_EMAIL) ||
+            status.error!.contains('Invalid e-mail address')) {
           _emailFocusNode.requestFocus();
+          errorMessage = appLocalisations.sign_up_page_provide_valid_email;
         } else if (status.statusErrors!
             .contains(SignUpStatusError.INVALID_PASSWORD)) {
           _password1FocusNode.requestFocus();
+          errorMessage = appLocalisations.sign_up_page_password_error_invalid;
         } else if (status.statusErrors!
-                .contains(SignUpStatusError.INVALID_USERNAME) ||
-            status.statusErrors!
-                .contains(SignUpStatusError.USERNAME_ALREADY_USED)) {
+            .contains(SignUpStatusError.INVALID_USERNAME)) {
           _userFocusNode.requestFocus();
+          errorMessage =
+              '${appLocalisations.sign_up_page_username_description}  ${appLocalisations.sign_up_page_username_length_invalid}';
+        } else if (status.statusErrors!
+            .contains(SignUpStatusError.USERNAME_ALREADY_USED)) {
+          _userFocusNode.requestFocus();
+          errorMessage = appLocalisations.sign_up_page_user_name_already_used;
+        } else {
+          errorMessage = status.error;
         }
       }
+
+      // ignore: use_build_context_synchronously
+      await LoadingDialog.error(context: context, title: errorMessage);
 
       return;
     }
@@ -373,7 +387,7 @@ class _SignUpPageState extends State<SignUpPage> with TraceableClientMixin {
     await showDialog<void>(
       context: context,
       builder: (BuildContext context) => SmoothAlertDialog(
-        body: Text(AppLocalizations.of(context).sign_up_page_action_ok),
+        body: Text(appLocalisations.sign_up_page_action_ok),
         positiveAction: SmoothActionButton(
           text: AppLocalizations.of(context).okay,
           onPressed: () => Navigator.of(context).pop(),


### PR DESCRIPTION
### What

- added proper error messages for possible errors we could get.
- wrapped an error message text widget with a padding widget in `loading_dialog.dart` so that it looks not conducted.
- added required texts in `app_en.arb`.

### Impacted_files 

  - `lib/generic_lib/loading_dialog.dart` 
  - `lib/pages/user_management/sign_up_page.dart`
  - `lib/l10n/app_en.arb`


### Screenshot
1) Invalid email address
    - Mock-up:
![image](https://user-images.githubusercontent.com/93595710/218252526-de4c2b69-06ce-4194-b702-2c12db133fbb.png)
    - Result:
![image](https://user-images.githubusercontent.com/93595710/218252557-f9ed2c35-3667-474a-9a74-66c6faa926ab.png)

2) Email exists already
    - Mock-up:
![image](https://user-images.githubusercontent.com/93595710/218252593-06fc2769-8f93-4f06-a5ce-eeee4e07eabd.png)
   - Result:
![image](https://user-images.githubusercontent.com/93595710/218252610-00e9e228-c6ee-4b4a-9aff-affa81eda62e.png)

3) User name exists already
    - Mock-up:
![image](https://user-images.githubusercontent.com/93595710/218252666-c9ca2c3e-7f7a-4c98-bbbe-62837666571e.png)
    - Result:   
![image](https://user-images.githubusercontent.com/93595710/218252691-5b0d10dd-bd42-4326-9209-a3c8a91da480.png)

- Other errors like too long user name, short password, password not matching errors we dont get because its validated before sending request to the server.

### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes: #3691 <!-- #1 Note: you can also use Closes: -->

### Part of 
- #525 <!-- Add the most granular issue possible -->
