### PR TITLE
feat: Add the Matomo's visitor ID in the debug settings

### DIFF
--- a/packages/smooth_app/lib/helpers/analytics_helper.dart
+++ b/packages/smooth_app/lib/helpers/analytics_helper.dart
@@ -242,4 +242,6 @@ class AnalyticsHelper {
       return fallback;
     }
   }
+
+  static String? get matomoVisitorId => MatomoTracker.instance.visitor.id;
 }

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_dev_debug_info.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_dev_debug_info.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:package_info_plus/package_info_plus.dart';
+import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/global_vars.dart';
 import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
@@ -22,6 +23,7 @@ class _UserPreferencesDebugInfoState extends State<UserPreferencesDebugInfo> {
     'Country': ProductQuery.getCountry().toString(),
     'IsLoggedIn': ProductQuery.isLoggedIn().toString(),
     'UUID': OpenFoodAPIConfiguration.uuid.toString(),
+    'Matomo Visitor ID': AnalyticsHelper.matomoVisitorId,
     'QueryType': OpenFoodAPIConfiguration.globalQueryType.toString(),
     'UserAgent-name': '${OpenFoodAPIConfiguration.userAgent?.name}',
     'UserAgent-system': '${OpenFoodAPIConfiguration.userAgent?.system}',


### PR DESCRIPTION
Hi everyone,

To better understand the current ID used by Matomo in the session, it's now displayed in the debug settings.

![Screenshot_1686131976](https://github.com/openfoodfacts/smooth-app/assets/246838/33b5d46b-3f49-4f78-a909-0d1177f04d98)
