### PR TITLE
feat: Force the checkbox color (on iOS)

### DIFF
--- a/packages/smooth_app/lib/pages/image_crop_page.dart
+++ b/packages/smooth_app/lib/pages/image_crop_page.dart
@@ -132,6 +132,7 @@ class _ImageSourcePickerState extends State<_ImageSourcePicker> {
                     shape: const RoundedRectangleBorder(
                       borderRadius: BorderRadius.all(Radius.circular(6.0)),
                     ),
+                    activeColor: Theme.of(context).primaryColor,
                     materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
                     value: rememberChoice,
                     onChanged: (final bool? value) => setState(


### PR DESCRIPTION
Hi everyone,

When we use `Checkbox.adaptive()`, it uses the Material one on all platforms and `CupertinoCheckbox` on iOS/macOS.
However, the implementation of this widget is very shitty, as it doesn't try to inherit the accent color.
The only way is to force a color on the constructor, otherwise it will be blue.

So here is a one-line fix because we use a `Checkbox` only in one place.

Android
![Screenshot_1690619827](https://github.com/openfoodfacts/smooth-app/assets/246838/f6e28fa6-ff54-461e-91f7-16096be58b96)

VS iOS (with this PR)
![Simulator Screenshot - iPhone 14 Pro - 2023-07-29 at 10 40 58](https://github.com/openfoodfacts/smooth-app/assets/246838/e05d2eb7-bf47-4517-b29c-4605465223c0)

It will fix #4395 