### PR TITLE
fix: 4601 - more robust management of product pending changes

### DIFF
--- a/packages/smooth_app/lib/data_models/up_to_date_mixin.dart
+++ b/packages/smooth_app/lib/data_models/up_to_date_mixin.dart
@@ -15,25 +15,25 @@ import 'package:smooth_app/database/local_database.dart';
 /// * we track the barcodes currently "opened" by the app
 @optionalTypeArgs
 mixin UpToDateMixin<T extends StatefulWidget> on State<T> {
-  /// To be used in the `initState` method.
+  /// To be used in the `initState` method, just after `super.initState();`.
   void initUpToDate(
     final Product initialProduct,
     final LocalDatabase localDatabase,
   ) {
-    this.initialProduct = initialProduct;
+    _initialProduct = initialProduct;
     _localDatabase = localDatabase;
+    _refreshUpToDate();
     localDatabase.upToDate.showInterest(barcode);
   }
 
-  @protected
-  late final Product initialProduct;
+  late final Product _initialProduct;
 
   late final LocalDatabase _localDatabase;
 
   late Product _product;
 
   @protected
-  String get barcode => initialProduct.barcode!;
+  String get barcode => _initialProduct.barcode!;
 
   @protected
   Product get upToDateProduct => _product;
@@ -50,6 +50,9 @@ mixin UpToDateMixin<T extends StatefulWidget> on State<T> {
   /// `context.watch<LocalDatabase>()`.
   void refreshUpToDate() {
     BackgroundTaskManager.getInstance(_localDatabase).run(); // no await
-    _product = _localDatabase.upToDate.getLocalUpToDate(initialProduct);
+    _refreshUpToDate();
   }
+
+  void _refreshUpToDate() =>
+      _product = _localDatabase.upToDate.getLocalUpToDate(_initialProduct);
 }

--- a/packages/smooth_app/lib/pages/product/add_new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_new_product_page.dart
@@ -110,6 +110,8 @@ class _AddNewProductPageState extends State<AddNewProductPage>
   @override
   void initState() {
     super.initState();
+    final LocalDatabase localDatabase = context.read<LocalDatabase>();
+    initUpToDate(widget.product, localDatabase);
     _editors = <ProductFieldEditor>[
       _packagingEditor,
       _ingredientsEditor,
@@ -142,8 +144,6 @@ class _AddNewProductPageState extends State<AddNewProductPage>
             _otherCount > 0 || _helper.isOneMainImagePopulated(upToDateProduct),
       ),
     ];
-    final LocalDatabase localDatabase = context.read<LocalDatabase>();
-    initUpToDate(widget.product, localDatabase);
     _daoProductList = DaoProductList(localDatabase);
     AnalyticsHelper.trackEvent(
       widget.events[EditProductAction.openPage]!,

--- a/packages/smooth_app/lib/pages/product/edit_new_packagings.dart
+++ b/packages/smooth_app/lib/pages/product/edit_new_packagings.dart
@@ -75,10 +75,10 @@ class _EditNewPackagingsState extends State<EditNewPackagings>
     _unitNumberFormat = SimpleInputNumberField.getNumberFormat(
       decimal: false,
     );
-    if (initialProduct.packagings != null) {
-      initialProduct.packagings!.forEach(_addPackagingToControllers);
+    if (upToDateProduct.packagings != null) {
+      upToDateProduct.packagings!.forEach(_addPackagingToControllers);
     }
-    _packagingsComplete = initialProduct.packagingsComplete;
+    _packagingsComplete = upToDateProduct.packagingsComplete;
   }
 
   @override

--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -98,7 +98,7 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded>
     initUpToDate(widget.product, context.read<LocalDatabase>());
     _nutritionContainer = NutritionContainer(
       orderedNutrients: widget.orderedNutrients,
-      product: initialProduct,
+      product: upToDateProduct,
     );
 
     _decimalNumberFormat =

--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -92,7 +92,7 @@ class _SummaryCardState extends State<SummaryCard> with UpToDateMixin {
     super.initState();
     initUpToDate(widget._product, context.read<LocalDatabase>());
     _questionsLayout = getUserQuestionsLayout(context.read<UserPreferences>());
-    if (ProductIncompleteCard.isProductIncomplete(initialProduct)) {
+    if (ProductIncompleteCard.isProductIncomplete(upToDateProduct)) {
       AnalyticsHelper.trackEvent(
         AnalyticsEvent.showFastTrackProductEditCard,
         barcode: barcode,


### PR DESCRIPTION
### What
- When we manage the product pending changes, we have to manage both the database product and the local pending changes (to be applied on top in order to get the "up to date" version).
- Recently, we introduced code that relied on the "up to date" version of the product inside `initState`.
- The main point of the fix in this PR is to compute the "up to date" version asap (i.e. at the top of `initState`), so it can be used inside `initState` and not only after `build`.

### Screenshot
Case where we did not initialize or compute the "up to date" version asap but used it all the same. Fixed by this PR:
![Screenshot_2023-08-26-18-17-30](https://github.com/openfoodfacts/smooth-app/assets/11576431/4164e660-68da-43b4-9773-90c1ff77923e)

### Fixes bug(s)
- Fixes: #4601

### Impacted files
* `add_new_product_page.dart`: moves the call to `initUpToDate` on top
* `edit_new_packagings.dart`: uses `upToDateProduct` and not `initialProduct` anymore
* `nutrition_page_loaded.dart`: uses `upToDateProduct` and not `initialProduct` anymore
* `summary_card.dart`: uses `upToDateProduct` and not `initialProduct` anymore
* `up_to_date_mixin.dart`: computes the `upToDateProduct` asap; makes `initialProduct` private