### PR TITLE
feat: Ensure the `SmoothSimpleButton` has a border on AMOLED theme

### DIFF
--- a/packages/smooth_app/lib/generic_lib/buttons/smooth_simple_button.dart
+++ b/packages/smooth_app/lib/generic_lib/buttons/smooth_simple_button.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/themes/theme_provider.dart';
 
 class SmoothSimpleButton extends StatelessWidget {
   const SmoothSimpleButton({
@@ -35,6 +37,18 @@ class SmoothSimpleButton extends StatelessWidget {
           shape: MaterialStateProperty.all<RoundedRectangleBorder>(
             RoundedRectangleBorder(borderRadius: borderRadius),
           ),
+          overlayColor: context.read<ThemeProvider>().isAmoledTheme
+              ? MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+                  return states.contains(MaterialState.pressed)
+                      ? Theme.of(context).colorScheme.primary.withOpacity(0.3)
+                      : null;
+                })
+              : null,
+          side: context.read<ThemeProvider>().isAmoledTheme
+              ? MaterialStateProperty.all<BorderSide>(
+                  const BorderSide(color: Colors.white),
+                )
+              : null,
         ),
         onPressed: onPressed,
         child: Padding(

--- a/packages/smooth_app/lib/themes/theme_provider.dart
+++ b/packages/smooth_app/lib/themes/theme_provider.dart
@@ -10,6 +10,7 @@ class ThemeProvider with ChangeNotifier {
   ThemeProvider(this._userPreferences);
 
   final UserPreferences _userPreferences;
+
   // The onboarding needs the light mode.
   bool _forceLight = false;
 
@@ -19,6 +20,12 @@ class ThemeProvider with ChangeNotifier {
   void setOnboardingComplete(final bool onboardingComplete) {
     _forceLight = !onboardingComplete;
   }
+
+  bool get isLightTheme => _forceLight || currentTheme == THEME_LIGHT;
+
+  bool get isDarkTheme => !_forceLight && currentTheme == THEME_DARK;
+
+  bool get isAmoledTheme => !_forceLight && currentTheme == THEME_AMOLED;
 
   void finishOnboarding() {
     setOnboardingComplete(true);

--- a/packages/smooth_app/test/pages/generic_lib/widgets/smooth_error_card_test.dart
+++ b/packages/smooth_app/test/pages/generic_lib/widgets/smooth_error_card_test.dart
@@ -1,9 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/generic_lib/buttons/smooth_simple_button.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_error_card.dart';
+import 'package:smooth_app/themes/theme_provider.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
+
+import '../../../tests_utils/mocks.dart';
 
 void main() {
   const String errorMessageTest = 'error message test';
@@ -40,15 +46,24 @@ void main() {
     tryAgainFunctionTest = () {};
   });
 
-  Future<void> pumpSmoothErrorCardOnScreen(WidgetTester tester) {
+  Future<void> pumpSmoothErrorCardOnScreen(WidgetTester tester) async {
+    SharedPreferences.setMockInitialValues(
+      mockSharedPreferences(),
+    );
+
+    final UserPreferences prefs = await UserPreferences.getUserPreferences();
+
     return tester.pumpWidget(
-      MaterialApp(
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        locale: const Locale('en'),
-        home: SmoothScaffold(
-          body: SmoothErrorCard(
-            errorMessage: errorMessageTest,
-            tryAgainFunction: tryAgainFunctionTest,
+      ChangeNotifierProvider<ThemeProvider>(
+        create: (_) => ThemeProvider(prefs),
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          locale: const Locale('en'),
+          home: SmoothScaffold(
+            body: SmoothErrorCard(
+              errorMessage: errorMessageTest,
+              tryAgainFunction: tryAgainFunctionTest,
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
Hi everyone,

When we use the `SmoothSimpleButton` and only with the AMOLED theme, there is no shadow, nor a Ripple color.
However, after testing it a bit, a border fits better.

Before:
![Screenshot_20230804-144537](https://github.com/openfoodfacts/smooth-app/assets/246838/13770c42-3302-47df-ac8d-018f082e4050)

After:
<img width="314" alt="Screenshot 2023-08-04 at 15 06 14" src="https://github.com/openfoodfacts/smooth-app/assets/246838/cc931022-8c87-4a29-97cc-c86504fcf472">