### PR TITLE
fix: Added text 'compare to category' for the comparison page

### DIFF
--- a/packages/smooth_app/lib/pages/product/common/product_query_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_query_page.dart
@@ -159,7 +159,7 @@ class _ProductQueryPageState extends State<ProductQueryPage>
               : MainAxisAlignment.center,
           children: <Widget>[
             Padding(
-              padding: EdgeInsets.symmetric(vertical: 5),
+              padding: const EdgeInsets.symmetric(vertical: 5),
               child: RankingFloatingActionButton(
                 onPressed: () => Navigator.push<Widget>(
                   context,
@@ -537,10 +537,10 @@ class _AppBarTitle extends StatelessWidget {
                 ? child
                 : Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
+                    children: <Widget>[
                       Text(
                         appLocalizations.product_search_same_category,
-                        style: TextStyle(fontWeight: FontWeight.bold),
+                        style: const TextStyle(fontWeight: FontWeight.bold),
                       ),
                       Text(
                         name,

--- a/packages/smooth_app/lib/pages/product/common/product_query_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_query_page.dart
@@ -212,6 +212,7 @@ class _ProductQueryPageState extends State<ProductQueryPage>
                 : appLocalizations.product_search_same_category,
             editableAppBarTitle:
                 widget.searchResult && widget.editableAppBarTitle,
+            multiLines: !widget.searchResult,
           ),
           subTitle: !widget.searchResult ? Text(widget.name) : null,
           actions: _getAppBarButtons(),

--- a/packages/smooth_app/lib/pages/product/common/product_query_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_query_page.dart
@@ -25,6 +25,7 @@ import 'package:smooth_app/pages/product/common/product_list_item_simple.dart';
 import 'package:smooth_app/pages/product/common/product_query_page_helper.dart';
 import 'package:smooth_app/query/paged_product_query.dart';
 import 'package:smooth_app/widgets/ranking_floating_action_button.dart';
+import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
 class ProductQueryPage extends StatefulWidget {
@@ -201,16 +202,23 @@ class _ProductQueryPageState extends State<ProductQueryPage>
             ),
           ],
         ),
-        appBar: AppBar(
+        appBar: SmoothAppBar(
           backgroundColor: themeData.scaffoldBackgroundColor,
           elevation: 2,
           automaticallyImplyLeading: false,
           leading: const SmoothBackButton(),
           title: _AppBarTitle(
-            name: widget.name,
+            name: widget.searchResult
+                ? widget.name
+                : appLocalizations.product_search_same_category,
             editableAppBarTitle: widget.editableAppBarTitle,
-            searchResult: widget.searchResult,
           ),
+          subTitle: !widget.searchResult
+              ? _AppBarTitle(
+                  name: widget.name,
+                  editableAppBarTitle: widget.editableAppBarTitle,
+                )
+              : null,
           actions: _getAppBarButtons(),
         ),
         body: RefreshIndicator(
@@ -510,13 +518,11 @@ class _AppBarTitle extends StatelessWidget {
   const _AppBarTitle({
     required this.name,
     required this.editableAppBarTitle,
-    this.searchResult = true,
     Key? key,
   }) : super(key: key);
 
   final String name;
   final bool editableAppBarTitle;
-  final bool searchResult;
   @override
   Widget build(BuildContext context) {
     final Widget child = AutoSizeText(
@@ -528,28 +534,11 @@ class _AppBarTitle extends StatelessWidget {
       final AppLocalizations appLocalizations = AppLocalizations.of(context);
 
       return GestureDetector(
-        onTap: () {
-          Navigator.of(context).pop(ProductQueryPageResult.editProductQuery);
-        },
-        child: Tooltip(
-            message: appLocalizations.tap_to_edit_search,
-            child: searchResult
-                ? child
-                : Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: <Widget>[
-                      Text(
-                        appLocalizations.product_search_same_category,
-                        style: const TextStyle(fontWeight: FontWeight.bold),
-                      ),
-                      Text(
-                        name,
-                        style: const TextStyle(
-                            fontWeight: FontWeight.w200, fontSize: 15),
-                      )
-                    ],
-                  )),
-      );
+          onTap: () {
+            Navigator.of(context).pop(ProductQueryPageResult.editProductQuery);
+          },
+          child: Tooltip(
+              message: appLocalizations.tap_to_edit_search, child: child));
     } else {
       return child;
     }

--- a/packages/smooth_app/lib/pages/product/common/product_query_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_query_page.dart
@@ -32,11 +32,13 @@ class ProductQueryPage extends StatefulWidget {
     required this.productListSupplier,
     required this.name,
     required this.editableAppBarTitle,
+    this.searchResult = true,
   });
 
   final ProductListSupplier productListSupplier;
   final String name;
   final bool editableAppBarTitle;
+  final bool searchResult;
 
   @override
   State<ProductQueryPage> createState() => _ProductQueryPageState();
@@ -204,6 +206,7 @@ class _ProductQueryPageState extends State<ProductQueryPage>
           title: _AppBarTitle(
             name: widget.name,
             editableAppBarTitle: widget.editableAppBarTitle,
+            searchResult: widget.searchResult,
           ),
           actions: _getAppBarButtons(),
         ),
@@ -504,12 +507,13 @@ class _AppBarTitle extends StatelessWidget {
   const _AppBarTitle({
     required this.name,
     required this.editableAppBarTitle,
+    this.searchResult = true,
     Key? key,
   }) : super(key: key);
 
   final String name;
   final bool editableAppBarTitle;
-
+  final bool searchResult;
   @override
   Widget build(BuildContext context) {
     final Widget child = AutoSizeText(
@@ -525,9 +529,23 @@ class _AppBarTitle extends StatelessWidget {
           Navigator.of(context).pop(ProductQueryPageResult.editProductQuery);
         },
         child: Tooltip(
-          message: appLocalizations.tap_to_edit_search,
-          child: child,
-        ),
+            message: appLocalizations.tap_to_edit_search,
+            child: searchResult
+                ? child
+                : Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        appLocalizations.product_search_same_category,
+                        style: TextStyle(fontWeight: FontWeight.bold),
+                      ),
+                      Text(
+                        name,
+                        style: const TextStyle(
+                            fontWeight: FontWeight.w200, fontSize: 15),
+                      )
+                    ],
+                  )),
       );
     } else {
       return child;

--- a/packages/smooth_app/lib/pages/product/common/product_query_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_query_page.dart
@@ -158,13 +158,16 @@ class _ProductQueryPageState extends State<ProductQueryPage>
               ? MainAxisAlignment.spaceBetween
               : MainAxisAlignment.center,
           children: <Widget>[
-            RankingFloatingActionButton(
-              onPressed: () => Navigator.push<Widget>(
-                context,
-                MaterialPageRoute<Widget>(
-                  builder: (BuildContext context) => PersonalizedRankingPage(
-                    barcodes: _model.displayBarcodes,
-                    title: widget.name,
+            Padding(
+              padding: EdgeInsets.symmetric(vertical: 5),
+              child: RankingFloatingActionButton(
+                onPressed: () => Navigator.push<Widget>(
+                  context,
+                  MaterialPageRoute<Widget>(
+                    builder: (BuildContext context) => PersonalizedRankingPage(
+                      barcodes: _model.displayBarcodes,
+                      title: widget.name,
+                    ),
                   ),
                 ),
               ),

--- a/packages/smooth_app/lib/pages/product/common/product_query_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_query_page.dart
@@ -160,7 +160,7 @@ class _ProductQueryPageState extends State<ProductQueryPage>
               : MainAxisAlignment.center,
           children: <Widget>[
             Padding(
-              padding: const EdgeInsets.symmetric(vertical: 5),
+              padding: const EdgeInsets.symmetric(vertical: 5.0),
               child: RankingFloatingActionButton(
                 onPressed: () => Navigator.push<Widget>(
                   context,
@@ -538,7 +538,9 @@ class _AppBarTitle extends StatelessWidget {
             Navigator.of(context).pop(ProductQueryPageResult.editProductQuery);
           },
           child: Tooltip(
-              message: appLocalizations.tap_to_edit_search, child: child));
+            message: appLocalizations.tap_to_edit_search,
+            child: child,
+          ));
     } else {
       return child;
     }

--- a/packages/smooth_app/lib/pages/product/common/product_query_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_query_page.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:iso_countries/iso_countries.dart';
@@ -208,17 +207,13 @@ class _ProductQueryPageState extends State<ProductQueryPage>
           automaticallyImplyLeading: false,
           leading: const SmoothBackButton(),
           title: _AppBarTitle(
-            name: widget.searchResult
+            title: widget.searchResult
                 ? widget.name
                 : appLocalizations.product_search_same_category,
-            editableAppBarTitle: widget.editableAppBarTitle,
+            editableAppBarTitle:
+                widget.searchResult && widget.editableAppBarTitle,
           ),
-          subTitle: !widget.searchResult
-              ? _AppBarTitle(
-                  name: widget.name,
-                  editableAppBarTitle: widget.editableAppBarTitle,
-                )
-              : null,
+          subTitle: !widget.searchResult ? Text(widget.name) : null,
           actions: _getAppBarButtons(),
         ),
         body: RefreshIndicator(
@@ -504,7 +499,7 @@ class _EmptyScreen extends StatelessWidget {
         backgroundColor: Theme.of(context).scaffoldBackgroundColor,
         leading: const SmoothBackButton(),
         title: _AppBarTitle(
-          name: name,
+          title: name,
           editableAppBarTitle: false,
         ),
         actions: actions,
@@ -516,31 +511,38 @@ class _EmptyScreen extends StatelessWidget {
 
 class _AppBarTitle extends StatelessWidget {
   const _AppBarTitle({
-    required this.name,
+    required this.title,
+    this.multiLines = true,
     required this.editableAppBarTitle,
     Key? key,
   }) : super(key: key);
 
-  final String name;
+  final String title;
+  final bool multiLines;
   final bool editableAppBarTitle;
+
   @override
   Widget build(BuildContext context) {
-    final Widget child = AutoSizeText(
-      name,
-      maxLines: 2,
+    final Widget child = Text(
+      title,
+      maxLines: multiLines ? 2 : 1,
     );
 
     if (editableAppBarTitle) {
       final AppLocalizations appLocalizations = AppLocalizations.of(context);
 
-      return GestureDetector(
-          onTap: () {
-            Navigator.of(context).pop(ProductQueryPageResult.editProductQuery);
-          },
-          child: Tooltip(
-            message: appLocalizations.tap_to_edit_search,
+      return InkWell(
+        onTap: () {
+          Navigator.of(context).pop(ProductQueryPageResult.editProductQuery);
+        },
+        child: Tooltip(
+          message: appLocalizations.tap_to_edit_search,
+          child: SizedBox(
+            width: double.infinity,
             child: child,
-          ));
+          ),
+        ),
+      );
     } else {
       return child;
     }

--- a/packages/smooth_app/lib/pages/product/common/product_query_page_helper.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_query_page_helper.dart
@@ -15,6 +15,7 @@ class ProductQueryPageHelper {
     required final String name,
     required final BuildContext context,
     bool editableAppBarTitle = true,
+    bool searchResult = true,
     EditProductQueryCallback? editQueryCallback,
   }) async {
     final ProductListSupplier supplier =
@@ -31,6 +32,7 @@ class ProductQueryPageHelper {
           productListSupplier: supplier,
           name: name,
           editableAppBarTitle: editableAppBarTitle,
+          searchResult: searchResult,
         ),
       ),
     );

--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -316,11 +316,12 @@ class _SummaryCardState extends State<SummaryCard> {
             localizations.product_search_same_category,
             iconData: Icons.leaderboard,
             onPressed: () async => ProductQueryPageHelper().openBestChoice(
-                name: categoryLabel!,
-                localDatabase: _localDatabase,
-                productQuery: CategoryProductQuery(categoryTag!),
-                context: context,
-                searchResult: false),
+              name: categoryLabel!,
+              localDatabase: _localDatabase,
+              productQuery: CategoryProductQuery(categoryTag!),
+              context: context,
+              searchResult: false,
+            ),
           ),
         );
       }

--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -316,11 +316,11 @@ class _SummaryCardState extends State<SummaryCard> {
             localizations.product_search_same_category,
             iconData: Icons.leaderboard,
             onPressed: () async => ProductQueryPageHelper().openBestChoice(
-              name: categoryLabel!,
-              localDatabase: _localDatabase,
-              productQuery: CategoryProductQuery(categoryTag!),
-              context: context,
-            ),
+                name: categoryLabel!,
+                localDatabase: _localDatabase,
+                productQuery: CategoryProductQuery(categoryTag!),
+                context: context,
+                searchResult: false),
           ),
         );
       }


### PR DESCRIPTION
### What
<!-- description of the PR -->
- On the comparison page for same category items, the title is now more descriptive and the subtitle says the category name
<!-- 
Please name your pull request following this scheme: `type: What you did` this allows us to automatically generate the changelog
Following `type`s are allowed:
  - `feat`, for Features
  - `fix`, for Bug Fixes
  - `docs`, for Documentation
  - `ci`, for Automation
  - `refactor`, for code Refactoring
  - `chore`, for Miscellaneous things


### Screenshot
<!-- Insert a screenshot to provide visual record of your changes, if visible -->

<img src="https://github.com/openfoodfacts/smooth-app/assets/86849857/e4a775b6-1d71-4488-8178-16ed322daddc" width=50%>


### Fixes 

- #4209 

### Part of
- #525
