### PR TITLE
fix: On the product page: ensure to refresh the screen if the product is added/removed from a list

### DIFF
--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -266,7 +266,7 @@ class _ProductPageState extends State<ProductPage>
       context,
       <String>{widget.product.barcode!},
     );
-    if (refreshed != null && refreshed) {
+    if (refreshed == true) {
       setState(() {});
     }
   }


### PR DESCRIPTION
Hi everyone,

This is not a major bug, but when we add/remove a product to a list, from the product page, nothing happens.
Basically, events were not dispatched correctly.

New behavior: 
[Lists.webm](https://github.com/openfoodfacts/smooth-app/assets/246838/9ce09218-b7b1-4cbf-bd96-19b2ebc49a22)
