### PR TITLE
fix: Additives Page- Button text on additives page is not centered.

### DIFF
--- a/packages/smooth_app/lib/generic_lib/buttons/smooth_large_button_with_icon.dart
+++ b/packages/smooth_app/lib/generic_lib/buttons/smooth_large_button_with_icon.dart
@@ -11,6 +11,7 @@ class SmoothLargeButtonWithIcon extends StatelessWidget {
     this.trailing,
     this.backgroundColor,
     this.foregroundColor,
+    this.textAlign,
   });
 
   final String text;
@@ -48,7 +49,7 @@ class SmoothLargeButtonWithIcon extends StatelessWidget {
             child: AutoSizeText(
               text,
               maxLines: 2,
-              textAlign: TextAlign.center,
+              textAlign,
               style: themeData.textTheme.bodyMedium!.copyWith(
                 color: _getForegroundColor(themeData),
               ),

--- a/packages/smooth_app/lib/generic_lib/buttons/smooth_large_button_with_icon.dart
+++ b/packages/smooth_app/lib/generic_lib/buttons/smooth_large_button_with_icon.dart
@@ -11,7 +11,6 @@ class SmoothLargeButtonWithIcon extends StatelessWidget {
     this.trailing,
     this.backgroundColor,
     this.foregroundColor,
-    this.textAlign,
   });
 
   final String text;
@@ -49,7 +48,7 @@ class SmoothLargeButtonWithIcon extends StatelessWidget {
             child: AutoSizeText(
               text,
               maxLines: 2,
-              textAlign,
+              textAlign: TextAlign.center,
               style: themeData.textTheme.bodyMedium!.copyWith(
                 color: _getForegroundColor(themeData),
               ),

--- a/packages/smooth_app/lib/generic_lib/buttons/smooth_large_button_with_icon.dart
+++ b/packages/smooth_app/lib/generic_lib/buttons/smooth_large_button_with_icon.dart
@@ -48,6 +48,7 @@ class SmoothLargeButtonWithIcon extends StatelessWidget {
             child: AutoSizeText(
               text,
               maxLines: 2,
+              textAlign: TextAlign.center,
               style: themeData.textTheme.bodyMedium!.copyWith(
                 color: _getForegroundColor(themeData),
               ),

--- a/packages/smooth_app/lib/generic_lib/buttons/smooth_large_button_with_icon.dart
+++ b/packages/smooth_app/lib/generic_lib/buttons/smooth_large_button_with_icon.dart
@@ -21,6 +21,7 @@ class SmoothLargeButtonWithIcon extends StatelessWidget {
   final IconData? trailing;
   final Color? backgroundColor;
   final Color? foregroundColor;
+  final TextAlign? textAlign;
 
   Color _getBackgroundColor(final ThemeData themeData) =>
       backgroundColor ?? themeData.colorScheme.secondary;
@@ -49,7 +50,7 @@ class SmoothLargeButtonWithIcon extends StatelessWidget {
             child: AutoSizeText(
               text,
               maxLines: 2,
-              textAlign,
+              textAlign: textAlign,
               style: themeData.textTheme.bodyMedium!.copyWith(
                 color: _getForegroundColor(themeData),
               ),

--- a/packages/smooth_app/lib/generic_lib/buttons/smooth_large_button_with_icon.dart
+++ b/packages/smooth_app/lib/generic_lib/buttons/smooth_large_button_with_icon.dart
@@ -7,7 +7,6 @@ class SmoothLargeButtonWithIcon extends StatelessWidget {
     required this.text,
     required this.icon,
     required this.onPressed,
-    this.textAlign,
     this.padding,
     this.trailing,
     this.backgroundColor,
@@ -16,7 +15,6 @@ class SmoothLargeButtonWithIcon extends StatelessWidget {
 
   final String text;
   final IconData icon;
-  final TextAlign? textAlign;
   final VoidCallback? onPressed;
   final EdgeInsets? padding;
   final IconData? trailing;
@@ -50,7 +48,7 @@ class SmoothLargeButtonWithIcon extends StatelessWidget {
             child: AutoSizeText(
               text,
               maxLines: 2,
-              textAlign: textAlign,
+              textAlign: TextAlign.center,
               style: themeData.textTheme.bodyMedium!.copyWith(
                 color: _getForegroundColor(themeData),
               ),

--- a/packages/smooth_app/lib/generic_lib/buttons/smooth_large_button_with_icon.dart
+++ b/packages/smooth_app/lib/generic_lib/buttons/smooth_large_button_with_icon.dart
@@ -7,6 +7,7 @@ class SmoothLargeButtonWithIcon extends StatelessWidget {
     required this.text,
     required this.icon,
     required this.onPressed,
+    this.textAlign,
     this.padding,
     this.trailing,
     this.backgroundColor,
@@ -15,6 +16,7 @@ class SmoothLargeButtonWithIcon extends StatelessWidget {
 
   final String text;
   final IconData icon;
+  final TextAlign? textAlign;
   final VoidCallback? onPressed;
   final EdgeInsets? padding;
   final IconData? trailing;
@@ -48,7 +50,7 @@ class SmoothLargeButtonWithIcon extends StatelessWidget {
             child: AutoSizeText(
               text,
               maxLines: 2,
-              textAlign: TextAlign.center,
+              textAlign: textAlign,
               style: themeData.textTheme.bodyMedium!.copyWith(
                 color: _getForegroundColor(themeData),
               ),

--- a/packages/smooth_app/lib/helpers/product_cards_helper.dart
+++ b/packages/smooth_app/lib/helpers/product_cards_helper.dart
@@ -157,6 +157,7 @@ List<Attribute> getFilteredAttributes(
 Widget addPanelButton(
   final String label, {
   final IconData? iconData,
+  final String? textAlign,
   required final Function() onPressed,
 }) =>
     Padding(
@@ -164,6 +165,7 @@ Widget addPanelButton(
       child: SmoothLargeButtonWithIcon(
         text: label,
         icon: iconData ?? Icons.add,
+        textAlign: textAlign ?? textAlign,
         onPressed: onPressed,
       ),
     );

--- a/packages/smooth_app/lib/helpers/product_cards_helper.dart
+++ b/packages/smooth_app/lib/helpers/product_cards_helper.dart
@@ -157,7 +157,6 @@ List<Attribute> getFilteredAttributes(
 Widget addPanelButton(
   final String label, {
   final IconData? iconData,
-  final String? textAlign,
   required final Function() onPressed,
 }) =>
     Padding(
@@ -165,7 +164,6 @@ Widget addPanelButton(
       child: SmoothLargeButtonWithIcon(
         text: label,
         icon: iconData ?? Icons.add,
-        textAlign: textAlign ?? textAlign,
         onPressed: onPressed,
       ),
     );

--- a/packages/smooth_app/lib/helpers/product_cards_helper.dart
+++ b/packages/smooth_app/lib/helpers/product_cards_helper.dart
@@ -157,7 +157,6 @@ List<Attribute> getFilteredAttributes(
 Widget addPanelButton(
   final String label, {
   final IconData? iconData,
-  final TextAlign? textAlign,
   required final Function() onPressed,
 }) =>
     Padding(
@@ -165,7 +164,6 @@ Widget addPanelButton(
       child: SmoothLargeButtonWithIcon(
         text: label,
         icon: iconData ?? Icons.add,
-        textAlign: textAlign,
         onPressed: onPressed,
       ),
     );

--- a/packages/smooth_app/lib/helpers/product_cards_helper.dart
+++ b/packages/smooth_app/lib/helpers/product_cards_helper.dart
@@ -165,8 +165,8 @@ Widget addPanelButton(
       child: SmoothLargeButtonWithIcon(
         text: label,
         icon: iconData ?? Icons.add,
-        textAlign: textAlign ?? textAlign,
         onPressed: onPressed,
+        textAlign: iconData == null ? TextAlign.center : null,
       ),
     );
 

--- a/packages/smooth_app/lib/helpers/product_cards_helper.dart
+++ b/packages/smooth_app/lib/helpers/product_cards_helper.dart
@@ -157,6 +157,7 @@ List<Attribute> getFilteredAttributes(
 Widget addPanelButton(
   final String label, {
   final IconData? iconData,
+  final TextAlign? textAlign,
   required final Function() onPressed,
 }) =>
     Padding(
@@ -164,6 +165,7 @@ Widget addPanelButton(
       child: SmoothLargeButtonWithIcon(
         text: label,
         icon: iconData ?? Icons.add,
+        textAlign: textAlign,
         onPressed: onPressed,
       ),
     );

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_element_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_element_card.dart
@@ -143,7 +143,6 @@ class _KnowledgePanelTextElementCard extends StatelessWidget {
               appLocalizations
                   .knowledge_panel_text_source(textElement.sourceText!),
               iconData: null,
-              textAlign: TextAlign.center,
               onPressed: () {
                 LaunchUrlHelper.launchURL(
                   textElement.sourceUrl!,

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_element_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_element_card.dart
@@ -143,6 +143,7 @@ class _KnowledgePanelTextElementCard extends StatelessWidget {
               appLocalizations
                   .knowledge_panel_text_source(textElement.sourceText!),
               iconData: null,
+              textAlign: TextAlign.center,
               onPressed: () {
                 LaunchUrlHelper.launchURL(
                   textElement.sourceUrl!,


### PR DESCRIPTION

fix:  The button text on the additives page is left-aligned and not centered. Better if we center-align it.

The button text on the additives page is left-aligned and not centered. Better if we center-align it.

### Screenshot
<!-- Insert a screenshot to provide visual record of your changes, if visible -->

### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes: #4214 

### Part of 
- #525 <!-- Add the most granular issue possible -->
