### PR TITLE
feat: Some improvements for the carousel (changing pages, a11n…)

### DIFF
--- a/packages/smooth_app/lib/data_models/continuous_scan_model.dart
+++ b/packages/smooth_app/lib/data_models/continuous_scan_model.dart
@@ -123,6 +123,7 @@ class ContinuousScanModel with ChangeNotifier {
       lastConsultedBarcode = code;
       return false;
     }
+
     AnalyticsHelper.trackEvent(
       AnalyticsEvent.scanAction,
       barcode: code,

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1069,21 +1069,6 @@
     "@camera_play_sound_subtitle": {
         "description": "SubTitle for the Camera play sound toggle"
     },
-    "camera_mode_title": "Scanner mode",
-    "@camera_mode_title": {
-        "description": "Title for the mode for the camera/scanner"
-    },
-    "camera_mode_subtitle": "Only change this value, if you have some issues with the scanner (unable to decode barcodes). Tap to switch between the two modes.\nThe current one is: {mode}",
-    "@camera_mode_subtitle": {
-        "description": "SubTitle for the mode for the camera/scanner",
-        "placeholders": {
-            "mode": {
-                "type": "String"
-            }
-        }
-    },
-    "camera_mode_file_based": "Safe mode (by default)",
-    "camera_mode_bytes_array_based": "Quick mode",
     "app_haptic_feedback_title": "Vibration & Haptics",
     "@app_haptic_feedback_title": {
         "description": "Title for the Haptic feedback toggle"
@@ -1918,6 +1903,16 @@
     "product_card_remove_product_tooltip": "Remove product",
     "@product_card_remove_product_tooltip": {
         "description": "Tooltip (message visible with a long-press) on a product item in the carousel"
+    },
+    "scan_announce_new_barcode": "On new barcode scanned: {barcode}",
+    "@scan_announce_new_barcode": {
+        "description": "Text to pronounce by the Accessibility tool when a new barcode is decoded",
+        "placeholders": {
+            "barcode": {
+                "type": "String",
+                "description": "barcode"
+            }
+        }
     },
     "scan_header_clear_button_tooltip": "Remove all products from the carousel",
     "@scan_header_clear_button_tooltip": {

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1904,7 +1904,7 @@
     "@product_card_remove_product_tooltip": {
         "description": "Tooltip (message visible with a long-press) on a product item in the carousel"
     },
-    "scan_announce_new_barcode": "On new barcode scanned: {barcode}",
+    "scan_announce_new_barcode": "New barcode scanned: {barcode}",
     "@scan_announce_new_barcode": {
         "description": "Text to pronounce by the Accessibility tool when a new barcode is decoded",
         "placeholders": {

--- a/packages/smooth_app/lib/pages/scan/camera_scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/camera_scan_page.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:audioplayers/audioplayers.dart';
 import 'package:flutter/material.dart' hide Listener;
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:matomo_tracker/matomo_tracker.dart';
@@ -10,7 +9,6 @@ import 'package:smooth_app/data_models/continuous_scan_model.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
-import 'package:smooth_app/helpers/app_helper.dart';
 import 'package:smooth_app/helpers/camera_helper.dart';
 import 'package:smooth_app/helpers/global_vars.dart';
 import 'package:smooth_app/helpers/haptic_feedback_helper.dart';
@@ -27,11 +25,6 @@ class CameraScannerPage extends StatefulWidget {
 class CameraScannerPageState extends State<CameraScannerPage>
     with TraceableClientMixin {
   final GlobalKey<State<StatefulWidget>> _headerKey = GlobalKey();
-
-  /// Audio player to play the beep sound on scan
-  /// This attribute is only initialized when a camera is available AND the
-  /// setting is set to ON
-  AudioPlayer? _musicPlayer;
 
   late ContinuousScanModel _model;
   late UserPreferences _userPreferences;
@@ -103,15 +96,6 @@ class CameraScannerPageState extends State<CameraScannerPage>
       return false;
     }
 
-    // Both are Future methods, but it doesn't matter to wait here
-    SmoothHapticFeedback.lightNotification();
-
-    if (_userPreferences.playCameraSound) {
-      await _initSoundManagerIfNecessary();
-      await _musicPlayer!.stop();
-      await _musicPlayer!.resume();
-    }
-
     _userPreferences.setFirstScanAchieved();
     return true;
   }
@@ -126,48 +110,5 @@ class CameraScannerPageState extends State<CameraScannerPage>
         body: Text(appLocalizations.camera_flash_error_dialog_message),
       ),
     );
-  }
-
-  /// Only initialize the "beep" player when needed
-  /// (at least one camera available + settings set to ON)
-  Future<void> _initSoundManagerIfNecessary() async {
-    if (_musicPlayer != null) {
-      return;
-    }
-
-    _musicPlayer = AudioPlayer(playerId: '1');
-    _musicPlayer!.audioCache.prefix = AppHelper.defaultAssetPath;
-    await _musicPlayer!.setSourceAsset('audio/beep.ogg');
-    await _musicPlayer!.setPlayerMode(PlayerMode.lowLatency);
-    await _musicPlayer!.setAudioContext(
-      const AudioContext(
-        android: AudioContextAndroid(
-          isSpeakerphoneOn: false,
-          stayAwake: false,
-          contentType: AndroidContentType.sonification,
-          usageType: AndroidUsageType.notificationEvent,
-          audioFocus: AndroidAudioFocus.gainTransientExclusive,
-        ),
-        iOS: AudioContextIOS(
-          category: AVAudioSessionCategory.soloAmbient,
-          options: <AVAudioSessionOptions>[
-            AVAudioSessionOptions.mixWithOthers,
-            AVAudioSessionOptions.defaultToSpeaker,
-          ],
-        ),
-      ),
-    );
-  }
-
-  Future<void> _disposeSoundManager() async {
-    await _musicPlayer?.release();
-    await _musicPlayer?.dispose();
-    _musicPlayer = null;
-  }
-
-  @override
-  void dispose() {
-    _disposeSoundManager();
-    super.dispose();
   }
 }

--- a/packages/smooth_app/lib/pages/scan/scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/scan_page.dart
@@ -63,6 +63,7 @@ class _ScanPageState extends State<ScanPage> {
       return const Center(child: CircularProgressIndicator.adaptive());
     }
 
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final TextDirection direction = Directionality.of(context);
 
     return SmoothScaffold(
@@ -115,7 +116,7 @@ class _ScanPageState extends State<ScanPage> {
                     }
 
                     SemanticsService.announce(
-                      'On new barcode scanned: $barcode',
+                      appLocalizations.scan_announce_new_barcode(barcode),
                       direction,
                       assertiveness: Assertiveness.assertive,
                     );

--- a/packages/smooth_app/lib/pages/scan/scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/scan_page.dart
@@ -1,13 +1,18 @@
 import 'dart:io';
 import 'dart:math' as math;
 
+import 'package:audioplayers/audioplayers.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/continuous_scan_model.dart';
+import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
+import 'package:smooth_app/helpers/app_helper.dart';
+import 'package:smooth_app/helpers/haptic_feedback_helper.dart';
 import 'package:smooth_app/helpers/permission_helper.dart';
 import 'package:smooth_app/pages/scan/camera_scan_page.dart';
 import 'package:smooth_app/widgets/smooth_product_carousel.dart';
@@ -21,6 +26,12 @@ class ScanPage extends StatefulWidget {
 }
 
 class _ScanPageState extends State<ScanPage> {
+  /// Audio player to play the beep sound on scan
+  /// This attribute is only initialized when a camera is available AND the
+  /// setting is set to ON
+  AudioPlayer? _musicPlayer;
+
+  late UserPreferences _userPreferences;
   ContinuousScanModel? _model;
 
   /// Percentage of the bottom part of the screen that hosts the carousel.
@@ -29,6 +40,11 @@ class _ScanPageState extends State<ScanPage> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
+
+    if (mounted) {
+      _userPreferences = context.watch<UserPreferences>();
+    }
+
     _updateModel();
   }
 
@@ -46,6 +62,8 @@ class _ScanPageState extends State<ScanPage> {
     if (_model == null) {
       return const Center(child: CircularProgressIndicator.adaptive());
     }
+
+    final TextDirection direction = Directionality.of(context);
 
     return SmoothScaffold(
       brightness:
@@ -75,17 +93,83 @@ class _ScanPageState extends State<ScanPage> {
                 },
               ),
             ),
-            const Expanded(
+            Expanded(
               flex: _carouselHeightPct,
               child: Padding(
-                padding: EdgeInsetsDirectional.only(bottom: 10),
-                child: SmoothProductCarousel(containSearchCard: true),
+                padding: const EdgeInsetsDirectional.only(bottom: 10),
+                child: SmoothProductCarousel(
+                  containSearchCard: true,
+                  onPageChangedTo: (int page, String? barcode) async {
+                    if (barcode == null) {
+                      // We only notify for new products
+                      return;
+                    }
+
+                    // Both are Future methods, but it doesn't matter to wait here
+                    SmoothHapticFeedback.lightNotification();
+
+                    if (_userPreferences.playCameraSound) {
+                      await _initSoundManagerIfNecessary();
+                      await _musicPlayer!.stop();
+                      await _musicPlayer!.resume();
+                    }
+
+                    SemanticsService.announce(
+                      'On new barcode scanned: $barcode',
+                      direction,
+                      assertiveness: Assertiveness.assertive,
+                    );
+                  },
+                ),
               ),
             ),
           ],
         ),
       ),
     );
+  }
+
+  /// Only initialize the "beep" player when needed
+  /// (at least one camera available + settings set to ON)
+  Future<void> _initSoundManagerIfNecessary() async {
+    if (_musicPlayer != null) {
+      return;
+    }
+
+    _musicPlayer = AudioPlayer(playerId: '1');
+    _musicPlayer!.audioCache.prefix = AppHelper.defaultAssetPath;
+    await _musicPlayer!.setSourceAsset('audio/beep.ogg');
+    await _musicPlayer!.setPlayerMode(PlayerMode.lowLatency);
+    await _musicPlayer!.setAudioContext(
+      const AudioContext(
+        android: AudioContextAndroid(
+          isSpeakerphoneOn: false,
+          stayAwake: false,
+          contentType: AndroidContentType.sonification,
+          usageType: AndroidUsageType.notificationEvent,
+          audioFocus: AndroidAudioFocus.gainTransientExclusive,
+        ),
+        iOS: AudioContextIOS(
+          category: AVAudioSessionCategory.soloAmbient,
+          options: <AVAudioSessionOptions>[
+            AVAudioSessionOptions.mixWithOthers,
+            AVAudioSessionOptions.defaultToSpeaker,
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _disposeSoundManager() async {
+    await _musicPlayer?.release();
+    await _musicPlayer?.dispose();
+    _musicPlayer = null;
+  }
+
+  @override
+  void dispose() {
+    _disposeSoundManager();
+    super.dispose();
   }
 }
 


### PR DESCRIPTION
Hi everyone,

The carousel works when now, but sometimes it moves in all directions when barcodes are detected.
Here are the improvements implements:
- If the selected card is also the barcode scanned => do nothing
- Wait for an animation to be finished, before starting a new one
- There were some specific cases, where the control wouldn't be called to change the page
- The vibration + audio part is now moved to the Scan page, to notify according to the carousel events and not the scanner
- There is also an improvement in terms of a11n: when a barcode is decoded, a voice will tell it

I'm not 100% sure that it will prevent the weird behavior that when a barcode is scanned, sometimes it goes back to the first card. But after my changes, I can't reproduce it anymore, so let's 🤞.

As always, a video is better than words: https://github.com/openfoodfacts/smooth-app/assets/246838/c23c40c2-6f40-4327-81b8-4587050ca80b

