### PR TITLE
feat: Pass `SentryNavigatorObserver` to the router

### DIFF
--- a/packages/smooth_app/lib/main.dart
+++ b/packages/smooth_app/lib/main.dart
@@ -13,6 +13,7 @@ import 'package:permission_handler/permission_handler.dart';
 import 'package:provider/provider.dart';
 import 'package:provider/single_child_widget.dart';
 import 'package:scanner_shared/scanner_shared.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:smooth_app/data_models/continuous_scan_model.dart';
 import 'package:smooth_app/data_models/product_preferences.dart';
 import 'package:smooth_app/data_models/user_management_provider.dart';
@@ -219,7 +220,10 @@ class _SmoothAppState extends State<SmoothApp> {
             provide<SmoothAppDataImporter>(_appDataImporter),
             provide<PermissionListener>(_permissionListener),
           ],
-          child: AppNavigator(child: Builder(builder: _buildApp)),
+          child: AppNavigator(
+            observers: <NavigatorObserver>[SentryNavigatorObserver()],
+            child: Builder(builder: _buildApp),
+          ),
         );
       },
     );

--- a/packages/smooth_app/lib/pages/navigator/app_navigator.dart
+++ b/packages/smooth_app/lib/pages/navigator/app_navigator.dart
@@ -34,8 +34,11 @@ import 'package:smooth_app/query/product_query.dart';
 class AppNavigator extends InheritedWidget {
   AppNavigator({
     Key? key,
+    List<NavigatorObserver>? observers,
     required Widget child,
-  })  : _router = _SmoothGoRouter(),
+  })  : _router = _SmoothGoRouter(
+          observers: observers,
+        ),
         super(key: key, child: child);
 
   // GoRouter is never accessible directly
@@ -86,8 +89,14 @@ class AppNavigator extends InheritedWidget {
 /// One drawback of the implementation is that we never know the base URL of the
 /// deep link (eg: es.openfoodfacts.org)
 class _SmoothGoRouter {
-  factory _SmoothGoRouter() {
-    return _singleton;
+  factory _SmoothGoRouter({
+    List<NavigatorObserver>? observers,
+  }) {
+    _singleton ??= _SmoothGoRouter._internal(
+      observers: observers,
+    );
+
+    return _singleton!;
   }
 
   _SmoothGoRouter._internal({
@@ -241,7 +250,7 @@ class _SmoothGoRouter {
     );
   }
 
-  static final _SmoothGoRouter _singleton = _SmoothGoRouter._internal();
+  static _SmoothGoRouter? _singleton;
   late GoRouter router;
 
   // Indicates whether [_initAppLanguage] was already called


### PR DESCRIPTION
Hi everyone,

As suggested by @M123-dev, we now pass a `SentryNavigatorObserver` to `GoRouter`.

It will fix #4328