### PR TITLE
chore: Revert to a custom fork of mobile_scanner

### DIFF
--- a/packages/scanner/ml_kit/pubspec.yaml
+++ b/packages/scanner/ml_kit/pubspec.yaml
@@ -13,7 +13,10 @@ dependencies:
   visibility_detector: 0.4.0+2
   async: 2.11.0
 
-  mobile_scanner: 3.4.0
+  mobile_scanner:
+    git:
+      url: https://github.com/openfoodfacts/mobile_scanner.git
+      ref: custom_release
   scanner_shared:
     path: ../shared
 


### PR DESCRIPTION
Hi everyone,

We are forced to revert to the custom fork of `mobile_scanner` as there is a MAJOR issue on iOS.
Basically, it's the latest version of the lib minus the faulty commit

https://github.com/openfoodfacts/mobile_scanner/commits/custom_release