### PR TITLE
fix: 3700 - Fixed widget overflow issues in product editing page

### DIFF
--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -227,8 +227,7 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         crossAxisAlignment: CrossAxisAlignment.center,
         children: <Widget>[
-          SizedBox(
-            width: getColumnSizeFromContext(context, 0.55),
+          Expanded(
             child: _getNutrientCell(
               appLocalizations,
               orderedNutrient,
@@ -236,7 +235,7 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
             ),
           ),
           SizedBox(
-            width: getColumnSizeFromContext(context, 0.25),
+            width: getColumnSizeFromContext(context, 0.3),
             child: _getUnitCell(orderedNutrient),
           ),
         ],

--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -228,7 +228,7 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
         crossAxisAlignment: CrossAxisAlignment.center,
         children: <Widget>[
           SizedBox(
-            width: getColumnSizeFromContext(context, 0.6),
+            width: getColumnSizeFromContext(context, 0.55),
             child: _getNutrientCell(
               appLocalizations,
               orderedNutrient,
@@ -236,7 +236,7 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
             ),
           ),
           SizedBox(
-            width: getColumnSizeFromContext(context, 0.3),
+            width: getColumnSizeFromContext(context, 0.25),
             child: _getUnitCell(orderedNutrient),
           ),
         ],

--- a/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
@@ -32,8 +32,7 @@ class SimpleInputTextField extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.center,
           mainAxisSize: MainAxisSize.max,
           children: <Widget>[
-            SizedBox(
-              width: constraints.maxWidth - LARGE_SPACE - MINIMUM_TOUCH_SIZE,
+            Expanded(
               child: RawAutocomplete<String>(
                 key: autocompleteKey,
                 focusNode: focusNode,

--- a/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
@@ -33,9 +33,7 @@ class SimpleInputTextField extends StatelessWidget {
           mainAxisSize: MainAxisSize.max,
           children: <Widget>[
             SizedBox(
-              width: constraints.maxWidth -
-                  LARGE_SPACE -
-                  (withClearButton ? MINIMUM_TOUCH_SIZE : 0),
+              width: constraints.maxWidth - LARGE_SPACE - MINIMUM_TOUCH_SIZE,
               child: RawAutocomplete<String>(
                 key: autocompleteKey,
                 focusNode: focusNode,


### PR DESCRIPTION
Fixed #3700 
Before: 
![photo_2023-02-13_11-12-33](https://user-images.githubusercontent.com/73269919/219776453-a05f8a56-c7dd-4507-80e9-13c5c4fed633.jpg)

After:
![photo_2023-02-18_01-23-27](https://user-images.githubusercontent.com/73269919/219777953-c051a3db-931d-435a-bcb3-9e61da6def41.jpg)

**It is checked and verified on various screen sizes.**