### PR TITLE
fix: Amoled color picker not working on non-english languages

### DIFF
--- a/packages/smooth_app/lib/pages/preferences/user_preferences_settings.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_settings.dart
@@ -328,7 +328,7 @@ class _ChooseAccentColor extends StatelessWidget {
       title: appLocalizations.select_accent_color,
       leadingBuilder: labels.keys.map(
         (String key) => (_) => CircleAvatar(
-              backgroundColor: getColorValue(labels[key]!),
+              backgroundColor: getColorValue(key),
               radius: SMALL_SPACE,
             ),
       ),


### PR DESCRIPTION
Hi everyone,

On non-english languages, the color picker doesn't work.
A single line fix for #4367 

<img width="912" alt="Screenshot 2023-07-28 at 09 06 06" src="https://github.com/openfoodfacts/smooth-app/assets/246838/045293c2-5a1f-4a29-91d7-e7cf692e68f1">
