### PR TITLE
fix: Permissions page with "a well balanced" style

### DIFF
--- a/packages/smooth_app/lib/pages/onboarding/permissions_page.dart
+++ b/packages/smooth_app/lib/pages/onboarding/permissions_page.dart
@@ -12,6 +12,7 @@ import 'package:smooth_app/helpers/permission_helper.dart';
 import 'package:smooth_app/helpers/provider_helper.dart';
 import 'package:smooth_app/pages/onboarding/onboarding_bottom_bar.dart';
 import 'package:smooth_app/pages/onboarding/onboarding_flow_navigator.dart';
+import 'package:smooth_app/widgets/smooth_text.dart';
 
 class PermissionsPage extends StatefulWidget {
   const PermissionsPage(
@@ -80,12 +81,14 @@ class _PermissionsPageState extends State<PermissionsPage> {
                       appLocalizations.permissions_page_body1,
                       maxLines: 2,
                       textAlign: TextAlign.center,
+                      style: WellSpacedTextHelper.TEXT_STYLE_WITH_WELL_SPACED,
                     ),
                     const SizedBox(height: MEDIUM_SPACE),
                     AutoSizeText(
                       appLocalizations.permissions_page_body2,
                       maxLines: 3,
                       textAlign: TextAlign.center,
+                      style: WellSpacedTextHelper.TEXT_STYLE_WITH_WELL_SPACED,
                     ),
                   ],
                 ),


### PR DESCRIPTION
Hi everyone,

The consent page uses a "well-balanced" style with a higher line height.
This PR does the same for the Permission's page.

Before:
![Screenshot_1689780593](https://github.com/openfoodfacts/smooth-app/assets/246838/658397dd-5c11-4d5b-bf75-c33a9765b0ac)

After:
![Screenshot_1689780503](https://github.com/openfoodfacts/smooth-app/assets/246838/c7b54c9a-9923-47ce-a1f8-73945f968d97)

It's part of #4230 