### PR TITLE
fix: 3912 - packaging weight now works

### DIFF
--- a/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
@@ -32,16 +32,18 @@ class SimpleInputTextField extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final SuggestionManager manager = SuggestionManager(
-      tagType!,
-      language: ProductQuery.getLanguage(),
-      country: ProductQuery.getCountry(),
-      categories: categories,
-      shape: shapeProvider?.call(),
-      user: ProductQuery.getUser(),
-      // number of suggestions the user can scroll through: compromise between quantity and readability of the suggestions
-      limit: 15,
-    );
+    final SuggestionManager? manager = tagType == null
+        ? null
+        : SuggestionManager(
+            tagType!,
+            language: ProductQuery.getLanguage(),
+            country: ProductQuery.getCountry(),
+            categories: categories,
+            shape: shapeProvider?.call(),
+            user: ProductQuery.getUser(),
+            // number of suggestions the user can scroll through: compromise between quantity and readability of the suggestions
+            limit: 15,
+          );
 
     return Padding(
       padding: const EdgeInsets.only(left: LARGE_SPACE),
@@ -65,7 +67,7 @@ class SimpleInputTextField extends StatelessWidget {
                   return <String>[];
                 }
 
-                return manager.getSuggestions(input);
+                return manager!.getSuggestions(input);
               },
               fieldViewBuilder: (BuildContext context,
                       TextEditingController textEditingController,


### PR DESCRIPTION
### What
- This PR fixes a "null check operator" error introduced in #3876: there are some packaging fields (e.g. weight) that do not have a tag type from which suggestions are given.

### Screenshot
| before | after |
| -- | -- |
l ![Screenshot_2023-04-27-16-08-39](https://user-images.githubusercontent.com/11576431/234891485-c80b2272-736a-42b4-b489-209248a4dfb5.png) | ![Screenshot_2023-04-27-16-12-12](https://user-images.githubusercontent.com/11576431/234891556-6f012aac-9953-426e-965c-92a322295e33.png) |

### Fixes bug(s)
- Fixes: #3912

### Files
#### Impacted file:
* `simple_input_text_field.dart`: fixed a "null check operator" error