### PR TITLE
fix: Revamp of the about screen #4412

### DIFF
--- a/packages/smooth_app/lib/pages/preferences/user_preferences_faq.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_faq.dart
@@ -100,81 +100,43 @@ class UserPreferencesFaq extends AbstractUserPreferences {
   Future<void> _about() async {
     final PackageInfo packageInfo = await PackageInfo.fromPlatform();
     // ignore: use_build_context_synchronously
-    showDialog<void>(
+    showModalBottomSheet<void>(
       context: context,
       builder: (BuildContext context) {
         final String logo = Theme.of(context).brightness == Brightness.light
             ? _iconLightAssetPath
             : _iconDarkAssetPath;
-
-        return SmoothAlertDialog(
-          body: Column(
+        return FractionallySizedBox(
+          heightFactor: 0.6,
+          child: Column(
             children: <Widget>[
-              Row(
-                children: <Widget>[
-                  SvgPicture.asset(
-                    logo,
-                    width: MediaQuery.of(context).size.width * 0.1,
-                    package: AppHelper.APP_PACKAGE,
-                  ),
-                  const SizedBox(width: SMALL_SPACE),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: <Widget>[
-                        FittedBox(
-                          child: Text(
-                            packageInfo.appName,
-                            style: themeData.textTheme.displayLarge,
-                          ),
-                        ),
-                        Text(
-                          '${packageInfo.version}+${packageInfo.buildNumber}-${GlobalVars.scannerLabel.name}-${GlobalVars.storeLabel.name}',
-                          style: themeData.textTheme.titleSmall,
-                        )
-                      ],
-                    ),
-                  ),
-                ],
-              ),
-              Divider(color: themeData.colorScheme.onSurface),
-              const SizedBox(height: VERY_LARGE_SPACE),
-              SingleChildScrollView(
-                child: Column(
+              Padding(
+                padding: const EdgeInsetsDirectional.only(
+                  top: MEDIUM_SPACE,
+                  end: LARGE_SPACE,
+                  start: LARGE_SPACE,
+                ),
+                child: Row(
                   children: <Widget>[
-                    Text(appLocalizations.whatIsOff),
-                    const SizedBox(height: LARGE_SPACE),
-                    IntrinsicHeight(
-                      child: Row(
-                        crossAxisAlignment: CrossAxisAlignment.stretch,
-                        mainAxisAlignment: MainAxisAlignment.center,
+                    SvgPicture.asset(
+                      logo,
+                      width: MINIMUM_TOUCH_SIZE,
+                      package: AppHelper.APP_PACKAGE,
+                    ),
+                    const SizedBox(width: SMALL_SPACE),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
                         children: <Widget>[
-                          Expanded(
-                            child: TextButton(
-                              onPressed: () => LaunchUrlHelper.launchURL(
-                                  'https://openfoodfacts.org/who-we-are', true),
-                              child: Text(
-                                appLocalizations.learnMore,
-                                textAlign: TextAlign.center,
-                                style: const TextStyle(
-                                  color: Colors.blue,
-                                ),
-                              ),
+                          FittedBox(
+                            child: Text(
+                              packageInfo.appName,
+                              style: themeData.textTheme.displayLarge,
                             ),
                           ),
-                          Expanded(
-                            child: TextButton(
-                              onPressed: () => LaunchUrlHelper.launchURL(
-                                  'https://openfoodfacts.org/terms-of-use',
-                                  true),
-                              child: Text(
-                                appLocalizations.termsOfUse,
-                                textAlign: TextAlign.center,
-                                style: const TextStyle(
-                                  color: Colors.blue,
-                                ),
-                              ),
-                            ),
+                          Text(
+                            '${packageInfo.version}+${packageInfo.buildNumber}-${GlobalVars.scannerLabel.name}-${GlobalVars.storeLabel.name}',
+                            style: themeData.textTheme.titleSmall,
                           )
                         ],
                       ),
@@ -182,27 +144,76 @@ class UserPreferencesFaq extends AbstractUserPreferences {
                   ],
                 ),
               ),
+              Divider(color: themeData.colorScheme.onBackground),
+              Column(
+                children: <Widget>[
+                  Padding(
+                    padding: const EdgeInsetsDirectional.only(
+                      top: VERY_SMALL_SPACE,
+                      end: LARGE_SPACE,
+                      start: LARGE_SPACE,
+                    ),
+                    child: Text(appLocalizations.whatIsOff),
+                  ),
+                  IntrinsicHeight(
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: <Widget>[
+                        Expanded(
+                          child: TextButton(
+                            onPressed: () => LaunchUrlHelper.launchURL(
+                                'https://openfoodfacts.org/who-we-are', true),
+                            child: Text(
+                              appLocalizations.learnMore,
+                              textAlign: TextAlign.center,
+                              style: const TextStyle(
+                                color: Colors.blue,
+                              ),
+                            ),
+                          ),
+                        ),
+                        Expanded(
+                          child: TextButton(
+                            onPressed: () => LaunchUrlHelper.launchURL(
+                                'https://openfoodfacts.org/terms-of-use', true),
+                            child: Text(
+                              appLocalizations.termsOfUse,
+                              textAlign: TextAlign.center,
+                              style: const TextStyle(
+                                color: Colors.blue,
+                              ),
+                            ),
+                          ),
+                        )
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: MEDIUM_SPACE),
+                  TextButton(
+                    onPressed: () async {
+                      Navigator.of(context).pop();
+                      showLicensePage(
+                        context: context,
+                        applicationName: packageInfo.appName,
+                        applicationVersion: packageInfo.version,
+                        applicationIcon: SvgPicture.asset(
+                          logo,
+                          height: MediaQuery.of(context).size.height * 0.1,
+                        ),
+                      );
+                    },
+                    child: Text(
+                      appLocalizations.licenses,
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(
+                        color: Colors.blue,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
             ],
-          ),
-          positiveAction: SmoothActionButton(
-            onPressed: () => Navigator.of(context, rootNavigator: true).pop(),
-            text: appLocalizations.okay,
-          ),
-          negativeAction: SmoothActionButton(
-            onPressed: () async {
-              Navigator.of(context).pop();
-
-              showLicensePage(
-                context: context,
-                applicationName: packageInfo.appName,
-                applicationVersion: packageInfo.version,
-                applicationIcon: SvgPicture.asset(
-                  logo,
-                  height: MediaQuery.of(context).size.height * 0.1,
-                ),
-              );
-            },
-            text: appLocalizations.licenses,
           ),
         );
       },

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_faq.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_faq.dart
@@ -1,10 +1,8 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:package_info_plus/package_info_plus.dart';
-import 'package:smooth_app/data_models/preferences/user_preferences.dart';
+import 'package:smooth_app/data_models/user_preferences.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/helpers/app_helper.dart';
@@ -14,7 +12,6 @@ import 'package:smooth_app/helpers/user_feedback_helper.dart';
 import 'package:smooth_app/pages/preferences/abstract_user_preferences.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_list_tile.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_page.dart';
-import 'package:smooth_app/query/product_query.dart';
 
 /// Display of "FAQ" for the preferences page.
 class UserPreferencesFaq extends AbstractUserPreferences {
@@ -50,104 +47,31 @@ class UserPreferencesFaq extends AbstractUserPreferences {
   @override
   Color? getHeaderColor() => const Color(0xFFDFF7E8);
 
-  bool get _isDark => Theme.of(context).brightness == Brightness.dark;
-
   @override
   List<Widget> getBody() => <Widget>[
         _getListTile(
           title: appLocalizations.faq,
-          leadingIconData: Icons.question_mark,
+          leading: Icons.question_mark,
           url: 'https://support.openfoodfacts.org/help',
-        ),
-        _getNutriListTile(
-          title: appLocalizations.nutriscore_generic,
-          url: 'https://world.openfoodfacts.org/nutriscore',
-          svg: 'assets/cache/nutriscore-b.svg',
-        ),
-        _getNutriListTile(
-          title: appLocalizations.ecoscore_generic,
-          url: 'https://world.openfoodfacts.org/ecoscore',
-          svg: 'assets/cache/ecoscore-b.svg',
-        ),
-        _getNutriListTile(
-          title: appLocalizations.nova_group_generic,
-          url: 'https://world.openfoodfacts.org/nova',
-          svg: 'assets/cache/nova-group-4.svg',
-        ),
-        _getNutriListTile(
-          title: appLocalizations.nutrition_facts,
-          url: 'https://world.openfoodfacts.org/traffic-lights',
-          svg: 'assets/cache/low.svg',
-          leadingSvgWidth: 1.5 * DEFAULT_ICON_SIZE,
         ),
         _getListTile(
           title: appLocalizations.discover,
-          leadingIconData: Icons.travel_explore,
-          url: ProductQuery.replaceSubdomain(
-            'https://world.openfoodfacts.org/discover',
-          ),
+          leading: Icons.travel_explore,
+          url: 'https://world.openfoodfacts.org/discover',
         ),
         _getListTile(
           title: appLocalizations.how_to_contribute,
-          leadingIconData: Icons.volunteer_activism,
-          url: ProductQuery.replaceSubdomain(
-            'https://world.openfoodfacts.org/contribute',
-          ),
+          leading: Icons.volunteer_activism,
+          url: 'https://world.openfoodfacts.org/contribute',
         ),
         _getListTile(
           title: appLocalizations.feed_back,
-          leadingIconData: Icons.add_comment,
+          leading: Icons.feedback_sharp,
           url: UserFeedbackHelper.getFeedbackFormLink(),
         ),
         _getListTile(
-          title: appLocalizations.faq_title_partners,
-          leadingIconData: Icons.handshake_outlined,
-          url: ProductQuery.replaceSubdomain(
-            'https://world.openfoodfacts.org/partners',
-          ),
-        ),
-        _getListTile(
-          title: appLocalizations.faq_title_vision,
-          leadingIconData: Icons.remove_red_eye_outlined,
-          url: ProductQuery.replaceSubdomain(
-            'https://world.openfoodfacts.org/open-food-facts-vision-mission-values-and-programs',
-          ),
-        ),
-        if (Platform.isAndroid || Platform.isIOS)
-          _getListTile(
-            title: appLocalizations.faq_title_install_beauty,
-            // for the record those svg files were edited, because svg flutter
-            // does not support the styles
-            // eg. <style>.b{fill:#008c8c;}.c{fill:#fff;}</style> is not taken into account
-            // and the initial rect creates a background we don't need
-            leadingSvg: _isDark
-                ? 'assets/app/RVB_ICON_BLACK_BG_OBF.svg'
-                : 'assets/app/RVB_ICON_WHITE_BG_OBF.svg',
-            url: Platform.isAndroid
-                ? 'https://play.google.com/store/apps/details?id=org.openbeautyfacts.scanner&hl=${ProductQuery.getLanguage().offTag}'
-                : 'https://apps.apple.com/${ProductQuery.getLanguage().offTag}/app/open-beauty-facts/id1122926380',
-          ),
-        if (Platform.isAndroid)
-          _getListTile(
-            title: appLocalizations.faq_title_install_pet,
-            leadingSvg: _isDark
-                ? 'assets/app/RVB_ICON_BLACK_BG_OPFF.svg'
-                : 'assets/app/RVB_ICON_WHITE_BG_OPFF.svg',
-            url:
-                'https://play.google.com/store/apps/details?id=org.openpetfoodfacts.scanner&hl=${ProductQuery.getLanguage().offTag}',
-          ),
-        if (Platform.isAndroid)
-          _getListTile(
-            title: appLocalizations.faq_title_install_product,
-            leadingSvg: _isDark
-                ? 'assets/app/RVB_ICON_BLACK_BG_OPF.svg'
-                : 'assets/app/RVB_ICON_WHITE_BG_OPF.svg',
-            url:
-                'https://play.google.com/store/apps/details?id=org.openpetfoodfacts.scanner&hl=${ProductQuery.getLanguage().offTag}',
-          ),
-        _getListTile(
           title: appLocalizations.about_this_app,
-          leadingIconData: Icons.info,
+          leading: Icons.info,
           onTap: () async => _about(),
           icon: getForwardIcon(),
         ),
@@ -155,9 +79,7 @@ class UserPreferencesFaq extends AbstractUserPreferences {
 
   Widget _getListTile({
     required final String title,
-    final IconData? leadingIconData,
-    final String? leadingSvg,
-    final double? leadingSvgWidth,
+    required final IconData leading,
     final String? url,
     final VoidCallback? onTap,
     final Icon? icon,
@@ -167,36 +89,7 @@ class UserPreferencesFaq extends AbstractUserPreferences {
         onTap: onTap ?? () async => LaunchUrlHelper.launchURL(url!, false),
         trailing: icon ??
             UserPreferencesListTile.getTintedIcon(Icons.open_in_new, context),
-        leading: SizedBox(
-          width: 2 * DEFAULT_ICON_SIZE,
-          height: 2 * DEFAULT_ICON_SIZE,
-          child: Center(
-            child: leadingIconData != null
-                ? UserPreferencesListTile.getTintedIcon(
-                    leadingIconData, context)
-                : leadingSvg == null
-                    ? null
-                    : SvgPicture.asset(
-                        leadingSvg,
-                        width: leadingSvgWidth ?? 2 * DEFAULT_ICON_SIZE,
-                        package: AppHelper.APP_PACKAGE,
-                      ),
-          ),
-        ),
-        externalLink: url != null,
-      );
-
-  Widget _getNutriListTile({
-    required final String title,
-    required final String url,
-    required final String svg,
-    final double? leadingSvgWidth,
-  }) =>
-      _getListTile(
-        title: title,
-        leadingSvg: svg,
-        leadingSvgWidth: leadingSvgWidth,
-        url: ProductQuery.replaceSubdomain(url),
+        leading: UserPreferencesListTile.getTintedIcon(leading, context),
       );
 
   static const String _iconLightAssetPath =
@@ -207,102 +100,120 @@ class UserPreferencesFaq extends AbstractUserPreferences {
   Future<void> _about() async {
     final PackageInfo packageInfo = await PackageInfo.fromPlatform();
     // ignore: use_build_context_synchronously
-    showDialog<void>(
+    showModalBottomSheet<void>(
       context: context,
       builder: (BuildContext context) {
         final String logo = Theme.of(context).brightness == Brightness.light
             ? _iconLightAssetPath
             : _iconDarkAssetPath;
-
-        return SmoothAlertDialog(
-          body: Column(
+        return FractionallySizedBox(
+          heightFactor: 0.6,
+          child: Column(
             children: <Widget>[
-              Row(
+              Padding(
+                padding: const EdgeInsetsDirectional.only(
+                  top: MEDIUM_SPACE,
+                  end: LARGE_SPACE,
+                  start: LARGE_SPACE,
+                ),
+                child: Row(
+                  children: <Widget>[
+                    SvgPicture.asset(
+                      logo,
+                      width: MINIMUM_TOUCH_SIZE,
+                      package: AppHelper.APP_PACKAGE,
+                    ),
+                    const SizedBox(width: SMALL_SPACE),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: <Widget>[
+                          FittedBox(
+                            child: Text(
+                              packageInfo.appName,
+                              style: themeData.textTheme.displayLarge,
+                            ),
+                          ),
+                          Text(
+                            '${packageInfo.version}+${packageInfo.buildNumber}-${GlobalVars.scannerLabel.name}-${GlobalVars.storeLabel.name}',
+                            style: themeData.textTheme.titleSmall,
+                          )
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Divider(color: themeData.colorScheme.onBackground),
+              Column(
                 children: <Widget>[
-                  SvgPicture.asset(
-                    logo,
-                    width: MediaQuery.of(context).size.width * 0.1,
-                    package: AppHelper.APP_PACKAGE,
+                  Padding(
+                    padding: const EdgeInsetsDirectional.only(
+                      top: VERY_SMALL_SPACE,
+                      end: LARGE_SPACE,
+                      start: LARGE_SPACE,
+                    ),
+                    child: Text(appLocalizations.whatIsOff),
                   ),
-                  const SizedBox(width: SMALL_SPACE),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
+                  IntrinsicHeight(
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      mainAxisAlignment: MainAxisAlignment.center,
                       children: <Widget>[
-                        FittedBox(
-                          child: Text(
-                            packageInfo.appName,
-                            style: themeData.textTheme.displayLarge,
+                        Expanded(
+                          child: TextButton(
+                            onPressed: () => LaunchUrlHelper.launchURL(
+                                'https://openfoodfacts.org/who-we-are', true),
+                            child: Text(
+                              appLocalizations.learnMore,
+                              textAlign: TextAlign.center,
+                              style: const TextStyle(
+                                color: Colors.blue,
+                              ),
+                            ),
                           ),
                         ),
-                        Text(
-                          '${packageInfo.version}+${packageInfo.buildNumber}-${GlobalVars.scannerLabel.name}-${GlobalVars.storeLabel.name}',
-                          style: themeData.textTheme.titleSmall,
+                        Expanded(
+                          child: TextButton(
+                            onPressed: () => LaunchUrlHelper.launchURL(
+                                'https://openfoodfacts.org/terms-of-use', true),
+                            child: Text(
+                              appLocalizations.termsOfUse,
+                              textAlign: TextAlign.center,
+                              style: const TextStyle(
+                                color: Colors.blue,
+                              ),
+                            ),
+                          ),
                         )
                       ],
                     ),
                   ),
+                  const SizedBox(height: MEDIUM_SPACE),
+                  TextButton(
+                    onPressed: () async {
+                      Navigator.of(context).pop();
+                      showLicensePage(
+                        context: context,
+                        applicationName: packageInfo.appName,
+                        applicationVersion: packageInfo.version,
+                        applicationIcon: SvgPicture.asset(
+                          logo,
+                          height: MediaQuery.of(context).size.height * 0.1,
+                        ),
+                      );
+                    },
+                    child: Text(
+                      appLocalizations.licenses,
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(
+                        color: Colors.blue,
+                      ),
+                    ),
+                  ),
                 ],
               ),
-              const SizedBox(height: VERY_LARGE_SPACE),
-              SingleChildScrollView(
-                child: IconTheme(
-                  data: const IconThemeData(size: 16.0),
-                  child: Column(
-                    children: <Widget>[
-                      FractionallySizedBox(
-                        widthFactor: 0.9,
-                        child: Text(appLocalizations.whatIsOff),
-                      ),
-                      const SizedBox(height: VERY_SMALL_SPACE),
-                      SmoothAlertContentButton(
-                        onPressed: () => LaunchUrlHelper.launchURL(
-                            'https://openfoodfacts.org/who-we-are', true),
-                        label: appLocalizations.learnMore,
-                        icon: Icons.open_in_new,
-                      ),
-                      const SizedBox(height: VERY_SMALL_SPACE),
-                      SmoothAlertContentButton(
-                        onPressed: () => LaunchUrlHelper.launchURL(
-                          'https://openfoodfacts.org/terms-of-use',
-                          true,
-                        ),
-                        label: appLocalizations.termsOfUse,
-                        icon: Icons.open_in_new,
-                      ),
-                      const SizedBox(height: VERY_SMALL_SPACE),
-                      SmoothAlertContentButton(
-                        onPressed: () => LaunchUrlHelper.launchURL(
-                          'https://openfoodfacts.org/legal',
-                          true,
-                        ),
-                        label: appLocalizations.legalNotices,
-                        icon: Icons.open_in_new,
-                      ),
-                      const SizedBox(height: VERY_SMALL_SPACE),
-                      SmoothAlertContentButton(
-                        onPressed: () => showLicensePage(
-                          context: context,
-                          applicationName: packageInfo.appName,
-                          applicationVersion: packageInfo.version,
-                          applicationIcon: SvgPicture.asset(
-                            logo,
-                            height: MediaQuery.of(context).size.height * 0.1,
-                          ),
-                        ),
-                        label: appLocalizations.licenses,
-                        icon: Icons.info,
-                      ),
-                      const SizedBox(height: SMALL_SPACE),
-                    ],
-                  ),
-                ),
-              ),
             ],
-          ),
-          negativeAction: SmoothActionButton(
-            onPressed: () => Navigator.of(context, rootNavigator: true).pop(),
-            text: appLocalizations.close,
           ),
         );
       },

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_faq.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_faq.dart
@@ -12,6 +12,7 @@ import 'package:smooth_app/helpers/user_feedback_helper.dart';
 import 'package:smooth_app/pages/preferences/abstract_user_preferences.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_list_tile.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_page.dart';
+import 'package:smooth_app/themes/constant_icons.dart';
 
 /// Display of "FAQ" for the preferences page.
 class UserPreferencesFaq extends AbstractUserPreferences {
@@ -91,7 +92,20 @@ class UserPreferencesFaq extends AbstractUserPreferences {
             UserPreferencesListTile.getTintedIcon(Icons.open_in_new, context),
         leading: UserPreferencesListTile.getTintedIcon(leading, context),
       );
-
+  Widget _getAboutListTile({
+    required final String title,
+    final IconData? trailing,
+    final String? url,
+    final VoidCallback? onTap,
+  }) =>
+      UserPreferencesListTile(
+        title: Text(title),
+        onTap: onTap ?? () async => LaunchUrlHelper.launchURL(url!, false),
+        trailing: trailing != null
+            ? Icon(trailing) // Use the Icon widget directly with the IconData.
+            : null,
+      );
+  ConstantIcons constantIcons = ConstantIcons.instance;
   static const String _iconLightAssetPath =
       'assets/app/release_icon_light_transparent_no_border.svg';
   static const String _iconDarkAssetPath =
@@ -100,48 +114,39 @@ class UserPreferencesFaq extends AbstractUserPreferences {
   Future<void> _about() async {
     final PackageInfo packageInfo = await PackageInfo.fromPlatform();
     // ignore: use_build_context_synchronously
-    showModalBottomSheet<void>(
+    showDialog<void>(
       context: context,
       builder: (BuildContext context) {
         final String logo = Theme.of(context).brightness == Brightness.light
             ? _iconLightAssetPath
             : _iconDarkAssetPath;
-        return FractionallySizedBox(
-          heightFactor: 0.6,
-          child: Column(
+
+        return SmoothAlertDialog(
+          body: Column(
             children: <Widget>[
               Padding(
-                padding: const EdgeInsetsDirectional.only(
-                  top: MEDIUM_SPACE,
-                  end: LARGE_SPACE,
-                  start: LARGE_SPACE,
-                ),
-                child: Row(
-                  children: <Widget>[
-                    SvgPicture.asset(
-                      logo,
-                      width: MINIMUM_TOUCH_SIZE,
-                      package: AppHelper.APP_PACKAGE,
-                    ),
-                    const SizedBox(width: SMALL_SPACE),
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: <Widget>[
-                          FittedBox(
-                            child: Text(
-                              packageInfo.appName,
-                              style: themeData.textTheme.displayLarge,
-                            ),
-                          ),
-                          Text(
-                            '${packageInfo.version}+${packageInfo.buildNumber}-${GlobalVars.scannerLabel.name}-${GlobalVars.storeLabel.name}',
-                            style: themeData.textTheme.titleSmall,
-                          )
-                        ],
+                padding: const EdgeInsetsDirectional.all(MEDIUM_SPACE),
+                child: ListTile(
+                  leading: SvgPicture.asset(
+                    logo,
+                    width: MINIMUM_TOUCH_SIZE,
+                    package: AppHelper.APP_PACKAGE,
+                  ),
+                  title: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      FittedBox(
+                        child: Text(
+                          packageInfo.appName,
+                          style: themeData.textTheme.displayLarge,
+                        ),
                       ),
-                    ),
-                  ],
+                      Text(
+                        '${packageInfo.version}+${packageInfo.buildNumber}-${GlobalVars.scannerLabel.name}-${GlobalVars.storeLabel.name}',
+                        style: themeData.textTheme.titleSmall,
+                      )
+                    ],
+                  ),
                 ),
               ),
               Divider(color: themeData.colorScheme.onBackground),
@@ -155,43 +160,26 @@ class UserPreferencesFaq extends AbstractUserPreferences {
                     ),
                     child: Text(appLocalizations.whatIsOff),
                   ),
-                  IntrinsicHeight(
-                    child: Row(
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: <Widget>[
-                        Expanded(
-                          child: TextButton(
-                            onPressed: () => LaunchUrlHelper.launchURL(
-                                'https://openfoodfacts.org/who-we-are', true),
-                            child: Text(
-                              appLocalizations.learnMore,
-                              textAlign: TextAlign.center,
-                              style: const TextStyle(
-                                color: Colors.blue,
-                              ),
-                            ),
-                          ),
-                        ),
-                        Expanded(
-                          child: TextButton(
-                            onPressed: () => LaunchUrlHelper.launchURL(
-                                'https://openfoodfacts.org/terms-of-use', true),
-                            child: Text(
-                              appLocalizations.termsOfUse,
-                              textAlign: TextAlign.center,
-                              style: const TextStyle(
-                                color: Colors.blue,
-                              ),
-                            ),
-                          ),
-                        )
-                      ],
+                  _getAboutListTile(
+                    title: appLocalizations.learnMore,
+                    trailing: constantIcons.getForwardIcon(),
+                    onTap: () => LaunchUrlHelper.launchURL(
+                      'https://openfoodfacts.org/who-we-are',
+                      true,
                     ),
                   ),
-                  const SizedBox(height: MEDIUM_SPACE),
-                  TextButton(
-                    onPressed: () async {
+                  _getAboutListTile(
+                    title: appLocalizations.termsOfUse,
+                    trailing: constantIcons.getForwardIcon(),
+                    onTap: () => LaunchUrlHelper.launchURL(
+                      'https://openfoodfacts.org/terms-of-use',
+                      false,
+                    ),
+                  ),
+                  _getAboutListTile(
+                    title: appLocalizations.licenses,
+                    trailing: Icons.info,
+                    onTap: () async {
                       Navigator.of(context).pop();
                       showLicensePage(
                         context: context,
@@ -203,17 +191,14 @@ class UserPreferencesFaq extends AbstractUserPreferences {
                         ),
                       );
                     },
-                    child: Text(
-                      appLocalizations.licenses,
-                      textAlign: TextAlign.center,
-                      style: const TextStyle(
-                        color: Colors.blue,
-                      ),
-                    ),
                   ),
                 ],
               ),
             ],
+          ),
+          negativeAction: SmoothActionButton(
+            onPressed: () => Navigator.of(context, rootNavigator: true).pop(),
+            text: appLocalizations.close,
           ),
         );
       },

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_faq.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_faq.dart
@@ -97,14 +97,19 @@ class UserPreferencesFaq extends AbstractUserPreferences {
     final IconData? trailing,
     final String? url,
     final VoidCallback? onTap,
-  }) =>
-      UserPreferencesListTile(
-        title: Text(title),
-        onTap: onTap ?? () async => LaunchUrlHelper.launchURL(url!, false),
-        trailing: trailing != null
-            ? Icon(trailing) // Use the Icon widget directly with the IconData.
-            : null,
-      );
+  }) {
+    final IconData trailingIcon = trailing ?? Icons.open_in_new;
+
+    return UserPreferencesListTile(
+      title: Text(title),
+      onTap: onTap ??
+          (url != null
+              ? () async => LaunchUrlHelper.launchURL(url, false)
+              : null),
+      trailing: Icon(trailingIcon),
+    );
+  }
+
   ConstantIcons constantIcons = ConstantIcons.instance;
   static const String _iconLightAssetPath =
       'assets/app/release_icon_light_transparent_no_border.svg';
@@ -162,7 +167,6 @@ class UserPreferencesFaq extends AbstractUserPreferences {
                   ),
                   _getAboutListTile(
                     title: appLocalizations.learnMore,
-                    trailing: constantIcons.getForwardIcon(),
                     onTap: () => LaunchUrlHelper.launchURL(
                       'https://openfoodfacts.org/who-we-are',
                       true,
@@ -170,7 +174,6 @@ class UserPreferencesFaq extends AbstractUserPreferences {
                   ),
                   _getAboutListTile(
                     title: appLocalizations.termsOfUse,
-                    trailing: constantIcons.getForwardIcon(),
                     onTap: () => LaunchUrlHelper.launchURL(
                       'https://openfoodfacts.org/terms-of-use',
                       false,


### PR DESCRIPTION
### What 
fix: Revamp of the about screen #4412
<!-- 
Please name your pull request following this scheme: `type: What you did` this allows us to automatically generate the changelog
Following `type`s are allowed: 
  - `feat`, for Features
  - `fix`, for Bug Fixes
  - `docs`, for Documentation
  - `ci`, for Automation
  - `refactor`, for code Refactoring
  - `chore`, for Miscellaneous things
-->
### Screenshot
<!-- Insert a screenshot to provide visual record of your changes, if visible -->
## From:
![Screenshot](https://user-images.githubusercontent.com/1689815/257140057-3e90b0f5-8ae6-494e-bf09-52e43443bd28.png)
## To:
![Screenshot 2](https://raw.githubusercontent.com/ADILAYOUB/100_flutter_challange/f52a534218295189823fba7b6f8c4f42c69b9174/screenshot/smooth_app.PNG)
### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes: <!-- #1 Note: you can also use Closes: -->
- Replaced showDialog with showModalBottomSheet to display the content in a bottom sheet instead of a dialog box.
- Wrapped the content in a FractionallySizedBox to make the top part of the bottom sheet circular.
- Removed the positiveAction and negativeAction buttons and replaced them with TextButton widgets for the "Learn More" and "Terms of Use" options.
- Added a "Licenses" TextButton to allow users to view licenses for the application.
The bottom sheet now displays the application name, version, build number, and other relevant details using PackageInfo from the platform.
Added a divider between the header section and the content section for better visual separation.
### Part of 
- #525 <!-- Add the most granular issue possible -->
