### PR TITLE
feat: Support for deep links

### DIFF
--- a/packages/smooth_app/android/app/src/main/AndroidManifest.xml
+++ b/packages/smooth_app/android/app/src/main/AndroidManifest.xml
@@ -46,6 +46,10 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="http" android:host="*.openfoodfacts.org" />
+                <data android:scheme="http" android:host="*.openfoodfacts.net" />
+                <data android:scheme="http" android:host="*.openbeautyfacts.org" />
+                <data android:scheme="http" android:host="*.openproductsfacts.org" />
+                <data android:scheme="http" android:host="*.openpetfoodfacts.org" />
                 <data android:scheme="https" />
             </intent-filter>
         </activity>

--- a/packages/smooth_app/android/app/src/main/AndroidManifest.xml
+++ b/packages/smooth_app/android/app/src/main/AndroidManifest.xml
@@ -39,13 +39,22 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <!-- Enable deep links in the app -->
+            <meta-data android:name="flutter_deeplinking_enabled" android:value="true" />
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="http" android:host="*.openfoodfacts.org" />
+                <data android:scheme="https" />
+            </intent-filter>
         </activity>
+
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data
                 android:name="flutterEmbedding"
                 android:value="2"/>
-
 
         <!-- Quick tile / setting (only available on Android 24+ / Nougat) -->
         <service android:name="org.openfoodfacts.app.AppMainTile"

--- a/packages/smooth_app/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/smooth_app/ios/Runner.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		3BA1CE0C2A18114C009FECD1 /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
 		6505AE5B14FDEF303D722C58 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -102,6 +103,7 @@
 		97C146F01CF9000F007C117D /* Runner */ = {
 			isa = PBXGroup;
 			children = (
+				3BA1CE0C2A18114C009FECD1 /* Runner.entitlements */,
 				97C146FA1CF9000F007C117D /* Main.storyboard */,
 				97C146FD1CF9000F007C117D /* Assets.xcassets */,
 				97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */,
@@ -356,6 +358,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = ZC9CYWD334;
 				ENABLE_BITCODE = NO;
@@ -485,6 +488,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = ZC9CYWD334;
 				ENABLE_BITCODE = NO;
@@ -508,6 +512,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = ZC9CYWD334;
 				ENABLE_BITCODE = NO;

--- a/packages/smooth_app/ios/Runner/Info.plist
+++ b/packages/smooth_app/ios/Runner/Info.plist
@@ -57,5 +57,7 @@
 	<false/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>FlutterDeepLinkingEnabled</key>
+	<true/>
 </dict>
 </plist>

--- a/packages/smooth_app/ios/Runner/Runner.entitlements
+++ b/packages/smooth_app/ios/Runner/Runner.entitlements
@@ -5,6 +5,7 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:*.openfoodfacts.org</string>
+		<string>applinks:*.openfoodfacts.net</string>
 	</array>
 </dict>
 </plist>

--- a/packages/smooth_app/ios/Runner/Runner.entitlements
+++ b/packages/smooth_app/ios/Runner/Runner.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:*.openfoodfacts.org</string>
+	</array>
+</dict>
+</plist>

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
@@ -11,7 +11,7 @@ import 'package:smooth_app/generic_lib/widgets/smooth_product_image.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/helpers/product_compatibility_helper.dart';
 import 'package:smooth_app/helpers/ui_helpers.dart';
-import 'package:smooth_app/pages/product/new_product_page.dart';
+import 'package:smooth_app/pages/navigator/app_navigator.dart';
 
 class SmoothProductCardFound extends StatelessWidget {
   const SmoothProductCardFound({
@@ -64,12 +64,10 @@ class SmoothProductCardFound extends StatelessWidget {
       child: InkWell(
         borderRadius: ROUNDED_BORDER_RADIUS,
         onTap: onTap ??
-            () async {
-              await Navigator.push<void>(
-                context,
-                MaterialPageRoute<void>(
-                  builder: (BuildContext context) => ProductPage(product),
-                ),
+            () {
+              AppNavigator.of(context).push(
+                AppRoutes.PRODUCT(product.barcode!),
+                extra: product,
               );
             },
         onLongPress: () {

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_not_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_not_found.dart
@@ -3,7 +3,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:smooth_app/cards/product_cards/smooth_product_base_card.dart';
 import 'package:smooth_app/generic_lib/buttons/smooth_large_button_with_icon.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
-import 'package:smooth_app/pages/navigator/app_navigator.dart';
+import 'package:smooth_app/pages/product/add_new_product_page.dart';
 
 class SmoothProductCardNotFound extends StatelessWidget {
   SmoothProductCardNotFound({
@@ -58,14 +58,17 @@ class SmoothProductCardNotFound extends StatelessWidget {
               icon: Icons.add,
               padding: const EdgeInsets.symmetric(vertical: LARGE_SPACE),
               onPressed: () async {
-                AppNavigator.of(context).push(
-                  AppRoutes.PRODUCT_CREATOR(barcode),
+                await Navigator.push<void>(
+                  context,
+                  MaterialPageRoute<void>(
+                    builder: (BuildContext context) =>
+                        AddNewProductPage(barcode: barcode),
+                  ),
                 );
 
-                // TODO(g123k): Find another way
-                // if (callback != null) {
-                //   await callback!();
-                // }
+                if (callback != null) {
+                  await callback!();
+                }
               },
             ),
           ),

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_not_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_not_found.dart
@@ -3,7 +3,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:smooth_app/cards/product_cards/smooth_product_base_card.dart';
 import 'package:smooth_app/generic_lib/buttons/smooth_large_button_with_icon.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
-import 'package:smooth_app/pages/product/add_new_product_page.dart';
+import 'package:smooth_app/pages/navigator/app_navigator.dart';
 
 class SmoothProductCardNotFound extends StatelessWidget {
   SmoothProductCardNotFound({
@@ -58,16 +58,14 @@ class SmoothProductCardNotFound extends StatelessWidget {
               icon: Icons.add,
               padding: const EdgeInsets.symmetric(vertical: LARGE_SPACE),
               onPressed: () async {
-                await Navigator.push<void>(
-                  context,
-                  MaterialPageRoute<void>(
-                    builder: (BuildContext context) =>
-                        AddNewProductPage(barcode),
-                  ),
+                AppNavigator.of(context).push(
+                  AppRoutes.PRODUCT_CREATOR(barcode),
                 );
-                if (callback != null) {
-                  await callback!();
-                }
+
+                // TODO(g123k): Find another way
+                // if (callback != null) {
+                //   await callback!();
+                // }
               },
             ),
           ),

--- a/packages/smooth_app/lib/helpers/analytics_helper.dart
+++ b/packages/smooth_app/lib/helpers/analytics_helper.dart
@@ -15,9 +15,11 @@ enum AnalyticsCategory {
   share(tag: 'share'),
   couldNotFindProduct(tag: 'could not find product'),
   productEdit(tag: 'product edit'),
-  list(tag: 'list');
+  list(tag: 'list'),
+  deepLink(tag: 'deep link');
 
   const AnalyticsCategory({required this.tag});
+
   final String tag;
 }
 
@@ -40,11 +42,15 @@ enum AnalyticsEvent {
     tag: 'opened product edit page',
     category: AnalyticsCategory.productEdit,
   ),
-
   shareList(tag: 'shared a list', category: AnalyticsCategory.list),
-  openListWeb(tag: 'open a list in wbe', category: AnalyticsCategory.list);
+  openListWeb(tag: 'open a list in wbe', category: AnalyticsCategory.list),
+  productDeepLink(
+      tag: 'open a product from an URL', category: AnalyticsCategory.deepLink),
+  genericDeepLink(
+      tag: 'generic deep link', category: AnalyticsCategory.deepLink);
 
   const AnalyticsEvent({required this.tag, required this.category});
+
   final String tag;
   final AnalyticsCategory category;
 }

--- a/packages/smooth_app/lib/helpers/extension_on_text_helper.dart
+++ b/packages/smooth_app/lib/helpers/extension_on_text_helper.dart
@@ -29,3 +29,18 @@ extension Selectable on Text {
           );
   }
 }
+
+extension StringExtensions on String {
+  int count(String character) {
+    assert(character.length == 1);
+
+    int count = 0;
+    for (int i = 0; i != length; i++) {
+      if (this[i] == character) {
+        count++;
+      }
+    }
+
+    return count;
+  }
+}

--- a/packages/smooth_app/lib/helpers/extension_on_text_helper.dart
+++ b/packages/smooth_app/lib/helpers/extension_on_text_helper.dart
@@ -35,7 +35,7 @@ extension StringExtensions on String {
     assert(character.length == 1);
 
     int count = 0;
-    for (int i = 0; i != length; i++) {
+    for (int i = 0; i < length; i++) {
       if (this[i] == character) {
         count++;
       }

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -2040,5 +2040,26 @@
     "contrast_low": "Low",
     "@contrast_low": {
         "description": "Low Contrast Text Color"
+    },
+    "product_loader_not_found_title": "Product not found!",
+    "@product_loader_not_found_title": {
+        "description": "When fetching a product opened via a link and it doesn't exist"
+    },
+    "product_loader_not_found_message": "A product with the following barcode doesn't exist in our database: {barcode}",
+    "@product_loader_not_found_message": {
+        "description": "When fetching a product opened via a link, it doesn't exist",
+        "placeholders": {
+            "barcode": {
+                "type": "String"
+            }
+        }
+    },
+    "product_loader_network_error_title": "No internet connection!",
+    "@product_loader_network_error_title": {
+        "description": "When fetching a product opened via a link and there is no connection"
+    },
+    "product_loader_network_error_message": "Please check that your smartphone is on a WiFi network or has mobile data enabled",
+    "@product_loader_network_error_message": {
+        "description": "When fetching a product opened via a link and there is no connection"
     }
 }

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -2061,5 +2061,13 @@
     "product_loader_network_error_message": "Please check that your smartphone is on a WiFi network or has mobile data enabled",
     "@product_loader_network_error_message": {
         "description": "When fetching a product opened via a link and there is no connection"
+    },
+    "page_not_found_title": "Page not found!",
+    "@page_not_found_title": {
+        "description": "Title for a page not found (when an URL is not recognized)"
+    },
+    "page_not_found_button": "Go back to the homepage",
+    "@page_not_found_button": {
+        "description": "Button to go back to the homepage"
     }
 }

--- a/packages/smooth_app/lib/main.dart
+++ b/packages/smooth_app/lib/main.dart
@@ -14,7 +14,6 @@ import 'package:permission_handler/permission_handler.dart';
 import 'package:provider/provider.dart';
 import 'package:provider/single_child_widget.dart';
 import 'package:scanner_shared/scanner_shared.dart';
-import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:smooth_app/data_models/continuous_scan_model.dart';
 import 'package:smooth_app/data_models/product_preferences.dart';
 import 'package:smooth_app/data_models/user_management_provider.dart';
@@ -28,6 +27,7 @@ import 'package:smooth_app/helpers/entry_points_helper.dart';
 import 'package:smooth_app/helpers/global_vars.dart';
 import 'package:smooth_app/helpers/network_config.dart';
 import 'package:smooth_app/helpers/permission_helper.dart';
+import 'package:smooth_app/pages/navigator/app_navigator.dart';
 import 'package:smooth_app/pages/onboarding/onboarding_flow_navigator.dart';
 import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/services/smooth_services.dart';
@@ -194,7 +194,7 @@ class _SmoothAppState extends State<SmoothApp> {
         }
         if (snapshot.connectionState != ConnectionState.done) {
           //We don't need a loading indicator since the splash screen is still visible
-          return Container();
+          return const SizedBox.shrink();
         }
 
         // The `create` constructor of [ChangeNotifierProvider] takes care of
@@ -220,13 +220,13 @@ class _SmoothAppState extends State<SmoothApp> {
             provide<SmoothAppDataImporter>(_appDataImporter),
             provide<PermissionListener>(_permissionListener),
           ],
-          builder: _buildApp,
+          child: AppNavigator(child: Builder(builder: _buildApp)),
         );
       },
     );
   }
 
-  Widget _buildApp(BuildContext context, Widget? child) {
+  Widget _buildApp(BuildContext context) {
     final ThemeProvider themeProvider = context.watch<ThemeProvider>();
     final ColorProvider colorProvider = context.watch<ColorProvider>();
     final TextContrastProvider textContrastProvider =
@@ -234,7 +234,6 @@ class _SmoothAppState extends State<SmoothApp> {
     final OnboardingPage lastVisitedOnboardingPage =
         _userPreferences.lastVisitedOnboardingPage;
     OnboardingFlowNavigator(_userPreferences);
-    final Widget appWidget = lastVisitedOnboardingPage.getPageWidget(context);
     final bool isOnboardingComplete =
         lastVisitedOnboardingPage.isOnboardingComplete();
     themeProvider.setOnboardingComplete(isOnboardingComplete);
@@ -245,20 +244,17 @@ class _SmoothAppState extends State<SmoothApp> {
     final String? languageCode =
         context.select((UserPreferences up) => up.appLanguageCode);
 
-    return MaterialApp(
+    return MaterialApp.router(
       locale: languageCode != null ? Locale(languageCode) : null,
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       debugShowCheckedModeBanner: !(kReleaseMode || _screenshots),
-      navigatorObservers: <NavigatorObserver>[
-        SentryNavigatorObserver(),
-      ],
       theme: SmoothTheme.getThemeData(
           Brightness.light, themeProvider, colorProvider, textContrastProvider),
       darkTheme: SmoothTheme.getThemeData(
           Brightness.dark, themeProvider, colorProvider, textContrastProvider),
       themeMode: themeProvider.currentThemeMode,
-      home: SmoothAppGetLanguage(appWidget, _userPreferences),
+      routerConfig: AppNavigator.of(context).router,
     );
   }
 
@@ -272,26 +268,5 @@ class _SmoothAppState extends State<SmoothApp> {
         ),
       ),
     );
-  }
-}
-
-/// Layer needed because we need to know the language. Language isn't available
-/// in the [context] in top level widget ([SmoothApp])
-class SmoothAppGetLanguage extends StatelessWidget {
-  const SmoothAppGetLanguage(this.appWidget, this.userPreferences);
-
-  final Widget appWidget;
-  final UserPreferences userPreferences;
-
-  @override
-  Widget build(BuildContext context) {
-    // TODO(monsieurtanuki): refactor removing the `SmoothAppGetLanguage` layer?
-    ProductQuery.setLanguage(context, userPreferences);
-    context.read<ProductPreferences>().refresh();
-
-    // The migration requires the language to be set in the app!
-    _appDataImporter.startMigrationAsync();
-
-    return appWidget;
   }
 }

--- a/packages/smooth_app/lib/main.dart
+++ b/packages/smooth_app/lib/main.dart
@@ -194,7 +194,7 @@ class _SmoothAppState extends State<SmoothApp> {
         }
         if (snapshot.connectionState != ConnectionState.done) {
           //We don't need a loading indicator since the splash screen is still visible
-          return const SizedBox.shrink();
+          return EMPTY_WIDGET;
         }
 
         // The `create` constructor of [ChangeNotifierProvider] takes care of

--- a/packages/smooth_app/lib/pages/inherited_data_manager.dart
+++ b/packages/smooth_app/lib/pages/inherited_data_manager.dart
@@ -14,6 +14,12 @@ class InheritedDataManager extends StatefulWidget {
         .data;
   }
 
+  static InheritedDataManagerState? find(BuildContext context) {
+    return context
+        .findAncestorWidgetOfExactType<_InheritedDataManagerProvider>()
+        ?.data;
+  }
+
   @override
   State<InheritedDataManager> createState() => InheritedDataManagerState();
 }

--- a/packages/smooth_app/lib/pages/navigator/app_navigator.dart
+++ b/packages/smooth_app/lib/pages/navigator/app_navigator.dart
@@ -325,7 +325,7 @@ class AppRoutes {
   static String PRODUCT(String barcode) =>
       '/${_InternalAppRoutes.PRODUCT_DETAILS_PAGE}/$barcode';
 
-  // Product loader (= when a product is not in the database)
+  // Product loader (= when a product is not in the database) - typical use case: deep links
   static String PRODUCT_LOADER(String barcode) =>
       '/${_InternalAppRoutes.PRODUCT_LOADER_PAGE}/$barcode';
 

--- a/packages/smooth_app/lib/pages/navigator/app_navigator.dart
+++ b/packages/smooth_app/lib/pages/navigator/app_navigator.dart
@@ -8,6 +8,7 @@ import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/helpers/data_importer/smooth_app_data_importer.dart';
 import 'package:smooth_app/helpers/extension_on_text_helper.dart';
 import 'package:smooth_app/pages/inherited_data_manager.dart';
+import 'package:smooth_app/pages/navigator/error_page.dart';
 import 'package:smooth_app/pages/navigator/external_page.dart';
 import 'package:smooth_app/pages/onboarding/onboarding_flow_navigator.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_page.dart';
@@ -88,122 +89,125 @@ class _SmoothGoRouter {
     List<NavigatorObserver>? observers,
   }) {
     router = GoRouter(
-        observers: observers,
-        routes: <GoRoute>[
-          GoRoute(
-            path: HOME_PAGE,
-            builder: (BuildContext context, GoRouterState state) {
-              if (!isInitialized) {
-                _initAppLanguage(context);
-                isInitialized = true;
-              }
-
-              return _findLastOnboardingPage(context);
-            },
-            // We use sub-routes to allow the back button to work correctly
-            // for deep links to go back to the homepage
-            routes: <GoRoute>[
-              GoRoute(
-                path: '$PRODUCT_DETAILS_PAGE/:productId',
-                builder: (BuildContext context, GoRouterState state) {
-                  Product product;
-
-                  if (state.extra is Product) {
-                    product = state.extra! as Product;
-                  } else {
-                    throw Exception('No product provided!');
-                  }
-
-                  final Widget widget = ProductPage(product);
-
-                  if (InheritedDataManager.find(context) == null) {
-                    return InheritedDataManager(child: widget);
-                  } else {
-                    return widget;
-                  }
-                },
-              ),
-              GoRoute(
-                path: '$PRODUCT_LOADER_PAGE/:productId',
-                builder: (BuildContext context, GoRouterState state) {
-                  final String barcode = state.pathParameters['productId']!;
-                  return ProductLoaderPage(barcode: barcode);
-                },
-              ),
-              GoRoute(
-                path: '$PRODUCT_CREATOR_PAGE/:productId',
-                builder: (BuildContext context, GoRouterState state) {
-                  final String barcode = state.pathParameters['productId']!;
-                  return AddNewProductPage(barcode: barcode);
-                },
-              ),
-              GoRoute(
-                path: SEARCH_PAGE,
-                builder: (_, __) {
-                  return SearchPage();
-                },
-              ),
-              GoRoute(
-                path: '$PREFERENCES_PAGE/:preferenceType',
-                builder: (BuildContext context, GoRouterState state) {
-                  final String? type = state.pathParameters['preferenceType'];
-
-                  final PreferencePageType? pageType = PreferencePageType.values
-                      .firstWhereOrNull(
-                          (PreferencePageType e) => e.name == type);
-
-                  if (pageType == null) {
-                    throw Exception('Unsupported preference page type: $type');
-                  }
-
-                  return UserPreferencesPage(
-                    type: pageType,
-                  );
-                },
-              ),
-              GoRoute(
-                path: '$EXTERNAL_PAGE/:path',
-                builder: (BuildContext context, GoRouterState state) {
-                  return ExternalPage(path: state.pathParameters['path']!);
-                },
-              ),
-            ],
-          ),
-        ],
-        redirect: (BuildContext context, GoRouterState state) {
-          final String path = state.matchedLocation;
-
-          // Ignore deep links if the onboarding is not yet completed
-          if (state.location != HOME_PAGE && !_isOnboardingComplete(context)) {
-            return HOME_PAGE;
-          } else if (_isAnInternalRoute(path)) {
-            return null;
-          }
-
-          // If a barcode is in the URL, ensure to manually fetch the product
-          if (path.isNotEmpty) {
-            final int subPaths = path.count('/');
-
-            if (subPaths > 1) {
-              final String? barcode = _extractProductBarcode(path);
-
-              if (barcode != null) {
-                if (state.extra is Product) {
-                  return AppRoutes.PRODUCT(barcode);
-                } else {
-                  return AppRoutes.PRODUCT_LOADER(barcode);
-                }
-              }
-            } else if (path != HOME_PAGE) {
-              // Unsupported link -> open the browser
-              return AppRoutes.EXTERNAL(
-                path[0] == '/' ? path.substring(1) : path,
-              );
+      observers: observers,
+      routes: <GoRoute>[
+        GoRoute(
+          path: HOME_PAGE,
+          builder: (BuildContext context, GoRouterState state) {
+            if (!isInitialized) {
+              _initAppLanguage(context);
+              isInitialized = true;
             }
-          }
 
-          return state.location;
-        });
+            return _findLastOnboardingPage(context);
+          },
+          // We use sub-routes to allow the back button to work correctly
+          // for deep links to go back to the homepage
+          routes: <GoRoute>[
+            GoRoute(
+              path: '$PRODUCT_DETAILS_PAGE/:productId',
+              builder: (BuildContext context, GoRouterState state) {
+                Product product;
+
+                if (state.extra is Product) {
+                  product = state.extra! as Product;
+                } else {
+                  throw Exception('No product provided!');
+                }
+
+                final Widget widget = ProductPage(product);
+
+                if (InheritedDataManager.find(context) == null) {
+                  return InheritedDataManager(child: widget);
+                } else {
+                  return widget;
+                }
+              },
+            ),
+            GoRoute(
+              path: '$PRODUCT_LOADER_PAGE/:productId',
+              builder: (BuildContext context, GoRouterState state) {
+                final String barcode = state.pathParameters['productId']!;
+                return ProductLoaderPage(barcode: barcode);
+              },
+            ),
+            GoRoute(
+              path: '$PRODUCT_CREATOR_PAGE/:productId',
+              builder: (BuildContext context, GoRouterState state) {
+                final String barcode = state.pathParameters['productId']!;
+                return AddNewProductPage(barcode: barcode);
+              },
+            ),
+            GoRoute(
+              path: SEARCH_PAGE,
+              builder: (_, __) {
+                return SearchPage();
+              },
+            ),
+            GoRoute(
+              path: '$PREFERENCES_PAGE/:preferenceType',
+              builder: (BuildContext context, GoRouterState state) {
+                final String? type = state.pathParameters['preferenceType'];
+
+                final PreferencePageType? pageType = PreferencePageType.values
+                    .firstWhereOrNull((PreferencePageType e) => e.name == type);
+
+                if (pageType == null) {
+                  throw Exception('Unsupported preference page type: $type');
+                }
+
+                return UserPreferencesPage(
+                  type: pageType,
+                );
+              },
+            ),
+            GoRoute(
+              path: '$EXTERNAL_PAGE/:path',
+              builder: (BuildContext context, GoRouterState state) {
+                return ExternalPage(path: state.pathParameters['path']!);
+              },
+            ),
+          ],
+        ),
+      ],
+      redirect: (BuildContext context, GoRouterState state) {
+        final String path = state.matchedLocation;
+
+        // Ignore deep links if the onboarding is not yet completed
+        if (state.location != HOME_PAGE && !_isOnboardingComplete(context)) {
+          return HOME_PAGE;
+        } else if (_isAnInternalRoute(path)) {
+          return null;
+        }
+
+        // If a barcode is in the URL, ensure to manually fetch the product
+        if (path.isNotEmpty) {
+          final int subPaths = path.count('/');
+
+          if (subPaths > 1) {
+            final String? barcode = _extractProductBarcode(path);
+
+            if (barcode != null) {
+              if (state.extra is Product) {
+                return AppRoutes.PRODUCT(barcode);
+              } else {
+                return AppRoutes.PRODUCT_LOADER(barcode);
+              }
+            }
+          } else if (path != HOME_PAGE) {
+            // Unsupported link -> open the browser
+            return AppRoutes.EXTERNAL(
+              path[0] == '/' ? path.substring(1) : path,
+            );
+          }
+        }
+
+        return state.location;
+      },
+      errorBuilder: (_, GoRouterState state) => ErrorPage(
+        url: state.location,
+      ),
+    );
   }
 
   late GoRouter router;

--- a/packages/smooth_app/lib/pages/navigator/app_navigator.dart
+++ b/packages/smooth_app/lib/pages/navigator/app_navigator.dart
@@ -5,6 +5,7 @@ import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/product_preferences.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
+import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/data_importer/smooth_app_data_importer.dart';
 import 'package:smooth_app/helpers/extension_on_text_helper.dart';
 import 'package:smooth_app/pages/inherited_data_manager.dart';
@@ -188,6 +189,11 @@ class _SmoothGoRouter {
             final String? barcode = _extractProductBarcode(path);
 
             if (barcode != null) {
+              AnalyticsHelper.trackEvent(
+                AnalyticsEvent.productDeepLink,
+                barcode: barcode,
+              );
+
               if (state.extra is Product) {
                 return AppRoutes.PRODUCT(barcode);
               } else {
@@ -195,6 +201,10 @@ class _SmoothGoRouter {
               }
             }
           } else if (path != HOME_PAGE) {
+            AnalyticsHelper.trackEvent(
+              AnalyticsEvent.genericDeepLink,
+            );
+
             // Unsupported link -> open the browser
             return AppRoutes.EXTERNAL(
               path[0] == '/' ? path.substring(1) : path,

--- a/packages/smooth_app/lib/pages/navigator/app_navigator.dart
+++ b/packages/smooth_app/lib/pages/navigator/app_navigator.dart
@@ -93,7 +93,7 @@ class _SmoothGoRouter {
       observers: observers,
       routes: <GoRoute>[
         GoRoute(
-          path: HOME_PAGE,
+          path: _InternalAppRoutes.HOME_PAGE.path,
           builder: (BuildContext context, GoRouterState state) {
             if (!isInitialized) {
               _initAppLanguage(context);
@@ -106,7 +106,8 @@ class _SmoothGoRouter {
           // for deep links to go back to the homepage
           routes: <GoRoute>[
             GoRoute(
-              path: '$PRODUCT_DETAILS_PAGE/:productId',
+              path:
+                  '${_InternalAppRoutes.PRODUCT_DETAILS_PAGE.path}/:productId',
               builder: (BuildContext context, GoRouterState state) {
                 Product product;
 
@@ -126,27 +127,28 @@ class _SmoothGoRouter {
               },
             ),
             GoRoute(
-              path: '$PRODUCT_LOADER_PAGE/:productId',
+              path: '${_InternalAppRoutes.PRODUCT_LOADER_PAGE.path}/:productId',
               builder: (BuildContext context, GoRouterState state) {
                 final String barcode = state.pathParameters['productId']!;
                 return ProductLoaderPage(barcode: barcode);
               },
             ),
             GoRoute(
-              path: '$PRODUCT_CREATOR_PAGE/:productId',
+              path:
+                  '${_InternalAppRoutes.PRODUCT_CREATOR_PAGE.path}/:productId',
               builder: (BuildContext context, GoRouterState state) {
                 final String barcode = state.pathParameters['productId']!;
                 return AddNewProductPage(barcode: barcode);
               },
             ),
             GoRoute(
-              path: SEARCH_PAGE,
+              path: _InternalAppRoutes.SEARCH_PAGE.path,
               builder: (_, __) {
                 return SearchPage();
               },
             ),
             GoRoute(
-              path: '$PREFERENCES_PAGE/:preferenceType',
+              path: '${_InternalAppRoutes.PREFERENCES_PAGE}/:preferenceType',
               builder: (BuildContext context, GoRouterState state) {
                 final String? type = state.pathParameters['preferenceType'];
 
@@ -163,7 +165,7 @@ class _SmoothGoRouter {
               },
             ),
             GoRoute(
-              path: '$EXTERNAL_PAGE/:path',
+              path: '${_InternalAppRoutes.EXTERNAL_PAGE}/:path',
               builder: (BuildContext context, GoRouterState state) {
                 return ExternalPage(path: state.pathParameters['path']!);
               },
@@ -175,8 +177,9 @@ class _SmoothGoRouter {
         final String path = state.matchedLocation;
 
         // Ignore deep links if the onboarding is not yet completed
-        if (state.location != HOME_PAGE && !_isOnboardingComplete(context)) {
-          return HOME_PAGE;
+        if (state.location != _InternalAppRoutes.HOME_PAGE.path &&
+            !_isOnboardingComplete(context)) {
+          return _InternalAppRoutes.HOME_PAGE.path;
         } else if (_isAnInternalRoute(path)) {
           return null;
         }
@@ -200,7 +203,7 @@ class _SmoothGoRouter {
                 return AppRoutes.PRODUCT_LOADER(barcode);
               }
             }
-          } else if (path != HOME_PAGE) {
+          } else if (path != _InternalAppRoutes.HOME_PAGE.path) {
             AnalyticsHelper.trackEvent(
               AnalyticsEvent.genericDeepLink,
             );
@@ -259,7 +262,7 @@ class _SmoothGoRouter {
   }
 
   bool _isAnInternalRoute(String path) {
-    if (path == HOME_PAGE) {
+    if (path == _InternalAppRoutes.HOME_PAGE.path) {
       return true;
     } else {
       return path.startsWith('/_');
@@ -284,18 +287,29 @@ class _SmoothGoRouter {
     return lastVisitedOnboardingPage;
   }
 
-  //endregion Onboarding
+//endregion Onboarding
+}
 
-  /// Internal routes
-  /// To differentiate external routes (eg: /product/12345678), we prefix all
-  /// internal routes with an underscore
-  static const String HOME_PAGE = '/';
-  static const String PRODUCT_DETAILS_PAGE = '_product';
-  static const String PRODUCT_LOADER_PAGE = '_product_loader';
-  static const String PRODUCT_CREATOR_PAGE = '_product_creator';
-  static const String PREFERENCES_PAGE = '_preferences';
-  static const String SEARCH_PAGE = '_search';
-  static const String EXTERNAL_PAGE = '_external';
+/// Internal routes
+/// To differentiate external routes (eg: /product/12345678), we prefix all
+/// internal routes with an underscore
+enum _InternalAppRoutes {
+  HOME_PAGE('/'),
+  PRODUCT_DETAILS_PAGE('_product'),
+  PRODUCT_LOADER_PAGE('_product_loader'),
+  PRODUCT_CREATOR_PAGE('_product_creator'),
+  PREFERENCES_PAGE('_preferences'),
+  SEARCH_PAGE('_search'),
+  EXTERNAL_PAGE('_external');
+
+  const _InternalAppRoutes(this.path);
+
+  final String path;
+
+  @override
+  String toString() {
+    return path;
+  }
 }
 
 /// A list of internal routes to use with [AppNavigator]
@@ -305,28 +319,28 @@ class AppRoutes {
   AppRoutes._();
 
   // Home page (or walkthrough during the onboarding)
-  static const String HOME = _SmoothGoRouter.HOME_PAGE;
+  static String get HOME => _InternalAppRoutes.HOME_PAGE.path;
 
   // Product details (a [Product] is mandatory in the extra)
   static String PRODUCT(String barcode) =>
-      '/${_SmoothGoRouter.PRODUCT_DETAILS_PAGE}/$barcode';
+      '/${_InternalAppRoutes.PRODUCT_DETAILS_PAGE}/$barcode';
 
   // Product loader (= when a product is not in the database)
   static String PRODUCT_LOADER(String barcode) =>
-      '/${_SmoothGoRouter.PRODUCT_LOADER_PAGE}/$barcode';
+      '/${_InternalAppRoutes.PRODUCT_LOADER_PAGE}/$barcode';
 
   // Product creator or "add product" feature
   static String PRODUCT_CREATOR(String barcode) =>
-      '/${_SmoothGoRouter.PRODUCT_CREATOR_PAGE}/$barcode';
+      '/${_InternalAppRoutes.PRODUCT_CREATOR_PAGE}/$barcode';
 
   // App preferences
   static String PREFERENCES(PreferencePageType type) =>
-      '/${_SmoothGoRouter.PREFERENCES_PAGE}/${type.name}';
+      '/${_InternalAppRoutes.PREFERENCES_PAGE}/${type.name}';
 
   // Search view
-  static const String SEARCH = '/${_SmoothGoRouter.SEARCH_PAGE}';
+  static String get SEARCH => '/${_InternalAppRoutes.SEARCH_PAGE.path}';
 
   // Open an external link (where path is relative to the OFF website)
   static String EXTERNAL(String path) =>
-      '/${_SmoothGoRouter.EXTERNAL_PAGE}/$path';
+      '/${_InternalAppRoutes.EXTERNAL_PAGE}/$path';
 }

--- a/packages/smooth_app/lib/pages/navigator/app_navigator.dart
+++ b/packages/smooth_app/lib/pages/navigator/app_navigator.dart
@@ -1,0 +1,253 @@
+import 'package:collection/collection.dart';
+import 'package:flutter/widgets.dart';
+import 'package:go_router/go_router.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:provider/provider.dart';
+import 'package:smooth_app/data_models/product_preferences.dart';
+import 'package:smooth_app/data_models/user_preferences.dart';
+import 'package:smooth_app/helpers/data_importer/smooth_app_data_importer.dart';
+import 'package:smooth_app/helpers/extension_on_text_helper.dart';
+import 'package:smooth_app/pages/inherited_data_manager.dart';
+import 'package:smooth_app/pages/navigator/external_page.dart';
+import 'package:smooth_app/pages/onboarding/onboarding_flow_navigator.dart';
+import 'package:smooth_app/pages/preferences/user_preferences_page.dart';
+import 'package:smooth_app/pages/product/new_product_page.dart';
+import 'package:smooth_app/pages/product/product_loader_page.dart';
+import 'package:smooth_app/pages/scan/search_page.dart';
+import 'package:smooth_app/query/product_query.dart';
+
+class AppNavigator extends InheritedWidget {
+  AppNavigator({
+    Key? key,
+    required Widget child,
+    List<NavigatorObserver>? observers,
+  })  : _router = _SmoothGoRouter(
+          observers: observers,
+        ),
+        super(key: key, child: child);
+
+  // GoRouter is never accessible directly
+  final _SmoothGoRouter _router;
+
+  static AppNavigator of(BuildContext context) {
+    final AppNavigator? result =
+        context.dependOnInheritedWidgetOfExactType<AppNavigator>();
+    assert(result != null, 'No AppNavigator found in context');
+    return result!;
+  }
+
+  @override
+  bool updateShouldNotify(AppNavigator oldWidget) {
+    return oldWidget._router != _router;
+  }
+
+  RouterConfig<Object> get router => _router.router;
+
+  void push(String routeName, {dynamic extra}) {
+    assert(routeName.isNotEmpty);
+    _router.router.push(routeName, extra: extra);
+  }
+
+  void pushReplacement(String routeName, {dynamic extra}) {
+    assert(routeName.isNotEmpty);
+    _router.router.pushReplacement(routeName, extra: extra);
+  }
+
+  void pop([dynamic result]) {
+    _router.router.pop(result);
+  }
+}
+
+class _SmoothGoRouter {
+  _SmoothGoRouter({
+    List<NavigatorObserver>? observers,
+  }) {
+    router = GoRouter(
+        observers: observers,
+        routes: <GoRoute>[
+          GoRoute(
+            path: HOME_PAGE,
+            builder: (BuildContext context, GoRouterState state) {
+              if (!isInitialized) {
+                _initAppLanguage(context);
+                isInitialized = true;
+              }
+
+              return _findLastOnboardingPage(context);
+            },
+            // We use sub-routes to allow the back button from deep links to
+            // go back to the homepage
+            routes: <GoRoute>[
+              GoRoute(
+                path: '$PRODUCT_PAGE/:productId',
+                builder: (BuildContext context, GoRouterState state) {
+                  Product product;
+
+                  if (state.extra is Product) {
+                    product = state.extra! as Product;
+                  } else {
+                    throw Exception('No product provided!');
+                  }
+
+                  final Widget widget = ProductPage(product);
+
+                  if (InheritedDataManager.find(context) == null) {
+                    return InheritedDataManager(child: widget);
+                  } else {
+                    return widget;
+                  }
+                },
+              ),
+              GoRoute(
+                path: '$PRODUCT_LOADER_PAGE/:productId',
+                builder: (BuildContext context, GoRouterState state) {
+                  final String barcode = state.pathParameters['productId']!;
+                  return ProductLoaderPage(barcode: barcode);
+                },
+              ),
+              GoRoute(
+                path: SEARCH_PAGE,
+                builder: (_, __) {
+                  return SearchPage();
+                },
+              ),
+              GoRoute(
+                path: '$PREFERENCES_PAGE/:preferenceType',
+                builder: (BuildContext context, GoRouterState state) {
+                  final String? type = state.pathParameters['preferenceType'];
+
+                  final PreferencePageType? pageType = PreferencePageType.values
+                      .firstWhereOrNull(
+                          (PreferencePageType e) => e.name == type);
+
+                  if (pageType == null) {
+                    throw Exception('Unsupported preference page type: $type');
+                  }
+
+                  return UserPreferencesPage(
+                    type: pageType,
+                  );
+                },
+              ),
+              GoRoute(
+                path: '$EXTERNAL_PAGE/:path',
+                builder: (BuildContext context, GoRouterState state) {
+                  return ExternalPage(path: state.pathParameters['path']!);
+                },
+              ),
+            ],
+          ),
+        ],
+        redirect: (BuildContext context, GoRouterState state) {
+          // Ignore deep links if the onboarding is not completed
+          if (state.location != HOME_PAGE && !_isOnboardingComplete(context)) {
+            return HOME_PAGE;
+          }
+
+          // If a barcode is in the URL, ensure to manually fetch the product
+          if (state.matchedLocation.isNotEmpty) {
+            final int paths = state.matchedLocation.count('/');
+
+            if (paths > 1) {
+              final String? barcode =
+                  _extractProductBarcode(state.matchedLocation);
+
+              if (barcode != null) {
+                if (state.extra is Product) {
+                  return AppRoutes.PRODUCT(barcode);
+                } else {
+                  return AppRoutes.PRODUCT_LOADER(barcode);
+                }
+              }
+            } else {
+              // Unsupported link
+              return AppRoutes.EXTERNAL(
+                state.matchedLocation[0] == '/'
+                    ? state.matchedLocation.substring(1)
+                    : state.matchedLocation,
+              );
+            }
+          }
+
+          return state.location;
+        });
+  }
+
+  late GoRouter router;
+
+  // Indicates whether [_initAppLanguage] was already called
+  bool isInitialized = false;
+
+  void _initAppLanguage(BuildContext context) {
+    final UserPreferences userPreferences = context.read<UserPreferences>();
+    ProductQuery.setLanguage(context, userPreferences);
+    context.read<ProductPreferences>().refresh();
+
+    // The migration requires the language to be set in the app!
+    context.read<SmoothAppDataImporter>().startMigrationAsync();
+  }
+
+  /// All paths containing at least 8 digits in the second part are considered
+  /// as a valid barcode
+  String? _extractProductBarcode(String path) {
+    if (path.isEmpty || path == HOME_PAGE) {
+      return null;
+    }
+
+    final List<String> pathParams = path.split('/').sublist(1);
+
+    if (pathParams.length > 1) {
+      final String barcode = pathParams[1];
+
+      if (int.tryParse(barcode) != null && barcode.length >= 8) {
+        return barcode;
+      }
+    }
+
+    return null;
+  }
+
+  bool _isOnboardingComplete(BuildContext context) {
+    return _getCurrentOnboardingPage(context).isOnboardingComplete();
+  }
+
+  Widget _findLastOnboardingPage(BuildContext context) {
+    return _getCurrentOnboardingPage(context).getPageWidget(context);
+  }
+
+  OnboardingPage _getCurrentOnboardingPage(BuildContext context) {
+    final UserPreferences userPreferences = context.read<UserPreferences>();
+
+    final OnboardingPage lastVisitedOnboardingPage =
+        userPreferences.lastVisitedOnboardingPage;
+    return lastVisitedOnboardingPage;
+  }
+
+  static const String HOME_PAGE = '/';
+  static const String PRODUCT_PAGE = 'product';
+  static const String PRODUCT_LOADER_PAGE = 'product_loader';
+  static const String PREFERENCES_PAGE = 'preferences';
+  static const String SEARCH_PAGE = 'search';
+  static const String EXTERNAL_PAGE = 'external';
+}
+
+// TODO(g123k): Improve this with sealed classes
+class AppRoutes {
+  AppRoutes._();
+
+  static const String HOME = _SmoothGoRouter.HOME_PAGE;
+
+  static String PRODUCT(String barcode) =>
+      '/${_SmoothGoRouter.PRODUCT_PAGE}/$barcode';
+
+  static String PRODUCT_LOADER(String barcode) =>
+      '/${_SmoothGoRouter.PRODUCT_LOADER_PAGE}/$barcode';
+
+  static String PREFERENCES(PreferencePageType type) =>
+      '/${_SmoothGoRouter.PREFERENCES_PAGE}/${type.name}';
+
+  static const String SEARCH = '/${_SmoothGoRouter.SEARCH_PAGE}';
+
+  static String EXTERNAL(String path) =>
+      '/${_SmoothGoRouter.EXTERNAL_PAGE}/${path}';
+}

--- a/packages/smooth_app/lib/pages/navigator/error_page.dart
+++ b/packages/smooth_app/lib/pages/navigator/error_page.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:smooth_app/generic_lib/buttons/smooth_large_button_with_icon.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/pages/navigator/app_navigator.dart';
+
+/// Similar to a 404 page
+class ErrorPage extends StatelessWidget {
+  const ErrorPage({
+    required this.url,
+    Key? key,
+  }) : super(key: key);
+
+  final String url;
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations localizations = AppLocalizations.of(context);
+
+    return Scaffold(
+      body: Center(
+        child: FractionallySizedBox(
+          widthFactor: 0.8,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              SvgPicture.asset('assets/misc/error.svg'),
+              const SizedBox(height: VERY_LARGE_SPACE),
+              Text(
+                localizations.page_not_found_title,
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.displayMedium,
+              ),
+              const SizedBox(height: LARGE_SPACE),
+              Text(
+                url,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: VERY_LARGE_SPACE * 2),
+              SmoothLargeButtonWithIcon(
+                text: localizations.page_not_found_button,
+                icon: Icons.home,
+                padding: const EdgeInsets.symmetric(vertical: LARGE_SPACE),
+                onPressed: () {
+                  AppNavigator.of(context).pop();
+                },
+              )
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/smooth_app/lib/pages/navigator/external_page.dart
+++ b/packages/smooth_app/lib/pages/navigator/external_page.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:path/path.dart' as path;
+import 'package:smooth_app/helpers/launch_url_helper.dart';
+import 'package:smooth_app/pages/navigator/app_navigator.dart';
+
+class ExternalPage extends StatefulWidget {
+  const ExternalPage({required this.path, Key? key})
+      : assert(path != ''),
+        super(key: key);
+
+  final String path;
+
+  @override
+  State<ExternalPage> createState() => _ExternalPageState();
+}
+
+class _ExternalPageState extends State<ExternalPage> {
+  @override
+  void initState() {
+    super.initState();
+
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      await LaunchUrlHelper.launchURL(
+        path.join('https://world.openfoodfacts.org', widget.path),
+        false,
+      );
+
+      if (mounted) {
+        AppNavigator.of(context).pop();
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold();
+  }
+}

--- a/packages/smooth_app/lib/pages/navigator/external_page.dart
+++ b/packages/smooth_app/lib/pages/navigator/external_page.dart
@@ -3,6 +3,8 @@ import 'package:path/path.dart' as path;
 import 'package:smooth_app/helpers/launch_url_helper.dart';
 import 'package:smooth_app/pages/navigator/app_navigator.dart';
 
+/// A screen opening a [path] relative to the OFF website.
+/// Eg: if path is "contact", it will open 'https://world.openfoodfacts.org/contact'
 class ExternalPage extends StatefulWidget {
   const ExternalPage({required this.path, Key? key})
       : assert(path != ''),

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_page.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_page.dart
@@ -22,14 +22,18 @@ import 'package:smooth_app/themes/theme_provider.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
 enum PreferencePageType {
-  ACCOUNT,
-  LISTS,
-  FOOD,
-  DEV_MODE,
-  SETTINGS,
-  CONTRIBUTE,
-  FAQ,
-  CONNECT,
+  ACCOUNT('account'),
+  LISTS('lists'),
+  FOOD('food'),
+  DEV_MODE('dev_mode'),
+  SETTINGS('settings'),
+  CONTRIBUTE('contribute'),
+  FAQ('faq'),
+  CONNECT('connect');
+
+  const PreferencePageType(this.name);
+
+  final String name;
 }
 
 /// Preferences page: main or detailed.

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_page.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_page.dart
@@ -31,9 +31,11 @@ enum PreferencePageType {
   FAQ('faq'),
   CONNECT('connect');
 
-  const PreferencePageType(this.name);
+  const PreferencePageType(this.tag);
 
-  final String name;
+  /// A tag used when opening a new screen
+  /// eg: preferences/account
+  final String tag;
 }
 
 /// Preferences page: main or detailed.

--- a/packages/smooth_app/lib/pages/product/add_new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_new_product_page.dart
@@ -22,7 +22,9 @@ const EdgeInsetsGeometry _ROW_PADDING_TOP = EdgeInsetsDirectional.only(
 
 /// "Create a product we couldn't find on the server" page.
 class AddNewProductPage extends StatefulWidget {
-  const AddNewProductPage(this.barcode);
+  const AddNewProductPage({
+    required this.barcode,
+  }) : assert(barcode != '');
 
   final String barcode;
 
@@ -33,6 +35,7 @@ class AddNewProductPage extends StatefulWidget {
 class _AddNewProductPageState extends State<AddNewProductPage> {
   // Just one file per main image field
   final Map<ImageField, File> _uploadedImages = <ImageField, File>{};
+
   // Many possible files for "other" image field
   final List<File> _otherUploadedImages = <File>[];
 
@@ -53,6 +56,7 @@ class _AddNewProductPageState extends State<AddNewProductPage> {
       _isProductFieldValid(product.brands);
 
   bool get _nutritionFactsAdded => _product.nutriments?.isEmpty() == false;
+
   bool get _basicDetailsAdded => isProductBasicValid(_product);
 
   bool _alreadyPushedtToHistory = false;

--- a/packages/smooth_app/lib/pages/product/common/product_dialog_helper.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_dialog_helper.dart
@@ -11,7 +11,7 @@ import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/generic_lib/loading_dialog.dart';
 import 'package:smooth_app/helpers/app_helper.dart';
-import 'package:smooth_app/pages/product/add_new_product_page.dart';
+import 'package:smooth_app/pages/navigator/app_navigator.dart';
 import 'package:smooth_app/query/barcode_product_query.dart';
 
 /// Dialog helper for product barcode search
@@ -130,11 +130,8 @@ class ProductDialogHelper {
           ),
           positiveAction: SmoothActionButton(
             text: AppLocalizations.of(context).contribute,
-            onPressed: () => Navigator.push<void>(
-              context,
-              MaterialPageRoute<void>(
-                builder: (BuildContext context) => AddNewProductPage(barcode),
-              ),
+            onPressed: () => AppNavigator.of(context).push(
+              AppRoutes.PRODUCT_CREATOR(barcode),
             ),
           ),
           negativeAction: SmoothActionButton(

--- a/packages/smooth_app/lib/pages/product/common/product_refresher.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_refresher.dart
@@ -3,7 +3,6 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
-
 import 'package:smooth_app/database/dao_product.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
@@ -84,6 +83,23 @@ class ProductRefresher {
   }) async {
     final _MetaProductRefresher meta =
         await _fetchAndRefresh(localDatabase, barcode);
+    return meta.product;
+  }
+
+  /// Fetches the product from the server and refreshes the local database.
+  /// In the case of an error, it will be send throw an [Exception]
+  /// Silent version.
+  Future<Product?> silentFetchAndRefreshWithException({
+    required final String barcode,
+    required final LocalDatabase localDatabase,
+  }) async {
+    final _MetaProductRefresher meta =
+        await _fetchAndRefresh(localDatabase, barcode);
+
+    if (meta.error != null) {
+      throw Exception(meta.error);
+    }
+
     return meta.product;
   }
 

--- a/packages/smooth_app/lib/pages/product/product_loader_page.dart
+++ b/packages/smooth_app/lib/pages/product/product_loader_page.dart
@@ -1,7 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_svg/svg.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/database/local_database.dart';
+import 'package:smooth_app/generic_lib/buttons/smooth_large_button_with_icon.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/pages/navigator/app_navigator.dart';
 import 'package:smooth_app/pages/product/common/product_refresher.dart';
 
@@ -19,6 +23,8 @@ class ProductLoaderPage extends StatefulWidget {
 }
 
 class _ProductLoaderPageState extends State<ProductLoaderPage> {
+  _ProductLoaderState _state = _ProductLoaderState.loading;
+
   @override
   void initState() {
     super.initState();
@@ -30,33 +36,159 @@ class _ProductLoaderPageState extends State<ProductLoaderPage> {
 
   Future<void> _loadProduct() async {
     final AppNavigator navigator = AppNavigator.of(context);
-    final Product? product = await ProductRefresher().silentFetchAndRefresh(
-      barcode: widget.barcode,
-      localDatabase: context.read<LocalDatabase>(),
-    );
+    setState(() {
+      _state = _ProductLoaderState.loading;
+    });
 
-    if (product != null && mounted) {
-      navigator.pushReplacement(
-        AppRoutes.PRODUCT(widget.barcode),
-        extra: product,
+    try {
+      final Product? product =
+          await ProductRefresher().silentFetchAndRefreshWithException(
+        barcode: widget.barcode,
+        localDatabase: context.read<LocalDatabase>(),
       );
+
+      if (product != null && mounted) {
+        navigator.pushReplacement(
+          AppRoutes.PRODUCT(widget.barcode),
+          extra: product,
+        );
+      } else {
+        setState(() {
+          _state = _ProductLoaderState.productNotFound;
+        });
+      }
+    } catch (err) {
+      setState(() {
+        _state = _ProductLoaderState.serverError;
+      });
     }
   }
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: FutureBuilder<Product?>(
-        future: ProductRefresher().silentFetchAndRefresh(
+    Widget child;
+
+    switch (_state) {
+      case _ProductLoaderState.loading:
+        child = const _ProductLoaderLoadingState();
+        break;
+      case _ProductLoaderState.productNotFound:
+        child = _ProductLoaderNotFoundState(
           barcode: widget.barcode,
-          localDatabase: context.read<LocalDatabase>(),
-        ),
-        builder: (BuildContext context, AsyncSnapshot<Product?> data) {
-          return const Center(
-            child: CircularProgressIndicator.adaptive(),
-          );
-        },
+        );
+        break;
+      case _ProductLoaderState.serverError:
+        child = _ProductLoaderNetworkErrorState(
+          onRetry: () => _loadProduct(),
+        );
+        break;
+    }
+
+    return Scaffold(
+      body: Center(child: child),
+    );
+  }
+}
+
+class _ProductLoaderLoadingState extends StatelessWidget {
+  const _ProductLoaderLoadingState({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return const CircularProgressIndicator.adaptive();
+  }
+}
+
+class _ProductLoaderNotFoundState extends StatelessWidget {
+  const _ProductLoaderNotFoundState({
+    required this.barcode,
+    Key? key,
+  }) : super(key: key);
+
+  final String barcode;
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations localizations = AppLocalizations.of(context);
+
+    return FractionallySizedBox(
+      widthFactor: 0.8,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          SvgPicture.asset('assets/misc/error.svg'),
+          const SizedBox(height: VERY_LARGE_SPACE),
+          Text(
+            localizations.product_loader_not_found_title,
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.displayMedium,
+          ),
+          const SizedBox(height: LARGE_SPACE),
+          Text(
+            localizations.product_loader_not_found_message(barcode),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: VERY_LARGE_SPACE * 2),
+          SmoothLargeButtonWithIcon(
+            text: localizations.add_product_information_button_label,
+            icon: Icons.add,
+            padding: const EdgeInsets.symmetric(vertical: LARGE_SPACE),
+            onPressed: () async {
+              AppNavigator.of(context).pushReplacement(
+                AppRoutes.PRODUCT_CREATOR(barcode),
+              );
+            },
+          )
+        ],
       ),
     );
   }
+}
+
+class _ProductLoaderNetworkErrorState extends StatelessWidget {
+  const _ProductLoaderNetworkErrorState({
+    required this.onRetry,
+    Key? key,
+  }) : super(key: key);
+
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations localizations = AppLocalizations.of(context);
+
+    return FractionallySizedBox(
+      widthFactor: 0.8,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          SvgPicture.asset('assets/misc/error.svg'),
+          const SizedBox(height: VERY_LARGE_SPACE),
+          Text(
+            localizations.product_loader_network_error_title,
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.displayMedium,
+          ),
+          const SizedBox(height: LARGE_SPACE),
+          Text(
+            localizations.product_loader_network_error_message,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: VERY_LARGE_SPACE * 2),
+          SmoothLargeButtonWithIcon(
+            text: localizations.retry_button_label,
+            icon: Icons.sync,
+            padding: const EdgeInsets.symmetric(vertical: LARGE_SPACE),
+            onPressed: onRetry,
+          )
+        ],
+      ),
+    );
+  }
+}
+
+enum _ProductLoaderState {
+  loading,
+  productNotFound,
+  serverError;
 }

--- a/packages/smooth_app/lib/pages/product/product_loader_page.dart
+++ b/packages/smooth_app/lib/pages/product/product_loader_page.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:provider/provider.dart';
+import 'package:smooth_app/database/local_database.dart';
+import 'package:smooth_app/pages/navigator/app_navigator.dart';
+import 'package:smooth_app/pages/product/common/product_refresher.dart';
+
+class ProductLoaderPage extends StatefulWidget {
+  const ProductLoaderPage({
+    required this.barcode,
+    Key? key,
+  })  : assert(barcode != ''),
+        super(key: key);
+
+  final String barcode;
+
+  @override
+  State<ProductLoaderPage> createState() => _ProductLoaderPageState();
+}
+
+class _ProductLoaderPageState extends State<ProductLoaderPage> {
+  @override
+  void initState() {
+    super.initState();
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _loadProduct();
+    });
+  }
+
+  Future<void> _loadProduct() async {
+    final AppNavigator navigator = AppNavigator.of(context);
+    final Product? product = await ProductRefresher().silentFetchAndRefresh(
+      barcode: widget.barcode,
+      localDatabase: context.read<LocalDatabase>(),
+    );
+
+    if (product != null && mounted) {
+      navigator.pushReplacement(
+        AppRoutes.PRODUCT(widget.barcode),
+        extra: product,
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: FutureBuilder<Product?>(
+        future: ProductRefresher().silentFetchAndRefresh(
+          barcode: widget.barcode,
+          localDatabase: context.read<LocalDatabase>(),
+        ),
+        builder: (BuildContext context, AsyncSnapshot<Product?> data) {
+          return const Center(
+            child: CircularProgressIndicator.adaptive(),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/packages/smooth_app/lib/pages/product/product_loader_page.dart
+++ b/packages/smooth_app/lib/pages/product/product_loader_page.dart
@@ -10,6 +10,7 @@ import 'package:smooth_app/pages/navigator/app_navigator.dart';
 import 'package:smooth_app/pages/product/common/product_refresher.dart';
 
 /// A page to show when a [Product] is not in the database
+/// This page shouldn't be opened directly, it's only for deep links
 class ProductLoaderPage extends StatefulWidget {
   const ProductLoaderPage({
     required this.barcode,

--- a/packages/smooth_app/lib/pages/product/product_loader_page.dart
+++ b/packages/smooth_app/lib/pages/product/product_loader_page.dart
@@ -134,7 +134,7 @@ class _ProductLoaderNotFoundState extends StatelessWidget {
             text: localizations.add_product_information_button_label,
             icon: Icons.add,
             padding: const EdgeInsets.symmetric(vertical: LARGE_SPACE),
-            onPressed: () async {
+            onPressed: () {
               AppNavigator.of(context).pushReplacement(
                 AppRoutes.PRODUCT_CREATOR(barcode),
               );

--- a/packages/smooth_app/lib/pages/product/product_loader_page.dart
+++ b/packages/smooth_app/lib/pages/product/product_loader_page.dart
@@ -9,6 +9,7 @@ import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/pages/navigator/app_navigator.dart';
 import 'package:smooth_app/pages/product/common/product_refresher.dart';
 
+/// A page to show when a [Product] is not in the database
 class ProductLoaderPage extends StatefulWidget {
   const ProductLoaderPage({
     required this.barcode,

--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -16,6 +16,7 @@ import 'package:smooth_app/helpers/product_compatibility_helper.dart';
 import 'package:smooth_app/helpers/ui_helpers.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_page.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels_builder.dart';
+import 'package:smooth_app/pages/navigator/app_navigator.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_page.dart';
 import 'package:smooth_app/pages/product/add_basic_details_page.dart';
 import 'package:smooth_app/pages/product/add_simple_input_button.dart';
@@ -70,6 +71,7 @@ class SummaryCard extends StatefulWidget {
 
   /// If true, the product will be editable
   final bool isProductEditable;
+
   @override
   State<SummaryCard> createState() => _SummaryCardState();
 }
@@ -444,14 +446,8 @@ class _SummaryCardState extends State<SummaryCard> {
           InkWell(
             borderRadius: const BorderRadius.only(topRight: ROUNDED_RADIUS),
             onTap: widget.isSettingClickable
-                ? () async => Navigator.push<void>(
-                      context,
-                      MaterialPageRoute<void>(
-                        builder: (BuildContext context) =>
-                            const UserPreferencesPage(
-                          type: PreferencePageType.FOOD,
-                        ),
-                      ),
+                ? () => AppNavigator.of(context).push(
+                      AppRoutes.PREFERENCES(PreferencePageType.FOOD),
                     )
                 : null,
             child: Tooltip(

--- a/packages/smooth_app/lib/pages/scan/scan_product_card.dart
+++ b/packages/smooth_app/lib/pages/scan/scan_product_card.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/product_preferences.dart';
+import 'package:smooth_app/pages/navigator/app_navigator.dart';
 import 'package:smooth_app/pages/product/hideable_container.dart';
-import 'package:smooth_app/pages/product/new_product_page.dart';
 import 'package:smooth_app/pages/product/summary_card.dart';
 
 class ScanProductCard extends StatelessWidget {
@@ -36,12 +36,10 @@ class ScanProductCard extends StatelessWidget {
     );
   }
 
-  Future<void> _openProductPage(BuildContext context) async {
-    await Navigator.push<void>(
-      context,
-      MaterialPageRoute<void>(
-        builder: (BuildContext context) => ProductPage(product),
-      ),
+  void _openProductPage(BuildContext context) {
+    AppNavigator.of(context).push(
+      AppRoutes.PRODUCT(product.barcode!),
+      extra: product,
     );
   }
 }

--- a/packages/smooth_app/lib/pages/scan/search_page.dart
+++ b/packages/smooth_app/lib/pages/scan/search_page.dart
@@ -7,9 +7,9 @@ import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/duration_constants.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
+import 'package:smooth_app/pages/navigator/app_navigator.dart';
 import 'package:smooth_app/pages/product/common/product_dialog_helper.dart';
 import 'package:smooth_app/pages/product/common/product_query_page_helper.dart';
-import 'package:smooth_app/pages/product/new_product_page.dart';
 import 'package:smooth_app/pages/scan/search_history_view.dart';
 import 'package:smooth_app/query/keywords_product_query.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
@@ -63,11 +63,9 @@ Future<void> _onSubmittedBarcode(
       searchCount: 1,
     );
     //ignore: use_build_context_synchronously
-    Navigator.push<Widget>(
-      context,
-      MaterialPageRoute<Widget>(
-        builder: (BuildContext context) => ProductPage(fetchedProduct.product!),
-      ),
+    AppNavigator.of(context).push(
+      AppRoutes.PRODUCT(fetchedProduct.product!.barcode!),
+      extra: fetchedProduct.product,
     );
   } else {
     AnalyticsHelper.trackSearch(

--- a/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
+++ b/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
@@ -18,6 +18,7 @@ import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/helpers/app_helper.dart';
 import 'package:smooth_app/pages/inherited_data_manager.dart';
+import 'package:smooth_app/pages/navigator/app_navigator.dart';
 import 'package:smooth_app/pages/scan/scan_product_card_loader.dart';
 import 'package:smooth_app/pages/scan/search_page.dart';
 import 'package:url_launcher/url_launcher_string.dart';
@@ -232,12 +233,7 @@ class SearchCard extends StatelessWidget {
   }
 
   void _openSearchPage(BuildContext context) {
-    Navigator.push<Widget>(
-      context,
-      MaterialPageRoute<Widget>(
-        builder: (_) => SearchPage(),
-      ),
-    );
+    AppNavigator.of(context).push(AppRoutes.SEARCH);
   }
 }
 
@@ -264,6 +260,7 @@ class _SearchCardTagLine extends StatefulWidget {
 
 class _SearchCardTagLineState extends State<_SearchCardTagLine> {
   late Future<Map<String, dynamic>> _initTagLineData;
+
   @override
   void initState() {
     super.initState();

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -625,6 +625,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
+  go_router:
+    dependency: "direct main"
+    description:
+      name: go_router
+      sha256: "80e37516b8d452d982fc32bd7bb22adbd20e422612ef2b3e1df8b8350cbf199b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   hive:
     dependency: "direct main"
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
 
+  go_router: 7.0.1
   barcode_widget: 2.0.3
   carousel_slider: 4.2.1
   cupertino_icons: 1.0.5

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
 
-  go_router: 7.0.1
+  go_router: 7.0.2
   barcode_widget: 2.0.3
   carousel_slider: 4.2.1
   cupertino_icons: 1.0.5


### PR DESCRIPTION
Hi everyone, 

This PR allows the app to support deep links (e.g.: clicking on a link in a search result and being redirected to the appropriate screen). We have decided to only support two routes: a product and the homepage.

A product will be opened if:
- The url has at least two parts
- The barcode contains at least 8 digits

Some examples: `product/123456789` or `produit/3017620422003/nutella-ferrero`

## Implementation

We now use the Navigator 2 (or router) in the app, with the help of [go_router](https://pub.dev/packages/go_router).
If this is the first time the user opens the app, the link will be ignored and, in general, if the onboarding is not successfully achieved, all links are ignored.

The `redirect` method of GoRouter is called both for internal routes and external ones (= url), that's why internal routes are prefixed with an underscore.

### Product loader

The `ProductDetails` screen requires it to be in the database. That's why a `ProductLoader` will load all the required stuff on the server and then show the details. Obviously, products not found, and network errors are handled.

### External links
A deep link can be called with an unsupported path (e.g.: `/contact`). In that case, we will redirect to the browser, through the `ExternalPage`.

## Migration from the Navigator

Instead of calling `Navigator.of(context)`, we now have to use `AppNavigator.of(context)` which embeds our GoRouter implementation.

## Notes

I have not migrated how the onboarding, tabs and preferences handle their navigation, as it's not mandatory.

## How to test it?

On Android, you can use this ADB command:
```
adb shell 'am start -a android.intent.action.VIEW -c android.intent.category.BROWSABLE -d "https://al.openfoodfacts.org/"' org.openfoodfacts.scanner

```