### PR TITLE
feat: When the compare mode is visible, ensure the visor is not covered by the header

### DIFF
--- a/packages/scanner/ml_kit/lib/src/scanner_ml_kit.dart
+++ b/packages/scanner/ml_kit/lib/src/scanner_ml_kit.dart
@@ -23,6 +23,7 @@ class ScannerMLKit extends Scanner {
     required bool hasMoreThanOneCamera,
     String? toggleCameraModeTooltip,
     String? toggleFlashModeTooltip,
+    EdgeInsetsGeometry? contentPadding,
   }) {
     return _SmoothBarcodeScannerMLKit(
       onScan: onScan,
@@ -32,6 +33,7 @@ class ScannerMLKit extends Scanner {
       hasMoreThanOneCamera: hasMoreThanOneCamera,
       toggleCameraModeTooltip: toggleCameraModeTooltip,
       toggleFlashModeTooltip: toggleFlashModeTooltip,
+      contentPadding: contentPadding,
     );
   }
 }
@@ -46,6 +48,7 @@ class _SmoothBarcodeScannerMLKit extends StatefulWidget {
     required this.hasMoreThanOneCamera,
     this.toggleCameraModeTooltip,
     this.toggleFlashModeTooltip,
+    this.contentPadding,
   });
 
   final Future<bool> Function(String) onScan;
@@ -56,6 +59,7 @@ class _SmoothBarcodeScannerMLKit extends StatefulWidget {
   final Function(BuildContext)? onCameraFlashError;
   final bool hasMoreThanOneCamera;
 
+  final EdgeInsetsGeometry? contentPadding;
   final String? toggleCameraModeTooltip;
   final String? toggleFlashModeTooltip;
 
@@ -79,7 +83,7 @@ class _SmoothBarcodeScannerMLKitState extends State<_SmoothBarcodeScannerMLKit>
 
   static const ValueKey<String> _visibilityKey =
       ValueKey<String>('VisibilityDetector');
-  static const double _cornerPadding = 26;
+  static const double _cornerPadding = 26.0;
 
   bool _isStarted = true;
 
@@ -194,10 +198,10 @@ class _SmoothBarcodeScannerMLKitState extends State<_SmoothBarcodeScannerMLKit>
               }
             },
           ),
-          const Center(
-            child: Padding(
-              padding: EdgeInsets.all(_cornerPadding),
-              child: SmoothBarcodeScannerVisor(),
+          Center(
+            child: SmoothBarcodeScannerVisor(
+              cornerRadius: _cornerPadding,
+              contentPadding: widget.contentPadding,
             ),
           ),
           Align(

--- a/packages/scanner/shared/lib/src/scanner.dart
+++ b/packages/scanner/shared/lib/src/scanner.dart
@@ -20,5 +20,8 @@ abstract class Scanner {
     required bool hasMoreThanOneCamera,
     String? toggleCameraModeTooltip,
     String? toggleFlashModeTooltip,
+
+    /// Padding to apply to the content (eg: the visor)
+    EdgeInsetsGeometry? contentPadding,
   });
 }

--- a/packages/scanner/shared/lib/src/scanner_mocked.dart
+++ b/packages/scanner/shared/lib/src/scanner_mocked.dart
@@ -19,6 +19,7 @@ class MockedScanner extends Scanner {
     required bool hasMoreThanOneCamera,
     String? toggleCameraModeTooltip,
     String? toggleFlashModeTooltip,
+    EdgeInsetsGeometry? contentPadding,
   }) =>
       Container();
 }

--- a/packages/scanner/shared/lib/src/scanner_visor.dart
+++ b/packages/scanner/shared/lib/src/scanner_visor.dart
@@ -2,10 +2,27 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 
 class SmoothBarcodeScannerVisor extends StatelessWidget {
-  const SmoothBarcodeScannerVisor({super.key});
+  const SmoothBarcodeScannerVisor({
+    required this.cornerRadius,
+    this.contentPadding,
+    super.key,
+  });
+
+  final double cornerRadius;
+  final EdgeInsetsGeometry? contentPadding;
 
   @override
-  Widget build(BuildContext context) => SizedBox.expand(
+  Widget build(BuildContext context) {
+    final EdgeInsetsGeometry contentPadding = _computePadding();
+
+    return AnimatedPadding(
+      padding: contentPadding,
+      // The duration is twice the time required to hide the header
+      duration: const Duration(milliseconds: 250),
+      curve: contentPadding.horizontal > cornerRadius * 2
+          ? Curves.easeOutQuad
+          : Curves.decelerate,
+      child: SizedBox.expand(
         child: CustomPaint(
           painter: _ScanVisorPainter(),
           child: Center(
@@ -16,7 +33,22 @@ class SmoothBarcodeScannerVisor extends StatelessWidget {
             ),
           ),
         ),
-      );
+      ),
+    );
+  }
+
+  EdgeInsetsGeometry _computePadding() {
+    if (contentPadding == null) {
+      return EdgeInsets.all(cornerRadius);
+    } else {
+      return EdgeInsets.only(
+        top: cornerRadius / 4.0,
+        left: cornerRadius,
+        right: cornerRadius,
+        bottom: cornerRadius,
+      ).add(contentPadding!);
+    }
+  }
 }
 
 class _ScanVisorPainter extends CustomPainter {

--- a/packages/scanner/zxing/lib/src/scanner_zxing.dart
+++ b/packages/scanner/zxing/lib/src/scanner_zxing.dart
@@ -25,6 +25,7 @@ class ScannerZXing extends Scanner {
     required bool hasMoreThanOneCamera,
     String? toggleCameraModeTooltip,
     String? toggleFlashModeTooltip,
+    EdgeInsetsGeometry? contentPadding,
   }) {
     return _SmoothBarcodeScannerZXing(
       onScan: onScan,
@@ -33,6 +34,7 @@ class ScannerZXing extends Scanner {
       hasMoreThanOneCamera: hasMoreThanOneCamera,
       toggleCameraModeTooltip: toggleCameraModeTooltip,
       toggleFlashModeTooltip: toggleFlashModeTooltip,
+      contentPadding: contentPadding,
     );
   }
 }
@@ -46,6 +48,7 @@ class _SmoothBarcodeScannerZXing extends StatefulWidget {
     required this.hasMoreThanOneCamera,
     this.toggleCameraModeTooltip,
     this.toggleFlashModeTooltip,
+    this.contentPadding,
   });
 
   final Future<bool> Function(String) onScan;
@@ -53,6 +56,7 @@ class _SmoothBarcodeScannerZXing extends StatefulWidget {
   final Function(BuildContext)? onCameraFlashError;
   final bool hasMoreThanOneCamera;
 
+  final EdgeInsetsGeometry? contentPadding;
   final String? toggleCameraModeTooltip;
   final String? toggleFlashModeTooltip;
 
@@ -125,10 +129,10 @@ class _SmoothBarcodeScannerZXingState
               onQRViewCreated: _onQRViewCreated,
               formatsAllowed: _barcodeFormats,
             ),
-            const Center(
-              child: Padding(
-                padding: EdgeInsets.all(_cornerPadding),
-                child: SmoothBarcodeScannerVisor(),
+            Center(
+              child: SmoothBarcodeScannerVisor(
+                cornerRadius: _cornerPadding,
+                contentPadding: widget.contentPadding,
               ),
             ),
             Align(

--- a/packages/smooth_app/lib/data_models/continuous_scan_model.dart
+++ b/packages/smooth_app/lib/data_models/continuous_scan_model.dart
@@ -65,6 +65,7 @@ class ContinuousScanModel with ChangeNotifier {
     try {
       _daoProduct = DaoProduct(localDatabase);
       _daoProductList = DaoProductList(localDatabase);
+
       if (!await _refresh()) {
         return null;
       }
@@ -306,4 +307,13 @@ class ContinuousScanModel with ChangeNotifier {
       return code;
     }
   }
+
+  /// Whether we can show the user an interface to compare products
+  /// BUT it doesn't necessary we can't compare yet.
+  /// Please refer instead to [compareFeatureAvailable]
+  bool get compareFeatureEnabled => getAvailableBarcodes().isNotEmpty;
+
+  /// If we can compare products
+  /// (= meaning we have at least two existing products)
+  bool get compareFeatureAvailable => getAvailableBarcodes().length >= 2;
 }

--- a/packages/smooth_app/lib/pages/scan/camera_scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/camera_scan_page.dart
@@ -26,6 +26,8 @@ class CameraScannerPage extends StatefulWidget {
 
 class CameraScannerPageState extends State<CameraScannerPage>
     with TraceableClientMixin {
+  final GlobalKey<State<StatefulWidget>> _headerKey = GlobalKey();
+
   /// Audio player to play the beep sound on scan
   /// This attribute is only initialized when a camera is available AND the
   /// setting is set to ON
@@ -33,6 +35,7 @@ class CameraScannerPageState extends State<CameraScannerPage>
 
   late ContinuousScanModel _model;
   late UserPreferences _userPreferences;
+  double? _headerHeight;
 
   @override
   void didChangeDependencies() {
@@ -42,6 +45,15 @@ class CameraScannerPageState extends State<CameraScannerPage>
       _model = context.watch<ContinuousScanModel>();
       _userPreferences = context.watch<UserPreferences>();
     }
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      setState(() {
+        _headerHeight =
+            (_headerKey.currentContext?.findRenderObject() as RenderBox?)
+                ?.size
+                .height;
+      });
+    });
   }
 
   @override
@@ -71,10 +83,15 @@ class CameraScannerPageState extends State<CameraScannerPage>
             hasMoreThanOneCamera: CameraHelper.hasMoreThanOneCamera,
             toggleCameraModeTooltip: appLocalizations.camera_toggle_camera,
             toggleFlashModeTooltip: appLocalizations.camera_toggle_flash,
+            contentPadding: _model.compareFeatureEnabled
+                ? EdgeInsets.only(top: _headerHeight ?? 0.0)
+                : null,
           ),
-          const Align(
+          Align(
             alignment: Alignment.topCenter,
-            child: ScanHeader(),
+            child: ScanHeader(
+              key: _headerKey,
+            ),
           ),
         ],
       ),

--- a/packages/smooth_app/lib/pages/scan/scan_header.dart
+++ b/packages/smooth_app/lib/pages/scan/scan_header.dart
@@ -8,7 +8,7 @@ import 'package:smooth_app/pages/personalized_ranking_page.dart';
 import 'package:smooth_app/pages/product/common/product_query_page_helper.dart';
 
 class ScanHeader extends StatefulWidget {
-  const ScanHeader();
+  const ScanHeader({super.key});
 
   @override
   State<ScanHeader> createState() => _ScanHeaderState();
@@ -31,11 +31,11 @@ class _ScanHeaderState extends State<ScanHeader> {
       ),
     );
 
-    final int validBarcodes = model.getAvailableBarcodes().length;
-    final bool compareFeatureAvailable = validBarcodes >= 2;
+    final bool compareFeatureAvailable = model.compareFeatureAvailable;
 
     return AnimatedOpacity(
-      opacity: validBarcodes > 0 ? _visibleOpacity : _invisibleOpacity,
+      opacity:
+          model.compareFeatureEnabled ? _visibleOpacity : _invisibleOpacity,
       duration: SmoothAnimationsDuration.brief,
       child: Padding(
         padding: const EdgeInsets.symmetric(
@@ -106,7 +106,7 @@ class _ScanHeaderState extends State<ScanHeader> {
                         label: FittedBox(
                           child: Text(
                             appLocalizations.plural_compare_x_products(
-                              validBarcodes,
+                              model.getAvailableBarcodes().length,
                             ),
                             maxLines: 1,
                           ),


### PR DESCRIPTION
Hi everyone,

On the camera/scanner page, if the compare mode is visible, two buttons are visible on top of the screen, but they may cover the visor. To prevent this, a slight padding is applied.

As always, a video: https://github.com/openfoodfacts/smooth-app/assets/246838/8f28a353-7222-4111-bb5a-fc6602fbc252

Will fix #4012

