### PR TITLE
feat: 3873 - less raw scan visor

### DIFF
--- a/packages/smooth_app/lib/pages/scan/smooth_barcode_scanner_mlkit.dart
+++ b/packages/smooth_app/lib/pages/scan/smooth_barcode_scanner_mlkit.dart
@@ -35,8 +35,6 @@ class _SmoothBarcodeScannerMLKitState extends State<SmoothBarcodeScannerMLKit>
     BarcodeFormat.upcE,
   ];
 
-  static const double _cornerPadding = 26;
-
   bool _isStarted = true;
 
   bool get _showFlipCameraButton => CameraHelper.hasMoreThanOneCamera;
@@ -112,12 +110,7 @@ class _SmoothBarcodeScannerMLKitState extends State<SmoothBarcodeScannerMLKit>
                 }
               },
             ),
-            const Center(
-              child: Padding(
-                padding: EdgeInsets.all(_cornerPadding),
-                child: SmoothBarcodeScannerVisor(),
-              ),
-            ),
+            const Center(child: SmoothBarcodeScannerVisor()),
             const Align(
               alignment: Alignment.topCenter,
               child: ScanHeader(),
@@ -125,7 +118,10 @@ class _SmoothBarcodeScannerMLKitState extends State<SmoothBarcodeScannerMLKit>
             Align(
               alignment: Alignment.bottomCenter,
               child: Padding(
-                padding: const EdgeInsets.all(_cornerPadding),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: SmoothBarcodeScannerVisor.cornerHorizontalPadding,
+                  vertical: SmoothBarcodeScannerVisor.cornerVerticalPadding,
+                ),
                 child: Row(
                   mainAxisAlignment: _showFlipCameraButton
                       ? MainAxisAlignment.spaceBetween

--- a/packages/smooth_app/lib/pages/scan/smooth_barcode_scanner_visor.dart
+++ b/packages/smooth_app/lib/pages/scan/smooth_barcode_scanner_visor.dart
@@ -1,14 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/helpers/app_helper.dart';
 
 class SmoothBarcodeScannerVisor extends StatelessWidget {
-  const SmoothBarcodeScannerVisor({super.key});
+  const SmoothBarcodeScannerVisor();
+
+  static const double cornerHorizontalPadding = 24;
+  static const double cornerVerticalPadding = 8;
 
   @override
   Widget build(BuildContext context) => SizedBox.expand(
         child: CustomPaint(
-          painter: _ScanVisorPainter(),
+          painter: _ScanVisorPainter(Theme.of(context).scaffoldBackgroundColor),
           child: Center(
             child: SvgPicture.asset(
               'assets/icons/visor_icon.svg',
@@ -22,97 +26,31 @@ class SmoothBarcodeScannerVisor extends StatelessWidget {
 }
 
 class _ScanVisorPainter extends CustomPainter {
-  _ScanVisorPainter();
+  _ScanVisorPainter(this.backgroundColor);
 
-  static const double strokeWidth = 3.0;
-  static const double _fullCornerSize = 31.0;
-  static const double _halfCornerSize = _fullCornerSize / 2;
-  static const Radius _borderRadius = Radius.circular(_halfCornerSize);
-
-  final Paint _paint = Paint()
-    ..strokeWidth = strokeWidth
-    ..color = Colors.white
-    ..style = PaintingStyle.stroke;
+  final Color backgroundColor;
 
   @override
   void paint(Canvas canvas, Size size) {
-    final Rect rect = Rect.fromLTRB(0.0, 0.0, size.width, size.height);
-    canvas.drawPath(getPath(rect, false), _paint);
+    final Paint paint = Paint()
+      ..color = backgroundColor
+      ..style = PaintingStyle.fill;
+
+    final Rect bigRect = Rect.fromLTRB(0.0, 0.0, size.width, size.height);
+    final Rect rect = Rect.fromLTRB(
+      SmoothBarcodeScannerVisor.cornerHorizontalPadding,
+      SmoothBarcodeScannerVisor.cornerVerticalPadding,
+      size.width - SmoothBarcodeScannerVisor.cornerHorizontalPadding,
+      size.height - SmoothBarcodeScannerVisor.cornerVerticalPadding,
+    );
+
+    final Path path = Path()..fillType = PathFillType.evenOdd;
+    path.addRect(bigRect);
+    path.addRRect(RRect.fromRectAndRadius(rect, ROUNDED_RADIUS));
+
+    canvas.drawPath(path, paint);
   }
 
   @override
   bool shouldRepaint(CustomPainter oldDelegate) => false;
-
-  /// Returns a path to draw the visor
-  /// [includeLineBetweenCorners] will draw lines between each corner, instead
-  /// of moving the cursor
-  static Path getPath(Rect rect, bool includeLineBetweenCorners) {
-    final double bottomPosition;
-    if (includeLineBetweenCorners) {
-      bottomPosition = rect.bottom - strokeWidth;
-    } else {
-      bottomPosition = rect.bottom;
-    }
-
-    final Path path = Path()
-      // Top left
-      ..moveTo(rect.left, rect.top + _fullCornerSize)
-      ..lineTo(rect.left, rect.top + _halfCornerSize)
-      ..arcToPoint(
-        Offset(rect.left + _halfCornerSize, rect.top),
-        radius: _borderRadius,
-      )
-      ..lineTo(rect.left + _fullCornerSize, rect.top);
-
-    // Top right
-    if (includeLineBetweenCorners) {
-      path.lineTo(rect.right - _fullCornerSize, rect.top);
-    } else {
-      path.moveTo(rect.right - _fullCornerSize, rect.top);
-    }
-
-    path
-      ..lineTo(rect.right - _halfCornerSize, rect.top)
-      ..arcToPoint(
-        Offset(rect.right, _halfCornerSize),
-        radius: _borderRadius,
-      )
-      ..lineTo(rect.right, rect.top + _fullCornerSize);
-
-    // Bottom right
-    if (includeLineBetweenCorners) {
-      path.lineTo(rect.right, bottomPosition - _fullCornerSize);
-    } else {
-      path.moveTo(rect.right, bottomPosition - _fullCornerSize);
-    }
-
-    path
-      ..lineTo(rect.right, bottomPosition - _halfCornerSize)
-      ..arcToPoint(
-        Offset(rect.right - _halfCornerSize, bottomPosition),
-        radius: _borderRadius,
-      )
-      ..lineTo(rect.right - _fullCornerSize, bottomPosition);
-
-    // Bottom left
-    if (includeLineBetweenCorners) {
-      path.lineTo(rect.left + _fullCornerSize, bottomPosition);
-    } else {
-      path.moveTo(rect.left + _fullCornerSize, bottomPosition);
-    }
-
-    path
-      ..lineTo(rect.left + _halfCornerSize, bottomPosition)
-      ..arcToPoint(
-        Offset(rect.left, bottomPosition - _halfCornerSize),
-        radius: _borderRadius,
-      )
-      ..lineTo(rect.left, bottomPosition - _fullCornerSize);
-
-    if (includeLineBetweenCorners) {
-      path.lineTo(rect.left, rect.top + _halfCornerSize);
-    }
-
-    return path;
-  }
 }

--- a/packages/smooth_app/lib/pages/scan/smooth_barcode_scanner_zxing.dart
+++ b/packages/smooth_app/lib/pages/scan/smooth_barcode_scanner_zxing.dart
@@ -35,8 +35,6 @@ class _SmoothBarcodeScannerZXingState extends State<SmoothBarcodeScannerZXing> {
     BarcodeFormat.upcE,
   ];
 
-  static const double _cornerPadding = 26;
-
   bool _visible = false;
   final GlobalKey _qrKey = GlobalKey(debugLabel: 'QR');
   QRViewController? _controller;
@@ -79,12 +77,7 @@ class _SmoothBarcodeScannerZXingState extends State<SmoothBarcodeScannerZXing> {
               onQRViewCreated: _onQRViewCreated,
               formatsAllowed: _barcodeFormats,
             ),
-            const Center(
-              child: Padding(
-                padding: EdgeInsets.all(_cornerPadding),
-                child: SmoothBarcodeScannerVisor(),
-              ),
-            ),
+            const Center(child: SmoothBarcodeScannerVisor()),
             const Align(
               alignment: Alignment.topCenter,
               child: ScanHeader(),
@@ -92,7 +85,10 @@ class _SmoothBarcodeScannerZXingState extends State<SmoothBarcodeScannerZXing> {
             Align(
               alignment: Alignment.bottomCenter,
               child: Padding(
-                padding: const EdgeInsets.all(_cornerPadding),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: SmoothBarcodeScannerVisor.cornerHorizontalPadding,
+                  vertical: SmoothBarcodeScannerVisor.cornerVerticalPadding,
+                ),
                 child: Row(
                   mainAxisAlignment: _showFlipCameraButton
                       ? MainAxisAlignment.spaceBetween


### PR DESCRIPTION
Impacted files:
* `smooth_barcode_scanner_mlkit.dart`: minor refactoring
* `smooth_barcode_scanner_visor.dart`: now painting a void RRect, taller than before
* `smooth_barcode_scanner_zxing.dart`: minor refactoring

### What
- With the camera that is not full screen anymore, we had to put the scanner on the top and the carousel on the bottom.
- The transition between the scanner and the carousel was a bit raw, like two rectangles side by side
- @CoryADavis suggested an improvement: this is the related try.

### Screenshot
| dark | light |
| -- | -- |
| ![Screenshot_2023-04-17-17-18-51](https://user-images.githubusercontent.com/11576431/232535378-674b6b68-884a-4b35-92c5-bacba45ae719.png) | ![Screenshot_2023-04-17-17-18-35](https://user-images.githubusercontent.com/11576431/232535388-78c2956f-76b5-4c60-ada5-c3f9986566a0.png) |

### Part of 
- #3873
