### PR TITLE
fix: 4231 - "new product" scan card with display flexibility

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_base_card.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_base_card.dart
@@ -54,10 +54,11 @@ class SmoothProductBaseCard extends StatelessWidget {
 class ProductCardCloseButton extends StatelessWidget {
   const ProductCardCloseButton({
     this.onRemove,
-    super.key,
+    this.iconData = Icons.clear_rounded,
   });
 
   final OnRemoveCallback? onRemove;
+  final IconData iconData;
 
   @override
   Widget build(BuildContext context) {
@@ -68,10 +69,10 @@ class ProductCardCloseButton extends StatelessWidget {
       onTap: () => onRemove?.call(context),
       child: Tooltip(
         message: appLocalizations.product_card_remove_product_tooltip,
-        child: const Padding(
-          padding: EdgeInsets.all(SMALL_SPACE),
+        child: Padding(
+          padding: const EdgeInsets.all(SMALL_SPACE),
           child: Icon(
-            Icons.clear_rounded,
+            iconData,
             size: DEFAULT_ICON_SIZE,
           ),
         ),

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_not_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_not_found.dart
@@ -1,3 +1,4 @@
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:smooth_app/cards/product_cards/smooth_product_base_card.dart';
@@ -24,6 +25,8 @@ class SmoothProductCardNotFound extends StatelessWidget {
 
     return SmoothProductBaseCard(
       child: Column(
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        crossAxisAlignment: CrossAxisAlignment.center,
         children: <Widget>[
           Align(
             alignment: AlignmentDirectional.topEnd,
@@ -37,58 +40,37 @@ class SmoothProductCardNotFound extends StatelessWidget {
             }),
           ),
           Expanded(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: <Widget>[
-                RichText(
-                  textAlign: TextAlign.center,
-                  text: TextSpan(
-                    style: textTheme.headlineSmall,
-                    children: <InlineSpan>[
-                      TextSpan(
-                        text: appLocalizations.missing_product,
-                        style: textTheme.displayMedium,
-                      ),
-                      const WidgetSpan(
-                        alignment: PlaceholderAlignment.belowBaseline,
-                        baseline: TextBaseline.alphabetic,
-                        child: SizedBox(
-                          height: LARGE_SPACE,
-                        ),
-                      ),
-                      TextSpan(
-                        text: '\n${appLocalizations.add_product_take_photos}\n',
-                        style: textTheme.bodyMedium,
-                      ),
-                      TextSpan(
-                        text: '(${appLocalizations.barcode_barcode(barcode)})',
-                        style: textTheme.bodyMedium,
-                      ),
-                    ],
-                  ),
-                ),
-                Padding(
-                  padding: const EdgeInsetsDirectional.only(top: LARGE_SPACE),
-                  child: SmoothLargeButtonWithIcon(
-                    text: appLocalizations.add_product_information_button_label,
-                    icon: Icons.add,
-                    padding: const EdgeInsets.symmetric(vertical: LARGE_SPACE),
-                    onPressed: () async {
-                      await Navigator.push<void>(
-                        context,
-                        MaterialPageRoute<void>(
-                          builder: (BuildContext context) =>
-                              AddNewProductPage(barcode: barcode),
-                        ),
-                      );
-
-                      await onAddProduct?.call();
-                    },
-                  ),
-                ),
-              ],
+            flex: 2,
+            child: AutoSizeText(
+              appLocalizations.missing_product,
+              style: textTheme.displayMedium,
+              textAlign: TextAlign.center,
             ),
+          ),
+          Expanded(
+            flex: 3,
+            child: AutoSizeText(
+              '\n${appLocalizations.add_product_take_photos}\n'
+              '(${appLocalizations.barcode_barcode(barcode)})',
+              style: textTheme.bodyMedium,
+              textAlign: TextAlign.center,
+            ),
+          ),
+          SmoothLargeButtonWithIcon(
+            text: appLocalizations.add_product_information_button_label,
+            icon: Icons.add,
+            padding: const EdgeInsets.symmetric(vertical: LARGE_SPACE),
+            onPressed: () async {
+              await Navigator.push<void>(
+                context,
+                MaterialPageRoute<void>(
+                  builder: (BuildContext context) =>
+                      AddNewProductPage(barcode: barcode),
+                ),
+              );
+
+              await onAddProduct?.call();
+            },
           ),
         ],
       ),

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_not_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_not_found.dart
@@ -1,4 +1,5 @@
 import 'package:auto_size_text/auto_size_text.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:smooth_app/cards/product_cards/smooth_product_base_card.dart';
@@ -30,14 +31,17 @@ class SmoothProductCardNotFound extends StatelessWidget {
         children: <Widget>[
           Align(
             alignment: AlignmentDirectional.topEnd,
-            child: ProductCardCloseButton(onRemove: (BuildContext context) {
-              AnalyticsHelper.trackEvent(
-                AnalyticsEvent.ignoreProductNotFound,
-                barcode: barcode,
-              );
+            child: ProductCardCloseButton(
+              onRemove: (BuildContext context) {
+                AnalyticsHelper.trackEvent(
+                  AnalyticsEvent.ignoreProductNotFound,
+                  barcode: barcode,
+                );
 
-              onRemoveProduct?.call(context);
-            }),
+                onRemoveProduct?.call(context);
+              },
+              iconData: CupertinoIcons.clear_circled,
+            ),
           ),
           Expanded(
             flex: 2,


### PR DESCRIPTION
### What
- Added flexibility so that the texts of the "new product" scan card always fit in the remaining space of the card after you put the "x" button (top) and the action button (bottom). Therefore no overflow on small screens.
- Just using `AutoSizeText` and `Expanded`

### Screenshot
| before | after | larger screen |
| -- | -- | -- |
| ![Screenshot_2023-06-25-08-47-07](https://github.com/openfoodfacts/smooth-app/assets/11576431/8d4d6598-51b5-49ad-ab7c-ae9721f639e5) | ![Screenshot_2023-06-25-09-24-01](https://github.com/openfoodfacts/smooth-app/assets/11576431/c6d83911-8370-4657-9f71-18e5932f84ee) | ![Screenshot_2023-06-25-09-29-52](https://github.com/openfoodfacts/smooth-app/assets/11576431/822bb887-a94c-4bd4-a79b-e75536f97ea1) |

### Fixes bug(s)
- Fixes: #4231