### PR TITLE
chore: upgraded to off-dart 2.5.0

### DIFF
--- a/packages/smooth_app/lib/pages/hunger_games/congrats.dart
+++ b/packages/smooth_app/lib/pages/hunger_games/congrats.dart
@@ -129,11 +129,10 @@ class CongratsWidget extends StatelessWidget {
 
     for (final MapEntry<String, InsightAnnotation> annotation
         in annotationList.entries) {
-      final Status status = await OpenFoodAPIClient.postInsightAnnotation(
+      final Status status = await RobotoffAPIClient.postInsightAnnotation(
         annotation.key,
         annotation.value,
         deviceId: OpenFoodAPIConfiguration.uuid,
-        user: OpenFoodAPIConfiguration.globalUser,
       );
 
       results.add(status.status == 1);

--- a/packages/smooth_app/lib/pages/hunger_games/question_page.dart
+++ b/packages/smooth_app/lib/pages/hunger_games/question_page.dart
@@ -263,11 +263,10 @@ class _QuestionPageState extends State<QuestionPage>
     required String? insightId,
     required InsightAnnotation insightAnnotation,
   }) async {
-    final Status status = await OpenFoodAPIClient.postInsightAnnotation(
+    final Status status = await RobotoffAPIClient.postInsightAnnotation(
       insightId,
       insightAnnotation,
       deviceId: OpenFoodAPIConfiguration.uuid,
-      user: OpenFoodAPIConfiguration.globalUser,
     );
     // TODO(monsieurtanuki): optim - do not ask QuestionCard to constantly refresh the product if we deal with several times the same product
     if (widget.product != null) {

--- a/packages/smooth_app/lib/pages/product/product_question_page.dart
+++ b/packages/smooth_app/lib/pages/product/product_question_page.dart
@@ -225,11 +225,10 @@ class _ProductQuestionPageState extends State<ProductQuestionPage>
       context: context,
       title: appLocalizations.saving_answer,
       // TODO(monsieurtanuki): remove that line when fixed in [off-dart #451](https://github.com/openfoodfacts/openfoodfacts-dart/pull/451)
-      future: OpenFoodAPIClient.postInsightAnnotation(
+      future: RobotoffAPIClient.postInsightAnnotation(
         insightId,
         insightAnnotation,
         deviceId: OpenFoodAPIConfiguration.uuid,
-        user: OpenFoodAPIConfiguration.globalUser,
       ),
     );
     if (barcode != null && insightId != null) {

--- a/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
@@ -39,8 +39,8 @@ class SimpleInputTextField extends StatelessWidget {
       categories: categories,
       shape: shapeProvider?.call(),
       user: ProductQuery.getUser(),
-      limit:
-          15, // number of suggestions the user can scroll through: compromise between quantity and readability of the suggestions
+      // number of suggestions the user can scroll through: compromise between quantity and readability of the suggestions
+      limit: 15,
     );
 
     return Padding(

--- a/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
@@ -31,90 +31,92 @@ class SimpleInputTextField extends StatelessWidget {
   final String? Function()? shapeProvider;
 
   @override
-  Widget build(BuildContext context) => Padding(
-        padding: const EdgeInsets.only(left: LARGE_SPACE),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          crossAxisAlignment: CrossAxisAlignment.center,
-          mainAxisSize: MainAxisSize.max,
-          children: <Widget>[
-            Expanded(
-              child: RawAutocomplete<String>(
-                key: autocompleteKey,
-                focusNode: focusNode,
-                textEditingController: controller,
-                optionsBuilder: (final TextEditingValue value) async {
-                  if (tagType == null) {
-                    return <String>[];
-                  }
+  Widget build(BuildContext context) {
+    final SuggestionManager manager = SuggestionManager(
+      tagType!,
+      language: ProductQuery.getLanguage()!,
+      country: ProductQuery.getCountry(),
+      categories: categories,
+      shape: shapeProvider?.call(),
+      user: ProductQuery.getUser(),
+      limit:
+          15, // number of suggestions the user can scroll through: compromise between quantity and readability of the suggestions
+    );
 
-                  final String input = value.text.trim();
-                  if (input.length < minLengthForSuggestions) {
-                    return <String>[];
-                  }
+    return Padding(
+      padding: const EdgeInsets.only(left: LARGE_SPACE),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        mainAxisSize: MainAxisSize.max,
+        children: <Widget>[
+          Expanded(
+            child: RawAutocomplete<String>(
+              key: autocompleteKey,
+              focusNode: focusNode,
+              textEditingController: controller,
+              optionsBuilder: (final TextEditingValue value) async {
+                if (tagType == null) {
+                  return <String>[];
+                }
 
-                  return OpenFoodAPIClient.getSuggestions(
-                    tagType!,
-                    language: ProductQuery.getLanguage()!,
-                    country: ProductQuery.getCountry(),
-                    categories: categories,
-                    shape: shapeProvider?.call(),
-                    user: ProductQuery.getUser(),
-                    limit:
-                        15, // number of suggestions the user can scroll through: compromise between quantity and readability of the suggestions
-                    input: input,
-                  );
-                },
-                fieldViewBuilder: (BuildContext context,
-                        TextEditingController textEditingController,
-                        FocusNode focusNode,
-                        VoidCallback onFieldSubmitted) =>
-                    TextField(
-                  controller: textEditingController,
-                  decoration: InputDecoration(
-                    filled: true,
-                    border: const OutlineInputBorder(
-                      borderRadius: ANGULAR_BORDER_RADIUS,
-                      borderSide: BorderSide.none,
-                    ),
-                    contentPadding: const EdgeInsets.symmetric(
-                      horizontal: SMALL_SPACE,
-                      vertical: SMALL_SPACE,
-                    ),
-                    hintText: hintText,
+                final String input = value.text.trim();
+                if (input.length < minLengthForSuggestions) {
+                  return <String>[];
+                }
+
+                return manager.getSuggestions(input);
+              },
+              fieldViewBuilder: (BuildContext context,
+                      TextEditingController textEditingController,
+                      FocusNode focusNode,
+                      VoidCallback onFieldSubmitted) =>
+                  TextField(
+                controller: textEditingController,
+                decoration: InputDecoration(
+                  filled: true,
+                  border: const OutlineInputBorder(
+                    borderRadius: ANGULAR_BORDER_RADIUS,
+                    borderSide: BorderSide.none,
                   ),
-                  // a lot of confusion if set to `true`
-                  autofocus: false,
-                  focusNode: focusNode,
+                  contentPadding: const EdgeInsets.symmetric(
+                    horizontal: SMALL_SPACE,
+                    vertical: SMALL_SPACE,
+                  ),
+                  hintText: hintText,
                 ),
-                optionsViewBuilder: (
-                  BuildContext lContext,
-                  AutocompleteOnSelected<String> onSelected,
-                  Iterable<String> options,
-                ) {
-                  final double screenHeight =
-                      MediaQuery.of(context).size.height;
+                // a lot of confusion if set to `true`
+                autofocus: false,
+                focusNode: focusNode,
+              ),
+              optionsViewBuilder: (
+                BuildContext lContext,
+                AutocompleteOnSelected<String> onSelected,
+                Iterable<String> options,
+              ) {
+                final double screenHeight = MediaQuery.of(context).size.height;
 
-                  return AutocompleteOptions<String>(
-                    displayStringForOption:
-                        RawAutocomplete.defaultStringForOption,
-                    onSelected: onSelected,
-                    options: options,
-                    // Width = Row width - horizontal padding
-                    maxOptionsWidth: constraints.maxWidth - (LARGE_SPACE * 2),
-                    maxOptionsHeight: screenHeight / 3,
-                  );
-                },
-              ),
+                return AutocompleteOptions<String>(
+                  displayStringForOption:
+                      RawAutocomplete.defaultStringForOption,
+                  onSelected: onSelected,
+                  options: options,
+                  // Width = Row width - horizontal padding
+                  maxOptionsWidth: constraints.maxWidth - (LARGE_SPACE * 2),
+                  maxOptionsHeight: screenHeight / 3,
+                );
+              },
             ),
-            if (withClearButton)
-              IconButton(
-                icon: const Icon(Icons.clear),
-                onPressed: () => controller.text = '',
-              ),
-          ],
-        ),
-      );
+          ),
+          if (withClearButton)
+            IconButton(
+              icon: const Icon(Icons.clear),
+              onPressed: () => controller.text = '',
+            ),
+        ],
+      ),
+    );
+  }
 }
 
 /// Allows to unfocus TextField (and dismiss the keyboard) when user tap outside the TextField and inside this widget.

--- a/packages/smooth_app/lib/query/product_questions_query.dart
+++ b/packages/smooth_app/lib/query/product_questions_query.dart
@@ -8,9 +8,9 @@ class ProductQuestionsQuery {
 
   Future<List<RobotoffQuestion>> getQuestions() async {
     final RobotoffQuestionResult result =
-        await OpenFoodAPIClient.getRobotoffQuestionsForProduct(
+        await RobotoffAPIClient.getProductQuestions(
       _barcode,
-      ProductQuery.getLanguage().code,
+      ProductQuery.getLanguage()!,
       count: 3,
     );
     return result.questions ?? <RobotoffQuestion>[];

--- a/packages/smooth_app/lib/query/questions_query.dart
+++ b/packages/smooth_app/lib/query/questions_query.dart
@@ -3,13 +3,10 @@ import 'package:smooth_app/query/product_query.dart';
 
 class QuestionsQuery {
   Future<List<RobotoffQuestion>> getQuestions() async {
-    final User? user = OpenFoodAPIConfiguration.globalUser;
-    final String lc = ProductQuery.getLanguage().code;
-
     final RobotoffQuestionResult result =
-        await OpenFoodAPIClient.getRandomRobotoffQuestion(
-      lc,
-      user,
+        await RobotoffAPIClient.getRandomQuestions(
+      ProductQuery.getLanguage()!,
+      OpenFoodAPIConfiguration.globalUser,
       count: 3,
     );
 

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -898,10 +898,10 @@ packages:
     dependency: "direct main"
     description:
       name: openfoodfacts
-      sha256: "30f43c0f2da44d27d2e53cff5adc9fb7933231da2ec2e6778fcf9072c84bc315"
+      sha256: "04b2e2691042ac1ff55ba90871858e789daae249c5c5a477f3e14930a70e6d12"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.5.0"
   openfoodfacts_flutter_lints:
     dependency: "direct dev"
     description:
@@ -939,10 +939,10 @@ packages:
     dependency: "direct main"
     description:
       name: path
-      sha256: "2ad4cddff7f5cc0e2d13069f2a3f7a73ca18f66abd6f5ecf215219cdb3638edb"
+      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.2"
   path_drawing:
     dependency: transitive
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -53,7 +53,7 @@ dependencies:
   shared_preferences: 2.0.18
   intl: 0.17.0
   collection: 1.17.0
-  path: 1.8.3
+  path: 1.8.2
   path_provider: 2.0.13
   data_importer_shared:
     path: ../data_importer_shared
@@ -86,7 +86,7 @@ dependencies:
 
 
 
-  openfoodfacts: 2.4.0
+  openfoodfacts: 2.5.0
   # openfoodfacts:
   #   path: ../../../openfoodfacts-dart
 
@@ -104,9 +104,6 @@ dev_dependencies:
   flutter_lints: 2.0.1
   openfoodfacts_flutter_lints:
     git: https://github.com/openfoodfacts/openfoodfacts_flutter_lints.git
-
-dependency_overrides:
-  path: 1.8.0
 
 # 'flutter pub run flutter_launcher_icons:main' to update
 flutter_icons:


### PR DESCRIPTION
Impacted files:
* `congrats.dart`: refactored Robotoff call
* `product_question_page.dart`: refactored Robotoff call
* `product_questions_query.dart`: refactored Robotoff call
* `pubspec.lock`: wtf
* `pubspec.yaml`: now using the latest 2.5.0 off-dart version; downgraded path accordingly
* `question_page.dart`: refactored Robotoff call
* `questions_query.dart`: refactored Robotoff call
* `simple_input_text_field.dart`: now using the new `SuggestionManager` class

### What
- Nothing really fantastic here: just upgrading to off-dart 2.5.0
- There was no big rush, except if we release a new smoothie version soon (and it does fix https://github.com/openfoodfacts/openfoodfacts-dart/issues/719)
