### PR TITLE
feat: 4061 - activate hunger games by default

### DIFF
--- a/packages/smooth_app/lib/pages/preferences/user_preferences_contribute.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_contribute.dart
@@ -13,7 +13,6 @@ import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/helpers/launch_url_helper.dart';
 import 'package:smooth_app/pages/hunger_games/question_page.dart';
 import 'package:smooth_app/pages/preferences/abstract_user_preferences.dart';
-import 'package:smooth_app/pages/preferences/user_preferences_dev_mode.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_list_tile.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_page.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_widgets.dart';
@@ -56,16 +55,11 @@ class UserPreferencesContribute extends AbstractUserPreferences {
 
   @override
   List<Widget> getBody() {
-    final bool hungerGamesEnabled = userPreferences
-            .getFlag(UserPreferencesDevMode.userPreferencesFlagHungerGames) ??
-        false;
-
     return <Widget>[
       _getListTile(
         'Hunger Games',
         () => _hungerGames(),
         Icons.games,
-        showed: hungerGamesEnabled,
       ),
       _getListTile(
         appLocalizations.contribute_improve_header,
@@ -320,16 +314,13 @@ class UserPreferencesContribute extends AbstractUserPreferences {
     final VoidCallback onTap,
     final IconData leading, {
     final Icon? icon,
-    final bool showed = true,
   }) =>
-      showed
-          ? UserPreferencesListTile(
-              title: Text(title),
-              onTap: onTap,
-              trailing: icon ?? getForwardIcon(),
-              leading: UserPreferencesListTile.getTintedIcon(leading, context),
-            )
-          : EMPTY_WIDGET;
+      UserPreferencesListTile(
+        title: Text(title),
+        onTap: onTap,
+        trailing: icon ?? getForwardIcon(),
+        leading: UserPreferencesListTile.getTintedIcon(leading, context),
+      );
 }
 
 class _DevModeSetting extends StatelessWidget {

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_dev_mode.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_dev_mode.dart
@@ -48,7 +48,6 @@ class UserPreferencesDevMode extends AbstractUserPreferences {
       '__accessibilityNoColor';
   static const String userPreferencesFlagAccessibilityEmoji =
       '__accessibilityEmoji';
-  static const String userPreferencesFlagHungerGames = '__hungerGames';
 
   final TextEditingController _textFieldController = TextEditingController();
 
@@ -328,18 +327,6 @@ class UserPreferencesDevMode extends AbstractUserPreferences {
               list.add(tag);
             }
             await userPreferences.setExcludedAttributeIds(list);
-            setState(() {});
-          },
-        ),
-        SwitchListTile(
-          value:
-              userPreferences.getFlag(userPreferencesFlagHungerGames) ?? false,
-          title: const Text('Activate Hunger Games'),
-          onChanged: (bool value) async {
-            await userPreferences.setFlag(
-              userPreferencesFlagHungerGames,
-              value,
-            );
             setState(() {});
           },
         ),


### PR DESCRIPTION
### What
- Now there's no on/off setter for hunger games anymore, and hunger games is always displayed.

### Fixes bug(s)
- Closes: #4061

### Impacted files
* `user_preferences_contribute.dart`: always displays hunger games; minor refactoring
* `user_preferences_dev_mode.dart`: removed the hunger games flag and setter