### PR TITLE
chore: fix the "one {}" translation bugs

### DIFF
--- a/packages/smooth_app/lib/l10n/app_be.arb
+++ b/packages/smooth_app/lib/l10n/app_be.arb
@@ -1675,7 +1675,7 @@
     "@user_list_all_empty": {
         "description": "Small message when there are no user lists"
     },
-    "user_list_length": "{count,plural, one {} few {{count} прадукты} many {{count} прадуктаў}=0{Пусты спіс} =1{Адзін прадукт} other{{count} прадукту}}",
+    "user_list_length": "{count,plural, few {{count} прадукты} many {{count} прадуктаў}=0{Пусты спіс} =1{Адзін прадукт} other{{count} прадукту}}",
     "@user_list_length": {
         "description": "Length of a user product list",
         "placeholders": {

--- a/packages/smooth_app/lib/l10n/app_cs.arb
+++ b/packages/smooth_app/lib/l10n/app_cs.arb
@@ -704,42 +704,42 @@
             "percent": {}
         }
     },
-    "plural_ago_days": "{count,plural,  one {}  few {před {count} dny}  many {před {count} dny}=1{včera} other{ před {count} dny}}",
+    "plural_ago_days": "{count,plural,  few {před {count} dny}  many {před {count} dny}=1{včera} other{ před {count} dny}}",
     "@plural_ago_days": {
         "description": "Cached results from: x days ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_hours": "{count,plural,  one {}  few {před {count} hodinami}  many {před {count} hodinami}=1{před hodinou} other{před {count} hodinami}}",
+    "plural_ago_hours": "{count,plural,  few {před {count} hodinami}  many {před {count} hodinami}=1{před hodinou} other{před {count} hodinami}}",
     "@plural_ago_hours": {
         "description": "Cached results from: x hours ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_minutes": "před {count,plural, one {} few {{count} minutami} many {{count} minutami} =0{méně než minutou} =1{minutou} other{{count} minutami}}",
+    "plural_ago_minutes": "před {count,plural, few {{count} minutami} many {{count} minutami} =0{méně než minutou} =1{minutou} other{{count} minutami}}",
     "@plural_ago_minutes": {
         "description": "Cached results from: x minutes ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_months": "{count,plural,  one {}  few {před {count} měsíci}  many {před {count} měsíci}=1{před měsícem} other{před {count} měsíci}}",
+    "plural_ago_months": "{count,plural,  few {před {count} měsíci}  many {před {count} měsíci}=1{před měsícem} other{před {count} měsíci}}",
     "@plural_ago_months": {
         "description": "Cached results from: x months ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_weeks": "před {count,plural,  one {}  few {{count} týdny}  many {{count} týdny}=1{1 týdnem} other{{count} týdny}}",
+    "plural_ago_weeks": "před {count,plural,  few {{count} týdny}  many {{count} týdny}=1{1 týdnem} other{{count} týdny}}",
     "@plural_ago_weeks": {
         "description": "Cached results from: x weeks ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_compare_x_products": "Porovnat {count,plural, one {} few {{count} produkty} many {{count} produktů}=1{1 produkt} other{{count} produktů}}",
+    "plural_compare_x_products": "Porovnat {count,plural, few {{count} produkty} many {{count} produktů}=1{1 produkt} other{{count} produktů}}",
     "@plural_compare_x_products": {
         "description": "Button label to open a page to compare all selected products to each other",
         "placeholders": {
@@ -923,14 +923,14 @@
     "@product_list_empty_message": {
         "description": "When the history list is empty, body of the message explaining to start scanning"
     },
-    "product_list_reloading_in_progress_multiple": "Obnovuji {count,plural, one {} few {produkty} many {produktů} =0{produkt} =1{produkt} other{produkty}} v historii",
+    "product_list_reloading_in_progress_multiple": "Obnovuji {count,plural, few {produkty} many {produktů} =0{produkt} =1{produkt} other{produkty}} v historii",
     "@product_list_reloading_in_progress_multiple": {
         "description": "Message to show while loading previous scanned items",
         "placeholders": {
             "count": {}
         }
     },
-    "product_list_reloading_success_multiple": "Aktualizace {count,plural,  one {}  few {produktů}  many {produktů}=0{produktů} =1{produktu} other{Products}} dokončena",
+    "product_list_reloading_success_multiple": "Aktualizace {count,plural,  few {produktů}  many {produktů}=0{produktů} =1{produktu} other{Products}} dokončena",
     "@product_list_reloading_success_multiple": {
         "description": "Message to show once previous scanned items are loaded",
         "placeholders": {
@@ -1675,7 +1675,7 @@
     "@user_list_all_empty": {
         "description": "Small message when there are no user lists"
     },
-    "user_list_length": "{count,plural, one {} few {{count} produkty} many {{count} produktů}=0{Prázdný seznam} =1{1 produkt} other{{count} produktů}}",
+    "user_list_length": "{count,plural, few {{count} produkty} many {{count} produktů}=0{Prázdný seznam} =1{1 produkt} other{{count} produktů}}",
     "@user_list_length": {
         "description": "Length of a user product list",
         "placeholders": {

--- a/packages/smooth_app/lib/l10n/app_da.arb
+++ b/packages/smooth_app/lib/l10n/app_da.arb
@@ -704,42 +704,42 @@
             "percent": {}
         }
     },
-    "plural_ago_days": "{count,plural,  one {}=1{én dag siden} other{{count} dage siden}}",
+    "plural_ago_days": "{count,plural,  =1{én dag siden} other{{count} dage siden}}",
     "@plural_ago_days": {
         "description": "Cached results from: x days ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_hours": "{count,plural,  one {}=1{én time siden} other{{count} timer siden}}",
+    "plural_ago_hours": "{count,plural,  =1{én time siden} other{{count} timer siden}}",
     "@plural_ago_hours": {
         "description": "Cached results from: x hours ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_minutes": "{count,plural,  one {}=0{under ét minut siden} =1{ét minut siden} other{{count} minutter siden}}",
+    "plural_ago_minutes": "{count,plural,  =0{under ét minut siden} =1{ét minut siden} other{{count} minutter siden}}",
     "@plural_ago_minutes": {
         "description": "Cached results from: x minutes ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_months": "{count,plural,  one {}=1{én måned siden} other{{count} måneder siden}}",
+    "plural_ago_months": "{count,plural,  =1{én måned siden} other{{count} måneder siden}}",
     "@plural_ago_months": {
         "description": "Cached results from: x months ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_weeks": "{count,plural,  one {}=1{én uge siden} other{{count} uger siden}}",
+    "plural_ago_weeks": "{count,plural,  =1{én uge siden} other{{count} uger siden}}",
     "@plural_ago_weeks": {
         "description": "Cached results from: x weeks ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_compare_x_products": "{count,plural, one {}=1{Sammenlign ét produkt} other{Sammenlign {count} produkter}}",
+    "plural_compare_x_products": "{count,plural, =1{Sammenlign ét produkt} other{Sammenlign {count} produkter}}",
     "@plural_compare_x_products": {
         "description": "Button label to open a page to compare all selected products to each other",
         "placeholders": {
@@ -923,14 +923,14 @@
     "@product_list_empty_message": {
         "description": "When the history list is empty, body of the message explaining to start scanning"
     },
-    "product_list_reloading_in_progress_multiple": "Opfrisker {count,plural, one {} =0{produkt} =1{produkt} other{produkter}} i historikken",
+    "product_list_reloading_in_progress_multiple": "Opfrisker {count,plural, =0{produkt} =1{produkt} other{produkter}} i historikken",
     "@product_list_reloading_in_progress_multiple": {
         "description": "Message to show while loading previous scanned items",
         "placeholders": {
             "count": {}
         }
     },
-    "product_list_reloading_success_multiple": "{count,plural, one {} =0{Produkt} =1{Produktopfriskning} other{Produktopfriskninger}} udført",
+    "product_list_reloading_success_multiple": "{count,plural, =0{Produkt} =1{Produktopfriskning} other{Produktopfriskninger}} udført",
     "@product_list_reloading_success_multiple": {
         "description": "Message to show once previous scanned items are loaded",
         "placeholders": {
@@ -1675,7 +1675,7 @@
     "@user_list_all_empty": {
         "description": "Small message when there are no user lists"
     },
-    "user_list_length": "{count,plural, one {} =0{Tom liste} =1{Et produkt} other{{count} produkter}}",
+    "user_list_length": "{count,plural, =0{Tom liste} =1{Et produkt} other{{count} produkter}}",
     "@user_list_length": {
         "description": "Length of a user product list",
         "placeholders": {

--- a/packages/smooth_app/lib/l10n/app_de.arb
+++ b/packages/smooth_app/lib/l10n/app_de.arb
@@ -704,7 +704,7 @@
             "percent": {}
         }
     },
-    "plural_ago_days": "{count,plural,  one {}=1{gestern} other{{count} Tage her}}",
+    "plural_ago_days": "{count,plural,  =1{gestern} other{{count} Tage her}}",
     "@plural_ago_days": {
         "description": "Cached results from: x days ago",
         "placeholders": {

--- a/packages/smooth_app/lib/l10n/app_el.arb
+++ b/packages/smooth_app/lib/l10n/app_el.arb
@@ -1675,7 +1675,7 @@
     "@user_list_all_empty": {
         "description": "Small message when there are no user lists"
     },
-    "user_list_length": "{count,plural, one {} =0{Κενή λίστα} =1{Ένα προϊόν} other{{count} προϊόντα}}",
+    "user_list_length": "{count,plural, =0{Κενή λίστα} =1{Ένα προϊόν} other{{count} προϊόντα}}",
     "@user_list_length": {
         "description": "Length of a user product list",
         "placeholders": {

--- a/packages/smooth_app/lib/l10n/app_eu.arb
+++ b/packages/smooth_app/lib/l10n/app_eu.arb
@@ -704,42 +704,42 @@
             "percent": {}
         }
     },
-    "plural_ago_days": "{count,plural,  one {}=1{duela egun bat} other{duela {count} egun}}",
+    "plural_ago_days": "{count,plural,  =1{duela egun bat} other{duela {count} egun}}",
     "@plural_ago_days": {
         "description": "Cached results from: x days ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_hours": "{count,plural,  one {}=1{duela ordu bat} other{duela {count} ordu}}",
+    "plural_ago_hours": "{count,plural,  =1{duela ordu bat} other{duela {count} ordu}}",
     "@plural_ago_hours": {
         "description": "Cached results from: x hours ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_minutes": "{count,plural,  one {}=0{duela minutu bat baino gutxiago} =1{duela minutu bat} other{duela {count} minutu}}",
+    "plural_ago_minutes": "{count,plural,  =0{duela minutu bat baino gutxiago} =1{duela minutu bat} other{duela {count} minutu}}",
     "@plural_ago_minutes": {
         "description": "Cached results from: x minutes ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_months": "{count,plural,  one {}=1{duela hilabete bat} other{duela {count} hilabete}}",
+    "plural_ago_months": "{count,plural,  =1{duela hilabete bat} other{duela {count} hilabete}}",
     "@plural_ago_months": {
         "description": "Cached results from: x months ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_weeks": "{count,plural,  one {}=1{duela aste bat} other{duela {count} aste}}",
+    "plural_ago_weeks": "{count,plural,  =1{duela aste bat} other{duela {count} aste}}",
     "@plural_ago_weeks": {
         "description": "Cached results from: x weeks ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_compare_x_products": "{count,plural, one {}=1{Produktu bat alderatu} other{{count} produktu alderatu}}",
+    "plural_compare_x_products": "{count,plural, =1{Produktu bat alderatu} other{{count} produktu alderatu}}",
     "@plural_compare_x_products": {
         "description": "Button label to open a page to compare all selected products to each other",
         "placeholders": {

--- a/packages/smooth_app/lib/l10n/app_he.arb
+++ b/packages/smooth_app/lib/l10n/app_he.arb
@@ -704,7 +704,7 @@
             "percent": {}
         }
     },
-    "plural_ago_days": "{count,plural,  one {}  two {לפני יומיים}  many {לפני {count} ימים}=1{אתמול} other{לפני {count} ימים}}",
+    "plural_ago_days": "{count,plural, two{לפני יומיים}  many {לפני {count} ימים} =1{אתמול} other{לפני {count} ימים}}",
     "@plural_ago_days": {
         "description": "Cached results from: x days ago",
         "placeholders": {
@@ -923,14 +923,14 @@
     "@product_list_empty_message": {
         "description": "When the history list is empty, body of the message explaining to start scanning"
     },
-    "product_list_reloading_in_progress_multiple": "{count,plural,  one {}  two {מוצרים מההיסטוריה שלך מתרעננים}  many {מוצרים מההיסטוריה שלך מתרעננים}=0{מוצר מההיסטוריה שלך מתרענן} =1{מוצר מההיסטוריה שלך מתרענן} other{מוצרים מההיסטוריה שלך מתרעננים}}",
+    "product_list_reloading_in_progress_multiple": "{count,plural,  two {מוצרים מההיסטוריה שלך מתרעננים}  many {מוצרים מההיסטוריה שלך מתרעננים}=0{מוצר מההיסטוריה שלך מתרענן} =1{מוצר מההיסטוריה שלך מתרענן} other{מוצרים מההיסטוריה שלך מתרעננים}}",
     "@product_list_reloading_in_progress_multiple": {
         "description": "Message to show while loading previous scanned items",
         "placeholders": {
             "count": {}
         }
     },
-    "product_list_reloading_success_multiple": "רענון ה{count,plural,  one {}  two {מוצרים}  many {מוצרים}=0{מוצר} =1{מוצר} other{מוצרים}} הושלם",
+    "product_list_reloading_success_multiple": "רענון ה{count,plural, two{מוצרים}  many{מוצרים}=0{מוצר} =1 {מוצר} other{מוצרים}} הושלם",
     "@product_list_reloading_success_multiple": {
         "description": "Message to show once previous scanned items are loaded",
         "placeholders": {
@@ -1675,7 +1675,7 @@
     "@user_list_all_empty": {
         "description": "Small message when there are no user lists"
     },
-    "user_list_length": "{count,plural, one {} two {שני מוצרים} many {{count} מוצרים} =0{רשימה ריקה} =1{מוצר אחד} other{{count} מוצרים}}",
+    "user_list_length": "{count,plural, two {שני מוצרים} many {{count} מוצרים} =0{רשימה ריקה} =1{מוצר אחד} other{{count} מוצרים}}",
     "@user_list_length": {
         "description": "Length of a user product list",
         "placeholders": {

--- a/packages/smooth_app/lib/l10n/app_it.arb
+++ b/packages/smooth_app/lib/l10n/app_it.arb
@@ -704,42 +704,42 @@
             "percent": {}
         }
     },
-    "plural_ago_days": "{count,plural,  one {}=1{un giorno fa} other{{count} giorni fa}}",
+    "plural_ago_days": "{count,plural,  =1{un giorno fa} other{{count} giorni fa}}",
     "@plural_ago_days": {
         "description": "Cached results from: x days ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_hours": "{count,plural,  one {}=1{un'ora fa} other{{count} ore fa}}",
+    "plural_ago_hours": "{count,plural,  =1{un'ora fa} other{{count} ore fa}}",
     "@plural_ago_hours": {
         "description": "Cached results from: x hours ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_minutes": "{count,plural,  one {}=0{meno di un minuto fa} =1{un minuto fa} other{{count} minuti fa}}",
+    "plural_ago_minutes": "{count,plural,  =0{meno di un minuto fa} =1{un minuto fa} other{{count} minuti fa}}",
     "@plural_ago_minutes": {
         "description": "Cached results from: x minutes ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_months": "{count,plural,  one {}=1{un mese fa} other{{count} mesi fa}}",
+    "plural_ago_months": "{count,plural,  =1{un mese fa} other{{count} mesi fa}}",
     "@plural_ago_months": {
         "description": "Cached results from: x months ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_weeks": "{count,plural,  one {}=1{una settimana fa} other{{count} settimane fa}}",
+    "plural_ago_weeks": "{count,plural,  =1{una settimana fa} other{{count} settimane fa}}",
     "@plural_ago_weeks": {
         "description": "Cached results from: x weeks ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_compare_x_products": "{count,plural, one {}=1{Confronta con un Prodotto} other{Confronta {count} Prodotti}}",
+    "plural_compare_x_products": "{count,plural, =1{Confronta con un Prodotto} other{Confronta {count} Prodotti}}",
     "@plural_compare_x_products": {
         "description": "Button label to open a page to compare all selected products to each other",
         "placeholders": {
@@ -923,14 +923,14 @@
     "@product_list_empty_message": {
         "description": "When the history list is empty, body of the message explaining to start scanning"
     },
-    "product_list_reloading_in_progress_multiple": "Aggiornando {count,plural,  one {}=0{prodotto} =1{prodotto} other{prodotti}} nella tua cronologia",
+    "product_list_reloading_in_progress_multiple": "Aggiornando {count,plural,  =0{prodotto} =1{prodotto} other{prodotti}} nella tua cronologia",
     "@product_list_reloading_in_progress_multiple": {
         "description": "Message to show while loading previous scanned items",
         "placeholders": {
             "count": {}
         }
     },
-    "product_list_reloading_success_multiple": "Aggiornamento di {count,plural,  one {}=0{Prodotto} =1{Prodotto} other{Prodotti}} completato",
+    "product_list_reloading_success_multiple": "Aggiornamento di {count,plural,  =0{Prodotto} =1{Prodotto} other{Prodotti}} completato",
     "@product_list_reloading_success_multiple": {
         "description": "Message to show once previous scanned items are loaded",
         "placeholders": {

--- a/packages/smooth_app/lib/l10n/app_nl.arb
+++ b/packages/smooth_app/lib/l10n/app_nl.arb
@@ -711,28 +711,28 @@
             "count": {}
         }
     },
-    "plural_ago_hours": "{count,plural, one {} =1{een uur geleden} other{{count} uren geleden}}",
+    "plural_ago_hours": "{count,plural, =1{een uur geleden} other{{count} uren geleden}}",
     "@plural_ago_hours": {
         "description": "Cached results from: x hours ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_minutes": "{count,plural, one {} =0{minder dan een minuut geleden} =1{een minuut geleden} other{{count} minuten geleden}}",
+    "plural_ago_minutes": "{count,plural, =0{minder dan een minuut geleden} =1{een minuut geleden} other{{count} minuten geleden}}",
     "@plural_ago_minutes": {
         "description": "Cached results from: x minutes ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_months": "{count,plural, one {} =1{een maand geleden} other{{count} maanden geleden}}",
+    "plural_ago_months": "{count,plural, =1{een maand geleden} other{{count} maanden geleden}}",
     "@plural_ago_months": {
         "description": "Cached results from: x months ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_weeks": "{count,plural, one {} =1{een week geleden} other{{count} weken geleden}}",
+    "plural_ago_weeks": "{count,plural, =1{een week geleden} other{{count} weken geleden}}",
     "@plural_ago_weeks": {
         "description": "Cached results from: x weeks ago",
         "placeholders": {
@@ -923,14 +923,14 @@
     "@product_list_empty_message": {
         "description": "When the history list is empty, body of the message explaining to start scanning"
     },
-    "product_list_reloading_in_progress_multiple": "Verversen van {count,plural, one {} =0{product} =1{product} other{products}} in jouw geschiedens",
+    "product_list_reloading_in_progress_multiple": "Verversen van {count,plural, =0{product} =1{product} other{products}} in jouw geschiedens",
     "@product_list_reloading_in_progress_multiple": {
         "description": "Message to show while loading previous scanned items",
         "placeholders": {
             "count": {}
         }
     },
-    "product_list_reloading_success_multiple": "{count,plural, one {} =0{Product} =1{Product} other{Producten}} verversen voltooid",
+    "product_list_reloading_success_multiple": "{count,plural, =0{Product} =1{Product} other{Producten}} verversen voltooid",
     "@product_list_reloading_success_multiple": {
         "description": "Message to show once previous scanned items are loaded",
         "placeholders": {
@@ -1675,7 +1675,7 @@
     "@user_list_all_empty": {
         "description": "Small message when there are no user lists"
     },
-    "user_list_length": "{count,plural, one {} =0{Lege lijst} =1{Een product} other{{count} producten}}",
+    "user_list_length": "{count,plural, =0{Lege lijst} =1{Een product} other{{count} producten}}",
     "@user_list_length": {
         "description": "Length of a user product list",
         "placeholders": {

--- a/packages/smooth_app/lib/l10n/app_pl.arb
+++ b/packages/smooth_app/lib/l10n/app_pl.arb
@@ -1675,7 +1675,7 @@
     "@user_list_all_empty": {
         "description": "Small message when there are no user lists"
     },
-    "user_list_length": "{count,plural, one {} few {{count} produkty} many {{count} produktów} =0{Lista pusta} =1{Jeden produkt} other{{count} produktów}}",
+    "user_list_length": "{count,plural, few {{count} produkty} many {{count} produktów} =0{Lista pusta} =1{Jeden produkt} other{{count} produktów}}",
     "@user_list_length": {
         "description": "Length of a user product list",
         "placeholders": {

--- a/packages/smooth_app/lib/l10n/app_pt.arb
+++ b/packages/smooth_app/lib/l10n/app_pt.arb
@@ -1675,7 +1675,7 @@
     "@user_list_all_empty": {
         "description": "Small message when there are no user lists"
     },
-    "user_list_length": "{count,plural, one {}=0{Lista vazia} =1{Um produto} other{{count} produtos}}",
+    "user_list_length": "{count,plural, =0{Lista vazia} =1{Um produto} other{{count} produtos}}",
     "@user_list_length": {
         "description": "Length of a user product list",
         "placeholders": {

--- a/packages/smooth_app/lib/l10n/app_ro.arb
+++ b/packages/smooth_app/lib/l10n/app_ro.arb
@@ -704,42 +704,42 @@
             "percent": {}
         }
     },
-    "plural_ago_days": "{count,plural,  one {}  few {{count} zile în urmă}=1{acum o zi} other{{count} zile în urmă}}",
+    "plural_ago_days": "{count,plural,  few {{count} zile în urmă}=1{acum o zi} other{{count} zile în urmă}}",
     "@plural_ago_days": {
         "description": "Cached results from: x days ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_hours": "{count,plural,  one {}  few {{count} ore în urmă}=1{acum o ora} other{{count} ore în urmă}}",
+    "plural_ago_hours": "{count,plural,  few {{count} ore în urmă}=1{acum o ora} other{{count} ore în urmă}}",
     "@plural_ago_hours": {
         "description": "Cached results from: x hours ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_minutes": "{count,plural,  one {}  few {{count} minute în urmă}=0{in urma cu mai puțin de un minut} =1{acum un minut} other{{count} minute în urmă}}",
+    "plural_ago_minutes": "{count,plural,  few {{count} minute în urmă}=0{in urma cu mai puțin de un minut} =1{acum un minut} other{{count} minute în urmă}}",
     "@plural_ago_minutes": {
         "description": "Cached results from: x minutes ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_months": "{count,plural,  one {}  few {{count} cu luni în urmă}=1{acum o luna} other{{count} cu luni în urmă}}",
+    "plural_ago_months": "{count,plural,  few {{count} cu luni în urmă}=1{acum o luna} other{{count} cu luni în urmă}}",
     "@plural_ago_months": {
         "description": "Cached results from: x months ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_ago_weeks": "{count,plural,  one {}  few {{count} săptămâni în urma}=1{acum o saptamana} other{{count} săptămâni în urma}}",
+    "plural_ago_weeks": "{count,plural,  few {{count} săptămâni în urma}=1{acum o saptamana} other{{count} săptămâni în urma}}",
     "@plural_ago_weeks": {
         "description": "Cached results from: x weeks ago",
         "placeholders": {
             "count": {}
         }
     },
-    "plural_compare_x_products": "{count,plural, one {} few {Compara {count} Produse}=1{Compara un produs} other{Compara {count} Produse}}",
+    "plural_compare_x_products": "{count,plural, few {Compara {count} Produse}=1{Compara un produs} other{Compara {count} Produse}}",
     "@plural_compare_x_products": {
         "description": "Button label to open a page to compare all selected products to each other",
         "placeholders": {
@@ -923,14 +923,14 @@
     "@product_list_empty_message": {
         "description": "When the history list is empty, body of the message explaining to start scanning"
     },
-    "product_list_reloading_in_progress_multiple": "Reîmprospătare {count,plural,  one {}  few {produse}=0{produs} =1{produs} other{produse}} în istoric",
+    "product_list_reloading_in_progress_multiple": "Reîmprospătare {count,plural,  few {produse}=0{produs} =1{produs} other{produse}} în istoric",
     "@product_list_reloading_in_progress_multiple": {
         "description": "Message to show while loading previous scanned items",
         "placeholders": {
             "count": {}
         }
     },
-    "product_list_reloading_success_multiple": "{count,plural,  one {}  few {Produse}=0{Produs} =1{Produs} other{Produse}} Reîmprospătare completă",
+    "product_list_reloading_success_multiple": "{count,plural,  few {Produse}=0{Produs} =1{Produs} other{Produse}} Reîmprospătare completă",
     "@product_list_reloading_success_multiple": {
         "description": "Message to show once previous scanned items are loaded",
         "placeholders": {
@@ -1675,7 +1675,7 @@
     "@user_list_all_empty": {
         "description": "Small message when there are no user lists"
     },
-    "user_list_length": "{count,plural, one {} few {{count} produse} =0{Lista goală} =1{Un singur produs} other{{count} produse}}",
+    "user_list_length": "{count,plural, few {{count} produse} =0{Lista goală} =1{Un singur produs} other{{count} produse}}",
     "@user_list_length": {
         "description": "Length of a user product list",
         "placeholders": {


### PR DESCRIPTION
### What
- Again, we get corrupted translations.
- For the record, probably since we switched to flutter 3.7 months ago, an additional test is performed on translations.
- In particular, we get a warning message if we have translations for  `one` and for `1`.
- It pollutes the `pub get` outputs, so if we could get rid of that bug that would be nice - probably at the crowdin level.

### Fixes bug(s)
<details>
<summary>warnings</summary>

[app_be.arb:user_list_length] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural, one {} few {{count} прадукты} many {{count} прадуктаў}=0{Пусты спіс} =1{Адзін прадукт} other{{count} прадукту}}
                   ^
[app_cs.arb:plural_ago_days] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural,  one {}  few {před {count} dny}  many {před {count} dny}=1{včera} other{ před {count} dny}}
                    ^
[app_cs.arb:plural_ago_hours] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural,  one {}  few {před {count} hodinami}  many {před {count} hodinami}=1{před hodinou} other{před {count} hodinami}}
                    ^
[app_cs.arb:plural_ago_minutes] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    před {count,plural, one {} few {{count} minutami} many {{count} minutami} =0{méně než minutou} =1{minutou} other{{count} minutami}}
                        ^
[app_cs.arb:plural_ago_months] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural,  one {}  few {před {count} měsíci}  many {před {count} měsíci}=1{před měsícem} other{před {count} měsíci}}
                    ^
[app_cs.arb:plural_ago_weeks] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    před {count,plural,  one {}  few {{count} týdny}  many {{count} týdny}=1{1 týdnem} other{{count} týdny}}
                         ^
[app_cs.arb:plural_compare_x_products] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    Porovnat {count,plural, one {} few {{count} produkty} many {{count} produktů}=1{1 produkt} other{{count} produktů}}
                            ^
[app_cs.arb:product_list_reloading_in_progress_multiple] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    Obnovuji {count,plural, one {} few {produkty} many {produktů} =0{produkt} =1{produkt} other{produkty}} v historii
                            ^
[app_cs.arb:product_list_reloading_success_multiple] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    Aktualizace {count,plural,  one {}  few {produktů}  many {produktů}=0{produktů} =1{produktu} other{Products}} dokončena
                                ^
[app_cs.arb:user_list_length] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural, one {} few {{count} produkty} many {{count} produktů}=0{Prázdný seznam} =1{1 produkt} other{{count} produktů}}
                   ^
[app_da.arb:plural_ago_days] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural,  one {}=1{én dag siden} other{{count} dage siden}}
                    ^
[app_da.arb:plural_ago_hours] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural,  one {}=1{én time siden} other{{count} timer siden}}
                    ^
[app_da.arb:plural_ago_minutes] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural,  one {}=0{under ét minut siden} =1{ét minut siden} other{{count} minutter siden}}
                    ^
[app_da.arb:plural_ago_months] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural,  one {}=1{én måned siden} other{{count} måneder siden}}
                    ^
[app_da.arb:plural_ago_weeks] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural,  one {}=1{én uge siden} other{{count} uger siden}}
                    ^
[app_da.arb:plural_compare_x_products] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural, one {}=1{Sammenlign ét produkt} other{Sammenlign {count} produkter}}
                   ^
[app_da.arb:product_list_reloading_in_progress_multiple] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    Opfrisker {count,plural, one {} =0{produkt} =1{produkt} other{produkter}} i historikken
                             ^
[app_da.arb:product_list_reloading_success_multiple] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural, one {} =0{Produkt} =1{Produktopfriskning} other{Produktopfriskninger}} udført
                   ^
[app_da.arb:user_list_length] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural, one {} =0{Tom liste} =1{Et produkt} other{{count} produkter}}
                   ^
[app_de.arb:plural_ago_days] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural,  one {}=1{gestern} other{{count} Tage her}}
                    ^
[app_el.arb:user_list_length] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural, one {} =0{Κενή λίστα} =1{Ένα προϊόν} other{{count} προϊόντα}}
                   ^
[app_eu.arb:plural_ago_days] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural,  one {}=1{duela egun bat} other{duela {count} egun}}
                    ^
[app_eu.arb:plural_ago_hours] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural,  one {}=1{duela ordu bat} other{duela {count} ordu}}
                    ^
[app_eu.arb:plural_ago_minutes] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural,  one {}=0{duela minutu bat baino gutxiago} =1{duela minutu bat} other{duela {count} minutu}}
                    ^
[app_eu.arb:plural_ago_months] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural,  one {}=1{duela hilabete bat} other{duela {count} hilabete}}
                    ^
[app_eu.arb:plural_ago_weeks] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural,  one {}=1{duela aste bat} other{duela {count} aste}}
                    ^
[app_eu.arb:plural_compare_x_products] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural, one {}=1{Produktu bat alderatu} other{{count} produktu alderatu}}
                   ^
[app_he.arb:plural_ago_days] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural,  one {}  two {לפני יומיים}  many {לפני {count} ימים}=1{אתמול} other{לפני {count} ימים}}
                    ^
[app_he.arb:product_list_reloading_in_progress_multiple] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural,  one {}  two {מוצרים מההיסטוריה שלך מתרעננים}  many {מוצרים מההיסטוריה שלך מתרעננים}=0{מוצר מההיסטוריה שלך מתרענן} =1{מוצר מההיסטוריה שלך מתרענן} other{מוצרים מההיסטוריה שלך מתרעננים}}
                    ^
[app_he.arb:product_list_reloading_success_multiple] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    רענון ה{count,plural,  one {}  two {מוצרים}  many {מוצרים}=0{מוצר} =1{מוצר} other{מוצרים}} הושלם
                           ^
[app_he.arb:user_list_length] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural, one {} two {שני מוצרים} many {{count} מוצרים} =0{רשימה ריקה} =1{מוצר אחד} other{{count} מוצרים}}
                   ^
[app_it.arb:plural_ago_days] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural,  one {}=1{un giorno fa} other{{count} giorni fa}}
                    ^
[app_it.arb:plural_ago_hours] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural,  one {}=1{un'ora fa} other{{count} ore fa}}
                    ^
[app_it.arb:plural_ago_minutes] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural,  one {}=0{meno di un minuto fa} =1{un minuto fa} other{{count} minuti fa}}
                    ^
[app_it.arb:plural_ago_months] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural,  one {}=1{un mese fa} other{{count} mesi fa}}
                    ^
[app_it.arb:plural_ago_weeks] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural,  one {}=1{una settimana fa} other{{count} settimane fa}}
                    ^
[app_it.arb:plural_compare_x_products] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural, one {}=1{Confronta con un Prodotto} other{Confronta {count} Prodotti}}
                   ^
[app_it.arb:product_list_reloading_in_progress_multiple] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    Aggiornando {count,plural,  one {}=0{prodotto} =1{prodotto} other{prodotti}} nella tua cronologia
                                ^
[app_it.arb:product_list_reloading_success_multiple] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    Aggiornamento di {count,plural,  one {}=0{Prodotto} =1{Prodotto} other{Prodotti}} completato
                                     ^
[app_nl.arb:plural_ago_hours] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural, one {} =1{een uur geleden} other{{count} uren geleden}}
                   ^
[app_nl.arb:plural_ago_minutes] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural, one {} =0{minder dan een minuut geleden} =1{een minuut geleden} other{{count} minuten geleden}}
                   ^
[app_nl.arb:plural_ago_months] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural, one {} =1{een maand geleden} other{{count} maanden geleden}}
                   ^
[app_nl.arb:plural_ago_weeks] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural, one {} =1{een week geleden} other{{count} weken geleden}}
                   ^
[app_nl.arb:product_list_reloading_in_progress_multiple] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    Verversen van {count,plural, one {} =0{product} =1{product} other{products}} in jouw geschiedens
                                 ^
[app_nl.arb:product_list_reloading_success_multiple] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural, one {} =0{Product} =1{Product} other{Producten}} verversen voltooid
                   ^
[app_nl.arb:user_list_length] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural, one {} =0{Lege lijst} =1{Een product} other{{count} producten}}
                   ^
[app_pl.arb:user_list_length] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural, one {} few {{count} produkty} many {{count} produktów} =0{Lista pusta} =1{Jeden produkt} other{{count} produktów}}
                   ^
[app_pt.arb:user_list_length] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural, one {}=0{Lista vazia} =1{Um produto} other{{count} produtos}}
                   ^
[app_ro.arb:plural_ago_days] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural,  one {}  few {{count} zile în urmă}=1{acum o zi} other{{count} zile în urmă}}
                    ^
[app_ro.arb:plural_ago_hours] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural,  one {}  few {{count} ore în urmă}=1{acum o ora} other{{count} ore în urmă}}
                    ^
[app_ro.arb:plural_ago_minutes] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural,  one {}  few {{count} minute în urmă}=0{in urma cu mai puțin de un minut} =1{acum un minut} other{{count} minute în urmă}}
                    ^
[app_ro.arb:plural_ago_months] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural,  one {}  few {{count} cu luni în urmă}=1{acum o luna} other{{count} cu luni în urmă}}
                    ^
[app_ro.arb:plural_ago_weeks] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural,  one {}  few {{count} săptămâni în urma}=1{acum o saptamana} other{{count} săptămâni în urma}}
                    ^
[app_ro.arb:plural_compare_x_products] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural, one {} few {Compara {count} Produse}=1{Compara un produs} other{Compara {count} Produse}}
                   ^
[app_ro.arb:product_list_reloading_in_progress_multiple] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    Reîmprospătare {count,plural,  one {}  few {produse}=0{produs} =1{produs} other{produse}} în istoric
                                   ^
[app_ro.arb:product_list_reloading_success_multiple] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural,  one {}  few {Produse}=0{Produs} =1{Produs} other{Produse}} Reîmprospătare completă
                    ^
[app_ro.arb:user_list_length] ICU Syntax Warning: The plural part specified below is overridden by a later plural part.
    {count,plural, one {} few {{count} produse} =0{Lista goală} =1{Un singur produs} other{{count} produse}}
                   ^
</details>