### PR TITLE
fix: Opening a product from a deep link shouldn't use the Hero animation

### DIFF
--- a/packages/smooth_app/lib/pages/navigator/app_navigator.dart
+++ b/packages/smooth_app/lib/pages/navigator/app_navigator.dart
@@ -120,7 +120,10 @@ class _SmoothGoRouter {
                   throw Exception('No product provided!');
                 }
 
-                final Widget widget = ProductPage(product);
+                final Widget widget = ProductPage(
+                  product,
+                  withHeroAnimation: state.queryParameters['hero'] != 'false',
+                );
 
                 if (InheritedDataManager.find(context) == null) {
                   return InheritedDataManager(child: widget);
@@ -201,7 +204,7 @@ class _SmoothGoRouter {
               );
 
               if (state.extra is Product) {
-                return AppRoutes.PRODUCT(barcode);
+                return AppRoutes.PRODUCT(barcode, useHeroAnimation: false);
               } else {
                 return AppRoutes.PRODUCT_LOADER(barcode);
               }
@@ -331,8 +334,8 @@ class AppRoutes {
   static String get HOME => _InternalAppRoutes.HOME_PAGE.path;
 
   // Product details (a [Product] is mandatory in the extra)
-  static String PRODUCT(String barcode) =>
-      '/${_InternalAppRoutes.PRODUCT_DETAILS_PAGE}/$barcode';
+  static String PRODUCT(String barcode, {bool useHeroAnimation = true}) =>
+      '/${_InternalAppRoutes.PRODUCT_DETAILS_PAGE}/$barcode?hero=$useHeroAnimation';
 
   // Product loader (= when a product is not in the database) - typical use case: deep links
   static String PRODUCT_LOADER(String barcode) =>

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -33,9 +33,15 @@ import 'package:smooth_app/themes/constant_icons.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
 class ProductPage extends StatefulWidget {
-  const ProductPage(this.product);
+  const ProductPage(
+    this.product, {
+    this.withHeroAnimation = true,
+  });
 
   final Product product;
+
+  // When using a deep link the Hero animation shouldn't be used
+  final bool withHeroAnimation;
 
   @override
   State<ProductPage> createState() => _ProductPageState();
@@ -188,13 +194,16 @@ class _ProductPageState extends State<ProductPage> with TraceableClientMixin {
             padding: const EdgeInsets.symmetric(
               horizontal: SMALL_SPACE,
             ),
-            child: Hero(
-              tag: _barcode,
-              child: SummaryCard(
-                _product,
-                _productPreferences,
-                isFullVersion: true,
-                showUnansweredQuestions: true,
+            child: HeroMode(
+              enabled: widget.withHeroAnimation,
+              child: Hero(
+                tag: _barcode,
+                child: SummaryCard(
+                  _product,
+                  _productPreferences,
+                  isFullVersion: true,
+                  showUnansweredQuestions: true,
+                ),
               ),
             ),
           ),


### PR DESCRIPTION
Hi everyone,

When a product is opened from a deep link, we have a kind of glitch, where the Hero animation tries to go to the previous state. You can understand the issue in this video: [Before.webm](https://github.com/openfoodfacts/smooth-app/assets/246838/4d8ddcad-24d0-4e7c-bef0-281e70f9d4e1)

The idea now is to use this animation in all cases, BUT disabling it with deep links
[After.webm](https://github.com/openfoodfacts/smooth-app/assets/246838/b6853be2-e165-43d1-98ed-ea90bea2872b)
