### PR TITLE
fix: 4549 - correct detection of errors for resetPassword

### DIFF
--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -1067,10 +1067,10 @@ packages:
     dependency: "direct main"
     description:
       name: openfoodfacts
-      sha256: "25d4906abb23c8f2667f3b97e5c787b7d3e02082456da7a82fad38518c04489a"
+      sha256: fa136e570e5751286882d4e62bcbfe1173df75f98c12dc7247eb89c7aeba8fa5
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.10.1"
   openfoodfacts_flutter_lints:
     dependency: "direct dev"
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -100,7 +100,7 @@ dependencies:
     path: ../scanner/zxing
 
 
-  openfoodfacts: 2.10.0
+  openfoodfacts: 2.10.1
   # openfoodfacts:
   #   path: ../../../openfoodfacts-dart
 


### PR DESCRIPTION
### What
- Upgrade to the latest version of off-dart.
- In this version, the `resetPassword` method detects errors regardless of the localization.
- This fixes completely #4549.

### Fixes bug(s)
- Fixes: #4549

### Impacted files
* `pubspec.lock`: wtf
* `pubspec.yaml`: upgraded the off-dart version