### PR TITLE
feat: Pass the language/country to the method to reset the password

### DIFF
--- a/packages/smooth_app/lib/pages/user_management/forgot_password_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/forgot_password_page.dart
@@ -5,6 +5,7 @@ import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_text_form_field.dart';
+import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
@@ -33,7 +34,11 @@ class _ForgotPasswordPageState extends State<ForgotPasswordPage>
 
     Status? status;
     try {
-      status = await OpenFoodAPIClient.resetPassword(_userIdController.text);
+      status = await OpenFoodAPIClient.resetPassword(
+        _userIdController.text,
+        country: ProductQuery.getCountry(),
+        language: ProductQuery.getLanguage(),
+      );
     } catch (e) {
       status = null;
     }

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -1010,10 +1010,10 @@ packages:
     dependency: "direct main"
     description:
       name: openfoodfacts
-      sha256: "4c3e095a20bca11006c957ec37d83fda1178dc03bde0254d4cc29d0eb09ebb3b"
+      sha256: "25d4906abb23c8f2667f3b97e5c787b7d3e02082456da7a82fad38518c04489a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.8.0"
+    version: "2.10.0"
   openfoodfacts_flutter_lints:
     dependency: "direct dev"
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -98,7 +98,7 @@ dependencies:
 
 
 
-  openfoodfacts: 2.9.0
+  openfoodfacts: 2.10.0
   # openfoodfacts:
   #   path: ../../../openfoodfacts-dart
 


### PR DESCRIPTION
Hi everyone,

As described in #4503, the email to reset the password is always in English.
Thanks to a new version of the Dart library, we can now pass the language/country and have a localized email.