### PR TITLE
fix: smooth_error_card_test.dart

### DIFF
--- a/packages/smooth_app/test/pages/generic_lib/widgets/smooth_error_card_test.dart
+++ b/packages/smooth_app/test/pages/generic_lib/widgets/smooth_error_card_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:smooth_app/data_models/user_preferences.dart';
+import 'package:smooth_app/data_models/preferences/user_preferences.dart';
 import 'package:smooth_app/generic_lib/buttons/smooth_simple_button.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_error_card.dart';
 import 'package:smooth_app/themes/theme_provider.dart';


### PR DESCRIPTION
### What
- Fixes the [following error](https://github.com/openfoodfacts/smooth-app/actions/runs/5771595299/job/15645721358):
```log
Run flutter analyze --fatal-infos --fatal-warnings .
Analyzing smooth-app...                                         

  error • Target of URI doesn't exist: 'package:smooth_app/data_models/user_preferences.dart' • packages/smooth_app/test/pages/generic_lib/widgets/smooth_error_card_test.dart:6:8 • uri_does_not_exist
  error • Undefined class 'UserPreferences' • packages/smooth_app/test/pages/generic_lib/widgets/smooth_error_card_test.dart:54:[11](https://github.com/openfoodfacts/smooth-app/actions/runs/5771595299/job/15645721358#step:9:12) • undefined_class
   info • Method invocation or property access on a 'dynamic' target • packages/smooth_app/test/pages/generic_lib/widgets/smooth_error_card_test.dart:54:41 • avoid_dynamic_calls
  error • Undefined name 'UserPreferences' • packages/smooth_app/test/pages/generic_lib/widgets/smooth_error_card_test.dart:54:41 • undefined_identifier

4 issues found. (ran in 43.7s)
```