### PR TITLE
fix: Smooth Dialog: when there is just on button, ensure we have equal padding

### DIFF
--- a/packages/smooth_app/lib/generic_lib/dialogs/smooth_alert_dialog.dart
+++ b/packages/smooth_app/lib/generic_lib/dialogs/smooth_alert_dialog.dart
@@ -103,10 +103,16 @@ class SmoothAlertDialog extends StatelessWidget {
   }
 
   Padding _buildBottomBar(EdgeInsetsDirectional padding) {
+    final bool singleButton =
+        positiveAction != null && negativeAction == null ||
+            negativeAction != null && positiveAction == null;
+
     return Padding(
       padding: EdgeInsetsDirectional.only(
         top: padding.bottom,
-        start: actionsAxis == Axis.horizontal ? SMALL_SPACE : 0.0,
+        start: (actionsAxis == Axis.horizontal || singleButton)
+            ? SMALL_SPACE
+            : 0.0,
         end: positiveAction != null && negativeAction != null
             ? 0.0
             : SMALL_SPACE,


### PR DESCRIPTION
Hi everyone,

A tiny fix for this one, where in Dialogs, we may have a padding only on the right:

Before:
<img width="317" alt="Screenshot 2023-08-04 at 15 43 59" src="https://github.com/openfoodfacts/smooth-app/assets/246838/d5ee39de-cfb8-4d11-852e-02545c34a84e">

After:
<img width="313" alt="Screenshot 2023-08-04 at 15 35 43" src="https://github.com/openfoodfacts/smooth-app/assets/246838/55ef3614-1102-45cc-8d37-19af51276a6e">