### PR TITLE
feat: Camera Visor: force icons to always be white

### DIFF
--- a/packages/scanner/shared/lib/src/scanner_visor.dart
+++ b/packages/scanner/shared/lib/src/scanner_visor.dart
@@ -174,7 +174,10 @@ class VisorButton extends StatelessWidget {
           enableFeedback: true,
           child: Padding(
             padding: const EdgeInsets.all(12.0),
-            child: child,
+            child: IconTheme(
+              data: const IconThemeData(color: Colors.white),
+              child: child,
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
Hi everyone,

In some cases, the icons in the visor may be black.
Here is a simple fix to ensure it's always white.

![Screenshot_1689772474](https://github.com/openfoodfacts/smooth-app/assets/246838/100e650c-8cd0-42ea-a511-9e60b52f2f2d)