### PR TITLE
fix: 3899 - back to the main photo page after cropping from gallery

### DIFF
--- a/packages/smooth_app/lib/l10n/app_cs.arb
+++ b/packages/smooth_app/lib/l10n/app_cs.arb
@@ -723,7 +723,7 @@
             "count": {}
         }
     },
-    "plural_compare_x_products": "Porovnat {count,plural, one {} few {{count} produkty} many {{count} produktů}=1{1 produkt} other{{count} produktů}}",
+    "plural_compare_x_products": "Porovnat {count,plural, few {{count} produkty} many {{count} produktů}=1{1 produkt} other{{count} produktů}}",
     "@plural_compare_x_products": {
         "description": "Button label to open a page to compare all selected products to each other",
         "placeholders": {

--- a/packages/smooth_app/lib/l10n/app_pl.arb
+++ b/packages/smooth_app/lib/l10n/app_pl.arb
@@ -1659,7 +1659,7 @@
     "@user_list_all_empty": {
         "description": "Small message when there are no user lists"
     },
-    "user_list_length": "{count,plural, one {} few {{count} produkty} many {{count} produktów} =0{Lista pusta} =1{Jeden produkt} other{{count} produktów}}",
+    "user_list_length": "{count,plural, few {{count} produkty} many {{count} produktów} =0{Lista pusta} =1{Jeden produkt} other{{count} produktów}}",
     "@user_list_length": {
         "description": "Length of a user product list",
         "placeholders": {

--- a/packages/smooth_app/lib/l10n/app_pt.arb
+++ b/packages/smooth_app/lib/l10n/app_pt.arb
@@ -1659,7 +1659,7 @@
     "@user_list_all_empty": {
         "description": "Small message when there are no user lists"
     },
-    "user_list_length": "{count,plural, one {}=0{Lista vazia} =1{Um produto} other{{count} produtos}}",
+    "user_list_length": "{count,plural, =0{Lista vazia} =1{Um produto} other{{count} produtos}}",
     "@user_list_length": {
         "description": "Length of a user product list",
         "placeholders": {

--- a/packages/smooth_app/lib/l10n/app_ro.arb
+++ b/packages/smooth_app/lib/l10n/app_ro.arb
@@ -1659,7 +1659,7 @@
     "@user_list_all_empty": {
         "description": "Small message when there are no user lists"
     },
-    "user_list_length": "{count,plural, one {} few {{count} produse} =0{Lista goală} =1{Un singur produs} other{{count} produse}}",
+    "user_list_length": "{count,plural, =0{Lista goală} =1{Un singur produs} other{{count} produse}}",
     "@user_list_length": {
         "description": "Length of a user product list",
         "placeholders": {

--- a/packages/smooth_app/lib/pages/crop_page.dart
+++ b/packages/smooth_app/lib/pages/crop_page.dart
@@ -140,12 +140,6 @@ class _CropPageState extends State<CropPage> {
     _initLoad();
   }
 
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
-
   Future<void> _initLoad() async => _load(await widget.inputFile.readAsBytes());
 
   @override

--- a/packages/smooth_app/lib/pages/image/uploaded_image_gallery.dart
+++ b/packages/smooth_app/lib/pages/image/uploaded_image_gallery.dart
@@ -73,7 +73,7 @@ class UploadedImageGallery extends StatelessWidget {
               if (imageFile == null) {
                 return;
               }
-              await navigatorState.push<File>(
+              final File? croppedFile = await navigatorState.push<File>(
                 MaterialPageRoute<File>(
                   builder: (BuildContext context) => CropPage(
                     barcode: barcode,
@@ -86,6 +86,9 @@ class UploadedImageGallery extends StatelessWidget {
                   fullscreenDialog: true,
                 ),
               );
+              if (croppedFile != null) {
+                navigatorState.pop();
+              }
             },
             child: ClipRRect(
               borderRadius: ROUNDED_BORDER_RADIUS,


### PR DESCRIPTION
### What
- UX improvement
  - we select "choose an existing image"
  - then we go to the uploaded images gallery
  - we select an image, we crop it, we send it to the server
  - and then, we used to go back to the previous page: the uploaded images gallery
  - which is not optimal, as now we don't care anymore about the uploaded images gallery: with this PR we go back an extra page

### Fixes bug(s)
- Fixes: #3899

### Files
* `app_cs.arb`: unrelated warning fix
* `app_pl.arb`: unrelated warning fix
* `app_pt.arb`: unrelated warning fix
* `app_ro.arb`: unrelated warning fix
* `crop_page.dart`: unrelated fix - the new `CropImage` we use does already dispose the controller
* `uploaded_image_gallery.dart`: when a file was returned from the crop page, we go back to the previous page