### PR TITLE
ci: First step towards F-Droid

### DIFF
--- a/.github/workflows/internal-release.yml
+++ b/.github/workflows/internal-release.yml
@@ -63,7 +63,7 @@ jobs:
         continue-on-error: true
         with:
           tag: "${{ env.NORMALIZED_TAG }}"
-          message: "Internal release: ${{ env.VERSION_NAME }}-${{ env.VERSION_CODE }}"
+          message: "Internal release: ${{ env.VERSION_NAME }}+${{ env.VERSION_CODE }}"
           force_push_tag: true
 
       - name: Set output

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -79,7 +79,7 @@ jobs:
         continue-on-error: true
         with:
           tag: "v${{ env.VERSION_NAME }}"
-          message: "Public release: ${{ env.VERSION_NAME }}-${{ env.VERSION_CODE }}"
+          message: "Public release: ${{ env.VERSION_NAME }}+${{ env.VERSION_CODE }}"
           force_push_tag: true
 
       - name: Set output

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -72,6 +72,15 @@ jobs:
 
       - name: Version
         run: echo "${{ env.VERSION_NAME }}+${{ env.VERSION_CODE }}"
+        
+      # We need to add the VERSION_CODE to the release in order for F-Droid to have the same VERSION_CODE as the other Stores
+      - name: Update release tag description 
+        uses: rickstaa/action-create-tag@v1
+        continue-on-error: true
+        with:
+          tag: "v${{ env.VERSION_NAME }}"
+          message: "Public release: ${{ env.VERSION_NAME }}-${{ env.VERSION_CODE }}"
+          force_push_tag: true
 
       - name: Set output
         id: set_output

--- a/ci/rename_package_name_F-Droid.sh
+++ b/ci/rename_package_name_F-Droid.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+
+# Replaces all occurrences of org.openfoodfacts.scanner -> openfoodfacts.github.scrachx.openfood for the F-Droid listing
+
+cd ../packages/smooth_app/android/ && grep -rli 'org.openfoodfacts.scanner' * | xargs -i@ sed -i 's/org.openfoodfacts.scanner/openfoodfacts.github.scrachx.openfood/g' @

--- a/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
+++ b/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
@@ -324,10 +324,20 @@ class _SearchCardTagLineState extends State<_SearchCardTagLine> {
     };
   }
 
-  Future<bool> _isApplicationDeprecated() {
-    return PackageInfo.fromPlatform().then(
-      (PackageInfo value) => value.packageName != 'org.openfoodfacts.scanner',
-    );
+  Future<bool> _isApplicationDeprecated() async {
+    final PackageInfo info = await PackageInfo.fromPlatform();
+
+    // The normal packageName
+    if (info.packageName == 'org.openfoodfacts.scanner') {
+      return false;
+    }
+
+    // packageName used on F-Droid
+    if (info.packageName == 'openfoodfacts.github.scrachx.openfood') {
+      return false;
+    }
+
+    return true;
   }
 }
 


### PR DESCRIPTION
### What

The first step towards an automated release on F-Droid

`release-please.yml`: Added a new step to edit the tag description, we somehow need to pass the version_code to the F-Droid server

`ci/rename_package_name_F-Droid.sh`: F-Droid uses another package name, and we plan to replace the current listing, so we need to change it.

`smooth_product_carousel.dart`: Update to accept the F-Droid package name.
