### PR TITLE
feat: Better support deep links with unsupported URLs

### DIFF
--- a/packages/smooth_app/lib/pages/navigator/external_page.dart
+++ b/packages/smooth_app/lib/pages/navigator/external_page.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
-import 'package:openfoodfacts/src/utils/country_helper.dart';
-import 'package:openfoodfacts/src/utils/language_helper.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:path/path.dart' as path;
 import 'package:smooth_app/helpers/launch_url_helper.dart';
 import 'package:smooth_app/pages/navigator/app_navigator.dart';

--- a/packages/smooth_app/lib/pages/navigator/external_page.dart
+++ b/packages/smooth_app/lib/pages/navigator/external_page.dart
@@ -1,10 +1,19 @@
 import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+import 'package:openfoodfacts/src/utils/country_helper.dart';
+import 'package:openfoodfacts/src/utils/language_helper.dart';
 import 'package:path/path.dart' as path;
 import 'package:smooth_app/helpers/launch_url_helper.dart';
 import 'package:smooth_app/pages/navigator/app_navigator.dart';
+import 'package:smooth_app/query/product_query.dart';
 
+/// This screen is only used for deep links!
+///
 /// A screen opening a [path] relative to the OFF website.
-/// Eg: if path is "contact", it will open 'https://world.openfoodfacts.org/contact'
+///
+/// Unfortunately the deep link we receive doesn't contain the base URL
+/// (eg: de.openfoodfacts.org), that's why we try to guess it with the country
+/// and the locale of the user
 class ExternalPage extends StatefulWidget {
   const ExternalPage({required this.path, Key? key})
       : assert(path != ''),
@@ -22,10 +31,34 @@ class _ExternalPageState extends State<ExternalPage> {
     super.initState();
 
     WidgetsBinding.instance.addPostFrameCallback((_) async {
-      await LaunchUrlHelper.launchURL(
-        path.join('https://world.openfoodfacts.org', widget.path),
-        false,
-      );
+      // First let's try with https://{country}.openfoodfacts.org
+      final OpenFoodFactsCountry? country = ProductQuery.getCountry();
+
+      String? url;
+      if (country != null) {
+        url = path.join(
+          'https://${country.offTag}.openfoodfacts.org',
+          widget.path,
+        );
+
+        if (await _testUrl(url)) {
+          url = null;
+        }
+      }
+
+      // If that's not OK, let's try with world.openfoodfacts.org?lc={language}
+      if (url == null) {
+        final OpenFoodFactsLanguage language = ProductQuery.getLanguage();
+
+        url = path.join(
+          'https://world.openfoodfacts.org',
+          widget.path,
+        );
+
+        url = '$url?lc=${language.offTag}';
+      }
+
+      await LaunchUrlHelper.launchURL(url, false);
 
       if (mounted) {
         AppNavigator.of(context).pop();
@@ -36,5 +69,12 @@ class _ExternalPageState extends State<ExternalPage> {
   @override
   Widget build(BuildContext context) {
     return const Scaffold();
+  }
+
+  /// Check if an URL exist
+  Future<bool> _testUrl(String url) {
+    return http
+        .head(Uri.parse(url))
+        .then((http.Response value) => value.statusCode != 404);
   }
 }


### PR DESCRIPTION
Hi everyone,

The problem that we have with deep links, is we are only notified of the content after the URL.
Eg: if the URL is `de.openfoodfacts.com/contact`, we only receive `/contact`.

To better try to guess the base URL, we now use the country and the locale of the app.
But clearly, this is not a "bulletproof" solution.