### PR TITLE
fix: On the product page, the Ripple on the back button doesn't work

### DIFF
--- a/packages/smooth_app/lib/generic_lib/widgets/smooth_back_button.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/smooth_back_button.dart
@@ -16,19 +16,23 @@ class SmoothBackButton extends StatelessWidget {
   final Color? iconColor;
 
   @override
-  Widget build(BuildContext context) => InkWell(
-        onTap: onPressed ?? () => Navigator.maybePop(context),
-        customBorder: const CircleBorder(),
-        child: Tooltip(
-          message: MaterialLocalizations.of(context).backButtonTooltip,
-          child: Padding(
-            padding: _iconPadding,
-            child: Icon(
-              ConstantIcons.instance.getBackIcon(),
-              color: iconColor ??
-                  (Theme.of(context).colorScheme.brightness == Brightness.light
-                      ? Colors.black
-                      : Colors.white),
+  Widget build(BuildContext context) => Material(
+        type: MaterialType.transparency,
+        child: InkWell(
+          onTap: onPressed ?? () => Navigator.maybePop(context),
+          customBorder: const CircleBorder(),
+          child: Tooltip(
+            message: MaterialLocalizations.of(context).backButtonTooltip,
+            child: Padding(
+              padding: _iconPadding,
+              child: Icon(
+                ConstantIcons.instance.getBackIcon(),
+                color: iconColor ??
+                    (Theme.of(context).colorScheme.brightness ==
+                            Brightness.light
+                        ? Colors.black
+                        : Colors.white),
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
Hi everyone,

One more fix for an invisible ripple:
[untitled.webm](https://github.com/openfoodfacts/smooth-app/assets/246838/42e75816-594f-4492-9217-290270d686f9)
