### PR TITLE
fix: 3858 - display nothing if no KP widget children found

### DIFF
--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels_builder.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels_builder.dart
@@ -8,47 +8,48 @@ import 'package:smooth_app/pages/preferences/user_preferences_dev_mode.dart';
 import 'package:smooth_app/pages/product/add_nutrition_button.dart';
 import 'package:smooth_app/pages/product/add_ocr_button.dart';
 import 'package:smooth_app/pages/product/ocr_ingredients_helper.dart';
+import 'package:smooth_app/services/smooth_services.dart';
 
+// TODO(monsieurtanuki): rename without "Widget", like the file: KnowledgePanelsBuilder?
 /// "Knowledge Panel" widget.
-class KnowledgePanelWidget extends StatelessWidget {
-  const KnowledgePanelWidget({
-    required this.panelElement,
-    required this.product,
-    required this.onboardingMode,
-  });
+class KnowledgePanelWidget {
+  const KnowledgePanelWidget._();
 
-  final KnowledgePanelElement panelElement;
-  final Product product;
-  final bool onboardingMode;
-
-  @override
-  Widget build(BuildContext context) {
-    final String panelId = panelElement.panelElement!.panelId;
-    final KnowledgePanel rootPanel =
-        KnowledgePanelWidget.getKnowledgePanel(product, panelId)!;
+  static List<Widget> getChildren(
+    BuildContext context, {
+    required KnowledgePanelElement panelElement,
+    required Product product,
+    required bool onboardingMode,
+  }) {
+    final String? panelId = panelElement.panelElement?.panelId;
+    final KnowledgePanel? rootPanel = panelId == null
+        ? null
+        : KnowledgePanelWidget.getKnowledgePanel(product, panelId);
     // [knowledgePanelElementWidgets] are a set of widgets inside the root panel.
     final List<Widget> children = <Widget>[];
-    children.add(
-      Padding(
-        padding: const EdgeInsets.symmetric(
-          vertical: VERY_SMALL_SPACE,
-          horizontal: SMALL_SPACE,
-        ),
-        child: Text(
-          rootPanel.titleElement!.title,
-          style: Theme.of(context).textTheme.displaySmall,
-        ),
-      ),
-    );
-    for (final KnowledgePanelElement knowledgePanelElement
-        in rootPanel.elements ?? <KnowledgePanelElement>[]) {
+    if (rootPanel != null) {
       children.add(
-        KnowledgePanelElementCard(
-          knowledgePanelElement: knowledgePanelElement,
-          product: product,
-          isInitiallyExpanded: false,
+        Padding(
+          padding: const EdgeInsets.symmetric(
+            vertical: VERY_SMALL_SPACE,
+            horizontal: SMALL_SPACE,
+          ),
+          child: Text(
+            rootPanel.titleElement!.title,
+            style: Theme.of(context).textTheme.displaySmall,
+          ),
         ),
       );
+      for (final KnowledgePanelElement knowledgePanelElement
+          in rootPanel.elements ?? <KnowledgePanelElement>[]) {
+        children.add(
+          KnowledgePanelElementCard(
+            knowledgePanelElement: knowledgePanelElement,
+            product: product,
+            isInitiallyExpanded: false,
+          ),
+        );
+      }
     }
     if (!onboardingMode) {
       if (panelId == 'health_card') {
@@ -78,10 +79,11 @@ class KnowledgePanelWidget extends StatelessWidget {
         }
       }
     }
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: children,
-    );
+    if (children.isEmpty) {
+      Logs.e(
+          'Unexpected empty panel data for product "${product.barcode}" and panelId "$panelId"');
+    }
+    return children;
   }
 
   /// Returns all the panel elements, in option only the one matching [panelId].

--- a/packages/smooth_app/lib/pages/onboarding/knowledge_panel_page_template.dart
+++ b/packages/smooth_app/lib/pages/onboarding/knowledge_panel_page_template.dart
@@ -75,7 +75,8 @@ class _KnowledgePanelPageTemplateState
           if (snapshot.connectionState != ConnectionState.done) {
             return const Center(child: CircularProgressIndicator.adaptive());
           }
-          final Widget knowledgePanelWidget = KnowledgePanelWidget(
+          final List<Widget> children = KnowledgePanelWidget.getChildren(
+            context,
             panelElement: KnowledgePanelWidget.getPanelElement(
               _product,
               widget.panelId,
@@ -113,8 +114,16 @@ class _KnowledgePanelPageTemplateState
                                     Theme.of(context).textTheme.displayMedium,
                               ),
                             ),
-                            KnowledgePanelProductCards(
-                                <Widget>[knowledgePanelWidget]),
+                            if (children.isNotEmpty)
+                              KnowledgePanelProductCards(
+                                <Widget>[
+                                  Column(
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
+                                    children: children,
+                                  ),
+                                ],
+                              ),
                           ],
                         ),
                       ),

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -259,13 +259,20 @@ class _ProductPageState extends State<ProductPage> with TraceableClientMixin {
       final List<KnowledgePanelElement> elements =
           KnowledgePanelWidget.getPanelElements(_product);
       for (final KnowledgePanelElement panelElement in elements) {
-        knowledgePanelWidgets.add(
-          KnowledgePanelWidget(
-            panelElement: panelElement,
-            product: _product,
-            onboardingMode: false,
-          ),
+        final List<Widget> children = KnowledgePanelWidget.getChildren(
+          context,
+          panelElement: panelElement,
+          product: _product,
+          onboardingMode: false,
         );
+        if (children.isNotEmpty) {
+          knowledgePanelWidgets.add(
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: children,
+            ),
+          );
+        }
       }
     }
     return KnowledgePanelProductCards(knowledgePanelWidgets);


### PR DESCRIPTION
### Impacted files
* `knowledge_panel_page_template.dart`: now using the KP children in order to be able to display nothing
* `knowledge_panels_builder.dart`: now we build a list of children, which gives us the opportunity to display nothing if empty
* `new_onboarding_page.dart`: now using the KP children in order to be able to display nothing

### What
- In some new cases, the KP data from the server is not exactly as we expect it.
- We used to consider that the server data was clean and could be displayed anyway. That caused the gentle crash.
- A Sentry call is now added if the KP data is not as expected, and we really display nothing.
- For the record, this is the Sentry call generated by my code test
`Unexpected empty panel data for product "5010477348678" and panel "contribution_card"`
- This is recent, as I had to refresh my product data to get the error.
- Of course we should also talk with the server side and understand what is wrong with the (new?) `contribution_card`, but meanwhile the crash is fixed in Smoothie.

### Fixes bug(s)
- Fixes: #3858