### PR TITLE
fix: `setState` called in a `build` method

### DIFF
--- a/packages/smooth_app/lib/pages/carousel_manager.dart
+++ b/packages/smooth_app/lib/pages/carousel_manager.dart
@@ -34,7 +34,7 @@ class ExternalCarouselManager extends StatefulWidget {
 class ExternalCarouselManagerState extends State<ExternalCarouselManager> {
   final CarouselController _controller = CarouselController();
 
-  String? _currentBarcode;
+  String? currentBarcode;
 
   @override
   Widget build(BuildContext context) {
@@ -60,13 +60,8 @@ class ExternalCarouselManagerState extends State<ExternalCarouselManager> {
 
   CarouselController get controller => _controller;
 
-  String? get currentBarcode => _currentBarcode;
-
-  set currentBarcode(String? barcode) =>
-      setState(() => _currentBarcode = barcode);
-
   bool updateShouldNotify(ExternalCarouselManagerState oldState) {
-    return oldState.currentBarcode != _currentBarcode;
+    return oldState.currentBarcode != currentBarcode;
   }
 }
 


### PR DESCRIPTION
Hi everyone,

Here is a fix for #4420, where `setState` was called for nothing.