### PR TITLE
fix: AMOLED theme not working with the default color (on non-English languages)

### DIFF
--- a/packages/smooth_app/lib/pages/preferences/user_preferences_settings.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_settings.dart
@@ -334,7 +334,7 @@ class _ChooseAccentColor extends StatelessWidget {
       ),
       labels: labels.values,
       values: labels.keys,
-      currentValue: labels[colorProvider.currentColor],
+      currentValue: colorProvider.currentColor,
       onChanged: (String? newValue) {
         colorProvider.setColor(newValue!);
       },


### PR DESCRIPTION
Hi everyone,

My previous PR (#4406) was fixing mainly all the issues, but I missed one case: we save the translated value as the color.
It was OK for Blue, Red… but not for the default one.

A single one-line fix as usual

