### PR TITLE
feat: Better suggestions in product edition (UI/UX) + debounce feature

### DIFF
--- a/packages/smooth_app/lib/pages/product/autocomplete.dart
+++ b/packages/smooth_app/lib/pages/product/autocomplete.dart
@@ -98,10 +98,7 @@ class _AutocompleteOptionsItem<T extends Object> extends StatelessWidget {
     return Material(
       type: MaterialType.transparency,
       child: InkWell(
-        onTap: () {
-          print('selected');
-          onSelected(option);
-        },
+        onTap: () => onSelected(option),
         child: Ink(
           color: highlight ? Theme.of(context).focusColor : null,
           padding: const EdgeInsets.all(LARGE_SPACE),

--- a/packages/smooth_app/lib/pages/product/autocomplete.dart
+++ b/packages/smooth_app/lib/pages/product/autocomplete.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/widgets/smooth_text.dart';
 
 /// The default Material-style Autocomplete options.
 ///
@@ -15,6 +16,7 @@ class AutocompleteOptions<T extends Object> extends StatelessWidget {
     required this.options,
     required this.maxOptionsHeight,
     required this.maxOptionsWidth,
+    this.search,
   })  : assert(maxOptionsHeight >= 0),
         assert(maxOptionsWidth >= 0),
         super(key: key);
@@ -25,6 +27,7 @@ class AutocompleteOptions<T extends Object> extends StatelessWidget {
   final Iterable<T> options;
   final double maxOptionsWidth;
   final double maxOptionsHeight;
+  final String? search;
 
   @override
   Widget build(BuildContext context) {
@@ -51,6 +54,7 @@ class AutocompleteOptions<T extends Object> extends StatelessWidget {
                 return _AutocompleteOptionsItem<T>(
                   key: Key(index.toString()),
                   option: option,
+                  search: search,
                   highlight: highlightedOption == index,
                   onSelected: onSelected,
                   displayStringForOption: displayStringForOption,
@@ -73,10 +77,12 @@ class _AutocompleteOptionsItem<T extends Object> extends StatelessWidget {
     required this.highlight,
     required this.displayStringForOption,
     required this.onSelected,
+    this.search,
     Key? key,
   }) : super(key: key);
 
   final T option;
+  final String? search;
   final bool highlight;
   final AutocompleteOptionToString<T> displayStringForOption;
   final AutocompleteOnSelected<T> onSelected;
@@ -89,15 +95,20 @@ class _AutocompleteOptionsItem<T extends Object> extends StatelessWidget {
       });
     }
 
-    return InkWell(
-      onTap: () {
-        onSelected(option);
-      },
-      child: Container(
-        color: highlight ? Theme.of(context).focusColor : null,
-        padding: const EdgeInsets.all(LARGE_SPACE),
-        child: Text(
-          displayStringForOption(option),
+    return Material(
+      type: MaterialType.transparency,
+      child: InkWell(
+        onTap: () {
+          print('selected');
+          onSelected(option);
+        },
+        child: Ink(
+          color: highlight ? Theme.of(context).focusColor : null,
+          padding: const EdgeInsets.all(LARGE_SPACE),
+          child: TextHighlighter(
+            text: displayStringForOption(option),
+            filter: search ?? '',
+          ),
         ),
       ),
     );

--- a/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
@@ -84,8 +84,7 @@ class _SimpleInputTextFieldState extends State<SimpleInputTextField> {
       }
     }
 
-    if (_suggestions[search]?.isEmpty == true &&
-        widget.controller.text == _searchInput) {
+    if (_suggestions[search]?.isEmpty == true && search == _searchInput) {
       _hideLoading();
     }
 

--- a/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
@@ -5,7 +6,7 @@ import 'package:smooth_app/pages/product/autocomplete.dart';
 import 'package:smooth_app/query/product_query.dart';
 
 /// Simple input text field, with autocompletion.
-class SimpleInputTextField extends StatelessWidget {
+class SimpleInputTextField extends StatefulWidget {
   const SimpleInputTextField({
     required this.focusNode,
     required this.autocompleteKey,
@@ -31,20 +32,63 @@ class SimpleInputTextField extends StatelessWidget {
   final String? Function()? shapeProvider;
 
   @override
-  Widget build(BuildContext context) {
-    final SuggestionManager? manager = tagType == null
+  State<SimpleInputTextField> createState() => _SimpleInputTextFieldState();
+}
+
+class _SimpleInputTextFieldState extends State<SimpleInputTextField> {
+  final Map<String, _SearchResults> _suggestions = <String, _SearchResults>{};
+  bool _loading = false;
+
+  late SuggestionManager? _manager;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _manager = widget.tagType == null
         ? null
         : SuggestionManager(
-            tagType!,
+            widget.tagType!,
             language: ProductQuery.getLanguage(),
             country: ProductQuery.getCountry(),
-            categories: categories,
-            shape: shapeProvider?.call(),
+            categories: widget.categories,
+            shape: widget.shapeProvider?.call(),
             user: ProductQuery.getUser(),
             // number of suggestions the user can scroll through: compromise between quantity and readability of the suggestions
             limit: 15,
           );
+  }
 
+  Future<_SearchResults> _getSuggestions(String search) async {
+    final DateTime start = DateTime.now();
+
+    if (_suggestions[search] == null) {
+      if (_manager == null || search.length < widget.minLengthForSuggestions) {
+        _suggestions[search] = _SearchResults.empty();
+      } else {
+        try {
+          _suggestions[search] =
+              _SearchResults(await _manager!.getSuggestions(search));
+        } catch (_) {}
+      }
+    }
+
+    if (_suggestions[search]?.isEmpty == true &&
+        widget.controller.text == _searchInput) {
+      _hideLoading();
+    }
+
+    if (_searchInput != search &&
+        start.difference(DateTime.now()).inSeconds > 5) {
+      // Ignore this request, it's too long and this is not even the current search
+      return _SearchResults.empty();
+    } else {
+      return _suggestions[search]!;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsetsDirectional.only(start: LARGE_SPACE),
       child: Row(
@@ -54,20 +98,11 @@ class SimpleInputTextField extends StatelessWidget {
         children: <Widget>[
           Expanded(
             child: RawAutocomplete<String>(
-              key: autocompleteKey,
-              focusNode: focusNode,
-              textEditingController: controller,
-              optionsBuilder: (final TextEditingValue value) async {
-                if (tagType == null) {
-                  return <String>[];
-                }
-
-                final String input = value.text.trim();
-                if (input.length < minLengthForSuggestions) {
-                  return <String>[];
-                }
-
-                return manager!.getSuggestions(input);
+              key: widget.autocompleteKey,
+              focusNode: widget.focusNode,
+              textEditingController: widget.controller,
+              optionsBuilder: (final TextEditingValue value) {
+                return _getSuggestions(value.text);
               },
               fieldViewBuilder: (BuildContext context,
                       TextEditingController textEditingController,
@@ -75,6 +110,7 @@ class SimpleInputTextField extends StatelessWidget {
                       VoidCallback onFieldSubmitted) =>
                   TextField(
                 controller: textEditingController,
+                onChanged: (_) => setState(() => _loading = true),
                 decoration: InputDecoration(
                   filled: true,
                   border: const OutlineInputBorder(
@@ -85,7 +121,21 @@ class SimpleInputTextField extends StatelessWidget {
                     horizontal: SMALL_SPACE,
                     vertical: SMALL_SPACE,
                   ),
-                  hintText: hintText,
+                  hintText: widget.hintText,
+                  suffix: Offstage(
+                    offstage: !_loading,
+                    child: SizedBox(
+                      width:
+                          Theme.of(context).textTheme.titleMedium?.fontSize ??
+                              15,
+                      height:
+                          Theme.of(context).textTheme.titleMedium?.fontSize ??
+                              15,
+                      child: const CircularProgressIndicator.adaptive(
+                        strokeWidth: 1.0,
+                      ),
+                    ),
+                  ),
                 ),
                 // a lot of confusion if set to `true`
                 autofocus: false,
@@ -97,6 +147,18 @@ class SimpleInputTextField extends StatelessWidget {
                 Iterable<String> options,
               ) {
                 final double screenHeight = MediaQuery.of(context).size.height;
+                String input = '';
+
+                for (final String key in _suggestions.keys) {
+                  if (_suggestions[key].hashCode == options.hashCode) {
+                    input = key;
+                    break;
+                  }
+                }
+
+                if (input == _searchInput) {
+                  _hideLoading();
+                }
 
                 return AutocompleteOptions<String>(
                   displayStringForOption:
@@ -104,21 +166,51 @@ class SimpleInputTextField extends StatelessWidget {
                   onSelected: onSelected,
                   options: options,
                   // Width = Row width - horizontal padding
-                  maxOptionsWidth: constraints.maxWidth - (LARGE_SPACE * 2),
+                  maxOptionsWidth:
+                      widget.constraints.maxWidth - (LARGE_SPACE * 2),
                   maxOptionsHeight: screenHeight / 3,
+                  search: input,
                 );
               },
             ),
           ),
-          if (withClearButton)
+          if (widget.withClearButton)
             IconButton(
               icon: const Icon(Icons.clear),
-              onPressed: () => controller.text = '',
+              onPressed: () => widget.controller.text = '',
             ),
         ],
       ),
     );
   }
+
+  String get _searchInput => widget.controller.text.trim();
+
+  void _hideLoading() {
+    if (_loading) {
+      WidgetsBinding.instance.addPostFrameCallback(
+        (_) => setState(() => _loading = false),
+      );
+    }
+  }
+}
+
+@immutable
+class _SearchResults extends DelegatingList<String> {
+  _SearchResults(List<String>? results) : super(results ?? <String>[]);
+
+  _SearchResults.empty() : super(<String>[]);
+  final int _uniqueId = DateTime.now().millisecondsSinceEpoch;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is _SearchResults &&
+          runtimeType == other.runtimeType &&
+          _uniqueId == other._uniqueId;
+
+  @override
+  int get hashCode => _uniqueId;
 }
 
 /// Allows to unfocus TextField (and dismiss the keyboard) when user tap outside the TextField and inside this widget.


### PR DESCRIPTION
Hi everyone,

In a product edition, we provide some suggestions for categories, labels…
The current implementation triggers a request for every single letter.
To improve this, the app will now show a loader because the results will appear with a delay.

A video of the change: [Video.webm](https://github.com/openfoodfacts/smooth-app/assets/246838/624d6fc7-0851-4ce2-8502-3b95cbc2bd26)

Just in case it's not clear, let's say you write "ABC" : you will see the suggestions for "A", then "B", then "C".
To be less confusing for the user, I have added a ProgressBar which is visible until the correct suggestions are visible (here "C").

Also, in some cases, the request may take a really long time, and in that case, if that's an intermediate case (eg: A or B), it won't be displayed.

Furthermore, I have added a cache, which may require fewer requests to the server.


Clearly, this is just a UI improvement, but we should implement a debounce-like mechanism to minimize the number of requests to the server.

**EDIT**: The debounce feature is implemented! (@see https://github.com/openfoodfacts/smooth-app/pull/4351#issuecomment-1646101680)