### PR TITLE
feat: 4616 - no food preferences displayed in onboarding

### DIFF
--- a/packages/smooth_app/lib/pages/onboarding/preferences_page.dart
+++ b/packages/smooth_app/lib/pages/onboarding/preferences_page.dart
@@ -7,14 +7,12 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/onboarding_data_product.dart';
-import 'package:smooth_app/data_models/preferences/user_preferences.dart';
 import 'package:smooth_app/data_models/product_preferences.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/helpers/app_helper.dart';
 import 'package:smooth_app/pages/onboarding/next_button.dart';
 import 'package:smooth_app/pages/onboarding/onboarding_flow_navigator.dart';
-import 'package:smooth_app/pages/preferences/user_preferences_food.dart';
 import 'package:smooth_app/pages/product/summary_card.dart';
 
 class PreferencesPage extends StatefulWidget {
@@ -77,7 +75,6 @@ class _HelperState extends State<_Helper> {
   Widget build(BuildContext context) {
     final ProductPreferences productPreferences =
         context.watch<ProductPreferences>();
-    final UserPreferences userPreferences = context.watch<UserPreferences>();
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final List<Widget> pageData = <Widget>[
       SvgPicture.asset(
@@ -112,16 +109,6 @@ class _HelperState extends State<_Helper> {
         ),
       ),
     ];
-    pageData.addAll(
-      UserPreferencesFood(
-        productPreferences: productPreferences,
-        setState: setState,
-        context: context,
-        userPreferences: userPreferences,
-        appLocalizations: appLocalizations,
-        themeData: Theme.of(context),
-      ).getOnboardingContent(),
-    );
     return ColoredBox(
       color: widget.backgroundColor,
       child: SafeArea(

--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -92,7 +92,8 @@ class _SummaryCardState extends State<SummaryCard> with UpToDateMixin {
     super.initState();
     initUpToDate(widget._product, context.read<LocalDatabase>());
     _questionsLayout = getUserQuestionsLayout(context.read<UserPreferences>());
-    if (ProductIncompleteCard.isProductIncomplete(initialProduct)) {
+    if (widget.isProductEditable &&
+        ProductIncompleteCard.isProductIncomplete(initialProduct)) {
       AnalyticsHelper.trackEvent(
         AnalyticsEvent.showFastTrackProductEditCard,
         barcode: barcode,
@@ -356,7 +357,8 @@ class _SummaryCardState extends State<SummaryCard> with UpToDateMixin {
             });
           },
         ),
-        if (ProductIncompleteCard.isProductIncomplete(upToDateProduct))
+        if (widget.isProductEditable &&
+            ProductIncompleteCard.isProductIncomplete(upToDateProduct))
           ProductIncompleteCard(product: upToDateProduct),
         ..._getAttributes(scoreAttributes),
         if (widget.isFullVersion &&


### PR DESCRIPTION
### What
- Now we don't display the food preference page during the onboarding.

### Screenshot
| top | bottom |
| -- | -- |
| ![Screenshot_2023-09-03-08-54-23](https://github.com/openfoodfacts/smooth-app/assets/11576431/f2214e76-f55b-4f27-a387-a88f14d3fa53) | ![Screenshot_2023-09-03-08-54-28](https://github.com/openfoodfacts/smooth-app/assets/11576431/2f1f6225-ccd3-4c03-8ecb-35b0dfb35872) |

### Fixes bug(s)
- Closes: #4616

### Impacted files
* `preferences_page.dart`: no food preferences displayed in onboarding
* `summary_card.dart`: minor bug fix where the fast track button was displayed on the onboarding