### PR TITLE
feat: Better support error when saving the picture locally 

### DIFF
--- a/packages/smooth_app/lib/generic_lib/dialogs/smooth_alert_dialog.dart
+++ b/packages/smooth_app/lib/generic_lib/dialogs/smooth_alert_dialog.dart
@@ -490,7 +490,7 @@ class SmoothSimpleErrorAlertDialog extends StatelessWidget {
   final SmoothActionButton? negativeAction;
   final Axis? actionsAxis;
   final SmoothButtonsBarOrder? actionsOrder;
-  final EdgeInsets? contentPadding;
+  final EdgeInsetsDirectional? contentPadding;
 
   @override
   Widget build(BuildContext context) {

--- a/packages/smooth_app/lib/generic_lib/dialogs/smooth_alert_dialog.dart
+++ b/packages/smooth_app/lib/generic_lib/dialogs/smooth_alert_dialog.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:smooth_app/generic_lib/buttons/smooth_simple_button.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_responsive.dart';
+import 'package:smooth_app/helpers/app_helper.dart';
 
 /// Custom Dialog to use in the app
 ///
@@ -463,6 +466,71 @@ class _SmoothActionFlatButton extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+}
+
+/// A custom dialog where you only have to pass a [title] and a [message].
+/// By default an "OK" button will be show., but you can override it by passing
+/// a [positiveAction] and/or [negativeAction]
+class SmoothSimpleErrorAlertDialog extends StatelessWidget {
+  const SmoothSimpleErrorAlertDialog({
+    required this.title,
+    required this.message,
+    this.positiveAction,
+    this.negativeAction,
+    this.actionsAxis,
+    this.actionsOrder,
+    this.contentPadding,
+  });
+
+  final String title;
+  final String message;
+  final SmoothActionButton? positiveAction;
+  final SmoothActionButton? negativeAction;
+  final Axis? actionsAxis;
+  final SmoothButtonsBarOrder? actionsOrder;
+  final EdgeInsets? contentPadding;
+
+  @override
+  Widget build(BuildContext context) {
+    final Widget content = Column(
+      children: <Widget>[
+        SvgPicture.asset(
+          'assets/misc/error.svg',
+          width: MINIMUM_TOUCH_SIZE * 2,
+          package: AppHelper.APP_PACKAGE,
+        ),
+        const SizedBox(height: MEDIUM_SPACE),
+        Text(
+          title,
+          textAlign: TextAlign.center,
+          style: Theme.of(context).textTheme.titleLarge,
+        ),
+        const SizedBox(height: LARGE_SPACE),
+        Text(
+          message,
+          textAlign: TextAlign.center,
+          style: Theme.of(context).textTheme.bodyMedium?.copyWith(height: 1.3),
+        ),
+      ],
+    );
+
+    SmoothActionButton? positiveButton = positiveAction;
+    if (positiveAction == null && negativeAction == null) {
+      final AppLocalizations appLocalizations = AppLocalizations.of(context);
+      positiveButton = SmoothActionButton(
+        text: appLocalizations.okay,
+        onPressed: () => Navigator.of(context).maybePop(),
+      );
+    }
+
+    return SmoothAlertDialog(
+      body: content,
+      positiveAction: positiveButton,
+      negativeAction: negativeAction,
+      actionsOrder: actionsOrder,
+      contentPadding: contentPadding,
     );
   }
 }

--- a/packages/smooth_app/lib/helpers/analytics_helper.dart
+++ b/packages/smooth_app/lib/helpers/analytics_helper.dart
@@ -324,6 +324,10 @@ class AnalyticsHelper {
     }
   }
 
+  static void sendException(dynamic throwable, {dynamic stackTrace}) {
+    Sentry.captureException(throwable, stackTrace: stackTrace);
+  }
+
   static String? get matomoVisitorId => MatomoTracker.instance.visitor.id;
 }
 

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -538,9 +538,13 @@
     "@crop_page_action_local": {
         "description": "Action being performed on the crop page"
     },
-    "crop_page_action_local_failed": "An error occurred while saving the image. Please try again later.",
-    "@crop_page_action_local_failed": {
-        "description": "The save of the picture locally failed"
+    "crop_page_action_local_failed_title": "Oops… there's something with your photo!",
+    "@crop_page_action_local_title": {
+        "description": "The save of the picture locally failed - error dialog message"
+    },
+    "crop_page_action_local_failed_message": "We are unable to process the image locally, before sending it to our server. Please try again later or contact-us if the issue persists.",
+    "@crop_page_action_local_message": {
+        "description": "The save of the picture locally failed - error dialog message"
     },
     "crop_page_too_small_image_title": "The image is too small!",
     "@crop_page_too_small_image_title": {

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -538,6 +538,10 @@
     "@crop_page_action_local": {
         "description": "Action being performed on the crop page"
     },
+    "crop_page_action_local_failed": "An error occurred while saving the image. Please try again later.",
+    "@crop_page_action_local_failed": {
+        "description": "The save of the picture locally failed"
+    },
     "crop_page_too_small_image_title": "The image is too small!",
     "@crop_page_too_small_image_title": {
         "description": "Title of a dialog warning the user that the image is too small for upload"

--- a/packages/smooth_app/lib/pages/crop_page.dart
+++ b/packages/smooth_app/lib/pages/crop_page.dart
@@ -504,10 +504,10 @@ class _CropPageState extends State<CropPage> {
     }
   }
 
-  void _showErrorDialog() {
+  Future<void> _showErrorDialog() {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
 
-    showDialog<void>(
+    return showDialog<void>(
       context: context,
       builder: (BuildContext context) {
         return SmoothSimpleErrorAlertDialog(

--- a/packages/smooth_app/lib/pages/crop_page.dart
+++ b/packages/smooth_app/lib/pages/crop_page.dart
@@ -228,7 +228,7 @@ class _CropPageState extends State<CropPage> {
   /// Returns a small file with the cropped image, for the transient image.
   ///
   /// Here we use BMP format as it's faster to encode.
-  Future<File?> _getCroppedImageFile(
+  Future<File> _getCroppedImageFile(
     final Directory directory,
     final int sequenceNumber,
   ) async {
@@ -314,14 +314,10 @@ class _CropPageState extends State<CropPage> {
         await getNextSequenceNumber(daoInt, _CROP_PAGE_SEQUENCE_KEY);
     final Directory directory = await getApplicationSupportDirectory();
 
-    final File? croppedFile = await _getCroppedImageFile(
+    final File croppedFile = await _getCroppedImageFile(
       directory,
       sequenceNumber,
     );
-
-    if (croppedFile == null) {
-      return null;
-    }
 
     setState(
       () => _progress = appLocalizations.crop_page_action_server,

--- a/packages/smooth_app/lib/pages/crop_page.dart
+++ b/packages/smooth_app/lib/pages/crop_page.dart
@@ -245,10 +245,8 @@ class _CropPageState extends State<CropPage> {
       await saveBmp(file: result, source: cropped)
           .timeout(const Duration(seconds: 10));
     } catch (e, trace) {
-      setState(
-          () => _progress = appLocalizations.crop_page_action_local_failed);
       AnalyticsHelper.sendException(e, stackTrace: trace);
-      return null;
+      rethrow;
     }
 
     return result;
@@ -402,6 +400,7 @@ class _CropPageState extends State<CropPage> {
         return true;
       }
     } catch (e) {
+      _showErrorDialog();
       return false;
     } finally {
       _progress = null;
@@ -507,6 +506,20 @@ class _CropPageState extends State<CropPage> {
       }
       return false;
     }
+  }
+
+  void _showErrorDialog() {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+
+    showDialog<void>(
+      context: context,
+      builder: (BuildContext context) {
+        return SmoothSimpleErrorAlertDialog(
+          title: appLocalizations.crop_page_action_local_failed_title,
+          message: appLocalizations.crop_page_action_local_failed_message,
+        );
+      },
+    );
   }
 }
 


### PR DESCRIPTION
Hi everyone,

If something fails in the photo-taking process, there is no error catching.
I will now catch the error and also provide a timeout, where sometimes the Isolate has weird behaviors.
We also have a dedicated method to send custom exceptions to Sentry to better track this kind of issue.

Related issue: #4304 