### PR TITLE
fix: 4222 - top barcode task refactoring

### DIFF
--- a/packages/smooth_app/lib/database/dao_work_barcode.dart
+++ b/packages/smooth_app/lib/database/dao_work_barcode.dart
@@ -17,11 +17,6 @@ class DaoWorkBarcode extends AbstractSqlDao {
   static const String _columnWork = 'work';
   static const String _columnBarcode = 'barcode';
 
-  static const List<String> _columns = <String>[
-    _columnWork,
-    _columnBarcode,
-  ];
-
   static FutureOr<void> onUpgrade(
     final Database db,
     final int oldVersion,
@@ -95,9 +90,13 @@ class DaoWorkBarcode extends AbstractSqlDao {
     int count = 0;
 
     Future<void> rawInsert() async {
-      final int inserted = await databaseExecutor.rawInsert(
-        'insert into $_table(${_columns.join(',')}) '
-        'values(?,?)${',(?,?)' * (parameters.length ~/ 2 - 1)}',
+      if (parameters.isEmpty) {
+        return;
+      }
+      final int inserted = parameters.length ~/ 2;
+      await databaseExecutor.rawInsert(
+        'insert into $_table($_columnWork,$_columnBarcode) '
+        'values(?,?)${',(?,?)' * (inserted - 1)}',
         parameters,
       );
       count += inserted;
@@ -111,9 +110,7 @@ class DaoWorkBarcode extends AbstractSqlDao {
         parameters.clear();
       }
     }
-    if (parameters.isNotEmpty) {
-      await rawInsert();
-    }
+    await rawInsert();
     return count;
   }
 
@@ -152,6 +149,9 @@ class DaoWorkBarcode extends AbstractSqlDao {
     int count = 0;
 
     Future<void> rawDelete() async {
+      if (parameters.length < 2) {
+        return;
+      }
       final int deleted = await databaseExecutor.delete(
         _table,
         where: '$_columnWork = ? '
@@ -170,9 +170,7 @@ class DaoWorkBarcode extends AbstractSqlDao {
         parameters.add(work);
       }
     }
-    if (parameters.isNotEmpty) {
-      await rawDelete();
-    }
+    await rawDelete();
     return count;
   }
 }

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -2061,6 +2061,7 @@
     "background_task_title": "Pending contributions",
     "background_task_subtitle": "Your contributions are automatically saved to our server, but not always in real-time.",
     "background_task_list_empty": "No Pending Background Tasks",
+    "background_task_error_server_time_out": "Server timeout",
     "background_task_error_no_internet": "Internet connection error. Try later.",
     "background_task_operation_unknown": "unknown operation type",
     "background_task_operation_details": "detailed changes",

--- a/packages/smooth_app/lib/pages/offline_tasks_page.dart
+++ b/packages/smooth_app/lib/pages/offline_tasks_page.dart
@@ -114,6 +114,11 @@ class _OfflineTaskState extends State<OfflineTaskPage> {
       case BackgroundTaskManager.taskStatusStopAsap:
         return appLocalizations.background_task_run_to_be_deleted;
     }
+    // "startsWith" because there's some kind of "chr(13)" at the end.
+    if (status.startsWith(
+        'Exception: JSON expected, html found: <head><title>504 Gateway Time-out</title></head>')) {
+      return appLocalizations.background_task_error_server_time_out;
+    }
     return status;
   }
 


### PR DESCRIPTION
### What
- Additional work on the "top barcodes" background task.
- In particular, working on "small" countries that have less than 10K products (e.g. Albania instead of France), for possible side-effects.
- As I detected a bug on the server (https://github.com/openfoodfacts/openfoodfacts-server/issues/8601), I added an explicit "page number" parameter in the "top barcodes" task. This way we avoid endless loops due to discrepancies between expected and actual downloaded barcodes, apparently due to paging.
- In addition to that, a small improvement about a "server timeout" message getting more user-friendly.

### Screenshot
![Screenshot_2023-06-24-13-52-59](https://github.com/openfoodfacts/smooth-app/assets/11576431/ecb9c6c8-102a-4515-818f-4f9f3cc166af)

### Fixes bug(s)
- Fixes: #4222

### Impacted files
* `app_en.arb`: added a label for "server timeout"
* `background_task_top_barcodes.dart`: now explicitly using page number parameter, as server data is not 100% reliable
* `dao_work_barcode.dart`: minor refactoring
* `offline_tasks_page.dart`: detected a typical "server timeout" error message and replaced it with a more user-friendly message