### PR TITLE
chore: upgrade to off-dart 2.7.4

### DIFF
--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -1011,10 +1011,10 @@ packages:
     dependency: "direct main"
     description:
       name: openfoodfacts
-      sha256: a39131388148839f08fe4772cfd5dd77f2393bd7995edb9712e70742201d41fb
+      sha256: "86ef1dc9a3cbb464cb020d6bdd87e52c9115df26cc04ac6144eb80d79a0972e2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.7.1"
+    version: "2.7.4"
   openfoodfacts_flutter_lints:
     dependency: "direct dev"
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -98,7 +98,7 @@ dependencies:
 
 
 
-  openfoodfacts: 2.7.1
+  openfoodfacts: 2.7.4
   # openfoodfacts:
   #   path: ../../../openfoodfacts-dart
 


### PR DESCRIPTION
### What
- Upgrade to off-dart 2.7.4
- https://github.com/openfoodfacts/openfoodfacts-dart/releases/tag/v2.7.4