### PR TITLE
fix: Add a missing ripple on the card

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
@@ -75,7 +75,7 @@ class SmoothProductCardFound extends StatelessWidget {
         },
         child: Hero(
           tag: heroTag,
-          child: Container(
+          child: Ink(
             decoration: BoxDecoration(
               borderRadius: ROUNDED_BORDER_RADIUS,
               color:


### PR DESCRIPTION
A new one 😅
In the scan history, the Ripple isn't visible

[untitled.webm](https://github.com/openfoodfacts/smooth-app/assets/246838/66a4404e-170d-40aa-823a-e2455047a2a0)
