### PR TITLE
feat: User lists picker in a modal sheet

### DIFF
--- a/packages/smooth_app/lib/data_models/product_list.dart
+++ b/packages/smooth_app/lib/data_models/product_list.dart
@@ -254,4 +254,6 @@ class ProductList {
             ',${country?.offTag ?? ''}';
     }
   }
+
+  bool get isEditable => listType == ProductListType.USER;
 }

--- a/packages/smooth_app/lib/generic_lib/bottom_sheets/smooth_bottom_sheet.dart
+++ b/packages/smooth_app/lib/generic_lib/bottom_sheets/smooth_bottom_sheet.dart
@@ -110,7 +110,8 @@ class SmoothModalSheetHeader extends StatelessWidget implements SizeWidget {
         start: VERY_LARGE_SPACE,
         top: VERY_SMALL_SPACE,
         bottom: VERY_SMALL_SPACE,
-        end: VERY_LARGE_SPACE - (suffix != null ? LARGE_SPACE : 0),
+        end: VERY_LARGE_SPACE -
+            (suffix?.requiresPadding == true ? 0 : LARGE_SPACE),
       ),
       child: IntrinsicHeight(
         child: Row(
@@ -147,6 +148,9 @@ class SmoothModalSheetHeader extends StatelessWidget implements SizeWidget {
 
     return math.max(MIN_HEIGHT, size);
   }
+
+  @override
+  bool get requiresPadding => true;
 }
 
 class SmoothModalSheetHeaderButton extends StatelessWidget
@@ -230,6 +234,9 @@ class SmoothModalSheetHeaderButton extends StatelessWidget
             suffix is Icon || prefix is Icon ? 20.0 : 0.0) +
         _padding.vertical;
   }
+
+  @override
+  bool get requiresPadding => true;
 }
 
 class SmoothModalSheetHeaderCloseButton extends StatelessWidget
@@ -265,8 +272,13 @@ class SmoothModalSheetHeaderCloseButton extends StatelessWidget
   @override
   double widgetHeight(BuildContext context) =>
       (MEDIUM_SPACE * 2) + (Theme.of(context).iconTheme.size ?? 20.0);
+
+  @override
+  bool get requiresPadding => false;
 }
 
 abstract class SizeWidget implements Widget {
   double widgetHeight(BuildContext context);
+
+  bool get requiresPadding;
 }

--- a/packages/smooth_app/lib/generic_lib/bottom_sheets/smooth_draggable_bottom_sheet.dart
+++ b/packages/smooth_app/lib/generic_lib/bottom_sheets/smooth_draggable_bottom_sheet.dart
@@ -157,6 +157,7 @@ class _SmoothDraggableContentState extends State<_SmoothDraggableContent> {
   @override
   Widget build(BuildContext context) {
     return Scrollbar(
+      controller: widget.scrollController,
       child: CustomScrollView(
         cacheExtent: widget.cacheExtent,
         key: _contentKey,
@@ -178,15 +179,18 @@ class _SmoothDraggableContentState extends State<_SmoothDraggableContent> {
 
 /// A fixed header
 class _SliverHeader extends SliverPersistentHeaderDelegate {
-  _SliverHeader({required this.child, required this.height})
-      : assert(height > 0.0);
+  _SliverHeader({
+    required this.child,
+    required this.height,
+  }) : assert(height > 0.0);
 
   final Widget child;
   final double height;
 
   @override
   Widget build(BuildContext context, _, __) {
-    return child;
+    // Align is mandatory here (a known-bug in the framework)
+    return Align(child: child);
   }
 
   @override

--- a/packages/smooth_app/lib/generic_lib/dialogs/smooth_alert_dialog.dart
+++ b/packages/smooth_app/lib/generic_lib/dialogs/smooth_alert_dialog.dart
@@ -388,19 +388,22 @@ class _SmoothActionElevatedButton extends StatelessWidget {
       value: buttonData.text,
       button: true,
       excludeSemantics: true,
-      child: SmoothSimpleButton(
-        onPressed: buttonData.onPressed,
-        minWidth: buttonData.minWidth ?? 20.0,
-        child: FittedBox(
-          fit: BoxFit.scaleDown,
-          child: Text(
-            buttonData.text.toUpperCase(),
-            textAlign: TextAlign.center,
-            overflow: TextOverflow.ellipsis,
-            maxLines: buttonData.lines ?? 2,
-            style: themeData.textTheme.bodyMedium!.copyWith(
-              fontWeight: FontWeight.bold,
-              color: buttonData.textColor ?? themeData.colorScheme.onPrimary,
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(minHeight: 30.0),
+        child: SmoothSimpleButton(
+          onPressed: buttonData.onPressed,
+          minWidth: buttonData.minWidth ?? 20.0,
+          child: FittedBox(
+            fit: BoxFit.scaleDown,
+            child: Text(
+              buttonData.text.toUpperCase(),
+              textAlign: TextAlign.center,
+              overflow: TextOverflow.ellipsis,
+              maxLines: buttonData.lines ?? 2,
+              style: themeData.textTheme.bodyMedium!.copyWith(
+                fontWeight: FontWeight.bold,
+                color: buttonData.textColor ?? themeData.colorScheme.onPrimary,
+              ),
             ),
           ),
         ),
@@ -444,6 +447,7 @@ class _SmoothActionFlatButton extends StatelessWidget {
             padding: const EdgeInsets.symmetric(
               horizontal: SMALL_SPACE,
             ),
+            minimumSize: const Size(0, 50.0),
           ),
           child: SizedBox(
             height: buttonData.lines != null

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1764,7 +1764,7 @@
             }
         }
     },
-    "confirm_delete_user_list": "You're about to delete this list ({name}): are you sure you want to continue?",
+    "confirm_delete_user_list": "You're about to delete the list \"{name}\".\nAre you sure you want to continue?",
     "@confirm_delete_user_list": {
         "description": "Asking about whether to delete the list or not",
         "placeholders": {
@@ -1772,6 +1772,10 @@
                 "type": "String"
             }
         }
+    },
+    "confirm_delete_user_list_button": "Delete list",
+    "@confirm_delete_user_list_button": {
+        "description": "Button to delete a list"
     },
     "importance_label": "{name} importance: {id}",
     "@importance_label": {

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -827,7 +827,7 @@
             "count": {}
         }
     },
-    "compare_products_mode": "Compare",
+    "compare_products_mode": "Compare products",
     "@compare_products_mode": {
         "description": "Button to switch to 'compare products mode'"
     },
@@ -1764,16 +1764,20 @@
             }
         }
     },
-    "confirm_delete_user_list": "You're about to delete the list \"{name}\".\nAre you sure you want to continue?",
-    "@confirm_delete_user_list": {
-        "description": "Asking about whether to delete the list or not",
+    "confirm_delete_user_list_title": "Delete the list?",
+    "@confirm_delete_user_list_title": {
+        "description": "Title when asking about whether to delete the list or not"
+    },
+    "confirm_delete_user_list_message": "You're about to delete the list \"{name}\".\nAre you sure you want to continue?",
+    "@confirm_delete_user_list_message": {
+        "description": "Message when asking about whether to delete the list or not",
         "placeholders": {
             "name": {
                 "type": "String"
             }
         }
     },
-    "confirm_delete_user_list_button": "Delete list",
+    "confirm_delete_user_list_button": "Yes, I confirm",
     "@confirm_delete_user_list_button": {
         "description": "Button to delete a list"
     },
@@ -2348,5 +2352,21 @@
     "country_selector_title": "Select your country:",
     "@country_selector_title": {
         "description": "Label written as the title of the dialog to select the user country"
+    },
+    "action_delete_list": "Delete",
+    "@action_delete_list": {
+        "description": "Delete a list action in a menu"
+    },
+    "action_change_list": "Change the current list",
+    "@action_change_list": {
+        "description": "Action to change the current visible list"
+    },
+    "product_list_create": "Create",
+    "@product_list_create": {
+        "description": "Button label to create a new list (short word)"
+    },
+    "product_list_create_tooltip": "Create a new list",
+    "@product_list_create_tooltip": {
+        "description": "Button description to create a new list (long sentence)"
     }
 }

--- a/packages/smooth_app/lib/pages/all_product_list_page.dart
+++ b/packages/smooth_app/lib/pages/all_product_list_page.dart
@@ -56,9 +56,25 @@ class AllProductListPage extends StatelessWidget {
                 return EMPTY_WIDGET;
               },
             ),
+            trailing: PopupMenuButton<PopupMenuEntries>(
+              itemBuilder: (BuildContext context) {
+                return <PopupMenuEntry<PopupMenuEntries>>[
+                  PopupMenuItem<PopupMenuEntries>(
+                    value: PopupMenuEntries.deleteList,
+                    child: const ListTile(
+                      leading: Icon(Icons.delete),
+                      title: Text('Delete'),
+                      contentPadding: EdgeInsets.zero,
+                    ),
+                    onTap: () async =>
+                        ProductListUserDialogHelper(daoProductList)
+                            .showDeleteUserListDialog(context, productList),
+                  )
+                ];
+              },
+              icon: const Icon(Icons.more_vert),
+            ),
             onTap: () => Navigator.of(context).pop(productList),
-            onLongPress: () async => ProductListUserDialogHelper(daoProductList)
-                .showDeleteUserListDialog(context, productList),
           );
         },
       ),
@@ -75,3 +91,5 @@ class AllProductListPage extends StatelessWidget {
     );
   }
 }
+
+enum PopupMenuEntries { deleteList }

--- a/packages/smooth_app/lib/pages/all_product_list_page.dart
+++ b/packages/smooth_app/lib/pages/all_product_list_page.dart
@@ -92,6 +92,12 @@ class AllProductListModal extends StatelessWidget {
                 selected: productList.listType == currentList.listType &&
                     productList.parameters == currentList.parameters,
                 selectedColor: Theme.of(context).primaryColor.withOpacity(0.2),
+                contentPadding: const EdgeInsetsDirectional.only(
+                  start: VERY_LARGE_SPACE,
+                  end: LARGE_SPACE,
+                  top: VERY_SMALL_SPACE,
+                  bottom: VERY_SMALL_SPACE,
+                ),
                 onTap: () => Navigator.of(context).pop(productList),
               ),
               if (index < productLists.length - 1) const Divider(height: 1.0),

--- a/packages/smooth_app/lib/pages/history_page.dart
+++ b/packages/smooth_app/lib/pages/history_page.dart
@@ -3,7 +3,7 @@ import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/product_list.dart';
 import 'package:smooth_app/database/dao_product_list.dart';
 import 'package:smooth_app/database/local_database.dart';
-import 'package:smooth_app/pages/product/common/product_list_page.dart';
+import 'package:smooth_app/pages/product/common/product_list_modal.dart';
 
 class HistoryPage extends StatefulWidget {
   const HistoryPage();

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_list_tile.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_list_tile.dart
@@ -11,6 +11,8 @@ class UserPreferencesListTile extends StatelessWidget {
     this.onTap,
     this.onLongPress,
     this.shape,
+    this.selected,
+    this.selectedColor,
   });
 
   final Widget title;
@@ -20,6 +22,8 @@ class UserPreferencesListTile extends StatelessWidget {
   final VoidCallback? onTap;
   final VoidCallback? onLongPress;
   final ShapeBorder? shape;
+  final bool? selected;
+  final Color? selectedColor;
 
   /// Icon (leading or trailing) with the standard color.
   static Icon getTintedIcon(
@@ -38,6 +42,8 @@ class UserPreferencesListTile extends StatelessWidget {
           style: Theme.of(context).textTheme.headlineMedium,
           child: title,
         ),
+        selected: selected ?? false,
+        selectedTileColor: selectedColor,
         contentPadding: EdgeInsets.symmetric(
           horizontal: LARGE_SPACE,
           vertical: subtitle != null ? VERY_SMALL_SPACE : 2.0,

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_list_tile.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_list_tile.dart
@@ -13,6 +13,7 @@ class UserPreferencesListTile extends StatelessWidget {
     this.shape,
     this.selected,
     this.selectedColor,
+    this.contentPadding,
   });
 
   final Widget title;
@@ -24,6 +25,7 @@ class UserPreferencesListTile extends StatelessWidget {
   final ShapeBorder? shape;
   final bool? selected;
   final Color? selectedColor;
+  final EdgeInsetsGeometry? contentPadding;
 
   /// Icon (leading or trailing) with the standard color.
   static Icon getTintedIcon(
@@ -44,10 +46,11 @@ class UserPreferencesListTile extends StatelessWidget {
         ),
         selected: selected ?? false,
         selectedTileColor: selectedColor,
-        contentPadding: EdgeInsets.symmetric(
-          horizontal: LARGE_SPACE,
-          vertical: subtitle != null ? VERY_SMALL_SPACE : 2.0,
-        ),
+        contentPadding: contentPadding ??
+            EdgeInsets.symmetric(
+              horizontal: LARGE_SPACE,
+              vertical: subtitle != null ? VERY_SMALL_SPACE : 2.0,
+            ),
         trailing: trailing,
         onTap: onTap,
         onLongPress: onLongPress,

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_widgets.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_widgets.dart
@@ -194,8 +194,9 @@ class UserPreferencesMultipleChoicesItem<T> extends StatelessWidget {
 
         // If there is not enough space, we use the scrolling sheet
         final T? res;
-        if ((itemHeight * labels.length +
-                SmoothModalSheetHeader.computeHeight(context, true)) >
+        final SmoothModalSheetHeader header =
+            SmoothModalSheetHeader(title: title);
+        if ((itemHeight * labels.length + header.computeHeight(context)) >
             (queryData.size.height * 0.9) - queryData.viewPadding.top) {
           res = await showSmoothDraggableModalSheet<T>(
               context: context,
@@ -224,39 +225,40 @@ class UserPreferencesMultipleChoicesItem<T> extends StatelessWidget {
                 );
               });
         } else {
+          final SmoothModalSheet smoothModalSheet = SmoothModalSheet(
+            title: title,
+            bodyPadding: EdgeInsets.zero,
+            body: SizedBox(
+              height: itemHeight * labels.length,
+              child: ListView.separated(
+                physics: const NeverScrollableScrollPhysics(),
+                itemCount: labels.length,
+                itemBuilder: (BuildContext context, int position) {
+                  final bool selected =
+                      currentValue == values.elementAt(position);
+
+                  return _ChoiceItem<T>(
+                    selected: selected,
+                    label: labels.elementAt(position),
+                    value: values.elementAt(position),
+                    description: descriptions?.elementAt(position),
+                    leading: leadingBuilder != null
+                        ? Builder(builder: leadingBuilder!.elementAt(position))
+                        : null,
+                    hasDivider: false,
+                  );
+                },
+                separatorBuilder: (_, __) => const Divider(height: 1.0),
+              ),
+            ),
+          );
+
           res = await showSmoothModalSheet<T>(
             context: context,
-            minHeight: SmoothModalSheetHeader.computeHeight(context, false) +
+            minHeight: smoothModalSheet.computeHeaderHeight(context) +
                 itemHeight * labels.length,
             builder: (BuildContext context) {
-              return SmoothModalSheet(
-                title: title,
-                bodyPadding: EdgeInsets.zero,
-                body: SizedBox(
-                  height: itemHeight * labels.length,
-                  child: ListView.separated(
-                    physics: const NeverScrollableScrollPhysics(),
-                    itemCount: labels.length,
-                    itemBuilder: (BuildContext context, int position) {
-                      final bool selected =
-                          currentValue == values.elementAt(position);
-
-                      return _ChoiceItem<T>(
-                        selected: selected,
-                        label: labels.elementAt(position),
-                        value: values.elementAt(position),
-                        description: descriptions?.elementAt(position),
-                        leading: leadingBuilder != null
-                            ? Builder(
-                                builder: leadingBuilder!.elementAt(position))
-                            : null,
-                        hasDivider: false,
-                      );
-                    },
-                    separatorBuilder: (_, __) => const Divider(height: 1.0),
-                  ),
-                ),
-              );
+              return smoothModalSheet;
             },
           );
         }

--- a/packages/smooth_app/lib/pages/product/common/product_list_modal.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_modal.dart
@@ -33,9 +33,13 @@ import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
 /// Displays the products of a product list, with access to other lists.
 class ProductListPage extends StatefulWidget {
-  const ProductListPage(this.productList);
+  const ProductListPage(
+    this.productList, {
+    this.allowToSwitchBetweenLists = true,
+  });
 
   final ProductList productList;
+  final bool allowToSwitchBetweenLists;
 
   @override
   State<ProductListPage> createState() => _ProductListPageState();
@@ -130,41 +134,42 @@ class _ProductListPageState extends State<ProductListPage>
       appBar: SmoothAppBar(
         centerTitle: false,
         actions: <Widget>[
-          IconButton(
-            icon: const Icon(CupertinoIcons.square_list),
-            tooltip: appLocalizations.action_change_list,
-            onPressed: () async {
-              final ProductList? selected =
-                  await showSmoothDraggableModalSheet<ProductList>(
-                context: context,
-                header: SmoothModalSheetHeader(
-                  title: appLocalizations.product_list_select,
-                  suffix: SmoothModalSheetHeaderButton(
-                    label: appLocalizations.product_list_create,
-                    prefix: const Icon(Icons.add_circle_outline_sharp),
-                    tooltip: appLocalizations.product_list_create_tooltip,
-                    onTap: () async =>
-                        ProductListUserDialogHelper(daoProductList)
-                            .showCreateUserListDialog(context),
+          if (widget.allowToSwitchBetweenLists)
+            IconButton(
+              icon: const Icon(CupertinoIcons.square_list),
+              tooltip: appLocalizations.action_change_list,
+              onPressed: () async {
+                final ProductList? selected =
+                    await showSmoothDraggableModalSheet<ProductList>(
+                  context: context,
+                  header: SmoothModalSheetHeader(
+                    title: appLocalizations.product_list_select,
+                    suffix: SmoothModalSheetHeaderButton(
+                      label: appLocalizations.product_list_create,
+                      prefix: const Icon(Icons.add_circle_outline_sharp),
+                      tooltip: appLocalizations.product_list_create_tooltip,
+                      onTap: () async =>
+                          ProductListUserDialogHelper(daoProductList)
+                              .showCreateUserListDialog(context),
+                    ),
                   ),
-                ),
-                bodyBuilder: (BuildContext context) => AllProductListModal(
-                  currentList: productList,
-                ),
-                initHeight: _computeModalInitHeight(context),
-              );
+                  bodyBuilder: (BuildContext context) => AllProductListModal(
+                    currentList: productList,
+                  ),
+                  initHeight: _computeModalInitHeight(context),
+                );
 
-              if (selected == null) {
-                return;
-              }
-              if (context.mounted) {
-                await daoProductList.get(selected);
-                if (context.mounted) {
-                  setState(() => productList = selected);
+                if (selected == null) {
+                  return;
                 }
-              }
-            },
-          ),
+                if (context.mounted) {
+                  await daoProductList.get(selected);
+                  if (context.mounted) {
+                    setState(() => productList = selected);
+                  }
+                }
+              },
+            ),
           PopupMenuButton<ProductListPopupItem>(
             onSelected: (final ProductListPopupItem action) async {
               final ProductList? differentProductList =

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -23,7 +23,7 @@ import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_product_cards.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels_builder.dart';
 import 'package:smooth_app/pages/inherited_data_manager.dart';
-import 'package:smooth_app/pages/product/common/product_list_page.dart';
+import 'package:smooth_app/pages/product/common/product_list_modal.dart';
 import 'package:smooth_app/pages/product/common/product_refresher.dart';
 import 'package:smooth_app/pages/product/edit_product_page.dart';
 import 'package:smooth_app/pages/product/product_questions_widget.dart';

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -448,8 +448,10 @@ class _ProductPageState extends State<ProductPage>
               await Navigator.push<void>(
                 context,
                 MaterialPageRoute<void>(
-                  builder: (BuildContext context) =>
-                      ProductListPage(productList),
+                  builder: (BuildContext context) => ProductListPage(
+                    productList,
+                    allowToSwitchBetweenLists: false,
+                  ),
                 ),
               );
               setState(() {});

--- a/packages/smooth_app/lib/pages/product_list_user_dialog_helper.dart
+++ b/packages/smooth_app/lib/pages/product_list_user_dialog_helper.dart
@@ -155,8 +155,9 @@ class ProductListUserDialogHelper {
     final bool? deleted = await showDialog<bool>(
       context: context,
       builder: (final BuildContext context) => SmoothAlertDialog(
+        title: appLocalizations.confirm_delete_user_list_title,
         body: Text(
-          appLocalizations.confirm_delete_user_list(
+          appLocalizations.confirm_delete_user_list_message(
             ProductQueryPageHelper.getProductListLabel(
               productList,
               appLocalizations,

--- a/packages/smooth_app/lib/pages/product_list_user_dialog_helper.dart
+++ b/packages/smooth_app/lib/pages/product_list_user_dialog_helper.dart
@@ -8,6 +8,7 @@ import 'package:smooth_app/database/dao_product_list.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_text_form_field.dart';
+import 'package:smooth_app/pages/product/common/product_query_page_helper.dart';
 
 /// Dialog helper class for user product list.
 class ProductListUserDialogHelper {
@@ -155,18 +156,22 @@ class ProductListUserDialogHelper {
       context: context,
       builder: (final BuildContext context) => SmoothAlertDialog(
         body: Text(
-          appLocalizations.confirm_delete_user_list(productList.parameters),
+          appLocalizations.confirm_delete_user_list(
+            ProductQueryPageHelper.getProductListLabel(
+              productList,
+              appLocalizations,
+            ),
+          ),
         ),
         negativeAction: SmoothActionButton(
           onPressed: () => Navigator.pop(context),
-          text: appLocalizations.cancel,
+          text: appLocalizations.no,
         ),
         positiveAction: SmoothActionButton(
-          onPressed: () {
-            Navigator.pop(context, true);
-          },
-          text: appLocalizations.okay,
+          onPressed: () => Navigator.pop(context, true),
+          text: appLocalizations.confirm_delete_user_list_button,
         ),
+        actionsAxis: Axis.vertical,
       ),
     );
     if (deleted == null) {


### PR DESCRIPTION
Hi everyone,

In the new "Lists" shortcut at the bottom of the screen, we open a new screen when we want to switch between them.
This PR does the same but in a modal sheet.

Here is a video: https://github.com/openfoodfacts/smooth-app/assets/246838/9a34f2e1-8457-45a4-8e7a-db781b687820

This PR also includes several bug fixes with the screen listing products, especially when the list is empty.