### PR TITLE
feat: 3719 - new "scan history" page among the account product lists

### DIFF
--- a/packages/smooth_app/lib/data_models/continuous_scan_model.dart
+++ b/packages/smooth_app/lib/data_models/continuous_scan_model.dart
@@ -30,6 +30,7 @@ class ContinuousScanModel with ChangeNotifier {
       <String, ScannedProductState>{};
   final List<String> _barcodes = <String>[];
   final ProductList _productList = ProductList.scanSession();
+  final ProductList _scanHistory = ProductList.scanHistory();
   final ProductList _history = ProductList.history();
 
   String? _latestScannedBarcode;
@@ -248,6 +249,7 @@ class ContinuousScanModel with ChangeNotifier {
     if (_latestFoundBarcode != barcode) {
       _latestFoundBarcode = barcode;
       await _daoProductList.push(productList, _latestFoundBarcode!);
+      await _daoProductList.push(_scanHistory, _latestFoundBarcode!);
       await _daoProductList.push(_history, _latestFoundBarcode!);
       _daoProductList.localDatabase.notifyListeners();
     }

--- a/packages/smooth_app/lib/data_models/product_list.dart
+++ b/packages/smooth_app/lib/data_models/product_list.dart
@@ -2,61 +2,41 @@ import 'package:openfoodfacts/openfoodfacts.dart';
 
 enum ProductListType {
   /// API search by [SearchTerms] keywords
-  HTTP_SEARCH_KEYWORDS,
+  HTTP_SEARCH_KEYWORDS('http/search/keywords'),
 
   /// API search for [CategoryProductQuery] category
-  HTTP_SEARCH_CATEGORY,
+  HTTP_SEARCH_CATEGORY('http/search/category'),
 
   /// Current scan session; can be easily cleared by the end-user
-  SCAN_SESSION,
+  SCAN_SESSION('scan_session'),
+
+  /// Whole scan history; items may be removed by the end-user
+  SCAN_HISTORY('scan_history'),
 
   /// History of products seen by the end-user
-  HISTORY,
+  HISTORY('history'),
 
   /// End-user product list
-  USER,
+  USER('user'),
 
   /// End-user as a contributor
-  HTTP_USER_CONTRIBUTOR,
+  HTTP_USER_CONTRIBUTOR('http/user/contributor'),
 
   /// End-user as an informer
-  HTTP_USER_INFORMER,
+  HTTP_USER_INFORMER('http/user/informer'),
 
   /// End-user as a photographer
-  HTTP_USER_PHOTOGRAPHER,
+  HTTP_USER_PHOTOGRAPHER('http/user/photographer'),
 
   /// End-user for products to be completed
-  HTTP_USER_TO_BE_COMPLETED,
+  HTTP_USER_TO_BE_COMPLETED('http/user/to_be_completed'),
 
   /// For products to be completed, all of them.
-  HTTP_ALL_TO_BE_COMPLETED,
-}
+  HTTP_ALL_TO_BE_COMPLETED('http/all/to_be_completed');
 
-extension ProductListTypeExtension on ProductListType {
-  String get key {
-    switch (this) {
-      case ProductListType.HTTP_SEARCH_KEYWORDS:
-        return 'http/search/keywords';
-      case ProductListType.HTTP_SEARCH_CATEGORY:
-        return 'http/search/category';
-      case ProductListType.SCAN_SESSION:
-        return 'scan_session';
-      case ProductListType.HTTP_USER_CONTRIBUTOR:
-        return 'http/user/contributor';
-      case ProductListType.HTTP_USER_INFORMER:
-        return 'http/user/informer';
-      case ProductListType.HTTP_USER_PHOTOGRAPHER:
-        return 'http/user/photographer';
-      case ProductListType.HTTP_USER_TO_BE_COMPLETED:
-        return 'http/user/to_be_completed';
-      case ProductListType.HTTP_ALL_TO_BE_COMPLETED:
-        return 'http/all/to_be_completed';
-      case ProductListType.HISTORY:
-        return 'history';
-      case ProductListType.USER:
-        return 'user';
-    }
-  }
+  const ProductListType(this.key);
+
+  final String key;
 }
 
 class ProductList {
@@ -168,6 +148,8 @@ class ProductList {
 
   ProductList.scanSession() : this._(listType: ProductListType.SCAN_SESSION);
 
+  ProductList.scanHistory() : this._(listType: ProductListType.SCAN_HISTORY);
+
   ProductList.user(final String name)
       : this._(
           listType: ProductListType.USER,
@@ -245,6 +227,7 @@ class ProductList {
       case ProductListType.USER:
         return false;
       case ProductListType.SCAN_SESSION:
+      case ProductListType.SCAN_HISTORY:
       case ProductListType.HISTORY:
         return true;
     }
@@ -253,6 +236,7 @@ class ProductList {
   String getParametersKey() {
     switch (listType) {
       case ProductListType.SCAN_SESSION:
+      case ProductListType.SCAN_HISTORY:
       case ProductListType.HISTORY:
       case ProductListType.USER:
         return parameters;

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -426,9 +426,13 @@
     "@filter": {
         "description": "A button that opens a menu where you can filter within categories. Juices => Apple juices/Orange juices"
     },
-    "scan": "Scan",
+    "scan": "Scan session",
     "@scan": {
-        "description": "Page title: List type: Scanned products"
+        "description": "Page title: List type: Products in the scan session"
+    },
+    "scan_history": "Scan history",
+    "@scan_history": {
+        "description": "Page title: List type: Products in the whole scan history"
     },
     "search": "Search",
     "@search": {

--- a/packages/smooth_app/lib/pages/product/common/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_page.dart
@@ -86,6 +86,7 @@ class _ProductListPageState extends State<ProductListPage>
     final bool dismissible;
     switch (productList.listType) {
       case ProductListType.SCAN_SESSION:
+      case ProductListType.SCAN_HISTORY:
       case ProductListType.HISTORY:
       case ProductListType.USER:
         dismissible = productList.barcodes.isNotEmpty;

--- a/packages/smooth_app/lib/pages/product/common/product_query_page_helper.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_query_page_helper.dart
@@ -94,6 +94,8 @@ class ProductQueryPageHelper {
         return productList.parameters;
       case ProductListType.SCAN_SESSION:
         return appLocalizations.scan;
+      case ProductListType.SCAN_HISTORY:
+        return appLocalizations.scan_history;
       case ProductListType.HISTORY:
         return appLocalizations.recently_seen_products;
     }


### PR DESCRIPTION
### What
- There is a "scan session" page, typically for recently scanned products.
- But there was no huge "scan history" page, with all the previously scanned products.
- Now this list does exist. It's populated at the same time as "scan session", but is not cleared when "scan session" is cleared. This list is accessed from the account page - that can be changed if needed.

### Screenshot
cf. "Scan History / 3"
![Screenshot_2023-05-26-16-44-29](https://github.com/openfoodfacts/smooth-app/assets/11576431/18397085-47e3-4df5-af4b-6f6c0b5566d2)

### Fixes bug(s)
- Closes: #3719

### Impacted files
* `app_en.arb`: added 1 label for "scan history"
* `continuous_scan_model.dart`: added the product to "scan history"
* `product_list.dart`: added "scan history"; refactored `ProductListType`
* `product_list_page.dart`: added "scan history"
* `product_query_page_helper.dart`: added "scan history"
* `user_preferences_account.dart`: added an access to the "scan history" page