### PR TITLE
fix: 4595 - no fast track if nutriscore is not applicable

### DIFF
--- a/packages/smooth_app/lib/helpers/analytics_helper.dart
+++ b/packages/smooth_app/lib/helpers/analytics_helper.dart
@@ -65,6 +65,14 @@ enum AnalyticsEvent {
     tag: 'showed fast-track product edit card',
     category: AnalyticsCategory.productFastTrackEdit,
   ),
+  notShowFastTrackProductEditCardNutriscore(
+    tag: 'nutriscore not applicable - no fast-track product edit card',
+    category: AnalyticsCategory.productFastTrackEdit,
+  ),
+  notShowFastTrackProductEditCardEcoscore(
+    tag: 'ecoscore not applicable - no fast-track product edit card',
+    category: AnalyticsCategory.productFastTrackEdit,
+  ),
   categoriesFastTrackProductPage(
     tag: 'set categories on fast track product page',
     category: AnalyticsCategory.productFastTrackEdit,

--- a/packages/smooth_app/lib/pages/product/product_incomplete_card.dart
+++ b/packages/smooth_app/lib/pages/product/product_incomplete_card.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/pages/product/add_new_product_page.dart';
 import 'package:smooth_app/pages/product/product_field_editor.dart';
 import 'package:smooth_app/pages/product/simple_input_page_helpers.dart';
@@ -20,7 +21,22 @@ class ProductIncompleteCard extends StatelessWidget {
   final bool isLoggedInMandatory;
 
   static bool isProductIncomplete(final Product product) {
+    bool checkScores = true;
     if (_isNutriscoreNotApplicable(product)) {
+      AnalyticsHelper.trackEvent(
+        AnalyticsEvent.notShowFastTrackProductEditCardNutriscore,
+        barcode: product.barcode,
+      );
+      checkScores = false;
+    }
+    if (_isEcoscoreNotApplicable(product)) {
+      AnalyticsHelper.trackEvent(
+        AnalyticsEvent.notShowFastTrackProductEditCardEcoscore,
+        barcode: product.barcode,
+      );
+      checkScores = false;
+    }
+    if (!checkScores) {
       return false;
     }
     final List<ProductFieldEditor> editors = <ProductFieldEditor>[
@@ -37,22 +53,32 @@ class ProductIncompleteCard extends StatelessWidget {
     return false;
   }
 
-  static bool _isNutriscoreNotApplicable(final Product product) {
+  static bool _isNutriscoreNotApplicable(final Product product) =>
+      _isScoreNotApplicable(product, 'nutriscore');
+
+  static bool _isEcoscoreNotApplicable(final Product product) =>
+      _isScoreNotApplicable(product, 'ecoscore');
+
+  static bool _isScoreNotApplicable(final Product product, final String tag) =>
+      _getAttribute(product, tag)?.iconUrl ==
+      'https://static.openfoodfacts.org/images/attributes/$tag-not-applicable.svg';
+
+  // TODO(monsieurtanuki): move to off-dart (or find it there)
+  static Attribute? _getAttribute(final Product product, final String id) {
     if (product.attributeGroups == null) {
-      return false;
+      return null;
     }
     for (final AttributeGroup attributeGroup in product.attributeGroups!) {
       if (attributeGroup.attributes == null) {
         continue;
       }
       for (final Attribute attribute in attributeGroup.attributes!) {
-        if (attribute.id == 'nutriscore') {
-          return attribute.iconUrl ==
-              'https://static.openfoodfacts.org/images/attributes/nutriscore-not-applicable.svg';
+        if (attribute.id == id) {
+          return attribute;
         }
       }
     }
-    return false;
+    return null;
   }
 
   @override

--- a/packages/smooth_app/lib/pages/product/product_incomplete_card.dart
+++ b/packages/smooth_app/lib/pages/product/product_incomplete_card.dart
@@ -20,6 +20,9 @@ class ProductIncompleteCard extends StatelessWidget {
   final bool isLoggedInMandatory;
 
   static bool isProductIncomplete(final Product product) {
+    if (_isNutriscoreNotApplicable(product)) {
+      return false;
+    }
     final List<ProductFieldEditor> editors = <ProductFieldEditor>[
       ProductFieldSimpleEditor(SimpleInputPageCategoryHelper()),
       ProductFieldNutritionEditor(),
@@ -29,6 +32,24 @@ class ProductIncompleteCard extends StatelessWidget {
     for (final ProductFieldEditor editor in editors) {
       if (!editor.isPopulated(product)) {
         return true;
+      }
+    }
+    return false;
+  }
+
+  static bool _isNutriscoreNotApplicable(final Product product) {
+    if (product.attributeGroups == null) {
+      return false;
+    }
+    for (final AttributeGroup attributeGroup in product.attributeGroups!) {
+      if (attributeGroup.attributes == null) {
+        continue;
+      }
+      for (final Attribute attribute in attributeGroup.attributes!) {
+        if (attribute.id == 'nutriscore') {
+          return attribute.iconUrl ==
+              'https://static.openfoodfacts.org/images/attributes/nutriscore-not-applicable.svg';
+        }
       }
     }
     return false;


### PR DESCRIPTION
### What
- We used to consider a product as incomplete in some cases, and displayed a "fast track" button in order to complete it.
- But there are categories of products (e.g. alcool, coffee) that would always be considered as incomplete under those rules.
- I've just added a test about the current nutriscore (computed by the server): if it's "not applicable", then we don't consider the product as incomplete and we don't display the fast-track button.

### Screenshot
| before | after | 
| -- | -- |
| ![Screenshot_2023-08-25-09-45-57](https://github.com/openfoodfacts/smooth-app/assets/11576431/307e4a36-cb52-49c6-8426-e159d6c0c5ec) | ![Screenshot_2023-08-25-09-49-38](https://github.com/openfoodfacts/smooth-app/assets/11576431/bde25e2e-b9f2-4050-8956-4d11ef8f2a9b) |

### Part of 
- #4595
