### PR TITLE
fix: 3964 - progress texts instead of circular indicator for crop page + isolate

### DIFF
--- a/packages/smooth_app/lib/background/background_task_image.dart
+++ b/packages/smooth_app/lib/background/background_task_image.dart
@@ -291,7 +291,7 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
       maxSize: null,
       quality: FilterQuality.high,
     );
-    await ImageComputeContainer(file: file, source: cropped).saveJpeg();
+    await saveJpeg(file: file, source: cropped);
     return true;
   }
 

--- a/packages/smooth_app/lib/helpers/image_compute_container.dart
+++ b/packages/smooth_app/lib/helpers/image_compute_container.dart
@@ -1,65 +1,121 @@
 import 'dart:async';
 import 'dart:io';
-import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_image_compress/flutter_image_compress.dart';
 import 'package:image/image.dart' as image;
 
-// TODO(monsieurtanuki): try to use simple isolates with `compute`
 /// Container for Image Compute and Compress operations.
-class ImageComputeContainer {
-  const ImageComputeContainer({
+class _ImageComputeContainer {
+  _ImageComputeContainer({
     required this.file,
-    required this.source,
+    required this.rawData,
+    required this.width,
+    required this.height,
   });
 
   final File file;
-  final ui.Image source;
-  //final image.Image rawImage;
+  final ByteData rawData;
+  final int width;
+  final int height;
+}
 
-  Future<image.Image> _convertImageFromUI() async {
-    final ByteData? rawData = await source.toByteData(
-      format: ui.ImageByteFormat.rawRgba,
-    );
-    if (rawData == null) {
-      throw Exception('Cannot convert file');
-    }
-    // TODO(monsieurtanuki): perhaps a bit slow, which would call for a isolate/compute
-    return image.Image.fromBytes(
+/// Saves an image to a BMP file. As BMP for better performances.
+Future<void> saveBmp({
+  required final File file,
+  required final ui.Image source,
+}) async {
+  final ByteData? rawData = await source.toByteData(
+    format: ui.ImageByteFormat.rawRgba,
+  );
+  if (rawData == null) {
+    throw Exception('Cannot convert file');
+  }
+  await compute(
+    _saveBmp,
+    _ImageComputeContainer(
+      file: file,
+      rawData: rawData,
       width: source.width,
       height: source.height,
+    ),
+  );
+}
+
+/// Saves an image to a JPEG file.
+///
+/// It's faster to encode as BMP and then compress to JPEG, instead of directly
+/// compressing the image to JPEG (standard flutter being slow).
+Future<void> saveJpeg({
+  required final File file,
+  required final ui.Image source,
+}) async {
+  final ByteData? rawData = await source.toByteData(
+    format: ui.ImageByteFormat.rawRgba,
+  );
+  if (rawData == null) {
+    throw Exception('Cannot convert file');
+  }
+  await compute(
+    _saveJpeg,
+    _ImageComputeContainer(
+      file: file,
+      rawData: rawData,
+      width: source.width,
+      height: source.height,
+    ),
+  );
+}
+
+Future<image.Image> _convertImageFromUI(
+  final ByteData rawData,
+  final int width,
+  final int height,
+) async =>
+    image.Image.fromBytes(
+      width: width,
+      height: height,
       bytes: rawData.buffer,
       format: image.Format.uint8,
       order: image.ChannelOrder.rgba,
     );
-  }
 
-  /// Saves an image to a BMP file. As BMP for better performances.
-  Future<void> saveBmp() async {
-    final image.Image rawImage = await _convertImageFromUI();
-    await file.writeAsBytes(
-      image.encodeBmp(rawImage),
-      flush: true,
-    );
-  }
+/// Saves an image to a BMP file. As BMP for better performances.
+Future<void> _saveBmp(final _ImageComputeContainer container) async {
+  final image.Image rawImage = await _convertImageFromUI(
+    container.rawData,
+    container.width,
+    container.height,
+  );
+  await container.file.writeAsBytes(
+    image.encodeBmp(rawImage),
+    flush: true,
+  );
+}
 
-  /// Saves an image to a JPEG file.
-  ///
-  /// It's faster to encode as BMP and then compress to JPEG, instead of directly
-  /// compressing the image to JPEG (standard flutter being slow).
-  Future<void> saveJpeg() async {
-    final image.Image rawImage = await _convertImageFromUI();
-    final Uint8List bmpData = Uint8List.fromList(image.encodeBmp(rawImage));
-    final Uint8List jpegData = await FlutterImageCompress.compressWithList(
-      bmpData,
-      autoCorrectionAngle: false,
-      quality: 100,
-      format: CompressFormat.jpeg,
-      minWidth: rawImage.width,
-      minHeight: rawImage.height,
-    );
-    await file.writeAsBytes(jpegData, flush: true);
-  }
+/// Saves an image to a JPEG file.
+///
+/// It's faster to encode as BMP and then compress to JPEG, instead of directly
+/// compressing the image to JPEG (standard flutter being slow).
+Future<void> _saveJpeg(final _ImageComputeContainer container) async {
+  image.Image? rawImage = await _convertImageFromUI(
+    container.rawData,
+    container.width,
+    container.height,
+  );
+  Uint8List? bmpData = Uint8List.fromList(image.encodeBmp(rawImage));
+  // gc?
+  rawImage = null;
+  final Uint8List jpegData = await FlutterImageCompress.compressWithList(
+    bmpData,
+    autoCorrectionAngle: false,
+    quality: 100,
+    format: CompressFormat.jpeg,
+    minWidth: container.width,
+    minHeight: container.height,
+  );
+  // gc?
+  bmpData = null;
+  await container.file.writeAsBytes(jpegData, flush: true);
 }

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -495,6 +495,22 @@
     },
     "confirm_button_label": "Confirm",
     "send_image_button_label": "Send image",
+    "crop_page_action_saving": "Saving the image…",
+    "@crop_page_action_saving": {
+        "description": "Action being performed on the crop page"
+    },
+    "crop_page_action_cropping": "Cropping the image…",
+    "@crop_page_action_cropping": {
+        "description": "Action being performed on the crop page"
+    },
+    "crop_page_action_local": "Saving a local version…",
+    "@crop_page_action_local": {
+        "description": "Action being performed on the crop page"
+    },
+    "crop_page_action_server": "Preparing a call to the server…",
+    "@crop_page_action_server": {
+        "description": "Action being performed on the crop page"
+    },
     "front_packaging_photo_title": "Front Packaging Photo",
     "ingredients_photo_title": "Ingredients Photo",
     "nutritional_facts_photo_title": "Nutrition Facts Photo",


### PR DESCRIPTION
### What
- Now we display progress texts in the crop page instead of a circular progress indicator.
- This way we avoid the stuttering of the indicator during computing expensive operations like image+file
- In addition to that, we now use more `compute` instead of main thread computations.

### Screenshot
| with image | with progress text |
| -- | -- |
| ![Screenshot_2023-05-14-17-39-51](https://github.com/openfoodfacts/smooth-app/assets/11576431/bf66f13f-ddb7-4460-b50f-f3244da7e74d) | ![Screenshot_2023-05-14-17-41-08](https://github.com/openfoodfacts/smooth-app/assets/11576431/9b9183c6-e51a-4ba9-935c-c28049f269e6) |


### Fixes bug(s)
- Fixes: #3964

### Impacted files
* `app_en.arb`: added 4 labels for the action progress on crop page
* `background_task_image.dart`: minor refactoring
* `crop_page.dart`: displays a text instead of a stuttering circular progress indicator; minor refactoring
* `image_compute_container.dart`: now using `compute` as much as possible - still not possible for `ui`