### PR TITLE
chore: Rename Tab_for_more => tap_for_more

### DIFF
--- a/packages/smooth_app/lib/l10n/app_aa.arb
+++ b/packages/smooth_app/lib/l10n/app_aa.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_af.arb
+++ b/packages/smooth_app/lib/l10n/app_af.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_ak.arb
+++ b/packages/smooth_app/lib/l10n/app_ak.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_am.arb
+++ b/packages/smooth_app/lib/l10n/app_am.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_ar.arb
+++ b/packages/smooth_app/lib/l10n/app_ar.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "نتاج",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_as.arb
+++ b/packages/smooth_app/lib/l10n/app_as.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_az.arb
+++ b/packages/smooth_app/lib/l10n/app_az.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Məhsul",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_be.arb
+++ b/packages/smooth_app/lib/l10n/app_be.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Прадукт",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_bg.arb
+++ b/packages/smooth_app/lib/l10n/app_bg.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Докосни, за повече информация…",
+    "tap_for_more": "Докосни, за повече информация…",
     "@Product": {},
     "product": "Продукт",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_bm.arb
+++ b/packages/smooth_app/lib/l10n/app_bm.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_bn.arb
+++ b/packages/smooth_app/lib/l10n/app_bn.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_bo.arb
+++ b/packages/smooth_app/lib/l10n/app_bo.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_br.arb
+++ b/packages/smooth_app/lib/l10n/app_br.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Produ",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_bs.arb
+++ b/packages/smooth_app/lib/l10n/app_bs.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_ca.arb
+++ b/packages/smooth_app/lib/l10n/app_ca.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Toqueu per veure més informació…",
+    "tap_for_more": "Toqueu per veure més informació…",
     "@Product": {},
     "product": "Producte",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_ce.arb
+++ b/packages/smooth_app/lib/l10n/app_ce.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_co.arb
+++ b/packages/smooth_app/lib/l10n/app_co.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_cs.arb
+++ b/packages/smooth_app/lib/l10n/app_cs.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Klepnutím zobrazíte více informací…",
+    "tap_for_more": "Klepnutím zobrazíte více informací…",
     "@Product": {},
     "product": "Produkt",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_cv.arb
+++ b/packages/smooth_app/lib/l10n/app_cv.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_cy.arb
+++ b/packages/smooth_app/lib/l10n/app_cy.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Gynnyrch",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_da.arb
+++ b/packages/smooth_app/lib/l10n/app_da.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Produkt",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_de.arb
+++ b/packages/smooth_app/lib/l10n/app_de.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Antippen, um mehr Infos anzuzeigen …",
+    "tap_for_more": "Antippen, um mehr Infos anzuzeigen …",
     "@Product": {},
     "product": "Produkt",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_el.arb
+++ b/packages/smooth_app/lib/l10n/app_el.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Προϊόν",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -453,7 +453,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_eo.arb
+++ b/packages/smooth_app/lib/l10n/app_eo.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Produkto",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_es.arb
+++ b/packages/smooth_app/lib/l10n/app_es.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Pulsa para ver más información…",
+    "tap_for_more": "Pulsa para ver más información…",
     "@Product": {},
     "product": "Producto",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_et.arb
+++ b/packages/smooth_app/lib/l10n/app_et.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Toode",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_eu.arb
+++ b/packages/smooth_app/lib/l10n/app_eu.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Sakatu informazio gehiago ikusteko…",
+    "tap_for_more": "Sakatu informazio gehiago ikusteko…",
     "@Product": {},
     "product": "Produktua",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_fa.arb
+++ b/packages/smooth_app/lib/l10n/app_fa.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "محصول",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_fi.arb
+++ b/packages/smooth_app/lib/l10n/app_fi.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Lisätietoja…",
+    "tap_for_more": "Lisätietoja…",
     "@Product": {},
     "product": "Tuote",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_fil.arb
+++ b/packages/smooth_app/lib/l10n/app_fil.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Produkto",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_fo.arb
+++ b/packages/smooth_app/lib/l10n/app_fo.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Appuyez pour plus d'informations...",
+    "tap_for_more": "Appuyez pour plus d'informations...",
     "@Product": {},
     "product": "Produit",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_ga.arb
+++ b/packages/smooth_app/lib/l10n/app_ga.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Táirge",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_gd.arb
+++ b/packages/smooth_app/lib/l10n/app_gd.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_gl.arb
+++ b/packages/smooth_app/lib/l10n/app_gl.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Produto",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_gu.arb
+++ b/packages/smooth_app/lib/l10n/app_gu.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_ha.arb
+++ b/packages/smooth_app/lib/l10n/app_ha.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_he.arb
+++ b/packages/smooth_app/lib/l10n/app_he.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "נגיעה לצפייה פרטים נוספים…",
+    "tap_for_more": "נגיעה לצפייה פרטים נוספים…",
     "@Product": {},
     "product": "מוצר",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_hi.arb
+++ b/packages/smooth_app/lib/l10n/app_hi.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_hr.arb
+++ b/packages/smooth_app/lib/l10n/app_hr.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Proizvod",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_ht.arb
+++ b/packages/smooth_app/lib/l10n/app_ht.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_hu.arb
+++ b/packages/smooth_app/lib/l10n/app_hu.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Termék",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_hy.arb
+++ b/packages/smooth_app/lib/l10n/app_hy.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_id.arb
+++ b/packages/smooth_app/lib/l10n/app_id.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Ketuk untuk lihat info selengkapnya…",
+    "tap_for_more": "Ketuk untuk lihat info selengkapnya…",
     "@Product": {},
     "product": "Produk",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_ii.arb
+++ b/packages/smooth_app/lib/l10n/app_ii.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_is.arb
+++ b/packages/smooth_app/lib/l10n/app_is.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_it.arb
+++ b/packages/smooth_app/lib/l10n/app_it.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tocca per visualizzare altre info…",
+    "tap_for_more": "Tocca per visualizzare altre info…",
     "@Product": {},
     "product": "Prodotto",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_iu.arb
+++ b/packages/smooth_app/lib/l10n/app_iu.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_ja.arb
+++ b/packages/smooth_app/lib/l10n/app_ja.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "詳細情報を表示するにはタップしてください…",
+    "tap_for_more": "詳細情報を表示するにはタップしてください…",
     "@Product": {},
     "product": "製品",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_jv.arb
+++ b/packages/smooth_app/lib/l10n/app_jv.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_ka.arb
+++ b/packages/smooth_app/lib/l10n/app_ka.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_kk.arb
+++ b/packages/smooth_app/lib/l10n/app_kk.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Өнім",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_km.arb
+++ b/packages/smooth_app/lib/l10n/app_km.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_kn.arb
+++ b/packages/smooth_app/lib/l10n/app_kn.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_ko.arb
+++ b/packages/smooth_app/lib/l10n/app_ko.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "생성물",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_ku.arb
+++ b/packages/smooth_app/lib/l10n/app_ku.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Berhem",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_kw.arb
+++ b/packages/smooth_app/lib/l10n/app_kw.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_ky.arb
+++ b/packages/smooth_app/lib/l10n/app_ky.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_la.arb
+++ b/packages/smooth_app/lib/l10n/app_la.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_lb.arb
+++ b/packages/smooth_app/lib/l10n/app_lb.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Produkt",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_lo.arb
+++ b/packages/smooth_app/lib/l10n/app_lo.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_lt.arb
+++ b/packages/smooth_app/lib/l10n/app_lt.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Bakstelėkite, kad pamatytumėte daugiau informacijos…",
+    "tap_for_more": "Bakstelėkite, kad pamatytumėte daugiau informacijos…",
     "@Product": {},
     "product": "Produktas",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_lv.arb
+++ b/packages/smooth_app/lib/l10n/app_lv.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Produkts",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_mg.arb
+++ b/packages/smooth_app/lib/l10n/app_mg.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_mi.arb
+++ b/packages/smooth_app/lib/l10n/app_mi.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_ml.arb
+++ b/packages/smooth_app/lib/l10n/app_ml.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_mn.arb
+++ b/packages/smooth_app/lib/l10n/app_mn.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_mr.arb
+++ b/packages/smooth_app/lib/l10n/app_mr.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "उत्पादन",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_ms.arb
+++ b/packages/smooth_app/lib/l10n/app_ms.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Produk",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_mt.arb
+++ b/packages/smooth_app/lib/l10n/app_mt.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_my.arb
+++ b/packages/smooth_app/lib/l10n/app_my.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_nb.arb
+++ b/packages/smooth_app/lib/l10n/app_nb.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Produkt",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_ne.arb
+++ b/packages/smooth_app/lib/l10n/app_ne.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "उत्पादन",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_nl.arb
+++ b/packages/smooth_app/lib/l10n/app_nl.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tik om meer info te zien…",
+    "tap_for_more": "Tik om meer info te zien…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_nn.arb
+++ b/packages/smooth_app/lib/l10n/app_nn.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Produkt",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_no.arb
+++ b/packages/smooth_app/lib/l10n/app_no.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Produkt",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_nr.arb
+++ b/packages/smooth_app/lib/l10n/app_nr.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_oc.arb
+++ b/packages/smooth_app/lib/l10n/app_oc.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Produit",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_or.arb
+++ b/packages/smooth_app/lib/l10n/app_or.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_pa.arb
+++ b/packages/smooth_app/lib/l10n/app_pa.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_pl.arb
+++ b/packages/smooth_app/lib/l10n/app_pl.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Kliknij, aby wyświetlić więcej informacji…",
+    "tap_for_more": "Kliknij, aby wyświetlić więcej informacji…",
     "@Product": {},
     "product": "Produkt",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_pt.arb
+++ b/packages/smooth_app/lib/l10n/app_pt.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Clique para ver mais informações…",
+    "tap_for_more": "Clique para ver mais informações…",
     "@Product": {},
     "product": "Produto",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_qu.arb
+++ b/packages/smooth_app/lib/l10n/app_qu.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_rm.arb
+++ b/packages/smooth_app/lib/l10n/app_rm.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_ro.arb
+++ b/packages/smooth_app/lib/l10n/app_ro.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Atingeți pentru a vedea mai multe informații…",
+    "tap_for_more": "Atingeți pentru a vedea mai multe informații…",
     "@Product": {},
     "product": "Produs",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_ru.arb
+++ b/packages/smooth_app/lib/l10n/app_ru.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Продукт",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_sa.arb
+++ b/packages/smooth_app/lib/l10n/app_sa.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_sc.arb
+++ b/packages/smooth_app/lib/l10n/app_sc.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_sd.arb
+++ b/packages/smooth_app/lib/l10n/app_sd.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_sg.arb
+++ b/packages/smooth_app/lib/l10n/app_sg.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_si.arb
+++ b/packages/smooth_app/lib/l10n/app_si.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_sk.arb
+++ b/packages/smooth_app/lib/l10n/app_sk.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_sl.arb
+++ b/packages/smooth_app/lib/l10n/app_sl.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Izdelek",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_sn.arb
+++ b/packages/smooth_app/lib/l10n/app_sn.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_so.arb
+++ b/packages/smooth_app/lib/l10n/app_so.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_sq.arb
+++ b/packages/smooth_app/lib/l10n/app_sq.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_sr.arb
+++ b/packages/smooth_app/lib/l10n/app_sr.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Proizvod",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_ss.arb
+++ b/packages/smooth_app/lib/l10n/app_ss.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_st.arb
+++ b/packages/smooth_app/lib/l10n/app_st.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_sv.arb
+++ b/packages/smooth_app/lib/l10n/app_sv.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Produkt",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_sw.arb
+++ b/packages/smooth_app/lib/l10n/app_sw.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_ta.arb
+++ b/packages/smooth_app/lib/l10n/app_ta.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_te.arb
+++ b/packages/smooth_app/lib/l10n/app_te.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_tg.arb
+++ b/packages/smooth_app/lib/l10n/app_tg.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_th.arb
+++ b/packages/smooth_app/lib/l10n/app_th.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "สินค้า",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_ti.arb
+++ b/packages/smooth_app/lib/l10n/app_ti.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_tl.arb
+++ b/packages/smooth_app/lib/l10n/app_tl.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Produkto",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_tn.arb
+++ b/packages/smooth_app/lib/l10n/app_tn.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_tr.arb
+++ b/packages/smooth_app/lib/l10n/app_tr.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Daha fazla bilgi görmek için dokunun…",
+    "tap_for_more": "Daha fazla bilgi görmek için dokunun…",
     "@Product": {},
     "product": "Ürün",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_ts.arb
+++ b/packages/smooth_app/lib/l10n/app_ts.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_tt.arb
+++ b/packages/smooth_app/lib/l10n/app_tt.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_tw.arb
+++ b/packages/smooth_app/lib/l10n/app_tw.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_ty.arb
+++ b/packages/smooth_app/lib/l10n/app_ty.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_ug.arb
+++ b/packages/smooth_app/lib/l10n/app_ug.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_uk.arb
+++ b/packages/smooth_app/lib/l10n/app_uk.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Натисніть, щоб побачити більше…",
+    "tap_for_more": "Натисніть, щоб побачити більше…",
     "@Product": {},
     "product": "Продукт",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_ur.arb
+++ b/packages/smooth_app/lib/l10n/app_ur.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_uz.arb
+++ b/packages/smooth_app/lib/l10n/app_uz.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_ve.arb
+++ b/packages/smooth_app/lib/l10n/app_ve.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_vi.arb
+++ b/packages/smooth_app/lib/l10n/app_vi.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Sản phẩm",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_wa.arb
+++ b/packages/smooth_app/lib/l10n/app_wa.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_wo.arb
+++ b/packages/smooth_app/lib/l10n/app_wo.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_xh.arb
+++ b/packages/smooth_app/lib/l10n/app_xh.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_yi.arb
+++ b/packages/smooth_app/lib/l10n/app_yi.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_yo.arb
+++ b/packages/smooth_app/lib/l10n/app_yo.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_zh.arb
+++ b/packages/smooth_app/lib/l10n/app_zh.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "產品",
     "@product": {},

--- a/packages/smooth_app/lib/l10n/app_zu.arb
+++ b/packages/smooth_app/lib/l10n/app_zu.arb
@@ -449,7 +449,7 @@
     "@search": {
         "description": "Hint text of a search text input field"
     },
-    "tab_for_more": "Tap to see more info…",
+    "tap_for_more": "Tap to see more info…",
     "@Product": {},
     "product": "Product",
     "@product": {},

--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -166,7 +166,7 @@ class _SummaryCardState extends State<SummaryCard> with UpToDateMixin {
                 ),
                 child: Center(
                   child: Text(
-                    AppLocalizations.of(context).tab_for_more,
+                    AppLocalizations.of(context).tap_for_more,
                     style:
                         Theme.of(context).primaryTextTheme.bodyLarge?.copyWith(
                               color: PRIMARY_BLUE_COLOR,


### PR DESCRIPTION
Hi everyone!

There is a slight typo with the `tab_for_more` translation which should be `tap_for_more`.
This PR just renames it.