### PR TITLE
feat: Support non-english languages for Signup errors

### DIFF
--- a/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
@@ -373,7 +373,23 @@ class _SignUpPageState extends State<SignUpPage> with TraceableClientMixin {
           _userFocusNode.requestFocus();
           errorMessage = appLocalisations.sign_up_page_user_name_already_used;
         } else {
-          errorMessage = status.error;
+          // Let's try to find the error in
+          final Iterable<RegExpMatch> allMatches =
+              RegExp('(<li class=\"error\">)(.*?)(</li>)')
+                  .allMatches(status.error!);
+          if (allMatches.isNotEmpty) {
+            final StringBuffer buffer = StringBuffer();
+            for (final RegExpMatch match in allMatches) {
+              if (buffer.isNotEmpty) {
+                buffer.write('\n\n');
+              }
+
+              buffer.write(match.group(2));
+            }
+            errorMessage = buffer.toString();
+          } else {
+            errorMessage = status.error;
+          }
         }
       }
 

--- a/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
@@ -375,7 +375,7 @@ class _SignUpPageState extends State<SignUpPage> with TraceableClientMixin {
         } else {
           // Let's try to find the error in
           final Iterable<RegExpMatch> allMatches =
-              RegExp('(<li class=\"error\">)(.*?)(</li>)')
+              RegExp('(<li class="error">)(.*?)(</li>)')
                   .allMatches(status.error!);
           if (allMatches.isNotEmpty) {
             final StringBuffer buffer = StringBuffer();


### PR DESCRIPTION
Hi everyone,

The Dart package parses the content of the webpage to find errors during the signup.
However the different messages are translated, hence a partially working feature.

So instead of showing that kind of error:
![Screenshot_1691411774](https://github.com/openfoodfacts/smooth-app/assets/246838/96666e67-306c-468e-a8a1-79532e9fb0fd)

It will now show:
![Screenshot_1691412088](https://github.com/openfoodfacts/smooth-app/assets/246838/898d3a6d-6739-4903-9fc3-4ce44d1e1aed)

That's could be better, but for the upcoming release, it will be OK.