### PR TITLE
feat: 4102 - bigger hunger games batch (10)

### DIFF
--- a/packages/smooth_app/lib/helpers/robotoff_insight_helper.dart
+++ b/packages/smooth_app/lib/helpers/robotoff_insight_helper.dart
@@ -43,7 +43,7 @@ class RobotoffInsightHelper {
         await DaoStringListMap(_localDatabase).getAll();
     for (final String barcode in records.keys) {
       final List<RobotoffQuestion> questions =
-          await ProductQuestionsQuery(barcode).getQuestions(_localDatabase);
+          await ProductQuestionsQuery(barcode).getQuestions(_localDatabase, 1);
       if (questions.isEmpty) {
         await DaoStringListMap(_localDatabase).removeKey(barcode);
       }

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1880,6 +1880,13 @@
     "@robotoff_continue": {
         "description": "Shown when robotoff question are all answered and user wants to continue answering"
     },
+    "robotoff_next_n_questions": "Next {count,plural,  =1{question} other{{count} questions}}",
+    "@robotoff_next_n_questions": {
+        "description": "Shown when robotoff question are all answered and user wants to continue answering",
+        "placeholders": {
+            "count": {}
+        }
+    },
     "show_password": "Show Password",
     "@show_password": {
         "description": "Show hidden password in password field"

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -1880,6 +1880,13 @@
     "@robotoff_continue": {
         "description": "Shown when robotoff question are all answered and user wants to continue answering"
     },
+    "robotoff_next_n_questions": "{count,plural,  =1{Une question} other{{count} questions}} de plus !",
+    "@robotoff_next_n_questions": {
+        "description": "Shown when robotoff question are all answered and user wants to continue answering",
+        "placeholders": {
+            "count": {}
+        }
+    },
     "show_password": "Afficher le Mot de Passe",
     "@show_password": {
         "description": "Show hidden password in password field"

--- a/packages/smooth_app/lib/pages/hunger_games/congrats.dart
+++ b/packages/smooth_app/lib/pages/hunger_games/congrats.dart
@@ -11,13 +11,12 @@ import 'package:smooth_app/pages/user_management/login_page.dart';
 
 class CongratsWidget extends StatelessWidget {
   const CongratsWidget({
-    required this.shouldDisplayContinueButton,
+    required this.continueButtonLabel,
     required this.anonymousAnnotationList,
     this.onContinue,
-    super.key,
   });
 
-  final bool shouldDisplayContinueButton;
+  final String? continueButtonLabel;
   final VoidCallback? onContinue;
   final Map<String, InsightAnnotation> anonymousAnnotationList;
 
@@ -60,10 +59,10 @@ class CongratsWidget extends StatelessWidget {
                   return _buildSignInButton(context, appLocalizations);
                 }
               }),
-          if (shouldDisplayContinueButton)
+          if (continueButtonLabel != null)
             SmoothSimpleButton(
               onPressed: onContinue,
-              child: Text(appLocalizations.robotoff_continue),
+              child: Text(continueButtonLabel!),
             )
           else
             EMPTY_WIDGET,

--- a/packages/smooth_app/lib/pages/product/product_questions_widget.dart
+++ b/packages/smooth_app/lib/pages/product/product_questions_widget.dart
@@ -98,7 +98,7 @@ class _ProductQuestionsWidgetState extends State<ProductQuestionsWidget> {
     final LocalDatabase localDatabase = context.read<LocalDatabase>();
     final List<RobotoffQuestion> questions =
         await ProductQuestionsQuery(widget.product.barcode!)
-            .getQuestions(localDatabase);
+            .getQuestions(localDatabase, 3);
     if (!mounted) {
       return null;
     }

--- a/packages/smooth_app/lib/query/product_questions_query.dart
+++ b/packages/smooth_app/lib/query/product_questions_query.dart
@@ -14,12 +14,13 @@ class ProductQuestionsQuery extends QuestionsQuery {
   @override
   Future<List<RobotoffQuestion>> getQuestions(
     final LocalDatabase localDatabase,
+    final int count,
   ) async {
     final RobotoffQuestionResult result =
         await RobotoffAPIClient.getProductQuestions(
       barcode,
       ProductQuery.getLanguage(),
-      count: 3,
+      count: count,
     );
     if (result.questions?.isNotEmpty != true) {
       return <RobotoffQuestion>[];

--- a/packages/smooth_app/lib/query/questions_query.dart
+++ b/packages/smooth_app/lib/query/questions_query.dart
@@ -7,5 +7,6 @@ abstract class QuestionsQuery {
 
   Future<List<RobotoffQuestion>> getQuestions(
     final LocalDatabase localDatabase,
+    final int count,
   );
 }

--- a/packages/smooth_app/lib/query/random_questions_query.dart
+++ b/packages/smooth_app/lib/query/random_questions_query.dart
@@ -9,12 +9,13 @@ class RandomQuestionsQuery extends QuestionsQuery {
   @override
   Future<List<RobotoffQuestion>> getQuestions(
     final LocalDatabase localDatabase,
+    final int count,
   ) async {
     final RobotoffQuestionResult result =
         await RobotoffAPIClient.getRandomQuestions(
       ProductQuery.getLanguage(),
       OpenFoodAPIConfiguration.globalUser,
-      count: 3,
+      count: count,
       // TODO(monsieurtanuki): should use Country too
     );
 


### PR DESCRIPTION
### What
- We used to play hunger games by batches of 3 questions.
- Now we start with 3, then 10, 10, ...
- The "continue" label (after a batch of questions) has changed to a more explicit "next _n_ questions" label

### Screenshot
| (edit: added) before | after |
| -- | -- |
| ![Screenshot_2023-06-09-08-16-53](https://github.com/openfoodfacts/smooth-app/assets/11576431/03c9f9d8-af87-4785-9cc8-d19a894a8f56) | ![Screenshot_2023-06-09-09-17-26](https://github.com/openfoodfacts/smooth-app/assets/11576431/daf83afa-3334-4a44-a8a7-b3a063189803) |

### Part of 
- #4102

### Impacted files
* `app_en.arb`: added the "next n questions" label for hunger games
* `app_fr.arb`: added the "next n questions" label for hunger games
* `congrats.dart`: "continue" button label as a String parameter
* `product_questions_query.dart`: added a `count` parameter
* `product_questions_widget.dart`: added the `count` parameter
* `question_page.dart`: different `count` parameters; set the "continue" button label
* `questions_query.dart`: added a `count` parameter
* `random_questions_query.dart`: added a `count` parameter
* `robotoff_insight_helper.dart`: added the `count` parameter