### PR TITLE
fix: Ensure the status bar is always visible on iOS

### DIFF
--- a/packages/smooth_app/lib/pages/product/product_image_swipeable_view.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_swipeable_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
@@ -80,6 +81,7 @@ class _ProductImageSwipeableViewState extends State<ProductImageSwipeableView> {
       appBar: AppBar(
         backgroundColor: Colors.black,
         foregroundColor: WHITE_COLOR,
+        systemOverlayStyle: SystemUiOverlayStyle.light,
         elevation: 0,
         title: ValueListenableBuilder<int>(
           valueListenable: _currentImageDataIndex,

--- a/packages/smooth_app/lib/tmp_crop_image/new_crop_page.dart
+++ b/packages/smooth_app/lib/tmp_crop_image/new_crop_page.dart
@@ -1,9 +1,9 @@
 import 'dart:async';
 import 'dart:io';
-import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:image/image.dart' as image2;
 import 'package:openfoodfacts/openfoodfacts.dart';
@@ -25,6 +25,7 @@ import 'package:smooth_app/tmp_crop_image/rotated_crop_controller.dart';
 import 'package:smooth_app/tmp_crop_image/rotated_crop_image.dart';
 import 'package:smooth_app/tmp_crop_image/rotation.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
+import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
 /// Page dedicated to image cropping. Pops the resulting file path if relevant.
 class CropPage extends StatefulWidget {
@@ -154,7 +155,7 @@ class _CropPageState extends State<CropPage> {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     return WillPopScope(
       onWillPop: () async => _mayExitPage(saving: false),
-      child: Scaffold(
+      child: SmoothScaffold(
         appBar: SmoothAppBar(
           centerTitle: false,
           titleSpacing: 0.0,

--- a/packages/smooth_app/lib/widgets/smooth_scaffold.dart
+++ b/packages/smooth_app/lib/widgets/smooth_scaffold.dart
@@ -128,8 +128,9 @@ class SmoothScaffoldState extends ScaffoldState {
       value: _overlayStyle,
       child: Theme(
         data: Theme.of(context).copyWith(
-          appBarTheme: AppBarTheme.of(context)
-              .copyWith(systemOverlayStyle: _overlayStyle),
+          appBarTheme: AppBarTheme.of(context).copyWith(
+            systemOverlayStyle: _overlayStyle,
+          ),
         ),
         child: child,
       ),
@@ -150,7 +151,7 @@ class SmoothScaffoldState extends ScaffoldState {
     final Brightness? brightness;
 
     // Invert brightness on iOS devices
-    if (Platform.isIOS) {
+    if (Platform.isIOS && _brightness == null) {
       switch (Theme.of(context).brightness) {
         case Brightness.dark:
           brightness = Brightness.light;


### PR DESCRIPTION
Hi everyone,

On iOS, on two screens the status bar may be invisible, as explained in #3813
This is now fixed (and tested on Android).

![Simulator Screenshot - iPhone 14 Pro Max - 2023-04-10 at 12 49 40](https://user-images.githubusercontent.com/246838/230889678-c77fa372-7e1d-402a-bccc-8bcf0bf5bab2.png)
![Simulator Screenshot - iPhone 14 Pro Max - 2023-04-10 at 12 49 47](https://user-images.githubusercontent.com/246838/230889683-85a48dd8-7d47-4fe9-b66e-93ee5df93034.png)
![Simulator Screenshot - iPhone 14 Pro Max - 2023-04-10 at 12 49 50](https://user-images.githubusercontent.com/246838/230889686-fd21fd31-a4de-42a8-b992-109de0de8195.png)
