### PR TITLE
fix: Add a missing Material Widget in the history

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
@@ -75,81 +75,84 @@ class SmoothProductCardFound extends StatelessWidget {
         },
         child: Hero(
           tag: heroTag,
-          child: Ink(
-            decoration: BoxDecoration(
-              borderRadius: ROUNDED_BORDER_RADIUS,
-              color:
-                  backgroundColor ?? (isDarkMode ? Colors.black : Colors.white),
-            ),
-            child: SmoothCard(
-              elevation: elevation,
-              color: Colors.transparent,
-              padding: const EdgeInsets.all(VERY_SMALL_SPACE),
-              child: Row(
-                children: <Widget>[
-                  SmoothMainProductImage(
-                    product: product,
-                    width: screenSize.width * 0.20,
-                    height: screenSize.width * 0.20,
-                  ),
-                  const Padding(
-                      padding:
-                          EdgeInsetsDirectional.only(start: VERY_SMALL_SPACE)),
-                  Expanded(
-                    child: SizedBox(
-                      height: screenSize.width * 0.2,
-                      child: Column(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: <Widget>[
-                          Text(
-                            getProductName(product, appLocalizations),
-                            overflow: TextOverflow.ellipsis,
-                            style: themeData.textTheme.headlineMedium,
-                          ),
-                          Text(
-                            getProductBrands(product, appLocalizations),
-                            overflow: TextOverflow.ellipsis,
-                            style: themeData.textTheme.titleMedium,
-                          ),
-                          Row(
-                            children: <Widget>[
-                              Icon(
-                                Icons.circle,
-                                size: 15,
-                                color: helper.getButtonColor(isDarkMode),
-                              ),
-                              const Padding(
-                                padding: EdgeInsetsDirectional.only(
-                                    start: VERY_SMALL_SPACE),
-                              ),
-                              Expanded(
-                                child: FittedBox(
-                                  fit: BoxFit.scaleDown,
-                                  alignment: AlignmentDirectional.centerStart,
-                                  child: Text(
-                                    helper.getSubtitle(appLocalizations),
-                                    style: themeData.textTheme.bodyMedium,
+          child: Material(
+            type: MaterialType.transparency,
+            child: Ink(
+              decoration: BoxDecoration(
+                borderRadius: ROUNDED_BORDER_RADIUS,
+                color: backgroundColor ??
+                    (isDarkMode ? Colors.black : Colors.white),
+              ),
+              child: SmoothCard(
+                elevation: elevation,
+                color: Colors.transparent,
+                padding: const EdgeInsets.all(VERY_SMALL_SPACE),
+                child: Row(
+                  children: <Widget>[
+                    SmoothMainProductImage(
+                      product: product,
+                      width: screenSize.width * 0.20,
+                      height: screenSize.width * 0.20,
+                    ),
+                    const Padding(
+                        padding: EdgeInsetsDirectional.only(
+                            start: VERY_SMALL_SPACE)),
+                    Expanded(
+                      child: SizedBox(
+                        height: screenSize.width * 0.2,
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: <Widget>[
+                            Text(
+                              getProductName(product, appLocalizations),
+                              overflow: TextOverflow.ellipsis,
+                              style: themeData.textTheme.headlineMedium,
+                            ),
+                            Text(
+                              getProductBrands(product, appLocalizations),
+                              overflow: TextOverflow.ellipsis,
+                              style: themeData.textTheme.titleMedium,
+                            ),
+                            Row(
+                              children: <Widget>[
+                                Icon(
+                                  Icons.circle,
+                                  size: 15,
+                                  color: helper.getButtonColor(isDarkMode),
+                                ),
+                                const Padding(
+                                  padding: EdgeInsetsDirectional.only(
+                                      start: VERY_SMALL_SPACE),
+                                ),
+                                Expanded(
+                                  child: FittedBox(
+                                    fit: BoxFit.scaleDown,
+                                    alignment: AlignmentDirectional.centerStart,
+                                    child: Text(
+                                      helper.getSubtitle(appLocalizations),
+                                      style: themeData.textTheme.bodyMedium,
+                                    ),
                                   ),
                                 ),
-                              ),
-                            ],
-                          ),
-                        ],
+                              ],
+                            ),
+                          ],
+                        ),
                       ),
                     ),
-                  ),
-                  const Padding(
-                    padding:
-                        EdgeInsetsDirectional.only(start: VERY_SMALL_SPACE),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.all(VERY_SMALL_SPACE),
-                    child: Column(
-                      children: scores,
+                    const Padding(
+                      padding:
+                          EdgeInsetsDirectional.only(start: VERY_SMALL_SPACE),
                     ),
-                  ),
-                ],
+                    Padding(
+                      padding: const EdgeInsets.all(VERY_SMALL_SPACE),
+                      child: Column(
+                        children: scores,
+                      ),
+                    ),
+                  ],
+                ),
               ),
             ),
           ),


### PR DESCRIPTION
Hi everyone,

From the history, opening a product and then going back to the history generates an issue with a missing `Material` widget.
The fix is not that hard to implement.

Before: [Before.webm](https://github.com/openfoodfacts/smooth-app/assets/246838/e5d408c7-245e-422c-bd6b-ef310ac7feab)

After: [After.webm](https://github.com/openfoodfacts/smooth-app/assets/246838/98d7bf0a-ce1f-4def-bade-53791e12bc13)
