### PR TITLE
feat: On lists, ensure to always add new items to the top

### DIFF
--- a/packages/smooth_app/lib/helpers/collections_helper.dart
+++ b/packages/smooth_app/lib/helpers/collections_helper.dart
@@ -84,6 +84,10 @@ extension ListExtensions<T> on List<T> {
     }
     insert(position, element);
   }
+
+  Iterable<T> diff(Iterable<T> other) {
+    return where((T item) => !other.contains(item));
+  }
 }
 
 extension SetExtensions<T> on Set<T> {


### PR DESCRIPTION
Hi everyone,

Still as part of #3986, on lists (labels, categories…), we currently append new items to the bottom.
When we have 10+ items, it's pretty difficult to know if the item is added or not.

To simplify things, the UI will now show the new items on top of the list, but internally, they still be added to the end.

As always, a video is better than words: [custom_sort.webm](https://github.com/openfoodfacts/smooth-app/assets/246838/bbd85b5f-e194-4414-8be2-38f72357976a)
