### PR TITLE
fix: 3780 - testing ios compilation with mobile_scanner fix

### DIFF
--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -47,7 +47,12 @@ dependencies:
   diacritic: 0.1.3
 
   camera: 0.10.3+2
-  mobile_scanner: 3.1.0
+  #mobile_scanner: 3.1.0
+  mobile_scanner:
+    git:
+      url: https://github.com/juliansteenbakker/mobile_scanner.git
+      ref: master
+
   qr_code_scanner: 1.0.1
   #qr_code_scanner:
   #  path: ../../../qr_code_scanner


### PR DESCRIPTION
Impacted file:
* `pubspec.yaml`: temporarily using the master branch for mobile_scanner

### What
- There were compilation problems in ios, probably due to different xcode versions, inside package mobile_scanner.
- Some code was merged (https://github.com/juliansteenbakker/mobile_scanner/pull/568) that is supposed to fix it.
- The current PR is a test if the compilation problems would go away with the latest mobile_scanner code.
- Eventually, there would be a new release of mobile_scanner and we would use it directly.

### Fixes bug(s)
- Fixes: #3780