### PR TITLE
fix: dialogs with actions impossible to understand they are clickable

### DIFF
--- a/packages/smooth_app/lib/generic_lib/dialogs/smooth_alert_dialog.dart
+++ b/packages/smooth_app/lib/generic_lib/dialogs/smooth_alert_dialog.dart
@@ -416,6 +416,7 @@ class _SmoothActionFlatButton extends StatelessWidget {
           textStyle: themeData.textTheme.bodyMedium!.copyWith(
             color: themeData.colorScheme.onPrimary,
           ),
+          backgroundColor: Theme.of(context).focusColor,
           padding: const EdgeInsets.symmetric(
             horizontal: SMALL_SPACE,
           ),

--- a/packages/smooth_app/lib/generic_lib/dialogs/smooth_alert_dialog.dart
+++ b/packages/smooth_app/lib/generic_lib/dialogs/smooth_alert_dialog.dart
@@ -409,16 +409,20 @@ class _SmoothActionFlatButton extends StatelessWidget {
       ),
       child: TextButton(
         onPressed: buttonData.onPressed,
-        style: TextButton.styleFrom(
-          shape: const RoundedRectangleBorder(
-            borderRadius: ROUNDED_BORDER_RADIUS,
+        style: ButtonStyle(
+          shape: MaterialStateProperty.all(const RoundedRectangleBorder(
+              borderRadius: ROUNDED_BORDER_RADIUS)),
+          textStyle: MaterialStateProperty.all<TextStyle>(
+            themeData.textTheme.bodyMedium!.copyWith(
+              color: themeData.colorScheme.onPrimary,
+            ),
           ),
-          textStyle: themeData.textTheme.bodyMedium!.copyWith(
-            color: themeData.colorScheme.onPrimary,
-          ),
-          backgroundColor: themeData.buttonTheme.colorScheme?.secondary,
-          padding: const EdgeInsets.symmetric(
-            horizontal: SMALL_SPACE,
+          backgroundColor:
+              MaterialStateProperty.all<Color>(themeData.colorScheme.secondary),
+          padding: MaterialStateProperty.all<EdgeInsetsGeometry>(
+            const EdgeInsets.symmetric(
+              horizontal: SMALL_SPACE,
+            ),
           ),
         ),
         child: SizedBox(

--- a/packages/smooth_app/lib/generic_lib/dialogs/smooth_alert_dialog.dart
+++ b/packages/smooth_app/lib/generic_lib/dialogs/smooth_alert_dialog.dart
@@ -416,7 +416,7 @@ class _SmoothActionFlatButton extends StatelessWidget {
           textStyle: themeData.textTheme.bodyMedium!.copyWith(
             color: themeData.colorScheme.onPrimary,
           ),
-          backgroundColor: Theme.of(context).focusColor,
+          backgroundColor: themeData.buttonTheme.colorScheme?.secondary,
           padding: const EdgeInsets.symmetric(
             horizontal: SMALL_SPACE,
           ),


### PR DESCRIPTION
### What

- We have smooth action buttons with two categories, the Text button, and the Elevated button. Where ever we have used text buttons it's impossible to understand whether it's a button or not.
- Added a light background color so that it will be distinguishable,
<!-- 
Please name your pull request following this scheme: `type: What you did` this allows us to automatically generate the changelog
Following `type`s are allowed:
  - `feat`, for Features
  - `fix`, for Bug Fixes
  - `docs`, for Documentation
  - `ci`, for Automation
  - `refactor`, for code Refactoring
  - `chore`, for Miscellaneous things
-->
### Screenshot
<p float="left"> 
<img src="https://user-images.githubusercontent.com/93595710/219760322-b08d847d-3cfc-41ab-8a66-1c5e1cba75f1.png" width="170">
<img src="https://user-images.githubusercontent.com/93595710/219760355-f51cf841-91fd-4b92-817e-140217b65832.png" width="170">
<img src="https://user-images.githubusercontent.com/93595710/219760763-fe504301-d9d7-4cb6-97d4-911a7b384e35.png" width="170">
<img src="https://user-images.githubusercontent.com/93595710/219761399-f073b201-ccc2-4cfc-aaa7-a973926e9f4c.png" width="170">
</p>

<!-- Insert a screenshot to provide visual record of your changes, if visible -->

### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- part of : #2635 <!-- #1 Note: you can also use Closes: -->

### Part of 
- #525 <!-- Add the most granular issue possible -->
