### PR TITLE
fix: Ensure that we can change tabs between the users lists and the scanner

### DIFF
--- a/packages/smooth_app/lib/pages/carousel_manager.dart
+++ b/packages/smooth_app/lib/pages/carousel_manager.dart
@@ -34,6 +34,10 @@ class ExternalCarouselManager extends StatefulWidget {
 class ExternalCarouselManagerState extends State<ExternalCarouselManager> {
   final CarouselController _controller = CarouselController();
 
+  /// A hidden attribute to force to return to the Scanner tab
+  /// This value should only be accessed via [forceShowScannerTab], as it will
+  /// consume this value (= turn it to false) when it is read.
+  bool _forceShowScannerTab = false;
   String? currentBarcode;
 
   @override
@@ -44,12 +48,23 @@ class ExternalCarouselManagerState extends State<ExternalCarouselManager> {
     );
   }
 
-  void showSearchCard({bool notify = false}) {
+  void showSearchCard({
+    bool notify = false,
+  }) {
     animatePageTo(0);
 
     if (notify) {
       SmoothHapticFeedback.lightNotification();
     }
+
+    setState(() => _forceShowScannerTab = true);
+  }
+
+  /// Get the info and consume it immediately
+  bool get forceShowScannerTab {
+    final bool value = _forceShowScannerTab;
+    _forceShowScannerTab = false;
+    return value;
   }
 
   // With an animation
@@ -61,7 +76,7 @@ class ExternalCarouselManagerState extends State<ExternalCarouselManager> {
   CarouselController get controller => _controller;
 
   bool updateShouldNotify(ExternalCarouselManagerState oldState) {
-    return oldState.currentBarcode != currentBarcode;
+    return oldState.currentBarcode != currentBarcode || _forceShowScannerTab;
   }
 }
 

--- a/packages/smooth_app/lib/pages/page_manager.dart
+++ b/packages/smooth_app/lib/pages/page_manager.dart
@@ -61,6 +61,13 @@ class PageManagerState extends State<PageManager> {
   @override
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final ExternalCarouselManagerState carouselManager =
+        ExternalCarouselManager.watch(context);
+
+    if (carouselManager.forceShowScannerTab) {
+      _currentPage = BottomNavigationTab.Scan;
+    }
+
     final List<Widget> tabs = <Widget>[
       _buildOffstageNavigator(BottomNavigationTab.Profile),
       _buildOffstageNavigator(BottomNavigationTab.Scan),
@@ -73,8 +80,6 @@ class PageManagerState extends State<PageManager> {
         true;
     final BottomNavigationBar bar = BottomNavigationBar(
       onTap: (int index) {
-        final ExternalCarouselManagerState carouselManager =
-            ExternalCarouselManager.read(context);
         if (_currentPage == BottomNavigationTab.Scan &&
             _pageKeys[index] == BottomNavigationTab.Scan) {
           carouselManager.showSearchCard();


### PR DESCRIPTION
Hi everyone,

We noticed that the "Start scan" button in the lists do nothing.
This PR should fix this.

[Scan.webm](https://github.com/openfoodfacts/smooth-app/assets/246838/f415e8d7-f9fa-48fe-bb51-bba3aba1160e)
