### PR TITLE
fix: When there is just a close button, the product card should have a full-width title

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/product_title_card.dart
+++ b/packages/smooth_app/lib/cards/product_cards/product_title_card.dart
@@ -23,6 +23,16 @@ class ProductTitleCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    Widget title = _ProductTitleCardTrailing(
+      removable: isRemovable,
+      selectable: isSelectable,
+      onRemove: onRemove,
+    );
+
+    if (!(isRemovable && !isSelectable)) {
+      title = Expanded(child: title);
+    }
+
     return Provider<Product>.value(
       value: product,
       child: Align(
@@ -38,13 +48,7 @@ class ProductTitleCard extends StatelessWidget {
                     selectable: isSelectable,
                   ),
                 ),
-                Expanded(
-                  child: _ProductTitleCardTrailing(
-                    removable: isRemovable,
-                    selectable: isSelectable,
-                    onRemove: onRemove,
-                  ),
-                )
+                title,
               ],
             ),
             _ProductTitleCardBrand(


### PR DESCRIPTION
Hi everyone,

In the carousel, product cards have a close button, but we lose so much space (here in red):
![Screenshot_20230730-090735](https://github.com/openfoodfacts/smooth-app/assets/246838/82388117-e0cf-4a03-badd-ba06c27a3240)

This PR fixes with:
![Screenshot_20230730-091107](https://github.com/openfoodfacts/smooth-app/assets/246838/839da0e8-82fb-444f-963e-5a89a472480b)

Note: This one + https://github.com/openfoodfacts/smooth-app/pull/4357 should really improve the layout on small screens