### PR TITLE
feat: Bring the "Hot reload" feature back

### DIFF
--- a/packages/smooth_app/lib/pages/navigator/app_navigator.dart
+++ b/packages/smooth_app/lib/pages/navigator/app_navigator.dart
@@ -35,10 +35,7 @@ class AppNavigator extends InheritedWidget {
   AppNavigator({
     Key? key,
     required Widget child,
-    List<NavigatorObserver>? observers,
-  })  : _router = _SmoothGoRouter(
-          observers: observers,
-        ),
+  })  : _router = _SmoothGoRouter(),
         super(key: key, child: child);
 
   // GoRouter is never accessible directly
@@ -89,7 +86,11 @@ class AppNavigator extends InheritedWidget {
 /// One drawback of the implementation is that we never know the base URL of the
 /// deep link (eg: es.openfoodfacts.org)
 class _SmoothGoRouter {
-  _SmoothGoRouter({
+  factory _SmoothGoRouter() {
+    return _singleton;
+  }
+
+  _SmoothGoRouter._internal({
     List<NavigatorObserver>? observers,
   }) {
     router = GoRouter(
@@ -237,6 +238,7 @@ class _SmoothGoRouter {
     );
   }
 
+  static final _SmoothGoRouter _singleton = _SmoothGoRouter._internal();
   late GoRouter router;
 
   // Indicates whether [_initAppLanguage] was already called


### PR DESCRIPTION
Hi everyone!

After the migration to GoRouter, the Hot Reload feature from Dart/Flutter didn't work anymore and was a real pain.
The problem was coming from the GoRouter object being recreated on every Hot Reload.

By using a singleton instead, we're now safe and the Hot Reload works again ☺️