### PR TITLE
fix: Invalid shape for Ripples in all "My account" items

### DIFF
--- a/packages/smooth_app/lib/pages/preferences/user_preferences_account.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_account.dart
@@ -426,6 +426,9 @@ class _UserPreferencesPageState extends State<UserPreferencesSection> {
         child: UserPreferencesListTile(
           title: Text(title),
           onTap: onTap,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(15),
+          ),
           leading: UserPreferencesListTile.getTintedIcon(leading, context),
           trailing: (type != null)
               ? FutureBuilder<int?>(

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_list_tile.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_list_tile.dart
@@ -9,6 +9,7 @@ class UserPreferencesListTile extends StatelessWidget {
     this.leading,
     this.onTap,
     this.onLongPress,
+    this.shape,
   });
 
   final Widget title;
@@ -17,6 +18,7 @@ class UserPreferencesListTile extends StatelessWidget {
   final Widget? leading;
   final VoidCallback? onTap;
   final VoidCallback? onLongPress;
+  final ShapeBorder? shape;
 
   /// Icon (leading or trailing) with the standard color.
   static Icon getTintedIcon(
@@ -39,5 +41,6 @@ class UserPreferencesListTile extends StatelessWidget {
         onTap: onTap,
         onLongPress: onLongPress,
         subtitle: subtitle,
+        shape: shape,
       );
 }


### PR DESCRIPTION
Hi everyone,

Here is a fix for #3887 
[untitled.webm](https://user-images.githubusercontent.com/246838/233585264-a46d990c-339e-4803-9d3f-2473db45a0c2.webm)
