### PR TITLE
fix: 3595 - transient file refactoring and fixes

### DIFF
--- a/packages/smooth_app/lib/background/abstract_background_task.dart
+++ b/packages/smooth_app/lib/background/abstract_background_task.dart
@@ -133,4 +133,12 @@ abstract class AbstractBackgroundTask {
         barcode: barcode,
         localDatabase: localDatabase,
       );
+
+  /// Checks that everything is fine and fix things if needed + if possible.
+  ///
+  /// To be run systematically for each task.
+  /// Especially useful for transient files: if a user closed the app before
+  /// successfully completing the upload task, the transient file - that is just
+  /// a static variable - won't be there at app restart. Unless you recover.
+  Future<void> recover(final LocalDatabase localDatabase) async {}
 }

--- a/packages/smooth_app/lib/background/background_task_manager.dart
+++ b/packages/smooth_app/lib/background/background_task_manager.dart
@@ -134,6 +134,9 @@ class BackgroundTaskManager {
       return;
     }
     final List<AbstractBackgroundTask> tasks = await _getAllTasks();
+    for (final AbstractBackgroundTask task in tasks) {
+      await task.recover(localDatabase);
+    }
     final Map<String, String> failedTaskFromStamps = <String, String>{};
     for (final AbstractBackgroundTask task in tasks) {
       final String stamp = task.stamp;
@@ -156,6 +159,7 @@ class BackgroundTaskManager {
         // Most likely, no internet, no reason to go on.
         if (e.toString().startsWith('Failed host lookup: ')) {
           await _setTaskErrorStatus(taskId, taskStatusNoInternet);
+          await _justFinished();
           return;
         }
         debugPrint('Background task error ($e)');

--- a/packages/smooth_app/lib/background/background_task_upload.dart
+++ b/packages/smooth_app/lib/background/background_task_upload.dart
@@ -1,0 +1,69 @@
+import 'dart:async';
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/background/abstract_background_task.dart';
+import 'package:smooth_app/database/local_database.dart';
+import 'package:smooth_app/database/transient_file.dart';
+
+/// Background task about generic file upload.
+abstract class BackgroundTaskUpload extends AbstractBackgroundTask {
+  const BackgroundTaskUpload({
+    required super.processName,
+    required super.uniqueId,
+    required super.barcode,
+    required super.languageCode,
+    required super.user,
+    required super.country,
+    required super.stamp,
+    required this.imageField,
+    required this.croppedPath,
+    required this.rotationDegrees,
+    required this.cropX1,
+    required this.cropY1,
+    required this.cropX2,
+    required this.cropY2,
+  });
+
+  final String imageField;
+  final String croppedPath;
+  final int rotationDegrees;
+  final int cropX1;
+  final int cropY1;
+  final int cropX2;
+  final int cropY2;
+
+  TransientFile _getTransientFile() => TransientFile(
+        ImageField.fromOffTag(imageField)!,
+        barcode,
+        getLanguage(),
+      );
+
+  @protected
+  void putTransientImage(final LocalDatabase localDatabase) =>
+      _getTransientFile().putImage(
+        localDatabase,
+        File(croppedPath),
+      );
+
+  @protected
+  void removeTransientImage(final LocalDatabase localDatabase) =>
+      _getTransientFile().removeImage(localDatabase);
+
+  File? _getTransientImage() => _getTransientFile().getImage();
+
+  @override
+  Future<void> recover(final LocalDatabase localDatabase) async {
+    final File? transientFile = _getTransientImage();
+    if (transientFile == null) {
+      putTransientImage(localDatabase);
+    }
+  }
+
+  static String getStamp(
+    final String barcode,
+    final String imageField,
+    final String language,
+  ) =>
+      '$barcode;image;$imageField;$language';
+}

--- a/packages/smooth_app/lib/cards/data_cards/image_upload_card.dart
+++ b/packages/smooth_app/lib/cards/data_cards/image_upload_card.dart
@@ -34,11 +34,11 @@ class _ImageUploadCardState extends State<ImageUploadCard> {
     final Size screenSize = MediaQuery.of(context).size;
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     context.watch<LocalDatabase>();
-    final ImageProvider? imageProvider = TransientFile.getImageProvider(
+    final ImageProvider? imageProvider = TransientFile.fromProductImageData(
       widget.productImageData,
       widget.product.barcode!,
       ProductQuery.getLanguage(),
-    );
+    ).getImageProvider();
 
     if (imageProvider == null) {
       return ElevatedButton.icon(

--- a/packages/smooth_app/lib/generic_lib/widgets/smooth_product_image.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/smooth_product_image.dart
@@ -4,7 +4,6 @@ import 'package:provider/provider.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/database/transient_file.dart';
 import 'package:smooth_app/generic_lib/widgets/images/smooth_image.dart';
-import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/query/product_query.dart';
 
 /// Main product image on a product card.
@@ -23,15 +22,11 @@ class SmoothMainProductImage extends StatelessWidget {
   Widget build(BuildContext context) {
     context.watch<LocalDatabase>();
     final OpenFoodFactsLanguage language = ProductQuery.getLanguage();
-    final ImageProvider? imageProvider = TransientFile.getImageProvider(
-      getProductImageData(
-        product,
-        ImageField.FRONT,
-        language,
-      ),
-      product.barcode!,
+    final ImageProvider? imageProvider = TransientFile.fromProduct(
+      product,
+      ImageField.FRONT,
       language,
-    );
+    ).getImageProvider();
 
     return SmoothImage(
       width: width,

--- a/packages/smooth_app/lib/helpers/product_cards_helper.dart
+++ b/packages/smooth_app/lib/helpers/product_cards_helper.dart
@@ -253,11 +253,11 @@ List<MapEntry<ProductImageData, ImageProvider?>> getSelectedImages(
   final List<ProductImageData> allProductImagesData =
       getProductMainImagesData(product, language, includeOther: false);
   for (final ProductImageData imageData in allProductImagesData) {
-    result[imageData] = TransientFile.getImageProvider(
+    result[imageData] = TransientFile.fromProductImageData(
       imageData,
       product.barcode!,
       language,
-    );
+    ).getImageProvider();
   }
   return result.entries.toList();
 }

--- a/packages/smooth_app/lib/pages/crop_page.dart
+++ b/packages/smooth_app/lib/pages/crop_page.dart
@@ -228,7 +228,7 @@ class _CropPageState extends State<CropPage> {
   /// Returns a small file with the cropped image, for the transient image.
   ///
   /// Here we use BMP format as it's faster to encode.
-  Future<File?> _getCroppedImageFile(
+  Future<File> _getCroppedImageFile(
     final Directory directory,
     final int sequenceNumber,
   ) async {
@@ -248,13 +248,10 @@ class _CropPageState extends State<CropPage> {
         await getNextSequenceNumber(daoInt, _CROP_PAGE_SEQUENCE_KEY);
     final Directory directory = await getApplicationSupportDirectory();
 
-    final File? croppedFile = await _getCroppedImageFile(
+    final File croppedFile = await _getCroppedImageFile(
       directory,
       sequenceNumber,
     );
-    if (croppedFile == null) {
-      return null;
-    }
 
     if (widget.imageId == null) {
       // in this case, it's a brand new picture, with crop parameters.

--- a/packages/smooth_app/lib/pages/product/product_image_viewer.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_viewer.dart
@@ -76,11 +76,7 @@ class _ProductImageViewerState extends State<ProductImageViewer> {
       widget.language,
       forceLanguage: true,
     );
-    final ImageProvider? imageProvider = TransientFile.getImageProvider(
-      _imageData,
-      _barcode,
-      widget.language,
-    );
+    final ImageProvider? imageProvider = _getTransientFile().getImageProvider();
     final Iterable<OpenFoodFactsLanguage> selectedLanguages =
         getProductImageLanguages(
       _product,
@@ -227,11 +223,7 @@ class _ProductImageViewerState extends State<ProductImageViewer> {
     }
 
     // alternate option: use the transient file.
-    File? imageFile = TransientFile.getImage(
-      _imageData.imageField,
-      _barcode,
-      widget.language,
-    );
+    File? imageFile = _getTransientFile().getImage();
     if (imageFile != null) {
       return _openCropPage(navigatorState, imageFile);
     }
@@ -249,6 +241,12 @@ class _ProductImageViewerState extends State<ProductImageViewer> {
 
     return null;
   }
+
+  TransientFile _getTransientFile() => TransientFile.fromProductImageData(
+        _imageData,
+        _barcode,
+        widget.language,
+      );
 
   Future<void> _actionUnselect(final AppLocalizations appLocalizations) async {
     final NavigatorState navigatorState = Navigator.of(context);


### PR DESCRIPTION
### What
- Refreshed the transient files, as a strong app restart erases all the transient files (stored as `static`) (but the FS files are still there), in a new `recover` method for background tasks.
- Fixed a bug, where an internet connection error is now considered as a clean end of task stack execution.
- Fixed a bug, when "unselect"ing without internet: now we remove immediately the transient file (which makes the image disappear without having to wait for an internet connection).
- As a side-effect, I've refactored `TransientFile`, that used to be a 100% `static` class.

### Part of 
- #3595

### Files

#### New file
* `background_task_upload.dart`: Background task about generic file upload.

#### Impacted files
* `abstract_background_task.dart`: added a `recover` abstract method
* `background_task_crop.dart`: now extends new class `BackgroundTaskUpload`
* `background_task_image.dart`: now extends new class `BackgroundTaskUpload`
* `background_task_manager.dart`: now calls `recover`for each task at run time; minor fix about "internet error"
* `background_task_unselect.dart`: minor refactoring; minor fix removing the transient file
* `crop_page.dart`: minor refactoring
* `edit_ingredients_page.dart`: minor refactoring
* `image_upload_card.dart`: minor refactoring
* `product_cards_helper.dart`: minor refactoring
* `product_image_viewer.dart`: minor refactoring
* `smooth_product_image.dart`: minor refactoring
* `transient_file.dart`: refactored as a "real" class, not a static one