### PR TITLE
fix: 4219 - check if new picture is big enough before server upload

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -534,6 +534,28 @@
     "@crop_page_action_local": {
         "description": "Action being performed on the crop page"
     },
+    "crop_page_too_small_image_title": "The image is too small!",
+    "@crop_page_too_small_image_title": {
+        "description": "Title of a dialog warning the user that the image is too small for upload"
+    },
+    "crop_page_too_small_image_message": "The minimum size in pixels for picture upload is {expectedMinWidth}x{expectedMinHeight}. The current picture is {actualWidth}x{actualHeight}.",
+    "@crop_page_too_small_image_message": {
+        "description": "Message of a dialog warning the user that the image is too small for upload",
+        "placeholders": {
+            "expectedMinWidth": {
+                "type": "int"
+            },
+            "expectedMinHeight": {
+                "type": "int"
+            },
+            "actualWidth": {
+                "type": "int"
+            },
+            "actualHeight": {
+                "type": "int"
+            }
+        }
+    },
     "crop_page_action_server": "Preparing a call to the server…",
     "@crop_page_action_server": {
         "description": "Action being performed on the crop page"

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -305,10 +305,10 @@ packages:
     dependency: "direct main"
     description:
       name: crop_image
-      sha256: "0b5b939106eb71cbb66d2b97e56d9ec3469d88b12324143439bf0911e4c9bf11"
+      sha256: "2c70294bdcb0f2fd8b7d660535b314eb5d2477000057e1f30db8295d1588c422"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.6"
+    version: "1.0.10"
   cross_file:
     dependency: transitive
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -50,7 +50,7 @@ dependencies:
   flutter_native_splash: 2.2.19
   image: ^4.0.17
   auto_size_text: 3.0.0
-  crop_image: 1.0.6
+  crop_image: 1.0.10
   shared_preferences: 2.1.1
   intl: 0.18.0
   collection: 1.17.1


### PR DESCRIPTION
### What
- On the server side, there are constraints on the size of the new pictures uploaded: at least width of 640 or height of 160.
- If that condition is not fulfilled, the server returns an error.
- Which is problematic for us, as we use background tasks
  - the user believes the image is uploaded (at least in the app)
  - the background task is doomed to fail forever at each retry
- The solution is to check the size before sending any new image to the server.
- This constraint does not seem to apply to existing image crop.

### Screenshot
![Screenshot_2023-06-22-19-59-53](https://github.com/openfoodfacts/smooth-app/assets/11576431/95569759-c810-40a4-bde8-099abe4199b4)

### Fixes bug(s)
- Fixes: #4219

### Impacted files
* `app_en.arb`: added 2 labels for a "too small image" dialog!
* `background_task_image.dart`: now we check before server call if the image is big enough
* `crop_page.dart`: now we check if the image is big enough before new image upload
* `pubspec.lock`: wtf
* `pubspec.yaml`: upgraded crop_image for controller bug fix