### PR TITLE
fix: Improve a little bit the ingredients page

### DIFF
--- a/packages/smooth_app/lib/pages/product/edit_ingredients_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_ingredients_page.dart
@@ -128,16 +128,30 @@ class _EditOcrPageState extends State<EditOcrPage> {
       _multilingualHelper.getCurrentLanguage(),
     );
 
+    final TextStyle appbarTextStyle = TextStyle(shadows: <Shadow>[
+      Shadow(
+        color: Theme.of(context).colorScheme.brightness == Brightness.light
+            ? Colors.white
+            : Colors.black,
+        offset: const Offset(0.5, 0.5),
+        blurRadius: 5.0,
+      )
+    ]);
+
     // TODO(monsieurtanuki): add WillPopScope / MayExitPage system
     return SmoothScaffold(
       extendBodyBehindAppBar: true,
       appBar: SmoothAppBar(
-        title: Text(_helper.getTitle(appLocalizations)),
+        title: Text(
+          _helper.getTitle(appLocalizations),
+          style: appbarTextStyle,
+        ),
         subTitle: _product.productName != null
             ? Text(
                 _product.productName!,
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
+                style: appbarTextStyle,
               )
             : null,
         backgroundColor: Colors.transparent,
@@ -259,14 +273,14 @@ class _EditOcrPageState extends State<EditOcrPage> {
           ),
           Flexible(
             flex: 1,
-            child: SingleChildScrollView(
-              child: Container(
-                decoration: BoxDecoration(
-                    color: Theme.of(context).colorScheme.background,
-                    borderRadius: const BorderRadius.only(
-                      topLeft: ANGULAR_RADIUS,
-                      topRight: ANGULAR_RADIUS,
-                    )),
+            child: Container(
+              decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.background,
+                  borderRadius: const BorderRadius.only(
+                    topLeft: ANGULAR_RADIUS,
+                    topRight: ANGULAR_RADIUS,
+                  )),
+              child: SingleChildScrollView(
                 child: Padding(
                   padding: const EdgeInsets.all(LARGE_SPACE),
                   child: Column(


### PR DESCRIPTION
Hi everyone,

As discussed in #3977, here are a few improvements for the ingredients page:

- The Appbar now have a slight shadow in the case where the picture has the same color as the text:
![Simulator Screenshot - iPhone 14 Pro Max - 2023-05-23 at 12 10 40](https://github.com/openfoodfacts/smooth-app/assets/246838/356b3b0b-53b8-42ca-a495-e0fd74646005)

The bouncing overscroll on iOS was weird also (see the video on #3977) and is now fixed:
https://github.com/openfoodfacts/smooth-app/assets/246838/b433864d-c857-45c4-aa13-dbb084774d23

