### PR TITLE
fix: Try/catch the exception that may be raised when changing the flash state

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1312,6 +1312,14 @@
     "@camera_disable_flash": {
         "description": "Disable flash (tooltip)"
     },
+    "camera_flash_error_dialog_title": "An error occurred!",
+    "@camera_flash_error_dialog_title": {
+        "description": "Title of the dialog explaining that an error happened while enabling/disabling the flash of the camera"
+    },
+    "camera_flash_error_dialog_message": "An error occurred while changing the state of your flash. Please ensure your smartphone has not the torch already enabled.",
+    "@camera_flash_error_dialog_message": {
+        "description": "Content of the dialog explaining that an error happened while enabling/disabling the flash of the camera"
+    },
     "category_picker_no_category_found_button": "Back",
     "@category_picker_no_category_found_button": {
         "description": "Button label when no category is available"

--- a/packages/smooth_app/lib/pages/scan/camera_scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/camera_scan_page.dart
@@ -7,6 +7,7 @@ import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/continuous_scan_model.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
+import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/helpers/app_helper.dart';
 import 'package:smooth_app/helpers/camera_helper.dart';
 import 'package:smooth_app/helpers/haptic_feedback_helper.dart';
@@ -67,9 +68,15 @@ class CameraScannerPageState extends State<CameraScannerPage>
 
     switch (scannerType) {
       case SmoothBarcodeScannerType.mlkit:
-        return SmoothBarcodeScannerMLKit(_onNewBarcodeDetected);
+        return SmoothBarcodeScannerMLKit(
+          _onNewBarcodeDetected,
+          onCameraFlashError: _onCameraFlashError,
+        );
       case SmoothBarcodeScannerType.zxing:
-        return SmoothBarcodeScannerZXing(_onNewBarcodeDetected);
+        return SmoothBarcodeScannerZXing(
+          _onNewBarcodeDetected,
+          onCameraFlashError: _onCameraFlashError,
+        );
       case SmoothBarcodeScannerType.mockup:
         return const SmoothBarcodeScannerMocked();
       case SmoothBarcodeScannerType.awesome:
@@ -94,6 +101,18 @@ class CameraScannerPageState extends State<CameraScannerPage>
 
     _userPreferences.setFirstScanAchieved();
     return true;
+  }
+
+  void _onCameraFlashError(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+
+    showDialog<void>(
+      context: context,
+      builder: (_) => SmoothAlertDialog(
+        title: appLocalizations.camera_flash_error_dialog_title,
+        body: Text(appLocalizations.camera_flash_error_dialog_message),
+      ),
+    );
   }
 
   /// Only initialize the "beep" player when needed

--- a/packages/smooth_app/lib/pages/scan/smooth_barcode_scanner_mlkit.dart
+++ b/packages/smooth_app/lib/pages/scan/smooth_barcode_scanner_mlkit.dart
@@ -13,9 +13,13 @@ import 'package:visibility_detector/visibility_detector.dart';
 
 /// Barcode scanner based on MLKit.
 class SmoothBarcodeScannerMLKit extends StatefulWidget {
-  const SmoothBarcodeScannerMLKit(this.onScan);
+  const SmoothBarcodeScannerMLKit(
+    this.onScan, {
+    this.onCameraFlashError,
+  });
 
   final Future<bool> Function(String) onScan;
+  final Function(BuildContext)? onCameraFlashError;
 
   @override
   State<StatefulWidget> createState() => _SmoothBarcodeScannerMLKitState();
@@ -46,7 +50,8 @@ class _SmoothBarcodeScannerMLKitState extends State<SmoothBarcodeScannerMLKit>
     formats: _barcodeFormats,
     facing: CameraFacing.back,
     detectionSpeed: DetectionSpeed.normal,
-    detectionTimeoutMs: 250, // to be raised in order to avoid crashes
+    detectionTimeoutMs: 250,
+    // to be raised in order to avoid crashes
     returnImage: false,
     autoStart: true,
   );
@@ -190,7 +195,12 @@ class _SmoothBarcodeScannerMLKitState extends State<SmoothBarcodeScannerMLKit>
                           ),
                           onPressed: () async {
                             SmoothHapticFeedback.click();
-                            await _controller.toggleTorch();
+
+                            try {
+                              await _controller.toggleTorch();
+                            } catch (err) {
+                              widget.onCameraFlashError?.call(context);
+                            }
                           },
                         );
                       },

--- a/packages/smooth_app/lib/pages/scan/smooth_barcode_scanner_zxing.dart
+++ b/packages/smooth_app/lib/pages/scan/smooth_barcode_scanner_zxing.dart
@@ -14,9 +14,13 @@ import 'package:visibility_detector/visibility_detector.dart';
 
 /// Barcode scanner based on ZXing.
 class SmoothBarcodeScannerZXing extends StatefulWidget {
-  const SmoothBarcodeScannerZXing(this.onScan);
+  const SmoothBarcodeScannerZXing(
+    this.onScan, {
+    this.onCameraFlashError,
+  });
 
   final Future<bool> Function(String) onScan;
+  final Function(BuildContext)? onCameraFlashError;
 
   @override
   State<StatefulWidget> createState() => _SmoothBarcodeScannerZXingState();
@@ -122,8 +126,13 @@ class _SmoothBarcodeScannerZXingState extends State<SmoothBarcodeScannerZXing> {
                           color: Colors.white,
                           onPressed: () async {
                             SmoothHapticFeedback.click();
-                            await _controller?.toggleFlash();
-                            setState(() {});
+
+                            try {
+                              await _controller?.toggleFlash();
+                              setState(() {});
+                            } catch (err) {
+                              widget.onCameraFlashError?.call(context);
+                            }
                           },
                         );
                       },


### PR DESCRIPTION
Hi everyone!

As suggested by @CoryADavis in #3873, we should try/catch the exception that can be raised by the platform when when changing the state of the flash.

Usually, this comes from the torch mode activated in parallel on the phone.