### PR TITLE
ci: remove cron for Crowdin

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -3,8 +3,6 @@ name: Crowdin Action
 on:
   push:
     branches: [ crowdin-trigger ]
-  schedule:
-  - cron: "0 19 * * *"
 jobs:
   synchronize-with-crowdin:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What
- ci: remove cron for Crowdin. The sync is now handled by Crowdin. CRON readds files at the root of crowdin in addition to the more organized sync made by crowdin