### PR TITLE
fix: Incorrect theme used for the AppBar title on the Product Edition page

### DIFF
--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -27,6 +27,7 @@ import 'package:smooth_app/pages/product/ocr_packaging_helper.dart';
 import 'package:smooth_app/pages/product/product_image_gallery_view.dart';
 import 'package:smooth_app/pages/product/simple_input_page.dart';
 import 'package:smooth_app/pages/product/simple_input_page_helpers.dart';
+import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
 /// Page where we can indirectly edit all data about a product.
@@ -66,7 +67,7 @@ class _EditProductPageState extends State<EditProductPage> {
     final ThemeData theme = Theme.of(context);
 
     return SmoothScaffold(
-      appBar: AppBar(
+      appBar: SmoothAppBar(
         centerTitle: false,
         leading: const SmoothBackButton(),
         title: Column(
@@ -74,11 +75,11 @@ class _EditProductPageState extends State<EditProductPage> {
           children: <Widget>[
             AutoSizeText(
               getProductName(_product, appLocalizations),
-              minFontSize: (theme.primaryTextTheme.titleLarge?.fontSize
-                      ?.clamp(13.0, 17.0)) ??
-                  13.0,
+              minFontSize:
+                  (theme.textTheme.titleLarge?.fontSize?.clamp(13.0, 17.0)) ??
+                      13.0,
               maxLines: !_barcodeVisibleInAppbar ? 2 : 1,
-              style: theme.primaryTextTheme.titleLarge
+              style: theme.textTheme.titleLarge
                   ?.copyWith(fontWeight: FontWeight.w500),
             ),
             if (_barcode.isNotEmpty)


### PR DESCRIPTION
To follow this issue #3804, the wrong theme is used on the Product Edition Page.
Instead of the `textTheme`, the `primaryTextTheme` is used in this screen.

The `primaryTextTheme` has a white color, so white on white gives this behavior.

Before:
![Simulator Screen Shot - iPhone 14 Pro Max - 2023-03-25 at 09 09 53](https://user-images.githubusercontent.com/246838/227706395-aea60ef8-930d-4e6f-8a08-75d86ffef2e1.png)

After:
![Simulator Screen Shot - iPhone 14 Pro Max - 2023-03-25 at 09 19 01](https://user-images.githubusercontent.com/246838/227706407-e2cdebed-acfe-405d-9f24-c3f703847355.png)

