### PR TITLE
feat: 3843 - matomo for new product page

### DIFF
--- a/packages/smooth_app/lib/helpers/analytics_helper.dart
+++ b/packages/smooth_app/lib/helpers/analytics_helper.dart
@@ -16,6 +16,7 @@ enum AnalyticsCategory {
   share(tag: 'share'),
   couldNotFindProduct(tag: 'could not find product'),
   productEdit(tag: 'product edit'),
+  newProduct(tag: 'new product'),
   list(tag: 'list'),
   deepLink(tag: 'deep link');
 
@@ -46,6 +47,30 @@ enum AnalyticsEvent {
   openProductEditPage(
     tag: 'opened product edit page',
     category: AnalyticsCategory.productEdit,
+  ),
+  openNewProductPage(
+    tag: 'opened new product page',
+    category: AnalyticsCategory.newProduct,
+  ),
+  categoriesNewProductPage(
+    tag: 'set categories on new product page',
+    category: AnalyticsCategory.newProduct,
+  ),
+  nutritionNewProductPage(
+    tag: 'set nutrition facts on new product page',
+    category: AnalyticsCategory.newProduct,
+  ),
+  ingredientsNewProductPage(
+    tag: 'set ingredients on new product page',
+    category: AnalyticsCategory.newProduct,
+  ),
+  imagesNewProductPage(
+    tag: 'set at least one image on new product page',
+    category: AnalyticsCategory.newProduct,
+  ),
+  closeEmptyNewProductPage(
+    tag: 'closed new product page without any input',
+    category: AnalyticsCategory.newProduct,
   ),
   shareList(tag: 'shared a list', category: AnalyticsCategory.list),
   openListWeb(tag: 'open a list in wbe', category: AnalyticsCategory.list),

--- a/packages/smooth_app/lib/pages/product/add_new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_new_product_page.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/product_list.dart';
@@ -44,7 +45,8 @@ class AddNewProductPage extends StatefulWidget {
   State<AddNewProductPage> createState() => _AddNewProductPageState();
 }
 
-class _AddNewProductPageState extends State<AddNewProductPage> {
+class _AddNewProductPageState extends State<AddNewProductPage>
+    with TraceableClientMixin {
   // Just one file per main image field
   final Map<ImageField, File> _uploadedImages = <ImageField, File>{};
 
@@ -80,6 +82,12 @@ class _AddNewProductPageState extends State<AddNewProductPage> {
   bool _trackedPopulatedIngredients = false;
   bool _trackedPopulatedNutrition = false;
   bool _trackedPopulatedImages = false;
+
+  @override
+  String get traceName => 'Opened add_new_product_page';
+
+  @override
+  String get traceTitle => 'add_new_product_page';
 
   @override
   void initState() {


### PR DESCRIPTION
### What
Now we track with matomo the following events regarding the "add new product" page:
1. opening the page
2. closing the page without any input
3. setting the category
4. setting the ingredients
5. setting the nutrition facts
6. uploading at least one image

### Fixes bug(s)
- Closes: #3843

### Impacted files
* `add_new_product_page.dart`: implemented the tracking of 6 events for matomo
* `analytics_helper.dart`: added 1 category and 6 related events for the "new product page"