### PR TITLE
fix: 3953 - explicitly using flutter 3.7.12 as 3.10 is available

### DIFF
--- a/.github/workflows/android-release-to-org-openfoodfacts-scanner.yml
+++ b/.github/workflows/android-release-to-org-openfoodfacts-scanner.yml
@@ -91,9 +91,9 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          channel: stable
+          #channel: stable
           cache: true
-          #flutter-version: '3.0.5'
+          flutter-version: '3.7.12'
           cache-key: current-stable
 
       - name: Flutter version    

--- a/.github/workflows/ios-release-to-org-openfoodfacts-scanner.yml
+++ b/.github/workflows/ios-release-to-org-openfoodfacts-scanner.yml
@@ -68,9 +68,9 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          channel: stable
+          #channel: stable
           cache: true
-          #flutter-version: '3.0.5'
+          flutter-version: '3.7.12'
           cache-key: current-stable
 
       - name: Flutter version    

--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -27,9 +27,9 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          channel: stable
+          #channel: stable
           cache: true
-          #flutter-version: '3.0.5'
+          flutter-version: '3.7.12'
           cache-key: current-stable
         
       - run: flutter --version

--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -39,8 +39,8 @@ jobs:
         run: ci/pub_upgrade.sh
 
       # Check for formatting issues
-      - name: Check for formatting issues (run "flutter format . ")
-        run: flutter format --set-exit-if-changed .
+      - name: Check for formatting issues (run "dart format . ")
+        run: dart format --set-exit-if-changed .
       
       # analyze Dart for errors
       - name: Analyze code

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -22,9 +22,9 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          channel: stable
+          #channel: stable
           cache: true
-          #flutter-version: '3.0.5'
+          flutter-version: '3.7.12'
           cache-key: current-stable
 
       - run: flutter --version

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -34,8 +34,8 @@ jobs:
         run: ci/pub_upgrade.sh
 
       # Check for formatting issues
-      - name: Check for formatting issues (run "flutter format . ")
-        run: flutter format --set-exit-if-changed .
+      - name: Check for formatting issues (run "dart format . ")
+        run: dart format --set-exit-if-changed .
 
       # analyze Dart for errors
       - name: Analyze code


### PR DESCRIPTION
### What
- As flutter 3.10 is available, it's being used in github actions.
- But the code is still in 3.7: there are some minor breaking changes.
- Before we agree to upgrade to 3.10, and before we let the early 3.10 versions being fixed, we need to explicitly use 3.7

### Part of 
- #3953