### PR TITLE
fix: Force all "Hero" widgets to have a unique tag

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
@@ -66,7 +66,10 @@ class SmoothProductCardFound extends StatelessWidget {
         onTap: onTap ??
             () {
               AppNavigator.of(context).push(
-                AppRoutes.PRODUCT(product.barcode!),
+                AppRoutes.PRODUCT(
+                  product.barcode!,
+                  heroTag: heroTag,
+                ),
                 extra: product,
               );
             },

--- a/packages/smooth_app/lib/helpers/analytics_helper.dart
+++ b/packages/smooth_app/lib/helpers/analytics_helper.dart
@@ -151,7 +151,10 @@ class AnalyticsHelper {
       }
 
       await MatomoTracker.instance.setOptOut(optout: false);
-      MatomoTracker.instance.setVisitorUserId(_uuid);
+
+      if (MatomoTracker.instance.initialized) {
+        MatomoTracker.instance.setVisitorUserId(_uuid);
+      }
     }
   }
 

--- a/packages/smooth_app/lib/pages/navigator/app_navigator.dart
+++ b/packages/smooth_app/lib/pages/navigator/app_navigator.dart
@@ -122,7 +122,9 @@ class _SmoothGoRouter {
 
                 final Widget widget = ProductPage(
                   product,
-                  withHeroAnimation: state.queryParameters['hero'] != 'false',
+                  withHeroAnimation:
+                      state.queryParameters['heroAnimation'] != 'false',
+                  heroTag: state.queryParameters['heroTag'],
                 );
 
                 if (InheritedDataManager.find(context) == null) {
@@ -334,8 +336,14 @@ class AppRoutes {
   static String get HOME => _InternalAppRoutes.HOME_PAGE.path;
 
   // Product details (a [Product] is mandatory in the extra)
-  static String PRODUCT(String barcode, {bool useHeroAnimation = true}) =>
-      '/${_InternalAppRoutes.PRODUCT_DETAILS_PAGE}/$barcode?hero=$useHeroAnimation';
+  static String PRODUCT(
+    String barcode, {
+    bool useHeroAnimation = true,
+    String? heroTag = '',
+  }) =>
+      '/${_InternalAppRoutes.PRODUCT_DETAILS_PAGE}/$barcode'
+      '?heroAnimation=$useHeroAnimation'
+      '&heroTag=$heroTag';
 
   // Product loader (= when a product is not in the database) - typical use case: deep links
   static String PRODUCT_LOADER(String barcode) =>

--- a/packages/smooth_app/lib/pages/product/common/product_list_item_simple.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_item_simple.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
@@ -68,7 +70,8 @@ class _ProductListItemSimpleState extends State<ProductListItemSimple> {
             case LoadingStatus.LOADED:
               if (_model.product != null) {
                 return SmoothProductCardFound(
-                  heroTag: _model.product!.barcode!,
+                  heroTag:
+                      '${_model.product!.barcode!}_${Random().nextInt(100)}',
                   product: _model.product!,
                   onTap: widget.onTap,
                   onLongPress: widget.onLongPress,

--- a/packages/smooth_app/lib/pages/product/common/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_page.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -106,6 +108,7 @@ class _ProductListPageState extends State<ProductListPage>
     return SmoothScaffold(
       floatingActionButton: products.isEmpty
           ? FloatingActionButton.extended(
+              heroTag: 'compare_fab_${Random(100)}',
               icon: const Icon(CupertinoIcons.barcode),
               label: Text(appLocalizations.product_list_empty_title),
               onPressed: () =>

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -35,10 +35,13 @@ import 'package:smooth_app/widgets/smooth_scaffold.dart';
 class ProductPage extends StatefulWidget {
   const ProductPage(
     this.product, {
+    this.heroTag,
     this.withHeroAnimation = true,
   });
 
   final Product product;
+
+  final String? heroTag;
 
   // When using a deep link the Hero animation shouldn't be used
   final bool withHeroAnimation;
@@ -195,9 +198,10 @@ class _ProductPageState extends State<ProductPage> with TraceableClientMixin {
               horizontal: SMALL_SPACE,
             ),
             child: HeroMode(
-              enabled: widget.withHeroAnimation,
+              enabled: widget.withHeroAnimation &&
+                  widget.heroTag?.isNotEmpty == true,
               child: Hero(
-                tag: _barcode,
+                tag: widget.heroTag ?? '',
                 child: SummaryCard(
                   _product,
                   _productPreferences,

--- a/packages/smooth_app/lib/pages/product/product_loader_page.dart
+++ b/packages/smooth_app/lib/pages/product/product_loader_page.dart
@@ -51,7 +51,10 @@ class _ProductLoaderPageState extends State<ProductLoaderPage> {
 
       if (product != null && mounted) {
         navigator.pushReplacement(
-          AppRoutes.PRODUCT(widget.barcode),
+          AppRoutes.PRODUCT(
+            widget.barcode,
+            heroTag: 'product_${widget.barcode}',
+          ),
           extra: product,
         );
       } else {

--- a/packages/smooth_app/lib/pages/scan/search_page.dart
+++ b/packages/smooth_app/lib/pages/scan/search_page.dart
@@ -64,7 +64,10 @@ Future<void> _onSubmittedBarcode(
     );
     //ignore: use_build_context_synchronously
     AppNavigator.of(context).push(
-      AppRoutes.PRODUCT(fetchedProduct.product!.barcode!),
+      AppRoutes.PRODUCT(
+        fetchedProduct.product!.barcode!,
+        heroTag: 'search_${fetchedProduct.product!.barcode!}',
+      ),
       extra: fetchedProduct.product,
     );
   } else {

--- a/packages/smooth_app/lib/widgets/ranking_floating_action_button.dart
+++ b/packages/smooth_app/lib/widgets/ranking_floating_action_button.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:smooth_app/generic_lib/animations/smooth_reveal_animation.dart';
@@ -23,6 +25,7 @@ class RankingFloatingActionButton extends StatelessWidget {
           children: <Widget>[
             SizedBox(width: MediaQuery.of(context).size.width * 0.09),
             FloatingActionButton.extended(
+              heroTag: 'ranking_fab_${Random(100)}',
               elevation: 12.0,
               icon: const Icon(rankingIconData),
               label: Text(AppLocalizations.of(context).myPersonalizedRanking),


### PR DESCRIPTION
Hi everyone!
We use some `Hero` widgets in the app, but we don't differentiate them with a unique ID. This PR should do the trick.
- Will fix #4114