### PR TITLE
fix: 4165 - new cases of default language for OCR

### DIFF
--- a/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
@@ -59,6 +59,7 @@ class _AddBasicDetailsPageState extends State<AddBasicDetailsPage> {
     _multilingualHelper.init(
       multilingualTexts: _product.productNameInLanguages,
       monolingualText: _product.productName,
+      productLanguage: _product.lang,
     );
   }
 

--- a/packages/smooth_app/lib/pages/product/edit_ocr_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_ocr_page.dart
@@ -61,6 +61,9 @@ class _EditOcrPageState extends State<EditOcrPage> {
     _multilingualHelper.init(
       multilingualTexts: _helper.getMultilingualTexts(widget.product),
       monolingualText: _helper.getMonolingualText(widget.product),
+      selectedImages: widget.product.selectedImages,
+      imageField: _helper.getImageField(),
+      productLanguage: widget.product.lang,
     );
   }
 


### PR DESCRIPTION
### What
- There were some side effect cases where we could not compute the language (e.g. ingredient language) from the product data.
- It meant "no default language" and "no language selector" for OCR page - we could not OCR a Japanese image in an app in French.
- A simple fix inspired by #4165 was to say: "if we have an ingredient image in a specific language, that language may be used in the OCR page". In #4165 the bug is fixed - we land on the page with a Japanese image, therefore Japanese may be used as a default language.
- Extending that principle, now in "new product" pages we have a language selector that uses by default the app language - and the user can change it.

### Screenshot
| OCR landing page | OCR after OCR | new product basic details with language |
| -- | -- | -- |
| ![Screenshot_2023-06-24-17-23-45](https://github.com/openfoodfacts/smooth-app/assets/11576431/2fd9fd60-e3b8-43fd-aa04-f85488ac743b) | ![Screenshot_2023-06-24-17-23-53](https://github.com/openfoodfacts/smooth-app/assets/11576431/b9c1a7d5-576b-44d2-aa71-d01ad2f2dc56) | ![Screenshot_2023-06-24-17-39-24](https://github.com/openfoodfacts/smooth-app/assets/11576431/5e0f84da-e4d0-41f7-8f48-c4f56ca75f34) |

### Fixes bug(s)
- Fixes: #4165

### Impacted files
* `add_basic_details_page.dart`: added parameters for `init` method.
* `edit_ocr_page.dart`: added parameters for `init` method.
* `multilingual_helper.dart`: added parameters for `init` method, that helps us compute the default language