### PR TITLE
ci: Remove FLUTTER_CACHE_KEY as it's not used anymore

### DIFF
--- a/.github/workflows/android-release-to-org-openfoodfacts-scanner.yml
+++ b/.github/workflows/android-release-to-org-openfoodfacts-scanner.yml
@@ -6,9 +6,6 @@ on:
       VERSION_NAME:
         required: true
         type: string
-      FLUTTER-CACHE-KEY:
-        required: true
-        type: string
       VERSION_CODE:
         required: true
         type: string

--- a/.github/workflows/ios-release-to-org-openfoodfacts-scanner.yml
+++ b/.github/workflows/ios-release-to-org-openfoodfacts-scanner.yml
@@ -3,9 +3,6 @@ name: App Store release to org.openfoodfacts.scanner
 on:
   workflow_call:
     inputs:
-      FLUTTER-CACHE-KEY:
-        required: true
-        type: string
       VERSION_NAME:
         required: true
         type: string

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -107,7 +107,6 @@ jobs:
     with:
       VERSION_NAME: ${{ needs.create-release.outputs.VERSION_NAME}}
       VERSION_CODE: ${{ needs.create-release.outputs.VERSION_CODE}}
-      FLUTTER-CACHE-KEY: '3.3.x'
       RELEASE_TYPE: 'PLAY'
       BUILD_TYPE: 'appbundle'
       FLAVOR: 'main_google_play'
@@ -131,7 +130,6 @@ jobs:
     with:
       VERSION_NAME: ${{ needs.create-release.outputs.VERSION_NAME}}
       VERSION_CODE: ${{ needs.create-release.outputs.VERSION_CODE}}
-      FLUTTER-CACHE-KEY: '3.3.x'
     secrets:
       SENTRY_AUTH_TOKEN: ${{secrets.SENTRY_AUTH_TOKEN }}
       FASTLANE_USER: ${{secrets.FASTLANE_USER }}
@@ -155,7 +153,6 @@ jobs:
     with:
       VERSION_NAME: ${{ needs.create-release.outputs.VERSION_NAME}}
       VERSION_CODE: ${{ needs.create-release.outputs.VERSION_CODE}}
-      FLUTTER-CACHE-KEY: '3.3.x'
       RELEASE_TYPE: 'GITHUB'
       BUILD_TYPE: 'apk'
       TAG_NAME: ${{ needs.release-please.outputs.tag_name}}
@@ -180,7 +177,6 @@ jobs:
     with:
       VERSION_NAME: ${{ needs.create-release.outputs.VERSION_NAME}}
       VERSION_CODE: ${{ needs.create-release.outputs.VERSION_CODE}}
-      FLUTTER-CACHE-KEY: '3.3.x'
       RELEASE_TYPE: 'GITHUB'
       BUILD_TYPE: 'apk'
       TAG_NAME: ${{ needs.release-please.outputs.tag_name}}


### PR DESCRIPTION
Hi everyone,

Previously we used a `FLUTTER_CACHE_KEY` variable in our GitHub Actions, but this is not the case, since we rely on `flutter-version.txt`