### PR TITLE
fix: 4241 - remove shimmering box if connection fails

### DIFF
--- a/packages/smooth_app/lib/pages/product/product_questions_widget.dart
+++ b/packages/smooth_app/lib/pages/product/product_questions_widget.dart
@@ -179,9 +179,13 @@ class _ProductQuestionsWidgetState extends State<ProductQuestionsWidget>
 
   Future<List<RobotoffQuestion>?> _loadProductQuestions() async {
     final LocalDatabase localDatabase = context.read<LocalDatabase>();
-    final List<RobotoffQuestion> questions =
-        await ProductQuestionsQuery(widget.product.barcode!)
-            .getQuestions(localDatabase, 3);
+    final List<RobotoffQuestion> questions;
+    try {
+      questions = await ProductQuestionsQuery(widget.product.barcode!)
+          .getQuestions(localDatabase, 3);
+    } catch (e) {
+      return null;
+    }
     if (!mounted) {
       return null;
     }


### PR DESCRIPTION
### What
- We did not check if the connection was OK when looking for hunger games questions for a product.
- Now we do.

### Fixes bug(s)
- Fixes: #4241