### PR TITLE
feat: Clearer 'Packaging components' preview and modified the maximum size of the autocomplete tab.

### DIFF
--- a/packages/smooth_app/lib/pages/product/edit_new_packagings.dart
+++ b/packages/smooth_app/lib/pages/product/edit_new_packagings.dart
@@ -99,7 +99,7 @@ class _EditNewPackagingsState extends State<EditNewPackagings> {
         SmoothCard(
           color: _getSmoothCardColorAlternate(context, index),
           child: EditNewPackagingsComponent(
-            title: appLocalizations.edit_packagings_element_title(index + 1),
+            title: _helpers[index].getSubTitle(),
             deleteCallback: () =>
                 setState(() => _removePackagingAt(deleteIndex)),
             helper: _helpers[index],

--- a/packages/smooth_app/lib/pages/product/edit_new_packagings_helper.dart
+++ b/packages/smooth_app/lib/pages/product/edit_new_packagings_helper.dart
@@ -75,23 +75,36 @@ class EditNewPackagingsHelper {
 
     void addIfNotEmpty(final String text) {
       if (text.isNotEmpty) {
-        result.add(text);
+        result.add('$text ');
       }
     }
 
-    addIfNotEmpty(controllerUnits.text);
+
+    if (controllerUnits.text.isNotEmpty) {
+      result.add('${controllerUnits.text} x ');
+    }
+    
     addIfNotEmpty(controllerShape.text);
-    addIfNotEmpty(controllerMaterial.text);
-    addIfNotEmpty(controllerRecycling.text);
-    addIfNotEmpty(controllerWeight.text);
     addIfNotEmpty(controllerQuantity.text);
+
+    if (controllerMaterial.text.isNotEmpty & controllerWeight.text.isNotEmpty) {
+      result.add('(${controllerMaterial.text} : ${controllerWeight.text}g)');
+    }
+
+    else if (controllerMaterial.text.isNotEmpty ) { // Therefore controllerWeight.text is empty
+          result.add('(${controllerMaterial.text})');
+    }
 
     if (result.isEmpty) {
       return null;
     }
-    return result.join(' ');
+    return result.join('');
   }
 
+  /// Returns the packaging subtitle from the controllers
+String getSubTitle() {
+    return controllerRecycling.text;
+}
   /// Returns the packaging from the controllers.
   ProductPackaging getPackaging() {
     final ProductPackaging packaging = ProductPackaging();

--- a/packages/smooth_app/lib/pages/product/edit_new_packagings_helper.dart
+++ b/packages/smooth_app/lib/pages/product/edit_new_packagings_helper.dart
@@ -86,18 +86,15 @@ class EditNewPackagingsHelper {
     addIfNotEmpty(controllerShape.text);
     addIfNotEmpty(controllerQuantity.text);
 
-    if (controllerMaterial.text.isNotEmpty & controllerWeight.text.isNotEmpty) {
-      result.add('(${controllerMaterial.text}: ${controllerWeight.text}g)');
-    }
-
-    if (controllerMaterial.text.isNotEmpty & controllerWeight.text.isEmpty) {
-      result.add('(${controllerMaterial.text})');
-    }
-
-    if (controllerMaterial.text.isEmpty & controllerWeight.text.isNotEmpty) {
+    if (controllerMaterial.text.isNotEmpty) {
+      if (controllerWeight.text.isNotEmpty) {
+        result.add('(${controllerMaterial.text}: ${controllerWeight.text}g)');
+      } else {
+        result.add('(${controllerMaterial.text})');
+      }
+    } else if (controllerWeight.text.isNotEmpty) {
       result.add('(${controllerWeight.text}g)');
     }
-    // And nothing is added if they are both empty.
 
     if (result.isEmpty) {
       return null;

--- a/packages/smooth_app/lib/pages/product/edit_new_packagings_helper.dart
+++ b/packages/smooth_app/lib/pages/product/edit_new_packagings_helper.dart
@@ -79,21 +79,25 @@ class EditNewPackagingsHelper {
       }
     }
 
-
     if (controllerUnits.text.isNotEmpty) {
       result.add('${controllerUnits.text} x ');
     }
-    
+
     addIfNotEmpty(controllerShape.text);
     addIfNotEmpty(controllerQuantity.text);
 
     if (controllerMaterial.text.isNotEmpty & controllerWeight.text.isNotEmpty) {
-      result.add('(${controllerMaterial.text} : ${controllerWeight.text}g)');
+      result.add('(${controllerMaterial.text}: ${controllerWeight.text}g)');
     }
 
-    else if (controllerMaterial.text.isNotEmpty ) { // Therefore controllerWeight.text is empty
-          result.add('(${controllerMaterial.text})');
+    if (controllerMaterial.text.isNotEmpty & controllerWeight.text.isEmpty) {
+      result.add('(${controllerMaterial.text})');
     }
+
+    if (controllerMaterial.text.isEmpty & controllerWeight.text.isNotEmpty) {
+      result.add('(${controllerWeight.text}g)');
+    }
+    // And nothing is added if they are both empty.
 
     if (result.isEmpty) {
       return null;
@@ -102,9 +106,10 @@ class EditNewPackagingsHelper {
   }
 
   /// Returns the packaging subtitle from the controllers
-String getSubTitle() {
+  String getSubTitle() {
     return controllerRecycling.text;
-}
+  }
+
   /// Returns the packaging from the controllers.
   ProductPackaging getPackaging() {
     final ProductPackaging packaging = ProductPackaging();

--- a/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
@@ -40,19 +40,16 @@ class SimpleInputTextField extends StatelessWidget {
                 optionsBuilder: (final TextEditingValue value) async {
                   final String input = value.text.trim();
 
-                  if (input.isEmpty) {
-                    return <String>[];
-                  }
 
                   if (tagType == null) {
                     return <String>[];
                   }
-
+                  
                   return OpenFoodAPIClient.getSuggestions(
                     tagType!,
                     language: ProductQuery.getLanguage()!,
-                    limit: 1000000, // lower max count on the server anyway
-                    input: value.text.trim(),
+                    limit: 15,
+                    input: input,
                   );
                 },
                 fieldViewBuilder: (BuildContext context,
@@ -100,17 +97,7 @@ class SimpleInputTextField extends StatelessWidget {
                     options: options,
                     // Width = Row width - horizontal padding
                     maxOptionsWidth: constraints.maxWidth - (LARGE_SPACE * 2),
-                    maxOptionsHeight: screenHeight -
-                        (keyboardHeight == 0
-                            ? kBottomNavigationBarHeight
-                            : keyboardHeight) -
-                        widgetPosition -
-                        // Vertical padding
-                        (LARGE_SPACE * 2) -
-                        // Height of the TextField
-                        (DefaultTextStyle.of(context).style.fontSize ?? 0) -
-                        // Elevation
-                        4.0,
+                    maxOptionsHeight: screenHeight/3,
                   );
                 },
               ),

--- a/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
@@ -94,14 +94,6 @@ class SimpleInputTextField extends StatelessWidget {
                 ) {
                   final double screenHeight =
                       MediaQuery.of(context).size.height;
-                  final double keyboardHeight =
-                      MediaQuery.of(lContext).viewInsets.bottom;
-
-                  final double widgetPosition =
-                      (context.findRenderObject() as RenderBox?)
-                              ?.localToGlobal(Offset.zero)
-                              .dy ??
-                          0.0;
 
                   return AutocompleteOptions<String>(
                     displayStringForOption:

--- a/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
@@ -52,7 +52,7 @@ class SimpleInputTextField extends StatelessWidget {
                   if (input.length < minLengthForSuggestions) {
                     return <String>[];
                   }
-                  
+
                   return OpenFoodAPIClient.getSuggestions(
                     tagType!,
                     language: ProductQuery.getLanguage()!,
@@ -60,7 +60,8 @@ class SimpleInputTextField extends StatelessWidget {
                     categories: categories,
                     shape: shapeProvider?.call(),
                     user: ProductQuery.getUser(),
-                    limit: 15, // number of suggestions the user can scroll through: compromise between quantity and readability of the suggestions
+                    limit:
+                        15, // number of suggestions the user can scroll through: compromise between quantity and readability of the suggestions
                     input: input,
                   );
                 },
@@ -109,7 +110,7 @@ class SimpleInputTextField extends StatelessWidget {
                     options: options,
                     // Width = Row width - horizontal padding
                     maxOptionsWidth: constraints.maxWidth - (LARGE_SPACE * 2),
-                    maxOptionsHeight: screenHeight/3,
+                    maxOptionsHeight: screenHeight / 3,
                   );
                 },
               ),

--- a/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
@@ -40,6 +40,9 @@ class SimpleInputTextField extends StatelessWidget {
                 optionsBuilder: (final TextEditingValue value) async {
                   final String input = value.text.trim();
 
+                  if (input.isEmpty) {
+                    return <String>[];
+                  }
 
                   if (tagType == null) {
                     return <String>[];

--- a/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
@@ -60,7 +60,7 @@ class SimpleInputTextField extends StatelessWidget {
                     categories: categories,
                     shape: shapeProvider?.call(),
                     user: ProductQuery.getUser(),
-                    limit: 15,
+                    limit: 15, // number of suggestions the user can scroll through: compromise between quantity and readability of the suggestions
                     input: input,
                   );
                 },


### PR DESCRIPTION
### What
<!-- description of the PR -->
- Updated the preview of the package in the 'Packaging components ' tab (cf two first screenshots)
    - Clearer
    - More coherent with what is shown on the product page.
    - Updated the getTitle() and created getSubTitle() function from packages/smooth_app/lib/pages/product/edit_new_packagings.dart 

- Autocomplete now gives hints before anything is typed. (removed from this PR, implemented in #3750)
    - The autocomplete now gives the most common answers for the field before user start typing. (Useful for packaging material, recycling...) (cf third screenshot)

- Modified the maximum size of the autocomplete tab.
    -  The autocomplete tab was unreadable if the text field was too close to the keyboard, even if the page was scrolled afterward. (cf two last screenshots) 
    - Fixing _AssertionError 'maxOptionsHeight >= 0': is not true: The old formula could give negative values.

### Screenshot
<!-- Insert a screenshot to provide visual record of your changes, if visible -->
- Old preview of the package in the 'Packaging components ' tab
![image](https://user-images.githubusercontent.com/105145857/221690480-6d106387-6a65-4c76-9b8a-dfe33ab0d2b5.png)

- New preview of the package in the 'Packaging components ' tab
![image](https://user-images.githubusercontent.com/105145857/221690636-5855cf95-49e3-4923-a6c7-9b4cd6c75d27.png)

- Autocomplete now gives hints before anything is typed
![image](https://user-images.githubusercontent.com/105145857/221696034-cdae1a59-8362-41d5-bf1e-32c09fbdb259.png)


- Old behavior of the autocomplete max size

![image](https://user-images.githubusercontent.com/105145857/221695543-5775b869-5742-42ad-9439-cbe1a5df0df9.jpeg)

Stays small even when moved:
![image](https://user-images.githubusercontent.com/105145857/221695243-2a007b88-2f52-4bd2-a7a6-95285aaf06aa.jpeg)
