### PR TITLE
feat: Use a correct a11n for "actions bar" in a product

### DIFF
--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -323,44 +323,47 @@ class _ProductPageState extends State<ProductPage>
 
   Widget _buildActionBar(final AppLocalizations appLocalizations) => Padding(
         padding: const EdgeInsets.all(SMALL_SPACE),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceAround,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            _buildActionBarItem(
-              Icons.bookmark_border,
-              appLocalizations.user_list_button_add_product,
-              _editList,
-            ),
-            _buildActionBarItem(
-              Icons.edit,
-              appLocalizations.edit_product_label,
-              () async {
-                setState(() => _keepRobotoffQuestionsAlive = false);
+        child: Semantics(
+          explicitChildNodes: true,
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              _buildActionBarItem(
+                Icons.bookmark_border,
+                appLocalizations.user_list_button_add_product,
+                _editList,
+              ),
+              _buildActionBarItem(
+                Icons.edit,
+                appLocalizations.edit_product_label,
+                () async {
+                  setState(() => _keepRobotoffQuestionsAlive = false);
 
-                AnalyticsHelper.trackEvent(
-                  AnalyticsEvent.openProductEditPage,
-                  barcode: barcode,
-                );
+                  AnalyticsHelper.trackEvent(
+                    AnalyticsEvent.openProductEditPage,
+                    barcode: barcode,
+                  );
 
-                await Navigator.push<void>(
-                  context,
-                  MaterialPageRoute<void>(
-                    builder: (BuildContext context) =>
-                        EditProductPage(upToDateProduct),
-                  ),
-                );
+                  await Navigator.push<void>(
+                    context,
+                    MaterialPageRoute<void>(
+                      builder: (BuildContext context) =>
+                          EditProductPage(upToDateProduct),
+                    ),
+                  );
 
-                // Force Robotoff questions to be reloaded
-                setState(() => _keepRobotoffQuestionsAlive = true);
-              },
-            ),
-            _buildActionBarItem(
-              ConstantIcons.instance.getShareIcon(),
-              appLocalizations.share,
-              _shareProduct,
-            ),
-          ],
+                  // Force Robotoff questions to be reloaded
+                  setState(() => _keepRobotoffQuestionsAlive = true);
+                },
+              ),
+              _buildActionBarItem(
+                ConstantIcons.instance.getShareIcon(),
+                appLocalizations.share,
+                _shareProduct,
+              ),
+            ],
+          ),
         ),
       );
 
@@ -372,24 +375,32 @@ class _ProductPageState extends State<ProductPage>
     final ThemeData themeData = Theme.of(context);
     final ColorScheme colorScheme = themeData.colorScheme;
     return Expanded(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.start,
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: <Widget>[
-          ElevatedButton(
-            onPressed: onPressed,
-            style: ElevatedButton.styleFrom(
-              shape: const CircleBorder(),
-              padding: const EdgeInsets.all(
-                18,
-              ), // TODO(monsieurtanuki): cf. FloatingActionButton
-              backgroundColor: colorScheme.primary,
+      child: Semantics(
+        value: label,
+        button: true,
+        excludeSemantics: true,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: <Widget>[
+            ElevatedButton(
+              onPressed: onPressed,
+              style: ElevatedButton.styleFrom(
+                shape: const CircleBorder(),
+                padding: const EdgeInsets.all(
+                  18,
+                ), // TODO(monsieurtanuki): cf. FloatingActionButton
+                backgroundColor: colorScheme.primary,
+              ),
+              child: Icon(iconData, color: colorScheme.onPrimary),
             ),
-            child: Icon(iconData, color: colorScheme.onPrimary),
-          ),
-          const SizedBox(height: VERY_SMALL_SPACE),
-          AutoSizeText(label, textAlign: TextAlign.center),
-        ],
+            const SizedBox(height: VERY_SMALL_SPACE),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 2.0),
+              child: AutoSizeText(label, textAlign: TextAlign.center),
+            ),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
Hi everyone,

The current "actions bar" (Add to list / Edit product / Share) is a nightmare in terms of accessibility:
![Screenshot_1690012409](https://github.com/openfoodfacts/smooth-app/assets/246838/25b5b3ed-6e77-4eb4-94e3-b9c7ebc4cfe7)
![Screenshot_1690012520](https://github.com/openfoodfacts/smooth-app/assets/246838/b674facb-a6e9-4de5-9d4b-13a01920eb67)
It selects the whole row, then each icon, then each text.

Here is instead the expected behavior:
![Screenshot_1690012600](https://github.com/openfoodfacts/smooth-app/assets/246838/04fa3ae8-f77d-41df-8f5d-f60caa6114a0)