### PR TITLE
fix: 3854 - fastlane - use back "xcversion" instead of "xcodes"

### DIFF
--- a/packages/smooth_app/ios/fastlane/Fastfile
+++ b/packages/smooth_app/ios/fastlane/Fastfile
@@ -2,10 +2,7 @@ setup_travis
 default_platform(:ios)
 
 before_all do
-  xcodes(
-    version: '14.2',
-    select_for_current_build_only: true
-  )
+  xcversion(version: "14.2")
 end
 
 platform :ios do


### PR DESCRIPTION
### What
- In #3855 the idea was to use an up-to-date version of the xcode selector tool; the previous tool was just deprecated.
- It didn't turn out well, cf. https://github.com/openfoodfacts/smooth-app/actions/runs/4645342722/jobs/8221134280
> [13:25:22]: ------------------------------
[13:25:22]: --- Step: default_platform ---
[13:25:22]: ------------------------------
[13:25:22]: Driving the lane 'ios beta' 🚀
[13:25:22]: 'xcodes' doesn't seem to be installed. Please follow the installation guide at https://github.com/RobotsAndPencils/xcodes#installation before proceeding

- The purpose of the current PR is to use back again the deprecated-but-successful tool `xcversion`

### Fixes bug(s)
- Fixes: #3854