### PR TITLE
feat: 3897 - now we display localized images

### DIFF
--- a/packages/smooth_app/lib/background/background_task_crop.dart
+++ b/packages/smooth_app/lib/background/background_task_crop.dart
@@ -182,6 +182,7 @@ class BackgroundTaskCrop extends AbstractBackgroundTask {
     TransientFile.putImage(
       ImageField.fromOffTag(imageField)!,
       barcode,
+      getLanguage(),
       localDatabase,
       File(croppedPath),
     );
@@ -217,6 +218,7 @@ class BackgroundTaskCrop extends AbstractBackgroundTask {
     TransientFile.removeImage(
       ImageField.fromOffTag(imageField)!,
       barcode,
+      getLanguage(),
       localDatabase,
     );
     localDatabase.notifyListeners();

--- a/packages/smooth_app/lib/background/background_task_image.dart
+++ b/packages/smooth_app/lib/background/background_task_image.dart
@@ -211,6 +211,7 @@ class BackgroundTaskImage extends AbstractBackgroundTask {
     TransientFile.putImage(
       ImageField.fromOffTag(imageField)!,
       barcode,
+      getLanguage(),
       localDatabase,
       File(croppedPath),
     );
@@ -253,6 +254,7 @@ class BackgroundTaskImage extends AbstractBackgroundTask {
     TransientFile.removeImage(
       ImageField.fromOffTag(imageField)!,
       barcode,
+      getLanguage(),
       localDatabase,
     );
     localDatabase.notifyListeners();

--- a/packages/smooth_app/lib/background/background_task_unselect.dart
+++ b/packages/smooth_app/lib/background/background_task_unselect.dart
@@ -153,19 +153,15 @@ class BackgroundTaskUnselect extends AbstractBackgroundTask {
     switch (ImageField.fromOffTag(imageField)!) {
       case ImageField.FRONT:
         result.imageFrontUrl = '';
-        result.imageFrontSmallUrl = '';
         break;
       case ImageField.INGREDIENTS:
         result.imageIngredientsUrl = '';
-        result.imageIngredientsSmallUrl = '';
         break;
       case ImageField.NUTRITION:
         result.imageNutritionUrl = '';
-        result.imageNutritionSmallUrl = '';
         break;
       case ImageField.PACKAGING:
         result.imagePackagingUrl = '';
-        result.imagePackagingSmallUrl = '';
         break;
       case ImageField.OTHER:
       // We do nothing. Actually we're not supposed to unselect other images.

--- a/packages/smooth_app/lib/cards/data_cards/image_upload_card.dart
+++ b/packages/smooth_app/lib/cards/data_cards/image_upload_card.dart
@@ -37,7 +37,7 @@ class _ImageUploadCardState extends State<ImageUploadCard> {
     final ImageProvider? imageProvider = TransientFile.getImageProvider(
       widget.productImageData,
       widget.product.barcode!,
-      ProductQuery.getLanguage()!,
+      ProductQuery.getLanguage(),
     );
 
     if (imageProvider == null) {

--- a/packages/smooth_app/lib/cards/data_cards/image_upload_card.dart
+++ b/packages/smooth_app/lib/cards/data_cards/image_upload_card.dart
@@ -8,6 +8,7 @@ import 'package:smooth_app/database/transient_file.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/pages/image_crop_page.dart';
 import 'package:smooth_app/pages/product/product_image_gallery_view.dart';
+import 'package:smooth_app/query/product_query.dart';
 
 // TODO(monsieurtanuki): rename that class, like `ProductImageCarouselItem`
 /// Displays a product image in the carousel: access to gallery, or new image.
@@ -36,6 +37,7 @@ class _ImageUploadCardState extends State<ImageUploadCard> {
     final ImageProvider? imageProvider = TransientFile.getImageProvider(
       widget.productImageData,
       widget.product.barcode!,
+      ProductQuery.getLanguage()!,
     );
 
     if (imageProvider == null) {

--- a/packages/smooth_app/lib/cards/product_cards/product_image_carousel.dart
+++ b/packages/smooth_app/lib/cards/product_cards/product_image_carousel.dart
@@ -34,7 +34,7 @@ class ProductImageCarousel extends StatelessWidget {
     } else {
       productImagesData = getProductMainImagesData(
         product,
-        ProductQuery.getLanguage()!,
+        ProductQuery.getLanguage(),
       );
     }
     return SizedBox(

--- a/packages/smooth_app/lib/cards/product_cards/product_image_carousel.dart
+++ b/packages/smooth_app/lib/cards/product_cards/product_image_carousel.dart
@@ -3,6 +3,7 @@ import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/cards/data_cards/image_upload_card.dart';
 import 'package:smooth_app/data_models/product_image_data.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
+import 'package:smooth_app/query/product_query.dart';
 
 class ProductImageCarousel extends StatelessWidget {
   /// Carousel of product images, or of just an [alternateImageUrl].
@@ -31,7 +32,10 @@ class ProductImageCarousel extends StatelessWidget {
         ),
       ];
     } else {
-      productImagesData = getProductMainImagesData(product);
+      productImagesData = getProductMainImagesData(
+        product,
+        ProductQuery.getLanguage()!,
+      );
     }
     return SizedBox(
       height: height,

--- a/packages/smooth_app/lib/data_models/product_list.dart
+++ b/packages/smooth_app/lib/data_models/product_list.dart
@@ -73,7 +73,7 @@ class ProductList {
     final String keywords, {
     required int pageSize,
     required int pageNumber,
-    required OpenFoodFactsLanguage? language,
+    required OpenFoodFactsLanguage language,
     required OpenFoodFactsCountry? country,
   }) : this._(
           listType: ProductListType.HTTP_SEARCH_KEYWORDS,
@@ -88,7 +88,7 @@ class ProductList {
     final String category, {
     required int pageSize,
     required int pageNumber,
-    required OpenFoodFactsLanguage? language,
+    required OpenFoodFactsLanguage language,
     required OpenFoodFactsCountry? country,
   }) : this._(
           listType: ProductListType.HTTP_SEARCH_CATEGORY,
@@ -103,7 +103,7 @@ class ProductList {
     final String userId, {
     required int pageSize,
     required int pageNumber,
-    required OpenFoodFactsLanguage? language,
+    required OpenFoodFactsLanguage language,
   }) : this._(
           listType: ProductListType.HTTP_USER_CONTRIBUTOR,
           parameters: userId,
@@ -116,7 +116,7 @@ class ProductList {
     final String userId, {
     required int pageSize,
     required int pageNumber,
-    required OpenFoodFactsLanguage? language,
+    required OpenFoodFactsLanguage language,
   }) : this._(
           listType: ProductListType.HTTP_USER_INFORMER,
           parameters: userId,
@@ -129,7 +129,7 @@ class ProductList {
     final String userId, {
     required int pageSize,
     required int pageNumber,
-    required OpenFoodFactsLanguage? language,
+    required OpenFoodFactsLanguage language,
   }) : this._(
           listType: ProductListType.HTTP_USER_PHOTOGRAPHER,
           parameters: userId,
@@ -142,7 +142,7 @@ class ProductList {
     final String userId, {
     required int pageSize,
     required int pageNumber,
-    required OpenFoodFactsLanguage? language,
+    required OpenFoodFactsLanguage language,
   }) : this._(
           listType: ProductListType.HTTP_USER_TO_BE_COMPLETED,
           parameters: userId,
@@ -154,7 +154,7 @@ class ProductList {
   ProductList.allToBeCompleted({
     required int pageSize,
     required int pageNumber,
-    required OpenFoodFactsLanguage? language,
+    required OpenFoodFactsLanguage language,
     required OpenFoodFactsCountry? country,
   }) : this._(
           listType: ProductListType.HTTP_ALL_TO_BE_COMPLETED,

--- a/packages/smooth_app/lib/data_models/up_to_date_changes.dart
+++ b/packages/smooth_app/lib/data_models/up_to_date_changes.dart
@@ -122,19 +122,9 @@ class UpToDateChanges {
         change.imageFrontUrl!,
       );
     }
-    if (change.imageFrontSmallUrl != null) {
-      initial.imageFrontSmallUrl = emptyMeansNull(
-        change.imageFrontSmallUrl!,
-      );
-    }
     if (change.imageIngredientsUrl != null) {
       initial.imageIngredientsUrl = emptyMeansNull(
         change.imageIngredientsUrl!,
-      );
-    }
-    if (change.imageIngredientsSmallUrl != null) {
-      initial.imageIngredientsSmallUrl = emptyMeansNull(
-        change.imageIngredientsSmallUrl!,
       );
     }
     if (change.imageNutritionUrl != null) {
@@ -142,19 +132,9 @@ class UpToDateChanges {
         change.imageNutritionUrl!,
       );
     }
-    if (change.imageNutritionSmallUrl != null) {
-      initial.imageNutritionSmallUrl = emptyMeansNull(
-        change.imageNutritionSmallUrl!,
-      );
-    }
     if (change.imagePackagingUrl != null) {
       initial.imagePackagingUrl = emptyMeansNull(
         change.imagePackagingUrl!,
-      );
-    }
-    if (change.imagePackagingSmallUrl != null) {
-      initial.imagePackagingSmallUrl = emptyMeansNull(
-        change.imagePackagingSmallUrl!,
       );
     }
     if (change.images != null && change.images!.isNotEmpty) {

--- a/packages/smooth_app/lib/database/transient_file.dart
+++ b/packages/smooth_app/lib/database/transient_file.dart
@@ -16,10 +16,15 @@ class TransientFile {
   static void putImage(
     final ImageField imageField,
     final String barcode,
+    final OpenFoodFactsLanguage language,
     final LocalDatabase localDatabase,
     final File file,
   ) {
-    _transientFiles[_getImageKey(imageField, barcode)] = file.path;
+    _transientFiles[_getImageKey(
+      imageField,
+      barcode,
+      language,
+    )] = file.path;
     localDatabase.notifyListeners();
   }
 
@@ -27,16 +32,26 @@ class TransientFile {
   static void removeImage(
     final ImageField imageField,
     final String barcode,
+    final OpenFoodFactsLanguage language,
     final LocalDatabase localDatabase,
   ) =>
-      _transientFiles.remove(_getImageKey(imageField, barcode));
+      _transientFiles.remove(_getImageKey(
+        imageField,
+        barcode,
+        language,
+      ));
 
   /// Returns the transient image for [imageField] and [barcode].
   static File? getImage(
     final ImageField imageField,
     final String barcode,
+    final OpenFoodFactsLanguage language,
   ) {
-    final String? path = _transientFiles[_getImageKey(imageField, barcode)];
+    final String? path = _transientFiles[_getImageKey(
+      imageField,
+      barcode,
+      language,
+    )];
     if (path == null) {
       return null;
     }
@@ -47,15 +62,17 @@ class TransientFile {
   static String _getImageKey(
     final ImageField imageField,
     final String barcode,
+    final OpenFoodFactsLanguage language,
   ) =>
-      '$barcode;$imageField';
+      '$barcode;$imageField;${language.code}';
 
   /// Returns a way to display the image, either locally or from the server.
   static ImageProvider? getImageProvider(
     final ProductImageData imageData,
     final String barcode,
+    final OpenFoodFactsLanguage language,
   ) {
-    final File? file = getImage(imageData.imageField, barcode);
+    final File? file = getImage(imageData.imageField, barcode, language);
     if (file != null) {
       return FileImage(file);
     }
@@ -72,8 +89,9 @@ class TransientFile {
   static bool isImageAvailable(
     final ProductImageData imageData,
     final String barcode,
+    final OpenFoodFactsLanguage language,
   ) =>
-      getImage(imageData.imageField, barcode) != null ||
+      getImage(imageData.imageField, barcode, language) != null ||
       imageData.imageUrl != null;
 
   /// Returns true if the displayed image comes from the server.
@@ -87,7 +105,8 @@ class TransientFile {
   static bool isServerImage(
     final ProductImageData imageData,
     final String barcode,
+    final OpenFoodFactsLanguage language,
   ) =>
-      getImage(imageData.imageField, barcode) == null &&
+      getImage(imageData.imageField, barcode, language) == null &&
       imageData.imageUrl != null;
 }

--- a/packages/smooth_app/lib/generic_lib/widgets/smooth_product_image.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/smooth_product_image.dart
@@ -5,6 +5,7 @@ import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/database/transient_file.dart';
 import 'package:smooth_app/generic_lib/widgets/images/smooth_image.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
+import 'package:smooth_app/query/product_query.dart';
 
 /// Main product image on a product card.
 class SmoothMainProductImage extends StatelessWidget {
@@ -21,9 +22,15 @@ class SmoothMainProductImage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     context.watch<LocalDatabase>();
+    final OpenFoodFactsLanguage language = ProductQuery.getLanguage()!;
     final ImageProvider? imageProvider = TransientFile.getImageProvider(
-      getProductImageData(product, ImageField.FRONT),
+      getProductImageData(
+        product,
+        ImageField.FRONT,
+        language,
+      ),
       product.barcode!,
+      language,
     );
 
     return SmoothImage(

--- a/packages/smooth_app/lib/generic_lib/widgets/smooth_product_image.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/smooth_product_image.dart
@@ -22,7 +22,7 @@ class SmoothMainProductImage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     context.watch<LocalDatabase>();
-    final OpenFoodFactsLanguage language = ProductQuery.getLanguage()!;
+    final OpenFoodFactsLanguage language = ProductQuery.getLanguage();
     final ImageProvider? imageProvider = TransientFile.getImageProvider(
       getProductImageData(
         product,

--- a/packages/smooth_app/lib/pages/product/common/product_refresher.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_refresher.dart
@@ -129,7 +129,6 @@ class ProductRefresher {
     final String barcode,
   ) async {
     try {
-      // ignore: deprecated_member_use
       final ProductResultV3 result = await OpenFoodAPIClient.getProductV3(
         getBarcodeQueryConfiguration(barcode),
       );

--- a/packages/smooth_app/lib/pages/product/edit_ingredients_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_ingredients_page.dart
@@ -115,7 +115,7 @@ class _EditOcrPageState extends State<EditOcrPage> {
     final ProductImageData productImageData = getProductImageData(
       _product,
       _helper.getImageField(),
-      ProductQuery.getLanguage()!,
+      ProductQuery.getLanguage(),
     );
 
     return SmoothScaffold(
@@ -161,7 +161,7 @@ class _EditOcrPageState extends State<EditOcrPage> {
     final ImageProvider? imageProvider = TransientFile.getImageProvider(
       productImageData,
       _initialProduct.barcode!,
-      ProductQuery.getLanguage()!,
+      ProductQuery.getLanguage(),
     );
 
     if (imageProvider != null) {

--- a/packages/smooth_app/lib/pages/product/edit_ingredients_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_ingredients_page.dart
@@ -15,6 +15,7 @@ import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/pages/product/ocr_helper.dart';
 import 'package:smooth_app/pages/product/ocr_widget.dart';
+import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
@@ -111,8 +112,11 @@ class _EditOcrPageState extends State<EditOcrPage> {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     context.watch<LocalDatabase>();
     _product = _localDatabase.upToDate.getLocalUpToDate(_initialProduct);
-    final ProductImageData productImageData =
-        getProductImageData(_product, _helper.getImageField());
+    final ProductImageData productImageData = getProductImageData(
+      _product,
+      _helper.getImageField(),
+      ProductQuery.getLanguage()!,
+    );
 
     return SmoothScaffold(
       extendBodyBehindAppBar: true,
@@ -157,6 +161,7 @@ class _EditOcrPageState extends State<EditOcrPage> {
     final ImageProvider? imageProvider = TransientFile.getImageProvider(
       productImageData,
       _initialProduct.barcode!,
+      ProductQuery.getLanguage()!,
     );
 
     if (imageProvider != null) {

--- a/packages/smooth_app/lib/pages/product/ocr_widget.dart
+++ b/packages/smooth_app/lib/pages/product/ocr_widget.dart
@@ -41,7 +41,7 @@ class _OcrWidgetState extends State<OcrWidget> {
   @override
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    final OpenFoodFactsLanguage language = ProductQuery.getLanguage()!;
+    final OpenFoodFactsLanguage language = ProductQuery.getLanguage();
     return Align(
       alignment: AlignmentDirectional.bottomStart,
       child: Column(

--- a/packages/smooth_app/lib/pages/product/ocr_widget.dart
+++ b/packages/smooth_app/lib/pages/product/ocr_widget.dart
@@ -11,6 +11,7 @@ import 'package:smooth_app/pages/product/explanation_widget.dart';
 import 'package:smooth_app/pages/product/ocr_helper.dart';
 import 'package:smooth_app/pages/product/product_image_local_button.dart';
 import 'package:smooth_app/pages/product/product_image_server_button.dart';
+import 'package:smooth_app/query/product_query.dart';
 
 /// Widget dedicated to OCR, with 3 actions: upload image, extract data, save.
 ///
@@ -40,6 +41,7 @@ class _OcrWidgetState extends State<OcrWidget> {
   @override
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final OpenFoodFactsLanguage language = ProductQuery.getLanguage()!;
     return Align(
       alignment: AlignmentDirectional.bottomStart,
       child: Column(
@@ -78,6 +80,7 @@ class _OcrWidgetState extends State<OcrWidget> {
                           firstPhoto: !TransientFile.isImageAvailable(
                             widget.productImageData,
                             widget.product.barcode!,
+                            language,
                           ),
                           barcode: widget.product.barcode!,
                           imageField: widget.helper.getImageField(),
@@ -106,6 +109,7 @@ class _OcrWidgetState extends State<OcrWidget> {
                       if (TransientFile.isServerImage(
                         widget.productImageData,
                         widget.product.barcode!,
+                        language,
                       ))
                         SmoothActionButtonsBar.single(
                           action: SmoothActionButton(
@@ -117,6 +121,7 @@ class _OcrWidgetState extends State<OcrWidget> {
                       else if (TransientFile.isImageAvailable(
                         widget.productImageData,
                         widget.product.barcode!,
+                        language,
                       ))
                         // TODO(monsieurtanuki): what if slow upload? text instead?
                         const CircularProgressIndicator.adaptive(),

--- a/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
@@ -58,7 +58,7 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView> {
   Widget build(BuildContext context) {
     BackgroundTaskManager(_localDatabase).run(); // no await
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    final OpenFoodFactsLanguage language = ProductQuery.getLanguage()!;
+    final OpenFoodFactsLanguage language = ProductQuery.getLanguage();
     final ThemeData theme = Theme.of(context);
     context.watch<LocalDatabase>();
     _product = _localDatabase.upToDate.getLocalUpToDate(_initialProduct);

--- a/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
@@ -14,6 +14,7 @@ import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/pages/image_crop_page.dart';
 import 'package:smooth_app/pages/product/common/product_refresher.dart';
 import 'package:smooth_app/pages/product/product_image_swipeable_view.dart';
+import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
@@ -37,9 +38,6 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView> {
 
   late Map<ProductImageData, ImageProvider?> _selectedImages;
 
-  ImageProvider? _provideImage(ProductImageData imageData) =>
-      TransientFile.getImageProvider(imageData, _barcode);
-
   String get _barcode => _initialProduct.barcode!;
 
   @override
@@ -60,15 +58,11 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView> {
   Widget build(BuildContext context) {
     BackgroundTaskManager(_localDatabase).run(); // no await
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final OpenFoodFactsLanguage language = ProductQuery.getLanguage()!;
     final ThemeData theme = Theme.of(context);
     context.watch<LocalDatabase>();
     _product = _localDatabase.upToDate.getLocalUpToDate(_initialProduct);
-    final List<ProductImageData> allProductImagesData =
-        getProductMainImagesData(_product, includeOther: false);
-    _selectedImages = Map<ProductImageData, ImageProvider?>.fromIterables(
-      allProductImagesData,
-      allProductImagesData.map(_provideImage),
-    );
+    _selectedImages = getSelectedImages(_product, language);
     return SmoothScaffold(
       appBar: SmoothAppBar(
         title: _product.productName != null
@@ -117,7 +111,7 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView> {
                   _,
                   int? initialImageIndex,
                 ) =>
-                    TransientFile.isImageAvailable(data, _barcode)
+                    TransientFile.isImageAvailable(data, _barcode, language)
                         ? _openImage(
                             imageData: data,
                             initialImageIndex: initialImageIndex ?? 0,

--- a/packages/smooth_app/lib/pages/product/product_image_swipeable_view.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_swipeable_view.dart
@@ -67,7 +67,7 @@ class _ProductImageSwipeableViewState extends State<ProductImageSwipeableView> {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     context.watch<LocalDatabase>();
     _product = _localDatabase.upToDate.getLocalUpToDate(_initialProduct);
-    _selectedImages = getSelectedImages(_product, ProductQuery.getLanguage()!);
+    _selectedImages = getSelectedImages(_product, ProductQuery.getLanguage());
     _imageDataList = List<ProductImageData>.from(_selectedImages.keys);
     return SmoothScaffold(
       appBar: AppBar(

--- a/packages/smooth_app/lib/pages/product/product_image_swipeable_view.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_swipeable_view.dart
@@ -5,11 +5,11 @@ import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/product_image_data.dart';
 import 'package:smooth_app/database/local_database.dart';
-import 'package:smooth_app/database/transient_file.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_back_button.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/pages/product/product_image_viewer.dart';
+import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
 /// Widget to display swipeable product images of particular category.
@@ -42,9 +42,6 @@ class _ProductImageSwipeableViewState extends State<ProductImageSwipeableView> {
   late final Product _initialProduct;
   late Product _product;
 
-  ImageProvider? _provideImage(ProductImageData imageData) =>
-      TransientFile.getImageProvider(imageData, _barcode);
-
   String get _barcode => _initialProduct.barcode!;
 
   @override
@@ -70,12 +67,7 @@ class _ProductImageSwipeableViewState extends State<ProductImageSwipeableView> {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     context.watch<LocalDatabase>();
     _product = _localDatabase.upToDate.getLocalUpToDate(_initialProduct);
-    final List<ProductImageData> allProductImagesData =
-        getProductMainImagesData(_product, includeOther: false);
-    _selectedImages = Map<ProductImageData, ImageProvider?>.fromIterables(
-      allProductImagesData,
-      allProductImagesData.map(_provideImage),
-    );
+    _selectedImages = getSelectedImages(_product, ProductQuery.getLanguage()!);
     _imageDataList = List<ProductImageData>.from(_selectedImages.keys);
     return SmoothScaffold(
       appBar: AppBar(

--- a/packages/smooth_app/lib/pages/product/product_image_viewer.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_viewer.dart
@@ -65,12 +65,18 @@ class _ProductImageViewerState extends State<ProductImageViewer> {
   @override
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final OpenFoodFactsLanguage language = ProductQuery.getLanguage()!;
     context.watch<LocalDatabase>();
     _product = _localDatabase.upToDate.getLocalUpToDate(_initialProduct);
-    _imageData = getProductImageData(_product, widget.imageField);
+    _imageData = getProductImageData(
+      _product,
+      widget.imageField,
+      language,
+    );
     final ImageProvider? imageProvider = TransientFile.getImageProvider(
       _imageData,
       _barcode,
+      language,
     );
     return SmoothScaffold(
       extendBodyBehindAppBar: true,
@@ -184,6 +190,7 @@ class _ProductImageViewerState extends State<ProductImageViewer> {
     File? imageFile = TransientFile.getImage(
       _imageData.imageField,
       _barcode,
+      ProductQuery.getLanguage()!,
     );
     if (imageFile != null) {
       return _openCropPage(navigatorState, imageFile);

--- a/packages/smooth_app/lib/pages/product/product_image_viewer.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_viewer.dart
@@ -65,7 +65,7 @@ class _ProductImageViewerState extends State<ProductImageViewer> {
   @override
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    final OpenFoodFactsLanguage language = ProductQuery.getLanguage()!;
+    final OpenFoodFactsLanguage language = ProductQuery.getLanguage();
     context.watch<LocalDatabase>();
     _product = _localDatabase.upToDate.getLocalUpToDate(_initialProduct);
     _imageData = getProductImageData(
@@ -190,7 +190,7 @@ class _ProductImageViewerState extends State<ProductImageViewer> {
     File? imageFile = TransientFile.getImage(
       _imageData.imageField,
       _barcode,
-      ProductQuery.getLanguage()!,
+      ProductQuery.getLanguage(),
     );
     if (imageFile != null) {
       return _openCropPage(navigatorState, imageFile);

--- a/packages/smooth_app/lib/query/paged_user_product_query.dart
+++ b/packages/smooth_app/lib/query/paged_user_product_query.dart
@@ -29,7 +29,7 @@ enum UserSearchType {
     final String userId,
     final int pageSize,
     final int pageNumber,
-    final OpenFoodFactsLanguage? language,
+    final OpenFoodFactsLanguage language,
     final List<ProductField> fields,
   ) =>
       ProductSearchQueryConfiguration(

--- a/packages/smooth_app/lib/query/product_query.dart
+++ b/packages/smooth_app/lib/query/product_query.dart
@@ -131,7 +131,6 @@ abstract class ProductQuery {
         ProductField.BARCODE,
         ProductField.NUTRISCORE,
         ProductField.FRONT_IMAGE,
-        ProductField.IMAGE_FRONT_SMALL_URL,
         ProductField.IMAGE_FRONT_URL,
         ProductField.IMAGE_INGREDIENTS_URL,
         ProductField.IMAGE_NUTRITION_URL,


### PR DESCRIPTION
### What
- We used to rely on one image URL per product field (e.g. `product.imageFrontUrl`).
- Which meant that if we changed the app language, the image wouldn't change.
- But there are cases when the image is different, depending on the language.
- With the current PR, we always instantly get the "best" image if we change languages: the image specific to the new language, and as a fallback the product image URL we used before
- This is only the first step to multilingual images.
- The next steps are multilingual image edits and OCR.

### Screenshot
| specific front image in French | specific front image in Spanish | default front image in Italian |
| -- | -- | -- |
| ![Screenshot_2023-04-23-16-37-02](https://user-images.githubusercontent.com/11576431/233846636-894f66bc-1876-4af0-971b-9180f4b5da6b.png) | ![Screenshot_2023-04-23-16-37-41](https://user-images.githubusercontent.com/11576431/233846631-ee6c3299-97e8-4582-b5cb-11fe68e8e0a6.png) | ![Screenshot_2023-04-23-16-52-48](https://user-images.githubusercontent.com/11576431/233846997-7de94032-2f5e-43b4-a21b-44a3193cf8cb.png) |

### Part of 
- #3897

### Impacted files
* `background_task_crop.dart`: added language to transient file key
* `background_task_image.dart`: added language to transient file key
* `background_task_unselect.dart`: unrelated removal of not used fields
* `edit_ingredients_page.dart`: now we display localized images
* `image_upload_card.dart`: added language to transient file key
* `ocr_widget.dart`: added language to transient file key
* `product_cards_helper.dart`: now returns a localized image; refactored; new method `getLocalizedProductImageUrl`
* `product_image_carousel.dart`: now we display localized images
* `product_image_gallery_view.dart`: now we display localized images
* `product_image_swipeable_view.dart`: now we display localized images
* `product_image_viewer.dart`: now we display localized images
* `product_query.dart`: unrelated removal of not used field
* `product_refresher.dart`: unrelated minor refactoring
* `smooth_product_image.dart`: now we display localized images
* `transient_file.dart`: added language to transient file key
* `up_to_date_changes.dart`: unrelated removal of not used fields