### PR TITLE
feat: 4041 - renamed "history" bottom item as "lists", w/ access to other lists

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -424,6 +424,10 @@
     "@history_navbar_label": {
         "description": "BottomNavigationBarLabel: For the history and compare mode"
     },
+    "list_navbar_label": "Lists",
+    "@list_navbar_label": {
+        "description": "BottomNavigationBarLabel: For the lists"
+    },
     "category": "Filter by category",
     "@category": {
         "description": "From a product list, there's a category filter: this is its title"
@@ -743,6 +747,10 @@
     "product_removed_history": "Product removed from history",
     "@product_removed_history": {
         "description": "Product got removed from history"
+    },
+    "product_removed_list": "Product removed from list",
+    "@product_removed_list": {
+        "description": "Product got removed from list"
     },
     "product_could_not_remove": "Could not remove product",
     "@product_could_not_remove": {

--- a/packages/smooth_app/lib/pages/page_manager.dart
+++ b/packages/smooth_app/lib/pages/page_manager.dart
@@ -9,7 +9,7 @@ import 'package:smooth_app/widgets/tab_navigator.dart';
 enum BottomNavigationTab {
   Profile,
   Scan,
-  History,
+  List,
 }
 
 /// Here the different tabs in the bottom navigation bar are taken care of,
@@ -27,14 +27,14 @@ class PageManagerState extends State<PageManager> {
   static const List<BottomNavigationTab> _pageKeys = <BottomNavigationTab>[
     BottomNavigationTab.Profile,
     BottomNavigationTab.Scan,
-    BottomNavigationTab.History,
+    BottomNavigationTab.List,
   ];
 
   final Map<BottomNavigationTab, GlobalKey<NavigatorState>> _navigatorKeys =
       <BottomNavigationTab, GlobalKey<NavigatorState>>{
     BottomNavigationTab.Profile: GlobalKey<NavigatorState>(),
     BottomNavigationTab.Scan: GlobalKey<NavigatorState>(),
-    BottomNavigationTab.History: GlobalKey<NavigatorState>(),
+    BottomNavigationTab.List: GlobalKey<NavigatorState>(),
   };
 
   BottomNavigationTab _currentPage = BottomNavigationTab.Scan;
@@ -76,7 +76,7 @@ class PageManagerState extends State<PageManager> {
     final List<Widget> tabs = <Widget>[
       _buildOffstageNavigator(BottomNavigationTab.Profile),
       _buildOffstageNavigator(BottomNavigationTab.Scan),
-      _buildOffstageNavigator(BottomNavigationTab.History),
+      _buildOffstageNavigator(BottomNavigationTab.List),
     ];
 
     final UserPreferences userPreferences = context.watch<UserPreferences>();
@@ -111,8 +111,8 @@ class PageManagerState extends State<PageManager> {
           label: appLocalizations.scan_navbar_label,
         ),
         BottomNavigationBarItem(
-          icon: const Icon(Icons.history),
-          label: appLocalizations.history_navbar_label,
+          icon: const Icon(Icons.list),
+          label: appLocalizations.list_navbar_label,
         ),
       ],
     );

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_account.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_account.dart
@@ -435,7 +435,10 @@ class _UserPreferencesPageState extends State<UserPreferencesSection> {
     required final LocalDatabase localDatabase,
   }) =>
       _getListTile(
-        ProductQueryPageHelper.getProductListLabel(productList, context),
+        ProductQueryPageHelper.getProductListLabel(
+          productList,
+          AppLocalizations.of(context),
+        ),
         () async {
           await DaoProductList(localDatabase).get(productList);
           if (!mounted) {

--- a/packages/smooth_app/lib/pages/product/common/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_page.dart
@@ -212,10 +212,10 @@ class _ProductListPageState extends State<ProductListPage>
                 ),
               ],
         title: AutoSizeText(
-          '${ProductQueryPageHelper.getProductListLabel(
+          ProductQueryPageHelper.getProductListLabel(
             productList,
             appLocalizations,
-          )} (liste)', // TODO localize here
+          ),
           maxLines: 2,
         ),
         actionMode: _selectionMode,

--- a/packages/smooth_app/lib/pages/product/common/product_list_popup_items.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_popup_items.dart
@@ -18,6 +18,8 @@ abstract class ProductListPopupItem {
   String getTitle(final AppLocalizations appLocalizations);
 
   /// Action of the popup menu item.
+  ///
+  /// Returns a different product list if there are changes, else null.
   Future<ProductList?> doSomething({
     required final ProductList productList,
     required final LocalDatabase localDatabase,
@@ -86,16 +88,9 @@ class ProductListPopupRename extends ProductListPopupItem {
     required final ProductList productList,
     required final LocalDatabase localDatabase,
     required final BuildContext context,
-  }) async {
-    final DaoProductList daoProductList = DaoProductList(localDatabase);
-    final ProductList? renamedProductList =
-        await ProductListUserDialogHelper(daoProductList)
-            .showRenameUserListDialog(context, productList);
-    if (renamedProductList == null) {
-      return null;
-    }
-    return renamedProductList;
-  }
+  }) async =>
+      ProductListUserDialogHelper(DaoProductList(localDatabase))
+          .showRenameUserListDialog(context, productList);
 }
 
 /// Popup menu item for the product list page: share list.

--- a/packages/smooth_app/lib/pages/product/common/product_list_popup_items.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_popup_items.dart
@@ -1,0 +1,168 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:share_plus/share_plus.dart';
+import 'package:smooth_app/data_models/product_list.dart';
+import 'package:smooth_app/database/dao_product_list.dart';
+import 'package:smooth_app/database/local_database.dart';
+import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
+import 'package:smooth_app/helpers/analytics_helper.dart';
+import 'package:smooth_app/helpers/temp_product_list_share_helper.dart';
+import 'package:smooth_app/pages/product/common/product_query_page_helper.dart';
+import 'package:smooth_app/pages/product_list_user_dialog_helper.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+/// Popup menu items for the product list page.
+abstract class ProductListPopupItem {
+  /// Title of the popup menu item.
+  @protected
+  String getTitle(final AppLocalizations appLocalizations);
+
+  /// Action of the popup menu item.
+  Future<ProductList?> doSomething({
+    required final ProductList productList,
+    required final LocalDatabase localDatabase,
+    required final BuildContext context,
+  });
+
+  /// Returns the popup menu item.
+  PopupMenuItem<ProductListPopupItem> getMenuItem(
+    final AppLocalizations appLocalizations,
+  ) =>
+      PopupMenuItem<ProductListPopupItem>(
+        value: this,
+        child: Text(getTitle(appLocalizations)),
+      );
+}
+
+/// Popup menu item for the product list page: clear list.
+class ProductListPopupClear extends ProductListPopupItem {
+  @override
+  String getTitle(final AppLocalizations appLocalizations) =>
+      appLocalizations.user_list_popup_clear;
+
+  @override
+  Future<ProductList?> doSomething({
+    required final ProductList productList,
+    required final LocalDatabase localDatabase,
+    required final BuildContext context,
+  }) async {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final DaoProductList daoProductList = DaoProductList(localDatabase);
+    final bool? ok = await showDialog<bool>(
+      context: context,
+      builder: (BuildContext context) => SmoothAlertDialog(
+        body: Text(
+          productList.listType == ProductListType.USER
+              ? appLocalizations.confirm_clear_user_list(productList.parameters)
+              : appLocalizations.confirm_clear,
+        ),
+        positiveAction: SmoothActionButton(
+          onPressed: () => Navigator.of(context).pop(true),
+          text: appLocalizations.yes,
+        ),
+        negativeAction: SmoothActionButton(
+          onPressed: () => Navigator.of(context).pop(),
+          text: appLocalizations.no,
+        ),
+      ),
+    );
+    if (ok == true) {
+      await daoProductList.clear(productList);
+      await daoProductList.get(productList);
+      return productList;
+    }
+    return null;
+  }
+}
+
+/// Popup menu item for the product list page: rename list.
+class ProductListPopupRename extends ProductListPopupItem {
+  @override
+  String getTitle(final AppLocalizations appLocalizations) =>
+      appLocalizations.user_list_popup_rename;
+
+  @override
+  Future<ProductList?> doSomething({
+    required final ProductList productList,
+    required final LocalDatabase localDatabase,
+    required final BuildContext context,
+  }) async {
+    final DaoProductList daoProductList = DaoProductList(localDatabase);
+    final ProductList? renamedProductList =
+        await ProductListUserDialogHelper(daoProductList)
+            .showRenameUserListDialog(context, productList);
+    if (renamedProductList == null) {
+      return null;
+    }
+    return renamedProductList;
+  }
+}
+
+/// Popup menu item for the product list page: share list.
+class ProductListPopupShare extends ProductListPopupItem {
+  @override
+  String getTitle(final AppLocalizations appLocalizations) =>
+      appLocalizations.share;
+
+  @override
+  Future<ProductList?> doSomething({
+    required final ProductList productList,
+    required final LocalDatabase localDatabase,
+    required final BuildContext context,
+  }) async {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final List<String> products = productList.getList();
+    final String url = shareProductList(products).toString();
+
+    final RenderBox? box = context.findRenderObject() as RenderBox?;
+    AnalyticsHelper.trackEvent(AnalyticsEvent.shareList);
+    Share.share(
+      appLocalizations.share_product_list_text(url),
+      sharePositionOrigin: box!.localToGlobal(Offset.zero) & box.size,
+    );
+    return null;
+  }
+}
+
+/// Popup menu item for the product list page: open list in web.
+class ProductListPopupOpenInWeb extends ProductListPopupItem {
+  @override
+  String getTitle(final AppLocalizations appLocalizations) =>
+      appLocalizations.label_web;
+
+  @override
+  Future<ProductList?> doSomething({
+    required final ProductList productList,
+    required final LocalDatabase localDatabase,
+    required final BuildContext context,
+  }) async {
+    final List<String> products = productList.getList();
+    AnalyticsHelper.trackEvent(AnalyticsEvent.openListWeb);
+    await launchUrl(shareProductList(products));
+    return null;
+  }
+}
+
+/// Popup menu item for the product list page: switch to another list.
+class ProductListPopupList extends ProductListPopupItem {
+  ProductListPopupList(this.newProductList);
+
+  final ProductList newProductList;
+
+  @override
+  String getTitle(final AppLocalizations appLocalizations) =>
+      ProductQueryPageHelper.getProductListLabel(
+        newProductList,
+        appLocalizations,
+      );
+
+  @override
+  Future<ProductList?> doSomething({
+    required final ProductList productList,
+    required final LocalDatabase localDatabase,
+    required final BuildContext context,
+  }) async {
+    await DaoProductList(localDatabase).get(newProductList);
+    return newProductList;
+  }
+}

--- a/packages/smooth_app/lib/pages/product/common/product_query_page_helper.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_query_page_helper.dart
@@ -79,9 +79,8 @@ class ProductQueryPageHelper {
 
   static String getProductListLabel(
     final ProductList productList,
-    final BuildContext context,
+    final AppLocalizations appLocalizations,
   ) {
-    final AppLocalizations appLocalizations = AppLocalizations.of(context);
     switch (productList.listType) {
       case ProductListType.HTTP_SEARCH_KEYWORDS:
       case ProductListType.HTTP_SEARCH_CATEGORY:

--- a/packages/smooth_app/lib/pages/scan/scan_header.dart
+++ b/packages/smooth_app/lib/pages/scan/scan_header.dart
@@ -96,7 +96,7 @@ class _ScanHeaderState extends State<ScanHeader> {
                                       title: ProductQueryPageHelper
                                           .getProductListLabel(
                                         model.productList,
-                                        context,
+                                        appLocalizations,
                                       ),
                                     ),
                                   ),

--- a/packages/smooth_app/lib/widgets/tab_navigator.dart
+++ b/packages/smooth_app/lib/widgets/tab_navigator.dart
@@ -21,7 +21,7 @@ class TabNavigator extends StatelessWidget {
       case BottomNavigationTab.Profile:
         child = const UserPreferencesPage();
         break;
-      case BottomNavigationTab.History:
+      case BottomNavigationTab.List:
         child = const HistoryPage();
         break;
       case BottomNavigationTab.Scan:


### PR DESCRIPTION
### What
- The "history" bottom navigation bar item is now renamed as "lists", with a different icon.
- From the product list page, we can go the other lists. For the moment, the other lists are among "scan session", "scan history" and "history".
- In a next PR, user lists will be added.

### Screenshots
| history page | history page with popup menu |
| -- | -- |
| ![Screenshot_2023-07-06-11-35-04](https://github.com/openfoodfacts/smooth-app/assets/11576431/e33a18d4-72d0-4629-8e39-f6f5c24c17d6) | ![Screenshot_2023-07-06-11-35-11](https://github.com/openfoodfacts/smooth-app/assets/11576431/558e53d2-1c3e-435f-b1c7-d01c9507dfa5) |

| scan history page | scan session page |
| -- | -- |
| ![Screenshot_2023-07-06-11-35-23](https://github.com/openfoodfacts/smooth-app/assets/11576431/8d1bb013-cc35-40cb-885c-64918201affd) | ![Screenshot_2023-07-06-11-35-16](https://github.com/openfoodfacts/smooth-app/assets/11576431/d8cfb917-973b-4176-bf3c-87e0a01eab26) |

### Part of 
- #4041

### Files
New file:
* `product_list_popup_items.dart`: Popup menu items for the product list page.

Impacted files:
* `app_en.arb`: added 2 labels
* `page_manager.dart`: new label and icon for bottom bar
* `product_list_page.dart`: added fast access to scan session, scan history and history; moved code to `product_list_popup_items.dart`
* `product_query_page_helper.dart`: minor refactoring
* `scan_header.dart`: minor refactoring
* `tab_navigator.dart`: minor refactoring
* `user_preferences_account.dart`: minor refactoring