### PR TITLE
feat: Add labels for camera selection and flash

### DIFF
--- a/packages/scanner/ml_kit/lib/src/scanner_ml_kit.dart
+++ b/packages/scanner/ml_kit/lib/src/scanner_ml_kit.dart
@@ -21,6 +21,8 @@ class ScannerMLKit extends Scanner {
             {int? eventValue, String? barcode})
         trackCustomEvent,
     required bool hasMoreThanOneCamera,
+    String? toggleCameraModeTooltip,
+    String? toggleFlashModeTooltip,
   }) {
     return _SmoothBarcodeScannerMLKit(
       onScan: onScan,
@@ -28,6 +30,8 @@ class ScannerMLKit extends Scanner {
       trackCustomEvent: trackCustomEvent,
       onCameraFlashError: onCameraFlashError,
       hasMoreThanOneCamera: hasMoreThanOneCamera,
+      toggleCameraModeTooltip: toggleCameraModeTooltip,
+      toggleFlashModeTooltip: toggleFlashModeTooltip,
     );
   }
 }
@@ -40,6 +44,8 @@ class _SmoothBarcodeScannerMLKit extends StatefulWidget {
     required this.trackCustomEvent,
     required this.onCameraFlashError,
     required this.hasMoreThanOneCamera,
+    this.toggleCameraModeTooltip,
+    this.toggleFlashModeTooltip,
   });
 
   final Future<bool> Function(String) onScan;
@@ -49,6 +55,9 @@ class _SmoothBarcodeScannerMLKit extends StatefulWidget {
       {int? eventValue, String? barcode}) trackCustomEvent;
   final Function(BuildContext)? onCameraFlashError;
   final bool hasMoreThanOneCamera;
+
+  final String? toggleCameraModeTooltip;
+  final String? toggleFlashModeTooltip;
 
   @override
   State<StatefulWidget> createState() => _SmoothBarcodeScannerMLKitState();
@@ -115,124 +124,132 @@ class _SmoothBarcodeScannerMLKitState extends State<_SmoothBarcodeScannerMLKit>
   }
 
   @override
-  Widget build(BuildContext context) => VisibilityDetector(
-        key: const ValueKey<String>('VisibilityDetector'),
-        onVisibilityChanged: (final VisibilityInfo info) async {
-          if (info.visibleBounds.height > 0.0) {
-            await _start();
-          } else {
-            await _stop();
-          }
-        },
-        child: Stack(
-          children: <Widget>[
-            MobileScanner(
-              controller: _controller,
-              fit: BoxFit.cover,
-              errorBuilder: (
-                BuildContext context,
-                MobileScannerException error,
-                Widget? child,
-              ) =>
-                  EMPTY_WIDGET,
-              onDetect: (final BarcodeCapture capture) async {
-                for (final Barcode barcode in capture.barcodes) {
-                  final String? string = barcode.displayValue;
-                  if (string != null) {
-                    await widget.onScan(string);
-                  }
+  Widget build(BuildContext context) {
+    return VisibilityDetector(
+      key: const ValueKey<String>('VisibilityDetector'),
+      onVisibilityChanged: (final VisibilityInfo info) async {
+        if (info.visibleBounds.height > 0.0) {
+          await _start();
+        } else {
+          await _stop();
+        }
+      },
+      child: Stack(
+        children: <Widget>[
+          MobileScanner(
+            controller: _controller,
+            fit: BoxFit.cover,
+            errorBuilder: (
+              BuildContext context,
+              MobileScannerException error,
+              Widget? child,
+            ) =>
+                EMPTY_WIDGET,
+            onDetect: (final BarcodeCapture capture) async {
+              for (final Barcode barcode in capture.barcodes) {
+                final String? string = barcode.displayValue;
+                if (string != null) {
+                  await widget.onScan(string);
                 }
-              },
+              }
+            },
+          ),
+          const Center(
+            child: Padding(
+              padding: EdgeInsets.all(_cornerPadding),
+              child: SmoothBarcodeScannerVisor(),
             ),
-            const Center(
-              child: Padding(
-                padding: EdgeInsets.all(_cornerPadding),
-                child: SmoothBarcodeScannerVisor(),
-              ),
-            ),
-            Align(
-              alignment: Alignment.bottomCenter,
-              child: Padding(
-                padding: const EdgeInsets.all(_cornerPadding),
-                child: Row(
-                  mainAxisAlignment: _showFlipCameraButton
-                      ? MainAxisAlignment.spaceBetween
-                      : MainAxisAlignment.end,
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: <Widget>[
-                    if (_showFlipCameraButton)
-                      IconButton(
+          ),
+          Align(
+            alignment: Alignment.bottomCenter,
+            child: Padding(
+              padding: const EdgeInsets.all(_cornerPadding),
+              child: Row(
+                mainAxisAlignment: _showFlipCameraButton
+                    ? MainAxisAlignment.spaceBetween
+                    : MainAxisAlignment.end,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: <Widget>[
+                  if (_showFlipCameraButton)
+                    IconButton(
+                      enableFeedback: true,
+                      tooltip: widget.toggleCameraModeTooltip ??
+                          'Switch between back and front camera',
+                      color: Colors.white,
+                      icon: ValueListenableBuilder<CameraFacing>(
+                        valueListenable: _controller.cameraFacingState,
+                        builder: (
+                          BuildContext context,
+                          CameraFacing state,
+                          Widget? child,
+                        ) {
+                          switch (state) {
+                            case CameraFacing.front:
+                              return const Icon(Icons.camera_front);
+                            case CameraFacing.back:
+                              return const Icon(Icons.camera_rear);
+                          }
+                        },
+                      ),
+                      onPressed: () async {
+                        widget.hapticFeedback.call();
+                        await _controller.switchCamera();
+                      },
+                    ),
+                  ValueListenableBuilder<bool?>(
+                    valueListenable: _controller.hasTorchState,
+                    builder: (
+                      BuildContext context,
+                      bool? state,
+                      Widget? child,
+                    ) {
+                      if (state != true) {
+                        return const SizedBox.shrink();
+                      }
+                      return IconButton(
+                        enableFeedback: true,
+                        tooltip: widget.toggleFlashModeTooltip ??
+                            'Turn ON or OFF the flash of the camera',
                         color: Colors.white,
-                        icon: ValueListenableBuilder<CameraFacing>(
-                          valueListenable: _controller.cameraFacingState,
+                        icon: ValueListenableBuilder<TorchState>(
+                          valueListenable: _controller.torchState,
                           builder: (
                             BuildContext context,
-                            CameraFacing state,
+                            TorchState state,
                             Widget? child,
                           ) {
                             switch (state) {
-                              case CameraFacing.front:
-                                return const Icon(Icons.camera_front);
-                              case CameraFacing.back:
-                                return const Icon(Icons.camera_rear);
+                              case TorchState.off:
+                                return const Icon(
+                                  Icons.flash_off,
+                                  color: Colors.white,
+                                );
+                              case TorchState.on:
+                                return const Icon(
+                                  Icons.flash_on,
+                                  color: Colors.white,
+                                );
                             }
                           },
                         ),
                         onPressed: () async {
                           widget.hapticFeedback.call();
-                          await _controller.switchCamera();
-                        },
-                      ),
-                    ValueListenableBuilder<bool?>(
-                      valueListenable: _controller.hasTorchState,
-                      builder: (
-                        BuildContext context,
-                        bool? state,
-                        Widget? child,
-                      ) {
-                        if (state != true) {
-                          return const SizedBox.shrink();
-                        }
-                        return IconButton(
-                          color: Colors.white,
-                          icon: ValueListenableBuilder<TorchState>(
-                            valueListenable: _controller.torchState,
-                            builder: (
-                              BuildContext context,
-                              TorchState state,
-                              Widget? child,
-                            ) {
-                              switch (state) {
-                                case TorchState.off:
-                                  return const Icon(
-                                    Icons.flash_off,
-                                    color: Colors.white,
-                                  );
-                                case TorchState.on:
-                                  return const Icon(
-                                    Icons.flash_on,
-                                    color: Colors.white,
-                                  );
-                              }
-                            },
-                          ),
-                          onPressed: () async {
-                            widget.hapticFeedback.call();
 
-                            try {
-                              await _controller.toggleTorch();
-                            } catch (err) {
-                              widget.onCameraFlashError?.call(context);
-                            }
-                          },
-                        );
-                      },
-                    ),
-                  ],
-                ),
+                          try {
+                            await _controller.toggleTorch();
+                          } catch (err) {
+                            widget.onCameraFlashError?.call(context);
+                          }
+                        },
+                      );
+                    },
+                  ),
+                ],
               ),
             ),
-          ],
-        ),
-      );
+          ),
+        ],
+      ),
+    );
+  }
 }

--- a/packages/scanner/shared/lib/src/scanner.dart
+++ b/packages/scanner/shared/lib/src/scanner.dart
@@ -18,5 +18,7 @@ abstract class Scanner {
             {int? eventValue, String? barcode})
         trackCustomEvent,
     required bool hasMoreThanOneCamera,
+    String? toggleCameraModeTooltip,
+    String? toggleFlashModeTooltip,
   });
 }

--- a/packages/scanner/shared/lib/src/scanner_mocked.dart
+++ b/packages/scanner/shared/lib/src/scanner_mocked.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-
 import 'package:scanner_shared/scanner_shared.dart';
 
 /// Empty implementation for an [AppStore]
@@ -18,6 +17,8 @@ class MockedScanner extends Scanner {
             {int? eventValue, String? barcode})
         trackCustomEvent,
     required bool hasMoreThanOneCamera,
+    String? toggleCameraModeTooltip,
+    String? toggleFlashModeTooltip,
   }) =>
       Container();
 }

--- a/packages/scanner/zxing/lib/src/scanner_zxing.dart
+++ b/packages/scanner/zxing/lib/src/scanner_zxing.dart
@@ -31,6 +31,8 @@ class ScannerZXing extends Scanner {
       hapticFeedback: hapticFeedback,
       onCameraFlashError: onCameraFlashError,
       hasMoreThanOneCamera: hasMoreThanOneCamera,
+      toggleCameraModeTooltip: toggleCameraModeTooltip,
+      toggleFlashModeTooltip: toggleFlashModeTooltip,
     );
   }
 }

--- a/packages/scanner/zxing/lib/src/scanner_zxing.dart
+++ b/packages/scanner/zxing/lib/src/scanner_zxing.dart
@@ -4,7 +4,6 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:qr_code_scanner/qr_code_scanner.dart';
-
 import 'package:scanner_shared/scanner_shared.dart';
 import 'package:visibility_detector/visibility_detector.dart';
 
@@ -24,6 +23,8 @@ class ScannerZXing extends Scanner {
             {int? eventValue, String? barcode})
         trackCustomEvent,
     required bool hasMoreThanOneCamera,
+    String? toggleCameraModeTooltip,
+    String? toggleFlashModeTooltip,
   }) {
     return _SmoothBarcodeScannerZXing(
       onScan: onScan,
@@ -41,12 +42,17 @@ class _SmoothBarcodeScannerZXing extends StatefulWidget {
     required this.hapticFeedback,
     required this.onCameraFlashError,
     required this.hasMoreThanOneCamera,
+    this.toggleCameraModeTooltip,
+    this.toggleFlashModeTooltip,
   });
 
   final Future<bool> Function(String) onScan;
   final Future<void> Function() hapticFeedback;
   final Function(BuildContext)? onCameraFlashError;
   final bool hasMoreThanOneCamera;
+
+  final String? toggleCameraModeTooltip;
+  final String? toggleFlashModeTooltip;
 
   @override
   State<StatefulWidget> createState() => _SmoothBarcodeScannerZXingState();
@@ -136,6 +142,8 @@ class _SmoothBarcodeScannerZXingState
                     if (_showFlipCameraButton)
                       IconButton(
                         icon: Icon(getCameraFlip()),
+                        tooltip: widget.toggleCameraModeTooltip ??
+                            'Switch between back and front camera',
                         color: Colors.white,
                         onPressed: () async {
                           widget.hapticFeedback.call();
@@ -153,6 +161,9 @@ class _SmoothBarcodeScannerZXingState
                         return IconButton(
                           icon:
                               Icon(flashOn ? Icons.flash_on : Icons.flash_off),
+                          enableFeedback: true,
+                          tooltip: widget.toggleFlashModeTooltip ??
+                              'Turn ON or OFF the flash of the camera',
                           color: Colors.white,
                           onPressed: () async {
                             widget.hapticFeedback.call();

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1343,6 +1343,14 @@
             }
         }
     },
+    "camera_toggle_camera": "Switch between back and front camera",
+    "@camera_toggle_camera": {
+        "description": "Explanation for the icon to switch between cameras"
+    },
+    "camera_toggle_flash": "Turn ON or OFF the flash of the camera",
+    "@camera_toggle_flash": {
+        "description": "Explanation for the icon to turn on/off the flash"
+    },
     "camera_enable_flash": "Enable flash",
     "@camera_enable_flash": {
         "description": "Enable flash (tooltip)"

--- a/packages/smooth_app/lib/pages/scan/camera_scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/camera_scan_page.dart
@@ -57,9 +57,11 @@ class CameraScannerPageState extends State<CameraScannerPage>
 
   @override
   Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+
     if (!CameraHelper.hasACamera) {
       return Center(
-        child: Text(AppLocalizations.of(context).permission_photo_none_found),
+        child: Text(appLocalizations.permission_photo_none_found),
       );
     }
 
@@ -71,6 +73,8 @@ class CameraScannerPageState extends State<CameraScannerPage>
           onCameraFlashError: _onCameraFlashError,
           trackCustomEvent: AnalyticsHelper.trackCustomEvent,
           hasMoreThanOneCamera: CameraHelper.hasMoreThanOneCamera,
+          toggleCameraModeTooltip: appLocalizations.camera_toggle_camera,
+          toggleFlashModeTooltip: appLocalizations.camera_toggle_flash,
         ),
         const Align(
           alignment: Alignment.topCenter,


### PR DESCRIPTION
Hi everyone,

The accessibility is really poor on the app, and we should at least add labels for the camera selection and the flash toggle:
<img width="555" alt="Screenshot 2023-06-10 at 20 54 02" src="https://github.com/openfoodfacts/smooth-app/assets/246838/72932f3b-1a29-49ce-9d34-e6d4b8e2f8fd">
