### PR TITLE
fix: 3868 - add basic and other details pages with "may exit page" feature

### DIFF
--- a/packages/smooth_app/lib/helpers/product_cards_helper.dart
+++ b/packages/smooth_app/lib/helpers/product_cards_helper.dart
@@ -15,15 +15,14 @@ String getProductBrands(Product product, AppLocalizations appLocalizations) {
   if (brands == null) {
     return appLocalizations.unknownBrand;
   } else {
-    return formatProductBrands(brands, appLocalizations);
+    return formatProductBrands(brands);
   }
 }
 
-/// Correctly format word separators between words (e.g. comma in English)
-String formatProductBrands(String brands, AppLocalizations appLocalizations) {
-  final String separator = appLocalizations.word_separator;
-  final String separatorChar =
-      RegExp.escape(appLocalizations.word_separator_char);
+/// Correctly format word separators between words.
+String formatProductBrands(String brands) {
+  const String separator = ', ';
+  final String separatorChar = RegExp.escape(',');
   final RegExp regex = RegExp('\\s*$separatorChar\\s*');
   return brands.replaceAll(regex, separator);
 }

--- a/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
@@ -8,6 +8,9 @@ import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_text_form_field.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
+import 'package:smooth_app/pages/product/common/product_refresher.dart';
+import 'package:smooth_app/pages/product/may_exit_page_helper.dart';
+import 'package:smooth_app/pages/text_field_helper.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
@@ -26,26 +29,32 @@ class AddBasicDetailsPage extends StatefulWidget {
 }
 
 class _AddBasicDetailsPageState extends State<AddBasicDetailsPage> {
-  final TextEditingController _productNameController = TextEditingController();
-  final TextEditingController _brandNameController = TextEditingController();
-  final TextEditingController _weightController = TextEditingController();
+  late final TextEditingControllerWithInitialValue _productNameController;
+  late final TextEditingControllerWithInitialValue _brandNameController;
+  late final TextEditingControllerWithInitialValue _weightController;
 
   final double _heightSpace = LARGE_SPACE;
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
-  late Product _product;
-  late AppLocalizations appLocalizations = AppLocalizations.of(context);
+  late final Product _product;
 
-  bool _initDone = false;
-
-  void _initializeProduct() {
-    if (_initDone) {
-      return;
-    }
-    _initDone = true;
+  @override
+  void initState() {
+    super.initState();
     _product = widget.product;
-    _productNameController.text = _product.productName ?? '';
-    _weightController.text = _product.quantity ?? '';
-    _brandNameController.text = _formatProductBrands(_product.brands);
+    _productNameController =
+        TextEditingControllerWithInitialValue(text: _product.productName ?? '');
+    _weightController =
+        TextEditingControllerWithInitialValue(text: _product.quantity ?? '');
+    _brandNameController = TextEditingControllerWithInitialValue(
+        text: _formatProductBrands(_product.brands));
+  }
+
+  @override
+  void dispose() {
+    _productNameController.dispose();
+    _weightController.dispose();
+    _brandNameController.dispose();
+    super.dispose();
   }
 
   /// Returns a [Product] with the values from the text fields.
@@ -56,97 +65,149 @@ class _AddBasicDetailsPageState extends State<AddBasicDetailsPage> {
     ..brands = _formatProductBrands(_brandNameController.text);
 
   String _formatProductBrands(String? text) =>
-      text == null ? '' : formatProductBrands(text, appLocalizations);
+      text == null ? '' : formatProductBrands(text);
 
   @override
   Widget build(BuildContext context) {
-    _initializeProduct();
     final Size size = MediaQuery.of(context).size;
-    return SmoothScaffold(
-      appBar: SmoothAppBar(
-        title: Text(appLocalizations.basic_details),
-        subTitle: widget.product.productName != null
-            ? Text(widget.product.productName!,
-                overflow: TextOverflow.ellipsis, maxLines: 1)
-            : null,
-      ),
-      body: Form(
-        key: _formKey,
-        child: ListView(
-          children: <Widget>[
-            Align(
-              alignment: AlignmentDirectional.topStart,
-              child: ProductImageCarousel(
-                _product,
-                height: size.height * 0.20,
-              ),
-            ),
-            SizedBox(height: _heightSpace),
-            Padding(
-              padding: EdgeInsets.symmetric(horizontal: size.width * 0.05),
-              child: Column(
-                children: <Widget>[
-                  Text(
-                    appLocalizations.barcode_barcode(_product.barcode!),
-                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                          fontWeight: FontWeight.bold,
-                        ),
-                  ),
-                  SizedBox(height: _heightSpace),
-                  SmoothTextFormField(
-                    controller: _productNameController,
-                    type: TextFieldTypes.PLAIN_TEXT,
-                    hintText: appLocalizations.product_name,
-                  ),
-                  SizedBox(height: _heightSpace),
-                  SmoothTextFormField(
-                    controller: _brandNameController,
-                    type: TextFieldTypes.PLAIN_TEXT,
-                    hintText: appLocalizations.brand_name,
-                  ),
-                  SizedBox(height: _heightSpace),
-                  SmoothTextFormField(
-                    controller: _weightController,
-                    type: TextFieldTypes.PLAIN_TEXT,
-                    hintText: appLocalizations.quantity,
-                  ),
-                  SizedBox(height: _heightSpace),
-                ],
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                horizontal: LARGE_SPACE,
-              ),
-              child: SmoothActionButtonsBar(
-                negativeAction: SmoothActionButton(
-                  text: appLocalizations.cancel,
-                  onPressed: () => Navigator.pop(context),
-                ),
-                positiveAction: SmoothActionButton(
-                  text: appLocalizations.save,
-                  onPressed: () async {
-                    AnalyticsHelper.trackProductEdit(
-                      AnalyticsEditEvents.basicDetails,
-                      _product.barcode!,
-                      true,
-                    );
-                    await BackgroundTaskDetails.addTask(
-                      _getMinimalistProduct(),
-                      widget: this,
-                      stamp: BackgroundTaskDetailsStamp.basicDetails,
-                    );
-                    if (!mounted) {
-                      return;
-                    }
-                    Navigator.pop(context);
-                  },
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    return WillPopScope(
+      onWillPop: () async => _mayExitPage(saving: false),
+      child: SmoothScaffold(
+        appBar: SmoothAppBar(
+          title: Text(appLocalizations.basic_details),
+          subTitle: widget.product.productName != null
+              ? Text(widget.product.productName!,
+                  overflow: TextOverflow.ellipsis, maxLines: 1)
+              : null,
+        ),
+        body: Form(
+          key: _formKey,
+          child: ListView(
+            children: <Widget>[
+              Align(
+                alignment: AlignmentDirectional.topStart,
+                child: ProductImageCarousel(
+                  _product,
+                  height: size.height * 0.20,
                 ),
               ),
-            ),
-          ],
+              SizedBox(height: _heightSpace),
+              Padding(
+                padding: EdgeInsets.symmetric(horizontal: size.width * 0.05),
+                child: Column(
+                  children: <Widget>[
+                    Text(
+                      appLocalizations.barcode_barcode(_product.barcode!),
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                            fontWeight: FontWeight.bold,
+                          ),
+                    ),
+                    SizedBox(height: _heightSpace),
+                    SmoothTextFormField(
+                      controller: _productNameController,
+                      type: TextFieldTypes.PLAIN_TEXT,
+                      hintText: appLocalizations.product_name,
+                    ),
+                    SizedBox(height: _heightSpace),
+                    SmoothTextFormField(
+                      controller: _brandNameController,
+                      type: TextFieldTypes.PLAIN_TEXT,
+                      hintText: appLocalizations.brand_name,
+                    ),
+                    SizedBox(height: _heightSpace),
+                    SmoothTextFormField(
+                      controller: _weightController,
+                      type: TextFieldTypes.PLAIN_TEXT,
+                      hintText: appLocalizations.quantity,
+                    ),
+                    SizedBox(height: _heightSpace),
+                  ],
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: LARGE_SPACE,
+                ),
+                child: SmoothActionButtonsBar(
+                  negativeAction: SmoothActionButton(
+                    text: appLocalizations.cancel,
+                    onPressed: () async => _exitPage(
+                      await _mayExitPage(saving: false),
+                    ),
+                  ),
+                  positiveAction: SmoothActionButton(
+                    text: appLocalizations.save,
+                    onPressed: () async => _exitPage(
+                      await _mayExitPage(saving: true),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );
+  }
+
+  /// Returns `true` if any value differs with initial state.
+  bool _isEdited() =>
+      _productNameController.valueHasChanged ||
+      _brandNameController.valueHasChanged ||
+      _weightController.valueHasChanged;
+
+  /// Exits the page if the [flag] is `true`.
+  void _exitPage(final bool flag) {
+    if (flag) {
+      Navigator.of(context).pop();
+    }
+  }
+
+  /// Returns `true` if we should really exit the page.
+  ///
+  /// Parameter [saving] tells about the context: are we leaving the page,
+  /// or have we clicked on the "save" button?
+  Future<bool> _mayExitPage({required final bool saving}) async {
+    if (!_isEdited()) {
+      return true;
+    }
+
+    if (!saving) {
+      final bool? pleaseSave =
+          await MayExitPageHelper().openSaveBeforeLeavingDialog(context);
+      if (pleaseSave == null) {
+        return false;
+      }
+      if (pleaseSave == false) {
+        return true;
+      }
+      if (!mounted) {
+        return false;
+      }
+    }
+
+    if (widget.isLoggedInMandatory) {
+      if (!mounted) {
+        return false;
+      }
+      final bool loggedIn = await ProductRefresher().checkIfLoggedIn(context);
+      if (!loggedIn) {
+        return false;
+      }
+    }
+
+    AnalyticsHelper.trackProductEdit(
+      AnalyticsEditEvents.basicDetails,
+      _product.barcode!,
+      true,
+    );
+    await BackgroundTaskDetails.addTask(
+      _getMinimalistProduct(),
+      widget: this,
+      stamp: BackgroundTaskDetailsStamp.basicDetails,
+    );
+
+    return true;
   }
 }

--- a/packages/smooth_app/lib/pages/product/add_other_details_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_other_details_page.dart
@@ -6,6 +6,8 @@ import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_text_form_field.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
+import 'package:smooth_app/pages/product/may_exit_page_helper.dart';
+import 'package:smooth_app/pages/text_field_helper.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
@@ -22,22 +24,24 @@ class AddOtherDetailsPage extends StatefulWidget {
 }
 
 class _AddOtherDetailsPageState extends State<AddOtherDetailsPage> {
-  final TextEditingController _websiteController = TextEditingController();
+  late final TextEditingControllerWithInitialValue _websiteController;
 
   final double _heightSpace = LARGE_SPACE;
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
-  late Product _product;
-  late AppLocalizations appLocalizations = AppLocalizations.of(context);
+  late final Product _product;
 
-  bool _initDone = false;
-
-  void _initializeProduct() {
-    if (_initDone) {
-      return;
-    }
-    _initDone = true;
+  @override
+  void initState() {
+    super.initState();
     _product = widget.product;
-    _websiteController.text = _product.website ?? '';
+    _websiteController =
+        TextEditingControllerWithInitialValue(text: _product.website ?? '');
+  }
+
+  @override
+  void dispose() {
+    _websiteController.dispose();
+    super.dispose();
   }
 
   /// Returns a [Product] with the values from the text fields.
@@ -47,78 +51,114 @@ class _AddOtherDetailsPageState extends State<AddOtherDetailsPage> {
 
   @override
   Widget build(BuildContext context) {
-    _initializeProduct();
     final Size size = MediaQuery.of(context).size;
-    return SmoothScaffold(
-      appBar: SmoothAppBar(
-        title:
-            Text(appLocalizations.edit_product_form_item_other_details_title),
-        subTitle: widget.product.productName != null
-            ? Text(widget.product.productName!,
-                overflow: TextOverflow.ellipsis, maxLines: 1)
-            : null,
-      ),
-      body: Form(
-        key: _formKey,
-        child: ListView(
-          children: <Widget>[
-            SizedBox(height: _heightSpace),
-            Padding(
-              padding: EdgeInsets.symmetric(horizontal: size.width * 0.05),
-              child: Column(
-                children: <Widget>[
-                  Text(
-                    appLocalizations.barcode_barcode(_product.barcode!),
-                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                          fontWeight: FontWeight.bold,
-                        ),
-                  ),
-                  SizedBox(height: _heightSpace),
-                  SmoothTextFormField(
-                    controller: _websiteController,
-                    type: TextFieldTypes.PLAIN_TEXT,
-                    hintText: appLocalizations.product_field_website_title,
-                  ),
-                  SizedBox(height: _heightSpace),
-                ],
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                horizontal: LARGE_SPACE,
-              ),
-              child: SmoothActionButtonsBar(
-                negativeAction: SmoothActionButton(
-                  text: appLocalizations.cancel,
-                  onPressed: () => Navigator.pop(context),
-                ),
-                positiveAction: SmoothActionButton(
-                  text: appLocalizations.save,
-                  onPressed: () async {
-                    if (!_formKey.currentState!.validate()) {
-                      return;
-                    }
-                    AnalyticsHelper.trackProductEdit(
-                      AnalyticsEditEvents.otherDetails,
-                      widget.product.barcode!,
-                      true,
-                    );
-                    await BackgroundTaskDetails.addTask(
-                      _getMinimalistProduct(),
-                      widget: this,
-                      stamp: BackgroundTaskDetailsStamp.otherDetails,
-                    );
-                    if (!mounted) {
-                      return;
-                    }
-                    Navigator.pop(context);
-                  },
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    return WillPopScope(
+      onWillPop: () async => _mayExitPage(saving: false),
+      child: SmoothScaffold(
+        appBar: SmoothAppBar(
+          title:
+              Text(appLocalizations.edit_product_form_item_other_details_title),
+          subTitle: widget.product.productName != null
+              ? Text(widget.product.productName!,
+                  overflow: TextOverflow.ellipsis, maxLines: 1)
+              : null,
+        ),
+        body: Form(
+          key: _formKey,
+          child: ListView(
+            children: <Widget>[
+              SizedBox(height: _heightSpace),
+              Padding(
+                padding: EdgeInsets.symmetric(horizontal: size.width * 0.05),
+                child: Column(
+                  children: <Widget>[
+                    Text(
+                      appLocalizations.barcode_barcode(_product.barcode!),
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                            fontWeight: FontWeight.bold,
+                          ),
+                    ),
+                    SizedBox(height: _heightSpace),
+                    SmoothTextFormField(
+                      controller: _websiteController,
+                      type: TextFieldTypes.PLAIN_TEXT,
+                      hintText: appLocalizations.product_field_website_title,
+                    ),
+                    SizedBox(height: _heightSpace),
+                  ],
                 ),
               ),
-            ),
-          ],
+              Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: LARGE_SPACE,
+                ),
+                child: SmoothActionButtonsBar(
+                  negativeAction: SmoothActionButton(
+                    text: appLocalizations.cancel,
+                    onPressed: () async => _exitPage(
+                      await _mayExitPage(saving: false),
+                    ),
+                  ),
+                  positiveAction: SmoothActionButton(
+                    text: appLocalizations.save,
+                    onPressed: () async => _exitPage(
+                      await _mayExitPage(saving: true),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );
+  }
+
+  /// Returns `true` if any value differs with initial state.
+  bool _isEdited() => _websiteController.valueHasChanged;
+
+  /// Exits the page if the [flag] is `true`.
+  void _exitPage(final bool flag) {
+    if (flag) {
+      Navigator.of(context).pop();
+    }
+  }
+
+  /// Returns `true` if we should really exit the page.
+  ///
+  /// Parameter [saving] tells about the context: are we leaving the page,
+  /// or have we clicked on the "save" button?
+  Future<bool> _mayExitPage({required final bool saving}) async {
+    if (!_isEdited()) {
+      return true;
+    }
+
+    if (!saving) {
+      final bool? pleaseSave =
+          await MayExitPageHelper().openSaveBeforeLeavingDialog(context);
+      if (pleaseSave == null) {
+        return false;
+      }
+      if (pleaseSave == false) {
+        return true;
+      }
+      if (!mounted) {
+        return false;
+      }
+    }
+
+    AnalyticsHelper.trackProductEdit(
+      AnalyticsEditEvents.otherDetails,
+      widget.product.barcode!,
+      true,
+    );
+    await BackgroundTaskDetails.addTask(
+      _getMinimalistProduct(),
+      widget: this,
+      stamp: BackgroundTaskDetailsStamp.otherDetails,
+    );
+
+    return true;
   }
 }


### PR DESCRIPTION
### Impacted files:
* `add_basic_details_page.dart`: added the "may exit page" feature; refactored
* `add_other_details_page.dart`: added the "may exit page" feature; refactored
* `product_cards_helper.dart`: simplified the `formatProductBrands` method as localized `word_separator` and `word_separator_char` _always_ had the same value since 6 months ago (and `AppLocalizations` provoked a bug as a side effect)

### What
- Now you cannot leave an "edit basic details" or "edit other details" page with edited data: you'll first have to confirm that you want (or don't want) to save the data first.

### Part of 
- #3868