### PR TITLE
fix: food preferences redirecting to a 404 page

### DIFF
--- a/packages/smooth_app/lib/pages/navigator/app_navigator.dart
+++ b/packages/smooth_app/lib/pages/navigator/app_navigator.dart
@@ -157,7 +157,8 @@ class _SmoothGoRouter {
               },
             ),
             GoRoute(
-              path: '${_InternalAppRoutes.PREFERENCES_PAGE}/:preferenceType',
+              path:
+                  '${_InternalAppRoutes.PREFERENCES_PAGE.path}/:preferenceType',
               builder: (BuildContext context, GoRouterState state) {
                 final String? type = state.pathParameters['preferenceType'];
 


### PR DESCRIPTION
In the product card, the link to food preferences is broken after a change I did recently on the router.
Not that hard to fix though