### PR TITLE
fix: 3746 - avoid crash with robotoff thanks to safe getUser

### DIFF
--- a/packages/smooth_app/lib/query/questions_query.dart
+++ b/packages/smooth_app/lib/query/questions_query.dart
@@ -3,7 +3,7 @@ import 'package:smooth_app/query/product_query.dart';
 
 class QuestionsQuery {
   Future<List<RobotoffQuestion>> getQuestions() async {
-    final User user = OpenFoodAPIConfiguration.globalUser!;
+    final User user = ProductQuery.getUser();
     final String lc = ProductQuery.getLanguage().code;
 
     final RobotoffQuestionResult result =


### PR DESCRIPTION
Impacted file:
* `questions_query.dart`

### What
- Quick fix of an app crash (I couldn't resist, sorry @prathamsoni11)
- Which does not prevent us from giving a more elaborate answer later, including "if the user is not logged in, how many hungergames queries before we ask for / suggest a proper connection?".

### Fixes bug(s)
- Fixes: #3746

### Related issue
- #3600