### PR TITLE
fix: A user can't exit the walkthrough

### DIFF
--- a/packages/smooth_app/lib/pages/onboarding/onboarding_flow_navigator.dart
+++ b/packages/smooth_app/lib/pages/onboarding/onboarding_flow_navigator.dart
@@ -154,7 +154,7 @@ class OnboardingFlowNavigator {
     );
 
     if (page.isOnboardingComplete()) {
-      await Navigator.of(context).pushAndRemoveUntil(
+      await Navigator.of(context, rootNavigator: true).pushAndRemoveUntil(
         route,
         (Route<dynamic> route) => false,
       );


### PR DESCRIPTION
Hi everyone,

When mixing a Navigator with route names and Widgets, it's not supported with version 2 (or Navigator.router).
But the fix is actually really easy.

The detailed stacktrace is:

`A page-based route cannot be completed using imperative api, provide a new list without the corresponding Page to Navigator.pages instead`

Will fix #4078