### PR TITLE
feat: 4031 - different layout for "empty" product list page

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -927,7 +927,7 @@
     "@product_list_icon_desc": {
         "description": "When the history list is empty, icon description (for accessibility) of the message explaining to start scanning"
     },
-    "product_list_empty_title": "Start scanning!",
+    "product_list_empty_title": "Start scanning",
     "@product_list_empty_title": {
         "description": "When the history list is empty, title of the message explaining to start scanning"
     },

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -923,7 +923,7 @@
     "@product_list_icon_desc": {
         "description": "When the history list is empty, icon description (for accessibility) of the message explaining to start scanning"
     },
-    "product_list_empty_title": "Lancez le scan !",
+    "product_list_empty_title": "Lancez le scan",
     "@product_list_empty_title": {
         "description": "When the history list is empty, title of the message explaining to start scanning"
     },

--- a/packages/smooth_app/lib/pages/product/common/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_page.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -9,7 +10,6 @@ import 'package:smooth_app/data_models/product_list.dart';
 import 'package:smooth_app/database/dao_product.dart';
 import 'package:smooth_app/database/dao_product_list.dart';
 import 'package:smooth_app/database/local_database.dart';
-import 'package:smooth_app/generic_lib/buttons/smooth_simple_button.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/generic_lib/duration_constants.dart';
@@ -80,7 +80,6 @@ class _ProductListPageState extends State<ProductListPage>
     final LocalDatabase localDatabase = context.watch<LocalDatabase>();
     final DaoProductList daoProductList = DaoProductList(localDatabase);
     final ThemeData themeData = Theme.of(context);
-    final ColorScheme colorScheme = Theme.of(context).colorScheme;
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final List<String> products = productList.getList();
     final bool dismissible;
@@ -103,22 +102,27 @@ class _ProductListPageState extends State<ProductListPage>
     final bool enableClear = products.isNotEmpty;
     final bool enableRename = productList.listType == ProductListType.USER;
 
-    final ThemeData theme = Theme.of(context);
-
     return SmoothScaffold(
-      floatingActionButton: _selectionMode || products.length <= 1
-          ? _CompareProductsButton(
-              selectedBarcodes: _selectedBarcodes,
-              barcodes: products,
-              onComparisonEnded: () {
-                setState(() => _selectionMode = false);
-              },
+      floatingActionButton: products.isEmpty
+          ? FloatingActionButton.extended(
+              icon: const Icon(CupertinoIcons.barcode),
+              label: Text(appLocalizations.product_list_empty_title),
+              onPressed: () =>
+                  InheritedDataManager.of(context).resetShowSearchCard(true),
             )
-          : FloatingActionButton.extended(
-              onPressed: () => setState(() => _selectionMode = true),
-              label: Text(appLocalizations.compare_products_mode),
-              icon: const Icon(Icons.compare_arrows),
-            ),
+          : _selectionMode || products.length <= 1
+              ? _CompareProductsButton(
+                  selectedBarcodes: _selectedBarcodes,
+                  barcodes: products,
+                  onComparisonEnded: () {
+                    setState(() => _selectionMode = false);
+                  },
+                )
+              : FloatingActionButton.extended(
+                  onPressed: () => setState(() => _selectionMode = true),
+                  label: Text(appLocalizations.compare_products_mode),
+                  icon: const Icon(Icons.compare_arrows),
+                ),
       appBar: SmoothAppBar(
         actions: !(enableClear || enableRename)
             ? null
@@ -224,37 +228,24 @@ class _ProductListPageState extends State<ProductListPage>
             Text(appLocalizations.compare_products_appbar_subtitle),
       ),
       body: products.isEmpty
-          ? Center(
+          ? Padding(
+              padding: const EdgeInsets.all(SMALL_SPACE),
               child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
+                mainAxisAlignment: MainAxisAlignment.spaceAround,
                 children: <Widget>[
-                  Expanded(
-                    child: SvgPicture.asset(
-                      'assets/misc/empty-list.svg',
-                      package: AppHelper.APP_PACKAGE,
+                  SvgPicture.asset(
+                    'assets/misc/empty-list.svg',
+                    package: AppHelper.APP_PACKAGE,
+                    width: MediaQuery.of(context).size.width / 2,
+                  ),
+                  Text(
+                    appLocalizations.product_list_empty_message,
+                    textAlign: TextAlign.center,
+                    style: themeData.textTheme.bodyMedium?.apply(
+                      color: themeData.colorScheme.onBackground,
                     ),
                   ),
-                  const Padding(padding: EdgeInsets.all(VERY_LARGE_SPACE)),
-                  SmoothSimpleButton(
-                    onPressed: () {
-                      InheritedDataManager.of(context)
-                          .resetShowSearchCard(true);
-                    },
-                    child: Text(appLocalizations.product_list_empty_title,
-                        style: theme.textTheme.headlineLarge?.copyWith(
-                          color: theme.colorScheme.onPrimary,
-                        )),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.all(VERY_LARGE_SPACE),
-                    child: Text(
-                      appLocalizations.product_list_empty_message,
-                      textAlign: TextAlign.center,
-                      style: themeData.textTheme.bodyMedium?.apply(
-                        color: colorScheme.onBackground,
-                      ),
-                    ),
-                  ),
+                  EMPTY_WIDGET,
                 ],
               ),
             )


### PR DESCRIPTION
Impacted files:
* `app_en.arb`: removed the `!` from the "start scanning" label
* `app_fr.arb`: removed the `!` from the "start scanning" label
* `product_list_page.dart`: FAB instead of custom button; different layout for svg and text

### What
- Different layout for "empty" product list page
  - FAB instead of custom button
  - Different layout for svg and text

### Screenshot
![Screenshot_2023-05-30-10-03-38](https://github.com/openfoodfacts/smooth-app/assets/11576431/0c83748c-4a54-4c22-967d-1b6d21bf42f5)

### Fixes bug(s)
- Fixes: #4031