### PR TITLE
fix: 4074 - added explicit isolate/ui settings

### DIFF
--- a/packages/smooth_app/lib/helpers/image_compute_container.dart
+++ b/packages/smooth_app/lib/helpers/image_compute_container.dart
@@ -49,9 +49,9 @@ Future<void> saveBmp({
     height: source.height,
   );
   if (container.isIsolatePossible) {
-    await _saveBmp(container);
-  } else {
     await compute(_saveBmp, container);
+  } else {
+    await _saveBmp(container);
   }
 }
 
@@ -76,9 +76,9 @@ Future<void> saveJpeg({
     height: source.height,
   );
   if (container.isIsolatePossible) {
-    await _saveJpeg(container);
-  } else {
     await compute(_saveJpeg, container);
+  } else {
+    await _saveJpeg(container);
   }
 }
 

--- a/packages/smooth_app/lib/pages/offline_tasks_page.dart
+++ b/packages/smooth_app/lib/pages/offline_tasks_page.dart
@@ -23,7 +23,17 @@ class _OfflineTaskState extends State<OfflineTaskPage> {
     final List<String> taskIds = localDatabase.getAllTaskIds();
     return Scaffold(
       appBar: AppBar(
-        title: Text(appLocalizations.background_task_title),
+        title: Text(
+          appLocalizations.background_task_title,
+          maxLines: 2,
+        ),
+        actions: <Widget>[
+          IconButton(
+            onPressed: () => // no await
+                BackgroundTaskManager(localDatabase).run(),
+            icon: const Icon(Icons.refresh),
+          ),
+        ],
       ),
       body: taskIds.isEmpty
           ? Center(


### PR DESCRIPTION
### What
- In some background tasks we manipulate pictures, which can be costly performance wise. That's why we recently switched to isolates, for some specific operations.
- For some reason the "isolate" part was not working anymore - or maybe it never worked on some specific cases.
- Looking back at the doc, the question was "how could it work before?".
- Anyway, now it works, and I even added an additional safety test, running the same method as non-isolate if relevant.
- For my tests it was useful to add a "refresh" button on top of the background task page (typically in order to run again tasks in error), and I think we should keep that button.

### Screenshot
New refresh button on top of background task page:
![Screenshot_2023-06-05-15-53-27](https://github.com/openfoodfacts/smooth-app/assets/11576431/92d19e1e-376f-470a-8966-1729a4cba982)

### Fixes bug(s)
- Fixes: #4074

### Impacted files
* `image_compute_container.dart`: added explicit isolate/ui settings
* `offline_tasks_page.dart`: added a "refresh" button on the app bar