### PR TITLE
chore: ProductQuery.getLanguage() is now not nullable

### DIFF
--- a/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
@@ -73,7 +73,7 @@ class _AddBasicDetailsPageState extends State<AddBasicDetailsPage> {
         }
       }
       if (_names.isNotEmpty) {
-        final OpenFoodFactsLanguage language = ProductQuery.getLanguage()!;
+        final OpenFoodFactsLanguage language = ProductQuery.getLanguage();
         if (_names.containsKey(language)) {
           // best choice
           _currentLanguage = language;

--- a/packages/smooth_app/lib/pages/product/ocr_helper.dart
+++ b/packages/smooth_app/lib/pages/product/ocr_helper.dart
@@ -54,7 +54,7 @@ abstract class OcrHelper {
   bool hasAddExtraPhotoButton();
 
   @protected
-  OpenFoodFactsLanguage getLanguage() => ProductQuery.getLanguage()!;
+  OpenFoodFactsLanguage getLanguage() => ProductQuery.getLanguage();
 
   @protected
   User getUser() => ProductQuery.getUser();

--- a/packages/smooth_app/lib/pages/product/ordered_nutrients_cache.dart
+++ b/packages/smooth_app/lib/pages/product/ordered_nutrients_cache.dart
@@ -56,7 +56,7 @@ class OrderedNutrientsCache {
   Future<OrderedNutrients> _download() async {
     final String string = await OpenFoodAPIClient.getOrderedNutrientsJsonString(
       country: ProductQuery.getCountry()!,
-      language: ProductQuery.getLanguage()!,
+      language: ProductQuery.getLanguage(),
     );
     final OrderedNutrients result = OrderedNutrients.fromJson(
       jsonDecode(string) as Map<String, dynamic>,
@@ -73,7 +73,7 @@ class OrderedNutrientsCache {
   /// Database key.
   String _getKey() {
     final OpenFoodFactsCountry country = ProductQuery.getCountry()!;
-    final OpenFoodFactsLanguage language = ProductQuery.getLanguage()!;
+    final OpenFoodFactsLanguage language = ProductQuery.getLanguage();
     return 'nutrients.pl'
         '/${country.offTag}'
         '/${language.code}'

--- a/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
@@ -119,7 +119,7 @@ abstract class AbstractSimpleInputPageHelper extends ChangeNotifier {
 
   /// Returns the current language.
   @protected
-  OpenFoodFactsLanguage getLanguage() => ProductQuery.getLanguage()!;
+  OpenFoodFactsLanguage getLanguage() => ProductQuery.getLanguage();
 
   /// Adds all the non-already existing items from the controller.
   ///

--- a/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
@@ -34,7 +34,7 @@ class SimpleInputTextField extends StatelessWidget {
   Widget build(BuildContext context) {
     final SuggestionManager manager = SuggestionManager(
       tagType!,
-      language: ProductQuery.getLanguage()!,
+      language: ProductQuery.getLanguage(),
       country: ProductQuery.getCountry(),
       categories: categories,
       shape: shapeProvider?.call(),

--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -262,7 +262,7 @@ class _SummaryCardState extends State<SummaryCard> {
     String? categoryTag;
     String? categoryLabel;
     final List<String>? labels =
-        _product.categoriesTagsInLanguages?[ProductQuery.getLanguage()!];
+        _product.categoriesTagsInLanguages?[ProductQuery.getLanguage()];
     final List<String>? tags = _product.categoriesTags;
     if (tags != null &&
         labels != null &&

--- a/packages/smooth_app/lib/query/paged_product_query.dart
+++ b/packages/smooth_app/lib/query/paged_product_query.dart
@@ -13,7 +13,7 @@ abstract class PagedProductQuery {
 
   int get pageNumber => _pageNumber;
 
-  final OpenFoodFactsLanguage? language = ProductQuery.getLanguage();
+  final OpenFoodFactsLanguage language = ProductQuery.getLanguage();
   OpenFoodFactsCountry? get country => world ? null : ProductQuery.getCountry();
 
   /// Is that the world mode (true), or the standard country mode (false).

--- a/packages/smooth_app/lib/query/product_query.dart
+++ b/packages/smooth_app/lib/query/product_query.dart
@@ -13,13 +13,13 @@ abstract class ProductQuery {
 
   static OpenFoodFactsCountry? _country;
 
-  // TODO(monsieurtanuki): make it non-nullable
   /// Returns the global language for API queries.
-  static OpenFoodFactsLanguage? getLanguage() {
+  static OpenFoodFactsLanguage getLanguage() {
     final List<OpenFoodFactsLanguage> languages =
         OpenFoodAPIConfiguration.globalLanguages ?? <OpenFoodFactsLanguage>[];
     if (languages.isEmpty) {
-      return null;
+      // very very unlikely
+      return OpenFoodFactsLanguage.UNDEFINED;
     }
     return languages[0];
   }
@@ -58,7 +58,7 @@ abstract class ProductQuery {
   }
 
   /// Returns the global locale string (e.g. 'pt_BR')
-  static String getLocaleString() => '${getLanguage()!.code}'
+  static String getLocaleString() => '${getLanguage().code}'
       '_'
       '${getCountry()!.offTag.toUpperCase()}';
 

--- a/packages/smooth_app/lib/query/product_questions_query.dart
+++ b/packages/smooth_app/lib/query/product_questions_query.dart
@@ -10,7 +10,7 @@ class ProductQuestionsQuery {
     final RobotoffQuestionResult result =
         await RobotoffAPIClient.getProductQuestions(
       _barcode,
-      ProductQuery.getLanguage()!,
+      ProductQuery.getLanguage(),
       count: 3,
     );
     return result.questions ?? <RobotoffQuestion>[];

--- a/packages/smooth_app/lib/query/questions_query.dart
+++ b/packages/smooth_app/lib/query/questions_query.dart
@@ -5,7 +5,7 @@ class QuestionsQuery {
   Future<List<RobotoffQuestion>> getQuestions() async {
     final RobotoffQuestionResult result =
         await RobotoffAPIClient.getRandomQuestions(
-      ProductQuery.getLanguage()!,
+      ProductQuery.getLanguage(),
       OpenFoodAPIConfiguration.globalUser,
       count: 3,
     );


### PR DESCRIPTION
### What
- One of the first things we do in the app init is setting the language. There are no accidental cases or typical use cases when the language is supposed to be `null`.
- For a better understanding of the app, it's better to make this method explicitly return a non null value.

### Part of 
- #3863
