### PR TITLE
fix: When a barcode is invalid, remove the blank space behind it

### DIFF
--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -360,7 +360,7 @@ class _SvgIcon extends StatelessWidget {
 }
 
 /// Barcodes only allowed have a length of 7, 8, 12 or 13 characters
-class _ProductBarcode extends StatelessWidget {
+class _ProductBarcode extends StatefulWidget {
   _ProductBarcode({required this.product, Key? key})
       : assert(product.barcode?.isNotEmpty == true),
         assert(isAValidBarcode(product.barcode)),
@@ -369,6 +369,16 @@ class _ProductBarcode extends StatelessWidget {
   static const double _barcodeHeight = 120.0;
 
   final Product product;
+
+  @override
+  State<_ProductBarcode> createState() => _ProductBarcodeState();
+
+  static bool isAValidBarcode(String? barcode) =>
+      barcode != null && <int>[7, 8, 12, 13].contains(barcode.length);
+}
+
+class _ProductBarcodeState extends State<_ProductBarcode> {
+  bool _isAnInvalidBarcode = false;
 
   @override
   Widget build(BuildContext context) {
@@ -382,19 +392,27 @@ class _ProductBarcode extends StatelessWidget {
         vertical: SMALL_SPACE,
       ),
       barcode: _barcodeType,
-      data: product.barcode!,
+      data: widget.product.barcode!,
       color: brightness == Brightness.dark ? Colors.white : Colors.black,
-      errorBuilder: (final BuildContext context, String? _) => Text(
-        '${appLocalizations.edit_product_form_item_barcode}\n'
-        '${product.barcode}',
-        textAlign: TextAlign.center,
-      ),
-      height: _barcodeHeight,
+      errorBuilder: (final BuildContext context, String? _) {
+        if (!_isAnInvalidBarcode) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            setState(() => _isAnInvalidBarcode = true);
+          });
+        }
+
+        return Text(
+          '${appLocalizations.edit_product_form_item_barcode}\n'
+          '${widget.product.barcode}',
+          textAlign: TextAlign.center,
+        );
+      },
+      height: _isAnInvalidBarcode ? null : _ProductBarcode._barcodeHeight,
     );
   }
 
   Barcode get _barcodeType {
-    switch (product.barcode!.length) {
+    switch (widget.product.barcode!.length) {
       case 7:
       case 8:
         return Barcode.ean8();
@@ -405,7 +423,4 @@ class _ProductBarcode extends StatelessWidget {
         throw Exception('Unknown barcode type!');
     }
   }
-
-  static bool isAValidBarcode(String? barcode) =>
-      barcode != null && <int>[7, 8, 12, 13].contains(barcode.length);
 }


### PR DESCRIPTION
Hi everyone,

If somehow a barcode is invalid (eg: invalid checksum), I've removed the weird blank space.
Before:
![Simulator Screenshot - iPhone 14 Pro - 2023-06-15 at 12 56 54](https://github.com/openfoodfacts/smooth-app/assets/246838/5c04fadd-ff2d-4882-81c5-cf3993533b20)

After:
![Simulator Screenshot - iPhone 14 Pro - 2023-06-15 at 13 14 24](https://github.com/openfoodfacts/smooth-app/assets/246838/9d81bbc9-8f80-4b7a-a57d-2c54a7171549)