### PR TITLE
fix: Ensure we use the same back arrow on all screens

### DIFF
--- a/packages/smooth_app/lib/pages/preferences/user_preferences_page.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_page.dart
@@ -6,6 +6,7 @@ import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/product_preferences.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/generic_lib/widgets/smooth_back_button.dart';
 import 'package:smooth_app/helpers/app_helper.dart';
 import 'package:smooth_app/pages/preferences/abstract_user_preferences.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_account.dart';
@@ -131,6 +132,7 @@ class _UserPreferencesPageState extends State<UserPreferencesPage>
       return SmoothScaffold(
         appBar: AppBar(
           title: Text(appBarTitle),
+          leading: const SmoothBackButton(),
         ),
         body: Scrollbar(child: list),
       );
@@ -154,7 +156,10 @@ class _UserPreferencesPageState extends State<UserPreferencesPage>
       brightness: Brightness.light,
       contentBehindStatusBar: false,
       spaceBehindStatusBar: false,
-      appBar: AppBar(title: Text(appBarTitle)),
+      appBar: AppBar(
+        title: Text(appBarTitle),
+        leading: const SmoothBackButton(),
+      ),
       body: ListView(children: children),
     );
   }


### PR DESCRIPTION
Hi everyone,

On all preferences pages, we use the default back arrow icon, but we have overridden the default look.

That PR ensures we use the correct icon on all Preferences pages (basically a one line fix). 

![Back](https://user-images.githubusercontent.com/246838/228800392-b47c3ea9-11a4-4244-af63-087ba259613b.png)

Fix #3827 