### PR TITLE
fix: Invisible ripple effect on the language selector

### DIFF
--- a/packages/smooth_app/lib/generic_lib/widgets/language_selector.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/language_selector.dart
@@ -39,33 +39,36 @@ class LanguageSelector extends StatelessWidget {
     }
     final String nameInEnglish = _languages.getNameInEnglish(language);
     final String nameInLanguage = _languages.getNameInLanguage(language);
-    return InkWell(
-      onTap: () async {
-        final OpenFoodFactsLanguage? language = await openLanguageSelector(
-          context,
-          selectedLanguages: selectedLanguages,
-        );
-        await setLanguage(language);
-      },
-      borderRadius: ANGULAR_BORDER_RADIUS,
-      child: ListTile(
-        leading: Icon(
-          Icons.language,
-          color: foregroundColor,
-        ),
-        title: Text(
-          '$nameInLanguage ($nameInEnglish)',
-          softWrap: false,
-          overflow: TextOverflow.fade,
-          style: Theme.of(context)
-                  .textTheme
-                  .bodyMedium
-                  ?.copyWith(color: foregroundColor) ??
-              TextStyle(color: foregroundColor),
-        ),
-        trailing: Icon(
-          Icons.arrow_drop_down,
-          color: foregroundColor,
+    return Material(
+      type: MaterialType.transparency,
+      child: InkWell(
+        onTap: () async {
+          final OpenFoodFactsLanguage? language = await openLanguageSelector(
+            context,
+            selectedLanguages: selectedLanguages,
+          );
+          await setLanguage(language);
+        },
+        borderRadius: ANGULAR_BORDER_RADIUS,
+        child: ListTile(
+          leading: Icon(
+            Icons.language,
+            color: foregroundColor,
+          ),
+          title: Text(
+            '$nameInLanguage ($nameInEnglish)',
+            softWrap: false,
+            overflow: TextOverflow.fade,
+            style: Theme.of(context)
+                    .textTheme
+                    .bodyMedium
+                    ?.copyWith(color: foregroundColor) ??
+                TextStyle(color: foregroundColor),
+          ),
+          trailing: Icon(
+            Icons.arrow_drop_down,
+            color: foregroundColor,
+          ),
         ),
       ),
     );


### PR DESCRIPTION
Hi everyone,

The button to select the langague does have a `Ripple` effect, but on many screens, it's invisible.
This is easy to solve as a two-lines fix.

[untitled.webm](https://github.com/openfoodfacts/smooth-app/assets/246838/0aad1185-7490-401c-98a9-eef25927893a)
