### PR TITLE
feat: Filterable text: ensure to remove accents when comparing

### DIFF
--- a/packages/smooth_app/lib/generic_lib/widgets/language_selector.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/language_selector.dart
@@ -1,3 +1,4 @@
+import 'package:diacritic/diacritic.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
@@ -145,19 +146,19 @@ class LanguageSelector extends StatelessWidget {
             prefixIcon: const Icon(Icons.search),
             controller: languageSelectorController,
             onChanged: (String? query) {
-              query = query?.trim().toLowerCase();
+              query = removeDiacritics(query!.trim().toLowerCase());
 
               setState(
                 () {
                   filteredList = leftovers
                       .where((OpenFoodFactsLanguage item) =>
-                          _languages
-                              .getNameInEnglish(item)
-                              .toLowerCase()
+                          removeDiacritics(_languages
+                                  .getNameInEnglish(item)
+                                  .toLowerCase())
                               .contains(query!.toLowerCase()) ||
-                          _languages
-                              .getNameInLanguage(item)
-                              .toLowerCase()
+                          removeDiacritics(_languages
+                                  .getNameInLanguage(item)
+                                  .toLowerCase())
                               .contains(query.toLowerCase()) ||
                           item.code.contains(query))
                       .toList();

--- a/packages/smooth_app/lib/pages/onboarding/country_selector.dart
+++ b/packages/smooth_app/lib/pages/onboarding/country_selector.dart
@@ -1,3 +1,4 @@
+import 'package:diacritic/diacritic.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -95,19 +96,23 @@ class _CountrySelectorState extends State<CountrySelector> {
                         prefixIcon: const Icon(Icons.search),
                         controller: _countryController,
                         onChanged: (String? query) {
-                          query = query?.trim().toLowerCase();
+                          query = removeDiacritics(query!.trim().toLowerCase());
 
                           setState(
                             () {
                               filteredList = _countryList
                                   .where(
                                     (Country item) =>
-                                        item.name.toLowerCase().contains(
-                                              query!,
-                                            ) ||
-                                        item.countryCode.toLowerCase().contains(
-                                              query,
-                                            ),
+                                        removeDiacritics(
+                                                item.name.toLowerCase())
+                                            .contains(
+                                          query!,
+                                        ) ||
+                                        removeDiacritics(
+                                                item.countryCode.toLowerCase())
+                                            .contains(
+                                          query,
+                                        ),
                                   )
                                   .toList(growable: false);
                             },

--- a/packages/smooth_app/lib/widgets/smooth_text.dart
+++ b/packages/smooth_app/lib/widgets/smooth_text.dart
@@ -1,3 +1,4 @@
+import 'package:diacritic/diacritic.dart';
 import 'package:flutter/material.dart';
 
 /// An extension on [TextStyle] that allows to have "well spaced" variant
@@ -86,8 +87,8 @@ class TextHighlighter extends StatelessWidget {
     required TextStyle? highlightedStyle,
   }) {
     final Iterable<RegExpMatch> highlightedParts =
-        RegExp(filter.toLowerCase().trim()).allMatches(
-      text.toLowerCase(),
+        RegExp(removeDiacritics(filter).toLowerCase().trim()).allMatches(
+      removeDiacritics(text).toLowerCase(),
     );
 
     final List<(String, TextStyle?)> parts = <(String, TextStyle?)>[];


### PR DESCRIPTION
Hi everyone,

While testing if #4389 was still OK once merged, I totally forgot to support accentuated characters.
For example: `Français` will be OK when spelled with `Francais`.

<img width="800" alt="Screenshot 2023-07-29 at 01 29 21" src="https://github.com/openfoodfacts/smooth-app/assets/246838/5a7cc481-b62d-47bf-acb2-b0cd04c496f4">
