### PR TITLE
fix: Remove the unused permission to record the audio on Android

### DIFF
--- a/packages/smooth_app/android/app/src/main/AndroidManifest.xml
+++ b/packages/smooth_app/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,10 @@
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.CAMERA"/>
+
+    <!-- Some dependencies may request this permission, which is not used in our app -->
+    <uses-permission android:name="android.permission.RECORD_AUDIO" tools:node="remove" />
+
     <queries>
         <intent> 
             <action android:name="android.intent.action.SENDTO" /> 


### PR DESCRIPTION
Hi everyone,

The `camera` plugin asks for the RECORD_AUDIO permission.
As we don't need it in the app, we force it to be removed.

Will fix #3971 