### PR TITLE
ci: Add an action to upload APKs to Waldo

### DIFF
--- a/.github/workflows/waldo_sessions.yml
+++ b/.github/workflows/waldo_sessions.yml
@@ -1,0 +1,57 @@
+name: Upload builds to Waldo
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+    
+jobs:
+  build:
+    runs-on: macos-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup Java JDK
+        uses: actions/setup-java@v3.11.0
+        with:
+          distribution: 'zulu'
+          java-version: 11
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          #channel: stable
+          cache: true
+          flutter-version: ${{ steps.flutter-version.outputs.FLUTTER_VERSION }}
+          cache-key: flutter-${{ hashFiles('flutter-version.txt')}}-${{ hashFiles('packages\smooth_app\pubspec.lock')}}
+
+      - run: flutter --version
+
+      - name: Get dependencies
+        run: ci/pub_upgrade.sh
+        
+      # Build apk.
+      - name: Build APK
+        run: flutter build apk --debug -t lib/entrypoints/android/main_google_play.dart
+        working-directory: ./packages/smooth_app
+
+      - name: Upload APK to Waldo
+        uses: waldoapp/gh-action-upload@v1
+        with:
+          build_path: packages/smooth_app/build/app/outputs/flutter-apk/app-debug.apk
+          upload_token: ${{ secrets.WALDO_SESSIONS_ANDROID }}
+
+      - name: Write comment
+        uses: mshick/add-pr-comment@v2
+        with:
+          message: "You can test this PR on: [https://app.waldo.com/applications/app-19d476740ba1bb36/sessions](Android)"
+
+      # TODO Build the iOS variant and upload it

--- a/.github/workflows/waldo_sessions.yml
+++ b/.github/workflows/waldo_sessions.yml
@@ -25,6 +25,10 @@ jobs:
           distribution: 'zulu'
           java-version: 11
 
+      # Get the flutter version from ./flutter-version.txt
+      - run: echo "FLUTTER_VERSION=$(cat flutter-version.txt)" >> $GITHUB_OUTPUT
+        id: flutter-version
+
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:


### PR DESCRIPTION
The code is now really to upload APKs (IPA will come once we are confident this one works well).

It will only be with PRs in a first time, and also we can't have a direct link to the website to test, as the Waldo session doesn't provide what's necessary yet (a bug is opened on their side)