### PR TITLE
fix: "Null check operator used on a null value" on search results

### DIFF
--- a/packages/smooth_app/lib/data_models/query_product_list_supplier.dart
+++ b/packages/smooth_app/lib/data_models/query_product_list_supplier.dart
@@ -21,7 +21,7 @@ class QueryProductListSupplier extends ProductListSupplier {
       partialProductList.clear();
       if (searchResult.products != null) {
         productList.setAll(searchResult.products!);
-        productList.totalSize = searchResult.count!;
+        productList.totalSize = searchResult.count ?? 0;
         partialProductList.add(productList);
         await DaoProduct(localDatabase).putAll(searchResult.products!);
       }


### PR DESCRIPTION
Hi everyone!

On search pages, when there are no results, the count field is `null`, hence generating an error.
Here is a simple fix to prevent it.

It will fix #4191