### PR TITLE
fix: 3865 Insufficient contrast for the error banner

### DIFF
--- a/packages/smooth_app/lib/pages/user_management/login_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/login_page.dart
@@ -150,10 +150,13 @@ class _LoginPageState extends State<LoginPage> with TraceableClientMixin {
                         SmoothCard(
                           padding: const EdgeInsets.all(10.0),
                           color: const Color(0xFFFF4446),
-                          child: Text(appLocalizations.incorrect_credentials,style: theme.textTheme.bodyMedium?.copyWith(
-                            fontSize: 18.0,
-                            color: const Color(0xFF000000),
-                          ),),
+                          child: Text(
+                            appLocalizations.incorrect_credentials,
+                            style: theme.textTheme.bodyMedium?.copyWith(
+                              fontSize: 18.0,
+                              color: const Color(0xFF000000),
+                            ),
+                          ),
                         ),
                         const SizedBox(
                           height: LARGE_SPACE * 2,

--- a/packages/smooth_app/lib/pages/user_management/login_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/login_page.dart
@@ -149,8 +149,11 @@ class _LoginPageState extends State<LoginPage> with TraceableClientMixin {
                       if (_wrongCredentials) ...<Widget>[
                         SmoothCard(
                           padding: const EdgeInsets.all(10.0),
-                          color: Colors.red,
-                          child: Text(appLocalizations.incorrect_credentials),
+                          color: const Color(0xFFFF4446),
+                          child: Text(appLocalizations.incorrect_credentials,style: theme.textTheme.bodyMedium?.copyWith(
+                            fontSize: 18.0,
+                            color: const Color(0xFF000000),
+                          ),),
                         ),
                         const SizedBox(
                           height: LARGE_SPACE * 2,


### PR DESCRIPTION
### What
<!-- description of the PR -->
- Changed Login Screen Page error banner fontSize and Color.
<!-- 
Please name your pull request following this scheme: `type: What you did` this allows us to automatically generate the changelog
Following `type`s are allowed:
  - `feat`, for Features
  - `fix`, for Bug Fixes
  - `docs`, for Documentation
  - `ci`, for Automation
  - `refactor`, for code Refactoring
  - `chore`, for Miscellaneous things
-->
### Screenshot
<!-- Insert a screenshot to provide visual record of your changes, if visible -->
![image](https://user-images.githubusercontent.com/50038492/236699615-c352bbff-7b81-44c7-8bc9-689bdb010e3f.png)

### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes: UI Color and font fixes<!-- #1 Note: you can also use Closes: -->

### Part of 
- #3865  <!-- Add the most granular issue possible -->
