### PR TITLE
feat: 3863 - multilingual input for product name

### DIFF
--- a/packages/smooth_app/lib/data_models/up_to_date_changes.dart
+++ b/packages/smooth_app/lib/data_models/up_to_date_changes.dart
@@ -54,6 +54,9 @@ class UpToDateChanges {
     if (change.productName != null) {
       initial.productName = change.productName;
     }
+    if (change.productNameInLanguages != null) {
+      initial.productNameInLanguages = change.productNameInLanguages;
+    }
     if (change.quantity != null) {
       initial.quantity = change.quantity;
     }

--- a/packages/smooth_app/lib/generic_lib/widgets/language_selector.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/language_selector.dart
@@ -11,28 +11,31 @@ class LanguageSelector extends StatelessWidget {
   const LanguageSelector({
     required this.setLanguage,
     this.selectedLanguages,
+    this.displayedLanguage,
   });
 
   /// What to do when the language is selected.
   final Future<void> Function(OpenFoodFactsLanguage?) setLanguage;
 
   /// Languages that are already selected (and will be displayed differently).
-  final List<OpenFoodFactsLanguage>? selectedLanguages;
+  final Iterable<OpenFoodFactsLanguage>? selectedLanguages;
+
+  /// Initial language displayed, before even calling the dialog.
+  final OpenFoodFactsLanguage? displayedLanguage;
 
   static const Languages _languages = Languages();
 
   @override
   Widget build(BuildContext context) {
-    // The languages that are supported by flutter widget
-    final String currentLanguageCode = ProductQuery.getLanguage().code;
-    final OpenFoodFactsLanguage language =
-        LanguageHelper.fromJson(currentLanguageCode);
-    final String nameInEnglish = _languages.getNameInEnglish(
-      language,
-    );
-    final String nameInLanguage = _languages.getNameInLanguage(
-      language,
-    );
+    final OpenFoodFactsLanguage language;
+    if (displayedLanguage != null) {
+      language = displayedLanguage!;
+    } else {
+      final String currentLanguageCode = ProductQuery.getLanguage().code;
+      language = LanguageHelper.fromJson(currentLanguageCode);
+    }
+    final String nameInEnglish = _languages.getNameInEnglish(language);
+    final String nameInLanguage = _languages.getNameInLanguage(language);
     return InkWell(
       onTap: () async {
         final OpenFoodFactsLanguage? language = await openLanguageSelector(
@@ -60,7 +63,7 @@ class LanguageSelector extends StatelessWidget {
   /// [selectedLanguages] have a specific "more important" display.
   static Future<OpenFoodFactsLanguage?> openLanguageSelector(
     final BuildContext context, {
-    final List<OpenFoodFactsLanguage>? selectedLanguages,
+    final Iterable<OpenFoodFactsLanguage>? selectedLanguages,
   }) async {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final TextEditingController languageSelectorController =

--- a/packages/smooth_app/lib/generic_lib/widgets/language_selector.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/language_selector.dart
@@ -1,24 +1,20 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart'
-    show AppLocalizations;
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
-import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_text_form_field.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_languages_list.dart';
 import 'package:smooth_app/query/product_query.dart';
 
-class LanguageSelectorSettings extends StatelessWidget {
-  const LanguageSelectorSettings({
-    required this.userPreferences,
-    required this.appLocalizations,
+class LanguageSelector extends StatelessWidget {
+  const LanguageSelector({
+    required this.setLanguage,
   });
 
-  final UserPreferences userPreferences;
-  final AppLocalizations appLocalizations;
+  final Function(OpenFoodFactsLanguage) setLanguage;
 
-  static final Languages _languages = Languages();
+  static const Languages _languages = Languages();
 
   @override
   Widget build(BuildContext context) {
@@ -26,104 +22,21 @@ class LanguageSelectorSettings extends StatelessWidget {
     final String currentLanguageCode = ProductQuery.getLanguage().code;
     final OpenFoodFactsLanguage language =
         LanguageHelper.fromJson(currentLanguageCode);
-    final String nameInEnglish =
-        _languages.getLanguageNameInEnglishFromOpenFoodFactsLanguage(
+    final String nameInEnglish = _languages.getNameInEnglish(
       language,
     );
-    final String nameInLanguage =
-        _languages.getLanguageNameInLanguageFromOpenFoodFactsLanguage(
+    final String nameInLanguage = _languages.getNameInLanguage(
       language,
     );
-    final TextEditingController languageSelectorController =
-        TextEditingController();
     return InkWell(
       onTap: () async {
-        final List<OpenFoodFactsLanguage> leftovers =
-            _languages.getSupportedLanguagesNameInEnglish();
-        leftovers.sort((OpenFoodFactsLanguage a, OpenFoodFactsLanguage b) =>
-            _languages
-                .getLanguageNameInEnglishFromOpenFoodFactsLanguage(a)
-                .compareTo(_languages
-                    .getLanguageNameInEnglishFromOpenFoodFactsLanguage(b)));
-        List<OpenFoodFactsLanguage> filteredList = leftovers;
-        await showDialog<void>(
-          context: context,
-          builder: (BuildContext context) {
-            return StatefulBuilder(
-              builder: (BuildContext context,
-                  void Function(VoidCallback fn) setState) {
-                return SmoothAlertDialog(
-                  body: SizedBox(
-                    height: MediaQuery.of(context).size.height / 2,
-                    width: MediaQuery.of(context).size.width,
-                    child: Column(
-                      children: <Widget>[
-                        SmoothTextFormField(
-                          type: TextFieldTypes.PLAIN_TEXT,
-                          hintText: appLocalizations.search,
-                          prefixIcon: const Icon(Icons.search),
-                          controller: languageSelectorController,
-                          onChanged: (String? query) {
-                            setState(
-                              () {
-                                filteredList = leftovers
-                                    .where((OpenFoodFactsLanguage item) =>
-                                        _languages
-                                            .getLanguageNameInEnglishFromOpenFoodFactsLanguage(
-                                                item)
-                                            .toLowerCase()
-                                            .contains(query!.toLowerCase()) ||
-                                        _languages
-                                            .getLanguageNameInLanguageFromOpenFoodFactsLanguage(
-                                                item)
-                                            .toLowerCase()
-                                            .contains(query.toLowerCase()) ||
-                                        item.code.contains(query))
-                                    .toList();
-                              },
-                            );
-                          },
-                        ),
-                        Expanded(
-                          child: ListView.builder(
-                            itemBuilder: (BuildContext context, int index) {
-                              final OpenFoodFactsLanguage
-                                  openFoodFactsLanguage = filteredList[index];
-                              final String nameInLanguage = _languages
-                                  .getLanguageNameInLanguageFromOpenFoodFactsLanguage(
-                                      openFoodFactsLanguage);
-                              return ListTile(
-                                title: Text(
-                                  '$nameInLanguage (${_languages.getLanguageNameInEnglishFromOpenFoodFactsLanguage(openFoodFactsLanguage)})',
-                                  softWrap: false,
-                                  overflow: TextOverflow.fade,
-                                ),
-                                onTap: () {
-                                  ProductQuery.setLanguage(
-                                    context,
-                                    userPreferences,
-                                    languageCode: openFoodFactsLanguage.code,
-                                  );
-                                  Navigator.of(context).pop();
-                                },
-                              );
-                            },
-                            itemCount: filteredList.length,
-                            shrinkWrap: true,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                  positiveAction: SmoothActionButton(
-                    onPressed: () => Navigator.pop(context),
-                    text: appLocalizations.cancel,
-                  ),
-                );
-              },
-            );
-          },
-        );
+        final OpenFoodFactsLanguage? language =
+            await openLanguageSelector(context);
+        if (context.mounted) {
+          if (language != null) {
+            setLanguage(language);
+          }
+        }
       },
       borderRadius: ANGULAR_BORDER_RADIUS,
       child: ListTile(
@@ -135,6 +48,91 @@ class LanguageSelectorSettings extends StatelessWidget {
           style: Theme.of(context).textTheme.bodyMedium,
         ),
         trailing: const Icon(Icons.arrow_drop_down),
+      ),
+    );
+  }
+
+  /// Returns the selected language.
+  static Future<OpenFoodFactsLanguage?> openLanguageSelector(
+    final BuildContext context,
+  ) async {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final TextEditingController languageSelectorController =
+        TextEditingController();
+    final List<OpenFoodFactsLanguage> leftovers =
+        _languages.getSupportedLanguagesNameInEnglish();
+    leftovers.sort((OpenFoodFactsLanguage a, OpenFoodFactsLanguage b) =>
+        _languages
+            .getNameInEnglish(a)
+            .compareTo(_languages.getNameInEnglish(b)));
+    List<OpenFoodFactsLanguage> filteredList = leftovers;
+    return showDialog<OpenFoodFactsLanguage>(
+      context: context,
+      builder: (BuildContext context) => StatefulBuilder(
+        builder: (
+          BuildContext context,
+          void Function(VoidCallback fn) setState,
+        ) =>
+            SmoothAlertDialog(
+          body: SizedBox(
+            height: MediaQuery.of(context).size.height / 2,
+            width: MediaQuery.of(context).size.width,
+            child: Column(
+              children: <Widget>[
+                SmoothTextFormField(
+                  type: TextFieldTypes.PLAIN_TEXT,
+                  hintText: appLocalizations.search,
+                  prefixIcon: const Icon(Icons.search),
+                  controller: languageSelectorController,
+                  onChanged: (String? query) {
+                    setState(
+                      () {
+                        filteredList = leftovers
+                            .where((OpenFoodFactsLanguage item) =>
+                                _languages
+                                    .getNameInEnglish(item)
+                                    .toLowerCase()
+                                    .contains(query!.toLowerCase()) ||
+                                _languages
+                                    .getNameInLanguage(item)
+                                    .toLowerCase()
+                                    .contains(query.toLowerCase()) ||
+                                item.code.contains(query))
+                            .toList();
+                      },
+                    );
+                  },
+                ),
+                Expanded(
+                  child: ListView.builder(
+                    itemBuilder: (BuildContext context, int index) {
+                      final OpenFoodFactsLanguage language =
+                          filteredList[index];
+                      final String nameInLanguage =
+                          _languages.getNameInLanguage(language);
+                      final String nameInEnglish =
+                          _languages.getNameInEnglish(language);
+                      return ListTile(
+                        title: Text(
+                          '$nameInLanguage ($nameInEnglish)',
+                          softWrap: false,
+                          overflow: TextOverflow.fade,
+                        ),
+                        onTap: () => Navigator.of(context).pop(language),
+                      );
+                    },
+                    itemCount: filteredList.length,
+                    shrinkWrap: true,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          positiveAction: SmoothActionButton(
+            onPressed: () => Navigator.of(context).pop(),
+            text: appLocalizations.cancel,
+          ),
+        ),
       ),
     );
   }

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_languages_list.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_languages_list.dart
@@ -4,10 +4,12 @@ import 'package:flutter_native_splash/cli_commands.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 
 class Languages {
+  const Languages();
+
   static const LocalizationsDelegate<MaterialLocalizations> _delegate =
       GlobalMaterialLocalizations.delegate;
 
-  static const Map<OpenFoodFactsLanguage, String> _openFoodFactsLanguagesList =
+  static const Map<OpenFoodFactsLanguage, String> _namesInLanguage =
       <OpenFoodFactsLanguage, String>{
     OpenFoodFactsLanguage.AFAR: 'Afar',
     OpenFoodFactsLanguage.AFRIKAANS: 'Afrikaans',
@@ -197,30 +199,25 @@ class Languages {
   List<OpenFoodFactsLanguage> getSupportedLanguagesNameInEnglish() {
     final List<OpenFoodFactsLanguage> languages = <OpenFoodFactsLanguage>[];
 
-    _openFoodFactsLanguagesList
-        .forEach((OpenFoodFactsLanguage lc, String _) => <void>{
-              if (_delegate.isSupported(Locale(lc.code)))
-                <void>{languages.add(lc)}
-            });
+    _namesInLanguage.forEach(
+      (OpenFoodFactsLanguage lc, String _) => <void>{
+        if (_delegate.isSupported(Locale(lc.code))) <void>{languages.add(lc)}
+      },
+    );
 
     return languages;
   }
 
-  String getLanguageNameInEnglishFromOpenFoodFactsLanguage(
-      OpenFoodFactsLanguage openFoodFactsLanguage) {
-    return openFoodFactsLanguage
-        .toString()
-        .split('.')
-        .last
-        .split('_')
-        .join(' ')
-        .toLowerCase()
-        .capitalize();
-  }
+  String getNameInEnglish(final OpenFoodFactsLanguage language) => language
+      .toString()
+      .split('.')
+      .last
+      .split('_')
+      .join(' ')
+      .toLowerCase()
+      .capitalize();
 
-  String getLanguageNameInLanguageFromOpenFoodFactsLanguage(
-      OpenFoodFactsLanguage lc) {
-    return _openFoodFactsLanguagesList[lc] ??
-        _openFoodFactsLanguagesList[OpenFoodFactsLanguage.ENGLISH]!;
-  }
+  String getNameInLanguage(final OpenFoodFactsLanguage language) =>
+      _namesInLanguage[language] ??
+      _namesInLanguage[OpenFoodFactsLanguage.ENGLISH]!;
 }

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_settings.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_settings.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:matomo_tracker/matomo_tracker.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
@@ -17,6 +18,7 @@ import 'package:smooth_app/pages/onboarding/country_selector.dart';
 import 'package:smooth_app/pages/preferences/abstract_user_preferences.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_page.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_widgets.dart';
+import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/services/smooth_services.dart';
 import 'package:smooth_app/themes/color_provider.dart';
 import 'package:smooth_app/themes/color_schemes.dart';
@@ -269,9 +271,13 @@ class _ApplicationSettings extends StatelessWidget {
             appLocalizations.choose_app_language,
             style: Theme.of(context).textTheme.headlineMedium,
           ),
-          subtitle: LanguageSelectorSettings(
-            userPreferences: userPreferences,
-            appLocalizations: appLocalizations,
+          subtitle: LanguageSelector(
+            setLanguage: (final OpenFoodFactsLanguage language) =>
+                ProductQuery.setLanguage(
+              context,
+              userPreferences,
+              languageCode: language.code,
+            ),
           ),
           minVerticalPadding: MEDIUM_SPACE,
         ),

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_settings.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_settings.dart
@@ -272,12 +272,15 @@ class _ApplicationSettings extends StatelessWidget {
             style: Theme.of(context).textTheme.headlineMedium,
           ),
           subtitle: LanguageSelector(
-            setLanguage: (final OpenFoodFactsLanguage language) =>
+            setLanguage: (final OpenFoodFactsLanguage? language) async {
+              if (language != null) {
                 ProductQuery.setLanguage(
-              context,
-              userPreferences,
-              languageCode: language.code,
-            ),
+                  context,
+                  userPreferences,
+                  languageCode: language.code,
+                );
+              }
+            },
           ),
           minVerticalPadding: MEDIUM_SPACE,
         ),

--- a/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
@@ -149,7 +149,7 @@ class _AddBasicDetailsPageState extends State<AddBasicDetailsPage> {
                     else
                       Card(
                         child: Column(
-                          children: [
+                          children: <Widget>[
                             LanguageSelector(
                               setLanguage: (
                                 final OpenFoodFactsLanguage? newLanguage,

--- a/packages/smooth_app/lib/query/product_query.dart
+++ b/packages/smooth_app/lib/query/product_query.dart
@@ -126,6 +126,7 @@ abstract class ProductQuery {
 
   static List<ProductField> get fields => const <ProductField>[
         ProductField.NAME,
+        ProductField.NAME_ALL_LANGUAGES,
         ProductField.BRANDS,
         ProductField.BARCODE,
         ProductField.NUTRISCORE,

--- a/packages/smooth_app/lib/query/product_query.dart
+++ b/packages/smooth_app/lib/query/product_query.dart
@@ -13,6 +13,7 @@ abstract class ProductQuery {
 
   static OpenFoodFactsCountry? _country;
 
+  // TODO(monsieurtanuki): make it non-nullable
   /// Returns the global language for API queries.
   static OpenFoodFactsLanguage? getLanguage() {
     final List<OpenFoodFactsLanguage> languages =


### PR DESCRIPTION
Impacted files:
* `language_selector.dart`: moved code to new static method `openLanguageSelector`
* `user_preferences_languages_list.dart`: minor refactoring
* `user_preferences_settings.dart`: minor refactoring

### What
- Preliminary work regarding multilingual features: we needed a reusable language selector method.

### Part of 
- #3863
