### PR TITLE
fix: Fix for `ScrollController has no ScrollPosition`

### DIFF
--- a/packages/smooth_app/lib/pages/preferences/user_preferences_page.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_page.dart
@@ -52,6 +52,8 @@ class UserPreferencesPage extends StatefulWidget {
 
 class _UserPreferencesPageState extends State<UserPreferencesPage>
     with TraceableClientMixin {
+  final ScrollController _controller = ScrollController();
+
   @override
   String get traceTitle => 'user_preferences_page';
 
@@ -120,6 +122,7 @@ class _UserPreferencesPageState extends State<UserPreferencesPage>
     final ListView list;
     if (addDividers) {
       list = ListView.separated(
+        controller: _controller,
         padding: padding,
         itemCount: children.length,
         itemBuilder: (BuildContext context, int position) => children[position],
@@ -128,6 +131,7 @@ class _UserPreferencesPageState extends State<UserPreferencesPage>
       );
     } else {
       list = ListView.builder(
+        controller: _controller,
         padding: padding,
         itemCount: children.length,
         itemBuilder: (BuildContext context, int position) => children[position],
@@ -143,7 +147,10 @@ class _UserPreferencesPageState extends State<UserPreferencesPage>
           ),
           leading: const SmoothBackButton(),
         ),
-        body: Scrollbar(child: list),
+        body: Scrollbar(
+          controller: _controller,
+          child: list,
+        ),
       );
     }
     final bool dark = Theme.of(context).brightness == Brightness.dark;
@@ -174,7 +181,10 @@ class _UserPreferencesPageState extends State<UserPreferencesPage>
           maxLines: 2,
         ),
       ),
-      body: ListView(children: children),
+      body: ListView(
+        controller: _controller,
+        children: children,
+      ),
     );
   }
 

--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -123,130 +123,127 @@ class _EditProductPageState extends State<EditProductPage> with UpToDateMixin {
           barcode: barcode,
           widget: this,
         ),
-        child: PrimaryScrollController(
+        child: Scrollbar(
           controller: _controller,
-          child: Scrollbar(
-            child: ListView(
-              children: <Widget>[
-                if (_ProductBarcode.isAValidBarcode(barcode))
-                  _ProductBarcode(product: upToDateProduct),
-                _ListTitleItem(
-                  title: appLocalizations.edit_product_form_item_details_title,
-                  subtitle:
-                      appLocalizations.edit_product_form_item_details_subtitle,
-                  onTap: () async => ProductFieldDetailsEditor().edit(
-                    context: context,
-                    product: upToDateProduct,
-                  ),
+          child: ListView(
+            controller: _controller,
+            children: <Widget>[
+              if (_ProductBarcode.isAValidBarcode(barcode))
+                _ProductBarcode(product: upToDateProduct),
+              _ListTitleItem(
+                title: appLocalizations.edit_product_form_item_details_title,
+                subtitle:
+                    appLocalizations.edit_product_form_item_details_subtitle,
+                onTap: () async => ProductFieldDetailsEditor().edit(
+                  context: context,
+                  product: upToDateProduct,
                 ),
-                _ListTitleItem(
-                  leading: const Icon(Icons.add_a_photo_rounded),
-                  title: appLocalizations.edit_product_form_item_photos_title,
-                  subtitle:
-                      appLocalizations.edit_product_form_item_photos_subtitle,
-                  onTap: () async {
-                    AnalyticsHelper.trackProductEdit(
-                      AnalyticsEditEvents.photos,
-                      barcode,
-                    );
+              ),
+              _ListTitleItem(
+                leading: const Icon(Icons.add_a_photo_rounded),
+                title: appLocalizations.edit_product_form_item_photos_title,
+                subtitle:
+                    appLocalizations.edit_product_form_item_photos_subtitle,
+                onTap: () async {
+                  AnalyticsHelper.trackProductEdit(
+                    AnalyticsEditEvents.photos,
+                    barcode,
+                  );
 
-                    await Navigator.push<void>(
-                      context,
-                      MaterialPageRoute<void>(
-                        builder: (BuildContext context) =>
-                            ProductImageGalleryView(
-                          product: upToDateProduct,
-                        ),
-                        fullscreenDialog: true,
-                      ),
-                    );
-                  },
-                ),
-                _getMultipleListTileItem(
-                  <AbstractSimpleInputPageHelper>[
-                    SimpleInputPageLabelHelper(),
-                    SimpleInputPageStoreHelper(),
-                    SimpleInputPageOriginHelper(),
-                    SimpleInputPageEmbCodeHelper(),
-                    SimpleInputPageCountryHelper(),
-                    SimpleInputPageCategoryHelper(),
-                  ],
-                ),
-                _ListTitleItem(
-                  leading:
-                      const _SvgIcon('assets/cacheTintable/ingredients.svg'),
-                  title:
-                      appLocalizations.edit_product_form_item_ingredients_title,
-                  onTap: () async => ProductFieldOcrIngredientEditor().edit(
-                    context: context,
-                    product: upToDateProduct,
-                  ),
-                ),
-                _getSimpleListTileItem(SimpleInputPageCategoryHelper()),
-                _ListTitleItem(
-                    leading: const _SvgIcon(
-                        'assets/cacheTintable/scale-balance.svg'),
-                    title: appLocalizations
-                        .edit_product_form_item_nutrition_facts_title,
-                    subtitle: appLocalizations
-                        .edit_product_form_item_nutrition_facts_subtitle,
-                    onTap: () async {
-                      AnalyticsHelper.trackProductEdit(
-                        AnalyticsEditEvents.nutrition_Facts,
-                        barcode,
-                      );
-                      await NutritionPageLoaded.showNutritionPage(
+                  await Navigator.push<void>(
+                    context,
+                    MaterialPageRoute<void>(
+                      builder: (BuildContext context) =>
+                          ProductImageGalleryView(
                         product: upToDateProduct,
-                        isLoggedInMandatory: true,
-                        context: context,
-                      );
-                    }),
-                _getSimpleListTileItem(SimpleInputPageLabelHelper()),
-                _ListTitleItem(
-                  leading: const _SvgIcon('assets/cacheTintable/packaging.svg'),
-                  title: appLocalizations.edit_packagings_title,
-                  onTap: () async => ProductFieldPackagingEditor().edit(
-                    context: context,
-                    product: upToDateProduct,
-                  ),
+                      ),
+                      fullscreenDialog: true,
+                    ),
+                  );
+                },
+              ),
+              _getMultipleListTileItem(
+                <AbstractSimpleInputPageHelper>[
+                  SimpleInputPageLabelHelper(),
+                  SimpleInputPageStoreHelper(),
+                  SimpleInputPageOriginHelper(),
+                  SimpleInputPageEmbCodeHelper(),
+                  SimpleInputPageCountryHelper(),
+                  SimpleInputPageCategoryHelper(),
+                ],
+              ),
+              _ListTitleItem(
+                leading: const _SvgIcon('assets/cacheTintable/ingredients.svg'),
+                title:
+                    appLocalizations.edit_product_form_item_ingredients_title,
+                onTap: () async => ProductFieldOcrIngredientEditor().edit(
+                  context: context,
+                  product: upToDateProduct,
                 ),
-                _ListTitleItem(
-                  leading: const Icon(Icons.recycling),
-                  title:
-                      appLocalizations.edit_product_form_item_packaging_title,
-                  onTap: () async => ProductFieldOcrPackagingEditor().edit(
-                    context: context,
-                    product: upToDateProduct,
-                  ),
-                ),
-                _getSimpleListTileItem(SimpleInputPageStoreHelper()),
-                _getSimpleListTileItem(SimpleInputPageOriginHelper()),
-                _getSimpleListTileItem(SimpleInputPageEmbCodeHelper()),
-                _getSimpleListTileItem(SimpleInputPageCountryHelper()),
-                _ListTitleItem(
+              ),
+              _getSimpleListTileItem(SimpleInputPageCategoryHelper()),
+              _ListTitleItem(
+                  leading:
+                      const _SvgIcon('assets/cacheTintable/scale-balance.svg'),
                   title: appLocalizations
-                      .edit_product_form_item_other_details_title,
+                      .edit_product_form_item_nutrition_facts_title,
                   subtitle: appLocalizations
-                      .edit_product_form_item_other_details_subtitle,
+                      .edit_product_form_item_nutrition_facts_subtitle,
                   onTap: () async {
-                    if (!await ProductRefresher().checkIfLoggedIn(context)) {
-                      return;
-                    }
                     AnalyticsHelper.trackProductEdit(
-                      AnalyticsEditEvents.otherDetails,
+                      AnalyticsEditEvents.nutrition_Facts,
                       barcode,
                     );
-                    await Navigator.push<void>(
-                      context,
-                      MaterialPageRoute<void>(
-                        builder: (_) => AddOtherDetailsPage(upToDateProduct),
-                        fullscreenDialog: true,
-                      ),
+                    await NutritionPageLoaded.showNutritionPage(
+                      product: upToDateProduct,
+                      isLoggedInMandatory: true,
+                      context: context,
                     );
-                  },
+                  }),
+              _getSimpleListTileItem(SimpleInputPageLabelHelper()),
+              _ListTitleItem(
+                leading: const _SvgIcon('assets/cacheTintable/packaging.svg'),
+                title: appLocalizations.edit_packagings_title,
+                onTap: () async => ProductFieldPackagingEditor().edit(
+                  context: context,
+                  product: upToDateProduct,
                 ),
-              ],
-            ),
+              ),
+              _ListTitleItem(
+                leading: const Icon(Icons.recycling),
+                title: appLocalizations.edit_product_form_item_packaging_title,
+                onTap: () async => ProductFieldOcrPackagingEditor().edit(
+                  context: context,
+                  product: upToDateProduct,
+                ),
+              ),
+              _getSimpleListTileItem(SimpleInputPageStoreHelper()),
+              _getSimpleListTileItem(SimpleInputPageOriginHelper()),
+              _getSimpleListTileItem(SimpleInputPageEmbCodeHelper()),
+              _getSimpleListTileItem(SimpleInputPageCountryHelper()),
+              _ListTitleItem(
+                title:
+                    appLocalizations.edit_product_form_item_other_details_title,
+                subtitle: appLocalizations
+                    .edit_product_form_item_other_details_subtitle,
+                onTap: () async {
+                  if (!await ProductRefresher().checkIfLoggedIn(context)) {
+                    return;
+                  }
+                  AnalyticsHelper.trackProductEdit(
+                    AnalyticsEditEvents.otherDetails,
+                    barcode,
+                  );
+                  await Navigator.push<void>(
+                    context,
+                    MaterialPageRoute<void>(
+                      builder: (_) => AddOtherDetailsPage(upToDateProduct),
+                      fullscreenDialog: true,
+                    ),
+                  );
+                },
+              ),
+            ],
           ),
         ),
       ),


### PR DESCRIPTION
Hi everyone,

On some screens (settings & product edition more particularly), we have such errors:

```
The Scrollbar's ScrollController has no ScrollPosition attached.
A Scrollbar cannot be painted without a ScrollPosition.
The Scrollbar attempted to use the PrimaryScrollController. This ScrollController should be associated with the ScrollView that the Scrollbar is being applied to.When ScrollView.scrollDirection is Axis.vertical on mobile platforms will automatically use the PrimaryScrollController if the user has not provided a ScrollController. To use the PrimaryScrollController explicitly, set ScrollView.primary to true for the Scrollable widget.
```

The issue is only to ensure to give the same controller both to the `Scrollbar` and the `ScrollView`-like Widget.
