### PR TITLE
fix: fixed safearea issue

### DIFF
--- a/packages/smooth_app/lib/pages/crop_page.dart
+++ b/packages/smooth_app/lib/pages/crop_page.dart
@@ -166,46 +166,48 @@ class _CropPageState extends State<CropPage> {
                   style: const TextStyle(color: Colors.white),
                 ),
               )
-            : Column(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: <Widget>[
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: <Widget>[
-                      _IconButton(
-                        iconData: Icons.rotate_90_degrees_ccw_outlined,
-                        onPressed: () => setState(
-                          () => _controller.rotateLeft(),
+            : SafeArea(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: <Widget>[
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: <Widget>[
+                        _IconButton(
+                          iconData: Icons.rotate_90_degrees_ccw_outlined,
+                          onPressed: () => setState(
+                            () => _controller.rotateLeft(),
+                          ),
                         ),
-                      ),
-                      _IconButton(
-                        iconData: Icons.rotate_90_degrees_cw_outlined,
-                        onPressed: () => setState(
-                          () => _controller.rotateRight(),
+                        _IconButton(
+                          iconData: Icons.rotate_90_degrees_cw_outlined,
+                          onPressed: () => setState(
+                            () => _controller.rotateRight(),
+                          ),
                         ),
+                      ],
+                    ),
+                    Expanded(
+                      child: CropImage(
+                        controller: _controller,
+                        image: Image.file(widget.inputFile),
+                        minimumImageSize: MINIMUM_TOUCH_SIZE,
+                        gridCornerSize: MINIMUM_TOUCH_SIZE * .75,
+                        touchSize: MINIMUM_TOUCH_SIZE,
+                        paddingSize: MINIMUM_TOUCH_SIZE * .5,
+                        alwaysMove: true,
                       ),
-                    ],
-                  ),
-                  Expanded(
-                    child: CropImage(
-                      controller: _controller,
-                      image: Image.file(widget.inputFile),
-                      minimumImageSize: MINIMUM_TOUCH_SIZE,
-                      gridCornerSize: MINIMUM_TOUCH_SIZE * .75,
-                      touchSize: MINIMUM_TOUCH_SIZE,
-                      paddingSize: MINIMUM_TOUCH_SIZE * .5,
-                      alwaysMove: true,
                     ),
-                  ),
-                  Center(
-                    child: EditImageButton(
-                      iconData: Icons.send,
-                      label: appLocalizations.send_image_button_label,
-                      onPressed: () async => _mayExitPage(saving: true),
+                    Center(
+                      child: EditImageButton(
+                        iconData: Icons.send,
+                        label: appLocalizations.send_image_button_label,
+                        onPressed: () async => _mayExitPage(saving: true),
+                      ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
       ),
     );


### PR DESCRIPTION
### What

-  In the image cropper, the Send image button is below the nav bar.
- Fixed this by wrap the widget in the safearea.

<!-- description of the PR -->
 <!-- Changed x to achieve y -->
<!-- 
Please name your pull request following this scheme: `type: What you did` this allows us to automatically generate the changelog
Following `type`s are allowed:
  - `feat`, for Features
  - `fix`, for Bug Fixes
  - `docs`, for Documentation
  - `ci`, for Automation
  - `refactor`, for code Refactoring
  - `chore`, for Miscellaneous things
-->
### Screenshot
Before:
![Simulator Screenshot - iPhone 14 Pro - 2023-07-26 at 13 20 04](https://github.com/openfoodfacts/smooth-app/assets/90781402/b67d50c9-ab26-400e-955b-ddf1139df904)

After:
![Simulator Screenshot - iPhone 14 Pro - 2023-07-26 at 13 20 43](https://github.com/openfoodfacts/smooth-app/assets/90781402/58ee7c46-814f-4f2e-b43f-b3f3e75f6be6)



### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes:  #4366

<!-- ### Part of -->
 <!-- Add the most granular issue possible -->
