### PR TITLE
fix: 4176 - border for some edit image buttons

### DIFF
--- a/packages/smooth_app/lib/pages/product/edit_image_button.dart
+++ b/packages/smooth_app/lib/pages/product/edit_image_button.dart
@@ -7,24 +7,35 @@ class EditImageButton extends StatelessWidget {
     required this.iconData,
     required this.label,
     required this.onPressed,
+    this.borderWidth,
   });
 
   final IconData iconData;
   final String label;
   final VoidCallback onPressed;
+  final double? borderWidth;
 
   @override
-  Widget build(BuildContext context) => OutlinedButton.icon(
-        icon: Icon(iconData),
-        style: ButtonStyle(
-          backgroundColor: MaterialStateProperty.all(
-            Theme.of(context).colorScheme.background,
-          ),
-          shape: MaterialStateProperty.all(
-            const RoundedRectangleBorder(borderRadius: ROUNDED_BORDER_RADIUS),
-          ),
+  Widget build(BuildContext context) {
+    final ColorScheme colorScheme = Theme.of(context).colorScheme;
+    return OutlinedButton.icon(
+      icon: Icon(iconData),
+      style: ButtonStyle(
+        backgroundColor: MaterialStateProperty.all(colorScheme.background),
+        shape: MaterialStateProperty.all(
+          const RoundedRectangleBorder(borderRadius: ROUNDED_BORDER_RADIUS),
         ),
-        onPressed: onPressed,
-        label: Text(label),
-      );
+        side: borderWidth == null
+            ? null
+            : MaterialStateBorderSide.resolveWith(
+                (_) => BorderSide(
+                  color: colorScheme.onBackground,
+                  width: borderWidth!,
+                ),
+              ),
+      ),
+      onPressed: onPressed,
+      label: Text(label),
+    );
+  }
 }

--- a/packages/smooth_app/lib/pages/product/edit_image_button.dart
+++ b/packages/smooth_app/lib/pages/product/edit_image_button.dart
@@ -21,7 +21,7 @@ class EditImageButton extends StatelessWidget {
     return OutlinedButton.icon(
       icon: Icon(iconData),
       style: ButtonStyle(
-        backgroundColor: MaterialStateProperty.all(colorScheme.background),
+        backgroundColor: MaterialStateProperty.all(colorScheme.onPrimary),
         shape: MaterialStateProperty.all(
           const RoundedRectangleBorder(borderRadius: ROUNDED_BORDER_RADIUS),
         ),
@@ -29,13 +29,16 @@ class EditImageButton extends StatelessWidget {
             ? null
             : MaterialStateBorderSide.resolveWith(
                 (_) => BorderSide(
-                  color: colorScheme.onBackground,
+                  color: colorScheme.primary,
                   width: borderWidth!,
                 ),
               ),
       ),
       onPressed: onPressed,
-      label: Text(label),
+      label: Padding(
+        padding: EdgeInsets.all(borderWidth ?? 0),
+        child: Text(label),
+      ),
     );
   }
 }

--- a/packages/smooth_app/lib/pages/product/edit_ocr_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_ocr_page.dart
@@ -14,6 +14,7 @@ import 'package:smooth_app/generic_lib/widgets/picture_not_found.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/pages/image_crop_page.dart';
+import 'package:smooth_app/pages/product/common/product_refresher.dart';
 import 'package:smooth_app/pages/product/explanation_widget.dart';
 import 'package:smooth_app/pages/product/multilingual_helper.dart';
 import 'package:smooth_app/pages/product/ocr_helper.dart';
@@ -29,10 +30,12 @@ class EditOcrPage extends StatefulWidget {
   const EditOcrPage({
     required this.product,
     required this.helper,
+    required this.isLoggedInMandatory,
   });
 
   final Product product;
   final OcrHelper helper;
+  final bool isLoggedInMandatory;
 
   @override
   State<EditOcrPage> createState() => _EditOcrPageState();
@@ -102,6 +105,11 @@ class _EditOcrPageState extends State<EditOcrPage> {
     final Product? changedProduct = _getMinimalistProduct();
     if (changedProduct == null) {
       return;
+    }
+    if (widget.isLoggedInMandatory) {
+      if (!await ProductRefresher().checkIfLoggedIn(context)) {
+        return;
+      }
     }
     AnalyticsHelper.trackProductEdit(
       _helper.getEditEventAnalyticsTag(),
@@ -248,9 +256,11 @@ class _EditOcrPageState extends State<EditOcrPage> {
                         padding:
                             const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
                         child: ProductImageServerButton(
-                          barcode: widget.product.barcode!,
+                          product: _product,
                           imageField: _helper.getImageField(),
                           language: language,
+                          isLoggedInMandatory: widget.isLoggedInMandatory,
+                          borderWidth: 2,
                         ),
                       ),
                     ),
@@ -263,6 +273,8 @@ class _EditOcrPageState extends State<EditOcrPage> {
                           barcode: widget.product.barcode!,
                           imageField: _helper.getImageField(),
                           language: language,
+                          isLoggedInMandatory: widget.isLoggedInMandatory,
+                          borderWidth: 2,
                         ),
                       ),
                     ),

--- a/packages/smooth_app/lib/pages/product/product_field_editor.dart
+++ b/packages/smooth_app/lib/pages/product/product_field_editor.dart
@@ -210,6 +210,7 @@ abstract class ProductFieldOcrEditor extends ProductFieldEditor {
         builder: (BuildContext context) => EditOcrPage(
           product: product,
           helper: helper,
+          isLoggedInMandatory: isLoggedInMandatory,
         ),
         fullscreenDialog: true,
       ),

--- a/packages/smooth_app/lib/pages/product/product_image_local_button.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_local_button.dart
@@ -12,12 +12,16 @@ class ProductImageLocalButton extends StatefulWidget {
     required this.barcode,
     required this.imageField,
     required this.language,
+    required this.isLoggedInMandatory,
+    this.borderWidth,
   });
 
   final bool firstPhoto;
   final String barcode;
   final ImageField imageField;
   final OpenFoodFactsLanguage language;
+  final bool isLoggedInMandatory;
+  final double? borderWidth;
 
   @override
   State<ProductImageLocalButton> createState() =>
@@ -33,13 +37,16 @@ class _ProductImageLocalButtonState extends State<ProductImageLocalButton> {
       label:
           widget.firstPhoto ? appLocalizations.add : appLocalizations.capture,
       onPressed: () async => _actionNewImage(context),
+      borderWidth: widget.borderWidth,
     );
   }
 
   Future<void> _actionNewImage(final BuildContext context) async {
-    final bool loggedIn = await ProductRefresher().checkIfLoggedIn(context);
-    if (!loggedIn) {
-      return;
+    if (widget.isLoggedInMandatory) {
+      final bool loggedIn = await ProductRefresher().checkIfLoggedIn(context);
+      if (!loggedIn) {
+        return;
+      }
     }
     if (context.mounted) {
     } else {

--- a/packages/smooth_app/lib/pages/product/product_image_server_button.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_server_button.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/generic_lib/loading_dialog.dart';
 import 'package:smooth_app/pages/image/uploaded_image_gallery.dart';
@@ -11,31 +12,45 @@ import 'package:smooth_app/query/product_query.dart';
 /// Button asking for a "server" photo (taken from what was already uploaded).
 class ProductImageServerButton extends StatelessWidget {
   const ProductImageServerButton({
-    required this.barcode,
+    required this.product,
     required this.imageField,
     required this.language,
+    required this.isLoggedInMandatory,
+    this.borderWidth,
   });
 
-  final String barcode;
+  final Product product;
   final ImageField imageField;
   final OpenFoodFactsLanguage language;
+  final bool isLoggedInMandatory;
+  final double? borderWidth;
+
+  static bool _hasServerImages(final Product product) =>
+      product.images?.isNotEmpty == true;
+
+  String get barcode => product.barcode!;
 
   @override
-  Widget build(BuildContext context) => EditImageButton(
-        iconData: Icons.image_search,
-        label: AppLocalizations.of(context)
-            .edit_photo_select_existing_button_label,
-        onPressed: () async => _actionGallery(context),
-      );
+  Widget build(BuildContext context) {
+    if (!_hasServerImages(product)) {
+      return EMPTY_WIDGET;
+    }
+    return EditImageButton(
+      iconData: Icons.image_search,
+      label:
+          AppLocalizations.of(context).edit_photo_select_existing_button_label,
+      onPressed: () async => _actionGallery(context),
+      borderWidth: borderWidth,
+    );
+  }
 
   Future<void> _actionGallery(final BuildContext context) async {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    if (!context.mounted) {
-      return;
-    }
-    final bool loggedIn = await ProductRefresher().checkIfLoggedIn(context);
-    if (!loggedIn) {
-      return;
+    if (isLoggedInMandatory) {
+      final bool loggedIn = await ProductRefresher().checkIfLoggedIn(context);
+      if (!loggedIn) {
+        return;
+      }
     }
 
     List<int>? result;

--- a/packages/smooth_app/lib/pages/product/product_image_viewer.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_viewer.dart
@@ -188,9 +188,10 @@ class _ProductImageViewerState extends State<ProductImageViewer> {
                 child: Padding(
                   padding: const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
                   child: ProductImageServerButton(
-                    barcode: _barcode,
+                    product: _product,
                     imageField: widget.imageField,
                     language: widget.language,
+                    isLoggedInMandatory: true,
                   ),
                 ),
               ),
@@ -202,6 +203,7 @@ class _ProductImageViewerState extends State<ProductImageViewer> {
                     barcode: _barcode,
                     imageField: widget.imageField,
                     language: widget.language,
+                    isLoggedInMandatory: true,
                   ),
                 ),
               ),


### PR DESCRIPTION
### What
Now in the OCR pages
- when no image was downloaded before for that product, we do not display the "select an existing picture" button, as it has no sense.
- we add a border for the image buttons for a better contrast with the background
- in addition to that, some "is logged in mandatory" issues were fixed, especially relevant for first time users with new products

### Screenshot
| no images before | images before |
| -- | -- |
| ![Screenshot_2023-06-20-12-59-00](https://github.com/openfoodfacts/smooth-app/assets/11576431/76edb22f-77cf-4eec-96be-8d2363e67d50) | ![Screenshot_2023-06-20-12-59-32](https://github.com/openfoodfacts/smooth-app/assets/11576431/27b0ec07-26f9-4cd9-9fb7-201711506b4b) |
| ![Screenshot_2023-06-20-12-56-16](https://github.com/openfoodfacts/smooth-app/assets/11576431/2684250a-63cd-4cfa-beac-8f29acfdd038) | ![Screenshot_2023-06-20-12-57-15](https://github.com/openfoodfacts/smooth-app/assets/11576431/cac6880e-522b-4fb2-83ad-06a0dc46a9ce) |

### Fixes bug(s)
- Fixes: #4176
- Fixes: #3974

### Impacted files
* `edit_image_button.dart`: added an optional border
* `edit_ocr_page.dart`: unrelated add of "logged in?" parameter
* `product_field_editor.dart`: unrelated add of a "logged in?" parameter
* `product_image_local_button.dart`: added an optional border and a "logged in?" parameter
* `product_image_server_button.dart`: added an optional border and a "logged in?" parameter; added a test if display is relevant
* `product_image_viewer.dart`: added a "logged in?" parameter