### PR TITLE
fix: 4123 - question image full page improvements

### DIFF
--- a/packages/smooth_app/lib/pages/hunger_games/question_card.dart
+++ b/packages/smooth_app/lib/pages/hunger_games/question_card.dart
@@ -64,7 +64,7 @@ class QuestionCard extends StatelessWidget {
                     height: screenSize.height / 6,
                     child: question.imageUrl == null
                         ? EMPTY_WIDGET
-                        : QuestionImageThumbnail(question.imageUrl!),
+                        : QuestionImageThumbnail(question),
                   ),
                   Padding(
                     padding:

--- a/packages/smooth_app/lib/pages/hunger_games/question_image_full_page.dart
+++ b/packages/smooth_app/lib/pages/hunger_games/question_image_full_page.dart
@@ -1,17 +1,20 @@
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
-import 'package:smooth_app/themes/constant_icons.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
 
 /// Zoomable full page of a question image.
 class QuestionImageFullPage extends StatelessWidget {
-  const QuestionImageFullPage(this.imageUrl);
+  const QuestionImageFullPage(this.question);
 
-  final String imageUrl;
+  final RobotoffQuestion question;
 
   @override
   Widget build(BuildContext context) => Scaffold(
-        floatingActionButton: FloatingActionButton(
-          child: Icon(ConstantIcons.instance.getBackIcon()),
-          onPressed: () => Navigator.of(context).pop(),
+        appBar: AppBar(
+          title: AutoSizeText(
+            '${question.question!} (${question.value!})',
+            maxLines: 2,
+          ),
         ),
         body: ConstrainedBox(
           constraints: const BoxConstraints.expand(),
@@ -20,7 +23,7 @@ class QuestionImageFullPage extends StatelessWidget {
             maxScale: 5,
             child: Image(
               fit: BoxFit.contain,
-              image: NetworkImage(imageUrl),
+              image: NetworkImage(question.imageUrl!),
             ),
           ),
         ),

--- a/packages/smooth_app/lib/pages/hunger_games/question_image_thumbnail.dart
+++ b/packages/smooth_app/lib/pages/hunger_games/question_image_thumbnail.dart
@@ -1,12 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/pages/hunger_games/question_image_full_page.dart';
 
 /// Thumbnail of a question image.
 class QuestionImageThumbnail extends StatelessWidget {
-  const QuestionImageThumbnail(this.imageUrl);
+  const QuestionImageThumbnail(this.question);
 
-  final String imageUrl;
+  final RobotoffQuestion question;
 
   @override
   Widget build(BuildContext context) => Container(
@@ -16,12 +17,12 @@ class QuestionImageThumbnail extends StatelessWidget {
           onTap: () async => Navigator.of(context).push<void>(
             MaterialPageRoute<void>(
               builder: (BuildContext context) =>
-                  QuestionImageFullPage(imageUrl),
+                  QuestionImageFullPage(question),
               fullscreenDialog: true,
             ),
           ),
           child: Image(
-            image: NetworkImage(imageUrl),
+            image: NetworkImage(question.imageUrl!),
             fit: BoxFit.cover,
             height: double.infinity,
             errorBuilder: (_, __, ___) => EMPTY_WIDGET,


### PR DESCRIPTION
### What
- The questions image full page used a floating action button for the "close" action, which was not appropriate.
- Now we use a standard `AppBar` with its standard "close" button.
- Now that we have an `AppBar`, we also have the text of the question.

### Screenshot
| question card | question page | question page (zoomed) |
| -- | -- | -- |
| ![Screenshot_2023-06-14-08-28-34](https://github.com/openfoodfacts/smooth-app/assets/11576431/eb2f8913-40c7-4ea5-a8e1-7d7954333d39) | ![Screenshot_2023-06-14-08-28-41](https://github.com/openfoodfacts/smooth-app/assets/11576431/2bfbaf48-f8dd-49f3-83e8-b684619b6bd8) | ![Screenshot_2023-06-14-08-28-50](https://github.com/openfoodfacts/smooth-app/assets/11576431/52e32c94-bc31-4d36-b412-5bfcef5518d6) |

### Part of 
- #4123

### Impacted files
* `question_card.dart`: minor refactoring
* `question_image_full_page.dart`: now we use the standard close button and display the question text
* `question_image_thumbnail.dart`: minor refactoring