### PR TITLE
fix: If an history item has an error, ensure the full message is visible

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_template.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_template.dart
@@ -71,13 +71,25 @@ class SmoothProductCardTemplate extends StatelessWidget {
                 child: SizedBox(
                   height: screenSize.width * 0.2,
                   child: Column(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    crossAxisAlignment: CrossAxisAlignment.center,
+                    crossAxisAlignment: CrossAxisAlignment.start,
                     children: <Widget>[
-                      if (barcode == null) textWidget else Text(barcode!),
+                      if (barcode == null)
+                        textWidget
+                      else
+                        Text(
+                          barcode!,
+                          style: const TextStyle(fontWeight: FontWeight.bold),
+                        ),
                       if (message == null) textWidget,
-                      if (message == null) textWidget,
-                      if (message != null) AutoSizeText(message!, maxLines: 3),
+                      if (message != null)
+                        Padding(
+                          padding: const EdgeInsets.only(top: SMALL_SPACE),
+                          child: AutoSizeText(
+                            message!,
+                            maxLines: 3,
+                            minFontSize: 5,
+                          ),
+                        ),
                     ],
                   ),
                 ),


### PR DESCRIPTION
Hi everyone,

As found in #4003, in some languages, the error message can be truncated in the history.
With this PR, it will now look like this:

- Barcode in bold
- Multiple lines supported
- Remove the fact that the message was displayed at the bottom of the card

![Simulator Screenshot - iPhone 14 Pro Max - 2023-05-23 at 12 46 12](https://github.com/openfoodfacts/smooth-app/assets/246838/2978feae-f2e1-4dd1-bd20-6af4e3575ca8)
