### PR TITLE
fix: checkBox not showing right mark in dark theme

### DIFF
--- a/packages/smooth_app/lib/pages/image_crop_page.dart
+++ b/packages/smooth_app/lib/pages/image_crop_page.dart
@@ -9,6 +9,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/database/dao_int.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/generic_lib/loading_dialog.dart';
 import 'package:smooth_app/helpers/camera_helper.dart';
@@ -53,6 +54,7 @@ Future<UserPictureSource?> _getUserPictureSource(
         title: appLocalizations.choose_image_source_title,
         actionsAxis: Axis.vertical,
         body: CheckboxListTile(
+          activeColor: FAIR_GREY_COLOR,
           value: remember,
           onChanged: (final bool? value) => setState(
             () => remember = value,


### PR DESCRIPTION
### What
<!-- description of the PR -->
- Checkbox tick color and active color were the same, thats why the tick was not visible<!-- Changed x to achieve y -->
<!-- 
Please name your pull request following this scheme: `type: What you did` this allows us to automatically generate the changelog
Following `type`s are allowed:
  - `feat`, for Features
  - `fix`, for Bug Fixes
  - `docs`, for Documentation
  - `ci`, for Automation
  - `refactor`, for code Refactoring
  - `chore`, for Miscellaneous things
-->
### Screenshot
<p float="left">
<img src="https://user-images.githubusercontent.com/93595710/220377011-52703d9b-1b64-43ce-ad07-a5248b219152.png" width="200">
<img src="https://user-images.githubusercontent.com/93595710/220377026-ca1747f0-b579-4bfa-b7d6-856b65a30d4f.png" width="200">
</p>
<!-- Insert a screenshot to provide visual record of your changes, if visible -->

### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes: #3720 <!-- #1 Note: you can also use Closes: -->

### Part of 
- #525 <!-- Add the most granular issue possible -->
