### PR TITLE
feat: Tiny UI tweaks for the product edition

### DIFF
--- a/packages/smooth_app/lib/generic_lib/dialogs/smooth_alert_dialog.dart
+++ b/packages/smooth_app/lib/generic_lib/dialogs/smooth_alert_dialog.dart
@@ -458,36 +458,40 @@ class _SmoothActionFlatButton extends StatelessWidget {
         value: buttonData.text,
         button: true,
         excludeSemantics: true,
-        child: TextButton(
-          onPressed: buttonData.onPressed,
-          style: TextButton.styleFrom(
-            shape: const RoundedRectangleBorder(
-              borderRadius: ROUNDED_BORDER_RADIUS,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 2.0),
+          child: TextButton(
+            onPressed: buttonData.onPressed,
+            style: TextButton.styleFrom(
+              shape: const RoundedRectangleBorder(
+                borderRadius: ROUNDED_BORDER_RADIUS,
+              ),
+              textStyle: themeData.textTheme.bodyMedium!.copyWith(
+                color: themeData.colorScheme.onPrimary,
+              ),
+              padding: const EdgeInsets.symmetric(
+                horizontal: SMALL_SPACE,
+              ),
+              minimumSize: const Size(0, 46.0),
             ),
-            textStyle: themeData.textTheme.bodyMedium!.copyWith(
-              color: themeData.colorScheme.onPrimary,
-            ),
-            padding: const EdgeInsets.symmetric(
-              horizontal: SMALL_SPACE,
-            ),
-            minimumSize: const Size(0, 50.0),
-          ),
-          child: SizedBox(
-            height: buttonData.lines != null
-                ? VERY_LARGE_SPACE * buttonData.lines!
-                : null,
-            width: buttonData.minWidth,
-            child: FittedBox(
-              fit: BoxFit.scaleDown,
-              child: Text(
-                buttonData.text.toUpperCase(),
-                style: TextStyle(
-                  fontWeight: FontWeight.bold,
-                  color: buttonData.textColor ?? themeData.colorScheme.primary,
+            child: SizedBox(
+              height: buttonData.lines != null
+                  ? VERY_LARGE_SPACE * buttonData.lines!
+                  : null,
+              width: buttonData.minWidth,
+              child: FittedBox(
+                fit: BoxFit.scaleDown,
+                child: Text(
+                  buttonData.text.toUpperCase(),
+                  style: TextStyle(
+                    fontWeight: FontWeight.bold,
+                    color:
+                        buttonData.textColor ?? themeData.colorScheme.primary,
+                  ),
+                  textAlign: TextAlign.center,
+                  overflow: TextOverflow.ellipsis,
+                  maxLines: buttonData.lines ?? 2,
                 ),
-                textAlign: TextAlign.center,
-                overflow: TextOverflow.ellipsis,
-                maxLines: buttonData.lines ?? 2,
               ),
             ),
           ),

--- a/packages/smooth_app/lib/pages/product/edit_image_button.dart
+++ b/packages/smooth_app/lib/pages/product/edit_image_button.dart
@@ -35,9 +35,12 @@ class EditImageButton extends StatelessWidget {
               ),
       ),
       onPressed: onPressed,
-      label: Padding(
-        padding: EdgeInsets.all(borderWidth ?? 0),
-        child: Text(label),
+      label: SizedBox(
+        width: double.infinity,
+        child: Padding(
+          padding: EdgeInsets.all(borderWidth ?? 0),
+          child: Text(label),
+        ),
       ),
     );
   }

--- a/packages/smooth_app/lib/pages/product/explanation_widget.dart
+++ b/packages/smooth_app/lib/pages/product/explanation_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
 
 /// Widget that displays explanations as a list, with expand/collapse mode.
 class ExplanationWidget extends StatefulWidget {
@@ -55,6 +56,10 @@ class _CollapsedExplanation extends StatelessWidget {
         overflow: TextOverflow.ellipsis,
       ),
       trailing: const Icon(Icons.info_outline),
+      contentPadding: const EdgeInsetsDirectional.only(
+        start: SMALL_SPACE * 2,
+        end: SMALL_SPACE,
+      ),
     );
   }
 }
@@ -82,6 +87,10 @@ class _ExpandedExplanation extends StatelessWidget {
             trailing: const RotatedBox(
               quarterTurns: 2,
               child: Icon(Icons.expand_circle_down_outlined),
+            ),
+            contentPadding: const EdgeInsetsDirectional.only(
+              start: SMALL_SPACE * 2,
+              end: SMALL_SPACE,
             ),
           ),
         );

--- a/packages/smooth_app/lib/pages/product/product_image_viewer.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_viewer.dart
@@ -154,13 +154,14 @@ class _ProductImageViewerState extends State<ProductImageViewer>
                         width: 3,
                       ),
                     ),
-                    child: Padding(
-                      padding: const EdgeInsets.all(SMALL_SPACE),
-                      child: LanguageSelector(
-                        setLanguage: widget.setLanguage,
-                        displayedLanguage: widget.language,
-                        selectedLanguages: selectedLanguages,
-                        foregroundColor: Colors.white,
+                    child: LanguageSelector(
+                      setLanguage: widget.setLanguage,
+                      displayedLanguage: widget.language,
+                      selectedLanguages: selectedLanguages,
+                      foregroundColor: Colors.white,
+                      padding: const EdgeInsetsDirectional.symmetric(
+                        horizontal: 13.0,
+                        vertical: SMALL_SPACE,
                       ),
                     ),
                   ),

--- a/packages/smooth_app/lib/pages/product/simple_input_page.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page.dart
@@ -1,4 +1,3 @@
-import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
@@ -94,9 +93,10 @@ class _SimpleInputPageState extends State<SimpleInputPage> {
           fixKeyboard: true,
           appBar: SmoothAppBar(
             centerTitle: false,
-            title: AutoSizeText(
+            title: Text(
               getProductName(widget.product, appLocalizations),
               maxLines: widget.product.barcode?.isNotEmpty == true ? 1 : 2,
+              overflow: TextOverflow.ellipsis,
             ),
             subTitle: widget.product.barcode != null
                 ? ExcludeSemantics(

--- a/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
@@ -20,6 +20,7 @@ class SimpleInputTextField extends StatefulWidget {
     this.minLengthForSuggestions = 1,
     this.categories,
     this.shapeProvider,
+    this.padding,
   });
 
   final FocusNode focusNode;
@@ -32,6 +33,7 @@ class SimpleInputTextField extends StatefulWidget {
   final int minLengthForSuggestions;
   final String? categories;
   final String? Function()? shapeProvider;
+  final EdgeInsetsGeometry? padding;
 
   @override
   State<SimpleInputTextField> createState() => _SimpleInputTextFieldState();
@@ -100,7 +102,8 @@ class _SimpleInputTextFieldState extends State<SimpleInputTextField> {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsetsDirectional.only(start: LARGE_SPACE),
+      padding: widget.padding ??
+          const EdgeInsetsDirectional.only(start: LARGE_SPACE),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         crossAxisAlignment: CrossAxisAlignment.center,

--- a/packages/smooth_app/lib/pages/product/simple_input_widget.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_widget.dart
@@ -72,34 +72,41 @@ class _SimpleInputWidgetState extends State<SimpleInputWidget> {
         if (explanations != null) ExplanationWidget(explanations),
         LayoutBuilder(
           builder: (_, BoxConstraints constraints) {
-            return Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: <Widget>[
-                Flexible(
-                  flex: 1,
-                  child: SimpleInputTextField(
-                    autocompleteKey: _autocompleteKey,
-                    focusNode: _focusNode,
-                    constraints: constraints,
-                    tagType: widget.helper.getTagType(),
-                    hintText: widget.helper.getAddHint(appLocalizations),
-                    controller: widget.controller,
+            return Padding(
+              padding: const EdgeInsetsDirectional.symmetric(
+                horizontal: VERY_SMALL_SPACE,
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: <Widget>[
+                  Flexible(
+                    flex: 1,
+                    child: SimpleInputTextField(
+                      autocompleteKey: _autocompleteKey,
+                      focusNode: _focusNode,
+                      constraints: constraints,
+                      tagType: widget.helper.getTagType(),
+                      hintText: widget.helper.getAddHint(appLocalizations),
+                      controller: widget.controller,
+                      padding: const EdgeInsetsDirectional.only(
+                        start: 4.5,
+                      ),
+                    ),
                   ),
-                ),
-                Tooltip(
-                  message: appLocalizations.edit_product_form_item_add_action(
-                      widget.helper.getTypeLabel(appLocalizations)),
-                  child: IconButton(
-                    onPressed: _onAddItem,
-                    icon: const Icon(Icons.add_circle),
-                  ),
-                )
-              ],
+                  Tooltip(
+                    message: appLocalizations.edit_product_form_item_add_action(
+                        widget.helper.getTypeLabel(appLocalizations)),
+                    child: IconButton(
+                      onPressed: _onAddItem,
+                      icon: const Icon(Icons.add_circle),
+                    ),
+                  )
+                ],
+              ),
             );
           },
         ),
-        Divider(color: themeData.colorScheme.onBackground),
         AnimatedList(
           key: _listKey,
           initialItemCount: _localTerms.length,

--- a/packages/smooth_app/lib/pages/product/simple_input_widget.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_widget.dart
@@ -72,38 +72,34 @@ class _SimpleInputWidgetState extends State<SimpleInputWidget> {
         if (explanations != null) ExplanationWidget(explanations),
         LayoutBuilder(
           builder: (_, BoxConstraints constraints) {
-            return Padding(
-              padding: const EdgeInsetsDirectional.symmetric(
-                horizontal: VERY_SMALL_SPACE,
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: <Widget>[
-                  Flexible(
-                    flex: 1,
-                    child: SimpleInputTextField(
-                      autocompleteKey: _autocompleteKey,
-                      focusNode: _focusNode,
-                      constraints: constraints,
-                      tagType: widget.helper.getTagType(),
-                      hintText: widget.helper.getAddHint(appLocalizations),
-                      controller: widget.controller,
-                      padding: const EdgeInsetsDirectional.only(
-                        start: 4.5,
-                      ),
+            return Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: <Widget>[
+                Flexible(
+                  flex: 1,
+                  child: SimpleInputTextField(
+                    autocompleteKey: _autocompleteKey,
+                    focusNode: _focusNode,
+                    constraints: constraints,
+                    tagType: widget.helper.getTagType(),
+                    hintText: widget.helper.getAddHint(appLocalizations),
+                    controller: widget.controller,
+                    padding: const EdgeInsetsDirectional.only(
+                      start: 9.0,
                     ),
                   ),
-                  Tooltip(
-                    message: appLocalizations.edit_product_form_item_add_action(
-                        widget.helper.getTypeLabel(appLocalizations)),
-                    child: IconButton(
-                      onPressed: _onAddItem,
-                      icon: const Icon(Icons.add_circle),
-                    ),
-                  )
-                ],
-              ),
+                ),
+                Tooltip(
+                  message: appLocalizations.edit_product_form_item_add_action(
+                      widget.helper.getTypeLabel(appLocalizations)),
+                  child: IconButton(
+                    onPressed: _onAddItem,
+                    icon: const Icon(Icons.add_circle),
+                    splashRadius: 20,
+                  ),
+                )
+              ],
             );
           },
         ),
@@ -130,10 +126,7 @@ class _SimpleInputWidgetState extends State<SimpleInputWidget> {
                       customBorder: const CircleBorder(),
                       onTap: () => _onRemoveItem(term, child),
                       child: const Padding(
-                        padding: EdgeInsets.symmetric(
-                          horizontal: MEDIUM_SPACE,
-                          vertical: SMALL_SPACE,
-                        ),
+                        padding: EdgeInsets.all(SMALL_SPACE),
                         child: Icon(Icons.delete),
                       ),
                     ),

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -78,7 +78,7 @@ packages:
     source: hosted
     version: "7.0.0"
   async:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: async
       sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"


### PR DESCRIPTION
Hi everyone,

I think you know me now, small details aren't that small and I've "pixel-perfected" some screens:

- Photo cropper/viewer: the Edit button is centered on the left
<img width="135" alt="Screenshot 2023-08-05 at 20 45 04" src="https://github.com/openfoodfacts/smooth-app/assets/246838/bd1bf0da-b0b4-47f3-ad0f-419655d263e8">

- Photo cropper/viewer: the `InkWell` takes the full height/width within the border
<img width="480" alt="Screenshot 2023-08-05 at 22 26 02" src="https://github.com/openfoodfacts/smooth-app/assets/246838/410546bc-4984-47e6-8046-ff5bca228614">

- Bottom bar buttons (the change will also affect Dialogs): the "negative" action has the same height as the positive one
<img width="586" alt="Screenshot 2023-08-05 at 22 24 32" src="https://github.com/openfoodfacts/smooth-app/assets/246838/dc444d20-0aad-48cf-92dd-d752b1312cdd">

- Cards to edit values: everything is perfectly aligned (on both sides) + I've removed the Divider (but if you don't like, I can revert this part)
<img width="1176" alt="Screenshot 2023-08-05 at 22 28 19" src="https://github.com/openfoodfacts/smooth-app/assets/246838/ec6f426f-098c-42d6-9046-fdef37b5961e">

This is brought to you by the only user that will notice the changes 🤪
