### PR TITLE
ci: Bump flutter_secure_storage to the latest version available

### DIFF
--- a/packages/data_importer/pubspec.yaml
+++ b/packages/data_importer/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
 
   sqflite: ^2.0.2+1
 
-  flutter_secure_storage: ^5.0.2
+  flutter_secure_storage: 8.0.0
   path: ^1.8.0
 
 dev_dependencies:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   flutter_map: 2.2.0
   flutter_widget_from_html_core: 0.8.3+1
   fwfh_selectable_text: 0.8.3+1
-  flutter_secure_storage: 5.1.2
+  flutter_secure_storage: 8.0.0
   hive: 2.2.3
   hive_flutter: 1.1.0
   http: 0.13.5


### PR DESCRIPTION
Hi everyone,

I'm not sure it will fix #3484, but let's try to bump the `flutter_secure_storage` dependency to the latest version available.