### PR TITLE
fix: 3842 - use Xcode 14.2

### DIFF
--- a/packages/smooth_app/ios/fastlane/Fastfile
+++ b/packages/smooth_app/ios/fastlane/Fastfile
@@ -2,7 +2,7 @@ setup_travis
 default_platform(:ios)
 
 before_all do
-  xcversion(version: "~> 13.4.1")
+  xcversion(version: "14.2")
 end
 
 platform :ios do


### PR DESCRIPTION
### What
- Explicit use of Xcode 14.2
  - That's needed by the App Store from April 25th, 2023.
  - There's a bug in the build, probably because we used an old Xcode version (13.4.1)

### Fixes bug(s)
- Closes: #3842