### PR TITLE
fix: 4466 - icons for list page popup items

### DIFF
--- a/packages/smooth_app/lib/pages/product/common/product_list_popup_items.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_popup_items.dart
@@ -44,7 +44,10 @@ abstract class ProductListPopupItem {
   ) =>
       PopupMenuItem<ProductListPopupItem>(
         value: this,
-        child: Text(getTitle(appLocalizations)),
+        child: ListTile(
+          leading: Icon(getIconData()),
+          title: Text(getTitle(appLocalizations)),
+        ),
       );
 }
 


### PR DESCRIPTION
### What
- Now the popup items have a similar display.
- More specifically, icons have been added to menu popup items.

### Screenshot
| before | after (light) | after (dark) |
| -- | -- | -- |
| ![Screenshot_2023-08-12-18-42-19](https://github.com/openfoodfacts/smooth-app/assets/11576431/d2d82767-2367-4a18-8f5f-b393d252fa81) | ![Screenshot_2023-08-12-18-43-41](https://github.com/openfoodfacts/smooth-app/assets/11576431/913b08cb-23ff-41d9-92a7-dd0d2000c774) | ![Screenshot_2023-08-12-18-44-08](https://github.com/openfoodfacts/smooth-app/assets/11576431/3186c1a4-af07-4245-8f9e-01d642e07a6d) |

### Fixes bug(s)
- Fixes: #4466