### PR TITLE
feat: Sign up request with the country and the language of the user

### DIFF
--- a/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
@@ -11,6 +11,7 @@ import 'package:smooth_app/generic_lib/loading_dialog.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_text_form_field.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/user_management_helper.dart';
+import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -334,6 +335,8 @@ class _SignUpPageState extends State<SignUpPage> with TraceableClientMixin {
         email: _emailController.trimmedText,
         newsletter: _subscribe,
         orgName: _foodProducer ? _brandController.trimmedText : null,
+        country: ProductQuery.getCountry(),
+        language: ProductQuery.getLanguage(),
       ),
       title: appLocalisations.sign_up_page_action_doing_it,
     );

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -1003,10 +1003,10 @@ packages:
     dependency: "direct main"
     description:
       name: openfoodfacts
-      sha256: "3573e7024423dbce1823d70ae0ba56363bd7f26ed89200d4cdc502d3990f695b"
+      sha256: a39131388148839f08fe4772cfd5dd77f2393bd7995edb9712e70742201d41fb
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.0"
+    version: "2.7.1"
   openfoodfacts_flutter_lints:
     dependency: "direct dev"
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -96,7 +96,7 @@ dependencies:
 
 
 
-  openfoodfacts: 2.6.0
+  openfoodfacts: 2.7.1
   # openfoodfacts:
   #   path: ../../../openfoodfacts-dart
 


### PR DESCRIPTION
Hi everyone!

Currently, all users are registered with the "world" website, and they receive the newsletter in English.
Before implementing a way to change the language dynamically, we now ensure to send the user's language and country to fit 95% of cases.