### PR TITLE
chore: iOS/macOS: "App Uses Non-Exempt Encryption"

### DIFF
--- a/packages/smooth_app/ios/Runner/Info.plist
+++ b/packages/smooth_app/ios/Runner/Info.plist
@@ -59,5 +59,7 @@
 	<true/>
 	<key>FlutterDeepLinkingEnabled</key>
 	<true/>
+	<key>ITSAppUsesNonExemptEncryption</key>
+    <false/>
 </dict>
 </plist>

--- a/packages/smooth_app/macos/Runner/Info.plist
+++ b/packages/smooth_app/macos/Runner/Info.plist
@@ -28,5 +28,7 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+    <false/>
 </dict>
 </plist>


### PR DESCRIPTION
Hi everyone,

On iOS, we have warnings about "missing compliance".
To remove it, we just have to state that we don't use a custom encryption.