### PR TITLE
feat: 4163 - "incomplete product" card added to product summary

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_not_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_not_found.dart
@@ -69,7 +69,7 @@ class SmoothProductCardNotFound extends StatelessWidget {
                 context,
                 MaterialPageRoute<void>(
                   builder: (BuildContext context) =>
-                      AddNewProductPage(barcode: barcode),
+                      AddNewProductPage.fromBarcode(barcode),
                 ),
               );
 

--- a/packages/smooth_app/lib/helpers/analytics_helper.dart
+++ b/packages/smooth_app/lib/helpers/analytics_helper.dart
@@ -16,6 +16,7 @@ enum AnalyticsCategory {
   share(tag: 'share'),
   couldNotFindProduct(tag: 'could not find product'),
   productEdit(tag: 'product edit'),
+  productFastTrackEdit(tag: 'product fast track edit'),
   newProduct(tag: 'new product'),
   list(tag: 'list'),
   deepLink(tag: 'deep link');
@@ -50,11 +51,27 @@ enum AnalyticsEvent {
   ),
   openFastTrackProductEditPage(
     tag: 'opened fast-track product edit page',
-    category: AnalyticsCategory.productEdit,
+    category: AnalyticsCategory.productFastTrackEdit,
   ),
   showFastTrackProductEditCard(
     tag: 'showed fast-track product edit card',
-    category: AnalyticsCategory.productEdit,
+    category: AnalyticsCategory.productFastTrackEdit,
+  ),
+  categoriesFastTrackProductPage(
+    tag: 'set categories on fast track product page',
+    category: AnalyticsCategory.productFastTrackEdit,
+  ),
+  nutritionFastTrackProductPage(
+    tag: 'set nutrition facts on fast track product page',
+    category: AnalyticsCategory.productFastTrackEdit,
+  ),
+  ingredientsFastTrackProductPage(
+    tag: 'set ingredients on fast track product page',
+    category: AnalyticsCategory.productFastTrackEdit,
+  ),
+  closeEmptyFastTrackProductPage(
+    tag: 'closed new product page without any input',
+    category: AnalyticsCategory.productFastTrackEdit,
   ),
   openNewProductPage(
     tag: 'opened new product page',

--- a/packages/smooth_app/lib/helpers/analytics_helper.dart
+++ b/packages/smooth_app/lib/helpers/analytics_helper.dart
@@ -48,6 +48,14 @@ enum AnalyticsEvent {
     tag: 'opened product edit page',
     category: AnalyticsCategory.productEdit,
   ),
+  openFastTrackProductEditPage(
+    tag: 'opened fast-track product edit page',
+    category: AnalyticsCategory.productEdit,
+  ),
+  showFastTrackProductEditCard(
+    tag: 'showed fast-track product edit card',
+    category: AnalyticsCategory.productEdit,
+  ),
   openNewProductPage(
     tag: 'opened new product page',
     category: AnalyticsCategory.newProduct,

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -587,6 +587,7 @@
     "new_product_desc_nova_unknown": "Food processing level unknown",
     "new_product_title_pictures": "Let's take some pictures!",
     "new_product_title_misc": "And some basic data…",
+    "hey_incomplete_product_message": "Hey! Answer 3 questions NOW to compute Nutri-Score, Eco-Score & Ultra-processing (NOVA)!",
     "nutritional_facts_photo_uploaded": "Nutrition facts photo uploaded",
     "@nutritional_facts_photo_uploaded": {},
     "recycling_photo_button_label": "Recycling information photo",

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -587,7 +587,7 @@
     "new_product_desc_nova_unknown": "Food processing level unknown",
     "new_product_title_pictures": "Let's take some pictures!",
     "new_product_title_misc": "And some basic data…",
-    "hey_incomplete_product_message": "Hey! Answer 3 questions NOW to compute Nutri-Score, Eco-Score & Ultra-processing (NOVA)!",
+    "hey_incomplete_product_message": "Tap to answer 3 questions NOW to compute Nutri-Score, Eco-Score & Ultra-processing (NOVA)!",
     "nutritional_facts_photo_uploaded": "Nutrition facts photo uploaded",
     "@nutritional_facts_photo_uploaded": {},
     "recycling_photo_button_label": "Recycling information photo",

--- a/packages/smooth_app/lib/pages/navigator/app_navigator.dart
+++ b/packages/smooth_app/lib/pages/navigator/app_navigator.dart
@@ -146,7 +146,7 @@ class _SmoothGoRouter {
                   '${_InternalAppRoutes.PRODUCT_CREATOR_PAGE.path}/:productId',
               builder: (BuildContext context, GoRouterState state) {
                 final String barcode = state.pathParameters['productId']!;
-                return AddNewProductPage(barcode: barcode);
+                return AddNewProductPage.fromBarcode(barcode);
               },
             ),
             GoRoute(

--- a/packages/smooth_app/lib/pages/product/add_new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_new_product_page.dart
@@ -35,25 +35,26 @@ double _getScoreIconHeight(final BuildContext context) =>
 
 /// "Create a product we couldn't find on the server" page.
 class AddNewProductPage extends StatefulWidget {
-  AddNewProductPage.fromBarcode(
-    final String barcode, {
-    this.displayPictures = true,
-    this.displayMisc = true,
-    this.isLoggedInMandatory = false,
-  })  : assert(barcode != ''),
-        product = Product(barcode: barcode);
+  AddNewProductPage.fromBarcode(final String barcode)
+      : assert(barcode != ''),
+        product = Product(barcode: barcode),
+        analyticsEvent = AnalyticsEvent.openNewProductPage,
+        displayPictures = true,
+        displayMisc = true,
+        isLoggedInMandatory = false;
 
   const AddNewProductPage.fromProduct(
     this.product, {
-    this.displayPictures = true,
-    this.displayMisc = true,
     this.isLoggedInMandatory = true,
-  });
+  })  : analyticsEvent = AnalyticsEvent.openFastTrackProductEditPage,
+        displayPictures = false,
+        displayMisc = false;
 
   final Product product;
   final bool displayPictures;
   final bool displayMisc;
   final bool isLoggedInMandatory;
+  final AnalyticsEvent analyticsEvent;
 
   @override
   State<AddNewProductPage> createState() => _AddNewProductPageState();
@@ -119,7 +120,7 @@ class _AddNewProductPageState extends State<AddNewProductPage>
     _localDatabase.upToDate.showInterest(barcode);
     _daoProductList = DaoProductList(_localDatabase);
     AnalyticsHelper.trackEvent(
-      AnalyticsEvent.openNewProductPage,
+      widget.analyticsEvent,
       barcode: barcode,
     );
   }

--- a/packages/smooth_app/lib/pages/product/add_new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_new_product_page.dart
@@ -33,12 +33,42 @@ TextStyle? _getSubtitleStyle(final BuildContext context) => null;
 double _getScoreIconHeight(final BuildContext context) =>
     MediaQuery.of(context).size.height * .2;
 
+/// Possible actions on that page.
+enum EditProductAction {
+  openPage,
+  leaveEmpty,
+  ingredients,
+  category,
+  nutritionFacts;
+}
+
+/// Events for each action, on the "add new product" page.
+const Map<EditProductAction, AnalyticsEvent> _addNewProductEvents =
+    <EditProductAction, AnalyticsEvent>{
+  EditProductAction.openPage: AnalyticsEvent.openNewProductPage,
+  EditProductAction.leaveEmpty: AnalyticsEvent.closeEmptyNewProductPage,
+  EditProductAction.ingredients: AnalyticsEvent.ingredientsNewProductPage,
+  EditProductAction.category: AnalyticsEvent.categoriesNewProductPage,
+  EditProductAction.nutritionFacts: AnalyticsEvent.nutritionNewProductPage,
+};
+
+/// Events for each action, on the "fast-track edit product" page.
+const Map<EditProductAction, AnalyticsEvent> _fastTrackEditEvents =
+    <EditProductAction, AnalyticsEvent>{
+  EditProductAction.openPage: AnalyticsEvent.openFastTrackProductEditPage,
+  EditProductAction.leaveEmpty: AnalyticsEvent.closeEmptyFastTrackProductPage,
+  EditProductAction.ingredients: AnalyticsEvent.ingredientsFastTrackProductPage,
+  EditProductAction.category: AnalyticsEvent.categoriesFastTrackProductPage,
+  EditProductAction.nutritionFacts:
+      AnalyticsEvent.nutritionFastTrackProductPage,
+};
+
 /// "Create a product we couldn't find on the server" page.
 class AddNewProductPage extends StatefulWidget {
   AddNewProductPage.fromBarcode(final String barcode)
       : assert(barcode != ''),
         product = Product(barcode: barcode),
-        analyticsEvent = AnalyticsEvent.openNewProductPage,
+        events = _addNewProductEvents,
         displayPictures = true,
         displayMisc = true,
         isLoggedInMandatory = false;
@@ -46,7 +76,7 @@ class AddNewProductPage extends StatefulWidget {
   const AddNewProductPage.fromProduct(
     this.product, {
     this.isLoggedInMandatory = true,
-  })  : analyticsEvent = AnalyticsEvent.openFastTrackProductEditPage,
+  })  : events = _fastTrackEditEvents,
         displayPictures = false,
         displayMisc = false;
 
@@ -54,7 +84,7 @@ class AddNewProductPage extends StatefulWidget {
   final bool displayPictures;
   final bool displayMisc;
   final bool isLoggedInMandatory;
-  final AnalyticsEvent analyticsEvent;
+  final Map<EditProductAction, AnalyticsEvent> events;
 
   @override
   State<AddNewProductPage> createState() => _AddNewProductPageState();
@@ -120,7 +150,7 @@ class _AddNewProductPageState extends State<AddNewProductPage>
     _localDatabase.upToDate.showInterest(barcode);
     _daoProductList = DaoProductList(_localDatabase);
     AnalyticsHelper.trackEvent(
-      widget.analyticsEvent,
+      widget.events[EditProductAction.openPage]!,
       barcode: barcode,
     );
   }
@@ -164,7 +194,7 @@ class _AddNewProductPageState extends State<AddNewProductPage>
         );
         if (leaveThePage == true) {
           AnalyticsHelper.trackEvent(
-            AnalyticsEvent.closeEmptyNewProductPage,
+            widget.events[EditProductAction.leaveEmpty]!,
             barcode: barcode,
           );
         }
@@ -401,7 +431,7 @@ class _AddNewProductPageState extends State<AddNewProductPage>
       if (_nutritionEditor.isPopulated(_product)) {
         _trackedPopulatedNutrition = true;
         AnalyticsHelper.trackEvent(
-          AnalyticsEvent.nutritionNewProductPage,
+          widget.events[EditProductAction.nutritionFacts]!,
           barcode: barcode,
         );
       }
@@ -440,7 +470,7 @@ class _AddNewProductPageState extends State<AddNewProductPage>
       if (_categoryEditor.isPopulated(_product)) {
         _trackedPopulatedCategories = true;
         AnalyticsHelper.trackEvent(
-          AnalyticsEvent.categoriesNewProductPage,
+          widget.events[EditProductAction.category]!,
           barcode: barcode,
         );
       }
@@ -472,7 +502,7 @@ class _AddNewProductPageState extends State<AddNewProductPage>
       if (_ingredientsEditor.isPopulated(_product)) {
         _trackedPopulatedIngredients = true;
         AnalyticsHelper.trackEvent(
-          AnalyticsEvent.ingredientsNewProductPage,
+          widget.events[EditProductAction.ingredients]!,
           barcode: barcode,
         );
       }

--- a/packages/smooth_app/lib/pages/product/add_nutrition_button.dart
+++ b/packages/smooth_app/lib/pages/product/add_nutrition_button.dart
@@ -5,23 +5,18 @@ import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/pages/product/nutrition_page_loaded.dart';
 
 /// "Add nutrition facts" button for user contribution.
-class AddNutritionButton extends StatefulWidget {
+class AddNutritionButton extends StatelessWidget {
   const AddNutritionButton(this.product);
 
   final Product product;
 
   @override
-  State<AddNutritionButton> createState() => _AddNutritionButtonState();
-}
-
-class _AddNutritionButtonState extends State<AddNutritionButton> {
-  @override
   Widget build(BuildContext context) => addPanelButton(
         AppLocalizations.of(context).score_add_missing_nutrition_facts,
         onPressed: () async => NutritionPageLoaded.showNutritionPage(
-          product: widget.product,
+          product: product,
           isLoggedInMandatory: true,
-          widget: this,
+          context: context,
         ),
       );
 }

--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -199,7 +199,7 @@ class _EditProductPageState extends State<EditProductPage> {
                       await NutritionPageLoaded.showNutritionPage(
                         product: _product,
                         isLoggedInMandatory: true,
-                        widget: this,
+                        context: context,
                       );
                     }),
                 _getSimpleListTileItem(SimpleInputPageLabelHelper()),

--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -42,46 +42,40 @@ class NutritionPageLoaded extends StatefulWidget {
   static Future<void> showNutritionPage({
     required final Product product,
     required final bool isLoggedInMandatory,
-    required final State<StatefulWidget> widget,
+    required final BuildContext context,
   }) async {
-    if (!widget.mounted) {
-      return;
-    }
     if (isLoggedInMandatory) {
-      // ignore: use_build_context_synchronously
-      if (!await ProductRefresher().checkIfLoggedIn(widget.context)) {
+      if (!await ProductRefresher().checkIfLoggedIn(context)) {
         return;
       }
     }
-    if (!widget.mounted) {
-      return;
-    }
-    final OrderedNutrientsCache? cache =
-        await OrderedNutrientsCache.getCache(widget.context);
-    if (!widget.mounted) {
-      return;
-    }
-    if (cache == null) {
-      ScaffoldMessenger.of(widget.context).showSnackBar(
-        SnackBar(
-          content: Text(
-            AppLocalizations.of(widget.context).nutrition_cache_loading_error,
+    if (context.mounted) {
+      final OrderedNutrientsCache? cache =
+          await OrderedNutrientsCache.getCache(context);
+      if (context.mounted) {
+        if (cache == null) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(
+                AppLocalizations.of(context).nutrition_cache_loading_error,
+              ),
+            ),
+          );
+          return;
+        }
+        await Navigator.push<void>(
+          context,
+          MaterialPageRoute<void>(
+            builder: (BuildContext context) => NutritionPageLoaded(
+              product,
+              cache.orderedNutrients,
+              isLoggedInMandatory: isLoggedInMandatory,
+            ),
+            fullscreenDialog: true,
           ),
-        ),
-      );
-      return;
+        );
+      }
     }
-    await Navigator.push<void>(
-      widget.context,
-      MaterialPageRoute<void>(
-        builder: (BuildContext context) => NutritionPageLoaded(
-          product,
-          cache.orderedNutrients,
-          isLoggedInMandatory: isLoggedInMandatory,
-        ),
-        fullscreenDialog: true,
-      ),
-    );
   }
 }
 

--- a/packages/smooth_app/lib/pages/product/product_compatibility_header.dart
+++ b/packages/smooth_app/lib/pages/product/product_compatibility_header.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/data_models/product_preferences.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/helpers/product_compatibility_helper.dart';
+import 'package:smooth_app/pages/navigator/app_navigator.dart';
+import 'package:smooth_app/pages/preferences/user_preferences_page.dart';
+
+/// Header showing the product compatibility (color + text).
+class ProductCompatibilityHeader extends StatelessWidget {
+  const ProductCompatibilityHeader({
+    required this.product,
+    required this.productPreferences,
+    required this.isSettingClickable,
+  });
+
+  final Product product;
+  final ProductPreferences productPreferences;
+  final bool isSettingClickable;
+
+  @override
+  Widget build(BuildContext context) {
+    final MatchedProductV2 matchedProduct = MatchedProductV2(
+      product,
+      productPreferences,
+    );
+    final ProductCompatibilityHelper helper =
+        ProductCompatibilityHelper.product(matchedProduct);
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final ThemeData themeData = Theme.of(context);
+    final bool isDarkMode = themeData.colorScheme.brightness == Brightness.dark;
+
+    return Ink(
+      decoration: BoxDecoration(
+        color: helper.getHeaderBackgroundColor(isDarkMode),
+        // Ensure that the header has the same circular radius as the SmoothCard.
+        borderRadius: const BorderRadius.only(
+          topLeft: ROUNDED_RADIUS,
+          topRight: ROUNDED_RADIUS,
+        ),
+      ),
+      child: Row(
+        children: <Widget>[
+          // Fake icon
+          const SizedBox(width: kMinInteractiveDimension),
+          Expanded(
+            child: Center(
+              child: Padding(
+                padding: const EdgeInsets.all(SMALL_SPACE),
+                child: Text(
+                  helper.getHeaderText(appLocalizations),
+                  style: themeData.textTheme.titleMedium?.copyWith(
+                    color: helper.getHeaderForegroundColor(isDarkMode),
+                  ),
+                ),
+              ),
+            ),
+          ),
+          InkWell(
+            borderRadius: const BorderRadius.only(topRight: ROUNDED_RADIUS),
+            onTap: isSettingClickable
+                ? () => AppNavigator.of(context).push(
+                      AppRoutes.PREFERENCES(PreferencePageType.FOOD),
+                    )
+                : null,
+            child: Tooltip(
+              message: appLocalizations.open_food_preferences_tooltip,
+              triggerMode: isSettingClickable
+                  ? TooltipTriggerMode.longPress
+                  : TooltipTriggerMode.tap,
+              child: const SizedBox.square(
+                dimension: kMinInteractiveDimension,
+                child: Icon(Icons.settings),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/smooth_app/lib/pages/product/product_field_editor.dart
+++ b/packages/smooth_app/lib/pages/product/product_field_editor.dart
@@ -6,6 +6,7 @@ import 'package:smooth_app/pages/product/add_basic_details_page.dart';
 import 'package:smooth_app/pages/product/common/product_refresher.dart';
 import 'package:smooth_app/pages/product/edit_new_packagings.dart';
 import 'package:smooth_app/pages/product/edit_ocr_page.dart';
+import 'package:smooth_app/pages/product/nutrition_page_loaded.dart';
 import 'package:smooth_app/pages/product/ocr_helper.dart';
 import 'package:smooth_app/pages/product/ocr_ingredients_helper.dart';
 import 'package:smooth_app/pages/product/ocr_packaging_helper.dart';
@@ -173,6 +174,28 @@ class ProductFieldPackagingEditor extends ProductFieldEditor {
       ),
     );
   }
+}
+
+class ProductFieldNutritionEditor extends ProductFieldEditor {
+  @override
+  bool isPopulated(final Product product) =>
+      product.nutriments?.isEmpty() == false;
+
+  @override
+  String getLabel(final AppLocalizations appLocalizations) =>
+      appLocalizations.nutritional_facts_input_button_label;
+
+  @override
+  Future<void> edit({
+    required final BuildContext context,
+    required final Product product,
+    final bool isLoggedInMandatory = true,
+  }) async =>
+      NutritionPageLoaded.showNutritionPage(
+        product: product,
+        isLoggedInMandatory: isLoggedInMandatory,
+        context: context,
+      );
 }
 
 abstract class ProductFieldOcrEditor extends ProductFieldEditor {

--- a/packages/smooth_app/lib/pages/product/product_incomplete_card.dart
+++ b/packages/smooth_app/lib/pages/product/product_incomplete_card.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/pages/product/add_new_product_page.dart';
+import 'package:smooth_app/pages/product/product_field_editor.dart';
+import 'package:smooth_app/pages/product/simple_input_page_helpers.dart';
+
+/// "Incomplete product!" card to be displayed in product summary, if relevant.
+///
+/// You're suppose to test [isProductIncomplete] first; if true you should
+/// display the card.
+class ProductIncompleteCard extends StatelessWidget {
+  const ProductIncompleteCard({
+    required this.product,
+    this.isLoggedInMandatory = true,
+  });
+
+  final Product product;
+  final bool isLoggedInMandatory;
+
+  static bool isProductIncomplete(final Product product) {
+    final List<ProductFieldEditor> editors = <ProductFieldEditor>[
+      ProductFieldSimpleEditor(SimpleInputPageCategoryHelper()),
+      ProductFieldNutritionEditor(),
+      ProductFieldOcrIngredientEditor(),
+    ];
+
+    for (final ProductFieldEditor editor in editors) {
+      if (!editor.isPopulated(product)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    if (!isProductIncomplete(product)) {
+      // not supposed to happen: you should check `isProductIncomplete == true` first
+      return EMPTY_WIDGET;
+    }
+
+    final ColorScheme colorScheme = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: SMALL_SPACE),
+      child: ElevatedButton.icon(
+        label: Padding(
+          padding: const EdgeInsets.symmetric(vertical: SMALL_SPACE),
+          child: Text(appLocalizations.hey_incomplete_product_message),
+        ),
+        icon: const Icon(
+          Icons.bolt,
+          color: Colors.amber,
+        ),
+        onPressed: () async => Navigator.push<void>(
+          context,
+          MaterialPageRoute<void>(
+            builder: (BuildContext context) => AddNewProductPage.fromProduct(
+              product,
+              displayPictures: false,
+              displayMisc: false,
+              isLoggedInMandatory: isLoggedInMandatory,
+            ),
+          ),
+        ),
+        style: ButtonStyle(
+          backgroundColor: MaterialStateProperty.all<Color>(
+            colorScheme.primary,
+          ),
+          foregroundColor: MaterialStateProperty.all<Color>(
+            colorScheme.onPrimary,
+          ),
+          shape: MaterialStateProperty.all<RoundedRectangleBorder>(
+            const RoundedRectangleBorder(borderRadius: ROUNDED_BORDER_RADIUS),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/smooth_app/lib/pages/product/product_incomplete_card.dart
+++ b/packages/smooth_app/lib/pages/product/product_incomplete_card.dart
@@ -59,8 +59,6 @@ class ProductIncompleteCard extends StatelessWidget {
           MaterialPageRoute<void>(
             builder: (BuildContext context) => AddNewProductPage.fromProduct(
               product,
-              displayPictures: false,
-              displayMisc: false,
               isLoggedInMandatory: isLoggedInMandatory,
             ),
           ),

--- a/packages/smooth_app/lib/pages/product/product_incomplete_card.dart
+++ b/packages/smooth_app/lib/pages/product/product_incomplete_card.dart
@@ -73,7 +73,7 @@ class ProductIncompleteCard extends StatelessWidget {
             colorScheme.onPrimary,
           ),
           shape: MaterialStateProperty.all<RoundedRectangleBorder>(
-            const RoundedRectangleBorder(borderRadius: ROUNDED_BORDER_RADIUS),
+            const RoundedRectangleBorder(borderRadius: ANGULAR_BORDER_RADIUS),
           ),
         ),
       ),

--- a/packages/smooth_app/lib/pages/product/summary_attribute_group.dart
+++ b/packages/smooth_app/lib/pages/product/summary_attribute_group.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+
+/// Shows the attribute groups in a product summary card.
+class SummaryAttributeGroup extends StatelessWidget {
+  const SummaryAttributeGroup({
+    required this.attributeChips,
+    required this.isClickable,
+    required this.isFirstGroup,
+    this.groupName,
+  });
+
+  final List<Widget> attributeChips;
+  final bool isClickable;
+  final bool isFirstGroup;
+  final String? groupName;
+
+  @override
+  Widget build(BuildContext context) => AbsorbPointer(
+        absorbing: !isClickable,
+        child: Column(
+          children: <Widget>[
+            _SummaryAttributeGroupHeader(
+              isFirstGroup: isFirstGroup,
+              groupName: groupName,
+            ),
+            Container(
+              alignment: Alignment.topLeft,
+              child: Wrap(
+                runSpacing: 16,
+                children: attributeChips,
+              ),
+            ),
+          ],
+        ),
+      );
+}
+
+class _SummaryAttributeGroupHeader extends StatelessWidget {
+  const _SummaryAttributeGroupHeader({
+    required this.isFirstGroup,
+    this.groupName,
+  });
+
+  final bool isFirstGroup;
+  final String? groupName;
+
+  @override
+  Widget build(BuildContext context) => groupName != null
+      ? Container(
+          alignment: Alignment.topLeft,
+          padding: const EdgeInsetsDirectional.only(
+            top: SMALL_SPACE,
+            bottom: LARGE_SPACE,
+          ),
+          child: Text(
+            groupName!,
+            style: Theme.of(context)
+                .textTheme
+                .bodyMedium!
+                .apply(color: Colors.grey),
+          ),
+        )
+      : Padding(
+          padding: const EdgeInsets.symmetric(vertical: SMALL_SPACE),
+          child: isFirstGroup
+              ? EMPTY_WIDGET
+              : const Divider(
+                  color: Colors.black12,
+                ),
+        );
+}

--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -9,6 +9,7 @@ import 'package:smooth_app/data_models/product_preferences.dart';
 import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/attributes_card_helper.dart';
 import 'package:smooth_app/helpers/haptic_feedback_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
@@ -91,6 +92,12 @@ class _SummaryCardState extends State<SummaryCard> {
     _initialProduct = widget._product;
     _localDatabase = context.read<LocalDatabase>();
     _localDatabase.upToDate.showInterest(_initialProduct.barcode!);
+    if (ProductIncompleteCard.isProductIncomplete(_initialProduct)) {
+      AnalyticsHelper.trackEvent(
+        AnalyticsEvent.showFastTrackProductEditCard,
+        barcode: _initialProduct.barcode!,
+      );
+    }
   }
 
   @override

--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -95,7 +95,7 @@ class _SummaryCardState extends State<SummaryCard> {
     if (ProductIncompleteCard.isProductIncomplete(_initialProduct)) {
       AnalyticsHelper.trackEvent(
         AnalyticsEvent.showFastTrackProductEditCard,
-        barcode: _initialProduct.barcode!,
+        barcode: _initialProduct.barcode,
       );
     }
   }

--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -12,18 +12,18 @@ import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/helpers/attributes_card_helper.dart';
 import 'package:smooth_app/helpers/haptic_feedback_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
-import 'package:smooth_app/helpers/product_compatibility_helper.dart';
 import 'package:smooth_app/helpers/ui_helpers.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_page.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels_builder.dart';
-import 'package:smooth_app/pages/navigator/app_navigator.dart';
-import 'package:smooth_app/pages/preferences/user_preferences_page.dart';
 import 'package:smooth_app/pages/product/add_simple_input_button.dart';
 import 'package:smooth_app/pages/product/common/product_query_page_helper.dart';
 import 'package:smooth_app/pages/product/hideable_container.dart';
+import 'package:smooth_app/pages/product/product_compatibility_header.dart';
 import 'package:smooth_app/pages/product/product_field_editor.dart';
+import 'package:smooth_app/pages/product/product_incomplete_card.dart';
 import 'package:smooth_app/pages/product/product_questions_widget.dart';
 import 'package:smooth_app/pages/product/simple_input_page_helpers.dart';
+import 'package:smooth_app/pages/product/summary_attribute_group.dart';
 import 'package:smooth_app/query/category_product_query.dart';
 import 'package:smooth_app/query/product_query.dart';
 
@@ -35,9 +35,6 @@ const List<String> _ATTRIBUTE_GROUP_ORDER = <String>[
   AttributeGroup.ATTRIBUTE_GROUP_LABELS,
   AttributeGroup.ATTRIBUTE_GROUP_ENVIRONMENT,
 ];
-
-// Each row in the summary card takes roughly 40px.
-const int _SUMMARY_CARD_ROW_HEIGHT = 40;
 
 class SummaryCard extends StatefulWidget {
   const SummaryCard(
@@ -85,10 +82,6 @@ class _SummaryCardState extends State<SummaryCard> {
   late final Product _initialProduct;
   late final LocalDatabase _localDatabase;
 
-  // Number of Rows that will be printed in the SummaryCard, initialized to a
-  // very high number for infinite rows.
-  int _totalPrintableRows = 10000;
-
   // For some reason, special case for "label" attributes
   final Set<String> _attributesToExcludeIfStatusIsUnknown = <String>{};
 
@@ -112,7 +105,11 @@ class _SummaryCardState extends State<SummaryCard> {
     _product = _localDatabase.upToDate.getLocalUpToDate(_initialProduct);
     if (widget.isFullVersion) {
       return buildProductSmoothCard(
-        header: _buildProductCompatibilityHeader(context),
+        header: ProductCompatibilityHeader(
+          product: _product,
+          productPreferences: widget._productPreferences,
+          isSettingClickable: widget.isSettingClickable,
+        ),
         body: Padding(
           padding: SMOOTH_CARD_PADDING,
           child: _buildSummaryCardContent(context),
@@ -127,7 +124,6 @@ class _SummaryCardState extends State<SummaryCard> {
   }
 
   Widget _buildLimitedSizeSummaryCard(double parentHeight) {
-    _totalPrintableRows = parentHeight ~/ _SUMMARY_CARD_ROW_HEIGHT;
     return Padding(
       padding: const EdgeInsets.symmetric(
         horizontal: SMALL_SPACE,
@@ -142,7 +138,11 @@ class _SummaryCardState extends State<SummaryCard> {
               minHeight: parentHeight,
               maxHeight: double.infinity,
               child: buildProductSmoothCard(
-                header: _buildProductCompatibilityHeader(context),
+                header: ProductCompatibilityHeader(
+                  product: _product,
+                  productPreferences: widget._productPreferences,
+                  isSettingClickable: widget.isSettingClickable,
+                ),
                 body: Padding(
                   padding: SMOOTH_CARD_PADDING,
                   child: _buildSummaryCardContent(context),
@@ -193,13 +193,6 @@ class _SummaryCardState extends State<SummaryCard> {
       excludedAttributeIds,
     );
 
-    // Header takes 1 row.
-    // Product Title Tile takes 2 rows to render.
-    // Footer takes 1 row.
-    _totalPrintableRows -= 4;
-    // Each Score card takes about 1.5 rows to render.
-    _totalPrintableRows -= (1.5 * scoreAttributes.length).ceil();
-
     final List<Widget> displayedGroups = <Widget>[];
 
     // First, a virtual group with mandatory attributes of all groups
@@ -213,12 +206,11 @@ class _SummaryCardState extends State<SummaryCard> {
     );
     if (attributeChips.isNotEmpty) {
       displayedGroups.add(
-        _buildAttributeGroup(
-          _buildAttributeGroupHeader(
-            isFirstGroup: displayedGroups.isEmpty,
-            groupName: null,
-          ),
-          attributeChips,
+        SummaryAttributeGroup(
+          attributeChips: attributeChips,
+          isClickable: widget.attributeGroupsClickable,
+          isFirstGroup: displayedGroups.isEmpty,
+          groupName: null,
         ),
       );
     }
@@ -244,13 +236,13 @@ class _SummaryCardState extends State<SummaryCard> {
       );
       if (attributeChips.isNotEmpty) {
         displayedGroups.add(
-          _buildAttributeGroup(
-            _buildAttributeGroupHeader(
-                isFirstGroup: displayedGroups.isEmpty,
-                groupName: group.id == AttributeGroup.ATTRIBUTE_GROUP_ALLERGENS
-                    ? group.name!
-                    : null),
-            attributeChips,
+          SummaryAttributeGroup(
+            attributeChips: attributeChips,
+            isClickable: widget.attributeGroupsClickable,
+            isFirstGroup: displayedGroups.isEmpty,
+            groupName: group.id == AttributeGroup.ATTRIBUTE_GROUP_ALLERGENS
+                ? group.name!
+                : null,
           ),
         );
       }
@@ -362,6 +354,8 @@ class _SummaryCardState extends State<SummaryCard> {
             });
           },
         ),
+        if (ProductIncompleteCard.isProductIncomplete(_product))
+          ProductIncompleteCard(product: _product),
         ..._getAttributes(scoreAttributes),
         if (widget.isFullVersion) ProductQuestionsWidget(_product),
         attributesContainer,
@@ -403,131 +397,16 @@ class _SummaryCardState extends State<SummaryCard> {
     return attributes;
   }
 
-  Widget _buildProductCompatibilityHeader(BuildContext context) {
-    final MatchedProductV2 matchedProduct = MatchedProductV2(
-      _product,
-      widget._productPreferences,
-    );
-    final ProductCompatibilityHelper helper =
-        ProductCompatibilityHelper.product(matchedProduct);
-    final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    final bool isDarkMode =
-        Theme.of(context).colorScheme.brightness == Brightness.dark;
-
-    return Ink(
-      decoration: BoxDecoration(
-        color: helper.getHeaderBackgroundColor(isDarkMode),
-        // Ensure that the header has the same circular radius as the SmoothCard.
-        borderRadius: const BorderRadius.only(
-          topLeft: ROUNDED_RADIUS,
-          topRight: ROUNDED_RADIUS,
-        ),
-      ),
-      child: Row(
-        children: <Widget>[
-          // Fake icon
-          const SizedBox(
-            width: kMinInteractiveDimension,
-          ),
-          Expanded(
-            child: Center(
-              child: Padding(
-                padding: const EdgeInsets.symmetric(
-                  vertical: SMALL_SPACE,
-                  horizontal: SMALL_SPACE,
-                ),
-                child: Text(
-                  helper.getHeaderText(appLocalizations),
-                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        color: helper.getHeaderForegroundColor(isDarkMode),
-                      ),
-                ),
-              ),
-            ),
-          ),
-          InkWell(
-            borderRadius: const BorderRadius.only(topRight: ROUNDED_RADIUS),
-            onTap: widget.isSettingClickable
-                ? () => AppNavigator.of(context).push(
-                      AppRoutes.PREFERENCES(PreferencePageType.FOOD),
-                    )
-                : null,
-            child: Tooltip(
-              message: appLocalizations.open_food_preferences_tooltip,
-              triggerMode: widget.isSettingClickable
-                  ? TooltipTriggerMode.longPress
-                  : TooltipTriggerMode.tap,
-              child: const SizedBox.square(
-                dimension: kMinInteractiveDimension,
-                child: Icon(
-                  Icons.settings,
-                ),
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildAttributeGroup(
-    final Widget header,
-    final List<Widget> attributeChips,
-  ) {
-    _totalPrintableRows -= (attributeChips.length / 2).ceil();
-    return AbsorbPointer(
-      absorbing: !widget.attributeGroupsClickable,
-      child: Column(
-        children: <Widget>[
-          header,
-          Container(
-            alignment: Alignment.topLeft,
-            child: Wrap(
-              runSpacing: 16,
-              children: attributeChips,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
   List<Widget> _buildAttributeChips(final List<Attribute> attributes) {
     final List<Widget> result = <Widget>[];
     for (final Attribute attribute in attributes) {
       final Widget? attributeChip =
           _buildAttributeChipForValidAttributes(attribute);
-      if (attributeChip != null && result.length / 2 < _totalPrintableRows) {
+      if (attributeChip != null) {
         result.add(attributeChip);
       }
     }
     return result;
-  }
-
-  Widget _buildAttributeGroupHeader({
-    required bool isFirstGroup,
-    String? groupName,
-  }) {
-    if (groupName != null) {
-      return Container(
-        alignment: Alignment.topLeft,
-        padding: const EdgeInsetsDirectional.only(
-            top: SMALL_SPACE, bottom: LARGE_SPACE),
-        child: Text(
-          groupName,
-          style:
-              Theme.of(context).textTheme.bodyMedium!.apply(color: Colors.grey),
-        ),
-      );
-    }
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: SMALL_SPACE),
-      child: isFirstGroup
-          ? EMPTY_WIDGET
-          : const Divider(
-              color: Colors.black12,
-            ),
-    );
   }
 
   Widget? _buildAttributeChipForValidAttributes(final Attribute attribute) {


### PR DESCRIPTION
### What
- When a scanned product was available but incomplete, it looked boring (grey colors because no scores computed) and without any explicit action button to complete the product.
- Now there's an additional button if at least category, ingredients or nutrition facts are missing. This button is added to the scan card and to the product page.
- When we click on the button, we go to a page similar to the "add new product" page, but focused on the scores (here we don't show images and basic details).

### Screenshots
| light | dark |
| -- | -- |
| ![Screenshot_2023-06-26-16-13-55](https://github.com/openfoodfacts/smooth-app/assets/11576431/7e6aefd2-4ce5-465e-a71f-cb49eb777ab4) | ![Screenshot_2023-06-26-16-14-51](https://github.com/openfoodfacts/smooth-app/assets/11576431/7f9356a3-17d7-4825-8d16-65363e855023) |
| ![Screenshot_2023-06-26-16-14-15](https://github.com/openfoodfacts/smooth-app/assets/11576431/6a0cd4c7-5022-432d-aa37-f296a5124294) | ![Screenshot_2023-06-26-16-14-59](https://github.com/openfoodfacts/smooth-app/assets/11576431/21e22cd4-7099-4e1d-97e2-0d47a5751138) |
| ![Screenshot_2023-06-26-16-15-30](https://github.com/openfoodfacts/smooth-app/assets/11576431/17f600ec-30e8-46e4-99cb-3446aa7872a2) | ![Screenshot_2023-06-26-16-15-11](https://github.com/openfoodfacts/smooth-app/assets/11576431/4ef83097-dc9d-4741-b270-9d84fb0af9f7) |

"Bigger" screen
| scan | page |
| -- | -- |
| ![Screenshot_2023-06-26-16-01-39](https://github.com/openfoodfacts/smooth-app/assets/11576431/b4b054f8-6135-4853-8f34-f4a541f8b361) | ![Screenshot_2023-06-26-16-01-53](https://github.com/openfoodfacts/smooth-app/assets/11576431/926c68cb-df5c-46d9-a657-4e8a24f16dd7) |

### Fixes bug(s)
- Closes: #4163

### Files
New files:
* `product_compatibility_header.dart`: Header showing the product compatibility (color + text). Used to be private in `summary_card.dart`.
* `product_incomplete_card.dart`: "Incomplete product!" card to be displayed in product summary, if relevant.
* `summary_attribute_group.dart`: Shows the attribute groups in a product summary card. Used to be private in `summary_card.dart`.

Impacted files:
* `add_new_product_page.dart`: added a constructor for product instead of barcode; added display parameters; now using new "nutrition field editor"
* `add_nutrition_button.dart`: minor refactoring
* `app_en.arb`: added 1 label for the "hey! please complete the product!" message
* `app_navigator.dart`: minor refactoring
* `edit_product_page.dart`: minor refactoring
* `nutrition_page_loaded.dart`: minor refactoring
* `product_field_editor.dart`: new "nutrition field editor"
* `smooth_product_card_not_found.dart`: minor refactoring
* `summary_card.dart`: refactored into additional files because the file was getting too big and possibly too confusing; added the "incomplete product" card (if relevant)