### PR TITLE
feat: Allow to show a floating message (replacement for `SnackBar`)

### DIFF
--- a/packages/smooth_app/lib/background/background_task.dart
+++ b/packages/smooth_app/lib/background/background_task.dart
@@ -7,6 +7,7 @@ import 'package:smooth_app/background/background_task_manager.dart';
 import 'package:smooth_app/background/background_task_refresh_later.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/duration_constants.dart';
+import 'package:smooth_app/widgets/smooth_floating_message.dart';
 
 /// Abstract background task.
 abstract class BackgroundTask {
@@ -96,11 +97,11 @@ abstract class BackgroundTask {
   /// [BackgroundTaskRefreshLater].
   bool mayRunNow() => true;
 
-  /// SnackBar message when we add the task, like "Added to the task queue!"
+  /// Floating message when we add the task, like "Added to the task queue!"
   ///
-  /// Null if no SnackBar message wanted (like, stealth mode).
+  /// Null if no message wanted (like, stealth mode).
   @protected
-  String? getSnackBarMessage(final AppLocalizations appLocalizations);
+  String? getFloatingMessage(final AppLocalizations appLocalizations);
 
   /// Adds this task to the [BackgroundTaskManager].
   @protected
@@ -116,14 +117,13 @@ abstract class BackgroundTask {
     if (!showSnackBar) {
       return;
     }
-    final String? snackBarMessage =
-        getSnackBarMessage(AppLocalizations.of(widget.context));
-    if (snackBarMessage != null) {
-      ScaffoldMessenger.of(widget.context).showSnackBar(
-        SnackBar(
-          content: Text(snackBarMessage),
-          duration: SnackBarDuration.medium,
-        ),
+    final String? floatingMessage =
+        getFloatingMessage(AppLocalizations.of(widget.context));
+    if (floatingMessage != null) {
+      SmoothFloatingMessage(message: floatingMessage).show(
+        widget.context,
+        duration: SnackBarDuration.medium,
+        alignment: Alignment.topCenter,
       );
     }
   }

--- a/packages/smooth_app/lib/background/background_task_crop.dart
+++ b/packages/smooth_app/lib/background/background_task_crop.dart
@@ -85,7 +85,7 @@ class BackgroundTaskCrop extends BackgroundTaskUpload {
   }
 
   @override
-  String? getSnackBarMessage(final AppLocalizations appLocalizations) =>
+  String? getFloatingMessage(final AppLocalizations appLocalizations) =>
       appLocalizations.product_task_background_schedule;
 
   /// Returns a new background task about cropping an existing image.

--- a/packages/smooth_app/lib/background/background_task_details.dart
+++ b/packages/smooth_app/lib/background/background_task_details.dart
@@ -91,7 +91,7 @@ class BackgroundTaskDetails extends BackgroundTaskBarcode {
   }
 
   @override
-  String? getSnackBarMessage(final AppLocalizations appLocalizations) =>
+  String? getFloatingMessage(final AppLocalizations appLocalizations) =>
       appLocalizations.product_task_background_schedule;
 
   /// Returns a new background task about changing a product.

--- a/packages/smooth_app/lib/background/background_task_download_products.dart
+++ b/packages/smooth_app/lib/background/background_task_download_products.dart
@@ -71,7 +71,7 @@ class BackgroundTaskDownloadProducts extends BackgroundTaskProgressing {
   }
 
   @override
-  String? getSnackBarMessage(final AppLocalizations appLocalizations) => null;
+  String? getFloatingMessage(final AppLocalizations appLocalizations) => null;
 
   static BackgroundTask _getNewTask(
     final String uniqueId,

--- a/packages/smooth_app/lib/background/background_task_full_refresh.dart
+++ b/packages/smooth_app/lib/background/background_task_full_refresh.dart
@@ -47,7 +47,7 @@ class BackgroundTaskFullRefresh extends BackgroundTaskPaged {
   }
 
   @override
-  String? getSnackBarMessage(final AppLocalizations appLocalizations) =>
+  String? getFloatingMessage(final AppLocalizations appLocalizations) =>
       appLocalizations.background_task_title_full_refresh;
 
   static BackgroundTaskFullRefresh _getNewTask(

--- a/packages/smooth_app/lib/background/background_task_hunger_games.dart
+++ b/packages/smooth_app/lib/background/background_task_hunger_games.dart
@@ -67,7 +67,7 @@ class BackgroundTaskHungerGames extends BackgroundTaskBarcode {
   }
 
   @override
-  String? getSnackBarMessage(final AppLocalizations appLocalizations) => null;
+  String? getFloatingMessage(final AppLocalizations appLocalizations) => null;
 
   /// Returns a new background task about hunger games.
   static BackgroundTaskHungerGames _getNewTask(

--- a/packages/smooth_app/lib/background/background_task_image.dart
+++ b/packages/smooth_app/lib/background/background_task_image.dart
@@ -99,7 +99,7 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
   }
 
   @override
-  String? getSnackBarMessage(final AppLocalizations appLocalizations) =>
+  String? getFloatingMessage(final AppLocalizations appLocalizations) =>
       appLocalizations.image_upload_queued;
 
   /// Returns a new background task about changing a product.

--- a/packages/smooth_app/lib/background/background_task_offline.dart
+++ b/packages/smooth_app/lib/background/background_task_offline.dart
@@ -51,7 +51,7 @@ class BackgroundTaskOffline extends BackgroundTaskProgressing {
   }
 
   @override
-  String? getSnackBarMessage(final AppLocalizations appLocalizations) =>
+  String? getFloatingMessage(final AppLocalizations appLocalizations) =>
       appLocalizations.background_task_title_top_n;
 
   static BackgroundTaskOffline _getNewTask(

--- a/packages/smooth_app/lib/background/background_task_refresh_later.dart
+++ b/packages/smooth_app/lib/background/background_task_refresh_later.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/background/background_task_barcode.dart';
@@ -64,7 +65,7 @@ class BackgroundTaskRefreshLater extends BackgroundTaskBarcode {
   }
 
   @override
-  String? getSnackBarMessage(final AppLocalizations appLocalizations) => null;
+  String? getFloatingMessage(final AppLocalizations appLocalizations) => null;
 
   /// Returns a new background task about refreshing a product later.
   static BackgroundTaskRefreshLater _getNewTask(

--- a/packages/smooth_app/lib/background/background_task_top_barcodes.dart
+++ b/packages/smooth_app/lib/background/background_task_top_barcodes.dart
@@ -66,7 +66,7 @@ class BackgroundTaskTopBarcodes extends BackgroundTaskProgressing {
   }
 
   @override
-  String? getSnackBarMessage(final AppLocalizations appLocalizations) => null;
+  String? getFloatingMessage(final AppLocalizations appLocalizations) => null;
 
   static BackgroundTask _getNewTask(
     final String uniqueId,

--- a/packages/smooth_app/lib/background/background_task_unselect.dart
+++ b/packages/smooth_app/lib/background/background_task_unselect.dart
@@ -65,7 +65,7 @@ class BackgroundTaskUnselect extends BackgroundTaskBarcode {
   }
 
   @override
-  String? getSnackBarMessage(final AppLocalizations appLocalizations) =>
+  String? getFloatingMessage(final AppLocalizations appLocalizations) =>
       appLocalizations.product_task_background_schedule;
 
   /// Returns a new background task about unselecting a product image.

--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -26,6 +26,7 @@ import 'package:smooth_app/pages/product/product_image_gallery_view.dart';
 import 'package:smooth_app/pages/product/simple_input_page.dart';
 import 'package:smooth_app/pages/product/simple_input_page_helpers.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
+import 'package:smooth_app/widgets/smooth_floating_message.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
 /// Page where we can indirectly edit all data about a product.
@@ -99,22 +100,21 @@ class _EditProductPageState extends State<EditProductPage> with UpToDateMixin {
             button: true,
             value: appLocalizations.clipboard_barcode_copy,
             excludeSemantics: true,
-            child: IconButton(
-              icon: const Icon(Icons.copy),
-              tooltip: appLocalizations.clipboard_barcode_copy,
-              onPressed: () {
-                Clipboard.setData(
-                  ClipboardData(text: barcode),
-                );
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(
-                    content: Text(
-                      appLocalizations.clipboard_barcode_copied(barcode),
-                    ),
-                  ),
-                );
-              },
-            ),
+            child: Builder(builder: (BuildContext context) {
+              return IconButton(
+                icon: const Icon(Icons.copy),
+                tooltip: appLocalizations.clipboard_barcode_copy,
+                onPressed: () {
+                  Clipboard.setData(
+                    ClipboardData(text: barcode),
+                  );
+
+                  SmoothFloatingMessage(
+                    message: appLocalizations.clipboard_barcode_copied(barcode),
+                  ).show(context, alignment: AlignmentDirectional.bottomCenter);
+                },
+              );
+            }),
           )
         ],
       ),

--- a/packages/smooth_app/lib/widgets/smooth_floating_message.dart
+++ b/packages/smooth_app/lib/widgets/smooth_floating_message.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/generic_lib/duration_constants.dart';
 
 class SmoothFloatingMessage {
   SmoothFloatingMessage({
@@ -88,7 +89,7 @@ class _SmoothFloatingMessageViewState extends State<_SmoothFloatingMessageView>
 
     return AnimatedOpacity(
       opacity: initial ? 0.0 : 1.0,
-      duration: const Duration(milliseconds: 200),
+      duration: SmoothAnimationsDuration.short,
       child: SafeArea(
         top: false,
         child: Container(

--- a/packages/smooth_app/lib/widgets/smooth_floating_message.dart
+++ b/packages/smooth_app/lib/widgets/smooth_floating_message.dart
@@ -1,0 +1,116 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+
+class SmoothFloatingMessage {
+  SmoothFloatingMessage({
+    required this.message,
+  });
+
+  final String message;
+
+  OverlayEntry? _entry;
+  Timer? _autoDismissMessage;
+
+  /// Show the message during [duration].
+  /// You can call [hide] if you want to dismiss it before
+  void show(
+    BuildContext context, {
+    AlignmentGeometry? alignment,
+    Duration? duration,
+  }) {
+    _entry?.remove();
+
+    final double appBarHeight = Scaffold.maybeOf(context)?.hasAppBar == true
+        ? (Scaffold.of(context).appBarMaxHeight ?? kToolbarHeight)
+        : 0.0;
+
+    _entry = OverlayEntry(builder: (BuildContext context) {
+      return _SmoothFloatingMessageView(
+        message: message,
+        alignment: alignment,
+        margin: EdgeInsetsDirectional.only(
+          top: appBarHeight,
+          start: SMALL_SPACE,
+          end: SMALL_SPACE,
+          bottom: SMALL_SPACE,
+        ),
+      );
+    });
+
+    Overlay.of(context).insert(_entry!);
+    _autoDismissMessage = Timer(duration ?? const Duration(seconds: 5), () {
+      hide();
+    });
+  }
+
+  void hide() {
+    _autoDismissMessage?.cancel();
+    _entry?.remove();
+  }
+}
+
+class _SmoothFloatingMessageView extends StatefulWidget {
+  const _SmoothFloatingMessageView({
+    required this.message,
+    this.alignment,
+    this.margin,
+  });
+
+  final String message;
+  final AlignmentGeometry? alignment;
+  final EdgeInsetsGeometry? margin;
+
+  @override
+  State<_SmoothFloatingMessageView> createState() =>
+      _SmoothFloatingMessageViewState();
+}
+
+class _SmoothFloatingMessageViewState extends State<_SmoothFloatingMessageView>
+    with SingleTickerProviderStateMixin {
+  bool initial = true;
+
+  @override
+  void initState() {
+    super.initState();
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      setState(() {
+        initial = false;
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final SnackBarThemeData snackBarTheme = Theme.of(context).snackBarTheme;
+
+    return AnimatedOpacity(
+      opacity: initial ? 0.0 : 1.0,
+      duration: const Duration(milliseconds: 200),
+      child: SafeArea(
+        top: false,
+        child: Container(
+          width: initial ? 0.0 : null,
+          height: initial ? 0.0 : null,
+          margin: widget.margin,
+          alignment: widget.alignment ?? AlignmentDirectional.topCenter,
+          child: Card(
+            elevation: 4.0,
+            shadowColor: Colors.black.withOpacity(0.1),
+            color: snackBarTheme.backgroundColor,
+            child: Container(
+              padding: const EdgeInsets.all(8.0),
+              child: Text(
+                widget.message,
+                textAlign: TextAlign.center,
+                style: snackBarTheme.contentTextStyle,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Hi everyone,

As mentioned in #4368, `SnackBar` can sometimes overlap content.
We now have a `SmoothFloatingMessage` allowing us to show the same kind of message, but with:
- a custom position
- a UI like a Toast on Android => with some margins (but can be customized)

This PR uses this new Widget when we copy/paste the barcode and upload an image in the background (to fix #4368).

<img width="800" alt="Screenshot 2023-07-27 at 10 26 33" src="https://github.com/openfoodfacts/smooth-app/assets/246838/4fefd539-4c2b-4491-82a0-cf369bb4320d">
