### PR TITLE
feat: Ensure native settings / rate app / share app entries look the same

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -2071,6 +2071,7 @@
     "@show_password": {
         "description": "Show hidden password in password field"
     },
+    "rate_app": "Rate the app",
     "app_rating_dialog_title": "Great! Let others know what you think of this app!",
     "app_rating_dialog_positive_action": "Rate the app",
     "app_rating_dialog_negative_action": "Later",

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_settings.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_settings.dart
@@ -117,7 +117,7 @@ class _RateUs extends StatelessWidget {
       child: Image.asset(getImagePath()),
     );
 
-    final String title = appLocalizations.app_rating_dialog_positive_action;
+    final String title = appLocalizations.rate_app;
 
     return UserPreferenceListTile(
       title: title,
@@ -421,28 +421,14 @@ class _AdvancedSettings extends StatelessWidget {
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: <Widget>[
         Expanded(
-          child: ListTile(
-            onTap: () async {
+          child: UserPreferenceListTile(
+            onTap: (_) async {
               await AppSettings.openAppSettings();
             },
-            title: Text(
-              appLocalizations.native_app_settings,
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-            subtitle: Padding(
-              padding: const EdgeInsets.only(top: SMALL_SPACE),
-              child: Text(
-                appLocalizations.native_app_description,
-                style: Theme.of(context).textTheme.bodyMedium,
-              ),
-            ),
-            leading: const Padding(
-              padding: EdgeInsets.all(VERY_SMALL_SPACE),
-              child: Icon(
-                CupertinoIcons.settings_solid,
-              ),
-            ),
-            minVerticalPadding: MEDIUM_SPACE,
+            title: appLocalizations.native_app_settings,
+            subTitle: appLocalizations.native_app_description,
+            leading: const Icon(CupertinoIcons.settings_solid),
+            showDivider: true,
           ),
         ),
       ],

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_widgets.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_widgets.dart
@@ -379,16 +379,20 @@ class UserPreferenceListTile extends StatelessWidget {
     required this.leading,
     required this.onTap,
     required this.showDivider,
+    this.subTitle,
     super.key,
   });
 
   final String title;
+  final String? subTitle;
   final Widget leading;
   final Future<void> Function(BuildContext) onTap;
   final bool showDivider;
 
   @override
   Widget build(BuildContext context) {
+    final TextTheme textTheme = Theme.of(context).textTheme;
+
     return Column(
       children: <Widget>[
         ListTile(
@@ -398,9 +402,19 @@ class UserPreferenceListTile extends StatelessWidget {
           ),
           title: Text(
             title,
-            style: const TextStyle(fontWeight: FontWeight.bold),
+            style: textTheme.headlineMedium,
           ),
+          subtitle: subTitle != null
+              ? Text(
+                  subTitle!,
+                  style: textTheme.bodyMedium,
+                )
+              : null,
           onTap: () => onTap(context),
+          contentPadding: const EdgeInsetsDirectional.symmetric(
+            horizontal: LARGE_SPACE,
+            vertical: SMALL_SPACE,
+          ),
         ),
         if (showDivider) const UserPreferencesListItemDivider(),
       ],


### PR DESCRIPTION
Hi everyone,

In the app settings, items to open native settings / rate the app / share the app weren't visualy consistent.

<img width="912" alt="Screenshot 2023-07-28 at 09 55 01" src="https://github.com/openfoodfacts/smooth-app/assets/246838/ac0e1eb8-576a-4b84-af41-a9d6870674b6">

Will fix #4359 