### PR TITLE
refactor: move usermanagementProvider after if check!

### DIFF
--- a/packages/smooth_app/lib/pages/user_management/login_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/login_page.dart
@@ -36,11 +36,12 @@ class _LoginPageState extends State<LoginPage> with TraceableClientMixin {
   final TextEditingController passwordController = TextEditingController();
 
   Future<void> _login(BuildContext context) async {
-    final UserManagementProvider userManagementProvider =
-        context.read<UserManagementProvider>();
     if (!_formKey.currentState!.validate()) {
       return;
     }
+
+    final UserManagementProvider userManagementProvider =
+        context.read<UserManagementProvider>();
 
     setState(() {
       _runningQuery = true;


### PR DESCRIPTION
### What
<!-- description of the PR -->
- Moved usermanagementProvide declaration after the form state if check. Because if we return from that check the provider will simply executes the read function.

- Impacted_files:
    - `packages/smooth_app/lib/pages/user_management/login_page.dart`

### Part of 
- #525 <!-- Add the most granular issue possible -->
