### PR TITLE
fix: Image placeholder now works again + a different animation

### DIFF
--- a/packages/smooth_app/lib/generic_lib/widgets/images/smooth_image.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/images/smooth_image.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:provider/provider.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/generic_lib/duration_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/picture_not_found.dart';
 
 /// Container to display a product image on a product card.
@@ -57,28 +59,40 @@ class SmoothImage extends StatelessWidget {
     Widget child,
     ImageChunkEvent? progress,
   ) {
-    final double? progressValue;
-
-    if (progress != null) {
-      progressValue =
-          progress.cumulativeBytesLoaded / progress.expectedTotalBytes!;
-    } else {
-      progressValue = null;
-    }
-
     final ThemeData theme = Theme.of(context);
 
-    return Container(
-      color: theme.primaryColor.withOpacity(0.1),
-      child: Center(
-        child: CircularProgressIndicator(
-          strokeWidth: 2.5,
-          valueColor: theme.brightness == Brightness.dark
-              ? const AlwaysStoppedAnimation<Color>(Colors.white)
-              : null,
-          value: progressValue,
-        ),
-      ),
+    return ExcludeSemantics(
+      child: AnimatedCrossFade(
+          crossFadeState: progress == null
+              ? CrossFadeState.showFirst
+              : CrossFadeState.showSecond,
+          duration: SmoothAnimationsDuration.long,
+          firstChild: child,
+          secondChild: Container(
+            color: theme.primaryColor.withOpacity(0.1),
+            alignment: AlignmentDirectional.center,
+            padding: const EdgeInsets.all(SMALL_SPACE),
+            child: const _SmoothAnimatedLogo(
+              opacityMax: 0.65,
+              opacityMin: 0.2,
+            ),
+          ),
+          layoutBuilder: (Widget topChild, Key topChildKey, Widget bottomChild,
+              Key bottomChildKey) {
+            return Stack(
+              clipBehavior: Clip.none,
+              children: <Widget>[
+                Positioned.fill(
+                  key: bottomChildKey,
+                  child: bottomChild,
+                ),
+                Positioned.fill(
+                  key: topChildKey,
+                  child: topChild,
+                ),
+              ],
+            );
+          }),
     );
   }
 
@@ -89,10 +103,142 @@ class SmoothImage extends StatelessWidget {
   ) {
     return Container(
       color: Theme.of(context).primaryColor.withOpacity(0.1),
-      padding: const EdgeInsets.all(MEDIUM_SPACE),
-      child: Center(
-        child: SvgPicture.asset('assets/misc/error.svg'),
+      padding: const EdgeInsets.all(SMALL_SPACE),
+      child: ColorFiltered(
+        colorFilter: ColorFilter.mode(
+          Colors.grey.withOpacity(0.7),
+          BlendMode.srcIn,
+        ),
+        child: const _SmoothAppLogo(),
       ),
     );
+  }
+}
+
+/// An animated logo which can depend on [SmoothSharedAnimationController]
+/// to ensure animations are synced
+class _SmoothAnimatedLogo extends StatefulWidget {
+  const _SmoothAnimatedLogo({
+    required this.opacityMax,
+    required this.opacityMin,
+  });
+
+  final double opacityMin;
+  final double opacityMax;
+
+  @override
+  State<_SmoothAnimatedLogo> createState() => _SmoothAnimatedLogoState();
+}
+
+class _SmoothAnimatedLogoState extends State<_SmoothAnimatedLogo>
+    with SingleTickerProviderStateMixin {
+  AnimationController? _controller;
+  Animation<double>? _animation;
+
+  @override
+  Widget build(BuildContext context) {
+    _attachAnimation();
+
+    return Opacity(
+      opacity: _animation?.value ?? widget.opacityMin,
+      child: const _SmoothAppLogo(),
+    );
+  }
+
+  void _attachAnimation() {
+    if (_animation != null) {
+      return;
+    }
+
+    AnimationController? controller =
+        _SmoothSharedAnimationControllerState.of(context);
+
+    if (controller == null) {
+      _controller = AnimationController(
+        duration: const Duration(seconds: 1),
+        vsync: this,
+      );
+      controller = _controller;
+    }
+
+    _animation = Tween<double>(begin: widget.opacityMin, end: widget.opacityMax)
+        .animate(controller!)
+      ..addListener(_onAnimationChanged);
+
+    if (!controller.isAnimating) {
+      controller.repeat(reverse: true);
+    }
+  }
+
+  void _onAnimationChanged() {
+    setState(() {});
+  }
+
+  @override
+  void dispose() {
+    _animation?.removeListener(_onAnimationChanged);
+    _controller?.dispose();
+    super.dispose();
+  }
+}
+
+class _SmoothAppLogo extends StatelessWidget {
+  const _SmoothAppLogo();
+
+  @override
+  Widget build(BuildContext context) {
+    return SvgPicture.asset('assets/app/release_icon_transparent.svg');
+  }
+}
+
+/// A shared [AnimationController] that can be used by multiple
+/// [_SmoothAnimatedLogo] and ensure they are all perfectly synced.
+class SmoothSharedAnimationController extends StatefulWidget {
+  const SmoothSharedAnimationController({
+    required this.child,
+  });
+
+  final Widget child;
+
+  @override
+  State<SmoothSharedAnimationController> createState() =>
+      _SmoothSharedAnimationControllerState();
+}
+
+class _SmoothSharedAnimationControllerState
+    extends State<SmoothSharedAnimationController>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      duration: const Duration(seconds: 1),
+      vsync: this,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Provider<_SmoothSharedAnimationControllerState>.value(
+      value: this,
+      child: widget.child,
+    );
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  static AnimationController? of(BuildContext context) {
+    try {
+      return Provider.of<_SmoothSharedAnimationControllerState>(context)
+          ._controller;
+    } catch (_) {
+      return null;
+    }
   }
 }

--- a/packages/smooth_app/lib/pages/product/common/product_query_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_query_page.dart
@@ -15,6 +15,7 @@ import 'package:smooth_app/generic_lib/buttons/smooth_large_button_with_icon.dar
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/duration_constants.dart';
 import 'package:smooth_app/generic_lib/loading_dialog.dart';
+import 'package:smooth_app/generic_lib/widgets/images/smooth_image.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_back_button.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_error_card.dart';
@@ -152,115 +153,118 @@ class _ProductQueryPageState extends State<ProductQueryPage>
     final ThemeData themeData,
     final AppLocalizations appLocalizations,
   ) =>
-      SmoothScaffold(
-        floatingActionButton: Row(
-          mainAxisAlignment: _showBackToTopButton
-              ? MainAxisAlignment.spaceBetween
-              : MainAxisAlignment.center,
-          children: <Widget>[
-            Padding(
-              padding: const EdgeInsets.symmetric(vertical: 5.0),
-              child: RankingFloatingActionButton(
-                onPressed: () => Navigator.push<Widget>(
-                  context,
-                  MaterialPageRoute<Widget>(
-                    builder: (BuildContext context) => PersonalizedRankingPage(
-                      barcodes: _model.displayBarcodes,
-                      title: widget.name,
-                    ),
-                  ),
-                ),
-              ),
-            ),
-            Visibility(
-              visible: _showBackToTopButton,
-              child: AnimatedOpacity(
-                duration: SmoothAnimationsDuration.short,
-                opacity: _showBackToTopButton ? 1.0 : 0.0,
-                child: SmoothRevealAnimation(
-                  animationCurve: Curves.easeInOutBack,
-                  startOffset: const Offset(0.0, 1.0),
-                  child: Padding(
-                    padding: const EdgeInsetsDirectional.only(
-                      start: SMALL_SPACE,
-                    ),
-                    child: FloatingActionButton(
-                      backgroundColor: themeData.colorScheme.secondary,
-                      onPressed: () {
-                        _scrollToTop();
-                      },
-                      tooltip: appLocalizations.go_back_to_top,
-                      child: Icon(
-                        Icons.arrow_upward,
-                        color: themeData.colorScheme.onSecondary,
+      SmoothSharedAnimationController(
+        child: SmoothScaffold(
+          floatingActionButton: Row(
+            mainAxisAlignment: _showBackToTopButton
+                ? MainAxisAlignment.spaceBetween
+                : MainAxisAlignment.center,
+            children: <Widget>[
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 5.0),
+                child: RankingFloatingActionButton(
+                  onPressed: () => Navigator.push<Widget>(
+                    context,
+                    MaterialPageRoute<Widget>(
+                      builder: (BuildContext context) =>
+                          PersonalizedRankingPage(
+                        barcodes: _model.displayBarcodes,
+                        title: widget.name,
                       ),
                     ),
                   ),
                 ),
               ),
-            ),
-          ],
-        ),
-        appBar: SmoothAppBar(
-          backgroundColor: themeData.scaffoldBackgroundColor,
-          elevation: 2,
-          automaticallyImplyLeading: false,
-          leading: const SmoothBackButton(),
-          title: _AppBarTitle(
-            title: widget.searchResult
-                ? widget.name
-                : appLocalizations.product_search_same_category,
-            editableAppBarTitle:
-                widget.searchResult && widget.editableAppBarTitle,
-            multiLines: !widget.searchResult,
+              Visibility(
+                visible: _showBackToTopButton,
+                child: AnimatedOpacity(
+                  duration: SmoothAnimationsDuration.short,
+                  opacity: _showBackToTopButton ? 1.0 : 0.0,
+                  child: SmoothRevealAnimation(
+                    animationCurve: Curves.easeInOutBack,
+                    startOffset: const Offset(0.0, 1.0),
+                    child: Padding(
+                      padding: const EdgeInsetsDirectional.only(
+                        start: SMALL_SPACE,
+                      ),
+                      child: FloatingActionButton(
+                        backgroundColor: themeData.colorScheme.secondary,
+                        onPressed: () {
+                          _scrollToTop();
+                        },
+                        tooltip: appLocalizations.go_back_to_top,
+                        child: Icon(
+                          Icons.arrow_upward,
+                          color: themeData.colorScheme.onSecondary,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
           ),
-          subTitle: !widget.searchResult ? Text(widget.name) : null,
-          actions: _getAppBarButtons(),
-        ),
-        body: RefreshIndicator(
-          onRefresh: () async => _refreshList(),
-          child: ListView.builder(
-            controller: _scrollController,
-            // To allow refresh even when not the whole page is filled
-            physics: const AlwaysScrollableScrollPhysics(),
-            itemBuilder: (BuildContext context, int index) {
-              if (index == 0) {
-                // on top, a message
-                return _getTopMessagesCard();
-              }
-              index--;
-
-              final int barcodesCount = _model.displayBarcodes.length;
-
-              // TODO(monsieurtanuki): maybe call it earlier, like for first unknown page index - 5?
-              if (index >= barcodesCount) {
-                _downloadNextPage();
-              }
-
-              if (index >= barcodesCount) {
-                // When scrolling below the last loaded item (index > barcodesCount)
-                // We first show a [SmoothProductCardTemplate]
-                // and after that a loading indicator + some space below it as the next item.
-
-                // The amount you scrolled over the index
-                final int overscrollIndex =
-                    index - barcodesCount + 1 - _OVERSCROLL_TEMPLATE_COUNT;
-
-                if (overscrollIndex <= 0) {
-                  return const SmoothProductCardTemplate();
+          appBar: SmoothAppBar(
+            backgroundColor: themeData.scaffoldBackgroundColor,
+            elevation: 2,
+            automaticallyImplyLeading: false,
+            leading: const SmoothBackButton(),
+            title: _AppBarTitle(
+              title: widget.searchResult
+                  ? widget.name
+                  : appLocalizations.product_search_same_category,
+              editableAppBarTitle:
+                  widget.searchResult && widget.editableAppBarTitle,
+              multiLines: !widget.searchResult,
+            ),
+            subTitle: !widget.searchResult ? Text(widget.name) : null,
+            actions: _getAppBarButtons(),
+          ),
+          body: RefreshIndicator(
+            onRefresh: () async => _refreshList(),
+            child: ListView.builder(
+              controller: _scrollController,
+              // To allow refresh even when not the whole page is filled
+              physics: const AlwaysScrollableScrollPhysics(),
+              itemBuilder: (BuildContext context, int index) {
+                if (index == 0) {
+                  // on top, a message
+                  return _getTopMessagesCard();
                 }
-                if (overscrollIndex == 1) {
-                  return const Center(child: CircularProgressIndicator());
+                index--;
+
+                final int barcodesCount = _model.displayBarcodes.length;
+
+                // TODO(monsieurtanuki): maybe call it earlier, like for first unknown page index - 5?
+                if (index >= barcodesCount) {
+                  _downloadNextPage();
                 }
-                return SizedBox(
-                  height: MediaQuery.of(context).size.height / 4,
+
+                if (index >= barcodesCount) {
+                  // When scrolling below the last loaded item (index > barcodesCount)
+                  // We first show a [SmoothProductCardTemplate]
+                  // and after that a loading indicator + some space below it as the next item.
+
+                  // The amount you scrolled over the index
+                  final int overscrollIndex =
+                      index - barcodesCount + 1 - _OVERSCROLL_TEMPLATE_COUNT;
+
+                  if (overscrollIndex <= 0) {
+                    return const SmoothProductCardTemplate();
+                  }
+                  if (overscrollIndex == 1) {
+                    return const Center(child: CircularProgressIndicator());
+                  }
+                  return SizedBox(
+                    height: MediaQuery.of(context).size.height / 4,
+                  );
+                }
+                return ProductListItemSimple(
+                  barcode: _model.displayBarcodes[index],
                 );
-              }
-              return ProductListItemSimple(
-                barcode: _model.displayBarcodes[index],
-              );
-            },
-            itemCount: _getItemCount(),
+              },
+              itemCount: _getItemCount(),
+            ),
           ),
         ),
       );


### PR DESCRIPTION
Hi everyone,

My commit displaying a `ProgressBar` when an image was loading was a bit too aggressive… as it was always being displayed.

The behavior is now fixed and there's also some changes:
- I've replaced the `ProgressBar` with an animated logo (only based on the opacity)
- I've created `SmoothSharedAnimationController` to ensure that multiple animations are synced ([to fix this](https://github.com/openfoodfacts/smooth-app/issues/4363#issuecomment-1646776037))
- The error is now a greyed logo

<img width="800" alt="Screenshot 2023-07-27 at 13 41 18" src="https://github.com/openfoodfacts/smooth-app/assets/246838/848ffeb3-ac97-4cdb-9002-e5f290926a83">
<img width="800" alt="Screenshot 2023-07-27 at 13 48 41" src="https://github.com/openfoodfacts/smooth-app/assets/246838/0924a4aa-4075-4bb2-b442-071e824e7ec1">
