### PR TITLE
fix: Misplaced SafeArea Widget in the product image viewer

### DIFF
--- a/packages/smooth_app/lib/pages/product/product_image_viewer.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_viewer.dart
@@ -82,73 +82,74 @@ class _ProductImageViewerState extends State<ProductImageViewer> {
       _product,
       widget.imageField,
     );
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-      crossAxisAlignment: CrossAxisAlignment.center,
-      children: <Widget>[
-        Expanded(
-          child: Padding(
-            padding: const EdgeInsets.all(MINIMUM_TOUCH_SIZE / 2),
-            child: imageProvider == null
-                ? Stack(
-                    children: <Widget>[
-                      const SizedBox.expand(child: PictureNotFound()),
-                      Center(
-                        child: Text(
-                          selectedLanguages.isEmpty
-                              ? appLocalizations.edit_photo_language_none
-                              : appLocalizations
-                                  .edit_photo_language_not_this_one,
-                          style: Theme.of(context)
-                                  .textTheme
-                                  .headlineMedium
-                                  ?.copyWith(color: Colors.black) ??
-                              const TextStyle(color: Colors.black),
-                          textAlign: TextAlign.center,
-                        ),
-                      ),
-                    ],
-                  )
-                : PhotoView(
-                    minScale: 0.2,
-                    imageProvider: imageProvider,
-                    heroAttributes: PhotoViewHeroAttributes(
-                        tag: 'photo_${widget.imageField.offTag}',
-                        flightShuttleBuilder: (
-                          _,
-                          Animation<double> animation,
-                          HeroFlightDirection flightDirection,
-                          BuildContext fromHeroContext,
-                          BuildContext toHeroContext,
-                        ) {
-                          return AnimatedBuilder(
-                            animation: animation,
-                            builder: (_, __) {
-                              Widget widget;
-                              if (flightDirection == HeroFlightDirection.push) {
-                                widget = fromHeroContext.widget;
-                              } else {
-                                widget = toHeroContext.widget;
-                              }
 
-                              return ClipRRect(
-                                borderRadius:
-                                    BorderRadius.circular(1 - animation.value) *
-                                        ROUNDED_RADIUS.x,
-                                child: widget,
-                              );
-                            },
-                          );
-                        }),
-                    backgroundDecoration: const BoxDecoration(
-                      color: Colors.black,
+    return SafeArea(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: <Widget>[
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.all(MINIMUM_TOUCH_SIZE / 2),
+              child: imageProvider == null
+                  ? Stack(
+                      children: <Widget>[
+                        const SizedBox.expand(child: PictureNotFound()),
+                        Center(
+                          child: Text(
+                            selectedLanguages.isEmpty
+                                ? appLocalizations.edit_photo_language_none
+                                : appLocalizations
+                                    .edit_photo_language_not_this_one,
+                            style: Theme.of(context)
+                                    .textTheme
+                                    .headlineMedium
+                                    ?.copyWith(color: Colors.black) ??
+                                const TextStyle(color: Colors.black),
+                            textAlign: TextAlign.center,
+                          ),
+                        ),
+                      ],
+                    )
+                  : PhotoView(
+                      minScale: 0.2,
+                      imageProvider: imageProvider,
+                      heroAttributes: PhotoViewHeroAttributes(
+                          tag: 'photo_${widget.imageField.offTag}',
+                          flightShuttleBuilder: (
+                            _,
+                            Animation<double> animation,
+                            HeroFlightDirection flightDirection,
+                            BuildContext fromHeroContext,
+                            BuildContext toHeroContext,
+                          ) {
+                            return AnimatedBuilder(
+                              animation: animation,
+                              builder: (_, __) {
+                                Widget widget;
+                                if (flightDirection ==
+                                    HeroFlightDirection.push) {
+                                  widget = fromHeroContext.widget;
+                                } else {
+                                  widget = toHeroContext.widget;
+                                }
+
+                                return ClipRRect(
+                                  borderRadius: BorderRadius.circular(
+                                          1 - animation.value) *
+                                      ROUNDED_RADIUS.x,
+                                  child: widget,
+                                );
+                              },
+                            );
+                          }),
+                      backgroundDecoration: const BoxDecoration(
+                        color: Colors.black,
+                      ),
                     ),
-                  ),
+            ),
           ),
-        ),
-        SafeArea(
-          bottom: true,
-          child: Row(
+          Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             crossAxisAlignment: CrossAxisAlignment.center,
             mainAxisSize: MainAxisSize.max,
@@ -166,36 +167,6 @@ class _ProductImageViewerState extends State<ProductImageViewer> {
               ),
             ],
           ),
-        ),
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          crossAxisAlignment: CrossAxisAlignment.center,
-          mainAxisSize: MainAxisSize.max,
-          children: <Widget>[
-            Expanded(
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
-                child: ProductImageServerButton(
-                  barcode: _barcode,
-                  imageField: widget.imageField,
-                  language: widget.language,
-                ),
-              ),
-            ),
-            Expanded(
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
-                child: ProductImageLocalButton(
-                  firstPhoto: imageProvider == null,
-                  barcode: _barcode,
-                  imageField: widget.imageField,
-                  language: widget.language,
-                ),
-              ),
-            ),
-          ],
-        ),
-        if (imageProvider != null)
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             crossAxisAlignment: CrossAxisAlignment.center,
@@ -204,18 +175,50 @@ class _ProductImageViewerState extends State<ProductImageViewer> {
               Expanded(
                 child: Padding(
                   padding: const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
-                  child: _getUnselectImageButton(appLocalizations),
+                  child: ProductImageServerButton(
+                    barcode: _barcode,
+                    imageField: widget.imageField,
+                    language: widget.language,
+                  ),
                 ),
               ),
               Expanded(
                 child: Padding(
                   padding: const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
-                  child: _getEditImageButton(appLocalizations),
+                  child: ProductImageLocalButton(
+                    firstPhoto: imageProvider == null,
+                    barcode: _barcode,
+                    imageField: widget.imageField,
+                    language: widget.language,
+                  ),
                 ),
               ),
             ],
           ),
-      ],
+          if (imageProvider != null)
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              mainAxisSize: MainAxisSize.max,
+              children: <Widget>[
+                Expanded(
+                  child: Padding(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
+                    child: _getUnselectImageButton(appLocalizations),
+                  ),
+                ),
+                Expanded(
+                  child: Padding(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
+                    child: _getEditImageButton(appLocalizations),
+                  ),
+                ),
+              ],
+            ),
+        ],
+      ),
     );
   }
 


### PR DESCRIPTION
Hi everyone,

On iOS, some buttons were behind the native bottom bar:
https://user-images.githubusercontent.com/246838/245729726-31f9d20a-538f-4244-81c9-2b59d3e9a770.PNG

We had a SafeArea, but not placed correctly in the hierarchy => it's now OK on both Android and iOS

iOS:
https://github.com/openfoodfacts/smooth-app/assets/246838/e234970d-5f95-4eb0-83c7-e4869d525a63

Android:
![Screenshot_1686753072](https://github.com/openfoodfacts/smooth-app/assets/246838/9eec2d43-98e8-4297-bc77-d78f475092f6)

It's part of #4140
