### PR TITLE
Revert "fix: "_allow" attribute (on Matomo) is never initialized"

### DIFF
--- a/packages/smooth_app/lib/helpers/analytics_helper.dart
+++ b/packages/smooth_app/lib/helpers/analytics_helper.dart
@@ -147,16 +147,12 @@ class AnalyticsHelper {
       setAnalyticsReports(false);
       return;
     }
-
     try {
       await MatomoTracker.instance.initialize(
         url: 'https://analytics.openfoodfacts.org/matomo.php',
         siteId: 2,
         visitorId: uuid,
       );
-
-      // Ensure to always initialize this value
-      _allow = !MatomoTracker.instance.getOptOut();
     } catch (err) {
       // With Hot Reload, this may trigger a late field already initialized
     }


### PR DESCRIPTION
Reverts openfoodfacts/smooth-app#4087

After investigating a little bit, we have issues with how the consent is managed in the app.
I will work on a new PR to ensure we differentiate better crash and analytics consents