### PR TITLE
feat: 3771 - ingredient page now uses the same product image local/server buttons as gallery

### DIFF
--- a/packages/smooth_app/lib/pages/product/edit_ingredients_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_ingredients_page.dart
@@ -12,7 +12,6 @@ import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/loading_dialog.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
-import 'package:smooth_app/pages/image_crop_page.dart';
 import 'package:smooth_app/pages/product/ocr_helper.dart';
 import 'package:smooth_app/pages/product/ocr_widget.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
@@ -60,13 +59,6 @@ class _EditOcrPageState extends State<EditOcrPage> {
 
   Future<void> _onSubmitField(ImageField imageField) async =>
       _updateText(_controller.text, imageField);
-
-  /// Opens a page to upload a new image.
-  Future<void> _newImage() async => confirmAndUploadNewPicture(
-        this,
-        barcode: _product.barcode!,
-        imageField: _helper.getImageField(),
-      );
 
   /// Extracts data with OCR from the image stored on the server.
   ///
@@ -147,7 +139,6 @@ class _EditOcrPageState extends State<EditOcrPage> {
           _getImageWidget(productImageData),
           OcrWidget(
             controller: _controller,
-            onTapNewImage: _newImage,
             onTapExtractData: _extractData,
             onSubmitField: _onSubmitField,
             productImageData: productImageData,

--- a/packages/smooth_app/lib/pages/product/ocr_widget.dart
+++ b/packages/smooth_app/lib/pages/product/ocr_widget.dart
@@ -9,6 +9,8 @@ import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/pages/image_crop_page.dart';
 import 'package:smooth_app/pages/product/explanation_widget.dart';
 import 'package:smooth_app/pages/product/ocr_helper.dart';
+import 'package:smooth_app/pages/product/product_image_local_button.dart';
+import 'package:smooth_app/pages/product/product_image_server_button.dart';
 
 /// Widget dedicated to OCR, with 3 actions: upload image, extract data, save.
 ///
@@ -17,7 +19,6 @@ class OcrWidget extends StatefulWidget {
   const OcrWidget({
     required this.controller,
     required this.onSubmitField,
-    required this.onTapNewImage,
     required this.onTapExtractData,
     required this.productImageData,
     required this.product,
@@ -25,7 +26,6 @@ class OcrWidget extends StatefulWidget {
   });
 
   final TextEditingController controller;
-  final Future<void> Function() onTapNewImage;
   final Future<void> Function() onTapExtractData;
   final Future<void> Function(ImageField) onSubmitField;
   final ProductImageData productImageData;
@@ -55,16 +55,36 @@ class _OcrWidgetState extends State<OcrWidget> {
                   start: LARGE_SPACE,
                   end: LARGE_SPACE,
                 ),
-                child: SmoothActionButtonsBar(
-                  positiveAction: SmoothActionButton(
-                    text: (TransientFile.isImageAvailable(
-                      widget.productImageData,
-                      widget.product.barcode!,
-                    ))
-                        ? widget.helper.getActionRefreshPhoto(appLocalizations)
-                        : appLocalizations.upload_image,
-                    onPressed: () async => widget.onTapNewImage(),
-                  ),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  mainAxisSize: MainAxisSize.max,
+                  children: <Widget>[
+                    Expanded(
+                      child: Padding(
+                        padding:
+                            const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
+                        child: ProductImageServerButton(
+                          barcode: widget.product.barcode!,
+                          imageField: widget.helper.getImageField(),
+                        ),
+                      ),
+                    ),
+                    Expanded(
+                      child: Padding(
+                        padding:
+                            const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
+                        child: ProductImageLocalButton(
+                          firstPhoto: !TransientFile.isImageAvailable(
+                            widget.productImageData,
+                            widget.product.barcode!,
+                          ),
+                          barcode: widget.product.barcode!,
+                          imageField: widget.helper.getImageField(),
+                        ),
+                      ),
+                    ),
+                  ],
                 ),
               ),
             ),

--- a/packages/smooth_app/lib/pages/product/product_image_local_button.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_local_button.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/pages/image_crop_page.dart';
+import 'package:smooth_app/pages/product/common/product_refresher.dart';
+import 'package:smooth_app/pages/product/edit_image_button.dart';
+
+/// Button asking for a "local" photo (new from camera, existing from gallery).
+class ProductImageLocalButton extends StatefulWidget {
+  const ProductImageLocalButton({
+    required this.firstPhoto,
+    required this.barcode,
+    required this.imageField,
+  });
+
+  final bool firstPhoto;
+  final String barcode;
+  final ImageField imageField;
+
+  @override
+  State<ProductImageLocalButton> createState() =>
+      _ProductImageLocalButtonState();
+}
+
+class _ProductImageLocalButtonState extends State<ProductImageLocalButton> {
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    return EditImageButton(
+      iconData: widget.firstPhoto ? Icons.add : Icons.add_a_photo,
+      label:
+          widget.firstPhoto ? appLocalizations.add : appLocalizations.capture,
+      onPressed: () async => _actionNewImage(context),
+    );
+  }
+
+  Future<void> _actionNewImage(final BuildContext context) async {
+    final bool loggedIn = await ProductRefresher().checkIfLoggedIn(context);
+    if (!loggedIn) {
+      return;
+    }
+    if (context.mounted) {
+    } else {
+      return;
+    }
+    await confirmAndUploadNewPicture(
+      this,
+      imageField: widget.imageField,
+      barcode: widget.barcode,
+    );
+  }
+}

--- a/packages/smooth_app/lib/pages/product/product_image_server_button.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_server_button.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
+import 'package:smooth_app/generic_lib/loading_dialog.dart';
+import 'package:smooth_app/pages/image/uploaded_image_gallery.dart';
+import 'package:smooth_app/pages/product/common/product_refresher.dart';
+import 'package:smooth_app/pages/product/edit_image_button.dart';
+import 'package:smooth_app/query/product_query.dart';
+
+/// Button asking for a "server" photo (taken from what was already uploaded).
+class ProductImageServerButton extends StatelessWidget {
+  const ProductImageServerButton({
+    required this.barcode,
+    required this.imageField,
+  });
+
+  final String barcode;
+  final ImageField imageField;
+
+  @override
+  Widget build(BuildContext context) => EditImageButton(
+        iconData: Icons.image_search,
+        label: AppLocalizations.of(context)
+            .edit_photo_select_existing_button_label,
+        onPressed: () async => _actionGallery(context),
+      );
+
+  Future<void> _actionGallery(final BuildContext context) async {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    if (!context.mounted) {
+      return;
+    }
+    final bool loggedIn = await ProductRefresher().checkIfLoggedIn(context);
+    if (!loggedIn) {
+      return;
+    }
+    if (context.mounted) {
+    } else {
+      return;
+    }
+    final List<int>? result = await LoadingDialog.run<List<int>>(
+      future: OpenFoodAPIClient.getProductImageIds(
+        barcode,
+        user: ProductQuery.getUser(),
+      ),
+      context: context,
+      title: appLocalizations.edit_photo_select_existing_download_label,
+    );
+    if (result == null) {
+      return;
+    }
+    if (context.mounted) {
+    } else {
+      return;
+    }
+    if (result.isEmpty) {
+      await showDialog<void>(
+        context: context,
+        builder: (BuildContext context) => SmoothAlertDialog(
+          body:
+              Text(appLocalizations.edit_photo_select_existing_downloaded_none),
+          actionsAxis: Axis.vertical,
+          positiveAction: SmoothActionButton(
+            text: appLocalizations.okay,
+            onPressed: () => Navigator.of(context).pop(),
+          ),
+        ),
+      );
+      return;
+    }
+    await Navigator.push<void>(
+      context,
+      MaterialPageRoute<void>(
+        builder: (BuildContext context) => UploadedImageGallery(
+          barcode: barcode,
+          imageIds: result,
+          imageField: imageField,
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
New files:
* `product_image_local_button.dart`: Button asking for a "local" photo (new from camera, existing from gallery). The code used to be in `product_image_view.dart`.
* `product_image_server_button.dart`: Button asking for a "server" photo (taken from what was already uploaded). The code used to be in `product_image_view.dart`.

Impacted files:
* `edit_ingredients_page.dart`: minor refactoring
* `ocr_widget.dart`: now using new buttons `ProductImageLocalButton` and `ProductImageServerButton`
* `product_image_view.dart`: now using new buttons `ProductImageLocalButton` and `ProductImageServerButton`, whose code used to be there.

### What
- The code was refactored with 2 new buttons ("get a new camera / local gallery picture" and "get an uploaded picture"), whose code already existed in the product gallery.
- Those 2 new buttons are now used in the ingredient page; more specifically the "get an uploaded picture" feature was added.
- The UI is not terrific.

### Screenshot
| first picture | additional picture |
| -- | -- |
| ![Screenshot_2023-04-06-11-49-28](https://user-images.githubusercontent.com/11576431/230345388-3fe6aa6d-e636-448e-8ce6-cdaaee4781c8.png) | ![Screenshot_2023-04-06-11-48-50](https://user-images.githubusercontent.com/11576431/230345407-884f9ece-5be2-4490-a202-dbc22df06e72.png) |

### Fixes bug(s)
- Closes: #3771