### PR TITLE
fix: 3782 - more relevant check and matomo message

### DIFF
--- a/packages/smooth_app/lib/helpers/analytics_helper.dart
+++ b/packages/smooth_app/lib/helpers/analytics_helper.dart
@@ -23,6 +23,10 @@ enum AnalyticsCategory {
 /// Event types for Matomo analytics
 enum AnalyticsEvent {
   scanAction(tag: 'scanned product', category: AnalyticsCategory.scanning),
+  scanStrangeRestart(
+      tag: 'strange restart', category: AnalyticsCategory.scanning),
+  scanStrangeRestop(
+      tag: 'strange restop', category: AnalyticsCategory.scanning),
   shareProduct(tag: 'shared product', category: AnalyticsCategory.share),
   loginAction(tag: 'logged in', category: AnalyticsCategory.userManagement),
   registerAction(tag: 'register', category: AnalyticsCategory.userManagement),
@@ -49,7 +53,7 @@ enum AnalyticsEvent {
 }
 
 enum AnalyticsEditEvents {
-  basicDetials(name: 'BasicDetails'),
+  basicDetails(name: 'BasicDetails'),
   photos(name: 'Photos'),
   powerEditScreen(name: 'Power Edit Screen'),
   ingredients_and_Origins(name: 'Ingredient And Origins'),

--- a/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
@@ -153,7 +153,7 @@ class _AddBasicDetailsPageState extends State<AddBasicDetailsPage> {
                       return;
                     }
                     AnalyticsHelper.trackProductEdit(
-                      AnalyticsEditEvents.basicDetials,
+                      AnalyticsEditEvents.basicDetails,
                       _product.barcode!,
                       true,
                     );

--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -134,7 +134,7 @@ class _EditProductPageState extends State<EditProductPage> {
                   }
 
                   AnalyticsHelper.trackProductEdit(
-                      AnalyticsEditEvents.basicDetials, _barcode);
+                      AnalyticsEditEvents.basicDetails, _barcode);
 
                   await Navigator.push<void>(
                     context,

--- a/packages/smooth_app/lib/pages/scan/smooth_barcode_scanner_mlkit.dart
+++ b/packages/smooth_app/lib/pages/scan/smooth_barcode_scanner_mlkit.dart
@@ -5,6 +5,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 import 'package:qr_code_scanner/qr_code_scanner.dart' as zxing;
 import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/app_helper.dart';
 import 'package:smooth_app/helpers/camera_helper.dart';
 import 'package:smooth_app/helpers/haptic_feedback_helper.dart';
@@ -36,7 +37,6 @@ class _SmoothBarcodeScannerMLKitState extends State<SmoothBarcodeScannerMLKit>
     BarcodeFormat.upcE,
   ];
 
-  bool _visible = false;
   bool _isStarted = true;
 
   bool get _showFlipCameraButton => CameraHelper.hasMoreThanOneCamera;
@@ -55,15 +55,15 @@ class _SmoothBarcodeScannerMLKitState extends State<SmoothBarcodeScannerMLKit>
     if (_isStarted) {
       return;
     }
+    if (_controller.isStarting) {
+      return;
+    }
     try {
       await _controller.start();
       _isStarted = true;
-    } on Exception catch (e) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text('Something went wrong (start)! $e'),
-          backgroundColor: Colors.red,
-        ),
+    } on Exception {
+      AnalyticsHelper.trackEvent(
+        AnalyticsEvent.scanStrangeRestart,
       );
     }
   }
@@ -75,12 +75,9 @@ class _SmoothBarcodeScannerMLKitState extends State<SmoothBarcodeScannerMLKit>
     try {
       await _controller.stop();
       _isStarted = false;
-    } on Exception catch (e) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text('Something went wrong (stop)! $e'),
-          backgroundColor: Colors.red,
-        ),
+    } on Exception {
+      AnalyticsHelper.trackEvent(
+        AnalyticsEvent.scanStrangeRestop,
       );
     }
   }
@@ -90,18 +87,10 @@ class _SmoothBarcodeScannerMLKitState extends State<SmoothBarcodeScannerMLKit>
         key: const ValueKey<String>('VisibilityDetector'),
         onVisibilityChanged: (final VisibilityInfo info) async {
           if (info.visible) {
-            if (_visible) {
-              return;
-            }
-            _visible = true;
             await _start();
-            return;
+          } else {
+            await _stop();
           }
-          if (!_visible) {
-            return;
-          }
-          _visible = false;
-          await _stop();
         },
         child: LayoutBuilder(
           builder: (BuildContext context, BoxConstraints constraints) {


### PR DESCRIPTION
Impacted files:
* `add_basic_details_page.dart`: unrelated typo fix
* `analytics_helper.dart`: added 2 events for matomo; unrelated typo fix
* `edit_product_page.dart`: unrelated typo fix
* `smooth_barcode_scanner_mlkit.dart`: added an `isStarting` check; now sends matomo instead of red snackbar; simplified

### What
- The red snackbars that we displayed are now replaced by matomo messages.
- In addition to that, we're now more careful about when to send an alert. More specifically, we use an additional controller check before trying to restart the camera/scanner

### Fixes bug(s)
- Fixes: #3782

### Part of 
- #3712