### PR TITLE
fix: 3600 - user may be null for robotoff random questions

### DIFF
--- a/packages/smooth_app/lib/query/questions_query.dart
+++ b/packages/smooth_app/lib/query/questions_query.dart
@@ -3,7 +3,7 @@ import 'package:smooth_app/query/product_query.dart';
 
 class QuestionsQuery {
   Future<List<RobotoffQuestion>> getQuestions() async {
-    final User user = OpenFoodAPIConfiguration.globalUser!;
+    final User? user = OpenFoodAPIConfiguration.globalUser;
     final String lc = ProductQuery.getLanguage().code;
 
     final RobotoffQuestionResult result =

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -839,7 +839,7 @@ packages:
       name: openfoodfacts
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.1"
+    version: "2.4.0"
   openfoodfacts_flutter_lints:
     dependency: "direct dev"
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   latlong2: 0.8.1
   matomo_tracker: 1.5.0
   modal_bottom_sheet: 2.1.2
-  openfoodfacts: 2.3.1
+  openfoodfacts: 2.4.0
   # openfoodfacts:
   #   path: ../../../openfoodfacts-dart
   package_info_plus: 1.4.3+1


### PR DESCRIPTION
Impacted files:
* `pubspec.lock`: wtf
* `pubspec.yaml`: used new version of off-dart, with optional user for robotoff random questions
* `questions_query.dart`: the user may be null

### What
- Now the user can be null for RobotOff random questions, so the user can be either logged in or not and the app won't crash here.

### Fixes bug(s)
- Fixes: #3600