### PR TITLE
fix: 4121 - text selectable only if not clickable

### DIFF
--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_title_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_title_card.dart
@@ -98,15 +98,14 @@ class KnowledgePanelTitleCard extends StatelessWidget {
                           knowledgePanelTitleElement.subtitle!,
                           style:
                               WellSpacedTextHelper.TEXT_STYLE_WITH_WELL_SPACED,
-                        ).selectable(),
+                        ).selectable(isSelectable: !isClickable),
                       ),
                   ],
                 );
               },
             ),
           ),
-          if (isClickable)
-            if (isClickable) Icon(ConstantIcons.instance.getForwardIcon()),
+          if (isClickable) Icon(ConstantIcons.instance.getForwardIcon()),
         ],
       ),
     );


### PR DESCRIPTION
### What
- In the product summary card, the KP texts are now selectable only if not clickable.
 
### Fixes bug(s)
- Fixes: #4121

### Impacted file
* `knowledge_panel_title_card.dart`: text is now selectable only if not clickable