### PR TITLE
feat: Chips in product cards (in the carousel) shouldn't intercept click events

### DIFF
--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -48,6 +48,7 @@ class SummaryCard extends StatefulWidget {
     this.isRemovable = true,
     this.isSettingClickable = true,
     this.isProductEditable = true,
+    this.attributeGroupsClickable = true,
   });
 
   final Product _product;
@@ -71,6 +72,9 @@ class SummaryCard extends StatefulWidget {
 
   /// If true, the product will be editable
   final bool isProductEditable;
+
+  /// If true, all chips / groups are clickable
+  final bool attributeGroupsClickable;
 
   @override
   State<SummaryCard> createState() => _SummaryCardState();
@@ -471,17 +475,20 @@ class _SummaryCardState extends State<SummaryCard> {
     final List<Widget> attributeChips,
   ) {
     _totalPrintableRows -= (attributeChips.length / 2).ceil();
-    return Column(
-      children: <Widget>[
-        header,
-        Container(
-          alignment: Alignment.topLeft,
-          child: Wrap(
-            runSpacing: 16,
-            children: attributeChips,
+    return AbsorbPointer(
+      absorbing: !widget.attributeGroupsClickable,
+      child: Column(
+        children: <Widget>[
+          header,
+          Container(
+            alignment: Alignment.topLeft,
+            child: Wrap(
+              runSpacing: 16,
+              children: attributeChips,
+            ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 

--- a/packages/smooth_app/lib/pages/scan/scan_product_card.dart
+++ b/packages/smooth_app/lib/pages/scan/scan_product_card.dart
@@ -30,7 +30,11 @@ class ScanProductCard extends StatelessWidget {
       child: Hero(
         tag: product.barcode ?? '',
         child: HideableContainer(
-          child: SummaryCard(product, productPreferences),
+          child: SummaryCard(
+            product,
+            productPreferences,
+            attributeGroupsClickable: false,
+          ),
         ),
       ),
     );


### PR DESCRIPTION
Hi everyone,

In the carousel, product cards should be totally clickable, except for the close button and the settings icon.

This PR allows disabling the click on attribute groups.
[device-2023-06-06-111114.webm](https://github.com/openfoodfacts/smooth-app/assets/246838/4cdce8a7-cfc5-4342-9980-4b217d771822)

