### PR TITLE
feat: Add legal notices + fix Terms of use

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -315,6 +315,10 @@
     "support_via_email_include_logs_dialog_body": "Do you wish to include application logs in attachment to your email?",
     "termsOfUse": "Terms of use",
     "@termsOfUse": {},
+    "legalNotices": "Legal notices",
+    "@legalNotices": {
+        "description": "A link to open the legal notices on the website"
+    },
     "about_this_app": "About this app",
     "@about_this_app": {
         "description": "Button label: Opens a pop up window which shows information about the app"

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_faq.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_faq.dart
@@ -153,21 +153,32 @@ class UserPreferencesFaq extends AbstractUserPreferences {
                         widthFactor: 0.9,
                         child: Text(appLocalizations.whatIsOff),
                       ),
-                      const SizedBox(height: LARGE_SPACE),
+                      const SizedBox(height: VERY_SMALL_SPACE),
                       SmoothAlertContentButton(
                         onPressed: () => LaunchUrlHelper.launchURL(
                             'https://openfoodfacts.org/who-we-are', true),
                         label: appLocalizations.learnMore,
                         icon: Icons.open_in_new,
                       ),
-                      const SizedBox(height: SMALL_SPACE),
+                      const SizedBox(height: VERY_SMALL_SPACE),
                       SmoothAlertContentButton(
                         onPressed: () => LaunchUrlHelper.launchURL(
-                            'https://openfoodfacts.org/terms-of-', true),
+                          'https://openfoodfacts.org/terms-of-use',
+                          true,
+                        ),
                         label: appLocalizations.termsOfUse,
                         icon: Icons.open_in_new,
                       ),
-                      const SizedBox(height: SMALL_SPACE),
+                      const SizedBox(height: VERY_SMALL_SPACE),
+                      SmoothAlertContentButton(
+                        onPressed: () => LaunchUrlHelper.launchURL(
+                          'https://openfoodfacts.org/legal',
+                          true,
+                        ),
+                        label: appLocalizations.legalNotices,
+                        icon: Icons.open_in_new,
+                      ),
+                      const SizedBox(height: VERY_SMALL_SPACE),
                       SmoothAlertContentButton(
                         onPressed: () => showLicensePage(
                           context: context,


### PR DESCRIPTION
Hi everyone,

In the about the app dialog:
- The link to the terms of use is fixed
- A link to the legal notices is added

[Legal.webm](https://github.com/openfoodfacts/smooth-app/assets/246838/5dfe5c94-04e9-4fc8-b735-5c89cbbd815c)
