### PR TITLE
feat: On iOS, the camera was never stopped after being resumed in some edge cases

### DIFF
--- a/packages/scanner/ml_kit/lib/src/scanner_ml_kit.dart
+++ b/packages/scanner/ml_kit/lib/src/scanner_ml_kit.dart
@@ -126,11 +126,17 @@ class _SmoothBarcodeScannerMLKitState extends State<_SmoothBarcodeScannerMLKit>
 
   void _checkIfAppIsRestarting([int retry = 0]) {
     /// When the app is resumed (from the launcher for example), the camera is
-    /// always started and we can't prevent this behavior.
+    /// always started due to the [autostart] feature and we can't
+    /// prevent this behavior.
     ///
     /// To fix it, we check when the app is resumed if the camera is the
     /// visible page and if that's not the case, we wait for the camera to be
-    /// initialized to stop it
+    /// initialized to stop it.
+    ///
+    /// Comment from @g123k: This is a very hacky way (temporary I hope) and
+    /// more explanation are available on the PR:
+    /// [https://github.com/openfoodfacts/smooth-app/pull/4292]
+    ///
     // ignore: prefer_function_declarations_over_variables
     final Function fn = () {
       if (ScreenVisibilityDetector.invisible(context)) {

--- a/packages/scanner/ml_kit/pubspec.yaml
+++ b/packages/scanner/ml_kit/pubspec.yaml
@@ -11,6 +11,8 @@ dependencies:
     sdk: flutter
 
   visibility_detector: 0.4.0+2
+  async: 2.11.0
+
   mobile_scanner:
     git:
       url: https://github.com/openfoodfacts/mobile_scanner.git

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -78,7 +78,7 @@ packages:
     source: hosted
     version: "7.0.0"
   async:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: async
       sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"


### PR DESCRIPTION
Woo that one, was tricky another time.

So let me explain everything:
- By default the camera is opened when its build method is called.
Since this Widget is always in the tree, it's restarted even if it's not even in foreground

That's why, my initial code was checking if the app was still visible after being resumed.
But the check was not strong enough, not on the first resume, but the second one!

By tweaking a little bit my implementation, I am not 100% sure, that it will force close the camera, if it's not visible.

Here is a test scenario (that's working now): https://youtu.be/mCUF5mSw83o
