### PR TITLE
feat: Unify all button bars in the product edition

### DIFF
--- a/packages/smooth_app/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/smooth_app/ios/Runner.xcodeproj/project.pbxproj
@@ -206,6 +206,7 @@
 			files = (
 			);
 			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
 			);
 			name = "Thin Binary";
 			outputPaths = (

--- a/packages/smooth_app/lib/generic_lib/dialogs/smooth_alert_dialog.dart
+++ b/packages/smooth_app/lib/generic_lib/dialogs/smooth_alert_dialog.dart
@@ -213,6 +213,7 @@ class SmoothActionButtonsBar extends StatelessWidget {
     this.negativeAction,
     this.axis,
     this.order,
+    this.padding,
     super.key,
   }) : assert(positiveAction != null || negativeAction != null,
             'At least one action must be passed!');
@@ -229,6 +230,7 @@ class SmoothActionButtonsBar extends StatelessWidget {
   final SmoothActionButton? negativeAction;
   final Axis? axis;
   final SmoothButtonsBarOrder? order;
+  final EdgeInsetsGeometry? padding;
 
   @override
   Widget build(BuildContext context) {
@@ -250,13 +252,17 @@ class SmoothActionButtonsBar extends StatelessWidget {
         );
       }
 
-      return Row(
-        mainAxisAlignment: MainAxisAlignment.spaceAround,
-        children: actions,
+      return Padding(
+        padding: padding ?? EdgeInsets.zero,
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceAround,
+          children: actions,
+        ),
       );
     } else {
-      return SizedBox(
+      return Container(
         width: double.infinity,
+        padding: padding ?? EdgeInsets.zero,
         child: Column(
           mainAxisAlignment: MainAxisAlignment.end,
           children: actions,

--- a/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
@@ -4,10 +4,10 @@ import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/background/background_task_details.dart';
 import 'package:smooth_app/cards/product_cards/product_image_carousel.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
-import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_text_form_field.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
+import 'package:smooth_app/pages/product/common/product_buttons.dart';
 import 'package:smooth_app/pages/product/common/product_refresher.dart';
 import 'package:smooth_app/pages/product/may_exit_page_helper.dart';
 import 'package:smooth_app/pages/product/multilingual_helper.dart';
@@ -81,6 +81,7 @@ class _AddBasicDetailsPageState extends State<AddBasicDetailsPage> {
     return WillPopScope(
       onWillPop: () async => _mayExitPage(saving: false),
       child: SmoothScaffold(
+        fixKeyboard: true,
         appBar: SmoothAppBar(
           centerTitle: false,
           title: Text(appLocalizations.basic_details),
@@ -91,85 +92,76 @@ class _AddBasicDetailsPageState extends State<AddBasicDetailsPage> {
         ),
         body: Form(
           key: _formKey,
-          child: ListView(
-            children: <Widget>[
-              Align(
-                alignment: AlignmentDirectional.topStart,
-                child: ProductImageCarousel(
-                  _product,
-                  height: size.height * 0.20,
+          child: Scrollbar(
+            child: ListView(
+              children: <Widget>[
+                Align(
+                  alignment: AlignmentDirectional.topStart,
+                  child: ProductImageCarousel(
+                    _product,
+                    height: size.height * 0.20,
+                  ),
                 ),
-              ),
-              SizedBox(height: _heightSpace),
-              Padding(
-                padding: EdgeInsets.symmetric(horizontal: size.width * 0.05),
-                child: Column(
-                  children: <Widget>[
-                    Text(
-                      appLocalizations.barcode_barcode(_product.barcode!),
-                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                            fontWeight: FontWeight.bold,
-                          ),
-                    ),
-                    SizedBox(height: _heightSpace),
-                    if (_multilingualHelper.isMonolingual())
-                      SmoothTextFormField(
-                        controller: _productNameController,
-                        type: TextFieldTypes.PLAIN_TEXT,
-                        hintText: appLocalizations.product_name,
-                      )
-                    else
-                      Card(
-                        child: Column(
-                          children: <Widget>[
-                            _multilingualHelper.getLanguageSelector(setState),
-                            Padding(
-                              padding: const EdgeInsets.all(8.0),
-                              child: SmoothTextFormField(
-                                controller: _productNameController,
-                                type: TextFieldTypes.PLAIN_TEXT,
-                                hintText: appLocalizations.product_name,
-                              ),
+                SizedBox(height: _heightSpace),
+                Padding(
+                  padding: EdgeInsets.symmetric(horizontal: size.width * 0.05),
+                  child: Column(
+                    children: <Widget>[
+                      Text(
+                        appLocalizations.barcode_barcode(_product.barcode!),
+                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                              fontWeight: FontWeight.bold,
                             ),
-                          ],
-                        ),
                       ),
-                    SizedBox(height: _heightSpace),
-                    SmoothTextFormField(
-                      controller: _brandNameController,
-                      type: TextFieldTypes.PLAIN_TEXT,
-                      hintText: appLocalizations.brand_name,
-                    ),
-                    SizedBox(height: _heightSpace),
-                    SmoothTextFormField(
-                      controller: _weightController,
-                      type: TextFieldTypes.PLAIN_TEXT,
-                      hintText: appLocalizations.quantity,
-                    ),
-                    SizedBox(height: _heightSpace),
-                  ],
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: LARGE_SPACE,
-                ),
-                child: SmoothActionButtonsBar(
-                  negativeAction: SmoothActionButton(
-                    text: appLocalizations.cancel,
-                    onPressed: () async => _exitPage(
-                      await _mayExitPage(saving: false),
-                    ),
+                      SizedBox(height: _heightSpace),
+                      if (_multilingualHelper.isMonolingual())
+                        SmoothTextFormField(
+                          controller: _productNameController,
+                          type: TextFieldTypes.PLAIN_TEXT,
+                          hintText: appLocalizations.product_name,
+                        )
+                      else
+                        Card(
+                          child: Column(
+                            children: <Widget>[
+                              _multilingualHelper.getLanguageSelector(setState),
+                              Padding(
+                                padding: const EdgeInsets.all(8.0),
+                                child: SmoothTextFormField(
+                                  controller: _productNameController,
+                                  type: TextFieldTypes.PLAIN_TEXT,
+                                  hintText: appLocalizations.product_name,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      SizedBox(height: _heightSpace),
+                      SmoothTextFormField(
+                        controller: _brandNameController,
+                        type: TextFieldTypes.PLAIN_TEXT,
+                        hintText: appLocalizations.brand_name,
+                      ),
+                      SizedBox(height: _heightSpace),
+                      SmoothTextFormField(
+                        controller: _weightController,
+                        type: TextFieldTypes.PLAIN_TEXT,
+                        hintText: appLocalizations.quantity,
+                      ),
+                      SizedBox(height: _heightSpace),
+                    ],
                   ),
-                  positiveAction: SmoothActionButton(
-                    text: appLocalizations.save,
-                    onPressed: () async => _exitPage(
-                      await _mayExitPage(saving: true),
-                    ),
-                  ),
                 ),
-              ),
-            ],
+              ],
+            ),
+          ),
+        ),
+        bottomNavigationBar: ProductBottomButtonsBar(
+          onSave: () async => _exitPage(
+            await _mayExitPage(saving: true),
+          ),
+          onCancel: () async => _exitPage(
+            await _mayExitPage(saving: false),
           ),
         ),
       ),

--- a/packages/smooth_app/lib/pages/product/add_other_details_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_other_details_page.dart
@@ -3,9 +3,9 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/background/background_task_details.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
-import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_text_form_field.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
+import 'package:smooth_app/pages/product/common/product_buttons.dart';
 import 'package:smooth_app/pages/product/may_exit_page_helper.dart';
 import 'package:smooth_app/pages/text_field_helper.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
@@ -56,6 +56,7 @@ class _AddOtherDetailsPageState extends State<AddOtherDetailsPage> {
     return WillPopScope(
       onWillPop: () async => _mayExitPage(saving: false),
       child: SmoothScaffold(
+        fixKeyboard: true,
         appBar: SmoothAppBar(
           centerTitle: false,
           title:
@@ -67,49 +68,40 @@ class _AddOtherDetailsPageState extends State<AddOtherDetailsPage> {
         ),
         body: Form(
           key: _formKey,
-          child: ListView(
-            children: <Widget>[
-              SizedBox(height: _heightSpace),
-              Padding(
-                padding: EdgeInsets.symmetric(horizontal: size.width * 0.05),
-                child: Column(
-                  children: <Widget>[
-                    Text(
-                      appLocalizations.barcode_barcode(_product.barcode!),
-                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                            fontWeight: FontWeight.bold,
-                          ),
-                    ),
-                    SizedBox(height: _heightSpace),
-                    SmoothTextFormField(
-                      controller: _websiteController,
-                      type: TextFieldTypes.PLAIN_TEXT,
-                      hintText: appLocalizations.product_field_website_title,
-                    ),
-                    SizedBox(height: _heightSpace),
-                  ],
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: LARGE_SPACE,
-                ),
-                child: SmoothActionButtonsBar(
-                  negativeAction: SmoothActionButton(
-                    text: appLocalizations.cancel,
-                    onPressed: () async => _exitPage(
-                      await _mayExitPage(saving: false),
-                    ),
-                  ),
-                  positiveAction: SmoothActionButton(
-                    text: appLocalizations.save,
-                    onPressed: () async => _exitPage(
-                      await _mayExitPage(saving: true),
-                    ),
+          child: Scrollbar(
+            child: ListView(
+              children: <Widget>[
+                SizedBox(height: _heightSpace),
+                Padding(
+                  padding: EdgeInsets.symmetric(horizontal: size.width * 0.05),
+                  child: Column(
+                    children: <Widget>[
+                      Text(
+                        appLocalizations.barcode_barcode(_product.barcode!),
+                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                              fontWeight: FontWeight.bold,
+                            ),
+                      ),
+                      SizedBox(height: _heightSpace),
+                      SmoothTextFormField(
+                        controller: _websiteController,
+                        type: TextFieldTypes.PLAIN_TEXT,
+                        hintText: appLocalizations.product_field_website_title,
+                      ),
+                      SizedBox(height: _heightSpace),
+                    ],
                   ),
                 ),
-              ),
-            ],
+              ],
+            ),
+          ),
+        ),
+        bottomNavigationBar: ProductBottomButtonsBar(
+          onSave: () async => _exitPage(
+            await _mayExitPage(saving: true),
+          ),
+          onCancel: () async => _exitPage(
+            await _mayExitPage(saving: false),
           ),
         ),
       ),

--- a/packages/smooth_app/lib/pages/product/common/product_buttons.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_buttons.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
+
+/// A button bar containing two actions : Save and Cancel
+/// To ensure a fully working scroll, please set the [fixKeyboard] attribute in
+/// the [SmoothScaffold] to [true]
+class ProductBottomButtonsBar extends StatelessWidget {
+  const ProductBottomButtonsBar({
+    required this.onSave,
+    required this.onCancel,
+    super.key,
+  });
+
+  final VoidCallback onSave;
+  final VoidCallback onCancel;
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+
+    return SafeArea(
+      child: SmoothActionButtonsBar(
+        axis: Axis.horizontal,
+        padding: const EdgeInsets.symmetric(horizontal: LARGE_SPACE),
+        positiveAction: SmoothActionButton(
+          text: appLocalizations.save,
+          onPressed: onSave,
+        ),
+        negativeAction: SmoothActionButton(
+          text: appLocalizations.cancel,
+          onPressed: onCancel,
+        ),
+      ),
+    );
+  }
+}

--- a/packages/smooth_app/lib/pages/product/edit_new_packagings.dart
+++ b/packages/smooth_app/lib/pages/product/edit_new_packagings.dart
@@ -6,12 +6,12 @@ import 'package:provider/provider.dart';
 import 'package:smooth_app/background/background_task_details.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
-import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/image_field_extension.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/pages/image_crop_page.dart';
+import 'package:smooth_app/pages/product/common/product_buttons.dart';
 import 'package:smooth_app/pages/product/edit_new_packagings_component.dart';
 import 'package:smooth_app/pages/product/edit_new_packagings_helper.dart';
 import 'package:smooth_app/pages/product/may_exit_page_helper.dart';
@@ -181,30 +181,12 @@ class _EditNewPackagingsState extends State<EditNewPackagings> {
         ),
       ),
     );
-    children.add(
-      Padding(
-        padding: const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
-        child: SmoothActionButtonsBar(
-          axis: Axis.horizontal,
-          positiveAction: SmoothActionButton(
-            text: appLocalizations.save,
-            onPressed: () async => _exitPage(
-              await _mayExitPage(saving: true),
-            ),
-          ),
-          negativeAction: SmoothActionButton(
-            text: appLocalizations.cancel,
-            onPressed: () async => _exitPage(
-              await _mayExitPage(saving: false),
-            ),
-          ),
-        ),
-      ),
-    );
+
     return WillPopScope(
       onWillPop: () async => _mayExitPage(saving: false),
       child: UnfocusWhenTapOutside(
         child: SmoothScaffold(
+          fixKeyboard: true,
           appBar: SmoothAppBar(
             title: Text(appLocalizations.edit_packagings_title),
             subTitle: _product.productName != null
@@ -218,6 +200,14 @@ class _EditNewPackagingsState extends State<EditNewPackagings> {
           body: ListView(
             padding: const EdgeInsets.only(top: LARGE_SPACE),
             children: children,
+          ),
+          bottomNavigationBar: ProductBottomButtonsBar(
+            onSave: () async => _exitPage(
+              await _mayExitPage(saving: true),
+            ),
+            onCancel: () async => _exitPage(
+              await _mayExitPage(saving: false),
+            ),
           ),
         ),
       ),

--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -8,11 +8,11 @@ import 'package:provider/provider.dart';
 import 'package:smooth_app/background/background_task_details.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
-import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/image_field_extension.dart';
 import 'package:smooth_app/helpers/text_input_formatters_helper.dart';
+import 'package:smooth_app/pages/product/common/product_buttons.dart';
 import 'package:smooth_app/pages/product/common/product_refresher.dart';
 import 'package:smooth_app/pages/product/may_exit_page_helper.dart';
 import 'package:smooth_app/pages/product/nutrition_add_nutrient_button.dart';
@@ -191,6 +191,7 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
     return WillPopScope(
       onWillPop: () async => _mayExitPage(saving: false),
       child: SmoothScaffold(
+        fixKeyboard: true,
         appBar: SmoothAppBar(
           title: AutoSizeText(
             appLocalizations.nutrition_page_title,
@@ -209,36 +210,20 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded> {
             horizontal: LARGE_SPACE,
             vertical: SMALL_SPACE,
           ),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              Flexible(
-                flex: 1,
-                child: Form(
-                  key: _formKey,
-                  child: Provider<List<FocusNode>>.value(
-                    value: focusNodes,
-                    child: ListView(children: children),
-                  ),
-                ),
-              ),
-              SmoothActionButtonsBar(
-                axis: Axis.horizontal,
-                positiveAction: SmoothActionButton(
-                  text: appLocalizations.save,
-                  onPressed: () async => _exitPage(
-                    await _mayExitPage(saving: true),
-                  ),
-                ),
-                negativeAction: SmoothActionButton(
-                  text: appLocalizations.cancel,
-                  onPressed: () async => _exitPage(
-                    await _mayExitPage(saving: false),
-                  ),
-                ),
-              ),
-            ],
+          child: Form(
+            key: _formKey,
+            child: Provider<List<FocusNode>>.value(
+              value: focusNodes,
+              child: ListView(children: children),
+            ),
+          ),
+        ),
+        bottomNavigationBar: ProductBottomButtonsBar(
+          onSave: () async => _exitPage(
+            await _mayExitPage(saving: true),
+          ),
+          onCancel: () async => _exitPage(
+            await _mayExitPage(saving: false),
           ),
         ),
       ),

--- a/packages/smooth_app/lib/pages/product/simple_input_page.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page.dart
@@ -5,11 +5,11 @@ import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/background/background_task_details.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
-import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/collections_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
+import 'package:smooth_app/pages/product/common/product_buttons.dart';
 import 'package:smooth_app/pages/product/may_exit_page_helper.dart';
 import 'package:smooth_app/pages/product/simple_input_page_helpers.dart';
 import 'package:smooth_app/pages/product/simple_input_text_field.dart';
@@ -41,6 +41,7 @@ class SimpleInputPage extends StatefulWidget {
 
 class _SimpleInputPageState extends State<SimpleInputPage> {
   final List<TextEditingController> _controllers = <TextEditingController>[];
+
   @override
   void initState() {
     super.initState();
@@ -90,6 +91,7 @@ class _SimpleInputPageState extends State<SimpleInputPage> {
       onWillPop: () async => _mayExitPage(saving: false),
       child: UnfocusWhenTapOutside(
         child: SmoothScaffold(
+          fixKeyboard: true,
           appBar: SmoothAppBar(
             centerTitle: false,
             title: AutoSizeText(
@@ -102,35 +104,16 @@ class _SimpleInputPageState extends State<SimpleInputPage> {
           ),
           body: Padding(
             padding: const EdgeInsets.all(SMALL_SPACE),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                Flexible(
-                  flex: 1,
-                  child: Scrollbar(
-                    child: ListView(children: simpleInputs),
-                  ),
-                ),
-                Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
-                  child: SmoothActionButtonsBar(
-                    axis: Axis.horizontal,
-                    positiveAction: SmoothActionButton(
-                      text: appLocalizations.save,
-                      onPressed: () async => _exitPage(
-                        await _mayExitPage(saving: true),
-                      ),
-                    ),
-                    negativeAction: SmoothActionButton(
-                      text: appLocalizations.cancel,
-                      onPressed: () async => _exitPage(
-                        await _mayExitPage(saving: false),
-                      ),
-                    ),
-                  ),
-                ),
-              ],
+            child: Scrollbar(
+              child: ListView(children: simpleInputs),
+            ),
+          ),
+          bottomNavigationBar: ProductBottomButtonsBar(
+            onSave: () async => _exitPage(
+              await _mayExitPage(saving: true),
+            ),
+            onCancel: () async => _exitPage(
+              await _mayExitPage(saving: false),
             ),
           ),
         ),

--- a/packages/smooth_app/lib/widgets/smooth_scaffold.dart
+++ b/packages/smooth_app/lib/widgets/smooth_scaffold.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:device_preview/device_preview.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -110,11 +109,8 @@ class SmoothScaffoldState extends ScaffoldState {
     }
 
     if ((widget as SmoothScaffold).fixKeyboard) {
-      double padding = MediaQuery.of(context).viewInsets.bottom;
-
-      if (DevicePreview.isEnabled(context)) {
-        padding -= MediaQuery.of(context).viewPadding.top;
-      }
+      final double padding = MediaQuery.of(context).viewInsets.bottom -
+          MediaQuery.of(context).viewPadding.bottom;
 
       if (padding > 0.0) {
         child = Padding(


### PR DESCRIPTION
Hi everyone,

This PR does multiple things:
- Provide a unified Widget for the two buttons, Cancel and Save
- Ensure all buttons are always at the bottom of the screen for consistency
- Ensure a SafeArea is always there (for iOS), by migrating it to the `bottomNavigationBar` attribute of the `Scaffold`
- Add a few missing `Scrollbar`

Demo on Android: 
[Android.webm](https://github.com/openfoodfacts/smooth-app/assets/246838/54a95cf3-ac53-4ce9-b2c9-28b858fd5b26)


Demo on iOS: 
https://github.com/openfoodfacts/smooth-app/assets/246838/aece5b0e-a438-46d9-abaf-aa228b20d813