### PR TITLE
fix: 4140 : rounded rectangle for the language selector

### DIFF
--- a/packages/smooth_app/lib/generic_lib/widgets/language_selector.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/language_selector.dart
@@ -50,25 +50,35 @@ class LanguageSelector extends StatelessWidget {
           await setLanguage(language);
         },
         borderRadius: ANGULAR_BORDER_RADIUS,
-        child: ListTile(
-          leading: Icon(
-            Icons.language,
-            color: foregroundColor,
-          ),
-          title: Text(
-            '$nameInLanguage ($nameInEnglish)',
-            softWrap: false,
-            overflow: TextOverflow.fade,
-            style: Theme.of(context)
-                    .textTheme
-                    .bodyMedium
-                    ?.copyWith(color: foregroundColor) ??
-                TextStyle(color: foregroundColor),
-          ),
-          trailing: Icon(
-            Icons.arrow_drop_down,
-            color: foregroundColor,
-          ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: <Widget>[
+            Icon(
+              Icons.language,
+              color: foregroundColor,
+            ),
+            Expanded(
+              flex: 1,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: LARGE_SPACE),
+                child: Text(
+                  '$nameInLanguage ($nameInEnglish)',
+                  softWrap: false,
+                  overflow: TextOverflow.fade,
+                  style: Theme.of(context)
+                          .textTheme
+                          .bodyMedium
+                          ?.copyWith(color: foregroundColor) ??
+                      TextStyle(color: foregroundColor),
+                ),
+              ),
+            ),
+            Icon(
+              Icons.arrow_drop_down,
+              color: foregroundColor,
+            ),
+          ],
         ),
       ),
     );

--- a/packages/smooth_app/lib/pages/onboarding/country_selector.dart
+++ b/packages/smooth_app/lib/pages/onboarding/country_selector.dart
@@ -163,14 +163,25 @@ class _CountrySelectorState extends State<CountrySelector> {
             decoration: const BoxDecoration(
               borderRadius: BorderRadius.all(Radius.circular(10)),
             ),
-            child: ListTile(
-              leading: const Icon(Icons.public),
-              title: Text(
-                selectedCountry.name,
-                style: widget.textStyle ??
-                    Theme.of(context).textTheme.displaySmall,
-              ),
-              trailing: const Icon(Icons.arrow_drop_down),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: <Widget>[
+                const Icon(Icons.public),
+                Expanded(
+                  flex: 1,
+                  child: Padding(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: LARGE_SPACE),
+                    child: Text(
+                      selectedCountry.name,
+                      style: widget.textStyle ??
+                          Theme.of(context).textTheme.displaySmall,
+                    ),
+                  ),
+                ),
+                const Icon(Icons.arrow_drop_down),
+              ],
             ),
           ),
         );

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_settings.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_settings.dart
@@ -268,8 +268,15 @@ class _ApplicationSettings extends StatelessWidget {
             appLocalizations.country_chooser_label,
             style: themeData.textTheme.headlineMedium,
           ),
-          subtitle: CountrySelector(
-            textStyle: themeData.textTheme.bodyMedium,
+          subtitle: Padding(
+            padding: const EdgeInsets.only(
+              top: SMALL_SPACE,
+              bottom: SMALL_SPACE,
+              left: SMALL_SPACE,
+            ),
+            child: CountrySelector(
+              textStyle: themeData.textTheme.bodyMedium,
+            ),
           ),
           minVerticalPadding: MEDIUM_SPACE,
         ),
@@ -279,19 +286,26 @@ class _ApplicationSettings extends StatelessWidget {
             appLocalizations.choose_app_language,
             style: themeData.textTheme.headlineMedium,
           ),
-          subtitle: LanguageSelector(
-            setLanguage: (final OpenFoodFactsLanguage? language) async {
-              if (language != null) {
-                ProductQuery.setLanguage(
-                  context,
-                  userPreferences,
-                  languageCode: language.code,
-                );
-              }
-            },
-            selectedLanguages: <OpenFoodFactsLanguage>[
-              ProductQuery.getLanguage(),
-            ],
+          subtitle: Padding(
+            padding: const EdgeInsets.only(
+              top: SMALL_SPACE,
+              bottom: SMALL_SPACE,
+              left: SMALL_SPACE,
+            ),
+            child: LanguageSelector(
+              setLanguage: (final OpenFoodFactsLanguage? language) async {
+                if (language != null) {
+                  ProductQuery.setLanguage(
+                    context,
+                    userPreferences,
+                    languageCode: language.code,
+                  );
+                }
+              },
+              selectedLanguages: <OpenFoodFactsLanguage>[
+                ProductQuery.getLanguage(),
+              ],
+            ),
           ),
           minVerticalPadding: MEDIUM_SPACE,
         ),

--- a/packages/smooth_app/lib/pages/product/product_image_viewer.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_viewer.dart
@@ -156,15 +156,27 @@ class _ProductImageViewerState extends State<ProductImageViewer> {
             children: <Widget>[
               Expanded(
                 child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
-                  child: LanguageSelector(
-                    setLanguage: widget.setLanguage,
-                    displayedLanguage: widget.language,
-                    selectedLanguages: selectedLanguages,
-                    foregroundColor: Colors.white,
+                  padding: const EdgeInsets.all(SMALL_SPACE),
+                  child: Container(
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(LARGE_SPACE),
+                      border: Border.all(
+                        color: Colors.white,
+                        width: 3,
+                      ),
+                    ),
+                    child: Padding(
+                      padding: const EdgeInsets.all(SMALL_SPACE),
+                      child: LanguageSelector(
+                        setLanguage: widget.setLanguage,
+                        displayedLanguage: widget.language,
+                        selectedLanguages: selectedLanguages,
+                        foregroundColor: Colors.white,
+                      ),
+                    ),
                   ),
                 ),
-              ),
+              )
             ],
           ),
           Row(


### PR DESCRIPTION
### What
- Added a rounded rectangle for the language selector on the image edit page.
- Had to change both the country and language selectors.

### Screenshots
| before | after | country + language |
| -- | -- | -- |
| ![Screenshot_2023-06-15-08-44-18](https://github.com/openfoodfacts/smooth-app/assets/11576431/1723650e-37b8-47e8-a711-7b65c07dec3b) | ![Screenshot_2023-06-15-09-00-49](https://github.com/openfoodfacts/smooth-app/assets/11576431/06c484d3-714a-4912-889b-4c9bf108f627) | ![Screenshot_2023-06-15-08-56-05](https://github.com/openfoodfacts/smooth-app/assets/11576431/0e19f47c-919e-4039-a55a-48d4a2a23fbc) |

### Fixes bug(s)
- Fixes: #4140

### Impacted files
* `country_selector.dart`: displays a `Row` instead of a `ListTile` (too big)
* `language_selector.dart`: displays a `Row` instead of a `ListTile` (too big)
* `product_image_viewer.dart`: added a rounded rectangle for the language selector
* `user_preferences_settings.dart`: added some paddings as the `Row` is smaller than a `ListTile`