### PR TITLE
feat: When there is no camera, show the search card in fullscreen

### DIFF
--- a/packages/smooth_app/lib/pages/scan/scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/scan_page.dart
@@ -12,6 +12,7 @@ import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/helpers/app_helper.dart';
+import 'package:smooth_app/helpers/camera_helper.dart';
 import 'package:smooth_app/helpers/haptic_feedback_helper.dart';
 import 'package:smooth_app/helpers/permission_helper.dart';
 import 'package:smooth_app/pages/scan/camera_scan_page.dart';
@@ -65,6 +66,7 @@ class _ScanPageState extends State<ScanPage> {
 
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final TextDirection direction = Directionality.of(context);
+    final bool hasACamera = CameraHelper.hasACamera;
 
     return SmoothScaffold(
       brightness:
@@ -74,26 +76,27 @@ class _ScanPageState extends State<ScanPage> {
       body: SafeArea(
         child: Column(
           children: <Widget>[
-            Expanded(
-              flex: 100 - _carouselHeightPct,
-              child: Consumer<PermissionListener>(
-                builder: (
-                  BuildContext context,
-                  PermissionListener listener,
-                  _,
-                ) {
-                  switch (listener.value.status) {
-                    case DevicePermissionStatus.checking:
-                      return EMPTY_WIDGET;
-                    case DevicePermissionStatus.granted:
-                      // TODO(m123): change
-                      return const CameraScannerPage();
-                    default:
-                      return const _PermissionDeniedCard();
-                  }
-                },
+            if (hasACamera)
+              Expanded(
+                flex: 100 - _carouselHeightPct,
+                child: Consumer<PermissionListener>(
+                  builder: (
+                    BuildContext context,
+                    PermissionListener listener,
+                    _,
+                  ) {
+                    switch (listener.value.status) {
+                      case DevicePermissionStatus.checking:
+                        return EMPTY_WIDGET;
+                      case DevicePermissionStatus.granted:
+                        // TODO(m123): change
+                        return const CameraScannerPage();
+                      default:
+                        return const _PermissionDeniedCard();
+                    }
+                  },
+                ),
               ),
-            ),
             Expanded(
               flex: _carouselHeightPct,
               child: Padding(


### PR DESCRIPTION
Hi everyone,

Today, when a device doesn't have a camera (eg: on desktop platforms or some devices), we show the scan card on half of the screen:

<img width="800" alt="Screenshot 2023-07-22 at 09 03 45" src="https://github.com/openfoodfacts/smooth-app/assets/246838/2f1c442c-20bf-47e3-9e97-253026564ab9">

Instead, this PR will now show it fullscreen:

<img width="800" alt="Screenshot 2023-07-22 at 09 04 30" src="https://github.com/openfoodfacts/smooth-app/assets/246838/4282a847-15de-43ef-8d06-45985bc43573">

I know this is ugly, but still better than "No camera detected"