### PR TITLE
fix: Added a close button to the tooltip in Onboarding

### DIFF
--- a/packages/smooth_app/lib/pages/onboarding/knowledge_panel_page_template.dart
+++ b/packages/smooth_app/lib/pages/onboarding/knowledge_panel_page_template.dart
@@ -150,8 +150,8 @@ class _KnowledgePanelPageTemplateState
 
   List<Widget> _buildHintPopup() {
     final Widget hintPopup = InkWell(
+      key: const Key('toolTipPopUp'),
       child: Card(
-        key: const Key('toolTipPopUp'),
         margin: const EdgeInsets.symmetric(horizontal: 30),
         color: Theme.of(context).hintColor.withOpacity(0.9),
         shape: const TooltipShapeBorder(arrowArc: 0.5),

--- a/packages/smooth_app/lib/pages/onboarding/knowledge_panel_page_template.dart
+++ b/packages/smooth_app/lib/pages/onboarding/knowledge_panel_page_template.dart
@@ -172,17 +172,9 @@ class _KnowledgePanelPageTemplateState
                 ),
               ),
               const SizedBox(width: VERY_LARGE_SPACE),
-              InkWell(
-                onTap: () {
-                  setState(() {
-                    _isHintDismissed = true;
-                  });
-                },
-                splashColor: Theme.of(context).splashColor,
-                child: const Icon(
-                  Icons.close,
-                  color: WHITE_COLOR,
-                ),
+              const Icon(
+                Icons.close,
+                color: WHITE_COLOR,
               ),
             ],
           ),

--- a/packages/smooth_app/lib/pages/onboarding/knowledge_panel_page_template.dart
+++ b/packages/smooth_app/lib/pages/onboarding/knowledge_panel_page_template.dart
@@ -149,44 +149,51 @@ class _KnowledgePanelPageTemplateState
       );
 
   List<Widget> _buildHintPopup() {
-    final Widget hintPopup = Card(
-      key: const Key('toolTipPopUp'),
-      margin: const EdgeInsets.symmetric(horizontal: 30),
-      color: Theme.of(context).hintColor.withOpacity(0.9),
-      shape: const TooltipShapeBorder(arrowArc: 0.5),
-      child: Container(
-        margin: const EdgeInsetsDirectional.only(
-          start: VERY_LARGE_SPACE,
-          top: 10,
-          end: 10,
-          bottom: 10,
-        ),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            Expanded(
-              child: Text(
-                appLocalizations.hint_knowledge_panel_message,
-                style: TextStyle(color: Theme.of(context).cardColor),
+    final Widget hintPopup = InkWell(
+      child: Card(
+        key: const Key('toolTipPopUp'),
+        margin: const EdgeInsets.symmetric(horizontal: 30),
+        color: Theme.of(context).hintColor.withOpacity(0.9),
+        shape: const TooltipShapeBorder(arrowArc: 0.5),
+        child: Container(
+          margin: const EdgeInsetsDirectional.only(
+            start: VERY_LARGE_SPACE,
+            top: 10,
+            end: 10,
+            bottom: 10,
+          ),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Expanded(
+                child: Text(
+                  appLocalizations.hint_knowledge_panel_message,
+                  style: TextStyle(color: Theme.of(context).cardColor),
+                ),
               ),
-            ),
-            const SizedBox(width: VERY_LARGE_SPACE),
-            InkWell(
-              onTap: () {
-                setState(() {
-                  _isHintDismissed = true;
-                });
-              },
-              splashColor: Theme.of(context).splashColor,
-              child: const Icon(
-                Icons.close,
-                color: WHITE_COLOR,
-                // size: LARGE_SPACE,
+              const SizedBox(width: VERY_LARGE_SPACE),
+              InkWell(
+                onTap: () {
+                  setState(() {
+                    _isHintDismissed = true;
+                  });
+                },
+                splashColor: Theme.of(context).splashColor,
+                child: const Icon(
+                  Icons.close,
+                  color: WHITE_COLOR,
+                  // size: LARGE_SPACE,
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
+      onTap: () {
+        setState(() {
+          _isHintDismissed = true;
+        });
+      },
     );
     final List<Widget> hitPopup = <Widget>[];
     if (!_isHintDismissed &&

--- a/packages/smooth_app/lib/pages/onboarding/knowledge_panel_page_template.dart
+++ b/packages/smooth_app/lib/pages/onboarding/knowledge_panel_page_template.dart
@@ -174,7 +174,7 @@ class _KnowledgePanelPageTemplateState
               const SizedBox(width: VERY_LARGE_SPACE),
               const Icon(
                 Icons.close,
-                color: WHITE_COLOR,
+                color: Theme.of(context).cardColor,
               ),
             ],
           ),

--- a/packages/smooth_app/lib/pages/onboarding/knowledge_panel_page_template.dart
+++ b/packages/smooth_app/lib/pages/onboarding/knowledge_panel_page_template.dart
@@ -172,7 +172,7 @@ class _KnowledgePanelPageTemplateState
                 ),
               ),
               const SizedBox(width: VERY_LARGE_SPACE),
-              const Icon(
+              Icon(
                 Icons.close,
                 color: Theme.of(context).cardColor,
               ),

--- a/packages/smooth_app/lib/pages/onboarding/knowledge_panel_page_template.dart
+++ b/packages/smooth_app/lib/pages/onboarding/knowledge_panel_page_template.dart
@@ -149,30 +149,44 @@ class _KnowledgePanelPageTemplateState
       );
 
   List<Widget> _buildHintPopup() {
-    final Widget hintPopup = InkWell(
+    final Widget hintPopup = Card(
       key: const Key('toolTipPopUp'),
-      child: Card(
-        margin: const EdgeInsets.symmetric(horizontal: 30),
-        color: Theme.of(context).hintColor.withOpacity(0.9),
-        shape: const TooltipShapeBorder(arrowArc: 0.5),
-        child: Container(
-          margin: const EdgeInsetsDirectional.only(
-            start: VERY_LARGE_SPACE,
-            top: 10,
-            end: VERY_LARGE_SPACE,
-            bottom: 10,
-          ),
-          child: Text(
-            appLocalizations.hint_knowledge_panel_message,
-            style: TextStyle(color: Theme.of(context).cardColor),
-          ),
+      margin: const EdgeInsets.symmetric(horizontal: 30),
+      color: Theme.of(context).hintColor.withOpacity(0.9),
+      shape: const TooltipShapeBorder(arrowArc: 0.5),
+      child: Container(
+        margin: const EdgeInsetsDirectional.only(
+          start: VERY_LARGE_SPACE,
+          top: 10,
+          end: 10,
+          bottom: 10,
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Expanded(
+              child: Text(
+                appLocalizations.hint_knowledge_panel_message,
+                style: TextStyle(color: Theme.of(context).cardColor),
+              ),
+            ),
+            const SizedBox(width: VERY_LARGE_SPACE),
+            InkWell(
+              onTap: () {
+                setState(() {
+                  _isHintDismissed = true;
+                });
+              },
+              splashColor: Theme.of(context).splashColor,
+              child: const Icon(
+                Icons.close,
+                color: WHITE_COLOR,
+                // size: LARGE_SPACE,
+              ),
+            ),
+          ],
         ),
       ),
-      onTap: () {
-        setState(() {
-          _isHintDismissed = true;
-        });
-      },
     );
     final List<Widget> hitPopup = <Widget>[];
     if (!_isHintDismissed &&

--- a/packages/smooth_app/lib/pages/onboarding/knowledge_panel_page_template.dart
+++ b/packages/smooth_app/lib/pages/onboarding/knowledge_panel_page_template.dart
@@ -182,7 +182,6 @@ class _KnowledgePanelPageTemplateState
                 child: const Icon(
                   Icons.close,
                   color: WHITE_COLOR,
-                  // size: LARGE_SPACE,
                 ),
               ),
             ],


### PR DESCRIPTION
### What

- A close button is added to the tooltip top-right corner in the onboarding flow.
- Now the user can tap on the close icon to close the tooltip instead of tapping on all of the tooltip.

### Screenshots
<table>
<tr>
<td>Before</td>
<td>After</td>
</tr>
<tr>
<td><img src="https://github.com/openfoodfacts/smooth-app/assets/59946442/4065e7b2-63cf-427a-96f5-62c43af7724f" width="300"/></td>
<td><img src="https://github.com/openfoodfacts/smooth-app/assets/59946442/64308113-970e-4061-b788-df05479c208d" width="300"/></td>
</tr>
</table>

### Fixes bug(s)
- Fixes: #4235 

### Part of 
- #4230
