### PR TITLE
feat: Increase padding for attribute groups

### DIFF
--- a/packages/smooth_app/lib/pages/product/summary_attribute_group.dart
+++ b/packages/smooth_app/lib/pages/product/summary_attribute_group.dart
@@ -16,24 +16,30 @@ class SummaryAttributeGroup extends StatelessWidget {
   final String? groupName;
 
   @override
-  Widget build(BuildContext context) => AbsorbPointer(
-        absorbing: !isClickable,
-        child: Column(
-          children: <Widget>[
-            _SummaryAttributeGroupHeader(
-              isFirstGroup: isFirstGroup,
-              groupName: groupName,
-            ),
-            Container(
-              alignment: AlignmentDirectional.topStart,
-              child: Wrap(
-                runSpacing: 16,
-                children: attributeChips,
-              ),
-            ),
-          ],
-        ),
-      );
+  Widget build(BuildContext context) {
+    return AbsorbPointer(
+      absorbing: !isClickable,
+      child: Column(
+        children: <Widget>[
+          _SummaryAttributeGroupHeader(
+            isFirstGroup: isFirstGroup,
+            groupName: groupName,
+          ),
+          Align(
+            alignment: AlignmentDirectional.topStart,
+            child: attributeChips.length == 1
+                ? SizedBox(
+                    width: double.infinity,
+                    child: attributeChips.first,
+                  )
+                : Wrap(
+                    children: attributeChips,
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
 }
 
 class _SummaryAttributeGroupHeader extends StatelessWidget {
@@ -62,7 +68,10 @@ class _SummaryAttributeGroupHeader extends StatelessWidget {
           ),
         )
       : Padding(
-          padding: const EdgeInsets.symmetric(vertical: SMALL_SPACE),
+          padding: const EdgeInsetsDirectional.only(
+            top: VERY_SMALL_SPACE,
+            bottom: SMALL_SPACE,
+          ),
           child: isFirstGroup
               ? EMPTY_WIDGET
               : const Divider(

--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -423,17 +423,21 @@ class _SummaryCardState extends State<SummaryCard> with UpToDateMixin {
         return SizedBox(
           width: constraints.maxWidth / 2,
           child: InkWell(
+            borderRadius: ANGULAR_BORDER_RADIUS,
             enableFeedback: _isAttributeOpeningAllowed(attribute),
             onTap: () async => _openFullKnowledgePanel(
               attribute: attribute,
             ),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.start,
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: <Widget>[
-                attributeIcon,
-                Expanded(child: Text(attributeDisplayTitle)),
-              ],
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: SMALL_SPACE),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.start,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: <Widget>[
+                  attributeIcon,
+                  Expanded(child: Text(attributeDisplayTitle)),
+                ],
+              ),
             ),
           ),
         );


### PR DESCRIPTION
Hi everyone!

On the product, the list of attribute groups can be improved by increasing simply their paddings.
Actually, we have a `Wrap` widget, with some spacing between elements.

Instead, we pass this space to the padding.

I have also tweaked a little bit the case, where there is only one attribute, to ensure it will fit all the width.

A video with multiple attributes: [Multiple.webm](https://github.com/openfoodfacts/smooth-app/assets/246838/cc949c43-b85d-4b9d-9d70-024dc95d88b0)
And a single one: [Single.webm](https://github.com/openfoodfacts/smooth-app/assets/246838/cc8b6724-42c9-4f7f-9aad-7f472d612c5b)
