### PR TITLE
feat: 4041 - now displaying user lists in "List" nav tab

### DIFF
--- a/packages/smooth_app/lib/database/dao_product_list.dart
+++ b/packages/smooth_app/lib/database/dao_product_list.dart
@@ -287,10 +287,7 @@ class DaoProductList extends AbstractDao {
   }
 
   /// Returns the names of the user lists.
-  ///
-  /// Possibly restricted to the user lists that contains ALL the given barcodes.
-  Future<List<String>> getUserLists({List<String>? withBarcodes}) async {
-    // TODO(m123): change return type to a set
+  List<String> getUserLists() {
     final List<String> result = <String>[];
     for (final dynamic key in _getBox().keys) {
       final String tmp = key.toString();
@@ -298,22 +295,34 @@ class DaoProductList extends AbstractDao {
       if (productListType != ProductListType.USER) {
         continue;
       }
-      if (withBarcodes != null) {
-        final _BarcodeList? barcodeList = await _getBox().get(key);
-        if (barcodeList == null) {
-          continue;
+      result.add(getProductListParameters(tmp));
+    }
+    return result;
+  }
+
+  /// Returns the names of the user lists that contains ALL the given barcodes.
+  Future<List<String>> getUserListsWithBarcodes(
+    final List<String> withBarcodes,
+  ) async {
+    final List<String> result = <String>[];
+    for (final dynamic key in _getBox().keys) {
+      final String tmp = key.toString();
+      final ProductListType productListType = getProductListType(tmp);
+      if (productListType != ProductListType.USER) {
+        continue;
+      }
+      final _BarcodeList? barcodeList = await _getBox().get(key);
+      if (barcodeList == null) {
+        continue;
+      }
+      for (final String barcode in withBarcodes) {
+        if (!barcodeList.barcodes.contains(barcode)) {
+          break;
         }
-        for (final String barcode in withBarcodes) {
-          if (!barcodeList.barcodes.contains(barcode)) {
-            break;
-          }
-          if (withBarcodes.last == barcode) {
-            result.add(getProductListParameters(tmp));
-            break;
-          }
+        if (withBarcodes.last == barcode) {
+          result.add(getProductListParameters(tmp));
+          break;
         }
-      } else {
-        result.add(getProductListParameters(tmp));
       }
     }
     return result;

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1773,6 +1773,10 @@
     "@user_list_all_empty": {
         "description": "Small message when there are no user lists"
     },
+    "product_list_select": "Select a list",
+    "@product_list_select": {
+        "description": "Top title for the selection of a list"
+    },
     "user_list_length": "{count,plural, =0{Empty list} =1{One product} other{{count} products}}",
     "@user_list_length": {
         "description": "Length of a user product list",

--- a/packages/smooth_app/lib/pages/all_product_list_page.dart
+++ b/packages/smooth_app/lib/pages/all_product_list_page.dart
@@ -12,14 +12,9 @@ import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
 /// Page that lists all product lists.
-class AllProductListPage extends StatefulWidget {
+class AllProductListPage extends StatelessWidget {
   const AllProductListPage();
 
-  @override
-  State<AllProductListPage> createState() => _AllProductListPageState();
-}
-
-class _AllProductListPageState extends State<AllProductListPage> {
   @override
   Widget build(BuildContext context) {
     final LocalDatabase localDatabase = context.watch<LocalDatabase>();
@@ -35,7 +30,7 @@ class _AllProductListPageState extends State<AllProductListPage> {
     }
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     return SmoothScaffold(
-      appBar: SmoothAppBar(title: Text('Select a list')),
+      appBar: SmoothAppBar(title: Text(appLocalizations.product_list_select)),
       body: ListView.builder(
         itemCount: productLists.length,
         itemBuilder: (final BuildContext context, final int index) {

--- a/packages/smooth_app/lib/pages/all_product_list_page.dart
+++ b/packages/smooth_app/lib/pages/all_product_list_page.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:provider/provider.dart';
+import 'package:smooth_app/data_models/product_list.dart';
+import 'package:smooth_app/database/dao_product_list.dart';
+import 'package:smooth_app/database/local_database.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/pages/preferences/user_preferences_list_tile.dart';
+import 'package:smooth_app/pages/product/common/product_query_page_helper.dart';
+import 'package:smooth_app/pages/product_list_user_dialog_helper.dart';
+import 'package:smooth_app/widgets/smooth_app_bar.dart';
+import 'package:smooth_app/widgets/smooth_scaffold.dart';
+
+/// Page that lists all product lists.
+class AllProductListPage extends StatefulWidget {
+  const AllProductListPage();
+
+  @override
+  State<AllProductListPage> createState() => _AllProductListPageState();
+}
+
+class _AllProductListPageState extends State<AllProductListPage> {
+  @override
+  Widget build(BuildContext context) {
+    final LocalDatabase localDatabase = context.watch<LocalDatabase>();
+    final DaoProductList daoProductList = DaoProductList(localDatabase);
+    final List<ProductList> productLists = <ProductList>[
+      ProductList.scanSession(),
+      ProductList.scanHistory(),
+      ProductList.history(),
+    ];
+    final List<String> userLists = daoProductList.getUserLists();
+    for (final String userList in userLists) {
+      productLists.add(ProductList.user(userList));
+    }
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    return SmoothScaffold(
+      appBar: SmoothAppBar(title: Text('Select a list')),
+      body: ListView.builder(
+        itemCount: productLists.length,
+        itemBuilder: (final BuildContext context, final int index) {
+          final ProductList productList = productLists[index];
+          return UserPreferencesListTile(
+            title: Text(
+              ProductQueryPageHelper.getProductListLabel(
+                productList,
+                appLocalizations,
+              ),
+            ),
+            subtitle: FutureBuilder<int>(
+              future: daoProductList.getLength(productList),
+              builder: (
+                final BuildContext context,
+                final AsyncSnapshot<int> snapshot,
+              ) {
+                if (snapshot.data != null) {
+                  return Text(
+                    appLocalizations.user_list_length(snapshot.data!),
+                  );
+                }
+                return EMPTY_WIDGET;
+              },
+            ),
+            onTap: () => Navigator.of(context).pop(productList),
+            onLongPress: () async => ProductListUserDialogHelper(daoProductList)
+                .showDeleteUserListDialog(context, productList),
+          );
+        },
+      ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () async => ProductListUserDialogHelper(daoProductList)
+            .showCreateUserListDialog(context),
+        label: Row(
+          children: <Widget>[
+            const Icon(Icons.add),
+            Text(appLocalizations.add_list_label),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/packages/smooth_app/lib/pages/all_user_product_list_page.dart
+++ b/packages/smooth_app/lib/pages/all_user_product_list_page.dart
@@ -15,48 +15,23 @@ import 'package:smooth_app/themes/constant_icons.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
+// TODO(monsieurtanuki): confirm if still relevant with the new ProductListPage and AllProductListPage
 /// Page that lists all user product lists.
-class AllUserProductList extends StatelessWidget {
+class AllUserProductList extends StatefulWidget {
   const AllUserProductList();
 
   @override
-  Widget build(BuildContext context) {
-    final LocalDatabase localDatabase = context.watch<LocalDatabase>();
-    final DaoProductList daoProductList = DaoProductList(localDatabase);
-    return FutureBuilder<List<String>>(
-      future: daoProductList.getUserLists(),
-      builder: (
-        final BuildContext context,
-        final AsyncSnapshot<List<String>> snapshot,
-      ) {
-        if (snapshot.data != null) {
-          return _AllUserProductListLoaded(snapshot.data!);
-        }
-        return const Center(child: CircularProgressIndicator.adaptive());
-      },
-    );
-  }
+  State<AllUserProductList> createState() => _AllUserProductListState();
 }
 
-/// Page that lists all user product lists, with already loaded data.
-class _AllUserProductListLoaded extends StatefulWidget {
-  const _AllUserProductListLoaded(this.userLists);
-
-  final List<String> userLists;
-
-  @override
-  State<_AllUserProductListLoaded> createState() =>
-      _AllUserProductListLoadedState();
-}
-
-class _AllUserProductListLoadedState extends State<_AllUserProductListLoaded> {
+class _AllUserProductListState extends State<AllUserProductList> {
   @override
   Widget build(BuildContext context) {
     final LocalDatabase localDatabase = context.watch<LocalDatabase>();
     final DaoProductList daoProductList = DaoProductList(localDatabase);
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final ThemeData themeData = Theme.of(context);
-    final List<String> userLists = widget.userLists;
+    final List<String> userLists = daoProductList.getUserLists();
     return SmoothScaffold(
       appBar: SmoothAppBar(title: Text(appLocalizations.user_list_all_title)),
       body: userLists.isEmpty

--- a/packages/smooth_app/lib/pages/product/common/product_list_popup_items.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_popup_items.dart
@@ -7,7 +7,6 @@ import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/temp_product_list_share_helper.dart';
-import 'package:smooth_app/pages/product/common/product_query_page_helper.dart';
 import 'package:smooth_app/pages/product_list_user_dialog_helper.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -40,7 +39,7 @@ abstract class ProductListPopupItem {
 class ProductListPopupClear extends ProductListPopupItem {
   @override
   String getTitle(final AppLocalizations appLocalizations) =>
-      appLocalizations.user_list_popup_clear;
+      appLocalizations.clear;
 
   @override
   Future<ProductList?> doSomething({
@@ -135,29 +134,5 @@ class ProductListPopupOpenInWeb extends ProductListPopupItem {
     AnalyticsHelper.trackEvent(AnalyticsEvent.openListWeb);
     await launchUrl(shareProductList(products));
     return null;
-  }
-}
-
-/// Popup menu item for the product list page: switch to another list.
-class ProductListPopupList extends ProductListPopupItem {
-  ProductListPopupList(this.newProductList);
-
-  final ProductList newProductList;
-
-  @override
-  String getTitle(final AppLocalizations appLocalizations) =>
-      ProductQueryPageHelper.getProductListLabel(
-        newProductList,
-        appLocalizations,
-      );
-
-  @override
-  Future<ProductList?> doSomething({
-    required final ProductList productList,
-    required final LocalDatabase localDatabase,
-    required final BuildContext context,
-  }) async {
-    await DaoProductList(localDatabase).get(newProductList);
-    return newProductList;
   }
 }

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -411,7 +411,7 @@ class _ProductPageState extends State<ProductPage> with TraceableClientMixin {
     final DaoProductList daoProductList,
   ) =>
       FutureBuilder<List<String>>(
-        future: daoProductList.getUserLists(withBarcodes: <String>[_barcode]),
+        future: daoProductList.getUserListsWithBarcodes(<String>[_barcode]),
         builder: (
           final BuildContext context,
           final AsyncSnapshot<List<String>> snapshot,

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -399,7 +399,7 @@ class _ProductPageState extends State<ProductPage>
     final DaoProductList daoProductList,
   ) =>
       FutureBuilder<List<String>>(
-        future: daoProductList.getUserListsWithBarcodes(<String>[_barcode]),
+        future: daoProductList.getUserListsWithBarcodes(<String>[barcode]),
         builder: (
           final BuildContext context,
           final AsyncSnapshot<List<String>> snapshot,

--- a/packages/smooth_app/lib/pages/product_list_user_dialog_helper.dart
+++ b/packages/smooth_app/lib/pages/product_list_user_dialog_helper.dart
@@ -22,7 +22,7 @@ class ProductListUserDialogHelper {
     final TextEditingController textEditingController = TextEditingController();
     final GlobalKey<FormState> formKey = GlobalKey<FormState>();
 
-    final List<String> lists = await daoProductList.getUserLists();
+    final List<String> lists = daoProductList.getUserLists();
     final String? title = await showDialog<String>(
       context: context,
       builder: (final BuildContext context) {
@@ -93,7 +93,7 @@ class ProductListUserDialogHelper {
 
     final String initialName = initialProductList.parameters;
     textEditingController.text = initialName;
-    final List<String> lists = await daoProductList.getUserLists();
+    final List<String> lists = daoProductList.getUserLists();
     final String? newName = await showDialog<String>(
       context: context,
       builder: (final BuildContext context) => SmoothAlertDialog(
@@ -185,7 +185,7 @@ class ProductListUserDialogHelper {
     final BuildContext context,
     final Set<String> barcodes,
   ) async {
-    final List<String> lists = await daoProductList.getUserLists();
+    final List<String> lists = daoProductList.getUserLists();
 
     if (lists.isEmpty) {
       final bool? newListCreated = await showDialog<bool>(
@@ -198,8 +198,9 @@ class ProductListUserDialogHelper {
       return false;
     }
 
-    final List<String> selectedLists = await daoProductList.getUserLists(
-      withBarcodes: barcodes.toList(growable: false),
+    final List<String> selectedLists =
+        await daoProductList.getUserListsWithBarcodes(
+      barcodes.toList(growable: false),
     );
 
     return showDialog<bool?>(


### PR DESCRIPTION
### What
- When the user clicked on the "select the other product lists" button, the user lists were not present.
- Now the user lists are present, and the user can create new user lists.

### Screenshot
![Screenshot_2023-07-13-08-23-08](https://github.com/openfoodfacts/smooth-app/assets/11576431/4e84a691-23fe-4d38-a82b-696cd79b5a5b)

### Part of 
- #4041

### Files
New file:
* `all_product_list_page.dart`: Page that lists all product lists.

Impacted files:
* `all_user_product_list_page.dart`: simplified thanks to a new not `async` getter of all user product lists
* `dao_product_list.dart`: split the "get user lists" method in two - one not `async`, one `async` with barcode checks
* `new_product_page.dart`: minor refactoring
* `product_list_page.dart`: now using new page `AllProductListPage` in order to list all product lists
* `product_list_popup_items.dart`: fixed a label; removed a class we don't use anymore as we put lists and actions in different buttons
* `product_list_user_dialog_helper.dart`: minor refactoring