### PR TITLE
fix: 4301 - "other lists" button always visible

### DIFF
--- a/packages/smooth_app/lib/pages/product/common/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_page.dart
@@ -125,53 +125,50 @@ class _ProductListPageState extends State<ProductListPage>
                 ),
       appBar: SmoothAppBar(
         centerTitle: _selectionMode ? false : null,
-        actions: !(enableClear || enableRename)
-            ? null
-            : <Widget>[
-                IconButton(
-                  icon: const Icon(CupertinoIcons.square_list),
-                  onPressed: () async {
-                    final ProductList? selected =
-                        await Navigator.push<ProductList>(
-                      context,
-                      MaterialPageRoute<ProductList>(
-                        builder: (BuildContext context) =>
-                            const AllProductListPage(),
-                        fullscreenDialog: true,
-                      ),
-                    );
-                    if (selected == null) {
-                      return;
-                    }
-                    if (context.mounted) {
-                      await DaoProductList(localDatabase).get(selected);
-                      if (context.mounted) {
-                        setState(() => productList = selected);
-                      }
-                    }
-                  },
+        actions: <Widget>[
+          IconButton(
+            icon: const Icon(CupertinoIcons.square_list),
+            onPressed: () async {
+              final ProductList? selected = await Navigator.push<ProductList>(
+                context,
+                MaterialPageRoute<ProductList>(
+                  builder: (BuildContext context) => const AllProductListPage(),
+                  fullscreenDialog: true,
                 ),
-                PopupMenuButton<ProductListPopupItem>(
-                  onSelected: (final ProductListPopupItem action) async {
-                    final ProductList? differentProductList =
-                        await action.doSomething(
-                      productList: productList,
-                      localDatabase: localDatabase,
-                      context: context,
-                    );
-                    if (differentProductList != null) {
-                      setState(() => productList = differentProductList);
-                    }
-                  },
-                  itemBuilder: (BuildContext context) =>
-                      <PopupMenuEntry<ProductListPopupItem>>[
-                    if (enableRename) _rename.getMenuItem(appLocalizations),
-                    _share.getMenuItem(appLocalizations),
-                    _openInWeb.getMenuItem(appLocalizations),
-                    if (enableClear) _clear.getMenuItem(appLocalizations),
-                  ],
-                ),
+              );
+              if (selected == null) {
+                return;
+              }
+              if (context.mounted) {
+                await DaoProductList(localDatabase).get(selected);
+                if (context.mounted) {
+                  setState(() => productList = selected);
+                }
+              }
+            },
+          ),
+          if (enableClear || enableRename)
+            PopupMenuButton<ProductListPopupItem>(
+              onSelected: (final ProductListPopupItem action) async {
+                final ProductList? differentProductList =
+                    await action.doSomething(
+                  productList: productList,
+                  localDatabase: localDatabase,
+                  context: context,
+                );
+                if (differentProductList != null) {
+                  setState(() => productList = differentProductList);
+                }
+              },
+              itemBuilder: (BuildContext context) =>
+                  <PopupMenuEntry<ProductListPopupItem>>[
+                if (enableRename) _rename.getMenuItem(appLocalizations),
+                _share.getMenuItem(appLocalizations),
+                _openInWeb.getMenuItem(appLocalizations),
+                if (enableClear) _clear.getMenuItem(appLocalizations),
               ],
+            ),
+        ],
         title: AutoSizeText(
           ProductQueryPageHelper.getProductListLabel(
             productList,


### PR DESCRIPTION
### What
- In the "product list" page, there is one "more ..." button that is not always visible (e.g. not much you can do with an empty list)
- But recently we added an "other lists" button, that must always be visible.
- The bug was that we used the same condition to display both buttons, making the "other lists" button invisible when the list was empty.
- The fix was just about moving the test.

### Screenshot
![Screenshot_2023-07-14-08-55-28](https://github.com/openfoodfacts/smooth-app/assets/11576431/891bb409-af6e-4a0d-8fa0-73e029e69abc)

### Part of 
- #4301 #4041

### Impacted file
* `product_list_page.dart`: the "other lists" button is now always visible
