### PR TITLE
chore: Use the latest version of mobile_scanner

### DIFF
--- a/packages/scanner/ml_kit/pubspec.yaml
+++ b/packages/scanner/ml_kit/pubspec.yaml
@@ -13,10 +13,7 @@ dependencies:
   visibility_detector: 0.4.0+2
   async: 2.11.0
 
-  mobile_scanner:
-    git:
-      url: https://github.com/openfoodfacts/mobile_scanner.git
-      ref: 5aa2c11915467b19dfc5fd3a9e59641d2958ffeb
+  mobile_scanner: 3.4.0
   scanner_shared:
     path: ../shared
 


### PR DESCRIPTION
Hi everyone,

Good news! My PR to fix #4413 is merged in `mobile_scanner` + a 3.4.0 version is released.
That's why we can re-use the package from Pub.dev

Will also fix #4284 