### PR TITLE
feat: Deep link support for "cgi/product.pl?type=edit&code=XXXX"

### DIFF
--- a/packages/smooth_app/lib/pages/product/product_loader_page.dart
+++ b/packages/smooth_app/lib/pages/product/product_loader_page.dart
@@ -15,11 +15,13 @@ import 'package:smooth_app/pages/product/common/product_refresher.dart';
 class ProductLoaderPage extends StatefulWidget {
   const ProductLoaderPage({
     required this.barcode,
+    required this.mode,
     Key? key,
   })  : assert(barcode != ''),
         super(key: key);
 
   final String barcode;
+  final ProductLoaderMode mode;
 
   @override
   State<ProductLoaderPage> createState() => _ProductLoaderPageState();
@@ -51,13 +53,22 @@ class _ProductLoaderPageState extends State<ProductLoaderPage> {
 
     if (mounted) {
       if (fetchedProduct.product != null) {
-        navigator.pushReplacement(
-          AppRoutes.PRODUCT(
-            widget.barcode,
-            heroTag: 'product_${widget.barcode}',
-          ),
-          extra: fetchedProduct.product,
-        );
+        if (widget.mode == ProductLoaderMode.viewProduct) {
+          navigator.pushReplacement(
+            AppRoutes.PRODUCT(
+              widget.barcode,
+              heroTag: 'product_${widget.barcode}',
+            ),
+            extra: fetchedProduct.product,
+          );
+        } else if (widget.mode == ProductLoaderMode.editProduct) {
+          navigator.pushReplacement(
+            AppRoutes.PRODUCT_EDITOR(
+              widget.barcode,
+            ),
+            extra: fetchedProduct.product,
+          );
+        }
         return;
       }
       if (fetchedProduct.status == FetchedProductStatus.internetNotFound) {
@@ -200,4 +211,9 @@ enum _ProductLoaderState {
   loading,
   productNotFound,
   serverError;
+}
+
+enum ProductLoaderMode {
+  viewProduct,
+  editProduct,
 }


### PR DESCRIPTION
Hi everyone,

Here is the implementation to support product edition.
For that, it's required to have both a `code` and a `type=edit` with the `cgi/product.pl` route.


https://github.com/openfoodfacts/smooth-app/assets/246838/3c266a90-d5cd-4a60-a282-9f3ca5c3d8f6

