### PR TITLE
feat: Provide a Hero animation between the list of photos and the viewer

### DIFF
--- a/packages/smooth_app/lib/generic_lib/widgets/images/smooth_image.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/images/smooth_image.dart
@@ -13,6 +13,7 @@ class SmoothImage extends StatelessWidget {
     this.color,
     this.decoration,
     this.fit,
+    this.heroTag,
   });
 
   final ImageProvider? imageProvider;
@@ -21,24 +22,33 @@ class SmoothImage extends StatelessWidget {
   final Color? color;
   final Decoration? decoration;
   final BoxFit? fit;
+  final String? heroTag;
 
   @override
-  Widget build(BuildContext context) => ClipRRect(
-        borderRadius: ROUNDED_BORDER_RADIUS,
-        child: Container(
-          decoration: decoration,
-          width: width,
-          height: height,
-          color: color,
-          child: imageProvider == null
-              ? const PictureNotFound()
-              : Image(
-                  image: imageProvider!,
-                  fit: fit ?? BoxFit.cover,
-                  loadingBuilder: _loadingBuilder,
-                ),
-        ),
-      );
+  Widget build(BuildContext context) {
+    Widget child = imageProvider == null
+        ? const PictureNotFound()
+        : Image(
+            image: imageProvider!,
+            fit: fit ?? BoxFit.cover,
+            loadingBuilder: _loadingBuilder,
+          );
+
+    if (heroTag != null) {
+      child = Hero(tag: heroTag!, child: child);
+    }
+
+    return ClipRRect(
+      borderRadius: ROUNDED_BORDER_RADIUS,
+      child: Container(
+        decoration: decoration,
+        width: width,
+        height: height,
+        color: color,
+        child: child,
+      ),
+    );
+  }
 
   Widget _loadingBuilder(
     BuildContext _,

--- a/packages/smooth_app/lib/generic_lib/widgets/smooth_list_tile_card.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/smooth_list_tile_card.dart
@@ -21,6 +21,7 @@ class SmoothListTileCard extends StatelessWidget {
     required ImageProvider? imageProvider,
     Widget? title,
     GestureTapCallback? onTap,
+    String? heroTag,
   }) : this(
           title: title,
           onTap: onTap,
@@ -28,6 +29,7 @@ class SmoothListTileCard extends StatelessWidget {
             width: VERY_LARGE_SPACE * 5,
             height: MEDIUM_SPACE * 5,
             imageProvider: imageProvider,
+            heroTag: heroTag,
           ),
         );
 

--- a/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
@@ -99,6 +99,7 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView> {
           itemBuilder: (final BuildContext context, int index) {
             final MapEntry<ProductImageData, ImageProvider?> item =
                 _selectedImages[index];
+
             return SmoothListTileCard.image(
               imageProvider: item.value,
               title: Text(
@@ -109,6 +110,7 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView> {
                 imageData: item.key,
                 initialImageIndex: index,
               ),
+              heroTag: 'photo_${item.key.imageField.offTag}',
             );
           },
         ),

--- a/packages/smooth_app/lib/pages/product/product_image_viewer.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_viewer.dart
@@ -113,31 +113,59 @@ class _ProductImageViewerState extends State<ProductImageViewer> {
                     minScale: 0.2,
                     imageProvider: imageProvider,
                     heroAttributes: PhotoViewHeroAttributes(
-                      tag: imageProvider,
-                    ),
+                        tag: 'photo_${widget.imageField.offTag}',
+                        flightShuttleBuilder: (
+                          _,
+                          Animation<double> animation,
+                          HeroFlightDirection flightDirection,
+                          BuildContext fromHeroContext,
+                          BuildContext toHeroContext,
+                        ) {
+                          return AnimatedBuilder(
+                            animation: animation,
+                            builder: (_, __) {
+                              Widget widget;
+                              if (flightDirection == HeroFlightDirection.push) {
+                                widget = fromHeroContext.widget;
+                              } else {
+                                widget = toHeroContext.widget;
+                              }
+
+                              return ClipRRect(
+                                borderRadius:
+                                    BorderRadius.circular(1 - animation.value) *
+                                        ROUNDED_RADIUS.x,
+                                child: widget,
+                              );
+                            },
+                          );
+                        }),
                     backgroundDecoration: const BoxDecoration(
                       color: Colors.black,
                     ),
                   ),
           ),
         ),
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          crossAxisAlignment: CrossAxisAlignment.center,
-          mainAxisSize: MainAxisSize.max,
-          children: <Widget>[
-            Expanded(
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
-                child: LanguageSelector(
-                  setLanguage: widget.setLanguage,
-                  displayedLanguage: widget.language,
-                  selectedLanguages: selectedLanguages,
-                  foregroundColor: Colors.white,
+        SafeArea(
+          bottom: true,
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            mainAxisSize: MainAxisSize.max,
+            children: <Widget>[
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
+                  child: LanguageSelector(
+                    setLanguage: widget.setLanguage,
+                    displayedLanguage: widget.language,
+                    selectedLanguages: selectedLanguages,
+                    foregroundColor: Colors.white,
+                  ),
                 ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
         Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,


### PR DESCRIPTION
Hi everyone,

This one is not really important, but I find the animation smoother like so.
Basically, there is a Hero between the list of photos and the carousel in the editor.

The video doesn't reflect the "smoothness" of the transition: 
[Hero.webm](https://github.com/openfoodfacts/smooth-app/assets/246838/862d6b7b-bb94-4b0a-bec3-0f6fc1797a7b)
