### PR TITLE
fix: Edit product page: ensure the barcode is not truncated on iOS

### DIFF
--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -84,7 +84,7 @@ class _EditProductPageState extends State<EditProductPage> {
             if (_barcode.isNotEmpty)
               AnimatedContainer(
                 duration: const Duration(milliseconds: 250),
-                height: _barcodeVisibleInAppbar ? 13.0 : 0.0,
+                height: _barcodeVisibleInAppbar ? 14.0 : 0.0,
                 child: Text(
                   _barcode,
                   style: theme.textTheme.titleMedium?.copyWith(


### PR DESCRIPTION
Hi everyone,

That one is a tiny UI issue, where the barcode in the `AppBar` is a little bit truncated.

As usual, a one line fix.

Before:
![228511678-55465f98-68ce-442d-a7cc-705916791ada](https://user-images.githubusercontent.com/246838/228802539-4b38e589-8fb3-4626-abd3-f9d5437143e7.png)

After:
![Simulator Screen Shot - iPhone 14 Pro - 2023-03-30 at 12 02 52](https://user-images.githubusercontent.com/246838/228802586-d7e90184-ec90-454b-adaf-35c7b2da4eb9.png)

Will fix #3821