### PR TITLE
fix: Improvement for the dialog to create a new list, when there is none

### DIFF
--- a/packages/smooth_app/lib/generic_lib/dialogs/smooth_alert_dialog.dart
+++ b/packages/smooth_app/lib/generic_lib/dialogs/smooth_alert_dialog.dart
@@ -197,8 +197,9 @@ class _SmoothDialogCrossButton extends StatelessWidget {
 }
 
 enum SmoothButtonsBarOrder {
-  /// If the [axis] is [Axis.horizontal], the positive button will be on the end
-  /// If the [axis] is [Axis.vertical], the positive button will be on the start
+  /// If the [axis] is [Axis.horizontal], the positive button will be at the end
+  /// If the [axis] is [Axis.vertical], the positive button will be at the first
+  /// position
   auto,
 
   /// Whatever the [axis] is, the positive button will always be at first place

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1354,7 +1354,7 @@
     "@user_list_button_new": {
         "description": "Short label of a 'create a new list' button"
     },
-    "user_list_empty_label": "No list available yet,\nplease start by creating one",
+    "user_list_empty_label": "No list available yet, please start by creating one",
     "@user_list_empty_label": {
         "description": "Content displayed when there is no list"
     },

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -1346,7 +1346,7 @@
     "@user_list_button_new": {
         "description": "Short label of a 'create a new list' button"
     },
-    "user_list_empty_label": "Aucune liste disponible pour le moment,\nveuillez commencer par en créer une",
+    "user_list_empty_label": "Aucune liste disponible pour le moment, veuillez commencer par en créer une",
     "@user_list_empty_label": {
         "description": "Content displayed when there is no list"
     },

--- a/packages/smooth_app/lib/pages/product_list_user_dialog_helper.dart
+++ b/packages/smooth_app/lib/pages/product_list_user_dialog_helper.dart
@@ -2,6 +2,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:smooth_app/data_models/product_list.dart';
 import 'package:smooth_app/database/dao_product_list.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
@@ -324,8 +325,8 @@ class _UserEmptyListsState extends State<_UserEmptyLists> {
     return SmoothAlertDialog(
       body: Column(
         children: <Widget>[
-          const Icon(Icons.warning),
-          const SizedBox(height: VERY_SMALL_SPACE),
+          SvgPicture.asset('assets/misc/error.svg'),
+          const SizedBox(height: LARGE_SPACE),
           Container(
             alignment: Alignment.center,
             padding: const EdgeInsets.symmetric(
@@ -337,12 +338,15 @@ class _UserEmptyListsState extends State<_UserEmptyLists> {
               textAlign: TextAlign.center,
               style: const TextStyle(
                 fontWeight: FontWeight.bold,
+                fontSize: 18.0,
               ),
             ),
           ),
-          const SizedBox(height: LARGE_SPACE * 2.5),
+          const SizedBox(height: LARGE_SPACE),
         ],
       ),
+      actionsAxis: Axis.vertical,
+      actionsOrder: SmoothButtonsBarOrder.auto,
       positiveAction: SmoothActionButton(
         onPressed: () async {
           final ProductList? productList =


### PR DESCRIPTION
Hi everyone!

As noted in #4293, the current dialog shown when there is no user list has some UI issues.
Here is the new look:

![Screenshot_1689227678](https://github.com/openfoodfacts/smooth-app/assets/246838/850a914d-36df-4ea4-bf15-6ea103c019dd)