### PR TITLE
fix: Fixed buttons not having equal heights

### DIFF
--- a/packages/smooth_app/lib/pages/product/edit_ocr_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_ocr_page.dart
@@ -258,7 +258,8 @@ class _EditOcrPageState extends State<EditOcrPage> {
                       Expanded(
                         child: Padding(
                           padding: const EdgeInsets.symmetric(
-                              horizontal: SMALL_SPACE),
+                              horizontal: SMALL_SPACE,
+                              ),
                           child: ProductImageServerButton(
                             product: _product,
                             imageField: _helper.getImageField(),
@@ -271,7 +272,8 @@ class _EditOcrPageState extends State<EditOcrPage> {
                       Expanded(
                         child: Padding(
                           padding: const EdgeInsets.symmetric(
-                              horizontal: SMALL_SPACE),
+                              horizontal: SMALL_SPACE,
+                              ),
                           child: ProductImageLocalButton(
                             firstPhoto: !transientFile.isImageAvailable(),
                             barcode: widget.product.barcode!,

--- a/packages/smooth_app/lib/pages/product/edit_ocr_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_ocr_page.dart
@@ -249,39 +249,41 @@ class _EditOcrPageState extends State<EditOcrPage> {
                   start: LARGE_SPACE,
                   end: LARGE_SPACE,
                 ),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  mainAxisSize: MainAxisSize.max,
-                  children: <Widget>[
-                    Expanded(
-                      child: Padding(
-                        padding:
-                            const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
-                        child: ProductImageServerButton(
-                          product: _product,
-                          imageField: _helper.getImageField(),
-                          language: language,
-                          isLoggedInMandatory: widget.isLoggedInMandatory,
-                          borderWidth: 2,
+                child: IntrinsicHeight(
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    mainAxisSize: MainAxisSize.max,
+                    children: <Widget>[
+                      Expanded(
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: SMALL_SPACE),
+                          child: ProductImageServerButton(
+                            product: _product,
+                            imageField: _helper.getImageField(),
+                            language: language,
+                            isLoggedInMandatory: widget.isLoggedInMandatory,
+                            borderWidth: 2,
+                          ),
                         ),
                       ),
-                    ),
-                    Expanded(
-                      child: Padding(
-                        padding:
-                            const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
-                        child: ProductImageLocalButton(
-                          firstPhoto: !transientFile.isImageAvailable(),
-                          barcode: widget.product.barcode!,
-                          imageField: _helper.getImageField(),
-                          language: language,
-                          isLoggedInMandatory: widget.isLoggedInMandatory,
-                          borderWidth: 2,
+                      Expanded(
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: SMALL_SPACE),
+                          child: ProductImageLocalButton(
+                            firstPhoto: !transientFile.isImageAvailable(),
+                            barcode: widget.product.barcode!,
+                            imageField: _helper.getImageField(),
+                            language: language,
+                            isLoggedInMandatory: widget.isLoggedInMandatory,
+                            borderWidth: 2,
+                          ),
                         ),
                       ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
               ),
             ),

--- a/packages/smooth_app/lib/pages/product/product_image_viewer.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_viewer.dart
@@ -179,38 +179,41 @@ class _ProductImageViewerState extends State<ProductImageViewer> {
               )
             ],
           ),
-          IntrinsicHeight(
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              mainAxisSize: MainAxisSize.max,
-              children: <Widget>[
-                Expanded(
-                  child: Padding(
-                    padding:
-                        const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
-                    child: ProductImageServerButton(
-                      product: _product,
-                      imageField: widget.imageField,
-                      language: widget.language,
-                      isLoggedInMandatory: true,
+          Container(
+            margin: EdgeInsets.only(bottom: SMALL_SPACE),
+            child: IntrinsicHeight(
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                mainAxisSize: MainAxisSize.max,
+                children: <Widget>[
+                  Expanded(
+                    child: Padding(
+                      padding:
+                          const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
+                      child: ProductImageServerButton(
+                        product: _product,
+                        imageField: widget.imageField,
+                        language: widget.language,
+                        isLoggedInMandatory: true,
+                      ),
                     ),
                   ),
-                ),
-                Expanded(
-                  child: Padding(
-                    padding:
-                        const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
-                    child: ProductImageLocalButton(
-                      firstPhoto: imageProvider == null,
-                      barcode: _barcode,
-                      imageField: widget.imageField,
-                      language: widget.language,
-                      isLoggedInMandatory: true,
+                  Expanded(
+                    child: Padding(
+                      padding:
+                          const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
+                      child: ProductImageLocalButton(
+                        firstPhoto: imageProvider == null,
+                        barcode: _barcode,
+                        imageField: widget.imageField,
+                        language: widget.language,
+                        isLoggedInMandatory: true,
+                      ),
                     ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
           if (imageProvider != null)

--- a/packages/smooth_app/lib/pages/product/product_image_viewer.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_viewer.dart
@@ -179,8 +179,8 @@ class _ProductImageViewerState extends State<ProductImageViewer> {
               )
             ],
           ),
-          Container(
-            margin: EdgeInsets.only(bottom: SMALL_SPACE),
+          Padding(
+            padding: const EdgeInsets.only(bottom: SMALL_SPACE),
             child: IntrinsicHeight(
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -202,7 +202,9 @@ class _ProductImageViewerState extends State<ProductImageViewer> {
                   Expanded(
                     child: Padding(
                       padding:
-                          const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
+                          const EdgeInsets.symmetric(
+                              horizontal: SMALL_SPACE,
+                            ),
                       child: ProductImageLocalButton(
                         firstPhoto: imageProvider == null,
                         barcode: _barcode,
@@ -233,7 +235,9 @@ class _ProductImageViewerState extends State<ProductImageViewer> {
                   Expanded(
                     child: Padding(
                       padding:
-                          const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
+                          const EdgeInsets.symmetric(
+                              horizontal: SMALL_SPACE,
+                            ),
                       child: _getEditImageButton(appLocalizations),
                     ),
                   ),

--- a/packages/smooth_app/lib/pages/product/product_image_viewer.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_viewer.dart
@@ -179,57 +179,63 @@ class _ProductImageViewerState extends State<ProductImageViewer> {
               )
             ],
           ),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            crossAxisAlignment: CrossAxisAlignment.center,
-            mainAxisSize: MainAxisSize.max,
-            children: <Widget>[
-              Expanded(
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
-                  child: ProductImageServerButton(
-                    product: _product,
-                    imageField: widget.imageField,
-                    language: widget.language,
-                    isLoggedInMandatory: true,
-                  ),
-                ),
-              ),
-              Expanded(
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
-                  child: ProductImageLocalButton(
-                    firstPhoto: imageProvider == null,
-                    barcode: _barcode,
-                    imageField: widget.imageField,
-                    language: widget.language,
-                    isLoggedInMandatory: true,
-                  ),
-                ),
-              ),
-            ],
-          ),
-          if (imageProvider != null)
-            Row(
+          IntrinsicHeight(
+            child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              crossAxisAlignment: CrossAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
               mainAxisSize: MainAxisSize.max,
               children: <Widget>[
                 Expanded(
                   child: Padding(
                     padding:
                         const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
-                    child: _getUnselectImageButton(appLocalizations),
+                    child: ProductImageServerButton(
+                      product: _product,
+                      imageField: widget.imageField,
+                      language: widget.language,
+                      isLoggedInMandatory: true,
+                    ),
                   ),
                 ),
                 Expanded(
                   child: Padding(
                     padding:
                         const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
-                    child: _getEditImageButton(appLocalizations),
+                    child: ProductImageLocalButton(
+                      firstPhoto: imageProvider == null,
+                      barcode: _barcode,
+                      imageField: widget.imageField,
+                      language: widget.language,
+                      isLoggedInMandatory: true,
+                    ),
                   ),
                 ),
               ],
+            ),
+          ),
+          if (imageProvider != null)
+            IntrinsicHeight(
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                mainAxisSize: MainAxisSize.max,
+                children: <Widget>[
+                  Expanded(
+                    child: Padding(
+                      padding:
+                          const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
+                      child: _getUnselectImageButton(appLocalizations),
+                    ),
+                  ),
+                  Expanded(
+                    child: Padding(
+                      padding:
+                          const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
+                      child: _getEditImageButton(appLocalizations),
+                    ),
+                  ),
+                ],
+              ),
             ),
         ],
       ),


### PR DESCRIPTION
### What
<!-- description of the PR -->
- Used IntrinsicHeight to fix unequal heights of buttons on small screen devices.
- Added a container with margin to add empty space between the button rows.
<!-- 
Please name your pull request following this scheme: `type: What you did` this allows us to automatically generate the changelog
Following `type`s are allowed:
  - `feat`, for Features
  - `fix`, for Bug Fixes
  - `docs`, for Documentation
  - `ci`, for Automation
  - `refactor`, for code Refactoring
  - `chore`, for Miscellaneous things
-->
### Screenshot
<!-- Insert a screenshot to provide visual record of your changes, if visible -->
![image](https://github.com/openfoodfacts/smooth-app/assets/86849857/3905ad41-9d83-4fd4-a013-91cf7f51a39f)

### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes: Unequal Heights of buttons on products image viewer page while on small screen devices.

### Part of 
- #4228 
