### PR TITLE
fix: 3816 - use a 3.2.0 mlkit version of mobile_scanner

### DIFF
--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -866,11 +866,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: master
-      resolved-ref: "05d6805ae3faf2b5ea72680b4f64af712635c9c4"
+      ref: "ios-mlkit-3.2.0"
+      resolved-ref: adf50594c80edaac712944372222ec8711f22067
       url: "https://github.com/juliansteenbakker/mobile_scanner.git"
     source: git
-    version: "3.1.1"
+    version: "3.2.0"
   mockito:
     dependency: "direct dev"
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -51,7 +51,7 @@ dependencies:
   mobile_scanner:
     git:
       url: https://github.com/juliansteenbakker/mobile_scanner.git
-      ref: master
+      ref: ios-mlkit-3.2.0
 
   qr_code_scanner: 1.0.1
   #qr_code_scanner:


### PR DESCRIPTION
### What
- Implementing @juliansteenbakker's [suggestion](https://github.com/openfoodfacts/smooth-app/pull/3824#issuecomment-1489882377) about mlkit pod.
- Of course one day we'll have to fix it in a more decent manner, but let's try this one!

### Part of 
- #3816