### PR TITLE
ci: Return to entrypoint based scanner

### DIFF
--- a/packages/smooth_app/integration_test/app_test.dart
+++ b/packages/smooth_app/integration_test/app_test.dart
@@ -57,8 +57,8 @@ void main() {
 
         await app.launchSmoothApp(
           scanner: SmoothBarcodeScannerType.mockup,
-          appStore: const MockedAppStore(),
-          appFlavour: 'test-runner',
+          store: const MockedAppStore(),
+          flavour: 'test-runner',
           screenshots: true,
         );
         await tester.pumpAndSettle();

--- a/packages/smooth_app/lib/data_models/user_preferences.dart
+++ b/packages/smooth_app/lib/data_models/user_preferences.dart
@@ -4,7 +4,6 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:smooth_app/data_models/product_preferences.dart';
 import 'package:smooth_app/pages/onboarding/onboarding_flow_navigator.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_dev_mode.dart';
-import 'package:smooth_app/pages/scan/smooth_barcode_scanner_type.dart';
 import 'package:smooth_app/themes/color_schemes.dart';
 
 /// User choice regarding the picture source.
@@ -87,8 +86,6 @@ class UserPreferences extends ChangeNotifier {
   /// If the in-app review was asked at least one time (false by default)
   static const String _TAG_IN_APP_REVIEW_ALREADY_DISPLAYED =
       'inAppReviewAlreadyAsked';
-
-  static const String _DEV_MODE_SCANNING_ENGINE = 'devModeScanningEngine';
 
   Future<void> init(final ProductPreferences productPreferences) async {
     if (_sharedPreferences.getBool(_TAG_INIT) != null) {
@@ -297,18 +294,6 @@ class UserPreferences extends ChangeNotifier {
 
   Future<void> setUserPictureSource(final UserPictureSource source) async {
     await _sharedPreferences.setString(_TAG_USER_PICTURE_SOURCE, source.tag);
-    notifyListeners();
-  }
-
-  SmoothBarcodeScannerType scanningEngine() {
-    final String name =
-        _sharedPreferences.getString(_DEV_MODE_SCANNING_ENGINE) ?? 'mlkit';
-    return SmoothBarcodeScannerType.values.singleWhere(
-        (SmoothBarcodeScannerType element) => element.name == name);
-  }
-
-  Future<void> setScanningEngine(final SmoothBarcodeScannerType source) async {
-    await _sharedPreferences.setString(_DEV_MODE_SCANNING_ENGINE, source.name);
     notifyListeners();
   }
 }

--- a/packages/smooth_app/lib/entrypoints/android/main_fdroid.dart
+++ b/packages/smooth_app/lib/entrypoints/android/main_fdroid.dart
@@ -8,11 +8,11 @@ import 'package:smooth_app/pages/scan/smooth_barcode_scanner_type.dart';
 void main() {
   launchSmoothApp(
     scanner: SmoothBarcodeScannerType.zxing,
-    appStore: URIAppStore(
+    store: URIAppStore(
       Uri.parse(
         'https://f-droid.org/fr/packages/openfoodfacts.github.scrachx.openfood/',
       ),
     ),
-    appFlavour: 'zxing-uri',
+    flavour: 'zxing-uri',
   );
 }

--- a/packages/smooth_app/lib/entrypoints/android/main_google_play.dart
+++ b/packages/smooth_app/lib/entrypoints/android/main_google_play.dart
@@ -8,7 +8,7 @@ import 'package:smooth_app/pages/scan/smooth_barcode_scanner_type.dart';
 void main() {
   launchSmoothApp(
     scanner: SmoothBarcodeScannerType.mlkit,
-    appStore: GooglePlayStore(),
-    appFlavour: 'ml-play',
+    store: GooglePlayStore(),
+    flavour: 'ml-play',
   );
 }

--- a/packages/smooth_app/lib/entrypoints/ios/main_ios.dart
+++ b/packages/smooth_app/lib/entrypoints/ios/main_ios.dart
@@ -8,7 +8,7 @@ import 'package:smooth_app/pages/scan/smooth_barcode_scanner_type.dart';
 void main() {
   launchSmoothApp(
     scanner: SmoothBarcodeScannerType.mlkit,
-    appStore: AppleAppStore('588797948'),
-    appFlavour: 'ml-ios',
+    store: AppleAppStore('588797948'),
+    flavour: 'ml-ios',
   );
 }

--- a/packages/smooth_app/lib/helpers/analytics_helper.dart
+++ b/packages/smooth_app/lib/helpers/analytics_helper.dart
@@ -107,7 +107,7 @@ class AnalyticsHelper {
         // To set a uniform sample rate
         options.tracesSampleRate = 1.0;
         options.beforeSend = _beforeSend;
-        options.environment = flavour;
+        options.environment = appFlavour;
       },
       appRunner: appRunner,
     );

--- a/packages/smooth_app/lib/main.dart
+++ b/packages/smooth_app/lib/main.dart
@@ -52,45 +52,47 @@ void main() {
   }
 }
 
-late bool _screenshots;
-late String flavour;
+late final bool _screenshots;
+
+late final String appFlavour;
+late final SmoothBarcodeScannerType scannerType;
+late final AppStore appStore;
 
 Future<void> launchSmoothApp({
   required SmoothBarcodeScannerType scanner,
-  required AppStore appStore,
-  required String appFlavour,
+  required AppStore store,
+  required String flavour,
   final bool screenshots = false,
 }) async {
   _screenshots = screenshots;
+  scannerType = scanner;
+  appStore = store;
+  appFlavour = flavour;
+
   if (_screenshots) {
-    await _init1(appStore);
-    runApp(SmoothApp(scanner, appStore));
+    await _init1();
+    runApp(const SmoothApp());
     return;
   }
   final WidgetsBinding widgetsBinding =
       WidgetsFlutterBinding.ensureInitialized();
   FlutterNativeSplash.preserve(widgetsBinding: widgetsBinding);
 
-  flavour = appFlavour;
-
   if (kReleaseMode) {
     await AnalyticsHelper.initSentry(
-        appRunner: () => runApp(SmoothApp(scanner, appStore)));
+        appRunner: () => runApp(const SmoothApp()));
   } else {
     runApp(
       DevicePreview(
         enabled: true,
-        builder: (_) => SmoothApp(scanner, appStore),
+        builder: (_) => const SmoothApp(),
       ),
     );
   }
 }
 
 class SmoothApp extends StatefulWidget {
-  const SmoothApp(this.scanner, this.appStore);
-
-  final SmoothBarcodeScannerType scanner;
-  final AppStore appStore;
+  const SmoothApp();
 
   // This widget is the root of your application
   @override
@@ -112,7 +114,7 @@ bool _init1done = false;
 // Had to split init in 2 methods, for test/screenshots reasons.
 // Don't know why, but some init codes seem to freeze the test.
 // Now we run them before running the app, during the tests.
-Future<bool> _init1(AppStore appStore) async {
+Future<bool> _init1() async {
   if (_init1done) {
     return false;
   }
@@ -167,7 +169,7 @@ class _SmoothAppState extends State<SmoothApp> {
   }
 
   Future<bool> _init2() async {
-    await _init1(widget.appStore);
+    await _init1();
     systemDarkmodeOn = brightness == Brightness.dark;
     if (!mounted) {
       return false;
@@ -216,10 +218,6 @@ class _SmoothAppState extends State<SmoothApp> {
             provide<ContinuousScanModel>(_continuousScanModel),
             provide<SmoothAppDataImporter>(_appDataImporter),
             provide<PermissionListener>(_permissionListener),
-            // TODO(m123): Re-add engine split
-            /*Provider<SmoothBarcodeScannerType>.value(
-              value: widget.scanner,
-            ),*/
           ],
           builder: _buildApp,
         );

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_dev_debug_info.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_dev_debug_info.dart
@@ -47,7 +47,7 @@ class _UserPreferencesDebugInfoState extends State<UserPreferencesDebugInfo> {
 
     infos.putIfAbsent('Version', () => packageInfo.version);
     infos.putIfAbsent('BuildNumber', () => packageInfo.buildNumber);
-    infos.putIfAbsent('Flavour', () => flavour);
+    infos.putIfAbsent('Flavour', () => appFlavour);
     infos.putIfAbsent('PackageName', () => packageInfo.packageName);
   }
 

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_dev_mode.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_dev_mode.dart
@@ -19,7 +19,6 @@ import 'package:smooth_app/pages/onboarding/onboarding_flow_navigator.dart';
 import 'package:smooth_app/pages/preferences/abstract_user_preferences.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_dev_debug_info.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_page.dart';
-import 'package:smooth_app/pages/scan/smooth_barcode_scanner_type.dart';
 import 'package:smooth_app/query/product_query.dart';
 
 /// Full page display of "dev mode" for the preferences page.
@@ -81,37 +80,6 @@ class UserPreferencesDevMode extends AbstractUserPreferences {
 
   @override
   List<Widget> getBody() => <Widget>[
-        ListTile(
-          title: const Text('Barcode scanning engine'),
-          trailing: DropdownButton<SmoothBarcodeScannerType>(
-            value: userPreferences.scanningEngine(),
-            elevation: 16,
-            onChanged: (SmoothBarcodeScannerType? newValue) async {
-              if (newValue != null) {
-                await userPreferences.setScanningEngine(newValue);
-              }
-              setState(() {});
-            },
-            items: const <DropdownMenuItem<SmoothBarcodeScannerType>>[
-              DropdownMenuItem<SmoothBarcodeScannerType>(
-                value: SmoothBarcodeScannerType.mlkit,
-                child: Text('ML Kit'),
-              ),
-              DropdownMenuItem<SmoothBarcodeScannerType>(
-                value: SmoothBarcodeScannerType.zxing,
-                child: Text('Zxing'),
-              ),
-              DropdownMenuItem<SmoothBarcodeScannerType>(
-                value: SmoothBarcodeScannerType.awesome,
-                child: Text('Awesome'),
-              ),
-              DropdownMenuItem<SmoothBarcodeScannerType>(
-                value: SmoothBarcodeScannerType.mockup,
-                child: Text('Mockup'),
-              ),
-            ],
-          ),
-        ),
         SwitchListTile(
           title: Text(
             appLocalizations.contribute_develop_dev_mode_title,

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_faq.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_faq.dart
@@ -129,7 +129,7 @@ class UserPreferencesFaq extends AbstractUserPreferences {
                           ),
                         ),
                         Text(
-                          '${packageInfo.version}+${packageInfo.buildNumber}-$flavour',
+                          '${packageInfo.version}+${packageInfo.buildNumber}-$appFlavour',
                           style: themeData.textTheme.titleSmall,
                         )
                       ],

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_settings.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_settings.dart
@@ -91,7 +91,6 @@ class _RateUs extends StatelessWidget {
   }
 
   String getImagePath() {
-    final String appFlavour = flavour;
     String imagePath = '';
     switch (appFlavour) {
       case 'zxing-uri':

--- a/packages/smooth_app/lib/pages/scan/camera_scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/camera_scan_page.dart
@@ -10,6 +10,7 @@ import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/helpers/app_helper.dart';
 import 'package:smooth_app/helpers/camera_helper.dart';
 import 'package:smooth_app/helpers/haptic_feedback_helper.dart';
+import 'package:smooth_app/main.dart';
 //import 'package:smooth_app/pages/scan/smooth_barcode_scanner_awesome.dart';
 import 'package:smooth_app/pages/scan/smooth_barcode_scanner_mlkit.dart';
 import 'package:smooth_app/pages/scan/smooth_barcode_scanner_mockup.dart';
@@ -18,9 +19,7 @@ import 'package:smooth_app/pages/scan/smooth_barcode_scanner_zxing.dart';
 
 /// A page showing the camera feed and decoding barcodes.
 class CameraScannerPage extends StatefulWidget {
-  const CameraScannerPage(this.scannerType);
-
-  final SmoothBarcodeScannerType scannerType;
+  const CameraScannerPage();
 
   @override
   CameraScannerPageState createState() => CameraScannerPageState();
@@ -53,25 +52,20 @@ class CameraScannerPageState extends State<CameraScannerPage>
   }
 
   @override
-  String get traceTitle => '${widget.scannerType}_page';
+  String get traceTitle => '${scannerType}_page';
 
   @override
-  String get traceName => 'Opened ${widget.scannerType}_page';
+  String get traceName => 'Opened ${scannerType}_page';
 
   @override
   Widget build(BuildContext context) {
-    final SmoothBarcodeScannerType prefsScanner =
-        _userPreferences.scanningEngine();
-
     if (!CameraHelper.hasACamera) {
       return Center(
         child: Text(AppLocalizations.of(context).permission_photo_none_found),
       );
     }
 
-    // TODO(m123): Re-add scanning engine
-    //switch (widget.scannerType) {
-    switch (prefsScanner) {
+    switch (scannerType) {
       case SmoothBarcodeScannerType.mlkit:
         return SmoothBarcodeScannerMLKit(_onNewBarcodeDetected);
       case SmoothBarcodeScannerType.zxing:

--- a/packages/smooth_app/lib/pages/scan/scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/scan_page.dart
@@ -4,13 +4,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/continuous_scan_model.dart';
-import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/helpers/permission_helper.dart';
 import 'package:smooth_app/pages/scan/camera_scan_page.dart';
-import 'package:smooth_app/pages/scan/smooth_barcode_scanner_type.dart';
 import 'package:smooth_app/widgets/smooth_product_carousel.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
@@ -48,11 +46,6 @@ class _ScanPageState extends State<ScanPage> {
       return const Center(child: CircularProgressIndicator.adaptive());
     }
 
-    final UserPreferences prefs = context.watch<UserPreferences>();
-
-    // TODO(m123): Scanning engine
-    /*final SmoothBarcodeScannerType scannerType =
-        context.read<SmoothBarcodeScannerType>();*/
     return SmoothScaffold(
       brightness: Brightness.light,
       body: SafeArea(
@@ -71,22 +64,20 @@ class _ScanPageState extends State<ScanPage> {
                       return EMPTY_WIDGET;
                     case DevicePermissionStatus.granted:
                       // TODO(m123): change
-                      return const CameraScannerPage(
-                          SmoothBarcodeScannerType.mockup);
+                      return const CameraScannerPage();
                     default:
                       return const _PermissionDeniedCard();
                   }
                 },
               ),
             ),
-            if (prefs.scanningEngine() != SmoothBarcodeScannerType.awesome)
-              const Expanded(
-                flex: _carouselHeightPct,
-                child: Padding(
-                  padding: EdgeInsetsDirectional.only(bottom: 10),
-                  child: SmoothProductCarousel(containSearchCard: true),
-                ),
+            const Expanded(
+              flex: _carouselHeightPct,
+              child: Padding(
+                padding: EdgeInsetsDirectional.only(bottom: 10),
+                child: SmoothProductCarousel(containSearchCard: true),
               ),
+            ),
           ],
         ),
       ),

--- a/packages/smooth_app/lib/pages/scan/smooth_barcode_scanner_mlkit.dart
+++ b/packages/smooth_app/lib/pages/scan/smooth_barcode_scanner_mlkit.dart
@@ -112,13 +112,6 @@ class _SmoothBarcodeScannerMLKitState extends State<SmoothBarcodeScannerMLKit>
                 }
               },
             ),
-            const Align(
-              alignment: Alignment.topCenter,
-              child: Text(
-                'ML Kit',
-                style: TextStyle(color: Colors.red),
-              ),
-            ),
             const Center(
               child: Padding(
                 padding: EdgeInsets.all(_cornerPadding),

--- a/packages/smooth_app/lib/pages/scan/smooth_barcode_scanner_zxing.dart
+++ b/packages/smooth_app/lib/pages/scan/smooth_barcode_scanner_zxing.dart
@@ -87,13 +87,6 @@ class _SmoothBarcodeScannerZXingState extends State<SmoothBarcodeScannerZXing> {
             ),
             const Align(
               alignment: Alignment.topCenter,
-              child: Text(
-                'ZXing',
-                style: TextStyle(color: Colors.red),
-              ),
-            ),
-            const Align(
-              alignment: Alignment.topCenter,
               child: ScanHeader(),
             ),
             Align(

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -209,34 +209,34 @@ packages:
     dependency: transitive
     description:
       name: camera_android
-      sha256: df9c3376ccfce13c98a09c1d6433c64b0c6b2de81eeade8151884f8c8f08881f
+      sha256: "772c111c78f31f868b98dbf6dbeda8d6ff77acea773a92ea5705ee2f7949ebfb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.4+1"
+    version: "0.10.5"
   camera_avfoundation:
     dependency: transitive
     description:
       name: camera_avfoundation
-      sha256: a1ebce7132e2c1ffd3138e672538f6f2360715e181cf5b7eb5a073f1a735235e
+      sha256: "7ac8b950672716722af235eed7a7c37896853669800b7da706bb0a9fd41d3737"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.12"
+    version: "0.9.13+1"
   camera_platform_interface:
     dependency: transitive
     description:
       name: camera_platform_interface
-      sha256: "00d972adee2e8a282b4d7445e8e694aa1dc0c36b70455b99afa96fbf5e814119"
+      sha256: "525017018d116c5db8c4c43ec2d9b1663216b369c9f75149158280168a7ce472"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.5.0"
   camera_web:
     dependency: transitive
     description:
       name: camera_web
-      sha256: f7a949ce4d2e091234f2e6607557a0a65398c34c84c1161fb249498595e3b4ce
+      sha256: d77965f32479ee6d8f48205dcf10f845d7210595c6c00faa51eab265d1cae993
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.1+2"
+    version: "0.3.1+3"
   carousel_slider:
     dependency: "direct main"
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -29,9 +29,6 @@ dependencies:
   latlong2: 0.8.1
   matomo_tracker: 2.0.0
   modal_bottom_sheet: 2.1.2
-  openfoodfacts: 2.4.0
-  # openfoodfacts:
-  #   path: ../../../openfoodfacts-dart
   package_info_plus: 3.0.3
   device_info_plus: 8.1.0
   permission_handler: 10.2.0
@@ -45,13 +42,6 @@ dependencies:
   assorted_layout_widgets: 7.0.0
   app_settings: 4.2.0
   diacritic: 0.1.3
-
-  camera: 0.10.3+2
-  mobile_scanner: 3.2.0
-
-  qr_code_scanner: 1.0.1
-  #qr_code_scanner:
-  #  path: ../../../qr_code_scanner
   app_store_shared:
     path: ../app_store/shared
   audioplayers: 3.0.1
@@ -86,8 +76,19 @@ dependencies:
 
   app_store_uri:
     path: ../app_store/uri_store
-  #camerawesome: 1.2.1
-  #google_mlkit_barcode_scanning: 0.5.0
+
+  # We use two different scanning engines, 
+  # mobile scanner powered by ML Kit for the Play Store and Apple App Store,
+  # but qr_code_scanner which uses the open source ZXing for F-Droid
+  camera: 0.10.3+2
+  mobile_scanner: 3.2.0
+  qr_code_scanner: 1.0.1
+
+
+
+  openfoodfacts: 2.4.0
+  # openfoodfacts:
+  #   path: ../../../openfoodfacts-dart
 
 dev_dependencies:
   integration_test:

--- a/packages/smooth_app/test/basic_test.dart
+++ b/packages/smooth_app/test/basic_test.dart
@@ -6,10 +6,7 @@ import 'package:smooth_app/pages/scan/smooth_barcode_scanner_type.dart';
 void main() {
   testWidgets('App Starts', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const SmoothApp(
-        SmoothBarcodeScannerType.mockup,
-        MockedAppStore(),
-      ),
+      const SmoothApp(),
     );
     expect(find.byType(SmoothApp), findsOneWidget);
   });

--- a/packages/smooth_app/test/basic_test.dart
+++ b/packages/smooth_app/test/basic_test.dart
@@ -1,7 +1,5 @@
-import 'package:app_store_shared/app_store_shared.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:smooth_app/main.dart';
-import 'package:smooth_app/pages/scan/smooth_barcode_scanner_type.dart';
 
 void main() {
   testWidgets('App Starts', (WidgetTester tester) async {


### PR DESCRIPTION
### What
- Nothing special, removing the switch in the dev settings. Now the scanner is again dependent on the entry point which is used.
- I removed the red text above the scanner
- Now we don't use a provider for the scanner type anymore. It won't change during runtime, so I decided to go with a global var


This will likely be a bit restructured in my next PR to allow building completely without ml kit for F-Droid