### PR TITLE
feat: 3880 - added a "get photo" button on the edit packaging component page

### DIFF
--- a/packages/smooth_app/lib/helpers/image_field_extension.dart
+++ b/packages/smooth_app/lib/helpers/image_field_extension.dart
@@ -1,5 +1,8 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/generic_lib/buttons/smooth_large_button_with_icon.dart';
+import 'package:smooth_app/pages/product/product_image_swipeable_view.dart';
 
 extension ImageFieldSmoothieExtension on ImageField {
   static const List<ImageField> orderedMain = <ImageField>[
@@ -112,4 +115,22 @@ extension ImageFieldSmoothieExtension on ImageField {
         return appLocalizations.other_interesting_photo_button_label;
     }
   }
+
+  Widget getPhotoButton(
+    final BuildContext context,
+    final Product product,
+  ) =>
+      SmoothLargeButtonWithIcon(
+        onPressed: () async => Navigator.push(
+          context,
+          MaterialPageRoute<void>(
+            builder: (_) => ProductImageSwipeableView.imageField(
+              imageField: this,
+              product: product,
+            ),
+          ),
+        ),
+        icon: Icons.camera_alt,
+        text: getProductImageButtonText(AppLocalizations.of(context)),
+      );
 }

--- a/packages/smooth_app/lib/pages/product/edit_new_packagings.dart
+++ b/packages/smooth_app/lib/pages/product/edit_new_packagings.dart
@@ -9,6 +9,7 @@ import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
+import 'package:smooth_app/helpers/image_field_extension.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/pages/image_crop_page.dart';
 import 'package:smooth_app/pages/product/edit_new_packagings_component.dart';
@@ -37,17 +38,14 @@ class _EditNewPackagingsState extends State<EditNewPackagings> {
   late final LocalDatabase _localDatabase;
   late final NumberFormat _decimalNumberFormat;
   late final NumberFormat _unitNumberFormat;
+  late Product _product;
+  late final Product _initialProduct;
 
   late bool? _packagingsComplete;
 
-  final List<EditNewPackagingsHelper> _helpers = <EditNewPackagingsHelper>[];
+  String get _barcode => _initialProduct.barcode!;
 
-  void _initPackagings() {
-    if (widget.product.packagings != null) {
-      widget.product.packagings!.forEach(_addPackagingToControllers);
-    }
-    _packagingsComplete = widget.product.packagingsComplete;
-  }
+  final List<EditNewPackagingsHelper> _helpers = <EditNewPackagingsHelper>[];
 
   void _addPackagingToControllers(
     final ProductPackaging packaging, {
@@ -71,20 +69,24 @@ class _EditNewPackagingsState extends State<EditNewPackagings> {
   @override
   void initState() {
     super.initState();
+    _initialProduct = widget.product;
     _decimalNumberFormat = SimpleInputNumberField.getNumberFormat(
       decimal: true,
     );
     _unitNumberFormat = SimpleInputNumberField.getNumberFormat(
       decimal: false,
     );
-    _initPackagings();
+    if (_initialProduct.packagings != null) {
+      _initialProduct.packagings!.forEach(_addPackagingToControllers);
+    }
+    _packagingsComplete = _initialProduct.packagingsComplete;
     _localDatabase = context.read<LocalDatabase>();
-    _localDatabase.upToDate.showInterest(widget.product.barcode!);
+    _localDatabase.upToDate.showInterest(_barcode);
   }
 
   @override
   void dispose() {
-    _localDatabase.upToDate.loseInterest(widget.product.barcode!);
+    _localDatabase.upToDate.loseInterest(_barcode);
     for (final EditNewPackagingsHelper helper in _helpers) {
       helper.dispose();
     }
@@ -94,7 +96,15 @@ class _EditNewPackagingsState extends State<EditNewPackagings> {
   @override
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    context.watch<LocalDatabase>();
+    _product = _localDatabase.upToDate.getLocalUpToDate(_initialProduct);
     final List<Widget> children = <Widget>[];
+    children.add(
+      Padding(
+        padding: const EdgeInsets.all(SMALL_SPACE),
+        child: ImageField.PACKAGING.getPhotoButton(context, _product),
+      ),
+    );
     for (int index = 0; index < _helpers.length; index++) {
       // needed for deleteCallback (if not final, will take unreachable value)
       final int deleteIndex = index;
@@ -106,7 +116,7 @@ class _EditNewPackagingsState extends State<EditNewPackagings> {
             deleteCallback: () =>
                 setState(() => _removePackagingAt(deleteIndex)),
             helper: _helpers[index],
-            categories: widget.product.categories,
+            categories: _product.categories,
           ),
         ),
       );
@@ -164,7 +174,7 @@ class _EditNewPackagingsState extends State<EditNewPackagings> {
           onPressed: () async => confirmAndUploadNewPicture(
             this,
             imageField: ImageField.OTHER,
-            barcode: widget.product.barcode!,
+            barcode: _barcode,
             language: ProductQuery.getLanguage(),
           ),
           iconData: Icons.add_a_photo,
@@ -197,9 +207,9 @@ class _EditNewPackagingsState extends State<EditNewPackagings> {
         child: SmoothScaffold(
           appBar: SmoothAppBar(
             title: Text(appLocalizations.edit_packagings_title),
-            subTitle: widget.product.productName != null
+            subTitle: _product.productName != null
                 ? Text(
-                    widget.product.productName!,
+                    _product.productName!,
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                   )
@@ -241,16 +251,16 @@ class _EditNewPackagingsState extends State<EditNewPackagings> {
       p1.numberOfUnits != p2.numberOfUnits;
 
   bool _hasPackagingsChanged(final List<ProductPackaging> packagings) {
-    if (widget.product.packagings == null) {
+    if (_product.packagings == null) {
       return packagings.isNotEmpty;
     }
-    if (widget.product.packagings!.length != packagings.length) {
+    if (_product.packagings!.length != packagings.length) {
       return true;
     }
     for (int i = 0; i < packagings.length; i++) {
       if (_isPackagingDifferent(
         packagings[i],
-        widget.product.packagings![i],
+        _product.packagings![i],
       )) {
         return true;
       }
@@ -263,7 +273,7 @@ class _EditNewPackagingsState extends State<EditNewPackagings> {
   /// Parameter [saving] tells about the context: are we leaving the page,
   /// or have we clicked on the "save" button?
   Future<bool> _mayExitPage({required final bool saving}) async {
-    final Product changedProduct = Product(barcode: widget.product.barcode);
+    final Product changedProduct = Product(barcode: _barcode);
     bool changed = false;
 
     final List<ProductPackaging> packagings = _getPackagingsFromControllers();
@@ -272,7 +282,7 @@ class _EditNewPackagingsState extends State<EditNewPackagings> {
       changedProduct.packagings = packagings;
     }
 
-    if (_packagingsComplete != widget.product.packagingsComplete) {
+    if (_packagingsComplete != _product.packagingsComplete) {
       changed = true;
       changedProduct.packagingsComplete = _packagingsComplete;
     }
@@ -297,7 +307,7 @@ class _EditNewPackagingsState extends State<EditNewPackagings> {
 
     AnalyticsHelper.trackProductEdit(
       AnalyticsEditEvents.packagingComponents,
-      changedProduct.barcode!,
+      _barcode,
       true,
     );
 


### PR DESCRIPTION
### What
- New "get packaging photo" button on top of the "edit packaging components" page
- As a side-effect, some refactoring.

### Screenshot

| before | after | for the record, nutrition |
| -- | -- | -- |
| ![Screenshot_2023-05-08-09-51-04](https://user-images.githubusercontent.com/11576431/236788262-1c6908c5-4b96-4ec3-91ae-1a3640fd70e4.png) | ![Screenshot_2023-05-08-10-47-20](https://user-images.githubusercontent.com/11576431/236788255-c1a181b5-ea4f-409e-8c5c-ca8d5bd0d710.png) | ![Screenshot_2023-05-08-10-53-48](https://user-images.githubusercontent.com/11576431/236787985-93ea2470-ad33-4f15-919b-02640cfe3eca.png) |

### Fixes bug(s)
- Closes: #3880

### Impacted files
* `edit_new_packagings.dart`: added a "get photo" button on top; refactored with the up-to-date provider
* `image_field_extension.dart`: new `getPhotoButton` method
* `nutrition_page_loaded.dart`: refactored with the up-to-date provider and the new `getPhotoButton` method