### PR TITLE
fix: localizations 3.7

### DIFF
--- a/packages/smooth_app/lib/l10n/app_ar.arb
+++ b/packages/smooth_app/lib/l10n/app_ar.arb
@@ -722,7 +722,7 @@
             "count": {}
         }
     },
-    "plural_compare_x_products": "{count,plural, zero {} one {يقارن {count} منتجات} two {يقارن {count} منتجات} few {يقارن {count} منتجات} many {يقارن {count} منتجات}=1{قارن منتج واحد} other{يقارن {count} منتجات}}",
+    "plural_compare_x_products": "{count,plural, zero {يقارن {count} منتجات} two {يقارن {count} منتجات} few {يقارن {count} منتجات} many {يقارن {count} منتجات}=1{قارن منتج واحد} other{يقارن {count} منتجات}}",
     "@plural_compare_x_products": {
         "description": "Button label to open a page to compare all selected products to each other",
         "placeholders": {
@@ -906,14 +906,14 @@
     "@product_list_empty_message": {
         "description": "When the history list is empty, body of the message explaining to start scanning"
     },
-    "product_list_reloading_in_progress_multiple": "تحديث {count,plural,  zero {}  one {منتجات}  two {منتجات}  few {منتجات}  many {منتجات}=0{منتج} =1{منتج} other{منتجات}} في السجل الخاص بك",
+    "product_list_reloading_in_progress_multiple": "تحديث {count,plural, two {منتجات}  few {منتجات}  many {منتجات}=0{منتج} =1{منتج} other{منتجات}} في السجل الخاص بك",
     "@product_list_reloading_in_progress_multiple": {
         "description": "Message to show while loading previous scanned items",
         "placeholders": {
             "count": {}
         }
     },
-    "product_list_reloading_success_multiple": "{count,plural,  zero {}  one {منتجات}  two {منتجات}  few {منتجات}  many {منتجات}=0{منتج} =1{منتج} other{منتجات}} اكتمال التحديث",
+    "product_list_reloading_success_multiple": "{count,plural,  two {منتجات}  few {منتجات}  many {منتجات}=0{منتج} =1{منتج} other{منتجات}} اكتمال التحديث",
     "@product_list_reloading_success_multiple": {
         "description": "Message to show once previous scanned items are loaded",
         "placeholders": {

--- a/packages/smooth_app/lib/l10n/app_be.arb
+++ b/packages/smooth_app/lib/l10n/app_be.arb
@@ -1642,7 +1642,7 @@
     "@user_list_all_empty": {
         "description": "Small message when there are no user lists"
     },
-    "user_list_length": "{count,plural, one {} few {{count} прадукты} many {{count} прадуктаў}=0{Пусты спіс} =1{Адзін прадукт} other{{count} прадукту}}",
+    "user_list_length": "{count,plural, =0{Пусты спіс} =1{Адзін прадукт} other{{count} прадукту}}",
     "@user_list_length": {
         "description": "Length of a user product list",
         "placeholders": {

--- a/packages/smooth_app/lib/l10n/app_cs.arb
+++ b/packages/smooth_app/lib/l10n/app_cs.arb
@@ -687,28 +687,28 @@
             "percent": {}
         }
     },
-    "plural_ago_days": "{count,plural,  one {}  few {před {count} dny}  many {před {count} dny}=1{včera} other{ před {count} dny}}",
+    "plural_ago_days": "{count,plural,  =1{včera} other{ před {count} dny}}",
     "@plural_ago_days": {
         "description": "Cached results from: x days ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_hours": "{count,plural,  one {}  few {před {count} hodinami}  many {před {count} hodinami}=1{před hodinou} other{před {count} hodinami}}",
+    "plural_ago_hours": "{count,plural,  =1{před hodinou} other{před {count} hodinami}}",
     "@plural_ago_hours": {
         "description": "Cached results from: x hours ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_minutes": "před {count,plural, one {} few {{count} minutami} many {{count} minutami} =0{méně než minutou} =1{minutou} other{{count} minutami}}",
+    "plural_ago_minutes": "před {count,plural, =0{méně než minutou} =1{minutou} other{{count} minutami}}",
     "@plural_ago_minutes": {
         "description": "Cached results from: x minutes ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_months": "{count,plural,  one {}  few {před {count} měsíci}  many {před {count} měsíci}=1{před měsícem} other{před {count} měsíci}}",
+    "plural_ago_months": "{count,plural,  =1{před měsícem} other{před {count} měsíci}}",
     "@plural_ago_months": {
         "description": "Cached results from: x months ago",
         "placeholders": {
@@ -906,7 +906,7 @@
     "@product_list_empty_message": {
         "description": "When the history list is empty, body of the message explaining to start scanning"
     },
-    "product_list_reloading_in_progress_multiple": "Obnovuji {count,plural, one {} few {produkty} many {produktů} =0{produkt} =1{produkt} other{produkty}} v historii",
+    "product_list_reloading_in_progress_multiple": "Obnovuji {count,plural,  =0{produkt} =1{produkt} other{produkty}} v historii",
     "@product_list_reloading_in_progress_multiple": {
         "description": "Message to show while loading previous scanned items",
         "placeholders": {
@@ -1642,7 +1642,7 @@
     "@user_list_all_empty": {
         "description": "Small message when there are no user lists"
     },
-    "user_list_length": "{count,plural, one {} few {{count} produkty} many {{count} produkty}=0{Prázdný seznam} =1{Jeden produkt} other{{count} produktů}}",
+    "user_list_length": "{count,plural, =0{Prázdný seznam} =1{Jeden produkt} other{{count} produktů}}",
     "@user_list_length": {
         "description": "Length of a user product list",
         "placeholders": {

--- a/packages/smooth_app/lib/l10n/app_da.arb
+++ b/packages/smooth_app/lib/l10n/app_da.arb
@@ -687,42 +687,42 @@
             "percent": {}
         }
     },
-    "plural_ago_days": "{count,plural,  one {}=1{én dag siden} other{{count} dage siden}}",
+    "plural_ago_days": "{count,plural,  =1{én dag siden} other{{count} dage siden}}",
     "@plural_ago_days": {
         "description": "Cached results from: x days ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_hours": "{count,plural,  one {}=1{én time siden} other{{count} timer siden}}",
+    "plural_ago_hours": "{count,plural,  =1{én time siden} other{{count} timer siden}}",
     "@plural_ago_hours": {
         "description": "Cached results from: x hours ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_minutes": "{count,plural,  one {}=0{under ét minut siden} =1{ét minut siden} other{{count} minutter siden}}",
+    "plural_ago_minutes": "{count,plural,  =0{under ét minut siden} =1{ét minut siden} other{{count} minutter siden}}",
     "@plural_ago_minutes": {
         "description": "Cached results from: x minutes ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_months": "{count,plural,  one {}=1{én måned siden} other{{count} måneder siden}}",
+    "plural_ago_months": "{count,plural,  =1{én måned siden} other{{count} måneder siden}}",
     "@plural_ago_months": {
         "description": "Cached results from: x months ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_weeks": "{count,plural,  one {}=1{én uge siden} other{{count} uger siden}}",
+    "plural_ago_weeks": "{count,plural,  =1{én uge siden} other{{count} uger siden}}",
     "@plural_ago_weeks": {
         "description": "Cached results from: x weeks ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_compare_x_products": "{count,plural, one {}=1{Sammenlign ét produkt} other{Sammenlign {count} produkter}}",
+    "plural_compare_x_products": "{count,plural, =1{Sammenlign ét produkt} other{Sammenlign {count} produkter}}",
     "@plural_compare_x_products": {
         "description": "Button label to open a page to compare all selected products to each other",
         "placeholders": {
@@ -906,14 +906,14 @@
     "@product_list_empty_message": {
         "description": "When the history list is empty, body of the message explaining to start scanning"
     },
-    "product_list_reloading_in_progress_multiple": "Opfrisker {count,plural, one {} =0{produkt} =1{produkt} other{produkter}} i historikken",
+    "product_list_reloading_in_progress_multiple": "Opfrisker {count,plural,  =0{produkt} =1{produkt} other{produkter}} i historikken",
     "@product_list_reloading_in_progress_multiple": {
         "description": "Message to show while loading previous scanned items",
         "placeholders": {
             "count": {}
         }
     },
-    "product_list_reloading_success_multiple": "{count,plural, one {} =0{Produkt} =1{Produktopfriskning} other{Produktopfriskninger}} udført",
+    "product_list_reloading_success_multiple": "{count,plural,  =0{Produkt} =1{Produktopfriskning} other{Produktopfriskninger}} udført",
     "@product_list_reloading_success_multiple": {
         "description": "Message to show once previous scanned items are loaded",
         "placeholders": {
@@ -1642,7 +1642,7 @@
     "@user_list_all_empty": {
         "description": "Small message when there are no user lists"
     },
-    "user_list_length": "{count,plural, one {} =0{Tom liste} =1{Et produkt} other{{count} produkter}}",
+    "user_list_length": "{count,plural, =0{Tom liste} =1{Et produkt} other{{count} produkter}}",
     "@user_list_length": {
         "description": "Length of a user product list",
         "placeholders": {

--- a/packages/smooth_app/lib/l10n/app_de.arb
+++ b/packages/smooth_app/lib/l10n/app_de.arb
@@ -687,7 +687,7 @@
             "percent": {}
         }
     },
-    "plural_ago_days": "{count,plural,  one {}=1{gestern} other{{count} Tage her}}",
+    "plural_ago_days": "{count,plural,  =1{gestern} other{{count} Tage her}}",
     "@plural_ago_days": {
         "description": "Cached results from: x days ago",
         "placeholders": {

--- a/packages/smooth_app/lib/l10n/app_el.arb
+++ b/packages/smooth_app/lib/l10n/app_el.arb
@@ -1642,7 +1642,7 @@
     "@user_list_all_empty": {
         "description": "Small message when there are no user lists"
     },
-    "user_list_length": "{count,plural, one {} =0{Κενή λίστα} =1{Ένα προϊόν} other{{count} προϊόντα}}",
+    "user_list_length": "{count,plural, =0{Κενή λίστα} =1{Ένα προϊόν} other{{count} προϊόντα}}",
     "@user_list_length": {
         "description": "Length of a user product list",
         "placeholders": {

--- a/packages/smooth_app/lib/l10n/app_eu.arb
+++ b/packages/smooth_app/lib/l10n/app_eu.arb
@@ -687,42 +687,42 @@
             "percent": {}
         }
     },
-    "plural_ago_days": "{count,plural,  one {}=1{duela egun bat} other{duela {count} egun}}",
+    "plural_ago_days": "{count,plural,  =1{duela egun bat} other{duela {count} egun}}",
     "@plural_ago_days": {
         "description": "Cached results from: x days ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_hours": "{count,plural,  one {}=1{duela ordu bat} other{duela {count} ordu}}",
+    "plural_ago_hours": "{count,plural,  =1{duela ordu bat} other{duela {count} ordu}}",
     "@plural_ago_hours": {
         "description": "Cached results from: x hours ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_minutes": "{count,plural,  one {}=0{duela minutu bat baino gutxiago} =1{duela minutu bat} other{duela {count} minutu}}",
+    "plural_ago_minutes": "{count,plural,  =0{duela minutu bat baino gutxiago} =1{duela minutu bat} other{duela {count} minutu}}",
     "@plural_ago_minutes": {
         "description": "Cached results from: x minutes ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_months": "{count,plural,  one {}=1{duela hilabete bat} other{duela {count} hilabete}}",
+    "plural_ago_months": "{count,plural,  =1{duela hilabete bat} other{duela {count} hilabete}}",
     "@plural_ago_months": {
         "description": "Cached results from: x months ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_weeks": "{count,plural,  one {}=1{duela aste bat} other{duela {count} aste}}",
+    "plural_ago_weeks": "{count,plural,  =1{duela aste bat} other{duela {count} aste}}",
     "@plural_ago_weeks": {
         "description": "Cached results from: x weeks ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_compare_x_products": "{count,plural, one {}=1{Produktu bat alderatu} other{{count} produktu alderatu}}",
+    "plural_compare_x_products": "{count,plural, =1{Produktu bat alderatu} other{{count} produktu alderatu}}",
     "@plural_compare_x_products": {
         "description": "Button label to open a page to compare all selected products to each other",
         "placeholders": {

--- a/packages/smooth_app/lib/l10n/app_he.arb
+++ b/packages/smooth_app/lib/l10n/app_he.arb
@@ -687,7 +687,7 @@
             "percent": {}
         }
     },
-    "plural_ago_days": "{count,plural,  one {}  two {לפני יומיים}  many {לפני {count} ימים}=1{אתמול} other{לפני {count} ימים}}",
+    "plural_ago_days": "{count,plural,  two {לפני יומיים}  many {לפני {count} ימים}=1{אתמול} other{לפני {count} ימים}}",
     "@plural_ago_days": {
         "description": "Cached results from: x days ago",
         "placeholders": {
@@ -906,14 +906,14 @@
     "@product_list_empty_message": {
         "description": "When the history list is empty, body of the message explaining to start scanning"
     },
-    "product_list_reloading_in_progress_multiple": "{count,plural,  one {}  two {מוצרים מההיסטוריה שלך מתרעננים}  many {מוצרים מההיסטוריה שלך מתרעננים}=0{מוצר מההיסטוריה שלך מתרענן} =1{מוצר מההיסטוריה שלך מתרענן} other{מוצרים מההיסטוריה שלך מתרעננים}}",
+    "product_list_reloading_in_progress_multiple": "{count,plural,  two {מוצרים מההיסטוריה שלך מתרעננים}  many {מוצרים מההיסטוריה שלך מתרעננים}=0{מוצר מההיסטוריה שלך מתרענן} =1{מוצר מההיסטוריה שלך מתרענן} other{מוצרים מההיסטוריה שלך מתרעננים}}",
     "@product_list_reloading_in_progress_multiple": {
         "description": "Message to show while loading previous scanned items",
         "placeholders": {
             "count": {}
         }
     },
-    "product_list_reloading_success_multiple": "רענון ה{count,plural,  one {}  two {מוצרים}  many {מוצרים}=0{מוצר} =1{מוצר} other{מוצרים}} הושלם",
+    "product_list_reloading_success_multiple": "רענון ה{count,plural,    two {מוצרים}  many {מוצרים}=0{מוצר} =1{מוצר} other{מוצרים}} הושלם",
     "@product_list_reloading_success_multiple": {
         "description": "Message to show once previous scanned items are loaded",
         "placeholders": {
@@ -1642,7 +1642,7 @@
     "@user_list_all_empty": {
         "description": "Small message when there are no user lists"
     },
-    "user_list_length": "{count,plural, one {} two {שני מוצרים} many {{count} מוצרים} =0{רשימה ריקה} =1{מוצר אחד} other{{count} מוצרים}}",
+    "user_list_length": "{count,plural, two {שני מוצרים} many {{count} מוצרים} =0{רשימה ריקה} =1{מוצר אחד} other{{count} מוצרים}}",
     "@user_list_length": {
         "description": "Length of a user product list",
         "placeholders": {

--- a/packages/smooth_app/lib/l10n/app_it.arb
+++ b/packages/smooth_app/lib/l10n/app_it.arb
@@ -687,42 +687,42 @@
             "percent": {}
         }
     },
-    "plural_ago_days": "{count,plural,  one {}=1{un giorno fa} other{{count} giorni fa}}",
+    "plural_ago_days": "{count,plural,  =1{un giorno fa} other{{count} giorni fa}}",
     "@plural_ago_days": {
         "description": "Cached results from: x days ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_hours": "{count,plural,  one {}=1{un'ora fa} other{{count} ore fa}}",
+    "plural_ago_hours": "{count,plural,  =1{un'ora fa} other{{count} ore fa}}",
     "@plural_ago_hours": {
         "description": "Cached results from: x hours ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_minutes": "{count,plural,  one {}=0{meno di un minuto fa} =1{un minuto fa} other{{count} minuti fa}}",
+    "plural_ago_minutes": "{count,plural,  =0{meno di un minuto fa} =1{un minuto fa} other{{count} minuti fa}}",
     "@plural_ago_minutes": {
         "description": "Cached results from: x minutes ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_months": "{count,plural,  one {}=1{un mese fa} other{{count} mesi fa}}",
+    "plural_ago_months": "{count,plural,  =1{un mese fa} other{{count} mesi fa}}",
     "@plural_ago_months": {
         "description": "Cached results from: x months ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_weeks": "{count,plural,  one {}=1{una settimana fa} other{{count} settimane fa}}",
+    "plural_ago_weeks": "{count,plural,  =1{una settimana fa} other{{count} settimane fa}}",
     "@plural_ago_weeks": {
         "description": "Cached results from: x weeks ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_compare_x_products": "{count,plural, one {}=1{Confronta con un Prodotto} other{Confronta {count} Prodotti}}",
+    "plural_compare_x_products": "{count,plural, =1{Confronta con un Prodotto} other{Confronta {count} Prodotti}}",
     "@plural_compare_x_products": {
         "description": "Button label to open a page to compare all selected products to each other",
         "placeholders": {
@@ -906,14 +906,14 @@
     "@product_list_empty_message": {
         "description": "When the history list is empty, body of the message explaining to start scanning"
     },
-    "product_list_reloading_in_progress_multiple": "Aggiornando {count,plural,  one {}=0{prodotto} =1{prodotto} other{prodotti}} nella tua cronologia",
+    "product_list_reloading_in_progress_multiple": "Aggiornando {count,plural,  =0{prodotto} =1{prodotto} other{prodotti}} nella tua cronologia",
     "@product_list_reloading_in_progress_multiple": {
         "description": "Message to show while loading previous scanned items",
         "placeholders": {
             "count": {}
         }
     },
-    "product_list_reloading_success_multiple": "Aggiornamento di {count,plural,  one {}=0{Prodotto} =1{Prodotto} other{Prodotti}} completato",
+    "product_list_reloading_success_multiple": "Aggiornamento di {count,plural,  =0{Prodotto} =1{Prodotto} other{Prodotti}} completato",
     "@product_list_reloading_success_multiple": {
         "description": "Message to show once previous scanned items are loaded",
         "placeholders": {

--- a/packages/smooth_app/lib/l10n/app_nl.arb
+++ b/packages/smooth_app/lib/l10n/app_nl.arb
@@ -1642,7 +1642,7 @@
     "@user_list_all_empty": {
         "description": "Small message when there are no user lists"
     },
-    "user_list_length": "{count,plural, one {} =0{Lege lijst} =1{Een product} other{{count} producten}}",
+    "user_list_length": "{count,plural, =0{Lege lijst} =1{Een product} other{{count} producten}}",
     "@user_list_length": {
         "description": "Length of a user product list",
         "placeholders": {

--- a/packages/smooth_app/lib/l10n/app_pl.arb
+++ b/packages/smooth_app/lib/l10n/app_pl.arb
@@ -1642,7 +1642,7 @@
     "@user_list_all_empty": {
         "description": "Small message when there are no user lists"
     },
-    "user_list_length": "{count,plural, one {} few {{count} produkty} many {{count} produktów} =0{Lista pusta} =1{Jeden produkt} other{{count} produktów}}",
+    "user_list_length": "{count,plural, =0{Lista pusta} =1{Jeden produkt} other{{count} produktów}}",
     "@user_list_length": {
         "description": "Length of a user product list",
         "placeholders": {

--- a/packages/smooth_app/lib/l10n/app_pt.arb
+++ b/packages/smooth_app/lib/l10n/app_pt.arb
@@ -1642,7 +1642,7 @@
     "@user_list_all_empty": {
         "description": "Small message when there are no user lists"
     },
-    "user_list_length": "{count,plural, one {}=0{Lista vazia} =1{Um produto} other{{count} produtos}}",
+    "user_list_length": "{count,plural, =0{Lista vazia} =1{Um produto} other{{count} produtos}}",
     "@user_list_length": {
         "description": "Length of a user product list",
         "placeholders": {

--- a/packages/smooth_app/lib/l10n/app_ro.arb
+++ b/packages/smooth_app/lib/l10n/app_ro.arb
@@ -687,42 +687,42 @@
             "percent": {}
         }
     },
-    "plural_ago_days": "{count,plural,  one {}  few {{count} zile în urmă}=1{acum o zi} other{{count} zile în urmă}}",
+    "plural_ago_days": "{count,plural,  =1{acum o zi} other{{count} zile în urmă}}",
     "@plural_ago_days": {
         "description": "Cached results from: x days ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_hours": "{count,plural,  one {}  few {{count} ore în urmă}=1{acum o ora} other{{count} ore în urmă}}",
+    "plural_ago_hours": "{count,plural,  =1{acum o ora} other{{count} ore în urmă}}",
     "@plural_ago_hours": {
         "description": "Cached results from: x hours ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_minutes": "{count,plural,  one {}  few {{count} minute în urmă}=0{in urma cu mai puțin de un minut} =1{acum un minut} other{{count} minute în urmă}}",
+    "plural_ago_minutes": "{count,plural,  =0{in urma cu mai puțin de un minut} =1{acum un minut} other{{count} minute în urmă}}",
     "@plural_ago_minutes": {
         "description": "Cached results from: x minutes ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_months": "{count,plural,  one {}  few {{count} cu luni în urmă}=1{acum o luna} other{{count} cu luni în urmă}}",
+    "plural_ago_months": "{count,plural,  =1{acum o luna} other{{count} cu luni în urmă}}",
     "@plural_ago_months": {
         "description": "Cached results from: x months ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_weeks": "{count,plural,  one {}  few {{count} săptămâni în urma}=1{acum o saptamana} other{{count} săptămâni în urma}}",
+    "plural_ago_weeks": "{count,plural,  =1{acum o saptamana} other{{count} săptămâni în urma}}",
     "@plural_ago_weeks": {
         "description": "Cached results from: x weeks ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_compare_x_products": "{count,plural, one {} few {Compara {count} Produse}=1{Compara un produs} other{Compara {count} Produse}}",
+    "plural_compare_x_products": "{count,plural, =1{Compara un produs} other{Compara {count} Produse}}",
     "@plural_compare_x_products": {
         "description": "Button label to open a page to compare all selected products to each other",
         "placeholders": {
@@ -906,14 +906,14 @@
     "@product_list_empty_message": {
         "description": "When the history list is empty, body of the message explaining to start scanning"
     },
-    "product_list_reloading_in_progress_multiple": "Reîmprospătare {count,plural,  one {}  few {produse}=0{produs} =1{produs} other{produse}} în istoric",
+    "product_list_reloading_in_progress_multiple": "Reîmprospătare {count,plural,  =0{produs} =1{produs} other{produse}} în istoric",
     "@product_list_reloading_in_progress_multiple": {
         "description": "Message to show while loading previous scanned items",
         "placeholders": {
             "count": {}
         }
     },
-    "product_list_reloading_success_multiple": "{count,plural,  one {}  few {Produse}=0{Produs} =1{Produs} other{Produse}} Reîmprospătare completă",
+    "product_list_reloading_success_multiple": "{count,plural,  =0{Produs} =1{Produs} other{Produse}} Reîmprospătare completă",
     "@product_list_reloading_success_multiple": {
         "description": "Message to show once previous scanned items are loaded",
         "placeholders": {
@@ -1642,7 +1642,7 @@
     "@user_list_all_empty": {
         "description": "Small message when there are no user lists"
     },
-    "user_list_length": "{count,plural, one {} few {{count} produse} =0{Lista goală} =1{Un singur produs} other{{count} produse}}",
+    "user_list_length": "{count,plural, =0{Lista goală} =1{Un singur produs} other{{count} produse}}",
     "@user_list_length": {
         "description": "Length of a user product list",
         "placeholders": {


### PR DESCRIPTION
Impacted files:
* `app_ar.arb`
* `app_be.arb`
* `app_cs.arb`
* `app_da.arb`
* `app_de.arb`
* `app_el.arb`
* `app_eu.arb`
* `app_he.arb`
* `app_it.arb`
* `app_nl.arb`
* `app_pl.arb`
* `app_pt.arb`
* `app_ro.arb`

### What
- Recently, and probably from flutter 3.7, some incoherences were detected by the localization generator as "ICU Syntax Warning", at each app reload or `flutter pub get`
- Typically, it looks like duplicate tags were inserted, like `one` as `=1` already existed.
```log
[app_pt.arb:user_list_length] ICU Syntax Warning: The plural part specified
below is overridden by a later plural part.
    {count,plural, one {}=0{Lista vazia} =1{Um produto} other{{count} produtos}}
                   ^
```
- The idea in the current PR is to remove duplicates.

Following are the impacted localizations:
* [app_ar.arb:plural_compare_x_products]
  * [app_ar.arb:product_list_reloading_in_progress_multiple]
  * [app_ar.arb:product_list_reloading_in_progress_multiple]
  * [app_ar.arb:product_list_reloading_success_multiple]
  * [app_ar.arb:product_list_reloading_success_multiple]
* [app_be.arb:user_list_length]
* [app_cs.arb:plural_ago_days]
  * [app_cs.arb:plural_ago_hours]
  * [app_cs.arb:plural_ago_minutes]
  * [app_cs.arb:plural_ago_months]
  * [app_cs.arb:product_list_reloading_in_progress_multiple]
  * [app_cs.arb:user_list_length]
* [app_da.arb:plural_ago_days]
  * [app_da.arb:plural_ago_hours]
  * [app_da.arb:plural_ago_minutes]
  * [app_da.arb:plural_ago_months]
  * [app_da.arb:plural_ago_weeks]
  * [app_da.arb:plural_compare_x_products]
  * [app_da.arb:product_list_reloading_in_progress_multiple]
  * [app_da.arb:product_list_reloading_success_multiple]
  * [app_da.arb:user_list_length]
* [app_de.arb:plural_ago_days]
* [app_el.arb:user_list_length]
* [app_eu.arb:plural_ago_days]
  * [app_eu.arb:plural_ago_hours]
  * [app_eu.arb:plural_ago_minutes]
  * [app_eu.arb:plural_ago_months]
  * [app_eu.arb:plural_ago_weeks]
  * [app_eu.arb:plural_compare_x_products]
* [app_he.arb:plural_ago_days]
  * [app_he.arb:product_list_reloading_in_progress_multiple]
  * [app_he.arb:product_list_reloading_success_multiple]
  * [app_he.arb:user_list_length]
* [app_it.arb:plural_ago_days]
  * [app_it.arb:plural_ago_hours]
  * [app_it.arb:plural_ago_minutes]
  * [app_it.arb:plural_ago_months]
  * [app_it.arb:plural_ago_weeks]
  * [app_it.arb:plural_compare_x_products]
  * [app_it.arb:product_list_reloading_in_progress_multiple]
  * [app_it.arb:product_list_reloading_success_multiple]
* [app_nl.arb:user_list_length]
* [app_pl.arb:user_list_length]
* [app_pt.arb:user_list_length]
* [app_ro.arb:plural_ago_days]
  * [app_ro.arb:plural_ago_hours]
  * [app_ro.arb:plural_ago_minutes]
  * [app_ro.arb:plural_ago_months]
  * [app_ro.arb:plural_ago_weeks]
  * [app_ro.arb:plural_compare_x_products]
  * [app_ro.arb:product_list_reloading_in_progress_multiple]
  * [app_ro.arb:product_list_reloading_success_multiple]
  * [app_ro.arb:user_list_length]