### PR TITLE
fix: When questions are answered, check if new ones are available

### DIFF
--- a/packages/smooth_app/lib/pages/product/product_questions_widget.dart
+++ b/packages/smooth_app/lib/pages/product/product_questions_widget.dart
@@ -83,10 +83,10 @@ class _ProductQuestionsWidgetState extends State<ProductQuestionsWidget>
     };
   }
 
-  void _openQuestions() {
+  Future<void> _openQuestions() async {
     _trackEvent(AnalyticsEvent.questionClicked);
 
-    openQuestionPage(
+    await openQuestionPage(
       context,
       product: widget.product,
       questions: (_state as _ProductQuestionsWithQuestions).questions.toList(
@@ -94,10 +94,19 @@ class _ProductQuestionsWidgetState extends State<ProductQuestionsWidget>
           ),
       updateProductUponAnswers: _updateProductUponAnswers,
     );
+
+    if (context.mounted) {
+      return _reloadQuestions(silentCheck: true);
+    }
   }
 
-  Future<void> _reloadQuestions() async {
-    setState(() => _state = const _ProductQuestionsLoading());
+  Future<void> _reloadQuestions({
+    bool silentCheck = false,
+  }) async {
+    if (!silentCheck) {
+      setState(() => _state = const _ProductQuestionsLoading());
+    }
+
     final List<RobotoffQuestion>? list = await _loadProductQuestions();
 
     if (!mounted) {


### PR DESCRIPTION
Hi everyone,

- When questions are answered in the app (from the banner or the bottom button), we now check if new questions are available.
- It should fix #4556 

### Part of
