### PR TITLE
feat: 3987 - now KP opens the new packaging page

### DIFF
--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_action_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_action_card.dart
@@ -4,10 +4,9 @@ import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/smooth_html_widget.dart';
 import 'package:smooth_app/pages/product/add_nutrition_button.dart';
 import 'package:smooth_app/pages/product/add_ocr_button.dart';
+import 'package:smooth_app/pages/product/add_packaging_button.dart';
 import 'package:smooth_app/pages/product/add_simple_input_button.dart';
-import 'package:smooth_app/pages/product/ocr_helper.dart';
 import 'package:smooth_app/pages/product/ocr_ingredients_helper.dart';
-import 'package:smooth_app/pages/product/ocr_packaging_helper.dart';
 import 'package:smooth_app/pages/product/simple_input_page_helpers.dart';
 import 'package:smooth_app/services/smooth_services.dart';
 
@@ -31,33 +30,11 @@ class KnowledgePanelActionCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final List<Widget> actionWidgets = <Widget>[];
     for (final String action in element.actions) {
-      final AbstractSimpleInputPageHelper? simpleInputPageHelper =
-          _getSimpleInputPageHelper(action);
-      if (simpleInputPageHelper != null) {
-        actionWidgets.add(
-          AddSimpleInputButton(
-            product: product,
-            helper: simpleInputPageHelper,
-          ),
-        );
-        continue;
-      }
-      final OcrHelper? ocrHelper = _getOcrHelper(action);
-      if (ocrHelper != null) {
-        actionWidgets.add(
-          AddOCRButton(
-            product: product,
-            helper: ocrHelper,
-          ),
-        );
-        continue;
-      }
-      switch (action) {
-        case KnowledgePanelActionElement.ACTION_ADD_NUTRITION_FACTS:
-          actionWidgets.add(AddNutritionButton(product));
-          break;
-        default:
-          Logs.e('unknown knowledge panel action: $action');
+      final Widget? button = _getButton(action);
+      if (button != null) {
+        actionWidgets.add(button);
+      } else {
+        Logs.e('unknown knowledge panel action: $action');
       }
     }
     return Column(
@@ -69,6 +46,33 @@ class KnowledgePanelActionCard extends StatelessWidget {
         ...actionWidgets,
       ],
     );
+  }
+
+  Widget? _getButton(final String action) {
+    final AbstractSimpleInputPageHelper? simpleInputPageHelper =
+        _getSimpleInputPageHelper(action);
+    if (simpleInputPageHelper != null) {
+      return AddSimpleInputButton(
+        product: product,
+        helper: simpleInputPageHelper,
+      );
+    }
+    if (_isPackaging(action)) {
+      return AddPackagingButton(
+        product: product,
+      );
+    }
+    if (_isIngredient(action)) {
+      return AddOCRButton(
+        product: product,
+        helper: OcrIngredientsHelper(),
+      );
+    }
+    if (action == KnowledgePanelActionElement.ACTION_ADD_NUTRITION_FACTS) {
+      return AddNutritionButton(product);
+    }
+    Logs.e('unknown knowledge panel action: $action');
+    return null;
   }
 
   AbstractSimpleInputPageHelper? _getSimpleInputPageHelper(
@@ -89,17 +93,27 @@ class KnowledgePanelActionCard extends StatelessWidget {
     return null;
   }
 
-  OcrHelper? _getOcrHelper(
+  bool _isIngredient(
     final String action,
   ) {
     switch (action) {
       case KnowledgePanelActionElement.ACTION_ADD_INGREDIENTS_TEXT:
       case _ACTION_ADD_INGREDIENTS_IMAGE:
-        return OcrIngredientsHelper();
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  bool _isPackaging(
+    final String action,
+  ) {
+    switch (action) {
       case _ACTION_ADD_PACKAGING_IMAGE:
       case _ACTION_ADD_PACKAGING_TEXT:
-        return OcrPackagingHelper();
+        return true;
+      default:
+        return false;
     }
-    return null;
   }
 }

--- a/packages/smooth_app/lib/pages/product/add_packaging_button.dart
+++ b/packages/smooth_app/lib/pages/product/add_packaging_button.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/helpers/product_cards_helper.dart';
+import 'package:smooth_app/pages/product/common/product_refresher.dart';
+import 'package:smooth_app/pages/product/edit_new_packagings.dart';
+import 'package:smooth_app/pages/product/ocr_packaging_helper.dart';
+
+/// "Add (new) packaging" button for user contribution.
+class AddPackagingButton extends StatelessWidget {
+  const AddPackagingButton({
+    required this.product,
+  });
+
+  final Product product;
+
+  @override
+  Widget build(BuildContext context) => addPanelButton(
+        OcrPackagingHelper().getAddButtonLabel(AppLocalizations.of(context)),
+        onPressed: () async {
+          // ignore: use_build_context_synchronously
+          if (!await ProductRefresher().checkIfLoggedIn(context)) {
+            return;
+          }
+          // ignore: use_build_context_synchronously
+          await Navigator.push<void>(
+            context,
+            MaterialPageRoute<void>(
+              builder: (BuildContext context) => EditNewPackagings(
+                product: product,
+              ),
+              fullscreenDialog: true,
+            ),
+          );
+        },
+      );
+}


### PR DESCRIPTION
New file:
* `add_packaging_button.dart`: "Add (new) packaging" button for user contribution.

Impacted file:
* `knowledge_panel_action_card.dart`: now opens the new packaging page; refactoring

### What
- Now the knowledge panel action opens the new packaging page instead of the Packaging OCR page

### Fixes bug(s)
- Closes: #3987