### PR TITLE
feat: Improve the Compare button in this history

### DIFF
--- a/packages/smooth_app/lib/pages/product/common/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_page.dart
@@ -469,36 +469,41 @@ class _CompareProductsButton extends StatelessWidget {
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
 
-    if (selectedBarcodes.length < 2) {
-      return EMPTY_WIDGET;
-    }
+    final bool enabled = selectedBarcodes.length >= 2;
 
-    return FloatingActionButton.extended(
-      label: Text(appLocalizations.compare_products_mode),
-      icon: const Icon(Icons.compare_arrows),
-      tooltip: appLocalizations.plural_compare_x_products(
-        selectedBarcodes.length,
+    return Opacity(
+      opacity: enabled ? 1.0 : 0.5,
+      child: FloatingActionButton.extended(
+        label: Text(appLocalizations.compare_products_mode),
+        icon: const Icon(Icons.compare_arrows),
+        tooltip: enabled
+            ? appLocalizations.plural_compare_x_products(
+                selectedBarcodes.length,
+              )
+            : appLocalizations.compare_products_appbar_subtitle,
+        onPressed: enabled
+            ? () async {
+                final List<String> list = <String>[];
+                for (final String barcode in barcodes) {
+                  if (selectedBarcodes.contains(barcode)) {
+                    list.add(barcode);
+                  }
+                }
+
+                await Navigator.push<void>(
+                  context,
+                  MaterialPageRoute<void>(
+                    builder: (_) => PersonalizedRankingPage(
+                      barcodes: list,
+                      title: appLocalizations.product_list_your_ranking,
+                    ),
+                  ),
+                );
+
+                onComparisonEnded?.call();
+              }
+            : null,
       ),
-      onPressed: () async {
-        final List<String> list = <String>[];
-        for (final String barcode in barcodes) {
-          if (selectedBarcodes.contains(barcode)) {
-            list.add(barcode);
-          }
-        }
-
-        await Navigator.push<void>(
-          context,
-          MaterialPageRoute<void>(
-            builder: (_) => PersonalizedRankingPage(
-              barcodes: list,
-              title: appLocalizations.product_list_your_ranking,
-            ),
-          ),
-        );
-
-        onComparisonEnded?.call();
-      },
     );
   }
 }


### PR DESCRIPTION
Hi everyone,

We can debate how the Compare feature is implemented in the app, but that's not the goal here.
Instead, I just want to improve the "Compare" button in the History, where it's a bit misleading to understand that we need to select at least two products.

With that in my mind, I have changed two things:
- The compare button is always visible, but greyed when the selection doesn't contain 2 products
- By long pressing the Compare button, we understand this issue

To better understand my changes, here is a before/after:

- [Before.webm](https://github.com/openfoodfacts/smooth-app/assets/246838/51bed6b2-9e60-4fc3-a23a-ac3b39223b6b)
- [After.webm](https://github.com/openfoodfacts/smooth-app/assets/246838/9512a152-8a3c-4720-9c63-8894fcb99ee7)
