### PR TITLE
fix: Clicking outside the suggestion popup should close it

### DIFF
--- a/packages/smooth_app/lib/pages/product/edit_new_packagings.dart
+++ b/packages/smooth_app/lib/pages/product/edit_new_packagings.dart
@@ -14,6 +14,7 @@ import 'package:smooth_app/pages/product/edit_new_packagings_component.dart';
 import 'package:smooth_app/pages/product/edit_new_packagings_helper.dart';
 import 'package:smooth_app/pages/product/may_exit_page_helper.dart';
 import 'package:smooth_app/pages/product/simple_input_number_field.dart';
+import 'package:smooth_app/pages/product/simple_input_text_field.dart';
 import 'package:smooth_app/themes/color_schemes.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
@@ -189,7 +190,8 @@ class _EditNewPackagingsState extends State<EditNewPackagings> {
     );
     return WillPopScope(
       onWillPop: () async => _mayExitPage(saving: false),
-      child: SmoothScaffold(
+      child: UnfocusWhenTapOutside(
+          child: SmoothScaffold(
         appBar: SmoothAppBar(
           title: Text(appLocalizations.edit_packagings_title),
           subTitle: widget.product.productName != null
@@ -204,7 +206,7 @@ class _EditNewPackagingsState extends State<EditNewPackagings> {
           padding: const EdgeInsets.only(top: LARGE_SPACE),
           children: children,
         ),
-      ),
+      )),
     );
   }
 

--- a/packages/smooth_app/lib/pages/product/edit_new_packagings.dart
+++ b/packages/smooth_app/lib/pages/product/edit_new_packagings.dart
@@ -191,22 +191,23 @@ class _EditNewPackagingsState extends State<EditNewPackagings> {
     return WillPopScope(
       onWillPop: () async => _mayExitPage(saving: false),
       child: UnfocusWhenTapOutside(
-          child: SmoothScaffold(
-        appBar: SmoothAppBar(
-          title: Text(appLocalizations.edit_packagings_title),
-          subTitle: widget.product.productName != null
-              ? Text(
-                  widget.product.productName!,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                )
-              : null,
+        child: SmoothScaffold(
+          appBar: SmoothAppBar(
+            title: Text(appLocalizations.edit_packagings_title),
+            subTitle: widget.product.productName != null
+                ? Text(
+                    widget.product.productName!,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  )
+                : null,
+          ),
+          body: ListView(
+            padding: const EdgeInsets.only(top: LARGE_SPACE),
+            children: children,
+          ),
         ),
-        body: ListView(
-          padding: const EdgeInsets.only(top: LARGE_SPACE),
-          children: children,
-        ),
-      )),
+      ),
     );
   }
 

--- a/packages/smooth_app/lib/pages/product/simple_input_page.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page.dart
@@ -88,50 +88,51 @@ class _SimpleInputPageState extends State<SimpleInputPage> {
     return WillPopScope(
       onWillPop: () async => _mayExitPage(saving: false),
       child: UnfocusWhenTapOutside(
-          child: SmoothScaffold(
-        appBar: SmoothAppBar(
-          title: AutoSizeText(
-            getProductName(widget.product, appLocalizations),
-            maxLines: widget.product.barcode?.isNotEmpty == true ? 1 : 2,
+        child: SmoothScaffold(
+          appBar: SmoothAppBar(
+            title: AutoSizeText(
+              getProductName(widget.product, appLocalizations),
+              maxLines: widget.product.barcode?.isNotEmpty == true ? 1 : 2,
+            ),
+            subTitle: widget.product.barcode != null
+                ? Text(widget.product.barcode!)
+                : null,
           ),
-          subTitle: widget.product.barcode != null
-              ? Text(widget.product.barcode!)
-              : null,
-        ),
-        body: Padding(
-          padding: const EdgeInsets.all(SMALL_SPACE),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              Flexible(
-                flex: 1,
-                child: Scrollbar(
-                  child: ListView(children: simpleInputs),
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
-                child: SmoothActionButtonsBar(
-                  axis: Axis.horizontal,
-                  positiveAction: SmoothActionButton(
-                    text: appLocalizations.save,
-                    onPressed: () async => _exitPage(
-                      await _mayExitPage(saving: true),
-                    ),
-                  ),
-                  negativeAction: SmoothActionButton(
-                    text: appLocalizations.cancel,
-                    onPressed: () async => _exitPage(
-                      await _mayExitPage(saving: false),
-                    ),
+          body: Padding(
+            padding: const EdgeInsets.all(SMALL_SPACE),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Flexible(
+                  flex: 1,
+                  child: Scrollbar(
+                    child: ListView(children: simpleInputs),
                   ),
                 ),
-              ),
-            ],
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
+                  child: SmoothActionButtonsBar(
+                    axis: Axis.horizontal,
+                    positiveAction: SmoothActionButton(
+                      text: appLocalizations.save,
+                      onPressed: () async => _exitPage(
+                        await _mayExitPage(saving: true),
+                      ),
+                    ),
+                    negativeAction: SmoothActionButton(
+                      text: appLocalizations.cancel,
+                      onPressed: () async => _exitPage(
+                        await _mayExitPage(saving: false),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
           ),
         ),
-      )),
+      ),
     );
   }
 

--- a/packages/smooth_app/lib/pages/product/simple_input_page.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page.dart
@@ -11,6 +11,7 @@ import 'package:smooth_app/helpers/collections_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/pages/product/may_exit_page_helper.dart';
 import 'package:smooth_app/pages/product/simple_input_page_helpers.dart';
+import 'package:smooth_app/pages/product/simple_input_text_field.dart';
 import 'package:smooth_app/pages/product/simple_input_widget.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
@@ -86,7 +87,8 @@ class _SimpleInputPageState extends State<SimpleInputPage> {
 
     return WillPopScope(
       onWillPop: () async => _mayExitPage(saving: false),
-      child: SmoothScaffold(
+      child: UnfocusWhenTapOutside(
+          child: SmoothScaffold(
         appBar: SmoothAppBar(
           title: AutoSizeText(
             getProductName(widget.product, appLocalizations),
@@ -129,7 +131,7 @@ class _SimpleInputPageState extends State<SimpleInputPage> {
             ],
           ),
         ),
-      ),
+      )),
     );
   }
 

--- a/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
@@ -133,3 +133,26 @@ class SimpleInputTextField extends StatelessWidget {
         ),
       );
 }
+
+/// Allows to unfocus TextField (and dismiss the keyboard) when user tap outside the TextField and inside this widget.
+/// Therefore, this widget should be put before the Scaffold to make the TextField unfocus when tapping anywhere.
+class UnfocusWhenTapOutside extends StatelessWidget {
+  const UnfocusWhenTapOutside({Key? key, required this.child})
+      : super(key: key);
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () {
+        final FocusScopeNode currentFocus = FocusScope.of(context);
+
+        if (!currentFocus.hasPrimaryFocus) {
+          currentFocus.unfocus();
+        }
+      },
+      child: child,
+    );
+  }
+}


### PR DESCRIPTION
### What
- Created a widget that allows to unfocus the text field (and dismiss the keyboard) when user tap outside the text field and inside this widget.
- Used this widget in the edit page: for the 'Packaging components' page and all the pages generated with 'simple_input_page.dart' (Categories, Labels & Cert, Stores, Origins, Traceability codes, Country and the MultipleListTile)
- The same method doesn't seem to work with the 'Nutrition facts' page

### Videos
- Old behavior (trying to tap outside the text field but the keyboard is not dismissed)
https://user-images.githubusercontent.com/105145857/222299278-9e6f8435-8489-43eb-8b1e-c02569656e10.mp4

- New behavior
https://user-images.githubusercontent.com/105145857/222299843-cda9c3c3-b214-4145-869a-607773693f22.mp4



### Fixes bug(s)
- Fixes: #3283 


