### PR TITLE
fix: 3854 - fastlane - use "xcodes" syntax instead of "xcversion"

### DIFF
--- a/packages/smooth_app/ios/fastlane/Fastfile
+++ b/packages/smooth_app/ios/fastlane/Fastfile
@@ -2,7 +2,10 @@ setup_travis
 default_platform(:ios)
 
 before_all do
-  xcversion(version: "14.2")
+  xcodes(
+    version: '14.2',
+    select_for_current_build_only: true
+  )
 end
 
 platform :ios do


### PR DESCRIPTION
### What
- Minor fix in order to avoid using deprecated build settings.

### Fixes bug(s)
- Fixes: #3854