### PR TITLE
refactor: reorder menuitems on history page

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1306,7 +1306,7 @@
     "@added_to_list_msg": {
         "description": "Message when products have been successfully added to a list"
     },
-    "user_list_popup_clear": "Clear",
+    "user_list_popup_clear": "Clear your history",
     "@user_list_popup_clear": {
         "description": "Short label of a 'clear list' popup"
     },

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1308,7 +1308,7 @@
     },
     "user_list_popup_clear": "Clear your history",
     "@user_list_popup_clear": {
-        "description": "Short label of a 'clear list' popup"
+        "description": "Short label of a 'clear your history list' popup"
     },
     "user_list_popup_rename": "Rename",
     "@user_list_popup_rename": {

--- a/packages/smooth_app/lib/pages/product/common/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_page.dart
@@ -199,24 +199,24 @@ class _ProductListPageState extends State<ProductListPage>
                   },
                   itemBuilder: (BuildContext context) =>
                       <PopupMenuEntry<String>>[
-                    if (enableClear)
-                      PopupMenuItem<String>(
-                        value: _popupActionClear,
-                        child: Text(appLocalizations.user_list_popup_clear),
-                      ),
                     if (enableRename)
                       PopupMenuItem<String>(
                         value: _popupActionRename,
                         child: Text(appLocalizations.user_list_popup_rename),
                       ),
                     PopupMenuItem<String>(
-                      value: _popupActionOpenInWeb,
-                      child: Text(appLocalizations.label_web),
-                    ),
-                    PopupMenuItem<String>(
                       value: _popupActionShare,
                       child: Text(appLocalizations.share),
                     ),
+                    PopupMenuItem<String>(
+                      value: _popupActionOpenInWeb,
+                      child: Text(appLocalizations.label_web),
+                    ),
+                    if (enableClear)
+                      PopupMenuItem<String>(
+                        value: _popupActionClear,
+                        child: Text(appLocalizations.user_list_popup_clear),
+                      ),
                   ],
                 )
               ],


### PR DESCRIPTION
### What
Reorder menu items of History Page from `Clear, View on the web, Share` to `Share, View on Web, Clear you history` 
### Screenshot
<!-- Insert a screenshot to provide visual record of your changes, if visible -->
![WhatsApp Image 2023-06-15 at 10 18 17 PM](https://github.com/openfoodfacts/smooth-app/assets/53305380/02097682-f6a9-4d16-ad2c-56613dc0d681)

- Fixes: #4152 
