### PR TITLE
fix: 3990 - rolled back to previous flutter_svg package version

### DIFF
--- a/packages/scanner/shared/pubspec.yaml
+++ b/packages/scanner/shared/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_svg: 2.0.5
+  flutter_svg: 1.1.6 # careful with upgrading, cf. https://github.com/openfoodfacts/smooth-app/issues/3990
   visibility_detector: 0.4.0+2
 
 dev_dependencies:

--- a/packages/smooth_app/lib/cards/category_cards/svg_async_asset.dart
+++ b/packages/smooth_app/lib/cards/category_cards/svg_async_asset.dart
@@ -1,5 +1,3 @@
-import 'dart:ui' as ui;
-
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -53,12 +51,7 @@ class _SvgAsyncAssetState extends State<SvgAsyncAsset> {
                 snapshot.data!,
                 width: widget.assetCacheHelper.width,
                 height: widget.assetCacheHelper.height,
-                colorFilter: widget.assetCacheHelper.color == null
-                    ? null
-                    : ui.ColorFilter.mode(
-                        widget.assetCacheHelper.color!,
-                        ui.BlendMode.srcIn,
-                      ),
+                color: widget.assetCacheHelper.color,
                 fit: BoxFit.contain,
                 placeholderBuilder: (BuildContext context) =>
                     widget.assetCacheHelper.getEmptySpace(),

--- a/packages/smooth_app/lib/cards/category_cards/svg_cache.dart
+++ b/packages/smooth_app/lib/cards/category_cards/svg_cache.dart
@@ -1,5 +1,3 @@
-import 'dart:ui' as ui;
-
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:smooth_app/cards/category_cards/abstract_cache.dart';
@@ -56,9 +54,7 @@ class SvgCache extends AbstractCache {
     }
     return SvgPicture.network(
       iconUrl!,
-      colorFilter: forcedColor == null
-          ? null
-          : ui.ColorFilter.mode(forcedColor, ui.BlendMode.srcIn),
+      color: forcedColor,
       width: width,
       height: height,
       fit: BoxFit.contain,

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_thanks.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_thanks.dart
@@ -1,5 +1,3 @@
-import 'dart:ui' as ui;
-
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -36,10 +34,7 @@ class SmoothProductCardThanks extends StatelessWidget {
                 'assets/misc/checkmark.svg',
                 width: 36.0,
                 height: 36.0,
-                colorFilter: const ui.ColorFilter.mode(
-                  Colors.greenAccent,
-                  ui.BlendMode.srcIn,
-                ),
+                color: Colors.greenAccent,
                 package: AppHelper.APP_PACKAGE,
               ),
             ],

--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -1,7 +1,5 @@
 // ignore_for_file: use_build_context_synchronously
 
-import 'dart:ui' as ui;
-
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:barcode_widget/barcode_widget.dart';
 import 'package:flutter/material.dart';
@@ -412,10 +410,7 @@ class _SvgIcon extends StatelessWidget {
         assetName,
         height: DEFAULT_ICON_SIZE,
         width: DEFAULT_ICON_SIZE,
-        colorFilter: ui.ColorFilter.mode(
-          _iconColor(Theme.of(context)),
-          ui.BlendMode.srcIn,
-        ),
+        color: _iconColor(Theme.of(context)),
         package: AppHelper.APP_PACKAGE,
       );
 

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -209,10 +209,10 @@ packages:
     dependency: transitive
     description:
       name: camera_android
-      sha256: "45313e6bd5e74ac369d5bef928ab81594b5494762ac5cb8f4f255c01daa77622"
+      sha256: "61bbae4af0204b9bbfd82182e313d405abf5a01bdb057ff6675f2269a5cab4fd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.8"
+    version: "0.10.8+1"
   camera_avfoundation:
     dependency: transitive
     description:
@@ -566,10 +566,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_svg
-      sha256: f991fdb1533c3caeee0cdc14b04f50f0c3916f0dbcbc05237ccbe4e3c6b93f3f
+      sha256: "6ff9fa12892ae074092de2fa6a9938fb21dbabfdaa2ff57dc697ff912fc8d4b2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.5"
+    version: "1.1.6"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -935,6 +935,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.8.2"
+  path_drawing:
+    dependency: transitive
+    description:
+      name: path_drawing
+      sha256: bbb1934c0cbb03091af082a6389ca2080345291ef07a5fa6d6e078ba8682f977
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   path_parsing:
     dependency: transitive
     description:
@@ -1465,30 +1473,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
-  vector_graphics:
-    dependency: transitive
-    description:
-      name: vector_graphics
-      sha256: ea8d3fc7b2e0f35de38a7465063ecfcf03d8217f7962aa2a6717132cb5d43a79
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.5"
-  vector_graphics_codec:
-    dependency: transitive
-    description:
-      name: vector_graphics_codec
-      sha256: a5eaa5d19e123ad4f61c3718ca1ed921c4e6254238d9145f82aa214955d9aced
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.5"
-  vector_graphics_compiler:
-    dependency: transitive
-    description:
-      name: vector_graphics_compiler
-      sha256: "15edc42f7eaa478ce854eaf1fbb9062a899c0e4e56e775dd73b7f4709c97c4ca"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.5"
   vector_math:
     dependency: transitive
     description:
@@ -1603,4 +1587,4 @@ packages:
     version: "3.1.2"
 sdks:
   dart: ">=2.19.0 <3.0.0"
-  flutter: ">=3.7.0-0"
+  flutter: ">=3.3.0"

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   carousel_slider: 4.2.1
   cupertino_icons: 1.0.5
   device_preview: 1.1.0
-  flutter_svg: 2.0.5
+  flutter_svg: 1.1.6 # careful with upgrading, cf. https://github.com/openfoodfacts/smooth-app/issues/3990
   flutter_map: 2.2.0
   flutter_widget_from_html_core: 0.8.3+1
   fwfh_selectable_text: 0.8.3+1


### PR DESCRIPTION
### What
- Rolled back to previous flutter_svg package version, because we had a rendering problem with one icon (nova unknown), and we had no good reason to upgrade in the first place anyway.

### Screenshot
![Screenshot_2023-05-19-19-04-42](https://github.com/openfoodfacts/smooth-app/assets/11576431/b4e21ae8-4ce7-49b1-9c67-a824c24100aa)

### Fixes bug(s)
- Fixes: #3990