### PR TITLE
feat: 3772 - access to nutrion photo from nutrition page

### DIFF
--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -6,6 +6,7 @@ import 'package:intl/intl.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/background/background_task_details.dart';
+import 'package:smooth_app/generic_lib/buttons/smooth_large_button_with_icon.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
@@ -16,6 +17,7 @@ import 'package:smooth_app/pages/product/may_exit_page_helper.dart';
 import 'package:smooth_app/pages/product/nutrition_add_nutrient_button.dart';
 import 'package:smooth_app/pages/product/nutrition_container.dart';
 import 'package:smooth_app/pages/product/ordered_nutrients_cache.dart';
+import 'package:smooth_app/pages/product/product_image_unswipeable_view.dart';
 import 'package:smooth_app/pages/product/simple_input_number_field.dart';
 import 'package:smooth_app/pages/text_field_helper.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
@@ -134,6 +136,7 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
     children.add(_switchNoNutrition(appLocalizations));
 
     if (!_nutritionContainer.noNutritionData) {
+      children.add(_goToPicture(appLocalizations));
       children.add(_getServingField(appLocalizations));
       children.add(_getServingSwitch(appLocalizations));
 
@@ -450,6 +453,23 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
               ),
             ),
           ],
+        ),
+      );
+
+  Widget _goToPicture(final AppLocalizations appLocalizations) => Padding(
+        padding: const EdgeInsets.symmetric(vertical: MEDIUM_SPACE),
+        child: SmoothLargeButtonWithIcon(
+          onPressed: () async => Navigator.push(
+            context,
+            MaterialPageRoute<void>(
+              builder: (_) => ProductImageUnswipeableView(
+                imageField: ImageField.NUTRITION,
+                product: _product,
+              ),
+            ),
+          ),
+          icon: Icons.camera_alt,
+          text: appLocalizations.nutrition_facts_photo,
         ),
       );
 

--- a/packages/smooth_app/lib/pages/product/product_image_swipeable_view.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_swipeable_view.dart
@@ -11,16 +11,20 @@ import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/pages/product/product_image_viewer.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
-///Widget to display swipeable product images of particular category,
-///Opens product image with [initialImageIndex].
+/// Widget to display swipeable product images of particular category.
+///
+/// Opens product image with [initialImageIndex].
+/// See also [ProductImageUnswipeableView].
 class ProductImageSwipeableView extends StatefulWidget {
   const ProductImageSwipeableView({
     super.key,
     required this.product,
     required this.initialImageIndex,
   });
+
   final Product product;
   final int initialImageIndex;
+
   @override
   State<ProductImageSwipeableView> createState() =>
       _ProductImageSwipeableViewState();
@@ -79,10 +83,13 @@ class _ProductImageSwipeableViewState extends State<ProductImageSwipeableView> {
         elevation: 0,
         title: ValueListenableBuilder<int>(
           valueListenable: _currentImageDataIndex,
-          builder: (_, int index, __) => Text(getImagePageTitle(
-            appLocalizations,
-            _imageDataList[index].imageField,
-          )),
+          builder: (_, int index, __) => Text(
+            getImagePageTitle(
+              appLocalizations,
+              _imageDataList[index].imageField,
+            ),
+            maxLines: 2,
+          ),
         ),
         leading: SmoothBackButton(
           iconColor: Colors.white,

--- a/packages/smooth_app/lib/pages/product/product_image_unswipeable_view.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_unswipeable_view.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/generic_lib/widgets/smooth_back_button.dart';
+import 'package:smooth_app/helpers/product_cards_helper.dart';
+import 'package:smooth_app/pages/product/product_image_viewer.dart';
+import 'package:smooth_app/widgets/smooth_scaffold.dart';
+
+/// Display of the photo of a product image field.
+///
+/// See also [ProductImageSwipeableView].
+class ProductImageUnswipeableView extends StatefulWidget {
+  const ProductImageUnswipeableView({
+    super.key,
+    required this.product,
+    required this.imageField,
+  });
+
+  final Product product;
+  final ImageField imageField;
+
+  @override
+  State<ProductImageUnswipeableView> createState() =>
+      _ProductImageUnswipeableViewState();
+}
+
+class _ProductImageUnswipeableViewState
+    extends State<ProductImageUnswipeableView> {
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    return SmoothScaffold(
+      appBar: AppBar(
+        backgroundColor: Colors.black,
+        foregroundColor: WHITE_COLOR,
+        elevation: 0,
+        title: Text(
+          getImagePageTitle(appLocalizations, widget.imageField),
+          maxLines: 2,
+        ),
+        leading: SmoothBackButton(
+          iconColor: Colors.white,
+          onPressed: () => Navigator.maybePop(context),
+        ),
+      ),
+      body: ProductImageViewer(
+        product: widget.product,
+        imageField: widget.imageField,
+      ),
+    );
+  }
+}

--- a/packages/smooth_app/lib/pages/product/product_image_unswipeable_view.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_unswipeable_view.dart
@@ -10,7 +10,7 @@ import 'package:smooth_app/widgets/smooth_scaffold.dart';
 /// Display of the photo of a product image field.
 ///
 /// See also [ProductImageSwipeableView].
-class ProductImageUnswipeableView extends StatefulWidget {
+class ProductImageUnswipeableView extends StatelessWidget {
   const ProductImageUnswipeableView({
     super.key,
     required this.product,
@@ -21,33 +21,23 @@ class ProductImageUnswipeableView extends StatefulWidget {
   final ImageField imageField;
 
   @override
-  State<ProductImageUnswipeableView> createState() =>
-      _ProductImageUnswipeableViewState();
-}
-
-class _ProductImageUnswipeableViewState
-    extends State<ProductImageUnswipeableView> {
-  @override
-  Widget build(BuildContext context) {
-    final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    return SmoothScaffold(
-      appBar: AppBar(
-        backgroundColor: Colors.black,
-        foregroundColor: WHITE_COLOR,
-        elevation: 0,
-        title: Text(
-          getImagePageTitle(appLocalizations, widget.imageField),
-          maxLines: 2,
+  Widget build(BuildContext context) => SmoothScaffold(
+        appBar: AppBar(
+          backgroundColor: Colors.black,
+          foregroundColor: WHITE_COLOR,
+          elevation: 0,
+          title: Text(
+            getImagePageTitle(AppLocalizations.of(context), imageField),
+            maxLines: 2,
+          ),
+          leading: SmoothBackButton(
+            iconColor: Colors.white,
+            onPressed: () => Navigator.maybePop(context),
+          ),
         ),
-        leading: SmoothBackButton(
-          iconColor: Colors.white,
-          onPressed: () => Navigator.maybePop(context),
+        body: ProductImageViewer(
+          product: product,
+          imageField: imageField,
         ),
-      ),
-      body: ProductImageViewer(
-        product: widget.product,
-        imageField: widget.imageField,
-      ),
-    );
-  }
+      );
 }


### PR DESCRIPTION
New file:
* `product_image_unswipeable_view.dart`: Display of the photo of a product image field.

Impacted files:
* `nutrition_page_loaded.dart`: added a "go to picture" button
* `product_image_swipeable_view.dart`: minor refactoring

### What
- A read/write access to the nutrition photo is now provided from the nutrition page, via a button.

### Screenshot
| nutrition page with new button | new unswipeable nutrition page |
| -- | -- | 
| ![Screenshot_2023-04-06-09-07-29](https://user-images.githubusercontent.com/11576431/230306828-b069ae55-f321-4f9e-9040-554b303334ac.png) | ![Screenshot_2023-04-06-09-07-37](https://user-images.githubusercontent.com/11576431/230306861-3194c69e-7d23-4be2-ab05-3429d37f75c4.png) |

### Fixes bug(s)
- Closes: #3772