### PR TITLE
refactor: score card refactoring

### DIFF
--- a/packages/smooth_app/lib/cards/data_cards/score_card.dart
+++ b/packages/smooth_app/lib/cards/data_cards/score_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/svg_icon_chip.dart';
 import 'package:smooth_app/helpers/score_card_helper.dart';
@@ -12,17 +13,60 @@ enum CardEvaluation {
   BAD,
   NEUTRAL,
   GOOD,
-  VERY_GOOD,
+  VERY_GOOD;
+
+  Color getBackgroundColor() {
+    switch (this) {
+      case CardEvaluation.UNKNOWN:
+        return GREY_COLOR;
+      case CardEvaluation.VERY_BAD:
+        return RED_BACKGROUND_COLOR;
+      case CardEvaluation.BAD:
+        return ORANGE_BACKGROUND_COLOR;
+      case CardEvaluation.NEUTRAL:
+        return YELLOW_BACKGROUND_COLOR;
+      case CardEvaluation.GOOD:
+        return LIGHT_GREEN_BACKGROUND_COLOR;
+      case CardEvaluation.VERY_GOOD:
+        return DARK_GREEN_BACKGROUND_COLOR;
+    }
+  }
+
+  Color getTextColor() {
+    switch (this) {
+      case CardEvaluation.UNKNOWN:
+        return PRIMARY_GREY_COLOR;
+      case CardEvaluation.VERY_BAD:
+        return RED_COLOR;
+      case CardEvaluation.BAD:
+        return LIGHT_ORANGE_COLOR;
+      case CardEvaluation.NEUTRAL:
+        return DARK_YELLOW_COLOR;
+      case CardEvaluation.GOOD:
+        return LIGHT_GREEN_COLOR;
+      case CardEvaluation.VERY_GOOD:
+        return DARK_GREEN_COLOR;
+    }
+  }
 }
 
 class ScoreCard extends StatelessWidget {
-  const ScoreCard({
-    required this.description,
-    required this.cardEvaluation,
+  ScoreCard.attribute({
+    required Attribute attribute,
     required this.isClickable,
-    this.iconUrl,
     this.margin,
-  });
+  })  : iconUrl = attribute.iconUrl,
+        description = attribute.descriptionShort ?? attribute.description ?? '',
+        cardEvaluation = getCardEvaluationFromAttribute(attribute);
+
+  ScoreCard.titleElement({
+    required TitleElement titleElement,
+    required this.isClickable,
+    this.margin,
+  })  : iconUrl = titleElement.iconUrl,
+        description = titleElement.title,
+        cardEvaluation =
+            getCardEvaluationFromKnowledgePanelTitleElement(titleElement);
 
   final String? iconUrl;
   final String description;
@@ -38,10 +82,10 @@ class ScoreCard extends StatelessWidget {
         ? 1
         : SmoothTheme.ADDITIONAL_OPACITY_FOR_DARK;
     final Color backgroundColor =
-        getBackgroundColor(cardEvaluation).withOpacity(opacity);
+        cardEvaluation.getBackgroundColor().withOpacity(opacity);
     final Color textColor = themeData.brightness == Brightness.dark
         ? Colors.white
-        : getTextColor(cardEvaluation).withOpacity(opacity);
+        : cardEvaluation.getTextColor().withOpacity(opacity);
     final SvgIconChip? iconChip =
         iconUrl == null ? null : SvgIconChip(iconUrl!, height: iconHeight);
 

--- a/packages/smooth_app/lib/helpers/attributes_card_helper.dart
+++ b/packages/smooth_app/lib/helpers/attributes_card_helper.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/cards/data_cards/score_card.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 
 // TODO(Stephane): Evaluation should come directly from the BE.
@@ -10,7 +11,25 @@ enum AttributeEvaluation {
   BAD,
   NEUTRAL,
   GOOD,
-  VERY_GOOD,
+  VERY_GOOD;
+
+// TODO(monsieurtanuki): not sure to see the added value of keeping both CardEvaluation and AttributeEvaluation
+  CardEvaluation getCardEvaluation() {
+    switch (this) {
+      case AttributeEvaluation.UNKNOWN:
+        return CardEvaluation.UNKNOWN;
+      case AttributeEvaluation.VERY_BAD:
+        return CardEvaluation.VERY_BAD;
+      case AttributeEvaluation.BAD:
+        return CardEvaluation.BAD;
+      case AttributeEvaluation.NEUTRAL:
+        return CardEvaluation.NEUTRAL;
+      case AttributeEvaluation.GOOD:
+        return CardEvaluation.GOOD;
+      case AttributeEvaluation.VERY_GOOD:
+        return CardEvaluation.VERY_GOOD;
+    }
+  }
 }
 
 Widget getAttributeDisplayIcon(final Attribute attribute) => Padding(

--- a/packages/smooth_app/lib/helpers/score_card_helper.dart
+++ b/packages/smooth_app/lib/helpers/score_card_helper.dart
@@ -1,79 +1,32 @@
-import 'package:flutter/material.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/cards/data_cards/score_card.dart';
-import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/helpers/attributes_card_helper.dart';
 
-Color getBackgroundColor(CardEvaluation evaluation) {
-  switch (evaluation) {
-    case CardEvaluation.UNKNOWN:
-      return GREY_COLOR;
-    case CardEvaluation.VERY_BAD:
-      return RED_BACKGROUND_COLOR;
-    case CardEvaluation.BAD:
-      return ORANGE_BACKGROUND_COLOR;
-    case CardEvaluation.NEUTRAL:
-      return YELLOW_BACKGROUND_COLOR;
-    case CardEvaluation.GOOD:
-      return LIGHT_GREEN_BACKGROUND_COLOR;
-    case CardEvaluation.VERY_GOOD:
-      return DARK_GREEN_BACKGROUND_COLOR;
-  }
-}
-
-Color getBackgroundColorFromAttribute(Attribute attribute) {
-  return getBackgroundColor(getCardEvaluationFromAttribute(attribute));
-}
-
-Color getTextColor(CardEvaluation evaluation) {
-  switch (evaluation) {
-    case CardEvaluation.UNKNOWN:
-      return PRIMARY_GREY_COLOR;
-    case CardEvaluation.VERY_BAD:
-      return RED_COLOR;
-    case CardEvaluation.BAD:
-      return LIGHT_ORANGE_COLOR;
-    case CardEvaluation.NEUTRAL:
-      return DARK_YELLOW_COLOR;
-    case CardEvaluation.GOOD:
-      return LIGHT_GREEN_COLOR;
-    case CardEvaluation.VERY_GOOD:
-      return DARK_GREEN_COLOR;
-  }
-}
-
 CardEvaluation getCardEvaluationFromAttribute(Attribute attribute) {
-  switch (getAttributeEvaluation(attribute)) {
-    case AttributeEvaluation.UNKNOWN:
-      return CardEvaluation.UNKNOWN;
-    case AttributeEvaluation.VERY_BAD:
-      return CardEvaluation.VERY_BAD;
-    case AttributeEvaluation.BAD:
-      return CardEvaluation.BAD;
-    case AttributeEvaluation.NEUTRAL:
-      return CardEvaluation.NEUTRAL;
-    case AttributeEvaluation.GOOD:
-      return CardEvaluation.GOOD;
-    case AttributeEvaluation.VERY_GOOD:
-      return CardEvaluation.VERY_GOOD;
+  return getAttributeEvaluation(attribute).getCardEvaluation();
+}
+
+extension GradeExtension on Grade? {
+  CardEvaluation getCardEvaluation() {
+    switch (this) {
+      case Grade.E:
+        return CardEvaluation.VERY_BAD;
+      case Grade.D:
+        return CardEvaluation.BAD;
+      case Grade.C:
+        return CardEvaluation.NEUTRAL;
+      case Grade.B:
+        return CardEvaluation.GOOD;
+      case Grade.A:
+        return CardEvaluation.VERY_GOOD;
+      case null:
+      case Grade.UNKNOWN:
+        return CardEvaluation.UNKNOWN;
+    }
   }
 }
 
 CardEvaluation getCardEvaluationFromKnowledgePanelTitleElement(
-    TitleElement titleElement) {
-  switch (titleElement.grade) {
-    case Grade.E:
-      return CardEvaluation.VERY_BAD;
-    case Grade.D:
-      return CardEvaluation.BAD;
-    case Grade.C:
-      return CardEvaluation.NEUTRAL;
-    case Grade.B:
-      return CardEvaluation.GOOD;
-    case Grade.A:
-      return CardEvaluation.VERY_GOOD;
-    case null:
-    case Grade.UNKNOWN:
-      return CardEvaluation.UNKNOWN;
-  }
-}
+  TitleElement titleElement,
+) =>
+    titleElement.grade.getCardEvaluation();

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_summary_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_summary_card.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/cards/data_cards/score_card.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
-import 'package:smooth_app/helpers/score_card_helper.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_title_card.dart';
 
 class KnowledgePanelSummaryCard extends StatelessWidget {
@@ -23,12 +22,8 @@ class KnowledgePanelSummaryCard extends StatelessWidget {
     }
     switch (knowledgePanel.titleElement!.type) {
       case TitleElementType.GRADE:
-        return ScoreCard(
-          iconUrl: knowledgePanel.titleElement!.iconUrl,
-          description: knowledgePanel.titleElement!.title,
-          cardEvaluation: getCardEvaluationFromKnowledgePanelTitleElement(
-            knowledgePanel.titleElement!,
-          ),
+        return ScoreCard.titleElement(
+          titleElement: knowledgePanel.titleElement!,
           isClickable: isClickable,
           margin: margin,
         );

--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -13,7 +13,6 @@ import 'package:smooth_app/helpers/attributes_card_helper.dart';
 import 'package:smooth_app/helpers/haptic_feedback_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/helpers/product_compatibility_helper.dart';
-import 'package:smooth_app/helpers/score_card_helper.dart';
 import 'package:smooth_app/helpers/ui_helpers.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_page.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels_builder.dart';
@@ -380,11 +379,8 @@ class _SummaryCardState extends State<SummaryCard> {
               onTap: () async => _openFullKnowledgePanel(
                 attribute: attribute,
               ),
-              child: ScoreCard(
-                iconUrl: attribute.iconUrl,
-                description:
-                    attribute.descriptionShort ?? attribute.description ?? '',
-                cardEvaluation: getCardEvaluationFromAttribute(attribute),
+              child: ScoreCard.attribute(
+                attribute: attribute,
                 isClickable: true,
                 margin: EdgeInsets.zero,
               ),
@@ -393,11 +389,8 @@ class _SummaryCardState extends State<SummaryCard> {
         );
       } else {
         attributes.add(
-          ScoreCard(
-            iconUrl: attribute.iconUrl,
-            description:
-                attribute.descriptionShort ?? attribute.description ?? '',
-            cardEvaluation: getCardEvaluationFromAttribute(attribute),
+          ScoreCard.attribute(
+            attribute: attribute,
             isClickable: false,
           ),
         );


### PR DESCRIPTION
### What
- Refactoring using the "new" `enum` features (for a code that is more compact and simpler to read)
- Refactoring using more explicit constructors for `ScoreCard`

### Impacted files
* `attributes_card_helper.dart`: refactor as advanced `enum` from `score_card_helper.dart`
* `knowledge_panel_summary_card.dart`: now using the new `ScoreCard.titleElement` constructor
* `score_card.dart`: refactored `CardEvaluation` as advanced `enum` from `score_card_helper.dart`; refactored `ScoreCard` with 2 explicit constructors instead of a single nameless one
* `score_card_helper.dart`: refactored `enum`s and moved code to more relevant files
* `summary_card.dart`: now using the new `ScoreCard.attribute` constructor