### PR TITLE
feat: 3897 - no language selector for gallery, only for swipeable page

### DIFF
--- a/packages/smooth_app/lib/background/background_task_crop.dart
+++ b/packages/smooth_app/lib/background/background_task_crop.dart
@@ -101,6 +101,7 @@ class BackgroundTaskCrop extends AbstractBackgroundTask {
   /// Adds the background task about uploading a product image.
   static Future<void> addTask(
     final String barcode, {
+    required final OpenFoodFactsLanguage language,
     required final int imageId,
     required final ImageField imageField,
     required final File croppedFile,
@@ -117,6 +118,7 @@ class BackgroundTaskCrop extends AbstractBackgroundTask {
       barcode,
     );
     final AbstractBackgroundTask task = _getNewTask(
+      language,
       barcode,
       imageId,
       imageField,
@@ -137,6 +139,7 @@ class BackgroundTaskCrop extends AbstractBackgroundTask {
 
   /// Returns a new background task about cropping an existing image.
   static BackgroundTaskCrop _getNewTask(
+    final OpenFoodFactsLanguage language,
     final String barcode,
     final int imageId,
     final ImageField imageField,
@@ -160,13 +163,13 @@ class BackgroundTaskCrop extends AbstractBackgroundTask {
         cropY1: cropY1,
         cropX2: cropX2,
         cropY2: cropY2,
-        languageCode: ProductQuery.getLanguage().code,
+        languageCode: language.code,
         user: jsonEncode(ProductQuery.getUser().toJson()),
         country: ProductQuery.getCountry()!.offTag,
         stamp: BackgroundTaskImage.getStamp(
           barcode,
           imageField.offTag,
-          ProductQuery.getLanguage().code,
+          language.code,
         ),
       );
 

--- a/packages/smooth_app/lib/background/background_task_image.dart
+++ b/packages/smooth_app/lib/background/background_task_image.dart
@@ -117,6 +117,7 @@ class BackgroundTaskImage extends AbstractBackgroundTask {
   /// Adds the background task about uploading a product image.
   static Future<void> addTask(
     final String barcode, {
+    required final OpenFoodFactsLanguage language,
     required final ImageField imageField,
     required final File fullFile,
     required final File croppedFile,
@@ -133,6 +134,7 @@ class BackgroundTaskImage extends AbstractBackgroundTask {
       barcode,
     );
     final AbstractBackgroundTask task = _getNewTask(
+      language,
       barcode,
       imageField,
       fullFile,
@@ -153,6 +155,7 @@ class BackgroundTaskImage extends AbstractBackgroundTask {
 
   /// Returns a new background task about changing a product.
   static BackgroundTaskImage _getNewTask(
+    final OpenFoodFactsLanguage language,
     final String barcode,
     final ImageField imageField,
     final File fullFile,
@@ -176,13 +179,13 @@ class BackgroundTaskImage extends AbstractBackgroundTask {
         cropY1: cropY1,
         cropX2: cropX2,
         cropY2: cropY2,
-        languageCode: ProductQuery.getLanguage().code,
+        languageCode: language.code,
         user: jsonEncode(ProductQuery.getUser().toJson()),
         country: ProductQuery.getCountry()!.offTag,
         stamp: getStamp(
           barcode,
           imageField.offTag,
-          ProductQuery.getLanguage().code,
+          language.code,
         ),
       );
 

--- a/packages/smooth_app/lib/background/background_task_unselect.dart
+++ b/packages/smooth_app/lib/background/background_task_unselect.dart
@@ -9,6 +9,7 @@ import 'package:smooth_app/background/background_task_image.dart';
 import 'package:smooth_app/background/background_task_refresh_later.dart';
 import 'package:smooth_app/data_models/operation_type.dart';
 import 'package:smooth_app/database/local_database.dart';
+import 'package:smooth_app/helpers/image_field_extension.dart';
 import 'package:smooth_app/query/product_query.dart';
 
 /// Background task about unselecting a product image.
@@ -154,22 +155,7 @@ class BackgroundTaskUnselect extends AbstractBackgroundTask {
   /// Here we put an empty string instead, to be understood as "force to null!".
   Product _getUnselectedProduct() {
     final Product result = Product(barcode: barcode);
-    switch (ImageField.fromOffTag(imageField)!) {
-      case ImageField.FRONT:
-        result.imageFrontUrl = '';
-        break;
-      case ImageField.INGREDIENTS:
-        result.imageIngredientsUrl = '';
-        break;
-      case ImageField.NUTRITION:
-        result.imageNutritionUrl = '';
-        break;
-      case ImageField.PACKAGING:
-        result.imagePackagingUrl = '';
-        break;
-      case ImageField.OTHER:
-      // We do nothing. Actually we're not supposed to unselect other images.
-    }
+    ImageField.fromOffTag(imageField)!.setUrl(result, '');
     return result;
   }
 }

--- a/packages/smooth_app/lib/background/background_task_unselect.dart
+++ b/packages/smooth_app/lib/background/background_task_unselect.dart
@@ -74,6 +74,7 @@ class BackgroundTaskUnselect extends AbstractBackgroundTask {
     final String barcode, {
     required final ImageField imageField,
     required final State<StatefulWidget> widget,
+    required final OpenFoodFactsLanguage language,
   }) async {
     final LocalDatabase localDatabase = widget.context.read<LocalDatabase>();
     final String uniqueId = await _operationType.getNewKey(
@@ -84,6 +85,7 @@ class BackgroundTaskUnselect extends AbstractBackgroundTask {
       barcode,
       imageField,
       uniqueId,
+      language,
     );
     await task.addToManager(localDatabase, widget: widget);
   }
@@ -97,20 +99,21 @@ class BackgroundTaskUnselect extends AbstractBackgroundTask {
     final String barcode,
     final ImageField imageField,
     final String uniqueId,
+    final OpenFoodFactsLanguage language,
   ) =>
       BackgroundTaskUnselect._(
         uniqueId: uniqueId,
         barcode: barcode,
         processName: _PROCESS_NAME,
         imageField: imageField.offTag,
-        languageCode: ProductQuery.getLanguage().code,
+        languageCode: language.code,
         user: jsonEncode(ProductQuery.getUser().toJson()),
         country: ProductQuery.getCountry()!.offTag,
         // same stamp as image upload
         stamp: BackgroundTaskImage.getStamp(
           barcode,
           imageField.offTag,
-          ProductQuery.getLanguage().code,
+          language.code,
         ),
       );
 
@@ -123,6 +126,7 @@ class BackgroundTaskUnselect extends AbstractBackgroundTask {
     final LocalDatabase localDatabase,
     final bool success,
   ) async {
+    // TODO(monsieurtanuki): we should also remove the hypothetical transient file, shouldn't we?
     localDatabase.upToDate.terminate(uniqueId);
     localDatabase.notifyListeners();
     if (success) {

--- a/packages/smooth_app/lib/cards/data_cards/image_upload_card.dart
+++ b/packages/smooth_app/lib/cards/data_cards/image_upload_card.dart
@@ -46,6 +46,7 @@ class _ImageUploadCardState extends State<ImageUploadCard> {
           this,
           barcode: widget.product.barcode!,
           imageField: widget.productImageData.imageField,
+          language: ProductQuery.getLanguage(),
         ),
         icon: const Icon(Icons.add_a_photo),
         label: Text(

--- a/packages/smooth_app/lib/database/transient_file.dart
+++ b/packages/smooth_app/lib/database/transient_file.dart
@@ -58,13 +58,20 @@ class TransientFile {
     return File(path);
   }
 
-  /// Returns the key of the transient image for [imageField] and [barcode].
+  /// Returns the key of the transient image.
   static String _getImageKey(
     final ImageField imageField,
     final String barcode,
     final OpenFoodFactsLanguage language,
   ) =>
-      '$barcode;$imageField;${language.code}';
+      '${_getImageKeyPrefix(imageField, barcode)}${language.code}';
+
+  /// Returns the key prefix of the transient image (without language).
+  static String _getImageKeyPrefix(
+    final ImageField imageField,
+    final String barcode,
+  ) =>
+      '$barcode;$imageField;';
 
   /// Returns a way to display the image, either locally or from the server.
   static ImageProvider? getImageProvider(
@@ -109,4 +116,28 @@ class TransientFile {
   ) =>
       getImage(imageData.imageField, barcode, language) == null &&
       imageData.imageUrl != null;
+
+  /// Returns the languages that have currently transient images.
+  static Iterable<OpenFoodFactsLanguage> getImageLanguages(
+    final ImageField imageField,
+    final String barcode,
+  ) {
+    final Set<OpenFoodFactsLanguage> result = <OpenFoodFactsLanguage>{};
+    final String prefix = _getImageKeyPrefix(imageField, barcode);
+    final int prefixLength = prefix.length;
+    for (final String key in _transientFiles.keys) {
+      if (key.length <= prefixLength) {
+        continue;
+      }
+      if (!key.startsWith(prefix)) {
+        continue;
+      }
+      final String lc = key.substring(prefixLength);
+      final OpenFoodFactsLanguage language = LanguageHelper.fromJson(lc);
+      if (language != OpenFoodFactsLanguage.UNDEFINED) {
+        result.add(language);
+      }
+    }
+    return result;
+  }
 }

--- a/packages/smooth_app/lib/helpers/image_field_extension.dart
+++ b/packages/smooth_app/lib/helpers/image_field_extension.dart
@@ -9,7 +9,15 @@ extension ImageFieldSmoothieExtension on ImageField {
     ImageField.PACKAGING,
   ];
 
-  String? getImageFieldUrl(final Product product) {
+  static const List<ImageField> orderedAll = <ImageField>[
+    ImageField.FRONT,
+    ImageField.INGREDIENTS,
+    ImageField.NUTRITION,
+    ImageField.PACKAGING,
+    ImageField.OTHER,
+  ];
+
+  String? getUrl(final Product product) {
     switch (this) {
       case ImageField.FRONT:
         return product.imageFrontUrl;
@@ -21,6 +29,25 @@ extension ImageFieldSmoothieExtension on ImageField {
         return product.imagePackagingUrl;
       case ImageField.OTHER:
         return null;
+    }
+  }
+
+  void setUrl(final Product product, final String url) {
+    switch (this) {
+      case ImageField.FRONT:
+        product.imageFrontUrl = url;
+        break;
+      case ImageField.INGREDIENTS:
+        product.imageIngredientsUrl = url;
+        break;
+      case ImageField.NUTRITION:
+        product.imageNutritionUrl = url;
+        break;
+      case ImageField.PACKAGING:
+        product.imagePackagingUrl = url;
+        break;
+      case ImageField.OTHER:
+      // We do nothing.
     }
   }
 
@@ -68,6 +95,21 @@ extension ImageFieldSmoothieExtension on ImageField {
         return appLocalizations.packaging_information;
       case ImageField.OTHER:
         return appLocalizations.more_photos;
+    }
+  }
+
+  String getAddPhotoButtonText(final AppLocalizations appLocalizations) {
+    switch (this) {
+      case ImageField.FRONT:
+        return appLocalizations.front_packaging_photo_button_label;
+      case ImageField.INGREDIENTS:
+        return appLocalizations.ingredients_photo_button_label;
+      case ImageField.NUTRITION:
+        return appLocalizations.nutritional_facts_photo_button_label;
+      case ImageField.PACKAGING:
+        return appLocalizations.recycling_photo_button_label;
+      case ImageField.OTHER:
+        return appLocalizations.other_interesting_photo_button_label;
     }
   }
 }

--- a/packages/smooth_app/lib/helpers/product_cards_helper.dart
+++ b/packages/smooth_app/lib/helpers/product_cards_helper.dart
@@ -215,7 +215,7 @@ ProductImageData getProductImageData(
     imageUrl = getLocalizedProductImageUrl(product, productImage);
   } else {
     imageLanguage = null;
-    imageUrl = forceLanguage ? null : imageField.getImageFieldUrl(product);
+    imageUrl = forceLanguage ? null : imageField.getUrl(product);
   }
 
   return ProductImageData(

--- a/packages/smooth_app/lib/helpers/product_cards_helper.dart
+++ b/packages/smooth_app/lib/helpers/product_cards_helper.dart
@@ -277,12 +277,16 @@ String _getBarcodeSubPath(final String barcode) {
   return '$p1/$p2/$p3/$p4';
 }
 
+String _getImageRoot() =>
+    OpenFoodAPIConfiguration.globalQueryType == QueryType.PROD
+        ? 'https://images.openfoodfacts.org/images/products'
+        : 'https://images.openfoodfacts.net/images/products';
+
 String getLocalizedProductImageUrl(
   final Product product,
   final ProductImage productImage,
 ) =>
-// TODO(monsieurtanuki): make it work in TEST env too (= .net)
-    'https://images.openfoodfacts.org/images/products/'
+    '${_getImageRoot()}/'
     '${_getBarcodeSubPath(product.barcode!)}/'
     '${ImageHelper.getProductImageFilename(productImage, imageSize: ImageSize.DISPLAY)}';
 

--- a/packages/smooth_app/lib/helpers/product_cards_helper.dart
+++ b/packages/smooth_app/lib/helpers/product_cards_helper.dart
@@ -193,11 +193,15 @@ List<ProductImageData> getProductMainImagesData(
   return result;
 }
 
+/// Returns data about the "best" image: for the language, or the default.
+///
+/// With [forceLanguage] you say you don't want the default as a fallback.
 ProductImageData getProductImageData(
   final Product product,
   final ImageField imageField,
-  final OpenFoodFactsLanguage language,
-) {
+  final OpenFoodFactsLanguage language, {
+  final bool forceLanguage = false,
+}) {
   final ProductImage? productImage = getLocalizedProductImage(
     product,
     imageField,
@@ -206,11 +210,12 @@ ProductImageData getProductImageData(
   final String? imageUrl;
   final OpenFoodFactsLanguage? imageLanguage;
   if (productImage != null) {
+    // we found a localized version for this image
     imageLanguage = language;
     imageUrl = getLocalizedProductImageUrl(product, productImage);
   } else {
     imageLanguage = null;
-    imageUrl = imageField.getImageFieldUrl(product);
+    imageUrl = forceLanguage ? null : imageField.getImageFieldUrl(product);
   }
 
   return ProductImageData(
@@ -257,29 +262,6 @@ List<MapEntry<ProductImageData, ImageProvider?>> getSelectedImages(
   return result.entries.toList();
 }
 
-OpenFoodFactsLanguage? getProductImageUrlLanguage(
-  final Product product,
-  final ImageField imageField,
-  final String url,
-) {
-  if (product.images == null) {
-    return null;
-  }
-  for (final ProductImage productImage in product.images!) {
-    if (productImage.field != imageField ||
-        productImage.language == null ||
-        productImage.rev == null) {
-      continue;
-    }
-    final String localizedUrl =
-        getLocalizedProductImageUrl(product, productImage);
-    if (url == localizedUrl) {
-      return productImage.language;
-    }
-  }
-  return null;
-}
-
 // TODO(monsieurtanuki): move to off-dart in ImageHelper
 String _getBarcodeSubPath(final String barcode) {
   if (barcode.length < 9) {
@@ -304,17 +286,18 @@ String getLocalizedProductImageUrl(
     '${_getBarcodeSubPath(product.barcode!)}/'
     '${ImageHelper.getProductImageFilename(productImage, imageSize: ImageSize.DISPLAY)}';
 
-/// Returns the languages for which image fields have images.
+/// Returns the languages for which [imageField] has images for that [product].
 Iterable<OpenFoodFactsLanguage> getProductImageLanguages(
   final Product product,
-  final Iterable<ImageField> imageFields,
+  final ImageField imageField,
 ) {
   final Set<OpenFoodFactsLanguage> result = <OpenFoodFactsLanguage>{};
+  result.addAll(TransientFile.getImageLanguages(imageField, product.barcode!));
   if (product.images == null) {
     return result;
   }
   for (final ProductImage productImage in product.images!) {
-    if (imageFields.contains(productImage.field) &&
+    if (imageField == productImage.field &&
         productImage.rev != null &&
         productImage.language != null) {
       result.add(productImage.language!);

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1583,6 +1583,14 @@
     "@edit_photo_select_existing_downloaded_none": {
         "description": "Error message"
     },
+    "edit_photo_language_not_this_one": "No image in that language yet",
+    "@edit_photo_language_not_this_one": {
+        "description": "Warning message: for this product and this field, there are 'translated' images, but not in that language"
+    },
+    "edit_photo_language_none": "No image yet",
+    "@edit_photo_language_none": {
+        "description": "Warning message: for this product and this field, there are no images at all, in any language"
+    },
     "category_picker_screen_title": "Categories",
     "@category_picker_screen_title": {
         "description": "Categories picker screen title"

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -1574,6 +1574,14 @@
     "@edit_photo_select_existing_downloaded_none": {
         "description": "Error message"
     },
+    "edit_photo_language_not_this_one": "Pas encore de photo dans cette langue",
+    "@edit_photo_language_not_this_one": {
+        "description": "Warning message: for this product and this field, there are 'translated' images, but not in that language"
+    },
+    "edit_photo_language_none": "Pas encore de photo",
+    "@edit_photo_language_none": {
+        "description": "Warning message: for this product and this field, there are no images at all, in any language"
+    },
     "category_picker_screen_title": "Catégories",
     "@category_picker_screen_title": {
         "description": "Categories picker screen title"

--- a/packages/smooth_app/lib/pages/image/uploaded_image_gallery.dart
+++ b/packages/smooth_app/lib/pages/image/uploaded_image_gallery.dart
@@ -18,11 +18,15 @@ class UploadedImageGallery extends StatelessWidget {
     required this.barcode,
     required this.imageIds,
     required this.imageField,
+    required this.language,
   });
 
   final String barcode;
   final List<int> imageIds;
   final ImageField imageField;
+
+  /// Language for which we'll save the cropped image.
+  final OpenFoodFactsLanguage language;
 
   @override
   Widget build(BuildContext context) {
@@ -77,6 +81,7 @@ class UploadedImageGallery extends StatelessWidget {
                     inputFile: imageFile,
                     imageId: imageId,
                     initiallyDifferent: true,
+                    language: language,
                   ),
                   fullscreenDialog: true,
                 ),

--- a/packages/smooth_app/lib/pages/image_crop_page.dart
+++ b/packages/smooth_app/lib/pages/image_crop_page.dart
@@ -91,6 +91,7 @@ Future<File?> confirmAndUploadNewPicture(
   final State<StatefulWidget> widget, {
   required final ImageField imageField,
   required final String barcode,
+  required final OpenFoodFactsLanguage language,
 }) async {
   final XFile? croppedPhoto = await pickImageFile(widget);
   if (croppedPhoto == null) {
@@ -107,6 +108,7 @@ Future<File?> confirmAndUploadNewPicture(
         imageField: imageField,
         inputFile: File(croppedPhoto.path),
         initiallyDifferent: true,
+        language: language,
       ),
       fullscreenDialog: true,
     ),

--- a/packages/smooth_app/lib/pages/product/add_new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_new_product_page.dart
@@ -12,6 +12,7 @@ import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/pages/image_crop_page.dart';
 import 'package:smooth_app/pages/product/add_basic_details_page.dart';
 import 'package:smooth_app/pages/product/nutrition_page_loaded.dart';
+import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
 const EdgeInsetsGeometry _ROW_PADDING_TOP = EdgeInsetsDirectional.only(
@@ -183,6 +184,7 @@ class _AddNewProductPageState extends State<AddNewProductPage> {
             this,
             barcode: widget.barcode,
             imageField: imageField,
+            language: ProductQuery.getLanguage(),
           );
           if (finalPhoto != null) {
             setState(() {

--- a/packages/smooth_app/lib/pages/product/add_new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_new_product_page.dart
@@ -9,6 +9,7 @@ import 'package:smooth_app/database/dao_product_list.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/buttons/smooth_large_button_with_icon.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/helpers/image_field_extension.dart';
 import 'package:smooth_app/pages/image_crop_page.dart';
 import 'package:smooth_app/pages/product/add_basic_details_page.dart';
 import 'package:smooth_app/pages/product/nutrition_page_loaded.dart';
@@ -18,15 +19,6 @@ import 'package:smooth_app/widgets/smooth_scaffold.dart';
 const EdgeInsetsGeometry _ROW_PADDING_TOP = EdgeInsetsDirectional.only(
   top: VERY_LARGE_SPACE,
 );
-
-// Buttons to add images will appear in this order.
-const List<ImageField> _SORTED_IMAGE_FIELD_LIST = <ImageField>[
-  ImageField.FRONT,
-  ImageField.NUTRITION,
-  ImageField.INGREDIENTS,
-  ImageField.PACKAGING,
-  ImageField.OTHER,
-];
 
 /// "Create a product we couldn't find on the server" page.
 class AddNewProductPage extends StatefulWidget {
@@ -145,7 +137,8 @@ class _AddNewProductPageState extends State<AddNewProductPage> {
   List<Widget> _buildImageCaptureRows(BuildContext context) {
     final List<Widget> rows = <Widget>[];
     // First build rows for buttons to ask user to upload images.
-    for (final ImageField imageField in _SORTED_IMAGE_FIELD_LIST) {
+    for (final ImageField imageField
+        in ImageFieldSmoothieExtension.orderedAll) {
       // Always add a button to "Add other photos" because there can be multiple
       // "other photos" uploaded by the user.
       if (imageField == ImageField.OTHER) {
@@ -177,7 +170,7 @@ class _AddNewProductPageState extends State<AddNewProductPage> {
     return Padding(
       padding: _ROW_PADDING_TOP,
       child: SmoothLargeButtonWithIcon(
-        text: _getAddPhotoButtonText(context, imageField),
+        text: imageField.getAddPhotoButtonText(AppLocalizations.of(context)),
         icon: Icons.camera_alt,
         onPressed: () async {
           final File? finalPhoto = await confirmAndUploadNewPicture(
@@ -201,28 +194,14 @@ class _AddNewProductPageState extends State<AddNewProductPage> {
   }
 
   Widget _buildImageUploadedRow(
-      BuildContext context, ImageField imageType, File image) {
-    return _InfoAddedRow(
-      text: _getAddPhotoButtonText(context, imageType),
-      imgStart: image,
-    );
-  }
-
-  String _getAddPhotoButtonText(BuildContext context, ImageField imageType) {
-    final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    switch (imageType) {
-      case ImageField.FRONT:
-        return appLocalizations.front_packaging_photo_button_label;
-      case ImageField.INGREDIENTS:
-        return appLocalizations.ingredients_photo_button_label;
-      case ImageField.NUTRITION:
-        return appLocalizations.nutritional_facts_photo_button_label;
-      case ImageField.PACKAGING:
-        return appLocalizations.recycling_photo_button_label;
-      case ImageField.OTHER:
-        return appLocalizations.other_interesting_photo_button_label;
-    }
-  }
+    BuildContext context,
+    ImageField imageField,
+    File image,
+  ) =>
+      _InfoAddedRow(
+        text: imageField.getAddPhotoButtonText(AppLocalizations.of(context)),
+        imgStart: image,
+      );
 
   Widget _buildNutritionInputButton() {
     // if the nutrition image is null, ie no image , we return nothing

--- a/packages/smooth_app/lib/pages/product/edit_ingredients_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_ingredients_page.dart
@@ -20,7 +20,6 @@ import 'package:smooth_app/pages/product/multilingual_helper.dart';
 import 'package:smooth_app/pages/product/ocr_helper.dart';
 import 'package:smooth_app/pages/product/product_image_local_button.dart';
 import 'package:smooth_app/pages/product/product_image_server_button.dart';
-import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
@@ -213,7 +212,8 @@ class _EditOcrPageState extends State<EditOcrPage> {
 
   Widget _getOcrWidget(final ProductImageData productImageData) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    final OpenFoodFactsLanguage language = ProductQuery.getLanguage();
+    final OpenFoodFactsLanguage language =
+        _multilingualHelper.getCurrentLanguage();
     return Align(
       alignment: AlignmentDirectional.bottomStart,
       child: Column(
@@ -241,6 +241,7 @@ class _EditOcrPageState extends State<EditOcrPage> {
                         child: ProductImageServerButton(
                           barcode: widget.product.barcode!,
                           imageField: _helper.getImageField(),
+                          language: language,
                         ),
                       ),
                     ),
@@ -256,6 +257,7 @@ class _EditOcrPageState extends State<EditOcrPage> {
                           ),
                           barcode: widget.product.barcode!,
                           imageField: _helper.getImageField(),
+                          language: language,
                         ),
                       ),
                     ),
@@ -327,6 +329,7 @@ class _EditOcrPageState extends State<EditOcrPage> {
                               this,
                               imageField: ImageField.OTHER,
                               barcode: widget.product.barcode!,
+                              language: language,
                             ),
                             iconData: Icons.add_a_photo,
                           ),

--- a/packages/smooth_app/lib/pages/product/edit_new_packagings.dart
+++ b/packages/smooth_app/lib/pages/product/edit_new_packagings.dart
@@ -16,6 +16,7 @@ import 'package:smooth_app/pages/product/edit_new_packagings_helper.dart';
 import 'package:smooth_app/pages/product/may_exit_page_helper.dart';
 import 'package:smooth_app/pages/product/simple_input_number_field.dart';
 import 'package:smooth_app/pages/product/simple_input_text_field.dart';
+import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/themes/color_schemes.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
@@ -164,6 +165,7 @@ class _EditNewPackagingsState extends State<EditNewPackagings> {
             this,
             imageField: ImageField.OTHER,
             barcode: widget.product.barcode!,
+            language: ProductQuery.getLanguage(),
           ),
           iconData: Icons.add_a_photo,
         ),

--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -20,7 +20,6 @@ import 'package:smooth_app/pages/product/ordered_nutrients_cache.dart';
 import 'package:smooth_app/pages/product/product_image_swipeable_view.dart';
 import 'package:smooth_app/pages/product/simple_input_number_field.dart';
 import 'package:smooth_app/pages/text_field_helper.dart';
-import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
@@ -354,7 +353,6 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
               builder: (_) => ProductImageSwipeableView.imageField(
                 imageField: ImageField.NUTRITION,
                 product: _product,
-                language: ProductQuery.getLanguage(),
               ),
             ),
           ),

--- a/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
@@ -5,7 +5,6 @@ import 'package:provider/provider.dart';
 import 'package:smooth_app/background/background_task_manager.dart';
 import 'package:smooth_app/data_models/product_image_data.dart';
 import 'package:smooth_app/database/local_database.dart';
-import 'package:smooth_app/generic_lib/widgets/language_selector.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_back_button.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_list_tile_card.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
@@ -37,7 +36,6 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView> {
   late Product _product;
 
   late List<MapEntry<ProductImageData, ImageProvider?>> _selectedImages;
-  late OpenFoodFactsLanguage _currentLanguage;
 
   String get _barcode => _initialProduct.barcode!;
 
@@ -47,7 +45,6 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView> {
     _initialProduct = widget.product;
     _localDatabase = context.read<LocalDatabase>();
     _localDatabase.upToDate.showInterest(_barcode);
-    _currentLanguage = ProductQuery.getLanguage();
   }
 
   @override
@@ -63,7 +60,7 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView> {
     final ThemeData theme = Theme.of(context);
     context.watch<LocalDatabase>();
     _product = _localDatabase.upToDate.getLocalUpToDate(_initialProduct);
-    _selectedImages = getSelectedImages(_product, _currentLanguage);
+    _selectedImages = getSelectedImages(_product, ProductQuery.getLanguage());
     return SmoothScaffold(
       appBar: SmoothAppBar(
         title: Text(appLocalizations.edit_product_form_item_photos_title),
@@ -86,6 +83,7 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView> {
             this,
             imageField: ImageField.OTHER,
             barcode: _barcode,
+            language: ProductQuery.getLanguage(),
           );
         },
         label: Text(appLocalizations.add_photo_button_label),
@@ -97,25 +95,8 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView> {
           widget: this,
         ),
         child: ListView.builder(
-          // the language header and then the images
-          itemCount: 1 + _selectedImages.length,
+          itemCount: _selectedImages.length,
           itemBuilder: (final BuildContext context, int index) {
-            if (index == 0) {
-              return LanguageSelector(
-                setLanguage: (final OpenFoodFactsLanguage? newLanguage) async {
-                  if (newLanguage == null || newLanguage == _currentLanguage) {
-                    return;
-                  }
-                  setState(() => _currentLanguage = newLanguage);
-                },
-                displayedLanguage: _currentLanguage,
-                selectedLanguages: getProductImageLanguages(
-                  _product,
-                  ImageFieldSmoothieExtension.orderedMain,
-                ),
-              );
-            }
-            index--;
             final MapEntry<ProductImageData, ImageProvider?> item =
                 _selectedImages[index];
             return SmoothListTileCard.image(
@@ -145,7 +126,6 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView> {
           builder: (_) => ProductImageSwipeableView(
             initialImageIndex: initialImageIndex,
             product: _product,
-            language: _currentLanguage,
           ),
         ),
       );

--- a/packages/smooth_app/lib/pages/product/product_image_local_button.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_local_button.dart
@@ -11,11 +11,13 @@ class ProductImageLocalButton extends StatefulWidget {
     required this.firstPhoto,
     required this.barcode,
     required this.imageField,
+    required this.language,
   });
 
   final bool firstPhoto;
   final String barcode;
   final ImageField imageField;
+  final OpenFoodFactsLanguage language;
 
   @override
   State<ProductImageLocalButton> createState() =>
@@ -47,6 +49,7 @@ class _ProductImageLocalButtonState extends State<ProductImageLocalButton> {
       this,
       imageField: widget.imageField,
       barcode: widget.barcode,
+      language: widget.language,
     );
   }
 }

--- a/packages/smooth_app/lib/pages/product/product_image_server_button.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_server_button.dart
@@ -13,10 +13,12 @@ class ProductImageServerButton extends StatelessWidget {
   const ProductImageServerButton({
     required this.barcode,
     required this.imageField,
+    required this.language,
   });
 
   final String barcode;
   final ImageField imageField;
+  final OpenFoodFactsLanguage language;
 
   @override
   Widget build(BuildContext context) => EditImageButton(
@@ -76,6 +78,7 @@ class ProductImageServerButton extends StatelessWidget {
           barcode: barcode,
           imageIds: result,
           imageField: imageField,
+          language: language,
         ),
       ),
     );

--- a/packages/smooth_app/lib/pages/product/product_image_swipeable_view.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_swipeable_view.dart
@@ -10,6 +10,7 @@ import 'package:smooth_app/generic_lib/widgets/smooth_back_button.dart';
 import 'package:smooth_app/helpers/image_field_extension.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/pages/product/product_image_viewer.dart';
+import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
 /// Widget to display swipeable product images of particular category.
@@ -19,20 +20,17 @@ class ProductImageSwipeableView extends StatefulWidget {
     super.key,
     required this.product,
     required this.initialImageIndex,
-    required this.language,
   }) : imageField = null;
 
   /// Version with only one main [ImageField].
   const ProductImageSwipeableView.imageField({
     super.key,
     required this.product,
-    required this.language,
     required this.imageField,
   }) : initialImageIndex = 0;
 
   final Product product;
   final int initialImageIndex;
-  final OpenFoodFactsLanguage language;
   final ImageField? imageField;
 
   @override
@@ -63,7 +61,7 @@ class _ProductImageSwipeableViewState extends State<ProductImageSwipeableView> {
       initialPage: widget.initialImageIndex,
     );
     _currentImageDataIndex = ValueNotifier<int>(widget.initialImageIndex);
-    _currentLanguage = widget.language;
+    _currentLanguage = ProductQuery.getLanguage();
   }
 
   @override

--- a/packages/smooth_app/lib/tmp_crop_image/new_crop_page.dart
+++ b/packages/smooth_app/lib/tmp_crop_image/new_crop_page.dart
@@ -33,6 +33,7 @@ class CropPage extends StatefulWidget {
     required this.inputFile,
     required this.barcode,
     required this.imageField,
+    required this.language,
     required this.initiallyDifferent,
     this.imageId,
     this.initialCropRect,
@@ -44,6 +45,7 @@ class CropPage extends StatefulWidget {
 
   final ImageField imageField;
   final String barcode;
+  final OpenFoodFactsLanguage language;
 
   /// Is the full picture initially different from the current selection?
   final bool initiallyDifferent;
@@ -273,6 +275,7 @@ class _CropPageState extends State<CropPage> {
       final Rect cropRect = _getLocalCropRect();
       await BackgroundTaskImage.addTask(
         widget.barcode,
+        language: widget.language,
         imageField: widget.imageField,
         fullFile: fullFile,
         croppedFile: croppedFile,
@@ -291,6 +294,7 @@ class _CropPageState extends State<CropPage> {
       final Rect cropRect = _getServerCropRect();
       await BackgroundTaskCrop.addTask(
         widget.barcode,
+        language: widget.language,
         imageField: widget.imageField,
         imageId: widget.imageId!,
         croppedFile: croppedFile,


### PR DESCRIPTION
### What
- This PR brings consistency about multilingual images, in read AND write.
- The carousel and the gallery images now match the app language.
- In the swipeable page, you have a language selector and you now see _actual_ multilingual images:
  - an image uploaded for that language
  - or an empty image with a "no image for that language yet" label
  - or an empty image with a "no image" label (in any language)

### Screenshot
App in French
| gallery | swipeable with image |
| -- | -- |
| ![Screenshot_2023-04-30-11-03-00](https://user-images.githubusercontent.com/11576431/235345221-cf71f522-6051-4e2b-a6d1-fe0eb4e17825.png) | ![Screenshot_2023-04-30-11-03-06](https://user-images.githubusercontent.com/11576431/235345218-7a98edeb-fcb8-48ea-89b8-cf8e46da30aa.png) |

| swipeable with no image / language | swipeable with no image at all |
| -- | -- |
| ![Screenshot_2023-04-30-11-03-29](https://user-images.githubusercontent.com/11576431/235345211-2863be58-9b96-4227-bf12-33e1ff6f6852.png) | ![Screenshot_2023-04-30-11-03-13](https://user-images.githubusercontent.com/11576431/235345217-f475ae6f-dc0b-454a-acbc-226216b3e447.png) |

### Fixes bug(s)
- Closes: #3897

### Files
Main changes:
* `app_en.arb`: added 2 translations ("no image" / "no image for that language")
* `app_fr.arb`: added 2 translations ("no image" / "no image for that language")
* `nutrition_page_loaded.dart`: removed an implicit `language` parameter
* `product_cards_helper.dart`: refactoring
* `product_image_gallery_view.dart`: removed the language selector
* `product_image_swipeable_view.dart`: removed the language parameter; now we always start with the app language
* `product_image_viewer.dart`: now always displays the (non) image for the specified language, with additional labels; added explicit `language` parameters
* `transient_file.dart`: new method `getImageLanguages`

Added explicit `language` parameters for:
* `add_new_product_page.dart`
* `background_task_crop.dart`
* `background_task_image.dart`
* `background_task_unselect.dart`
* `edit_ingredients_page.dart`
* `edit_new_packagings.dart`
* `image_crop_page.dart`
* `image_upload_card.dart`
* `new_crop_page.dart`
* `product_image_local_button.dart`
* `product_image_server_button.dart`
* `uploaded_image_gallery.dart`