### PR TITLE
feat: Setup `image_picker` for macOS

### DIFF
--- a/packages/smooth_app/macos/Runner/DebugProfile.entitlements
+++ b/packages/smooth_app/macos/Runner/DebugProfile.entitlements
@@ -9,8 +9,10 @@
 	<key>com.apple.security.network.server</key>
 	<true/>
 	<key>com.apple.security.network.client</key>
-    <true/>
-    <key>keychain-access-groups</key>
-    <array/>
+	<true/>
+	<key>keychain-access-groups</key>
+	<array/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
 </dict>
 </plist>

--- a/packages/smooth_app/macos/Runner/Release.entitlements
+++ b/packages/smooth_app/macos/Runner/Release.entitlements
@@ -4,7 +4,9 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
-    <key>keychain-access-groups</key>
-    <array/>
+	<key>keychain-access-groups</key>
+	<array/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Hi everyone,

It seems that the configuration of the `image_picker` was not fully implemented, as the macOS is missing.
Windows and Linux don't require a specific configuration according to the doc.

It will fix #4396 (= the file picker was never showing)

![Screenshot 2023-07-29 at 10 28 25](https://github.com/openfoodfacts/smooth-app/assets/246838/7abe93ea-ae01-4220-b840-f28c0a2161d9)