### PR TITLE
fix: 4122 - added a country filter for hunger games

### DIFF
--- a/packages/smooth_app/lib/query/random_questions_query.dart
+++ b/packages/smooth_app/lib/query/random_questions_query.dart
@@ -11,12 +11,12 @@ class RandomQuestionsQuery extends QuestionsQuery {
     final LocalDatabase localDatabase,
     final int count,
   ) async {
-    final RobotoffQuestionResult result =
-        await RobotoffAPIClient.getRandomQuestions(
+    final RobotoffQuestionResult result = await RobotoffAPIClient.getQuestions(
       ProductQuery.getLanguage(),
-      OpenFoodAPIConfiguration.globalUser,
+      user: ProductQuery.getUser(),
+      country: ProductQuery.getCountry(),
       count: count,
-      // TODO(monsieurtanuki): should use Country too
+      questionOrder: RobotoffQuestionOrder.random,
     );
 
     if (result.questions?.isNotEmpty != true) {

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -923,10 +923,10 @@ packages:
     dependency: "direct main"
     description:
       name: openfoodfacts
-      sha256: cece543297ea60107b63cb7ba9a2bdb95fa2e1be9eb8d4f9c3816bff05f9f8b4
+      sha256: "3573e7024423dbce1823d70ae0ba56363bd7f26ed89200d4cdc502d3990f695b"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.2"
+    version: "2.6.0"
   openfoodfacts_flutter_lints:
     dependency: "direct dev"
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -96,7 +96,7 @@ dependencies:
 
 
 
-  openfoodfacts: 2.5.2
+  openfoodfacts: 2.6.0
   # openfoodfacts:
   #   path: ../../../openfoodfacts-dart
 


### PR DESCRIPTION
### What
- Without a filter on the country, hunger games suggested questions from all over the world - often France.
- Now we filter products/questions by country.

### Fixes bug(s)
- Fixes: #4122

### Impacted files
* `pubspec.lock`: wtf
* `pubspec.yaml`: upgraded to off-dart 2.6.0
* `random_questions_query.dart`: added a country filter for hunger games