### PR TITLE
feat: Onboarding improvements (country picker + Authorize buttons)

### DIFF
--- a/packages/smooth_app/lib/generic_lib/dialogs/smooth_alert_dialog.dart
+++ b/packages/smooth_app/lib/generic_lib/dialogs/smooth_alert_dialog.dart
@@ -28,6 +28,7 @@ class SmoothAlertDialog extends StatelessWidget {
     this.actionsAxis,
     this.actionsOrder,
     this.close = false,
+    this.contentPadding,
   });
 
   final String? title;
@@ -37,6 +38,7 @@ class SmoothAlertDialog extends StatelessWidget {
   final SmoothActionButton? negativeAction;
   final Axis? actionsAxis;
   final SmoothButtonsBarOrder? actionsOrder;
+  final EdgeInsets? contentPadding;
 
   static const EdgeInsets _smallContentPadding = EdgeInsets.only(
     left: SMALL_SPACE,
@@ -55,8 +57,8 @@ class SmoothAlertDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final Widget content = _buildContent(context);
-    final EdgeInsets padding =
-        context.isSmallDevice() ? _smallContentPadding : _contentPadding;
+    final EdgeInsets padding = contentPadding ??
+        (context.isSmallDevice() ? _smallContentPadding : _contentPadding);
 
     return AlertDialog(
       scrollable: false,
@@ -87,6 +89,9 @@ class SmoothAlertDialog extends StatelessWidget {
       padding: EdgeInsetsDirectional.only(
         top: padding.bottom,
         start: SMALL_SPACE,
+        end: positiveAction != null && negativeAction != null
+            ? 0.0
+            : SMALL_SPACE,
       ),
       child: SmoothActionButtonsBar(
         positiveAction: positiveAction,

--- a/packages/smooth_app/lib/pages/onboarding/country_selector.dart
+++ b/packages/smooth_app/lib/pages/onboarding/country_selector.dart
@@ -81,63 +81,81 @@ class _CountrySelectorState extends State<CountrySelector> {
                   builder: (BuildContext context,
                       void Function(VoidCallback fn) setState) {
                     return SmoothAlertDialog(
+                      contentPadding: const EdgeInsets.symmetric(
+                        horizontal: 0.0,
+                        vertical: SMALL_SPACE,
+                      ),
                       body: SizedBox(
                         height: MediaQuery.of(context).size.height / 2,
                         width: MediaQuery.of(context).size.width,
                         child: Column(
                           children: <Widget>[
-                            SmoothTextFormField(
-                              type: TextFieldTypes.PLAIN_TEXT,
-                              prefixIcon: const Icon(Icons.search),
-                              controller: countryController,
-                              onChanged: (String? query) {
-                                setState(
-                                  () {
-                                    filteredList = _countryList
-                                        .where(
-                                          (Country item) =>
-                                              item.name.toLowerCase().contains(
-                                                    query!.toLowerCase(),
-                                                  ) ||
-                                              item.countryCode
-                                                  .toLowerCase()
-                                                  .contains(
-                                                    query.toLowerCase(),
-                                                  ),
-                                        )
-                                        .toList(growable: false);
-                                  },
-                                );
-                              },
-                              hintText: appLocalizations.search,
-                            ),
-                            Expanded(
-                              child: ListView.builder(
-                                itemBuilder: (BuildContext context, int index) {
-                                  final Country country = filteredList[index];
-                                  final bool selected =
-                                      country == selectedCountry;
-                                  return ListTile(
-                                    dense: true,
-                                    trailing: selected
-                                        ? const Icon(Icons.check)
-                                        : null,
-                                    title: Text(
-                                      country.name,
-                                      softWrap: false,
-                                      overflow: TextOverflow.fade,
-                                      style: selected
-                                          ? const TextStyle(
-                                              fontWeight: FontWeight.bold,
-                                            )
-                                          : null,
-                                    ),
-                                    onTap: () =>
-                                        Navigator.of(context).pop(country),
+                            Padding(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: SMALL_SPACE,
+                              ),
+                              child: SmoothTextFormField(
+                                type: TextFieldTypes.PLAIN_TEXT,
+                                prefixIcon: const Icon(Icons.search),
+                                controller: countryController,
+                                onChanged: (String? query) {
+                                  setState(
+                                    () {
+                                      filteredList = _countryList
+                                          .where(
+                                            (Country item) =>
+                                                item.name
+                                                    .toLowerCase()
+                                                    .contains(
+                                                      query!.toLowerCase(),
+                                                    ) ||
+                                                item.countryCode
+                                                    .toLowerCase()
+                                                    .contains(
+                                                      query.toLowerCase(),
+                                                    ),
+                                          )
+                                          .toList(growable: false);
+                                    },
                                   );
                                 },
-                                itemCount: filteredList.length,
-                                shrinkWrap: true,
+                                hintText: appLocalizations.search,
+                              ),
+                            ),
+                            Expanded(
+                              child: Scrollbar(
+                                child: ListView.builder(
+                                  itemBuilder:
+                                      (BuildContext context, int index) {
+                                    final Country country = filteredList[index];
+                                    final bool selected =
+                                        country == selectedCountry;
+                                    return ListTile(
+                                      dense: true,
+                                      contentPadding:
+                                          const EdgeInsets.symmetric(
+                                        horizontal: 16.0 + SMALL_SPACE,
+                                      ),
+                                      trailing: selected
+                                          ? const Icon(Icons.check)
+                                          : null,
+                                      title: Text(
+                                        country.name,
+                                        softWrap: false,
+                                        overflow: TextOverflow.fade,
+                                        style: selected
+                                            ? const TextStyle(
+                                                fontWeight: FontWeight.bold,
+                                              )
+                                            : null,
+                                      ),
+                                      onTap: () =>
+                                          Navigator.of(context).pop(country),
+                                    );
+                                  },
+                                  itemCount: filteredList.length,
+                                  shrinkWrap: true,
+                                ),
                               ),
                             )
                           ],
@@ -162,6 +180,9 @@ class _CountrySelectorState extends State<CountrySelector> {
           child: Container(
             decoration: const BoxDecoration(
               borderRadius: BorderRadius.all(Radius.circular(10)),
+            ),
+            padding: const EdgeInsets.symmetric(
+              vertical: SMALL_SPACE,
             ),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/packages/smooth_app/lib/pages/onboarding/onboarding_bottom_bar.dart
+++ b/packages/smooth_app/lib/pages/onboarding/onboarding_bottom_bar.dart
@@ -79,6 +79,10 @@ class OnboardingBottomButton extends StatelessWidget {
           onPressed: onPressed,
           style: ButtonStyle(
             backgroundColor: MaterialStateProperty.all(backgroundColor),
+            overlayColor: backgroundColor == Colors.white
+                ? MaterialStateProperty.all<Color>(
+                    Theme.of(context).splashColor)
+                : null,
             shape: MaterialStateProperty.all<RoundedRectangleBorder>(
               const RoundedRectangleBorder(
                   borderRadius: BorderRadius.all(Radius.circular(40))),

--- a/packages/smooth_app/lib/pages/onboarding/welcome_page.dart
+++ b/packages/smooth_app/lib/pages/onboarding/welcome_page.dart
@@ -96,7 +96,6 @@ class WelcomePage extends StatelessWidget {
                       ),
                       Padding(
                         padding: const EdgeInsetsDirectional.only(
-                          start: SMALL_SPACE,
                           bottom: VERY_SMALL_SPACE,
                         ),
                         child: Text(


### PR DESCRIPTION
Hi everyone,

In the onboarding, there are two visuals issues:

- The country picker doesn't have any padding any more (+ the dialog doesn't have any `Scrollbar`, nor correct padding)
- The Authorize button have an invisible `InkWell` (white on white)

Here is a video of the country picker: 
[CountryPicker.webm](https://github.com/openfoodfacts/smooth-app/assets/246838/30d09bf2-ff62-4f59-8a98-c20bba4d1dd1)

(I've there is no regression on other screens)