### PR TITLE
fix: 4206 - search page misalignment in search-history_view.dart (#4210)

### DIFF
--- a/packages/smooth_app/lib/pages/scan/search_history_view.dart
+++ b/packages/smooth_app/lib/pages/scan/search_history_view.dart
@@ -50,11 +50,14 @@ class _SearchHistoryViewState extends State<SearchHistoryView> {
           _handleDismissed(context, query),
       background: Container(color: RED_COLOR),
       child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: LARGE_SPACE),
+        padding: const EdgeInsets.only(left: 18, right: 21),
         child: ListTile(
           leading: const Padding(
             padding: EdgeInsetsDirectional.only(top: VERY_SMALL_SPACE),
-            child: Icon(Icons.search, size: 18.0),
+            child: Icon(
+              Icons.search,
+              size: 18.0,
+            ),
           ),
           trailing: InkWell(
             customBorder: const CircleBorder(),
@@ -64,24 +67,21 @@ class _SearchHistoryViewState extends State<SearchHistoryView> {
                 context,
                 listen: false,
               );
-      
+
               controller.text = query;
-              controller.selection =
-                  TextSelection.fromPosition(TextPosition(offset: query.length));
-      
+              controller.selection = TextSelection.fromPosition(
+                  TextPosition(offset: query.length));
+
               // If the keyboard is hidden, show it.
               if (View.of(context).viewInsets.bottom == 0) {
                 widget.focusNode?.unfocus();
-      
+
                 WidgetsBinding.instance.addPostFrameCallback((_) {
                   FocusScope.of(context).requestFocus(widget.focusNode);
                 });
               }
             },
-            child: const Padding(
-              padding: EdgeInsets.all(SMALL_SPACE),
-              child: Icon(Icons.edit, size: 18.0),
-            ),
+            child: Icon(Icons.edit, size: 18.0),
           ),
           minLeadingWidth: 10,
           title: Text(query, style: const TextStyle(fontSize: 20.0)),

--- a/packages/smooth_app/lib/pages/scan/search_history_view.dart
+++ b/packages/smooth_app/lib/pages/scan/search_history_view.dart
@@ -49,43 +49,46 @@ class _SearchHistoryViewState extends State<SearchHistoryView> {
       onDismissed: (DismissDirection direction) async =>
           _handleDismissed(context, query),
       background: Container(color: RED_COLOR),
-      child: Padding(
-        padding: const EdgeInsets.only(left: 18, right: 21),
-        child: ListTile(
-          leading: const Padding(
-            padding: EdgeInsetsDirectional.only(top: VERY_SMALL_SPACE),
-            child: Icon(
-              Icons.search,
-              size: 18.0,
+      child: InkWell(
+        onTap: () => widget.onTap?.call(query),
+        child: Padding(
+          padding: const EdgeInsets.only(left: 18, right: 21),
+          child: ListTile(
+            contentPadding: EdgeInsets.only(left: 18, right: 21),
+            leading: const Padding(
+              padding: EdgeInsetsDirectional.only(top: VERY_SMALL_SPACE),
+              child: Icon(
+                Icons.search,
+                size: 18.0,
+              ),
             ),
+            trailing: InkWell(
+              customBorder: const CircleBorder(),
+              onTap: () {
+                final TextEditingController controller =
+                    Provider.of<TextEditingController>(
+                  context,
+                  listen: false,
+                );
+      
+                controller.text = query;
+                controller.selection = TextSelection.fromPosition(
+                    TextPosition(offset: query.length));
+      
+                // If the keyboard is hidden, show it.
+                if (View.of(context).viewInsets.bottom == 0) {
+                  widget.focusNode?.unfocus();
+      
+                  WidgetsBinding.instance.addPostFrameCallback((_) {
+                    FocusScope.of(context).requestFocus(widget.focusNode);
+                  });
+                }
+              },
+              child: Icon(Icons.edit, size: 18.0),
+            ),
+            minLeadingWidth: 10,
+            title: Text(query, style: const TextStyle(fontSize: 20.0)),
           ),
-          trailing: InkWell(
-            customBorder: const CircleBorder(),
-            onTap: () {
-              final TextEditingController controller =
-                  Provider.of<TextEditingController>(
-                context,
-                listen: false,
-              );
-
-              controller.text = query;
-              controller.selection = TextSelection.fromPosition(
-                  TextPosition(offset: query.length));
-
-              // If the keyboard is hidden, show it.
-              if (View.of(context).viewInsets.bottom == 0) {
-                widget.focusNode?.unfocus();
-
-                WidgetsBinding.instance.addPostFrameCallback((_) {
-                  FocusScope.of(context).requestFocus(widget.focusNode);
-                });
-              }
-            },
-            child: Icon(Icons.edit, size: 18.0),
-          ),
-          minLeadingWidth: 10,
-          title: Text(query, style: const TextStyle(fontSize: 20.0)),
-          onTap: () => widget.onTap?.call(query),
         ),
       ),
     );

--- a/packages/smooth_app/lib/pages/scan/search_history_view.dart
+++ b/packages/smooth_app/lib/pages/scan/search_history_view.dart
@@ -52,7 +52,7 @@ class _SearchHistoryViewState extends State<SearchHistoryView> {
       child: InkWell(
         onTap: () => widget.onTap?.call(query),
         child: Padding(
-          padding: const EdgeInsets.only(left: 18.0, right: 21.0),
+          padding: const EdgeInsets.only(left: 18.0, right: 13.0),
           child: ListTile(
             leading: const Padding(
               padding: EdgeInsetsDirectional.only(top: VERY_SMALL_SPACE),
@@ -83,7 +83,10 @@ class _SearchHistoryViewState extends State<SearchHistoryView> {
                   });
                 }
               },
-              child: const Icon(Icons.edit, size: 18.0),
+              child: const Padding(
+                padding: EdgeInsets.all(8.0),
+                child: Icon(Icons.edit, size: 18.0),
+              ),
             ),
             minLeadingWidth: 10,
             title: Text(query, style: const TextStyle(fontSize: 20.0)),

--- a/packages/smooth_app/lib/pages/scan/search_history_view.dart
+++ b/packages/smooth_app/lib/pages/scan/search_history_view.dart
@@ -48,13 +48,20 @@ class _SearchHistoryViewState extends State<SearchHistoryView> {
       direction: DismissDirection.endToStart,
       onDismissed: (DismissDirection direction) async =>
           _handleDismissed(context, query),
-      background: Container(color: RED_COLOR),
+      background: Container(
+          alignment: Alignment.centerRight,
+          color: RED_COLOR,
+          padding: const EdgeInsetsDirectional.only(end: 30),
+          child: const Icon(
+            Icons.delete,
+            color: Colors.white,
+          ),
+        ),
       child: InkWell(
         onTap: () => widget.onTap?.call(query),
         child: Padding(
-          padding: const EdgeInsets.only(left: 18, right: 21),
+          padding: const EdgeInsets.only(left: 18.0, right: 21.0),
           child: ListTile(
-            contentPadding: EdgeInsets.only(left: 18, right: 21),
             leading: const Padding(
               padding: EdgeInsetsDirectional.only(top: VERY_SMALL_SPACE),
               child: Icon(
@@ -70,21 +77,21 @@ class _SearchHistoryViewState extends State<SearchHistoryView> {
                   context,
                   listen: false,
                 );
-      
+
                 controller.text = query;
                 controller.selection = TextSelection.fromPosition(
                     TextPosition(offset: query.length));
-      
+
                 // If the keyboard is hidden, show it.
                 if (View.of(context).viewInsets.bottom == 0) {
                   widget.focusNode?.unfocus();
-      
+
                   WidgetsBinding.instance.addPostFrameCallback((_) {
                     FocusScope.of(context).requestFocus(widget.focusNode);
                   });
                 }
               },
-              child: Icon(Icons.edit, size: 18.0),
+              child: const Icon(Icons.edit, size: 18.0),
             ),
             minLeadingWidth: 10,
             title: Text(query, style: const TextStyle(fontSize: 20.0)),

--- a/packages/smooth_app/lib/pages/scan/search_history_view.dart
+++ b/packages/smooth_app/lib/pages/scan/search_history_view.dart
@@ -48,15 +48,7 @@ class _SearchHistoryViewState extends State<SearchHistoryView> {
       direction: DismissDirection.endToStart,
       onDismissed: (DismissDirection direction) async =>
           _handleDismissed(context, query),
-      background: Container(
-          alignment: Alignment.centerRight,
-          color: RED_COLOR,
-          padding: const EdgeInsetsDirectional.only(end: 30),
-          child: const Icon(
-            Icons.delete,
-            color: Colors.white,
-          ),
-        ),
+      background: Container(color: RED_COLOR),
       child: InkWell(
         onTap: () => widget.onTap?.call(query),
         child: Padding(

--- a/packages/smooth_app/lib/pages/scan/search_history_view.dart
+++ b/packages/smooth_app/lib/pages/scan/search_history_view.dart
@@ -49,41 +49,44 @@ class _SearchHistoryViewState extends State<SearchHistoryView> {
       onDismissed: (DismissDirection direction) async =>
           _handleDismissed(context, query),
       background: Container(color: RED_COLOR),
-      child: ListTile(
-        leading: const Padding(
-          padding: EdgeInsetsDirectional.only(top: VERY_SMALL_SPACE),
-          child: Icon(Icons.search, size: 18.0),
-        ),
-        trailing: InkWell(
-          customBorder: const CircleBorder(),
-          onTap: () {
-            final TextEditingController controller =
-                Provider.of<TextEditingController>(
-              context,
-              listen: false,
-            );
-
-            controller.text = query;
-            controller.selection =
-                TextSelection.fromPosition(TextPosition(offset: query.length));
-
-            // If the keyboard is hidden, show it.
-            if (View.of(context).viewInsets.bottom == 0) {
-              widget.focusNode?.unfocus();
-
-              WidgetsBinding.instance.addPostFrameCallback((_) {
-                FocusScope.of(context).requestFocus(widget.focusNode);
-              });
-            }
-          },
-          child: const Padding(
-            padding: EdgeInsets.all(SMALL_SPACE),
-            child: Icon(Icons.edit, size: 18.0),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: LARGE_SPACE),
+        child: ListTile(
+          leading: const Padding(
+            padding: EdgeInsetsDirectional.only(top: VERY_SMALL_SPACE),
+            child: Icon(Icons.search, size: 18.0),
           ),
+          trailing: InkWell(
+            customBorder: const CircleBorder(),
+            onTap: () {
+              final TextEditingController controller =
+                  Provider.of<TextEditingController>(
+                context,
+                listen: false,
+              );
+      
+              controller.text = query;
+              controller.selection =
+                  TextSelection.fromPosition(TextPosition(offset: query.length));
+      
+              // If the keyboard is hidden, show it.
+              if (View.of(context).viewInsets.bottom == 0) {
+                widget.focusNode?.unfocus();
+      
+                WidgetsBinding.instance.addPostFrameCallback((_) {
+                  FocusScope.of(context).requestFocus(widget.focusNode);
+                });
+              }
+            },
+            child: const Padding(
+              padding: EdgeInsets.all(SMALL_SPACE),
+              child: Icon(Icons.edit, size: 18.0),
+            ),
+          ),
+          minLeadingWidth: 10,
+          title: Text(query, style: const TextStyle(fontSize: 20.0)),
+          onTap: () => widget.onTap?.call(query),
         ),
-        minLeadingWidth: 10,
-        title: Text(query, style: const TextStyle(fontSize: 20.0)),
-        onTap: () => widget.onTap?.call(query),
       ),
     );
   }


### PR DESCRIPTION
Impacted file:

search-history_view.dart: added padding to the list tile for proper alignment Resolved the misalignment issue on the search page by adding appropriate padding to the list tile in the search-history_view.dart file. This adjustment ensures that the elements within the list are properly aligned, improving the visual consistency of the search page.

### What
- Added padding to the list tile in the `search-history_view.dart` file to achieve proper alignment.
- This adjustment ensures that the elements within the list are properly aligned, improving the visual consistency of the search page.

### Screenshot
![Screenshot_1688317600](https://github.com/openfoodfacts/smooth-app/assets/69450092/b2060942-9347-44d0-9e5a-9022d33efdab)

### Fixes bug(s)
- Fixes: #4206 search page history tiles are misaligned

### Part of 
- #4206 
