### PR TITLE
feat: 4551 - minor cosmetic changes on settings display

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -362,7 +362,7 @@
     "@contribute_translate_text": {},
     "contribute_translate_text_2": "Translations is one of the key tasks of the project",
     "@contribute_translate_text_2": {},
-    "contribute_join_skill_pool": "Join the skill pool!",
+    "contribute_join_skill_pool": "Contribute your skills to Open Food Facts. Join the skill pool!",
     "contribute_share_header": "Share Open Food Facts with your friends",
     "@contribute_share_header": {},
     "contribute_share_content": "I wanted to let you know about the app I've been using, Open Food Facts, which allows you to get the health and environmental impacts of your food, in a personalized way. It works by scanning the barcodes on the packaging. Finally it's free, does not require registration, and you can even help increase the number of products decyphered. Here's the link to get it for your phone: https://openfoodfacts.app",

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -362,6 +362,7 @@
     "@contribute_translate_text": {},
     "contribute_translate_text_2": "Translations is one of the key tasks of the project",
     "@contribute_translate_text_2": {},
+    "contribute_join_skill_pool": "Join the skill pool!",
     "contribute_share_header": "Share Open Food Facts with your friends",
     "@contribute_share_header": {},
     "contribute_share_content": "I wanted to let you know about the app I've been using, Open Food Facts, which allows you to get the health and environmental impacts of your food, in a personalized way. It works by scanning the barcodes on the packaging. Finally it's free, does not require registration, and you can even help increase the number of products decyphered. Here's the link to get it for your phone: https://openfoodfacts.app",

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_connect.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_connect.dart
@@ -83,6 +83,7 @@ class UserPreferencesConnect extends AbstractUserPreferences {
           url: 'https://blog.openfoodfacts.org',
           leadingIconData: Icons.newspaper,
         ),
+        const Divider(),
         _getListTile(
           title: appLocalizations.support_via_forum,
           url: 'https://forum.openfoodfacts.org/',
@@ -93,6 +94,7 @@ class UserPreferencesConnect extends AbstractUserPreferences {
           url: 'https://slack.openfoodfacts.org/',
           leadingIconData: Icons.chat,
         ),
+        const Divider(),
         _getListTile(
           title: appLocalizations.contact_title_pro_page,
           url: ProductQuery.replaceSubdomain(
@@ -102,7 +104,7 @@ class UserPreferencesConnect extends AbstractUserPreferences {
         ),
         _getListTile(
           title: appLocalizations.contact_title_pro_email,
-          leadingIconData: Icons.drafts_outlined,
+          leadingIconData: Icons.drafts,
           onTap: () async => _sendEmail(
             recipient:
                 ProductQuery.getLanguage() == OpenFoodFactsLanguage.FRENCH
@@ -110,6 +112,7 @@ class UserPreferencesConnect extends AbstractUserPreferences {
                     : 'producers@openfoodfacts.org',
           ),
         ),
+        const Divider(),
         _getListTile(
           title: appLocalizations.contact_title_press_page,
           url: ProductQuery.replaceSubdomain(
@@ -119,7 +122,7 @@ class UserPreferencesConnect extends AbstractUserPreferences {
         ),
         _getListTile(
           title: appLocalizations.contact_title_press_email,
-          leadingIconData: Icons.drafts_outlined,
+          leadingIconData: Icons.drafts,
           onTap: () async => _sendEmail(
             recipient:
                 ProductQuery.getLanguage() == OpenFoodFactsLanguage.FRENCH
@@ -127,10 +130,11 @@ class UserPreferencesConnect extends AbstractUserPreferences {
                     : 'press@openfoodfacts.org',
           ),
         ),
+        const Divider(),
         _getListTile(
           title: appLocalizations.contact_title_newsletter,
           url: 'https://link.openfoodfacts.org/newsletter-en',
-          leadingIconData: Icons.subscriptions_outlined,
+          leadingIconData: CupertinoIcons.news_solid,
         ),
         _getListTile(
           title: appLocalizations.support_via_email,

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_connect.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_connect.dart
@@ -118,7 +118,7 @@ class UserPreferencesConnect extends AbstractUserPreferences {
           url: ProductQuery.replaceSubdomain(
             'https://world.openfoodfacts.org/press',
           ),
-          leadingIconData: CupertinoIcons.news,
+          leadingIconData: CupertinoIcons.news_solid,
         ),
         _getListTile(
           title: appLocalizations.contact_title_press_email,

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_contribute.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_contribute.dart
@@ -18,6 +18,7 @@ import 'package:smooth_app/pages/preferences/user_preferences_page.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_widgets.dart';
 import 'package:smooth_app/pages/product/common/product_query_page_helper.dart';
 import 'package:smooth_app/query/paged_to_be_completed_product_query.dart';
+import 'package:smooth_app/query/product_query.dart';
 
 /// Display of "Contribute" for the preferences page.
 class UserPreferencesContribute extends AbstractUserPreferences {
@@ -58,39 +59,62 @@ class UserPreferencesContribute extends AbstractUserPreferences {
     return <Widget>[
       _getListTile(
         'Hunger Games',
-        () => _hungerGames(),
+        () async => _hungerGames(),
         Icons.games,
       ),
       _getListTile(
         appLocalizations.contribute_improve_header,
-        () => _contribute(),
+        () async => _contribute(),
         Icons.data_saver_on,
       ),
       _getListTile(
         appLocalizations.contribute_sw_development,
-        () => _develop(),
+        () async => _develop(),
         Icons.app_shortcut,
       ),
       _getListTile(
         appLocalizations.contribute_translate_header,
-        () => _translate(),
+        () async => _translate(),
         Icons.translate,
       ),
       _getListTile(
+        appLocalizations.how_to_contribute,
+        () async => LaunchUrlHelper.launchURL(
+          ProductQuery.replaceSubdomain(
+            'https://world.openfoodfacts.org/contribute',
+          ),
+          false,
+        ),
+        Icons.volunteer_activism_outlined,
+        externalLink: true,
+      ),
+      _getListTile(
+        appLocalizations.contribute_join_skill_pool,
+        () async => LaunchUrlHelper.launchURL(
+          'https://docs.google.com/forms/d/e/1FAIpQLSfGHAn5KxW7ko3_GlDfQpVGKpPAMHMbDvY2IjtxfJSXxKJQ2A/viewform?usp=sf_link',
+          false,
+        ),
+        Icons.group,
+        externalLink: true,
+      ),
+      _getListTile(
         appLocalizations.contribute_share_header,
-        () => _share(appLocalizations.contribute_share_content),
+        () async => _share(appLocalizations.contribute_share_content),
         Icons.adaptive.share,
       ),
       _getListTile(
         appLocalizations.contribute_donate_header,
-        () => _donate(),
+        () async => LaunchUrlHelper.launchURL(
+          AppLocalizations.of(context).donate_url,
+          false,
+        ),
         Icons.volunteer_activism,
         icon: UserPreferencesListTile.getTintedIcon(Icons.open_in_new, context),
         externalLink: true,
       ),
       _getListTile(
         appLocalizations.contributors_label,
-        () => _contributors(),
+        () async => _contributors(),
         Icons.emoji_people,
         description: appLocalizations.contributors_description,
       ),
@@ -221,11 +245,6 @@ class UserPreferencesContribute extends AbstractUserPreferences {
       );
 
   Future<void> _share(String content) async => Share.share(content);
-
-  Future<void> _donate() async => LaunchUrlHelper.launchURL(
-        AppLocalizations.of(context).donate_url,
-        false,
-      );
 
   Future<void> _contributors() => showDialog<void>(
         context: context,

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_faq.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_faq.dart
@@ -95,7 +95,7 @@ class UserPreferencesFaq extends AbstractUserPreferences {
         ),
         _getListTile(
           title: appLocalizations.feed_back,
-          leadingIconData: Icons.feedback_sharp,
+          leadingIconData: Icons.add_comment,
           url: UserFeedbackHelper.getFeedbackFormLink(),
         ),
         _getListTile(

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_faq.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_faq.dart
@@ -78,6 +78,7 @@ class UserPreferencesFaq extends AbstractUserPreferences {
           title: appLocalizations.nutrition_facts,
           url: 'https://world.openfoodfacts.org/traffic-lights',
           svg: 'assets/cache/low.svg',
+          leadingSvgWidth: 1.5 * DEFAULT_ICON_SIZE,
         ),
         _getListTile(
           title: appLocalizations.discover,
@@ -156,6 +157,7 @@ class UserPreferencesFaq extends AbstractUserPreferences {
     required final String title,
     final IconData? leadingIconData,
     final String? leadingSvg,
+    final double? leadingSvgWidth,
     final String? url,
     final VoidCallback? onTap,
     final Icon? icon,
@@ -176,7 +178,7 @@ class UserPreferencesFaq extends AbstractUserPreferences {
                     ? null
                     : SvgPicture.asset(
                         leadingSvg,
-                        width: 2 * DEFAULT_ICON_SIZE,
+                        width: leadingSvgWidth ?? 2 * DEFAULT_ICON_SIZE,
                         package: AppHelper.APP_PACKAGE,
                       ),
           ),
@@ -188,10 +190,12 @@ class UserPreferencesFaq extends AbstractUserPreferences {
     required final String title,
     required final String url,
     required final String svg,
+    final double? leadingSvgWidth,
   }) =>
       _getListTile(
         title: title,
         leadingSvg: svg,
+        leadingSvgWidth: leadingSvgWidth,
         url: ProductQuery.replaceSubdomain(url),
       );
 


### PR DESCRIPTION
### Impacted files
* `app_en.arb`: new "join the skill pool" label
* `user_preferences_connect.dart`: added dividers; changed the newsletter icon; same email icon everywhere
* `user_preferences_contribute.dart`: added "contribute" and a "join the pool" items; minor refactoring
* `user_preferences_faq.dart`: changed the "feedback" icon

### Screenshot
| faq (new feedback icon) | contribute (2 new items) |
| -- | -- |
| ![Screenshot_2023-08-22-12-48-47](https://github.com/openfoodfacts/smooth-app/assets/11576431/6d8df113-4953-4997-925c-62e189ba9ec5) | ![Screenshot_2023-08-22-12-47-20](https://github.com/openfoodfacts/smooth-app/assets/11576431/88e17d2a-8b00-4e9c-b5f0-0837a2ff83e4) |

| connect (top) | connect (bottom) |
| -- | -- |
| ![Screenshot_2023-08-22-12-49-19](https://github.com/openfoodfacts/smooth-app/assets/11576431/4db5dab1-87b6-465c-a5c0-29adef999f27) | ![Screenshot_2023-08-22-12-49-04](https://github.com/openfoodfacts/smooth-app/assets/11576431/6e516570-110b-4451-90b1-2ab7f60823f2) |

### Fixes bug(s)
- Fixes: #4551

### Part of 
- #4580