### PR TITLE
fix: No back button for the User preferences' page

### DIFF
--- a/packages/smooth_app/lib/pages/preferences/user_preferences_page.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_page.dart
@@ -170,7 +170,6 @@ class _UserPreferencesPageState extends State<UserPreferencesPage>
           appBarTitle,
           maxLines: 2,
         ),
-        leading: const SmoothBackButton(),
       ),
       body: ListView(children: children),
     );


### PR DESCRIPTION
Hi everyone,

I don't know why, but the back button is visible in the user preferences homepage.
![Screenshot_1686407757](https://github.com/openfoodfacts/smooth-app/assets/246838/940b83f7-9e2e-4359-8b45-c63c21e0b833)
