### PR TITLE
feat: Images with a working placeholder + error icon

### DIFF
--- a/packages/smooth_app/lib/generic_lib/widgets/images/smooth_image.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/images/smooth_image.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/picture_not_found.dart';
 
@@ -32,6 +33,7 @@ class SmoothImage extends StatelessWidget {
             image: imageProvider!,
             fit: fit ?? BoxFit.cover,
             loadingBuilder: _loadingBuilder,
+            errorBuilder: _errorBuilder,
           );
 
     if (heroTag != null) {
@@ -51,24 +53,45 @@ class SmoothImage extends StatelessWidget {
   }
 
   Widget _loadingBuilder(
-    BuildContext _,
+    BuildContext context,
     Widget child,
     ImageChunkEvent? progress,
   ) {
-    if (progress == null) {
-      return child;
+    final double? progressValue;
+
+    if (progress != null) {
+      progressValue =
+          progress.cumulativeBytesLoaded / progress.expectedTotalBytes!;
+    } else {
+      progressValue = null;
     }
 
-    final double progressValue =
-        progress.cumulativeBytesLoaded / progress.expectedTotalBytes!;
+    final ThemeData theme = Theme.of(context);
 
-    return Center(
-      child: CircularProgressIndicator(
-        strokeWidth: 2.5,
-        valueColor: const AlwaysStoppedAnimation<Color>(
-          Colors.white,
+    return Container(
+      color: theme.primaryColor.withOpacity(0.1),
+      child: Center(
+        child: CircularProgressIndicator(
+          strokeWidth: 2.5,
+          valueColor: theme.brightness == Brightness.dark
+              ? const AlwaysStoppedAnimation<Color>(Colors.white)
+              : null,
+          value: progressValue,
         ),
-        value: progressValue,
+      ),
+    );
+  }
+
+  Widget _errorBuilder(
+    BuildContext context,
+    Object _,
+    StackTrace? __,
+  ) {
+    return Container(
+      color: Theme.of(context).primaryColor.withOpacity(0.1),
+      padding: const EdgeInsets.all(MEDIUM_SPACE),
+      child: Center(
+        child: SvgPicture.asset('assets/misc/error.svg'),
       ),
     );
   }


### PR DESCRIPTION
Hi everyone,

The [SmoothImage] Widget is really good to handle loading images… but the progress bar is not always showing, because a white on white color… is invisible.

That's why I have tweaked the code and also added a generic image for errors (now, there is a text message).

![Screenshot_1689771160](https://github.com/openfoodfacts/smooth-app/assets/246838/c927d000-4d76-4ac2-b34c-691ed3481da3)
![Screenshot_1689771168](https://github.com/openfoodfacts/smooth-app/assets/246838/b89aace1-3503-45da-a091-c0859f60df44)
![Screenshot_1689771210](https://github.com/openfoodfacts/smooth-app/assets/246838/00524e5f-a601-48e8-9e91-9bedb2beb985)
