### PR TITLE
fix: 4424 - longer label for "empty the list" + refactoring

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -774,7 +774,11 @@
     "recently_seen_products": "History",
     "clear": "Clear",
     "@clear": {
-        "description": "Clears a product list"
+        "description": "Clears a product list (short label)"
+    },
+    "clear_long": "Empty the list",
+    "@clear_long": {
+        "description": "Clears a product list (long label)"
     },
     "really_clear": "Do you really want to delete this list?",
     "@Plural": {},

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -776,6 +776,10 @@
     "@clear": {
         "description": "Clears a product list"
     },
+    "clear_long": "Vider la liste",
+    "@clear_long": {
+        "description": "Clears a product list (long label)"
+    },
     "really_clear": "Voulez-vous vraiment supprimer cette liste ?",
     "@Plural": {},
     "pct_match": "{percent}% de correspondance",

--- a/packages/smooth_app/lib/pages/all_product_list_page.dart
+++ b/packages/smooth_app/lib/pages/all_product_list_page.dart
@@ -8,7 +8,6 @@ import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_list_tile.dart';
 import 'package:smooth_app/pages/product/common/product_list_popup_items.dart';
 import 'package:smooth_app/pages/product/common/product_query_page_helper.dart';
-import 'package:smooth_app/pages/product_list_user_dialog_helper.dart';
 
 /// Page that lists all product lists.
 class AllProductListModal extends StatelessWidget {
@@ -18,7 +17,7 @@ class AllProductListModal extends StatelessWidget {
 
   final ProductList currentList;
 
-  final List<ProductList> hardcodedProductLists = <ProductList>[
+  final List<ProductList> _hardcodedProductLists = <ProductList>[
     ProductList.scanSession(),
     ProductList.scanHistory(),
     ProductList.history(),
@@ -31,7 +30,7 @@ class AllProductListModal extends StatelessWidget {
 
     final List<String> userLists = daoProductList.getUserLists();
     final List<ProductList> productLists =
-        List<ProductList>.from(hardcodedProductLists);
+        List<ProductList>.from(_hardcodedProductLists);
     for (final String userList in userLists) {
       productLists.add(ProductList.user(userList));
     }
@@ -62,39 +61,42 @@ class AllProductListModal extends StatelessWidget {
                     subtitle: Text(
                       appLocalizations.user_list_length(productsLength),
                     ),
-                    trailing: PopupMenuButton<PopupMenuEntries>(
+                    trailing: PopupMenuButton<ProductListPopupMenuEntry>(
                       itemBuilder: (BuildContext context) {
-                        return <PopupMenuEntry<PopupMenuEntries>>[
-                          _shareMenu(
-                            appLocalizations,
-                            daoProductList,
-                            localDatabase,
-                            context,
-                            productList,
-                          ),
-                          _openInWebMenu(
-                            appLocalizations,
-                            daoProductList,
-                            localDatabase,
-                            context,
-                            productList,
-                          ),
-                          if (productsLength > 0)
-                            _clearListMenu(
-                              appLocalizations,
-                              daoProductList,
-                              localDatabase,
-                              context,
-                              productList,
-                            ),
-                          if (productList.isEditable)
-                            _deleteListMenu(
-                              appLocalizations,
-                              daoProductList,
-                              context,
-                              productList,
-                            ),
+                        final bool enableRename =
+                            productList.listType == ProductListType.USER;
+                        final List<ProductListPopupItem> list =
+                            <ProductListPopupItem>[
+                          if (enableRename) ProductListPopupRename(),
+                          ProductListPopupShare(),
+                          ProductListPopupOpenInWeb(),
+                          if (productsLength > 0) ProductListPopupClear(),
+                          if (productList.isEditable) ProductListPopupDelete(),
                         ];
+                        final List<PopupMenuEntry<ProductListPopupMenuEntry>>
+                            result =
+                            <PopupMenuEntry<ProductListPopupMenuEntry>>[];
+                        for (final ProductListPopupItem item in list) {
+                          result.add(
+                            PopupMenuItem<ProductListPopupMenuEntry>(
+                              value: item.getEntry(),
+                              child: ListTile(
+                                leading: Icon(item.getIconData()),
+                                title: Text(item.getTitle(appLocalizations)),
+                                contentPadding: EdgeInsets.zero,
+                                onTap: () async {
+                                  Navigator.of(context).pop();
+                                  await item.doSomething(
+                                    productList: productList,
+                                    localDatabase: localDatabase,
+                                    context: context,
+                                  );
+                                },
+                              ),
+                            ),
+                          );
+                        }
+                        return result;
                       },
                       icon: const Icon(Icons.more_vert),
                     ),
@@ -119,112 +121,4 @@ class AllProductListModal extends StatelessWidget {
       ),
     );
   }
-
-  PopupMenuItem<PopupMenuEntries> _shareMenu(
-    AppLocalizations appLocalizations,
-    DaoProductList daoProductList,
-    LocalDatabase localDatabase,
-    BuildContext context,
-    ProductList productList,
-  ) {
-    final ProductListPopupShare popupShare = ProductListPopupShare();
-    return PopupMenuItem<PopupMenuEntries>(
-      value: PopupMenuEntries.shareList,
-      child: ListTile(
-        leading: const Icon(Icons.share),
-        title: Text(popupShare.getTitle(appLocalizations)),
-        contentPadding: EdgeInsets.zero,
-        onTap: () {
-          Navigator.of(context).pop();
-          popupShare.doSomething(
-            productList: productList,
-            localDatabase: localDatabase,
-            context: context,
-          );
-        },
-      ),
-    );
-  }
-
-  PopupMenuItem<PopupMenuEntries> _openInWebMenu(
-    AppLocalizations appLocalizations,
-    DaoProductList daoProductList,
-    LocalDatabase localDatabase,
-    BuildContext context,
-    ProductList productList,
-  ) {
-    final ProductListPopupOpenInWeb webItem = ProductListPopupOpenInWeb();
-    return PopupMenuItem<PopupMenuEntries>(
-      value: PopupMenuEntries.openListInBrowser,
-      child: ListTile(
-        leading: const Icon(Icons.public),
-        title: Text(webItem.getTitle(appLocalizations)),
-        contentPadding: EdgeInsets.zero,
-        onTap: () {
-          Navigator.of(context).pop();
-          webItem.doSomething(
-            productList: productList,
-            localDatabase: localDatabase,
-            context: context,
-          );
-        },
-      ),
-    );
-  }
-
-  PopupMenuItem<PopupMenuEntries> _clearListMenu(
-    AppLocalizations appLocalizations,
-    DaoProductList daoProductList,
-    LocalDatabase localDatabase,
-    BuildContext context,
-    ProductList productList,
-  ) {
-    final ProductListPopupClear clearItem = ProductListPopupClear();
-    return PopupMenuItem<PopupMenuEntries>(
-      value: PopupMenuEntries.clearList,
-      child: ListTile(
-        leading: const Icon(Icons.delete_sweep),
-        title: Text(clearItem.getTitle(appLocalizations)),
-        contentPadding: EdgeInsets.zero,
-        onTap: () async {
-          Navigator.of(context).pop();
-
-          clearItem.doSomething(
-            productList: productList,
-            localDatabase: localDatabase,
-            context: context,
-          );
-        },
-      ),
-    );
-  }
-
-  PopupMenuItem<PopupMenuEntries> _deleteListMenu(
-    AppLocalizations appLocalizations,
-    DaoProductList daoProductList,
-    BuildContext context,
-    ProductList productList,
-  ) {
-    return PopupMenuItem<PopupMenuEntries>(
-        value: PopupMenuEntries.deleteList,
-        child: ListTile(
-          leading: const Icon(Icons.delete),
-          title: Text(appLocalizations.action_delete_list),
-          contentPadding: EdgeInsets.zero,
-        ),
-        onTap: () {
-          WidgetsBinding.instance.addPostFrameCallback((_) {
-            ProductListUserDialogHelper(daoProductList)
-                .showDeleteUserListDialog(context, productList);
-          });
-        });
-  }
-}
-
-enum PopupMenuEntries {
-  shareList,
-  openListInBrowser,
-  renameList,
-  clearList,
-  deleteList,
 }

--- a/packages/smooth_app/lib/pages/product/common/product_list_popup_items.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_popup_items.dart
@@ -10,11 +10,24 @@ import 'package:smooth_app/helpers/temp_product_list_share_helper.dart';
 import 'package:smooth_app/pages/product_list_user_dialog_helper.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+enum ProductListPopupMenuEntry {
+  share,
+  openInBrowser,
+  rename,
+  clear,
+  delete,
+}
+
 /// Popup menu items for the product list page.
 abstract class ProductListPopupItem {
   /// Title of the popup menu item.
-  @protected
   String getTitle(final AppLocalizations appLocalizations);
+
+  /// IconData of the popup menu item.
+  IconData getIconData();
+
+  /// Popup menu entry of the popup menu item.
+  ProductListPopupMenuEntry getEntry();
 
   /// Action of the popup menu item.
   ///
@@ -39,7 +52,13 @@ abstract class ProductListPopupItem {
 class ProductListPopupClear extends ProductListPopupItem {
   @override
   String getTitle(final AppLocalizations appLocalizations) =>
-      appLocalizations.clear;
+      appLocalizations.clear_long;
+
+  @override
+  IconData getIconData() => Icons.delete_sweep;
+
+  @override
+  ProductListPopupMenuEntry getEntry() => ProductListPopupMenuEntry.clear;
 
   @override
   Future<ProductList?> doSomething({
@@ -84,6 +103,12 @@ class ProductListPopupRename extends ProductListPopupItem {
       appLocalizations.user_list_popup_rename;
 
   @override
+  IconData getIconData() => Icons.edit;
+
+  @override
+  ProductListPopupMenuEntry getEntry() => ProductListPopupMenuEntry.rename;
+
+  @override
   Future<ProductList?> doSomething({
     required final ProductList productList,
     required final LocalDatabase localDatabase,
@@ -98,6 +123,12 @@ class ProductListPopupShare extends ProductListPopupItem {
   @override
   String getTitle(final AppLocalizations appLocalizations) =>
       appLocalizations.share;
+
+  @override
+  IconData getIconData() => Icons.share;
+
+  @override
+  ProductListPopupMenuEntry getEntry() => ProductListPopupMenuEntry.share;
 
   @override
   Future<ProductList?> doSomething({
@@ -126,6 +157,13 @@ class ProductListPopupOpenInWeb extends ProductListPopupItem {
       appLocalizations.label_web;
 
   @override
+  IconData getIconData() => Icons.public;
+
+  @override
+  ProductListPopupMenuEntry getEntry() =>
+      ProductListPopupMenuEntry.openInBrowser;
+
+  @override
   Future<ProductList?> doSomething({
     required final ProductList productList,
     required final LocalDatabase localDatabase,
@@ -135,5 +173,30 @@ class ProductListPopupOpenInWeb extends ProductListPopupItem {
     AnalyticsHelper.trackEvent(AnalyticsEvent.openListWeb);
     await launchUrl(shareProductList(products));
     return null;
+  }
+}
+
+/// Popup menu item for the product list page: delete.
+class ProductListPopupDelete extends ProductListPopupItem {
+  @override
+  String getTitle(final AppLocalizations appLocalizations) =>
+      appLocalizations.action_delete_list;
+
+  @override
+  IconData getIconData() => Icons.delete;
+
+  @override
+  ProductListPopupMenuEntry getEntry() => ProductListPopupMenuEntry.delete;
+
+  @override
+  Future<ProductList?> doSomething({
+    required final ProductList productList,
+    required final LocalDatabase localDatabase,
+    required final BuildContext context,
+  }) async {
+    final bool deleted =
+        await ProductListUserDialogHelper(DaoProductList(localDatabase))
+            .showDeleteUserListDialog(context, productList);
+    return deleted ? null : productList;
   }
 }


### PR DESCRIPTION
### What
- Now we use a new and more explicit label for "empty the list" in popup menu and modal menu.
- In the process, I refactored, for code clarity.

### Screenshot
| popup menu | model menu |
| -- | -- |
| ![Screenshot_2023-08-04-18-22-42](https://github.com/openfoodfacts/smooth-app/assets/11576431/f2ffa48f-1faf-4683-818f-8410d5376971) | ![Screenshot_2023-08-04-18-20-18](https://github.com/openfoodfacts/smooth-app/assets/11576431/0cf38e34-11bb-40b8-8fea-d063387b592d) |

### Fixes bug(s)
- Fixes: #4424

### Impacted files
* `all_products_list_page.dart`: refactored around `ProductListPopupItem`
* `app_en.arb`: new label for a more explicit "empty the list"
* `app_fr.arb`: new label for a more explicit "empty the list"
* `product_list_popup_items.dart`: moved there `ProductListPopupMenuEntry`; added 2 methods to `ProductListPopupItem`; added 1 implementation of `ProductListPopupItem`