### PR TITLE
feat: 3783 - brought back the old visor

### DIFF
--- a/packages/smooth_app/lib/pages/scan/smooth_barcode_scanner_visor.dart
+++ b/packages/smooth_app/lib/pages/scan/smooth_barcode_scanner_visor.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:smooth_app/helpers/app_helper.dart';
+
+/// Barcode Scanner Visor widget.
+class SmoothBarcodeScannerVisor extends StatelessWidget {
+  /// Returns the Size of the visor
+  static Size _getSize(BuildContext context) => Size(
+        MediaQuery.of(context).size.width * 0.8,
+        150.0,
+      );
+
+  @override
+  Widget build(BuildContext context) => SizedBox.fromSize(
+        size: _getSize(context),
+        child: CustomPaint(
+          painter: _ScanVisorPainter(),
+          child: Center(
+            child: SvgPicture.asset(
+              'assets/icons/visor_icon.svg',
+              width: 35.0,
+              height: 32.0,
+              package: AppHelper.APP_PACKAGE,
+            ),
+          ),
+        ),
+      );
+}
+
+class _ScanVisorPainter extends CustomPainter {
+  static const double strokeWidth = 3.0;
+  static const double _fullCornerSize = 31.0;
+  static const double _halfCornerSize = _fullCornerSize / 2;
+  static const Radius _borderRadius = Radius.circular(_halfCornerSize);
+
+  final Paint _paint = Paint()
+    ..strokeWidth = strokeWidth
+    ..color = Colors.white
+    ..style = PaintingStyle.stroke;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final Rect rect = Rect.fromLTRB(0.0, 0.0, size.width, size.height);
+    canvas.drawPath(getPath(rect, false), _paint);
+  }
+
+  @override
+  bool shouldRepaint(CustomPainter oldDelegate) => false;
+
+  /// Returns a path to draw the visor
+  /// [includeLineBetweenCorners] will draw lines between each corner, instead
+  /// of moving the cursor
+  static Path getPath(Rect rect, bool includeLineBetweenCorners) {
+    final double bottomPosition;
+    if (includeLineBetweenCorners) {
+      bottomPosition = rect.bottom - strokeWidth;
+    } else {
+      bottomPosition = rect.bottom;
+    }
+
+    final Path path = Path()
+      // Top left
+      ..moveTo(rect.left, rect.top + _fullCornerSize)
+      ..lineTo(rect.left, rect.top + _halfCornerSize)
+      ..arcToPoint(
+        Offset(rect.left + _halfCornerSize, rect.top),
+        radius: _borderRadius,
+      )
+      ..lineTo(rect.left + _fullCornerSize, rect.top);
+
+    // Top right
+    if (includeLineBetweenCorners) {
+      path.lineTo(rect.right - _fullCornerSize, rect.top);
+    } else {
+      path.moveTo(rect.right - _fullCornerSize, rect.top);
+    }
+
+    path
+      ..lineTo(rect.right - _halfCornerSize, rect.top)
+      ..arcToPoint(
+        Offset(rect.right, _halfCornerSize),
+        radius: _borderRadius,
+      )
+      ..lineTo(rect.right, rect.top + _fullCornerSize);
+
+    // Bottom right
+    if (includeLineBetweenCorners) {
+      path.lineTo(rect.right, bottomPosition - _fullCornerSize);
+    } else {
+      path.moveTo(rect.right, bottomPosition - _fullCornerSize);
+    }
+
+    path
+      ..lineTo(rect.right, bottomPosition - _halfCornerSize)
+      ..arcToPoint(
+        Offset(rect.right - _halfCornerSize, bottomPosition),
+        radius: _borderRadius,
+      )
+      ..lineTo(rect.right - _fullCornerSize, bottomPosition);
+
+    // Bottom left
+    if (includeLineBetweenCorners) {
+      path.lineTo(rect.left + _fullCornerSize, bottomPosition);
+    } else {
+      path.moveTo(rect.left + _fullCornerSize, bottomPosition);
+    }
+
+    path
+      ..lineTo(rect.left + _halfCornerSize, bottomPosition)
+      ..arcToPoint(
+        Offset(rect.left, bottomPosition - _halfCornerSize),
+        radius: _borderRadius,
+      )
+      ..lineTo(rect.left, bottomPosition - _fullCornerSize);
+
+    if (includeLineBetweenCorners) {
+      path.lineTo(rect.left, rect.top + _halfCornerSize);
+    }
+
+    return path;
+  }
+}

--- a/packages/smooth_app/lib/pages/scan/smooth_barcode_scanner_zxing.dart
+++ b/packages/smooth_app/lib/pages/scan/smooth_barcode_scanner_zxing.dart
@@ -2,13 +2,12 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:qr_code_scanner/qr_code_scanner.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
-import 'package:smooth_app/helpers/app_helper.dart';
 import 'package:smooth_app/helpers/camera_helper.dart';
 import 'package:smooth_app/helpers/haptic_feedback_helper.dart';
 import 'package:smooth_app/pages/scan/scan_header.dart';
+import 'package:smooth_app/pages/scan/smooth_barcode_scanner_visor.dart';
 import 'package:smooth_app/themes/constant_icons.dart';
 import 'package:smooth_app/widgets/screen_visibility.dart';
 import 'package:visibility_detector/visibility_detector.dart';
@@ -71,74 +70,58 @@ class _SmoothBarcodeScannerZXingState extends State<SmoothBarcodeScannerZXing> {
           _visible = false;
           _controller?.pauseCamera();
         },
-        child: LayoutBuilder(
-          builder: (BuildContext context, BoxConstraints constraints) => Stack(
-            children: <Widget>[
-              QRView(
-                key: _qrKey,
-                onQRViewCreated: _onQRViewCreated,
-                overlay: QrScannerOverlayShape(
-                  borderColor: Colors.white,
-                  borderRadius: 10,
-                  borderLength: 30,
-                  borderWidth: 10,
-                  cutOutWidth: constraints.maxWidth - 2 * MINIMUM_TOUCH_SIZE,
-                  cutOutHeight: constraints.maxHeight,
-                ),
-                formatsAllowed: _barcodeFormats,
-              ),
-              const Align(
-                alignment: Alignment.topCenter,
-                child: ScanHeader(),
-              ),
-              Center(
-                child: SvgPicture.asset(
-                  'assets/icons/visor_icon.svg',
-                  package: AppHelper.APP_PACKAGE,
-                ),
-              ),
-              Align(
-                alignment: Alignment.bottomCenter,
-                child: Row(
-                  mainAxisAlignment: _showFlipCameraButton
-                      ? MainAxisAlignment.spaceBetween
-                      : MainAxisAlignment.end,
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: <Widget>[
-                    if (_showFlipCameraButton)
-                      IconButton(
-                        icon: Icon(ConstantIcons.instance.getCameraFlip()),
+        child: Stack(
+          children: <Widget>[
+            QRView(
+              key: _qrKey,
+              onQRViewCreated: _onQRViewCreated,
+              formatsAllowed: _barcodeFormats,
+            ),
+            Center(child: SmoothBarcodeScannerVisor()),
+            const Align(
+              alignment: Alignment.topCenter,
+              child: ScanHeader(),
+            ),
+            Align(
+              alignment: Alignment.bottomCenter,
+              child: Row(
+                mainAxisAlignment: _showFlipCameraButton
+                    ? MainAxisAlignment.spaceBetween
+                    : MainAxisAlignment.end,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: <Widget>[
+                  if (_showFlipCameraButton)
+                    IconButton(
+                      icon: Icon(ConstantIcons.instance.getCameraFlip()),
+                      color: Colors.white,
+                      onPressed: () async {
+                        SmoothHapticFeedback.click();
+                        await _controller?.flipCamera();
+                        setState(() {});
+                      },
+                    ),
+                  FutureBuilder<bool?>(
+                    future: _controller?.getFlashStatus(),
+                    builder: (_, final AsyncSnapshot<bool?> snapshot) {
+                      final bool? flashOn = snapshot.data;
+                      if (flashOn == null) {
+                        return EMPTY_WIDGET;
+                      }
+                      return IconButton(
+                        icon: Icon(flashOn ? Icons.flash_on : Icons.flash_off),
                         color: Colors.white,
                         onPressed: () async {
                           SmoothHapticFeedback.click();
-                          await _controller?.flipCamera();
+                          await _controller?.toggleFlash();
                           setState(() {});
                         },
-                      ),
-                    FutureBuilder<bool?>(
-                      future: _controller?.getFlashStatus(),
-                      builder: (_, final AsyncSnapshot<bool?> snapshot) {
-                        final bool? flashOn = snapshot.data;
-                        if (flashOn == null) {
-                          return EMPTY_WIDGET;
-                        }
-                        return IconButton(
-                          icon:
-                              Icon(flashOn ? Icons.flash_on : Icons.flash_off),
-                          color: Colors.white,
-                          onPressed: () async {
-                            SmoothHapticFeedback.click();
-                            await _controller?.toggleFlash();
-                            setState(() {});
-                          },
-                        );
-                      },
-                    ),
-                  ],
-                ),
+                      );
+                    },
+                  ),
+                ],
               ),
-            ],
-          ),
+            ),
+          ],
         ),
       );
 


### PR DESCRIPTION
New file:
* `smooth_barcode_scanner_visor.dart`: Barcode Scanner Visor widget.

Impacted files:
* `smooth_barcode_scanner_mlkit.dart`: now using the new `SmoothBarcodeScannerVisor` widget
* `smooth_barcode_scanner_zxing.dart`: now using the new `SmoothBarcodeScannerVisor` widget

### What
- In #3712 #3767 the Zxing visor was used for both Zxing and MLKit.
- In this PR the old visor is being brought back.

### Screenshot
| before (zxing) | after (zxing) | after (mlkit) |
| -- | -- | -- |
| ![Screenshot_2023-03-19-09-04-54](https://user-images.githubusercontent.com/11576431/226162967-5e723f49-e481-4262-8a64-47325b4f1153.png) | ![Screenshot_2023-03-19-09-17-04](https://user-images.githubusercontent.com/11576431/226162965-12f86ce1-7ddb-425a-a404-68c4315e7138.png) | ![Screenshot_2023-03-19-09-16-31](https://user-images.githubusercontent.com/11576431/226162966-1db7365d-982a-44f0-889c-f41f6ac719aa.png) |

### Fixes bug(s)
- Closes #3783