### PR TITLE
fix: "_allow" attribute (on Matomo) is never initialized

### DIFF
--- a/packages/smooth_app/lib/helpers/analytics_helper.dart
+++ b/packages/smooth_app/lib/helpers/analytics_helper.dart
@@ -147,12 +147,16 @@ class AnalyticsHelper {
       setAnalyticsReports(false);
       return;
     }
+
     try {
       await MatomoTracker.instance.initialize(
         url: 'https://analytics.openfoodfacts.org/matomo.php',
         siteId: 2,
         visitorId: uuid,
       );
+
+      // Ensure to always initialize this value
+      _allow = !MatomoTracker.instance.getOptOut();
     } catch (err) {
       // With Hot Reload, this may trigger a late field already initialized
     }


### PR DESCRIPTION
Hi everyone,

We didn't understand why we had so many users with 00000 ids on Matomo.
The fact is the `_allow` attribute is never set on boot.