### PR TITLE
feat: "Contributors" >> "Mobile app contributors" + a11n

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -282,7 +282,7 @@
         "description": "Indicator inside the darkmode switch (system default)"
     },
     "thanks_for_contributing": "Thanks for contributing!",
-    "contributors_label": "Mobile app contributors",
+    "contributors_label": "They are building the app",
     "@contributors_label": {
         "description": "Button label: Opens a pop up window where all contributors of this app are shown"
     },

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -282,10 +282,25 @@
         "description": "Indicator inside the darkmode switch (system default)"
     },
     "thanks_for_contributing": "Thanks for contributing!",
-    "@contributors": {
+    "contributors_label": "Mobile app contributors",
+    "@contributors_label": {
         "description": "Button label: Opens a pop up window where all contributors of this app are shown"
     },
-    "contributors": "Contributors",
+    "contributors_dialog_title": "Contributors",
+    "@contributors_dialog_title": {
+        "description": "Dialog title: A list of all contributors of this app"
+    },
+    "contributors_dialog_entry_description": "Contributor: {name}",
+    "@contributors_dialog_entry_description": {
+        "description": "The user id of the contributor.",
+        "placeholders": {
+            "name": {}
+        }
+    },
+    "contributors_description": "A list of all contributors of this app",
+    "@contributors_description": {
+        "description": "Button description for accessibility purposes to explain what the Contributors button do"
+    },
     "support": "Support",
     "@support": {
         "description": "Button label: Opens a pop up window where all ways to get support are shown"


### PR DESCRIPTION
Hi everyone,

As requested in #4417, I've changed "Contributors" to "Mobile app contributors".
I've made some modifications to enhance accessibility, as usual.

![Screenshot_1691132378](https://github.com/openfoodfacts/smooth-app/assets/246838/1a87efde-1266-4f8f-9bd9-7f04b5d2b9b5)
![Screenshot_1691132476](https://github.com/openfoodfacts/smooth-app/assets/246838/08af87f9-e7c3-4b64-9afb-1408c5551484)
![Screenshot_1691132902](https://github.com/openfoodfacts/smooth-app/assets/246838/d604a346-0913-4392-b2a7-c79ce190077a)
