### PR TITLE
fix: 4123 - dedicated widget and page for robotoff question images

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/product_image_carousel.dart
+++ b/packages/smooth_app/lib/cards/product_cards/product_image_carousel.dart
@@ -5,39 +5,26 @@ import 'package:smooth_app/data_models/product_image_data.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/query/product_query.dart';
 
+/// Carousel of product images.
 class ProductImageCarousel extends StatelessWidget {
-  /// Carousel of product images, or of just an [alternateImageUrl].
   const ProductImageCarousel(
     this.product, {
     required this.height,
     this.controller,
     this.onUpload,
-    this.alternateImageUrl,
   });
 
   final Product product;
   final double height;
   final ScrollController? controller;
   final Function(BuildContext)? onUpload;
-  final String? alternateImageUrl;
 
   @override
   Widget build(BuildContext context) {
-    final List<ProductImageData> productImagesData;
-    if (alternateImageUrl != null) {
-      productImagesData = <ProductImageData>[
-        ProductImageData(
-          imageUrl: alternateImageUrl,
-          imageField: ImageField.OTHER,
-          language: null,
-        ),
-      ];
-    } else {
-      productImagesData = getProductMainImagesData(
-        product,
-        ProductQuery.getLanguage(),
-      );
-    }
+    final List<ProductImageData> productImagesData = getProductMainImagesData(
+      product,
+      ProductQuery.getLanguage(),
+    );
     return SizedBox(
       height: height,
       child: ListView.builder(

--- a/packages/smooth_app/lib/pages/hunger_games/question_card.dart
+++ b/packages/smooth_app/lib/pages/hunger_games/question_card.dart
@@ -2,11 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:shimmer/shimmer.dart';
-import 'package:smooth_app/cards/product_cards/product_image_carousel.dart';
 import 'package:smooth_app/cards/product_cards/product_title_card.dart';
 import 'package:smooth_app/database/dao_product.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/pages/hunger_games/question_image_thumbnail.dart';
 import 'package:smooth_app/pages/product/common/product_refresher.dart';
 
 /// Display of a Robotoff question text.
@@ -60,10 +60,11 @@ class QuestionCard extends StatelessWidget {
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: <Widget>[
-                  ProductImageCarousel(
-                    product,
+                  SizedBox(
                     height: screenSize.height / 6,
-                    alternateImageUrl: question.imageUrl,
+                    child: question.imageUrl == null
+                        ? EMPTY_WIDGET
+                        : QuestionImageThumbnail(question.imageUrl!),
                   ),
                   Padding(
                     padding:

--- a/packages/smooth_app/lib/pages/hunger_games/question_image_full_page.dart
+++ b/packages/smooth_app/lib/pages/hunger_games/question_image_full_page.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:smooth_app/themes/constant_icons.dart';
+
+/// Zoomable full page of a question image.
+class QuestionImageFullPage extends StatelessWidget {
+  const QuestionImageFullPage(this.imageUrl);
+
+  final String imageUrl;
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+        floatingActionButton: FloatingActionButton(
+          child: Icon(ConstantIcons.instance.getBackIcon()),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+        body: ConstrainedBox(
+          constraints: const BoxConstraints.expand(),
+          child: InteractiveViewer(
+            minScale: 0.1,
+            maxScale: 5,
+            child: Image(
+              fit: BoxFit.contain,
+              image: NetworkImage(imageUrl),
+            ),
+          ),
+        ),
+      );
+}

--- a/packages/smooth_app/lib/pages/hunger_games/question_image_thumbnail.dart
+++ b/packages/smooth_app/lib/pages/hunger_games/question_image_thumbnail.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/pages/hunger_games/question_image_full_page.dart';
+
+/// Thumbnail of a question image.
+class QuestionImageThumbnail extends StatelessWidget {
+  const QuestionImageThumbnail(this.imageUrl);
+
+  final String imageUrl;
+
+  @override
+  Widget build(BuildContext context) => Container(
+        margin: const EdgeInsets.fromLTRB(0, 0, 5, 0),
+        decoration: const BoxDecoration(color: Colors.black12),
+        child: GestureDetector(
+          onTap: () async => Navigator.of(context).push<void>(
+            MaterialPageRoute<void>(
+              builder: (BuildContext context) =>
+                  QuestionImageFullPage(imageUrl),
+              fullscreenDialog: true,
+            ),
+          ),
+          child: Image(
+            image: NetworkImage(imageUrl),
+            fit: BoxFit.cover,
+            height: double.infinity,
+            errorBuilder: (_, __, ___) => EMPTY_WIDGET,
+            loadingBuilder: (
+              _,
+              Widget child,
+              ImageChunkEvent? progress,
+            ) =>
+                progress == null
+                    ? child
+                    : const CircularProgressIndicator.adaptive(),
+          ),
+        ),
+      );
+}


### PR DESCRIPTION
### What
- Much smoother hunger games experience: a click on the image gives access to a read-only full page zoomable image.

### Screenshot
| question page | question image page | ...with zoom |
| -- | -- | -- |
| ![Screenshot_2023-06-13-18-41-30](https://github.com/openfoodfacts/smooth-app/assets/11576431/c4a28eb4-d6f8-4420-93ba-1c3ec121f58d) | ![Screenshot_2023-06-13-18-41-34](https://github.com/openfoodfacts/smooth-app/assets/11576431/dc9fd1ed-a1cd-443f-8aa3-a96c2fc508f6) | ![Screenshot_2023-06-13-18-41-55](https://github.com/openfoodfacts/smooth-app/assets/11576431/e98cd2e9-c48e-4ec7-9e0e-64ffaa57b64e) |

### Part of 
- #4123

### Files
New files:
* `question_image_full_page.dart`: Zoomable full page of a question image.
* `question_image_thumbnail.dart`: Thumbnail of a question image.

Impacted files:
* `product_image_carousel.dart`: removed a now unreachable case.
* `question_card.dart`: now displays the question image with a new zoomable read-only widget