### PR TITLE
fix: 3042 - saving explicitly product name in the correct language

### DIFF
--- a/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
@@ -8,7 +8,6 @@ import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_text_form_field.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
-import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
@@ -50,17 +49,11 @@ class _AddBasicDetailsPageState extends State<AddBasicDetailsPage> {
   }
 
   /// Returns a [Product] with the values from the text fields.
-  Product _getMinimalistProduct() {
-    final String productName = _productNameController.text;
-    return Product()
-      ..barcode = _product.barcode
-      ..productName = productName // for the app, locally
-      ..productNameInLanguages = <OpenFoodFactsLanguage, String>{
-        ProductQuery.getLanguage()!: productName,
-      } // for the server update
-      ..quantity = _weightController.text
-      ..brands = _formatProductBrands(_brandNameController.text);
-  }
+  Product _getMinimalistProduct() => Product()
+    ..barcode = _product.barcode
+    ..productName = _productNameController.text
+    ..quantity = _weightController.text
+    ..brands = _formatProductBrands(_brandNameController.text);
 
   String _formatProductBrands(String? text) =>
       text == null ? '' : formatProductBrands(text, appLocalizations);

--- a/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
@@ -8,6 +8,7 @@ import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_text_form_field.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
+import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
@@ -49,11 +50,17 @@ class _AddBasicDetailsPageState extends State<AddBasicDetailsPage> {
   }
 
   /// Returns a [Product] with the values from the text fields.
-  Product _getMinimalistProduct() => Product()
-    ..barcode = _product.barcode
-    ..productName = _productNameController.text
-    ..quantity = _weightController.text
-    ..brands = _formatProductBrands(_brandNameController.text);
+  Product _getMinimalistProduct() {
+    final String productName = _productNameController.text;
+    return Product()
+      ..barcode = _product.barcode
+      ..productName = productName // for the app, locally
+      ..productNameInLanguages = <OpenFoodFactsLanguage, String>{
+        ProductQuery.getLanguage()!: productName,
+      } // for the server update
+      ..quantity = _weightController.text
+      ..brands = _formatProductBrands(_brandNameController.text);
+  }
 
   String _formatProductBrands(String? text) =>
       text == null ? '' : formatProductBrands(text, appLocalizations);


### PR DESCRIPTION
### What
- Now the `lang` field of product is set explicitly for each server update.
- As a result, when we set `productName`, we set it _just_ for that language. The other translations are not impacted.
- That should also impact `ingredients`, but I haven't double-checked yet.

### Fixes bug(s)
- Fixes: #3042