### PR TITLE
fix: Ingredients page: the "Enter" button should not save and send the con…

### DIFF
--- a/packages/smooth_app/lib/pages/product/edit_ingredients_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_ingredients_page.dart
@@ -295,8 +295,7 @@ class _EditOcrPageState extends State<EditOcrPage> {
                           ),
                         ),
                         maxLines: null,
-                        textInputAction: TextInputAction.done,
-                        onSubmitted: (_) async => _updateText(),
+                        textInputAction: TextInputAction.newline,
                       ),
                       const SizedBox(height: SMALL_SPACE),
                       ExplanationWidget(


### PR DESCRIPTION
Hi everyone,

As discussed in #3976, by pressing the Enter key on the ingredients'page, it acts as a Save button.
This PR disables this, by returning to the normal behavior => only a new line.

[untitled.webm](https://github.com/openfoodfacts/smooth-app/assets/246838/cc114ed0-2971-4bdb-95a5-f05f5c9dfadb)
