### PR TITLE
feat: Remove the unused alternative scan mode

### DIFF
--- a/packages/smooth_app/lib/data_models/user_preferences.dart
+++ b/packages/smooth_app/lib/data_models/user_preferences.dart
@@ -67,10 +67,6 @@ class UserPreferences extends ChangeNotifier {
   // Use the flash/torch with the camera
   static const String _TAG_USE_FLASH_WITH_CAMERA = 'enable_flash_with_camera';
 
-  // Alternative mode for the camera (file based implementation on Android)
-  static const String _TAG_CAMERA_USE_FILE_BASED_MODE =
-      'camera_alternative_mode';
-
   // Play sound when decoding a barcode
   static const String _TAG_PLAY_CAMERA_SCAN_SOUND = 'camera_scan_sound';
 
@@ -242,18 +238,6 @@ class UserPreferences extends ChangeNotifier {
 
   Future<void> setUseFlashWithCamera(final bool useFlash) async {
     await _sharedPreferences.setBool(_TAG_USE_FLASH_WITH_CAMERA, useFlash);
-    notifyListeners();
-  }
-
-  bool? get useFileBasedCameraMode =>
-      _sharedPreferences.getBool(_TAG_CAMERA_USE_FILE_BASED_MODE);
-
-  Future<void> setUseFileBasedCameraMode(final bool fileBasedMode) async {
-    await _sharedPreferences.setBool(
-      _TAG_CAMERA_USE_FILE_BASED_MODE,
-      fileBasedMode,
-    );
-
     notifyListeners();
   }
 


### PR DESCRIPTION
Hi everyone!

With the old camera/scanner implementation, we had the ability to switch between two modes.
This is not used anymore, and this pref can safely be removed.