### PR TITLE
feat: Improve how we manage user consent for tracking & crash reports

### DIFF
--- a/packages/smooth_app/lib/helpers/analytics_helper.dart
+++ b/packages/smooth_app/lib/helpers/analytics_helper.dart
@@ -5,6 +5,7 @@ import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
+import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/helpers/entry_points_helper.dart';
 import 'package:smooth_app/helpers/global_vars.dart';
 
@@ -90,11 +91,25 @@ class AnalyticsHelper {
   AnalyticsHelper._();
 
   static bool _crashReports = false;
+  static _AnalyticsTrackingMode _analyticsReporting =
+      _AnalyticsTrackingMode.disabled;
 
   static String latestSearch = '';
 
-  /// Did the user allow the analytic reports?
-  static bool _allow = false;
+  static void linkPreferences(UserPreferences userPreferences) {
+    // Init the value
+    _setAnalyticsReports(userPreferences.onAnalyticsChanged.value);
+    _setCrashReports(userPreferences.onCrashReportingChanged.value);
+
+    // Listen to changes
+    userPreferences.onAnalyticsChanged.addListener(() {
+      _setAnalyticsReports(userPreferences.onAnalyticsChanged.value);
+    });
+
+    userPreferences.onCrashReportingChanged.addListener(() {
+      _setCrashReports(userPreferences.onCrashReportingChanged.value);
+    });
+  }
 
   static Future<void> initSentry({
     required Function()? appRunner,
@@ -117,17 +132,26 @@ class AnalyticsHelper {
     );
   }
 
-  static void setCrashReports(final bool crashReports) =>
+  /// Don't call this method directly, it is automatically updated via the
+  /// [UserPreferences]
+  static void _setCrashReports(final bool crashReports) =>
       _crashReports = crashReports;
 
-  static Future<void> setAnalyticsReports(final bool allow) async {
-    _allow = allow;
-
-    // F-Droid special case
-    if (GlobalVars.storeLabel == StoreLabel.FDroid && !allow) {
+  /// Don't call this method directly, it is automatically updated via the
+  /// [UserPreferences]
+  static Future<void> _setAnalyticsReports(final bool allow) async {
+    if (GlobalVars.storeLabel == StoreLabel.FDroid) {
+      _analyticsReporting = _AnalyticsTrackingMode.disabled;
       await MatomoTracker.instance.setOptOut(optout: true);
     } else {
+      if (allow) {
+        _analyticsReporting = _AnalyticsTrackingMode.enabled;
+      } else {
+        _analyticsReporting = _AnalyticsTrackingMode.anonymous;
+      }
+
       await MatomoTracker.instance.setOptOut(optout: false);
+      MatomoTracker.instance.setVisitorUserId(_uuid);
     }
   }
 
@@ -143,15 +167,15 @@ class AnalyticsHelper {
     final bool screenshotMode,
   ) async {
     if (screenshotMode) {
-      setCrashReports(false);
-      setAnalyticsReports(false);
+      _setCrashReports(false);
+      _setAnalyticsReports(false);
       return;
     }
     try {
       await MatomoTracker.instance.initialize(
         url: 'https://analytics.openfoodfacts.org/matomo.php',
         siteId: 2,
-        visitorId: uuid,
+        visitorId: _uuid,
       );
     } catch (err) {
       // With Hot Reload, this may trigger a late field already initialized
@@ -159,15 +183,21 @@ class AnalyticsHelper {
   }
 
   /// A UUID must be at least one 16 characters
-  static String? get uuid {
+  static String? get _uuid {
     // if user opts out then track anonymously with userId containg zeros
     if (kDebugMode) {
       return 'smoothie_debug--';
     }
-    if (!_allow) {
-      return '0' * 16;
+
+    switch (_analyticsReporting) {
+      case _AnalyticsTrackingMode.anonymous:
+        return '0' * 16;
+      case _AnalyticsTrackingMode.disabled:
+        return '';
+      case _AnalyticsTrackingMode.enabled:
+      default:
+        return OpenFoodAPIConfiguration.uuid;
     }
-    return OpenFoodAPIConfiguration.uuid;
   }
 
   static void trackEvent(
@@ -244,4 +274,13 @@ class AnalyticsHelper {
   }
 
   static String? get matomoVisitorId => MatomoTracker.instance.visitor.id;
+}
+
+enum _AnalyticsTrackingMode {
+  // With the user consent
+  enabled,
+  // Without the user consent
+  anonymous,
+  // On F-Droid builds
+  disabled,
 }

--- a/packages/smooth_app/lib/main.dart
+++ b/packages/smooth_app/lib/main.dart
@@ -137,7 +137,8 @@ Future<bool> _init1() async {
   );
   UserManagementProvider().checkUserLoginValidity();
 
-  AnalyticsHelper.setCrashReports(_userPreferences.crashReports);
+  AnalyticsHelper.linkPreferences(_userPreferences);
+
   await ProductQuery.setCountry(_userPreferences);
   _themeProvider = ThemeProvider(_userPreferences);
   _colorProvider = ColorProvider(_userPreferences);

--- a/packages/smooth_app/lib/pages/onboarding/consent_analytics_page.dart
+++ b/packages/smooth_app/lib/pages/onboarding/consent_analytics_page.dart
@@ -7,7 +7,6 @@ import 'package:smooth_app/data_models/onboarding_loader.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
-import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/app_helper.dart';
 import 'package:smooth_app/pages/onboarding/onboarding_bottom_bar.dart';
 import 'package:smooth_app/pages/onboarding/onboarding_flow_navigator.dart';
@@ -104,7 +103,8 @@ class ConsentAnalyticsPage extends StatelessWidget {
     final ThemeProvider themeProvider,
   ) async {
     await userPreferences.setCrashReports(accept);
-    AnalyticsHelper.setAnalyticsReports(accept);
+    await userPreferences.setUserTracking(accept);
+
     themeProvider.finishOnboarding();
     //ignore: use_build_context_synchronously
     await OnboardingLoader(localDatabase).runAtNextTime(

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_settings.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_settings.dart
@@ -3,14 +3,12 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/language_selector.dart';
-import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/camera_helper.dart';
 import 'package:smooth_app/helpers/entry_points_helper.dart';
 import 'package:smooth_app/helpers/global_vars.dart';
@@ -548,14 +546,14 @@ class _SendAnonymousDataSettingState extends State<_SendAnonymousDataSetting> {
   @override
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final UserPreferences userPreferences = context.watch<UserPreferences>();
 
     return UserPreferencesSwitchItem(
       title: appLocalizations.send_anonymous_data_toggle_title,
       subtitle: appLocalizations.send_anonymous_data_toggle_subtitle,
-      value: !MatomoTracker.instance.getOptOut(),
+      value: userPreferences.userTracking,
       onChanged: (final bool allow) async {
-        await AnalyticsHelper.setAnalyticsReports(allow);
-        setState(() {});
+        await userPreferences.setUserTracking(allow);
       },
     );
   }
@@ -575,7 +573,6 @@ class _CrashReportingSetting extends StatelessWidget {
       value: userPreferences.crashReports,
       onChanged: (final bool value) async {
         await userPreferences.setCrashReports(value);
-        AnalyticsHelper.setCrashReports(value);
       },
     );
   }


### PR DESCRIPTION
Hi everyone,

In the current state, we have several issues with the app:
- We don't clearly differentiate the consent between user tracking (analytics) and crash reporting
- The user ID is not refreshed when the user consent has changed (from 00000 to a generated one)
- Even with the consent, we use a 00000 id
- We have to send the changes both in the app preferences and the `AnalyticsHelper`

To simplify things, here are my changes:
- It's now possible to listen to changes in the user preferences specifically for crash & tracking consents
- The `AnalyticsHelper` listens to those changes 
- There are 2 prefs: one for crash reporting (already existing) and another for the tracking
- By default, I copy the consent from crash reporting to tracking
- To ease future migrations, the preferences are now versioned (currently V1)
- We ensure, we're fully compliant with #4092