### PR TITLE
fix: Force all `Appbar`s in the product edition to have left aligned titles

### DIFF
--- a/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
@@ -82,6 +82,7 @@ class _AddBasicDetailsPageState extends State<AddBasicDetailsPage> {
       onWillPop: () async => _mayExitPage(saving: false),
       child: SmoothScaffold(
         appBar: SmoothAppBar(
+          centerTitle: false,
           title: Text(appLocalizations.basic_details),
           subTitle: widget.product.productName != null
               ? Text(widget.product.productName!,

--- a/packages/smooth_app/lib/pages/product/add_other_details_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_other_details_page.dart
@@ -57,6 +57,7 @@ class _AddOtherDetailsPageState extends State<AddOtherDetailsPage> {
       onWillPop: () async => _mayExitPage(saving: false),
       child: SmoothScaffold(
         appBar: SmoothAppBar(
+          centerTitle: false,
           title:
               Text(appLocalizations.edit_product_form_item_other_details_title),
           subTitle: widget.product.productName != null

--- a/packages/smooth_app/lib/pages/product/common/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_page.dart
@@ -128,6 +128,7 @@ class _ProductListPageState extends State<ProductListPage>
                   icon: const Icon(Icons.compare_arrows),
                 ),
       appBar: SmoothAppBar(
+        centerTitle: _selectionMode ? false : null,
         actions: !(enableClear || enableRename)
             ? null
             : <Widget>[

--- a/packages/smooth_app/lib/pages/product/edit_ocr_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_ocr_page.dart
@@ -141,6 +141,7 @@ class _EditOcrPageState extends State<EditOcrPage> {
     return SmoothScaffold(
       extendBodyBehindAppBar: true,
       appBar: SmoothAppBar(
+        centerTitle: false,
         title: Text(
           _helper.getTitle(appLocalizations),
           style: appbarTextStyle,

--- a/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
@@ -63,6 +63,7 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView> {
     _selectedImages = getSelectedImages(_product, ProductQuery.getLanguage());
     return SmoothScaffold(
       appBar: SmoothAppBar(
+        centerTitle: false,
         title: Text(appLocalizations.edit_product_form_item_photos_title),
         subTitle: _product.productName == null
             ? null

--- a/packages/smooth_app/lib/pages/product/product_image_swipeable_view.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_swipeable_view.dart
@@ -91,6 +91,7 @@ class _ProductImageSwipeableViewState extends State<ProductImageSwipeableView> {
         foregroundColor: WHITE_COLOR,
         systemOverlayStyle: SystemUiOverlayStyle.light,
         elevation: 0,
+        centerTitle: false,
         title: ValueListenableBuilder<int>(
           valueListenable: _currentImageDataIndex,
           builder: (_, int index, __) => Text(

--- a/packages/smooth_app/lib/pages/product/simple_input_page.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page.dart
@@ -91,6 +91,7 @@ class _SimpleInputPageState extends State<SimpleInputPage> {
       child: UnfocusWhenTapOutside(
         child: SmoothScaffold(
           appBar: SmoothAppBar(
+            centerTitle: false,
             title: AutoSizeText(
               getProductName(widget.product, appLocalizations),
               maxLines: widget.product.barcode?.isNotEmpty == true ? 1 : 2,


### PR DESCRIPTION
Hi everyone,

In this PR, I force all titles in the Product edition workflow to never have centered titles on iOS.
However, in the other screens (prefs, history…), we keep the default behavior:


https://github.com/openfoodfacts/smooth-app/assets/246838/a22610af-fbc1-4779-8078-c3810a550f7a

