### PR TITLE
feat: 3783 - now using the same padded visor for MLKit and ZXing

### DIFF
--- a/packages/smooth_app/lib/pages/scan/smooth_barcode_scanner_mlkit.dart
+++ b/packages/smooth_app/lib/pages/scan/smooth_barcode_scanner_mlkit.dart
@@ -1,15 +1,13 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
-import 'package:qr_code_scanner/qr_code_scanner.dart' as zxing;
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
-import 'package:smooth_app/helpers/app_helper.dart';
 import 'package:smooth_app/helpers/camera_helper.dart';
 import 'package:smooth_app/helpers/haptic_feedback_helper.dart';
 import 'package:smooth_app/pages/scan/scan_header.dart';
+import 'package:smooth_app/pages/scan/smooth_barcode_scanner_visor.dart';
 import 'package:smooth_app/widgets/screen_visibility.dart';
 import 'package:visibility_detector/visibility_detector.dart';
 
@@ -36,6 +34,8 @@ class _SmoothBarcodeScannerMLKitState extends State<SmoothBarcodeScannerMLKit>
     BarcodeFormat.upcA,
     BarcodeFormat.upcE,
   ];
+
+  static const double _cornerPadding = 26;
 
   bool _isStarted = true;
 
@@ -92,144 +92,121 @@ class _SmoothBarcodeScannerMLKitState extends State<SmoothBarcodeScannerMLKit>
             await _stop();
           }
         },
-        child: LayoutBuilder(
-          builder: (BuildContext context, BoxConstraints constraints) {
-            final Rect scanWindow = Rect.fromCenter(
-              center: Offset(
-                constraints.maxWidth / 2,
-                constraints.maxHeight / 2,
+        child: Stack(
+          children: <Widget>[
+            MobileScanner(
+              controller: _controller,
+              fit: BoxFit.cover,
+              errorBuilder: (
+                BuildContext context,
+                MobileScannerException error,
+                Widget? child,
+              ) =>
+                  EMPTY_WIDGET,
+              onDetect: (final BarcodeCapture capture) async {
+                for (final Barcode barcode in capture.barcodes) {
+                  final String? string = barcode.displayValue;
+                  if (string != null) {
+                    await widget.onScan(string);
+                  }
+                }
+              },
+            ),
+            const Align(
+              alignment: Alignment.topCenter,
+              child: Text(
+                'ML Kit',
+                style: TextStyle(color: Colors.red),
               ),
-              width: constraints.maxWidth - 2 * MINIMUM_TOUCH_SIZE,
-              height: constraints.maxHeight,
-            );
-            return Stack(
-              children: <Widget>[
-                MobileScanner(
-                  controller: _controller,
-                  fit: BoxFit.cover,
-                  scanWindow: scanWindow,
-                  errorBuilder: (
-                    BuildContext context,
-                    MobileScannerException error,
-                    Widget? child,
-                  ) =>
-                      EMPTY_WIDGET,
-                  onDetect: (final BarcodeCapture capture) async {
-                    for (final Barcode barcode in capture.barcodes) {
-                      final String? string = barcode.displayValue;
-                      if (string != null) {
-                        await widget.onScan(string);
-                      }
-                    }
-                  },
-                ),
-                const Align(
-                  alignment: Alignment.topCenter,
-                  child: Text(
-                    'ML Kit',
-                    style: TextStyle(color: Colors.red),
-                  ),
-                ),
-                Container(
-                  decoration: ShapeDecoration(
-                    shape: zxing.QrScannerOverlayShape(
-                      borderColor: Colors.white,
-                      borderRadius: 10,
-                      borderLength: 30,
-                      borderWidth: 10,
-                      cutOutWidth:
-                          constraints.maxWidth - 2 * MINIMUM_TOUCH_SIZE,
-                      cutOutHeight: constraints.maxHeight,
-                    ),
-                  ),
-                ),
-                const Align(
-                  alignment: Alignment.topCenter,
-                  child: ScanHeader(),
-                ),
-                Center(
-                  child: SvgPicture.asset(
-                    'assets/icons/visor_icon.svg',
-                    package: AppHelper.APP_PACKAGE,
-                  ),
-                ),
-                Align(
-                  alignment: Alignment.bottomCenter,
-                  child: Row(
-                    mainAxisAlignment: _showFlipCameraButton
-                        ? MainAxisAlignment.spaceBetween
-                        : MainAxisAlignment.end,
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    children: <Widget>[
-                      if (_showFlipCameraButton)
-                        IconButton(
+            ),
+            const Center(
+              child: Padding(
+                padding: EdgeInsets.all(_cornerPadding),
+                child: SmoothBarcodeScannerVisor(),
+              ),
+            ),
+            const Align(
+              alignment: Alignment.topCenter,
+              child: ScanHeader(),
+            ),
+            Align(
+              alignment: Alignment.bottomCenter,
+              child: Padding(
+                padding: const EdgeInsets.all(_cornerPadding),
+                child: Row(
+                  mainAxisAlignment: _showFlipCameraButton
+                      ? MainAxisAlignment.spaceBetween
+                      : MainAxisAlignment.end,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: <Widget>[
+                    if (_showFlipCameraButton)
+                      IconButton(
+                        color: Colors.white,
+                        icon: ValueListenableBuilder<CameraFacing>(
+                          valueListenable: _controller.cameraFacingState,
+                          builder: (
+                            BuildContext context,
+                            CameraFacing state,
+                            Widget? child,
+                          ) {
+                            switch (state) {
+                              case CameraFacing.front:
+                                return const Icon(Icons.camera_front);
+                              case CameraFacing.back:
+                                return const Icon(Icons.camera_rear);
+                            }
+                          },
+                        ),
+                        onPressed: () async {
+                          SmoothHapticFeedback.click();
+                          await _controller.switchCamera();
+                        },
+                      ),
+                    ValueListenableBuilder<bool?>(
+                      valueListenable: _controller.hasTorchState,
+                      builder: (
+                        BuildContext context,
+                        bool? state,
+                        Widget? child,
+                      ) {
+                        if (state != true) {
+                          return EMPTY_WIDGET;
+                        }
+                        return IconButton(
                           color: Colors.white,
-                          icon: ValueListenableBuilder<CameraFacing>(
-                            valueListenable: _controller.cameraFacingState,
+                          icon: ValueListenableBuilder<TorchState>(
+                            valueListenable: _controller.torchState,
                             builder: (
                               BuildContext context,
-                              CameraFacing state,
+                              TorchState state,
                               Widget? child,
                             ) {
                               switch (state) {
-                                case CameraFacing.front:
-                                  return const Icon(Icons.camera_front);
-                                case CameraFacing.back:
-                                  return const Icon(Icons.camera_rear);
+                                case TorchState.off:
+                                  return const Icon(
+                                    Icons.flash_off,
+                                    color: Colors.white,
+                                  );
+                                case TorchState.on:
+                                  return const Icon(
+                                    Icons.flash_on,
+                                    color: Colors.white,
+                                  );
                               }
                             },
                           ),
                           onPressed: () async {
                             SmoothHapticFeedback.click();
-                            await _controller.switchCamera();
+                            await _controller.toggleTorch();
                           },
-                        ),
-                      ValueListenableBuilder<bool?>(
-                        valueListenable: _controller.hasTorchState,
-                        builder: (
-                          BuildContext context,
-                          bool? state,
-                          Widget? child,
-                        ) {
-                          if (state != true) {
-                            return EMPTY_WIDGET;
-                          }
-                          return IconButton(
-                            color: Colors.white,
-                            icon: ValueListenableBuilder<TorchState>(
-                              valueListenable: _controller.torchState,
-                              builder: (
-                                BuildContext context,
-                                TorchState state,
-                                Widget? child,
-                              ) {
-                                switch (state) {
-                                  case TorchState.off:
-                                    return const Icon(
-                                      Icons.flash_off,
-                                      color: Colors.white,
-                                    );
-                                  case TorchState.on:
-                                    return const Icon(
-                                      Icons.flash_on,
-                                      color: Colors.white,
-                                    );
-                                }
-                              },
-                            ),
-                            onPressed: () async {
-                              SmoothHapticFeedback.click();
-                              await _controller.toggleTorch();
-                            },
-                          );
-                        },
-                      ),
-                    ],
-                  ),
+                        );
+                      },
+                    ),
+                  ],
                 ),
-              ],
-            );
-          },
+              ),
+            ),
+          ],
         ),
       );
 }

--- a/packages/smooth_app/lib/pages/scan/smooth_barcode_scanner_visor.dart
+++ b/packages/smooth_app/lib/pages/scan/smooth_barcode_scanner_visor.dart
@@ -1,61 +1,28 @@
-/*
-import 'package:camerawesome/camerawesome_plugin.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:smooth_app/helpers/app_helper.dart';
-import 'package:smooth_app/pages/scan/awesome_widgets/awesome_flash.dart';
 
-/// This Widget is a [StatefulWidget], as it uses a [GlobalKey] to allow an
-/// external access
-class ScannerVisorWidget extends StatefulWidget {
-  const ScannerVisorWidget({
-    super.key,
-    required this.state,
-  });
-  final CameraState state;
+class SmoothBarcodeScannerVisor extends StatelessWidget {
+  const SmoothBarcodeScannerVisor({super.key});
 
   @override
-  State<ScannerVisorWidget> createState() => ScannerVisorWidgetState();
-
-  /// Returns the Size of the visor
-  static Size getSize(BuildContext context) => Size(
-        MediaQuery.of(context).size.width * 0.8,
-        150.0,
-      );
-}
-
-class ScannerVisorWidgetState extends State<ScannerVisorWidget> {
-  @override
-  Widget build(BuildContext context) {
-    return Stack(
-      children: <Widget>[
-        SizedBox.fromSize(
-          size: ScannerVisorWidget.getSize(context),
-          child: CustomPaint(
-            painter: ScanVisorPainter(),
-            child: Center(
-              child: SvgPicture.asset(
-                'assets/icons/visor_icon.svg',
-                width: 35.0,
-                height: 32.0,
-                package: AppHelper.APP_PACKAGE,
-              ),
+  Widget build(BuildContext context) => SizedBox.expand(
+        child: CustomPaint(
+          painter: _ScanVisorPainter(),
+          child: Center(
+            child: SvgPicture.asset(
+              'assets/icons/visor_icon.svg',
+              width: 35.0,
+              height: 32.0,
+              package: AppHelper.APP_PACKAGE,
             ),
           ),
         ),
-        Positioned.directional(
-          textDirection: Directionality.of(context),
-          end: 0.0,
-          bottom: 0.0,
-          child: SmoothAwesomeFlashButton(state: widget.state),
-        )
-      ],
-    );
-  }
+      );
 }
 
-class ScanVisorPainter extends CustomPainter {
-  ScanVisorPainter();
+class _ScanVisorPainter extends CustomPainter {
+  _ScanVisorPainter();
 
   static const double strokeWidth = 3.0;
   static const double _fullCornerSize = 31.0;
@@ -149,4 +116,3 @@ class ScanVisorPainter extends CustomPainter {
     return path;
   }
 }
-*/

--- a/packages/smooth_app/lib/pages/scan/smooth_barcode_scanner_zxing.dart
+++ b/packages/smooth_app/lib/pages/scan/smooth_barcode_scanner_zxing.dart
@@ -2,13 +2,12 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:qr_code_scanner/qr_code_scanner.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
-import 'package:smooth_app/helpers/app_helper.dart';
 import 'package:smooth_app/helpers/camera_helper.dart';
 import 'package:smooth_app/helpers/haptic_feedback_helper.dart';
 import 'package:smooth_app/pages/scan/scan_header.dart';
+import 'package:smooth_app/pages/scan/smooth_barcode_scanner_visor.dart';
 import 'package:smooth_app/themes/constant_icons.dart';
 import 'package:smooth_app/widgets/screen_visibility.dart';
 import 'package:visibility_detector/visibility_detector.dart';
@@ -35,6 +34,8 @@ class _SmoothBarcodeScannerZXingState extends State<SmoothBarcodeScannerZXing> {
     BarcodeFormat.upcA,
     BarcodeFormat.upcE,
   ];
+
+  static const double _cornerPadding = 26;
 
   bool _visible = false;
   final GlobalKey _qrKey = GlobalKey(debugLabel: 'QR');
@@ -71,41 +72,34 @@ class _SmoothBarcodeScannerZXingState extends State<SmoothBarcodeScannerZXing> {
           _visible = false;
           _controller?.pauseCamera();
         },
-        child: LayoutBuilder(
-          builder: (BuildContext context, BoxConstraints constraints) => Stack(
-            children: <Widget>[
-              QRView(
-                key: _qrKey,
-                onQRViewCreated: _onQRViewCreated,
-                overlay: QrScannerOverlayShape(
-                  borderColor: Colors.white,
-                  borderRadius: 10,
-                  borderLength: 30,
-                  borderWidth: 10,
-                  cutOutWidth: constraints.maxWidth - 2 * MINIMUM_TOUCH_SIZE,
-                  cutOutHeight: constraints.maxHeight,
-                ),
-                formatsAllowed: _barcodeFormats,
+        child: Stack(
+          children: <Widget>[
+            QRView(
+              key: _qrKey,
+              onQRViewCreated: _onQRViewCreated,
+              formatsAllowed: _barcodeFormats,
+            ),
+            const Center(
+              child: Padding(
+                padding: EdgeInsets.all(_cornerPadding),
+                child: SmoothBarcodeScannerVisor(),
               ),
-              const Align(
-                alignment: Alignment.topCenter,
-                child: Text(
-                  'ZXing',
-                  style: TextStyle(color: Colors.red),
-                ),
+            ),
+            const Align(
+              alignment: Alignment.topCenter,
+              child: Text(
+                'ZXing',
+                style: TextStyle(color: Colors.red),
               ),
-              const Align(
-                alignment: Alignment.topCenter,
-                child: ScanHeader(),
-              ),
-              Center(
-                child: SvgPicture.asset(
-                  'assets/icons/visor_icon.svg',
-                  package: AppHelper.APP_PACKAGE,
-                ),
-              ),
-              Align(
-                alignment: Alignment.bottomCenter,
+            ),
+            const Align(
+              alignment: Alignment.topCenter,
+              child: ScanHeader(),
+            ),
+            Align(
+              alignment: Alignment.bottomCenter,
+              child: Padding(
+                padding: const EdgeInsets.all(_cornerPadding),
                 child: Row(
                   mainAxisAlignment: _showFlipCameraButton
                       ? MainAxisAlignment.spaceBetween
@@ -144,8 +138,8 @@ class _SmoothBarcodeScannerZXingState extends State<SmoothBarcodeScannerZXing> {
                   ],
                 ),
               ),
-            ],
-          ),
+            ),
+          ],
         ),
       );
 


### PR DESCRIPTION
Impacted files:
* `smooth_barcode_scanner_mlkit.dart`: now using `SmoothBarcodeScannerVisor`
* `smooth_barcode_scanner_visor.dart`: removed the flash button
* `smooth_barcode_scanner_zxing.dart`: now using `SmoothBarcodeScannerVisor`

### What
- Again, the same visor for MLKit and ZXing, but with relevant paddings.
- It was easier to start again from scratch than to resolve the conflicts.

### Screenshot
| mlkit | zxing |
| -- | -- |
| ![Screenshot_2023-04-05-18-38-08](https://user-images.githubusercontent.com/11576431/230149429-8c3215e9-3ca3-4819-ac90-f64dde0a2af7.png) | ![Screenshot_2023-04-05-18-39-21](https://user-images.githubusercontent.com/11576431/230149455-0648f5f1-df2f-4018-a73d-b1878d1a79b0.png) |

### Fixes bug(s)
- Closes: #3783