### PR TITLE
fix: 4606 - translucent top status bar on on-boarding page 1

### DIFF
--- a/packages/smooth_app/lib/pages/onboarding/reinvention_page.dart
+++ b/packages/smooth_app/lib/pages/onboarding/reinvention_page.dart
@@ -30,10 +30,10 @@ class ReinventionPage extends StatelessWidget {
     final Size screenSize = MediaQuery.of(context).size;
     final double animHeight = 352.0 * screenSize.width / 375.0;
 
-    return SafeArea(
-      bottom: false,
-      child: Container(
-        color: backgroundColor,
+    return Container(
+      color: backgroundColor,
+      child: SafeArea(
+        bottom: false,
         child: Stack(
           children: <Widget>[
             Positioned(


### PR DESCRIPTION
### What
- In order to have a translucent top bar, the trick is to start with a colored `Container` AND THEN use a `SafeArea`.
- This way, the system will use the `Container` color with its own shade for the top status bar, and the body of the page will still use a `SafeArea`.
- @bishalbera Very strange that on your android you already had a translucent top bar. I had not. The solution is in the end not what I assumed, but it mimics what is coded in other similar pages.

### Screenshot
![Screenshot_2023-09-01-14-19-33](https://github.com/openfoodfacts/smooth-app/assets/11576431/cebc7c01-5024-4497-8ceb-fefd512e75a3)

### Fixes bug(s)
- Fixes: #4606

### Impacted file
* `reinvention_page.dart`: put the color (container) and THEN the SafeArea