### PR TITLE
fix: Hungergames user null exception

### DIFF
--- a/packages/smooth_app/lib/pages/preferences/user_preferences_contribute.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_contribute.dart
@@ -18,6 +18,7 @@ import 'package:smooth_app/pages/preferences/user_preferences_list_tile.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_page.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_widgets.dart';
 import 'package:smooth_app/pages/product/common/product_query_page_helper.dart';
+import 'package:smooth_app/pages/product/common/product_refresher.dart';
 import 'package:smooth_app/query/paged_to_be_completed_product_query.dart';
 
 /// Display of "Contribute" for the preferences page.
@@ -308,12 +309,17 @@ class UserPreferencesContribute extends AbstractUserPreferences {
         },
       );
 
-  Future<void> _hungerGames() async => Navigator.push(
-        context,
-        MaterialPageRoute<QuestionPage>(
-          builder: (_) => const QuestionPage(),
-        ),
-      );
+  Future<void> _hungerGames() async {
+    if (!await ProductRefresher().checkIfLoggedIn(context)) {
+      return;
+    }
+    Navigator.push(
+      context,
+      MaterialPageRoute<QuestionPage>(
+        builder: (_) => const QuestionPage(),
+      ),
+    );
+  }
 
   Widget _getListTile(
     final String title,


### PR DESCRIPTION
### What
<!-- description of the PR -->
- Hungergames gives the user a null exception if the user is not signed. Showing AlertDialog to join us
<!-- 
Please name your pull request following this scheme: `type: What you did` this allows us to automatically generate the changelog
Following `type`s are allowed:
  - `feat`, for Features
  - `fix`, for Bug Fixes
  - `docs`, for Documentation
  - `ci`, for Automation
  - `refactor`, for code Refactoring
  - `chore`, for Miscellaneous things
-->
### Screenshot
<img src="https://user-images.githubusercontent.com/75238158/221754580-6b9bfbaf-427a-46c6-be64-5354c40e0cbe.jpg" width=250 height=500>



### Part of 
- #3600 
