### PR TITLE
feat: Allow to animate lists (in the product edition flow)

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1116,6 +1116,15 @@
     "@edit_product_label": {
         "description": "Edit product button label"
     },
+    "edit_product_form_item_add_action": "Add a new {itemType}",
+    "description": "Tooltip to show when the user long presses the (+) button",
+    "@edit_product_form_item_add_action": {
+        "placeholders": {
+            "itemType": {
+                "type": "String"
+            }
+        }
+    },
     "edit_product_form_item_barcode": "Barcode",
     "@edit_product_form_item_barcode": {
         "description": "Product edition - Barcode"
@@ -1156,6 +1165,10 @@
     "@edit_product_form_item_labels_hint": {
         "description": "Product edition - Labels - input textfield hint"
     },
+    "edit_product_form_item_labels_type": "label",
+    "@edit_product_form_item_labels_type": {
+        "description": "Product edition - Labels - input textfield label"
+    },
     "edit_product_form_item_stores_title": "Stores",
     "@edit_product_form_item_stores_title": {
         "description": "Product edition - Stores - Title"
@@ -1164,6 +1177,10 @@
     "@edit_product_form_item_stores_hint": {
         "description": "Product edition - Stores - input textfield hint"
     },
+    "edit_product_form_item_stores_type": "store",
+    "@edit_product_form_item_stores_type": {
+        "description": "Product edition - Stores - input textfield type"
+    },
     "edit_product_form_item_origins_title": "Origins",
     "@edit_product_form_item_origins_title": {
         "description": "Product edition - Origins - Title"
@@ -1171,6 +1188,10 @@
     "edit_product_form_item_origins_hint": "Spain",
     "@edit_product_form_item_origins_hint": {
         "description": "Product edition - Origins - input textfield hint"
+    },
+    "edit_product_form_item_origins_type": "country",
+    "@edit_product_form_item_origins_type": {
+        "description": "Product edition - Origins - input textfield type"
     },
     "edit_product_form_item_origins_explainer_1": "Add any indications of origins you can find on the packaging. You need not worry about origins indicated directly in the ingredient list.",
     "@edit_product_form_item_origins_explainer_1": {
@@ -1188,6 +1209,10 @@
     "@edit_product_form_item_countries_hint": {
         "description": "Product edition - Countries - input textfield hint"
     },
+    "edit_product_form_item_countries_type": "country",
+    "@edit_product_form_item_countries_type": {
+        "description": "Product edition - Countries - input textfield type"
+    },
     "edit_product_form_item_countries_explanations": "Countries where the product is widely available (not including stores specialising in foreign products).",
     "@edit_product_form_item_countries_explanations": {
         "description": "Product edition - Countries - explanations"
@@ -1200,6 +1225,10 @@
     "@edit_product_form_item_emb_codes_hint": {
         "description": "Product edition - Traceability Codes - input textfield hint"
     },
+    "edit_product_form_item_emb_codes_type": "traceability code",
+    "@edit_product_form_item_emb_codes_type": {
+        "description": "Product edition - Traceability Codes - input textfield type"
+    },
     "edit_product_form_item_emb_codes_explanations": "In Europe, code in an ellipse with the 2 country initials followed by a number and CE.\nExamples: EMB 53062, FR 62.448.034 CE, 84 R 20, 33 RECOLTANT 522",
     "@edit_product_form_item_emb_codes_examples": {
         "description": "Product edition - EMB Codes - explanations"
@@ -1211,6 +1240,10 @@
     "edit_product_form_item_categories_hint": "category",
     "@edit_product_form_item_categories_hint": {
         "description": "Product edition - Categories - input textfield hint"
+    },
+    "edit_product_form_item_categories_type": "category",
+    "@edit_product_form_item_categories_type": {
+        "description": "Product edition - Categories - input textfield type"
     },
     "edit_product_form_item_categories_explainer_1": "Indicate only the most specific category. Parent categories will be automatically added.",
     "@edit_product_form_item_categories_explainer_1": {

--- a/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
@@ -83,6 +83,9 @@ abstract class AbstractSimpleInputPageHelper extends ChangeNotifier {
   /// Returns the hint of the "add" text field.
   String getAddHint(final AppLocalizations appLocalizations);
 
+  /// Returns the type of the text field (eg: label, category…).
+  String getTypeLabel(final AppLocalizations appLocalizations);
+
   /// Returns additional examples about the "add" text field.
   String? getAddExplanations(final AppLocalizations appLocalizations) => null;
 
@@ -167,6 +170,10 @@ class SimpleInputPageStoreHelper extends AbstractSimpleInputPageHelper {
       appLocalizations.edit_product_form_item_stores_hint;
 
   @override
+  String getTypeLabel(AppLocalizations appLocalizations) =>
+      appLocalizations.edit_product_form_item_stores_type;
+
+  @override
   TagType? getTagType() => null;
 
   @override
@@ -199,6 +206,10 @@ class SimpleInputPageOriginHelper extends AbstractSimpleInputPageHelper {
   @override
   String getAddHint(final AppLocalizations appLocalizations) =>
       appLocalizations.edit_product_form_item_origins_hint;
+
+  @override
+  String getTypeLabel(AppLocalizations appLocalizations) =>
+      appLocalizations.edit_product_form_item_origins_type;
 
   @override
   String? getAddExplanations(final AppLocalizations appLocalizations) =>
@@ -240,6 +251,10 @@ class SimpleInputPageEmbCodeHelper extends AbstractSimpleInputPageHelper {
   @override
   String getAddHint(final AppLocalizations appLocalizations) =>
       appLocalizations.edit_product_form_item_emb_codes_hint;
+
+  @override
+  String getTypeLabel(AppLocalizations appLocalizations) =>
+      appLocalizations.edit_product_form_item_emb_codes_type;
 
   @override
   String getAddExplanations(final AppLocalizations appLocalizations) =>
@@ -291,6 +306,10 @@ class SimpleInputPageLabelHelper extends AbstractSimpleInputPageHelper {
       appLocalizations.edit_product_form_item_labels_hint;
 
   @override
+  String getTypeLabel(AppLocalizations appLocalizations) =>
+      appLocalizations.edit_product_form_item_labels_type;
+
+  @override
   TagType? getTagType() => TagType.LABELS;
 
   @override
@@ -340,6 +359,10 @@ class SimpleInputPageCategoryHelper extends AbstractSimpleInputPageHelper {
       appLocalizations.edit_product_form_item_categories_hint;
 
   @override
+  String getTypeLabel(AppLocalizations appLocalizations) =>
+      appLocalizations.edit_product_form_item_categories_type;
+
+  @override
   TagType? getTagType() => TagType.CATEGORIES;
 
   @override
@@ -379,6 +402,10 @@ class SimpleInputPageCountryHelper extends AbstractSimpleInputPageHelper {
   @override
   String getAddHint(final AppLocalizations appLocalizations) =>
       appLocalizations.edit_product_form_item_countries_hint;
+
+  @override
+  String getTypeLabel(AppLocalizations appLocalizations) =>
+      appLocalizations.edit_product_form_item_countries_type;
 
   @override
   String getAddExplanations(final AppLocalizations appLocalizations) =>

--- a/packages/smooth_app/lib/pages/product/simple_input_widget.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_widget.dart
@@ -80,9 +80,13 @@ class _SimpleInputWidgetState extends State<SimpleInputWidget> {
                     controller: widget.controller,
                   ),
                 ),
-                IconButton(
-                  onPressed: _onRemoveItem,
-                  icon: const Icon(Icons.add_circle),
+                Tooltip(
+                  message: appLocalizations.edit_product_form_item_add_action(
+                      widget.helper.getTypeLabel(appLocalizations)),
+                  child: IconButton(
+                    onPressed: _onAddItem,
+                    icon: const Icon(Icons.add_circle),
+                  ),
                 )
               ],
             );
@@ -110,7 +114,7 @@ class _SimpleInputWidgetState extends State<SimpleInputWidget> {
                         .edit_product_form_item_remove_item_tooltip,
                     child: InkWell(
                       customBorder: const CircleBorder(),
-                      onTap: () => _onAddItem(term, position, child),
+                      onTap: () => _onRemoveItem(term, position, child),
                       child: const Padding(
                         padding: EdgeInsets.symmetric(
                           horizontal: MEDIUM_SPACE,
@@ -135,23 +139,7 @@ class _SimpleInputWidgetState extends State<SimpleInputWidget> {
     );
   }
 
-  void _onAddItem(String term, int position, Widget child) {
-    if (widget.helper.removeTerm(term)) {
-      _listKey.currentState?.removeItem(position,
-          (_, Animation<double> animation) {
-        return FadeTransition(
-          opacity: animation,
-          child: SizeTransition(
-            sizeFactor: animation,
-            child: ListTile(title: child),
-          ),
-        );
-      });
-      SmoothHapticFeedback.lightNotification();
-    }
-  }
-
-  void _onRemoveItem() {
+  void _onAddItem() {
     final List<String> terms = widget.controller.text.split(',');
 
     bool atLeastOneAnimatedItem = false;
@@ -170,5 +158,21 @@ class _SimpleInputWidgetState extends State<SimpleInputWidget> {
     }
 
     SmoothHapticFeedback.lightNotification();
+  }
+
+  void _onRemoveItem(String term, int position, Widget child) {
+    if (widget.helper.removeTerm(term)) {
+      _listKey.currentState?.removeItem(position,
+          (_, Animation<double> animation) {
+        return FadeTransition(
+          opacity: animation,
+          child: SizeTransition(
+            sizeFactor: animation,
+            child: ListTile(title: child),
+          ),
+        );
+      });
+      SmoothHapticFeedback.lightNotification();
+    }
   }
 }


### PR DESCRIPTION
Hi everyone,

As part of #3986, I want to be able to animate the insertion/removal of an item.
This PR simply adds this feature, that you can see in action: [AnimatedLists.webm](https://github.com/openfoodfacts/smooth-app/assets/246838/58679ab5-90e9-4a47-9e1e-2ef6a3214d1e)

Edit: I've also improved a bit the accessibility with the + button
![Screenshot_1687010455](https://github.com/openfoodfacts/smooth-app/assets/246838/dc2e53f7-658e-4e1c-a7a1-75717710802c)