### PR TITLE
feat: 3765 - "red rectangle" possible side-effect fix

### DIFF
--- a/packages/smooth_app/lib/tmp_crop_image/rotated_crop_controller.dart
+++ b/packages/smooth_app/lib/tmp_crop_image/rotated_crop_controller.dart
@@ -186,14 +186,6 @@ class RotatedCropController extends ValueNotifier<RotatedCropControllerValue> {
       }
     }
 
-    // just checking
-    canvas.drawRect(
-      Rect.fromLTWH(0, 0, cropWidth * factor, cropHeight * factor),
-      Paint()
-        ..color = Colors.red
-        ..style = PaintingStyle.fill,
-    );
-
     final Offset cropCenter = rotation.getRotatedOffset(
       crop.center,
       image.width.toDouble(),


### PR DESCRIPTION
### What
- This is only a quick fix of a possible side-effect (for transparent images) of the crop tool (cf. #3904)
- An additional PR will use the latest version of `crop_image` (which also fixes that bug), but that takes longer to code, so first the quick fix!

### Part of 
- #3765