### PR TITLE
feat: Improve the accessibility for the Edit product flow

### DIFF
--- a/packages/smooth_app/lib/generic_lib/dialogs/smooth_alert_dialog.dart
+++ b/packages/smooth_app/lib/generic_lib/dialogs/smooth_alert_dialog.dart
@@ -373,20 +373,24 @@ class _SmoothActionElevatedButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ThemeData themeData = Theme.of(context);
-    return SmoothSimpleButton(
-      onPressed: buttonData.onPressed,
-      minWidth: buttonData.minWidth ?? 20.0,
-      // Ensures FittedBox not used then even the one word text overflows into next line,
-      child: FittedBox(
-        fit: BoxFit.scaleDown,
-        child: Text(
-          buttonData.text.toUpperCase(),
-          textAlign: TextAlign.center,
-          overflow: TextOverflow.ellipsis,
-          maxLines: buttonData.lines ?? 2,
-          style: themeData.textTheme.bodyMedium!.copyWith(
-            fontWeight: FontWeight.bold,
-            color: buttonData.textColor ?? themeData.colorScheme.onPrimary,
+    return Semantics(
+      value: buttonData.text,
+      button: true,
+      excludeSemantics: true,
+      child: SmoothSimpleButton(
+        onPressed: buttonData.onPressed,
+        minWidth: buttonData.minWidth ?? 20.0,
+        child: FittedBox(
+          fit: BoxFit.scaleDown,
+          child: Text(
+            buttonData.text.toUpperCase(),
+            textAlign: TextAlign.center,
+            overflow: TextOverflow.ellipsis,
+            maxLines: buttonData.lines ?? 2,
+            style: themeData.textTheme.bodyMedium!.copyWith(
+              fontWeight: FontWeight.bold,
+              color: buttonData.textColor ?? themeData.colorScheme.onPrimary,
+            ),
           ),
         ),
       ),
@@ -413,35 +417,40 @@ class _SmoothActionFlatButton extends StatelessWidget {
           ),
         ),
       ),
-      child: TextButton(
-        onPressed: buttonData.onPressed,
-        style: TextButton.styleFrom(
-          shape: const RoundedRectangleBorder(
-            borderRadius: ROUNDED_BORDER_RADIUS,
+      child: Semantics(
+        value: buttonData.text,
+        button: true,
+        excludeSemantics: true,
+        child: TextButton(
+          onPressed: buttonData.onPressed,
+          style: TextButton.styleFrom(
+            shape: const RoundedRectangleBorder(
+              borderRadius: ROUNDED_BORDER_RADIUS,
+            ),
+            textStyle: themeData.textTheme.bodyMedium!.copyWith(
+              color: themeData.colorScheme.onPrimary,
+            ),
+            padding: const EdgeInsets.symmetric(
+              horizontal: SMALL_SPACE,
+            ),
           ),
-          textStyle: themeData.textTheme.bodyMedium!.copyWith(
-            color: themeData.colorScheme.onPrimary,
-          ),
-          padding: const EdgeInsets.symmetric(
-            horizontal: SMALL_SPACE,
-          ),
-        ),
-        child: SizedBox(
-          height: buttonData.lines != null
-              ? VERY_LARGE_SPACE * buttonData.lines!
-              : null,
-          width: buttonData.minWidth,
-          child: FittedBox(
-            fit: BoxFit.scaleDown,
-            child: Text(
-              buttonData.text.toUpperCase(),
-              style: TextStyle(
-                fontWeight: FontWeight.bold,
-                color: buttonData.textColor ?? themeData.colorScheme.primary,
+          child: SizedBox(
+            height: buttonData.lines != null
+                ? VERY_LARGE_SPACE * buttonData.lines!
+                : null,
+            width: buttonData.minWidth,
+            child: FittedBox(
+              fit: BoxFit.scaleDown,
+              child: Text(
+                buttonData.text.toUpperCase(),
+                style: TextStyle(
+                  fontWeight: FontWeight.bold,
+                  color: buttonData.textColor ?? themeData.colorScheme.primary,
+                ),
+                textAlign: TextAlign.center,
+                overflow: TextOverflow.ellipsis,
+                maxLines: buttonData.lines ?? 2,
               ),
-              textAlign: TextAlign.center,
-              overflow: TextOverflow.ellipsis,
-              maxLines: buttonData.lines ?? 2,
             ),
           ),
         ),

--- a/packages/smooth_app/lib/pages/product/add_other_details_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_other_details_page.dart
@@ -65,6 +65,7 @@ class _AddOtherDetailsPageState extends State<AddOtherDetailsPage> {
               ? Text(widget.product.productName!,
                   overflow: TextOverflow.ellipsis, maxLines: 1)
               : null,
+          ignoreSemanticsForSubtitle: true,
         ),
         body: Form(
           key: _formKey,
@@ -76,11 +77,14 @@ class _AddOtherDetailsPageState extends State<AddOtherDetailsPage> {
                   padding: EdgeInsets.symmetric(horizontal: size.width * 0.05),
                   child: Column(
                     children: <Widget>[
-                      Text(
-                        appLocalizations.barcode_barcode(_product.barcode!),
-                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                              fontWeight: FontWeight.bold,
-                            ),
+                      ExcludeSemantics(
+                        child: Text(
+                          appLocalizations.barcode_barcode(_product.barcode!),
+                          style:
+                              Theme.of(context).textTheme.bodyMedium?.copyWith(
+                                    fontWeight: FontWeight.bold,
+                                  ),
+                        ),
                       ),
                       SizedBox(height: _heightSpace),
                       SmoothTextFormField(

--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -63,52 +63,63 @@ class _EditProductPageState extends State<EditProductPage> {
     context.watch<LocalDatabase>();
     _product = _localDatabase.upToDate.getLocalUpToDate(_initialProduct);
     final ThemeData theme = Theme.of(context);
+    final String productName = getProductName(_product, appLocalizations);
 
     return SmoothScaffold(
       appBar: SmoothAppBar(
         centerTitle: false,
         leading: const SmoothBackButton(),
-        title: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            AutoSizeText(
-              getProductName(_product, appLocalizations),
-              minFontSize:
-                  theme.textTheme.titleLarge?.fontSize?.clamp(13.0, 17.0) ??
-                      13.0,
-              maxLines: !_barcodeVisibleInAppbar ? 2 : 1,
-              style: theme.textTheme.titleLarge
-                  ?.copyWith(fontWeight: FontWeight.w500),
-            ),
-            if (_barcode.isNotEmpty)
-              AnimatedContainer(
-                duration: const Duration(milliseconds: 250),
-                height: _barcodeVisibleInAppbar ? 14.0 : 0.0,
-                child: Text(
-                  _barcode,
-                  style: theme.textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.normal,
-                  ),
+        title: Semantics(
+          value: productName,
+          child: ExcludeSemantics(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                AutoSizeText(
+                  productName,
+                  minFontSize:
+                      theme.textTheme.titleLarge?.fontSize?.clamp(13.0, 17.0) ??
+                          13.0,
+                  maxLines: !_barcodeVisibleInAppbar ? 2 : 1,
+                  style: theme.textTheme.titleLarge
+                      ?.copyWith(fontWeight: FontWeight.w500),
                 ),
-              ),
-          ],
+                if (_barcode.isNotEmpty)
+                  AnimatedContainer(
+                    duration: const Duration(milliseconds: 250),
+                    height: _barcodeVisibleInAppbar ? 14.0 : 0.0,
+                    child: Text(
+                      _barcode,
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.normal,
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
         ),
         actions: <Widget>[
-          IconButton(
-            icon: const Icon(Icons.copy),
-            tooltip: appLocalizations.clipboard_barcode_copy,
-            onPressed: () {
-              Clipboard.setData(
-                ClipboardData(text: _barcode),
-              );
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                  content: Text(
-                    appLocalizations.clipboard_barcode_copied(_barcode),
+          Semantics(
+            button: true,
+            value: appLocalizations.clipboard_barcode_copy,
+            excludeSemantics: true,
+            child: IconButton(
+              icon: const Icon(Icons.copy),
+              tooltip: appLocalizations.clipboard_barcode_copy,
+              onPressed: () {
+                Clipboard.setData(
+                  ClipboardData(text: _barcode),
+                );
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(
+                    content: Text(
+                      appLocalizations.clipboard_barcode_copied(_barcode),
+                    ),
                   ),
-                ),
-              );
-            },
+                );
+              },
+            ),
           )
         ],
       ),

--- a/packages/smooth_app/lib/pages/product/simple_input_page.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page.dart
@@ -99,7 +99,8 @@ class _SimpleInputPageState extends State<SimpleInputPage> {
               maxLines: widget.product.barcode?.isNotEmpty == true ? 1 : 2,
             ),
             subTitle: widget.product.barcode != null
-                ? Text(widget.product.barcode!)
+                ? ExcludeSemantics(
+                    excluding: true, child: Text(widget.product.barcode!))
                 : null,
           ),
           body: Padding(

--- a/packages/smooth_app/lib/widgets/smooth_app_bar.dart
+++ b/packages/smooth_app/lib/widgets/smooth_app_bar.dart
@@ -40,6 +40,7 @@ class SmoothAppBar extends StatelessWidget implements PreferredSizeWidget {
     this.actionMode = false,
     this.actionModeCloseTooltip,
     this.onLeaveActionMode,
+    this.ignoreSemanticsForSubtitle = false,
     Key? key,
   })  : assert(!actionMode || actionModeTitle != null),
         preferredSize =
@@ -78,6 +79,7 @@ class SmoothAppBar extends StatelessWidget implements PreferredSizeWidget {
   final TextStyle? toolbarTextStyle;
   final TextStyle? titleTextStyle;
   final SystemUiOverlayStyle? systemOverlayStyle;
+  final bool? ignoreSemanticsForSubtitle;
 
   final VoidCallback? onLeaveActionMode;
   final String? actionModeCloseTooltip;
@@ -161,6 +163,7 @@ class SmoothAppBar extends StatelessWidget implements PreferredSizeWidget {
               ? _AppBarTitle(
                   title: actionModeTitle!,
                   subTitle: actionModeSubTitle,
+                  ignoreSemanticsForSubtitle: ignoreSemanticsForSubtitle,
                 )
               : null,
           actions: actionModeActions,
@@ -230,11 +233,13 @@ class _AppBarTitle extends StatelessWidget {
   const _AppBarTitle({
     required this.title,
     required this.subTitle,
+    this.ignoreSemanticsForSubtitle,
     Key? key,
   }) : super(key: key);
 
   final Widget title;
   final Widget? subTitle;
+  final bool? ignoreSemanticsForSubtitle;
 
   @override
   Widget build(BuildContext context) {
@@ -245,7 +250,10 @@ class _AppBarTitle extends StatelessWidget {
         if (subTitle != null)
           DefaultTextStyle(
             style: Theme.of(context).textTheme.bodyMedium ?? const TextStyle(),
-            child: subTitle!,
+            child: ExcludeSemantics(
+              excluding: ignoreSemanticsForSubtitle ?? false,
+              child: subTitle,
+            ),
           ),
       ],
     );


### PR DESCRIPTION
Hi everyone,

As part of #4186, I've improved a bit the a11n on the Edit product flow:
- `AppBar` containing barcodes won't tell them when it's a subtitle
- The Save/Cancel button won't be considered as their Uppercase versions

This is a really small step, but this is on a long trend.
The next important fix in this flow will be the items, where `ListTile`s prevent us from having two separated items: the label and a button