### PR TITLE
fix: Android signing config

### DIFF
--- a/packages/smooth_app/android/app/build.gradle
+++ b/packages/smooth_app/android/app/build.gradle
@@ -61,7 +61,7 @@ android {
 
     buildTypes {
         release {
-            signingConfig signingConfigs.debug
+            signingConfig signingConfigs.release
         }
         debug{
             signingConfig signingConfigs.debug


### PR DESCRIPTION
### What
I have wrongly committed a local change for testing. Of course, we should use the singing identity for the release and due to that the android release is failing at the moment
