### PR TITLE
fix: The nutrition page is unusable on iOS

### DIFF
--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -89,6 +89,7 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded>
       <Nutrient, TextEditingControllerWithInitialValue>{};
   TextEditingControllerWithInitialValue? _servingController;
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+  final List<FocusNode> _focusNodes = <FocusNode>[];
 
   @override
   void initState() {
@@ -98,12 +99,15 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded>
       orderedNutrients: widget.orderedNutrients,
       product: initialProduct,
     );
+
     _decimalNumberFormat =
         SimpleInputNumberField.getNumberFormat(decimal: true);
   }
 
   @override
   void dispose() {
+    _focusNodes.clear();
+
     for (final TextEditingControllerWithInitialValue controller
         in _controllers.values) {
       controller.dispose();
@@ -121,7 +125,6 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded>
     final List<Widget> children = <Widget>[];
 
     // List of focus nodes for all text fields except the serving one.
-    final List<FocusNode> focusNodes;
 
     children.add(_switchNoNutrition(appLocalizations));
 
@@ -138,11 +141,16 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded>
       final Iterable<OrderedNutrient> displayableNutrients =
           _nutritionContainer.getDisplayableNutrients();
 
-      focusNodes = List<FocusNode>.generate(
-        displayableNutrients.length,
-        (_) => FocusNode(),
-        growable: false,
-      );
+      if (_focusNodes.length != displayableNutrients.length) {
+        _focusNodes.clear();
+        _focusNodes.addAll(
+          List<FocusNode>.generate(
+            displayableNutrients.length,
+            (_) => FocusNode(),
+            growable: false,
+          ),
+        );
+      }
 
       for (int i = 0; i != displayableNutrients.length; i++) {
         final OrderedNutrient orderedNutrient =
@@ -173,7 +181,7 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded>
         ),
       );
     } else {
-      focusNodes = <FocusNode>[];
+      _focusNodes.clear();
     }
 
     return WillPopScope(
@@ -201,7 +209,7 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded>
           child: Form(
             key: _formKey,
             child: Provider<List<FocusNode>>.value(
-              value: focusNodes,
+              value: _focusNodes,
               child: ListView(children: children),
             ),
           ),


### PR DESCRIPTION
Hi everyone,

On iOS, the nutrition page is pretty much unusable because we create focus nodes on every builds.
This is absolutely not necessary and creates a weird issue, preventing sometimes entering values.

Before: https://github.com/openfoodfacts/smooth-app/assets/246838/e1672ad1-7d24-41aa-9232-81e75b8168f0
After: https://github.com/openfoodfacts/smooth-app/assets/246838/be172123-46f9-4c2d-b296-79271d01c173

