### PR TITLE
feat: Nutrition facts array in a bottom sheet

### DIFF
--- a/packages/smooth_app/lib/pages/product/portion_calculator.dart
+++ b/packages/smooth_app/lib/pages/product/portion_calculator.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/generic_lib/bottom_sheets/smooth_bottom_sheet.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
-import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/generic_lib/duration_constants.dart';
 import 'package:smooth_app/pages/product/ordered_nutrients_cache.dart';
 import 'package:smooth_app/pages/product/portion_helper.dart';
@@ -167,28 +167,40 @@ class _PortionCalculatorState extends State<PortionCalculator> {
     if (helper.isEmpty) {
       return;
     }
-    await showDialog<void>(
+    await showSmoothDraggableModalSheet<void>(
       context: context,
-      builder: (final BuildContext context) => SmoothAlertDialog(
+      header: SmoothModalSheetHeader(
         title: appLocalizations.portion_calculator_result_title(quantity),
-        body: Column(
-          children: List<Widget>.generate(
-            helper.length,
-            (final int index) => Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: <Widget>[
-                Text(helper.getName(index)),
-                Text(helper.getValue(index)),
-              ],
-            ),
-          ),
-        ),
-        positiveAction: SmoothActionButton(
-          text: appLocalizations.okay,
-          onPressed: () => Navigator.of(context).pop(),
-        ),
       ),
+      initHeight: 0.7,
+      bodyBuilder: (BuildContext context) {
+        return SliverList(
+          delegate: SliverChildBuilderDelegate(
+            childCount: helper.length,
+            (BuildContext context, int position) {
+              return Column(
+                children: <Widget>[
+                  Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: VERY_LARGE_SPACE,
+                      vertical: LARGE_SPACE,
+                    ),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      children: <Widget>[
+                        Text(helper.getName(position)),
+                        Text(helper.getValue(position)),
+                      ],
+                    ),
+                  ),
+                  if (position < helper.length - 1) const Divider(height: 1.0)
+                ],
+              );
+            },
+          ),
+        );
+      },
     );
   }
 

--- a/packages/smooth_app/lib/pages/product/portion_calculator.dart
+++ b/packages/smooth_app/lib/pages/product/portion_calculator.dart
@@ -185,13 +185,15 @@ class _PortionCalculatorState extends State<PortionCalculator> {
                       horizontal: VERY_LARGE_SPACE,
                       vertical: LARGE_SPACE,
                     ),
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      crossAxisAlignment: CrossAxisAlignment.center,
-                      children: <Widget>[
-                        Text(helper.getName(position)),
-                        Text(helper.getValue(position)),
-                      ],
+                    child: MergeSemantics(
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        children: <Widget>[
+                          Text(helper.getName(position)),
+                          Text(helper.getValue(position)),
+                        ],
+                      ),
                     ),
                   ),
                   if (position < helper.length - 1) const Divider(height: 1.0)


### PR DESCRIPTION
Hi everyone,

As suggested by @teolemon in https://github.com/openfoodfacts/smooth-app/pull/4278#issuecomment-1637677377, here are nutrition facts in a modal sheet:

<img width="800" alt="Screenshot 2023-07-22 at 17 43 12" src="https://github.com/openfoodfacts/smooth-app/assets/246838/626ed4e8-79ae-464c-a4c2-bd7fc31dc422">
<img width="800" alt="Screenshot 2023-07-22 at 17 43 18" src="https://github.com/openfoodfacts/smooth-app/assets/246838/19eb660c-cb78-467b-bfc9-0fb834c0694d">
