### PR TITLE
fix: [iOS] Ensure the status bar is OK with the light theme

### DIFF
--- a/packages/smooth_app/lib/pages/preferences/user_preferences_page.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_page.dart
@@ -165,9 +165,9 @@ class _UserPreferencesPageState extends State<UserPreferencesPage>
     return SmoothScaffold(
       statusBarBackgroundColor: dark ? null : headerColor,
       brightness:
-      Theme.of(context).brightness == Brightness.light && Platform.isIOS
-          ? Brightness.dark
-          : Brightness.light,
+          Theme.of(context).brightness == Brightness.light && Platform.isIOS
+              ? Brightness.dark
+              : Brightness.light,
       contentBehindStatusBar: false,
       spaceBehindStatusBar: false,
       appBar: AppBar(

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_page.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_page.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -162,7 +164,10 @@ class _UserPreferencesPageState extends State<UserPreferencesPage>
     );
     return SmoothScaffold(
       statusBarBackgroundColor: dark ? null : headerColor,
-      brightness: Brightness.light,
+      brightness:
+      Theme.of(context).brightness == Brightness.light && Platform.isIOS
+          ? Brightness.dark
+          : Brightness.light,
       contentBehindStatusBar: false,
       spaceBehindStatusBar: false,
       appBar: AppBar(

--- a/packages/smooth_app/lib/pages/scan/scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/scan_page.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
@@ -47,7 +48,10 @@ class _ScanPageState extends State<ScanPage> {
     }
 
     return SmoothScaffold(
-      brightness: Brightness.light,
+      brightness:
+          Theme.of(context).brightness == Brightness.light && Platform.isIOS
+              ? Brightness.dark
+              : null,
       body: SafeArea(
         child: Column(
           children: <Widget>[


### PR DESCRIPTION
Hi everyone,

I don't really understand why on some screens, the color of the status bar is incorrect on iOS and only with the light theme.
As everything is OK on Android, I've only added an if for "is IOS" and "is light theme"

Before:
https://github.com/openfoodfacts/smooth-app/assets/246838/e59f8f8b-58bc-4b90-9090-2c319bb43cc2

After:
https://github.com/openfoodfacts/smooth-app/assets/246838/6b606a50-8686-4f08-9065-0edc91ebd506

