### PR TITLE
fix: 3844 - same "picture not found" widget for OCR and gallery

### DIFF
--- a/packages/smooth_app/lib/pages/product/edit_ingredients_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_ingredients_page.dart
@@ -10,6 +10,7 @@ import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/database/transient_file.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/loading_dialog.dart';
+import 'package:smooth_app/generic_lib/widgets/picture_not_found.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/pages/image_crop_page.dart';
@@ -194,9 +195,9 @@ class _EditOcrPageState extends State<EditOcrPage> {
         mainAxisAlignment: MainAxisAlignment.center,
         crossAxisAlignment: CrossAxisAlignment.center,
         children: <Widget>[
-          Icon(
-            Icons.image_not_supported,
-            size: size.height / 4,
+          SizedBox(
+            height: size.height / 4,
+            child: const PictureNotFound(),
           ),
           Text(
             appLocalizations.ocr_image_upload_instruction,


### PR DESCRIPTION
Impacted file:
* `edit_ingredients_page.dart`: same "picture not found" widget as in gallery

### What
- The "picture not found" widget used in OCR was not explicit, and it was not the same as in gallery.
- Now it's the same.
- Is that more explicit? That's another story.
- Does that fit on my screen? That's also another story, to be dealt with anyway in #3771

### Screenshot
| before | after |
| -- | -- |
| ![Screenshot_2023-04-05-17-04-20](https://user-images.githubusercontent.com/11576431/230125541-9670f4fa-5343-4d12-a984-76e3cd1777a7.png) | ![Screenshot_2023-04-05-17-07-29](https://user-images.githubusercontent.com/11576431/230125597-5bd512c0-4735-45ea-b149-585ae87c0cab.png) |

In gallery (no change):
![Screenshot_2023-04-05-16-54-34](https://user-images.githubusercontent.com/11576431/230125833-f3fb47e7-bc33-45ef-a592-18587f819da6.png)

### Fixes bug(s)
- Fixes: #3844