### PR TITLE
feat: 4513 - user preferences pages simple refactoring

### DIFF
--- a/packages/smooth_app/lib/data_models/preferences/user_preferences.dart
+++ b/packages/smooth_app/lib/data_models/preferences/user_preferences.dart
@@ -314,8 +314,10 @@ class UserPreferences extends ChangeNotifier {
   String? getDevModeString(final String tag) =>
       _sharedPreferences.getString(tag);
 
-  Future<void> setActiveAttributeGroup(final String value) async =>
-      _sharedPreferences.setString(_TAG_ACTIVE_ATTRIBUTE_GROUP, value);
+  Future<void> setActiveAttributeGroup(final String value) async {
+    await _sharedPreferences.setString(_TAG_ACTIVE_ATTRIBUTE_GROUP, value);
+    notifyListeners();
+  }
 
   String get activeAttributeGroup =>
       _sharedPreferences.getString(_TAG_ACTIVE_ATTRIBUTE_GROUP) ??

--- a/packages/smooth_app/lib/pages/onboarding/preferences_page.dart
+++ b/packages/smooth_app/lib/pages/onboarding/preferences_page.dart
@@ -115,7 +115,6 @@ class _HelperState extends State<_Helper> {
     pageData.addAll(
       UserPreferencesFood(
         productPreferences: productPreferences,
-        setState: setState,
         context: context,
         userPreferences: userPreferences,
         appLocalizations: appLocalizations,

--- a/packages/smooth_app/lib/pages/preferences/abstract_user_preferences.dart
+++ b/packages/smooth_app/lib/pages/preferences/abstract_user_preferences.dart
@@ -8,15 +8,11 @@ import 'package:smooth_app/themes/constant_icons.dart';
 /// Abstraction of a display for the preference pages.
 abstract class AbstractUserPreferences {
   AbstractUserPreferences({
-    required this.setState,
     required this.context,
     required this.userPreferences,
     required this.appLocalizations,
     required this.themeData,
   });
-
-  /// Function that refreshes the page.
-  final Function(Function()) setState;
 
   final BuildContext context;
   final UserPreferences userPreferences;
@@ -24,7 +20,8 @@ abstract class AbstractUserPreferences {
   final ThemeData themeData;
 
   /// Returns the type of the corresponding page if relevant, or else null.
-  PreferencePageType? getPreferencePageType();
+  @protected
+  PreferencePageType getPreferencePageType();
 
   /// Title of the header, always visible.
   String getTitleString();
@@ -45,6 +42,7 @@ abstract class AbstractUserPreferences {
         child: getHeaderHelper(false),
       );
 
+  @protected
   Icon? getForwardIcon() => UserPreferencesListTile.getTintedIcon(
         ConstantIcons.instance.getForwardIcon(),
         context,
@@ -71,25 +69,10 @@ abstract class AbstractUserPreferences {
   IconData getLeadingIconData();
 
   /// Body of the content.
-  @protected
   List<Widget> getBody();
 
-  /// Returns possibly the header and the body.
-  List<Widget> getContent({
-    final bool withHeader = true,
-    final bool withBody = true,
-  }) {
-    final List<Widget> result = <Widget>[];
-    if (withHeader) {
-      result.add(getHeader());
-    }
-    if (withBody) {
-      result.addAll(getBody());
-    }
-    return result;
-  }
-
   /// Returns the action when we tap on the header.
+  @protected
   Future<void> runHeaderAction() async => Navigator.push<Widget>(
         context,
         MaterialPageRoute<Widget>(

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_advanced_settings.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_advanced_settings.dart
@@ -1,0 +1,20 @@
+import 'package:app_settings/app_settings.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:smooth_app/pages/preferences/user_preferences_widgets.dart';
+
+class UserPreferencesAdvancedSettings extends StatelessWidget {
+  const UserPreferencesAdvancedSettings();
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    return UserPreferenceListTile(
+      onTap: (_) async => AppSettings.openAppSettings(),
+      title: appLocalizations.native_app_settings,
+      subTitle: appLocalizations.native_app_description,
+      leading: const Icon(CupertinoIcons.settings_solid),
+      showDivider: true,
+    );
+  }
+}

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_attribute_group.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_attribute_group.dart
@@ -4,55 +4,49 @@ import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/data_models/preferences/user_preferences.dart';
 import 'package:smooth_app/data_models/product_preferences.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
-import 'package:smooth_app/pages/preferences/abstract_user_preferences.dart';
 import 'package:smooth_app/pages/preferences/attribute_group_list_tile.dart';
-import 'package:smooth_app/pages/preferences/user_preferences_page.dart';
 import 'package:smooth_app/widgets/attribute_button.dart';
 
 /// Collapsed/expanded display of an attribute group for the preferences page.
-class UserPreferencesAttributeGroup extends AbstractUserPreferences {
+class UserPreferencesAttributeGroup {
   UserPreferencesAttributeGroup({
     required this.productPreferences,
     required this.group,
-    required final Function(Function()) setState,
-    required final BuildContext context,
-    required final UserPreferences userPreferences,
-    required final AppLocalizations appLocalizations,
-    required final ThemeData themeData,
-  }) : super(
-          setState: setState,
-          context: context,
-          userPreferences: userPreferences,
-          appLocalizations: appLocalizations,
-          themeData: themeData,
-        );
+    required this.context,
+    required this.userPreferences,
+    required this.appLocalizations,
+    required this.themeData,
+  });
+
+  final BuildContext context;
+  final UserPreferences userPreferences;
+  final AppLocalizations appLocalizations;
+  final ThemeData themeData;
 
   final ProductPreferences productPreferences;
   final AttributeGroup group;
 
-  @override
-  PreferencePageType? getPreferencePageType() => null;
+  bool get _isCollapsed => userPreferences.activeAttributeGroup != group.id;
 
-  @override
-  String getTitleString() => group.name ?? appLocalizations.unknown;
-
-  @override
-  Widget getTitle() => Text(
-        getTitleString(),
-        style: themeData.textTheme.titleLarge,
-      );
-
-  @override
-  Widget? getSubtitle() =>
-      null; // TODO(monsieurtanuki): useless here, we should refactor, one day
-
-  @override
-  IconData getLeadingIconData() => Icons
-      .question_mark; // TODO(monsieurtanuki): useless here, we should refactor, one day
-
-  @override
-  List<Widget> getBody() {
+  List<Widget> getContent() {
     final List<Widget> result = <Widget>[];
+    result.add(
+      InkWell(
+        onTap: () async => userPreferences.setActiveAttributeGroup(group.id!),
+        child: AttributeGroupListTile(
+          title: Text(
+            group.name ?? appLocalizations.unknown,
+            style: themeData.textTheme.titleLarge,
+          ),
+          icon: _isCollapsed
+              ? const Icon(Icons.keyboard_arrow_right)
+              : const Icon(Icons.keyboard_arrow_down),
+        ),
+      ),
+    );
+    if (_isCollapsed) {
+      return result;
+    }
     if (group.warning != null) {
       result.add(
         Container(
@@ -78,35 +72,5 @@ class UserPreferencesAttributeGroup extends AbstractUserPreferences {
       result.add(AttributeButton(attribute, productPreferences));
     }
     return result;
-  }
-
-  @override
-  Widget getHeader() =>
-      _isCollapsed() ? super.getHeader() : getHeaderHelper(false);
-
-  @override
-  Widget getHeaderHelper(final bool? collapsed) => AttributeGroupListTile(
-        title: getTitle(),
-        icon: collapsed!
-            ? const Icon(Icons.keyboard_arrow_right)
-            : const Icon(Icons.keyboard_arrow_down),
-      );
-
-  bool _isCollapsed() => userPreferences.activeAttributeGroup != group.id;
-
-  @override
-  List<Widget> getContent({
-    final bool withHeader = true,
-    final bool withBody = true,
-  }) =>
-      super.getContent(
-        withHeader: withHeader,
-        withBody: !_isCollapsed(),
-      );
-
-  @override
-  Future<void> runHeaderAction() async {
-    await userPreferences.setActiveAttributeGroup(group.id!);
-    setState(() {});
   }
 }

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_camera_sound.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_camera_sound.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:provider/provider.dart';
+import 'package:smooth_app/data_models/preferences/user_preferences.dart';
+import 'package:smooth_app/pages/preferences/user_preferences_widgets.dart';
+
+class UserPreferencesCameraSound extends StatelessWidget {
+  const UserPreferencesCameraSound();
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final UserPreferences userPreferences = context.watch<UserPreferences>();
+    return UserPreferencesSwitchItem(
+      title: appLocalizations.camera_play_sound_title,
+      subtitle: appLocalizations.camera_play_sound_subtitle,
+      value: userPreferences.playCameraSound,
+      onChanged: (final bool value) async =>
+          userPreferences.setPlayCameraSound(value),
+    );
+  }
+}

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_choose_accent_color.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_choose_accent_color.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:provider/provider.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/pages/preferences/user_preferences_widgets.dart';
+import 'package:smooth_app/themes/color_provider.dart';
+import 'package:smooth_app/themes/color_schemes.dart';
+
+class UserPreferencesChooseAccentColor extends StatelessWidget {
+  const UserPreferencesChooseAccentColor();
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final ColorProvider colorProvider = context.watch<ColorProvider>();
+    final Map<String, String> labels = _localizedNames(appLocalizations);
+
+    return UserPreferencesMultipleChoicesItem<String>(
+      title: appLocalizations.select_accent_color,
+      leadingBuilder: labels.keys.map(
+        (String key) => (_) => CircleAvatar(
+              backgroundColor: getColorValue(key),
+              radius: SMALL_SPACE,
+            ),
+      ),
+      labels: labels.values,
+      values: labels.keys,
+      currentValue: colorProvider.currentColor,
+      onChanged: (String? newValue) => colorProvider.setColor(newValue!),
+    );
+  }
+
+  Map<String, String> _localizedNames(AppLocalizations appLocalizations) =>
+      <String, String>{
+        'Blue': appLocalizations.color_blue,
+        'Cyan': appLocalizations.color_cyan,
+        'Green': appLocalizations.color_green,
+        'Default': appLocalizations.color_light_brown,
+        'Magenta': appLocalizations.color_magenta,
+        'Orange': appLocalizations.color_orange,
+        'Pink': appLocalizations.color_pink,
+        'Red': appLocalizations.color_red,
+        'Rust': appLocalizations.color_rust,
+        'Teal': appLocalizations.color_teal,
+      };
+}

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_choose_app_theme.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_choose_app_theme.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:provider/provider.dart';
+import 'package:smooth_app/pages/preferences/user_preferences_widgets.dart';
+import 'package:smooth_app/themes/theme_provider.dart';
+
+class UserPreferencesChooseAppTheme extends StatelessWidget {
+  const UserPreferencesChooseAppTheme();
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final ThemeProvider themeProvider = context.watch<ThemeProvider>();
+
+    return UserPreferencesMultipleChoicesItem<String>(
+      title: appLocalizations.darkmode,
+      leadingBuilder: <WidgetBuilder>[
+        (_) => const Icon(Icons.brightness_medium),
+        (_) => const Icon(Icons.light_mode),
+        (_) => const Icon(Icons.dark_mode_outlined),
+        (_) => const Icon(Icons.dark_mode),
+      ],
+      labels: <String>[
+        appLocalizations.darkmode_system_default,
+        appLocalizations.darkmode_light,
+        appLocalizations.darkmode_dark,
+        appLocalizations.theme_amoled,
+      ],
+      values: const <String>[
+        THEME_SYSTEM_DEFAULT,
+        THEME_LIGHT,
+        THEME_DARK,
+        THEME_AMOLED,
+      ],
+      currentValue: themeProvider.currentTheme,
+      onChanged: (String? newValue) => themeProvider.setTheme(newValue!),
+    );
+  }
+}

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_choose_text_color_contrast.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_choose_text_color_contrast.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:provider/provider.dart';
+import 'package:smooth_app/pages/preferences/user_preferences_widgets.dart';
+import 'package:smooth_app/themes/color_schemes.dart';
+import 'package:smooth_app/themes/contrast_provider.dart';
+
+class UserPreferencesChooseTextColorContrast extends StatelessWidget {
+  const UserPreferencesChooseTextColorContrast();
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final TextContrastProvider textContrastProvider =
+        context.watch<TextContrastProvider>();
+
+    return UserPreferencesMultipleChoicesItem<String>(
+      title: appLocalizations.text_contrast_mode,
+      values: const <String>[
+        CONTRAST_HIGH,
+        CONTRAST_MEDIUM,
+        CONTRAST_LOW,
+      ],
+      labels: <String>[
+        appLocalizations.contrast_high,
+        appLocalizations.contrast_medium,
+        appLocalizations.contrast_low,
+      ],
+      currentValue: textContrastProvider.currentContrastLevel,
+      onChanged: (String? contrast) =>
+          textContrastProvider.setContrast(contrast!),
+    );
+  }
+}

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_connect.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_connect.dart
@@ -23,13 +23,11 @@ import 'package:smooth_app/services/smooth_services.dart';
 /// Display of "Connect" for the preferences page.
 class UserPreferencesConnect extends AbstractUserPreferences {
   UserPreferencesConnect({
-    required final Function(Function()) setState,
     required final BuildContext context,
     required final UserPreferences userPreferences,
     required final AppLocalizations appLocalizations,
     required final ThemeData themeData,
   }) : super(
-          setState: setState,
           context: context,
           userPreferences: userPreferences,
           appLocalizations: appLocalizations,
@@ -37,7 +35,7 @@ class UserPreferencesConnect extends AbstractUserPreferences {
         );
 
   @override
-  PreferencePageType? getPreferencePageType() => PreferencePageType.CONNECT;
+  PreferencePageType getPreferencePageType() => PreferencePageType.CONNECT;
 
   @override
   String getTitleString() => appLocalizations.connect_with_us;

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_contribute.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_contribute.dart
@@ -23,13 +23,11 @@ import 'package:smooth_app/query/product_query.dart';
 /// Display of "Contribute" for the preferences page.
 class UserPreferencesContribute extends AbstractUserPreferences {
   UserPreferencesContribute({
-    required final Function(Function()) setState,
     required final BuildContext context,
     required final UserPreferences userPreferences,
     required final AppLocalizations appLocalizations,
     required final ThemeData themeData,
   }) : super(
-          setState: setState,
           context: context,
           userPreferences: userPreferences,
           appLocalizations: appLocalizations,
@@ -37,7 +35,7 @@ class UserPreferencesContribute extends AbstractUserPreferences {
         );
 
   @override
-  PreferencePageType? getPreferencePageType() => PreferencePageType.CONTRIBUTE;
+  PreferencePageType getPreferencePageType() => PreferencePageType.CONTRIBUTE;
 
   @override
   String getTitleString() => appLocalizations.contribute;

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_country_selector.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_country_selector.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/pages/onboarding/country_selector.dart';
+
+class UserPreferencesCountrySelector extends StatelessWidget {
+  const UserPreferencesCountrySelector();
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final ThemeData themeData = Theme.of(context);
+    return ListTile(
+      title: Text(
+        appLocalizations.country_chooser_label,
+        style: themeData.textTheme.headlineMedium,
+      ),
+      subtitle: Padding(
+        padding: const EdgeInsetsDirectional.only(
+          top: SMALL_SPACE,
+          bottom: SMALL_SPACE,
+        ),
+        child: CountrySelector(
+          textStyle: themeData.textTheme.bodyMedium,
+          icon: Icons.edit,
+          padding: const EdgeInsetsDirectional.only(
+            start: SMALL_SPACE,
+          ),
+        ),
+      ),
+      minVerticalPadding: MEDIUM_SPACE,
+    );
+  }
+}

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_crash_reporting.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_crash_reporting.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:provider/provider.dart';
+import 'package:smooth_app/data_models/preferences/user_preferences.dart';
+import 'package:smooth_app/pages/preferences/user_preferences_widgets.dart';
+
+class UserPreferencesCrashReporting extends StatelessWidget {
+  const UserPreferencesCrashReporting();
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final UserPreferences userPreferences = context.watch<UserPreferences>();
+    return UserPreferencesSwitchItem(
+      title: appLocalizations.crash_reporting_toggle_title,
+      subtitle: appLocalizations.crash_reporting_toggle_subtitle,
+      value: userPreferences.crashReports,
+      onChanged: (final bool value) async =>
+          userPreferences.setCrashReports(value),
+    );
+  }
+}

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_dev_mode.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_dev_mode.dart
@@ -26,13 +26,11 @@ import 'package:smooth_app/query/product_query.dart';
 /// Settings => FAQ => Develop => Clicking switch
 class UserPreferencesDevMode extends AbstractUserPreferences {
   UserPreferencesDevMode({
-    required final Function(Function()) setState,
     required final BuildContext context,
     required final UserPreferences userPreferences,
     required final AppLocalizations appLocalizations,
     required final ThemeData themeData,
   }) : super(
-          setState: setState,
           context: context,
           userPreferences: userPreferences,
           appLocalizations: appLocalizations,
@@ -57,7 +55,7 @@ class UserPreferencesDevMode extends AbstractUserPreferences {
       GlobalMaterialLocalizations.delegate;
 
   @override
-  PreferencePageType? getPreferencePageType() => PreferencePageType.DEV_MODE;
+  PreferencePageType getPreferencePageType() => PreferencePageType.DEV_MODE;
 
   @override
   String getTitleString() => appLocalizations.dev_preferences_screen_title;
@@ -117,7 +115,6 @@ class UserPreferencesDevMode extends AbstractUserPreferences {
             onChanged: (bool? newValue) async {
               await userPreferences.setFlag(userPreferencesFlagProd, newValue);
               ProductQuery.setQueryType(userPreferences);
-              setState(() {});
             },
             items: const <DropdownMenuItem<bool>>[
               DropdownMenuItem<bool>(
@@ -329,7 +326,6 @@ class UserPreferencesDevMode extends AbstractUserPreferences {
               list.add(tag);
             }
             await userPreferences.setExcludedAttributeIds(list);
-            setState(() {});
           },
         ),
         ListTile(
@@ -383,14 +379,11 @@ class UserPreferencesDevMode extends AbstractUserPreferences {
   }
 
   ScaffoldFeatureController<SnackBar, SnackBarClosedReason>
-      _showSuccessMessage() {
-    setState(() {});
-    return ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(appLocalizations.dev_preferences_button_positive),
-      ),
-    );
-  }
+      _showSuccessMessage() => ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(appLocalizations.dev_preferences_button_positive),
+            ),
+          );
 
   Future<void> _changeTestEnvHost() async {
     _textFieldController.text =
@@ -415,7 +408,6 @@ class UserPreferencesDevMode extends AbstractUserPreferences {
       await userPreferences.setDevModeString(
           userPreferencesTestEnvHost, _textFieldController.text);
       ProductQuery.setQueryType(userPreferences);
-      setState(() {});
     }
   }
 }

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_faq.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_faq.dart
@@ -19,13 +19,11 @@ import 'package:smooth_app/query/product_query.dart';
 /// Display of "FAQ" for the preferences page.
 class UserPreferencesFaq extends AbstractUserPreferences {
   UserPreferencesFaq({
-    required final Function(Function()) setState,
     required final BuildContext context,
     required final UserPreferences userPreferences,
     required final AppLocalizations appLocalizations,
     required final ThemeData themeData,
   }) : super(
-          setState: setState,
           context: context,
           userPreferences: userPreferences,
           appLocalizations: appLocalizations,
@@ -33,7 +31,7 @@ class UserPreferencesFaq extends AbstractUserPreferences {
         );
 
   @override
-  PreferencePageType? getPreferencePageType() => PreferencePageType.FAQ;
+  PreferencePageType getPreferencePageType() => PreferencePageType.FAQ;
 
   @override
   String getTitleString() => appLocalizations.faq;

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_food.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_food.dart
@@ -16,13 +16,11 @@ import 'package:smooth_app/widgets/smooth_text.dart';
 class UserPreferencesFood extends AbstractUserPreferences {
   UserPreferencesFood({
     required this.productPreferences,
-    required final Function(Function()) setState,
     required final BuildContext context,
     required final UserPreferences userPreferences,
     required final AppLocalizations appLocalizations,
     required final ThemeData themeData,
   }) : super(
-          setState: setState,
           context: context,
           userPreferences: userPreferences,
           appLocalizations: appLocalizations,
@@ -41,7 +39,7 @@ class UserPreferencesFood extends AbstractUserPreferences {
   ];
 
   @override
-  PreferencePageType? getPreferencePageType() => PreferencePageType.FOOD;
+  PreferencePageType getPreferencePageType() => PreferencePageType.FOOD;
 
   @override
   String getTitleString() => appLocalizations.myPreferences_food_title;
@@ -131,18 +129,16 @@ class UserPreferencesFood extends AbstractUserPreferences {
       ),
     ];
     for (final AttributeGroup group in groups) {
-      final AbstractUserPreferences abstractUserPreferences =
-          UserPreferencesAttributeGroup(
-        productPreferences: productPreferences,
-        group: group,
-        setState: setState,
-        context: context,
-        userPreferences: userPreferences,
-        appLocalizations: appLocalizations,
-        themeData: themeData,
+      result.addAll(
+        UserPreferencesAttributeGroup(
+          productPreferences: productPreferences,
+          group: group,
+          context: context,
+          userPreferences: userPreferences,
+          appLocalizations: appLocalizations,
+          themeData: themeData,
+        ).getContent(),
       );
-
-      result.addAll(abstractUserPreferences.getContent());
     }
     return result;
   }

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_haptic_feedback.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_haptic_feedback.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:provider/provider.dart';
+import 'package:smooth_app/data_models/preferences/user_preferences.dart';
+import 'package:smooth_app/pages/preferences/user_preferences_widgets.dart';
+
+class UserPreferencesHapticFeedback extends StatelessWidget {
+  const UserPreferencesHapticFeedback();
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final UserPreferences userPreferences = context.watch<UserPreferences>();
+    return UserPreferencesSwitchItem(
+      title: appLocalizations.app_haptic_feedback_title,
+      subtitle: appLocalizations.app_haptic_feedback_subtitle,
+      value: userPreferences.hapticFeedbackEnabled,
+      onChanged: (final bool value) async =>
+          userPreferences.setHapticFeedbackEnabled(value),
+    );
+  }
+}

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_image_source.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_image_source.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:provider/provider.dart';
+import 'package:smooth_app/data_models/preferences/user_preferences.dart';
+import 'package:smooth_app/pages/preferences/user_preferences_widgets.dart';
+
+class UserPreferencesImageSource extends StatelessWidget {
+  const UserPreferencesImageSource();
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final UserPreferences userPreferences = context.watch<UserPreferences>();
+    return UserPreferencesMultipleChoicesItem<UserPictureSource>(
+      title: appLocalizations.choose_image_source_title,
+      leadingBuilder: <WidgetBuilder>[
+        (_) => const Icon(Icons.edit_note_rounded),
+        (_) => const Icon(Icons.camera),
+        (_) => const Icon(Icons.image),
+      ],
+      labels: <String>[
+        appLocalizations.user_picture_source_select,
+        appLocalizations.settings_app_camera,
+        appLocalizations.gallery_source_label,
+      ],
+      values: const <UserPictureSource>[
+        UserPictureSource.SELECT,
+        UserPictureSource.CAMERA,
+        UserPictureSource.GALLERY,
+      ],
+      currentValue: userPreferences.userPictureSource,
+      onChanged: (final UserPictureSource? newValue) async =>
+          userPreferences.setUserPictureSource(newValue!),
+    );
+  }
+}

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_language_selector.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_language_selector.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:provider/provider.dart';
+import 'package:smooth_app/data_models/preferences/user_preferences.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/generic_lib/widgets/language_selector.dart';
+import 'package:smooth_app/query/product_query.dart';
+
+class UserPreferencesLanguageSelector extends StatelessWidget {
+  const UserPreferencesLanguageSelector();
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final UserPreferences userPreferences = context.watch<UserPreferences>();
+    return ListTile(
+      title: Text(
+        appLocalizations.language_picker_label,
+        style: Theme.of(context).textTheme.headlineMedium,
+      ),
+      subtitle: Padding(
+        padding: const EdgeInsetsDirectional.only(
+          top: SMALL_SPACE,
+          bottom: SMALL_SPACE,
+        ),
+        child: LanguageSelector(
+          setLanguage: (final OpenFoodFactsLanguage? language) async {
+            if (language != null) {
+              ProductQuery.setLanguage(
+                context,
+                userPreferences,
+                languageCode: language.code,
+              );
+            }
+          },
+          selectedLanguages: <OpenFoodFactsLanguage>[
+            ProductQuery.getLanguage(),
+          ],
+          icon: Icons.edit,
+          padding: const EdgeInsetsDirectional.only(
+            start: SMALL_SPACE,
+          ),
+        ),
+      ),
+      minVerticalPadding: MEDIUM_SPACE,
+    );
+  }
+}

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_page.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_page.dart
@@ -7,6 +7,7 @@ import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/preferences/user_preferences.dart';
 import 'package:smooth_app/data_models/product_preferences.dart';
+import 'package:smooth_app/data_models/user_management_provider.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_back_button.dart';
 import 'package:smooth_app/helpers/app_helper.dart';
@@ -108,7 +109,7 @@ class _UserPreferencesPageState extends State<UserPreferencesPage>
         userPreferences: userPreferences,
       );
 
-      children.addAll(abstractUserPreferences.getContent(withHeader: false));
+      children.addAll(abstractUserPreferences.getBody());
       appBarTitle = abstractUserPreferences.getTitleString();
       addDividers = false;
 
@@ -197,11 +198,11 @@ class _UserPreferencesPageState extends State<UserPreferencesPage>
     final ThemeData themeData = Theme.of(context);
     final ProductPreferences productPreferences =
         context.watch<ProductPreferences>();
+    context.watch<UserManagementProvider>();
 
     switch (type) {
       case PreferencePageType.ACCOUNT:
         return UserPreferencesAccount(
-          setState: setState,
           context: context,
           userPreferences: userPreferences,
           appLocalizations: appLocalizations,
@@ -210,7 +211,6 @@ class _UserPreferencesPageState extends State<UserPreferencesPage>
       case PreferencePageType.FOOD:
         return UserPreferencesFood(
           productPreferences: productPreferences,
-          setState: setState,
           context: context,
           userPreferences: userPreferences,
           appLocalizations: appLocalizations,
@@ -219,7 +219,6 @@ class _UserPreferencesPageState extends State<UserPreferencesPage>
       case PreferencePageType.SETTINGS:
         return UserPreferencesSettings(
           themeProvider: themeProvider,
-          setState: setState,
           context: context,
           userPreferences: userPreferences,
           appLocalizations: appLocalizations,
@@ -227,7 +226,6 @@ class _UserPreferencesPageState extends State<UserPreferencesPage>
         );
       case PreferencePageType.DEV_MODE:
         return UserPreferencesDevMode(
-          setState: setState,
           context: context,
           userPreferences: userPreferences,
           appLocalizations: appLocalizations,
@@ -235,7 +233,6 @@ class _UserPreferencesPageState extends State<UserPreferencesPage>
         );
       case PreferencePageType.CONTRIBUTE:
         return UserPreferencesContribute(
-          setState: setState,
           context: context,
           userPreferences: userPreferences,
           appLocalizations: appLocalizations,
@@ -243,7 +240,6 @@ class _UserPreferencesPageState extends State<UserPreferencesPage>
         );
       case PreferencePageType.FAQ:
         return UserPreferencesFaq(
-          setState: setState,
           context: context,
           userPreferences: userPreferences,
           appLocalizations: appLocalizations,
@@ -251,7 +247,6 @@ class _UserPreferencesPageState extends State<UserPreferencesPage>
         );
       case PreferencePageType.CONNECT:
         return UserPreferencesConnect(
-          setState: setState,
           context: context,
           userPreferences: userPreferences,
           appLocalizations: appLocalizations,

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_rate_us.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_rate_us.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/helpers/entry_points_helper.dart';
+import 'package:smooth_app/helpers/global_vars.dart';
+import 'package:smooth_app/pages/preferences/user_preferences_widgets.dart';
+import 'package:smooth_app/services/smooth_services.dart';
+
+class UserPreferencesRateUs extends StatelessWidget {
+  const UserPreferencesRateUs();
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+
+    return UserPreferenceListTile(
+      title: appLocalizations.rate_app,
+      leading: SizedBox(
+        key: const Key('settings.rate_us'),
+        height: DEFAULT_ICON_SIZE,
+        width: DEFAULT_ICON_SIZE,
+        child: Image.asset(_getImagePath()),
+      ),
+      showDivider: true,
+      onTap: (BuildContext context) async {
+        try {
+          await ApplicationStore.openAppDetails();
+        } on PlatformException {
+          final AppLocalizations appLocalizations =
+              AppLocalizations.of(context);
+          final ThemeData themeData = Theme.of(context);
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(
+                appLocalizations.error_occurred,
+                textAlign: TextAlign.center,
+                style: TextStyle(color: themeData.colorScheme.background),
+              ),
+              behavior: SnackBarBehavior.floating,
+              backgroundColor: themeData.colorScheme.onBackground,
+            ),
+          );
+        }
+      },
+    );
+  }
+
+  String _getImagePath() {
+    switch (GlobalVars.storeLabel) {
+      case StoreLabel.FDroid:
+        return 'assets/app/f-droid.png';
+      case StoreLabel.AppleAppStore:
+        return 'assets/app/app-store.png';
+      default:
+        return 'assets/app/playstore.png';
+    }
+  }
+}

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_send_anonymous.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_send_anonymous.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:provider/provider.dart';
+import 'package:smooth_app/data_models/preferences/user_preferences.dart';
+import 'package:smooth_app/pages/preferences/user_preferences_widgets.dart';
+
+class UserPreferencesSendAnonymous extends StatelessWidget {
+  const UserPreferencesSendAnonymous();
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final UserPreferences userPreferences = context.watch<UserPreferences>();
+    return UserPreferencesSwitchItem(
+      title: appLocalizations.send_anonymous_data_toggle_title,
+      subtitle: appLocalizations.send_anonymous_data_toggle_subtitle,
+      value: userPreferences.userTracking,
+      onChanged: (final bool allow) async =>
+          userPreferences.setUserTracking(allow),
+    );
+  }
+}

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_settings.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_settings.dart
@@ -1,40 +1,36 @@
-import 'package:app_settings/app_settings.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
-import 'package:share_plus/share_plus.dart';
 import 'package:smooth_app/data_models/preferences/user_preferences.dart';
-import 'package:smooth_app/generic_lib/design_constants.dart';
-import 'package:smooth_app/generic_lib/widgets/language_selector.dart';
 import 'package:smooth_app/helpers/camera_helper.dart';
-import 'package:smooth_app/helpers/entry_points_helper.dart';
-import 'package:smooth_app/helpers/global_vars.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_card.dart';
-import 'package:smooth_app/pages/onboarding/country_selector.dart';
 import 'package:smooth_app/pages/preferences/abstract_user_preferences.dart';
+import 'package:smooth_app/pages/preferences/user_preferences_advanced_settings.dart';
+import 'package:smooth_app/pages/preferences/user_preferences_camera_sound.dart';
+import 'package:smooth_app/pages/preferences/user_preferences_choose_accent_color.dart';
+import 'package:smooth_app/pages/preferences/user_preferences_choose_app_theme.dart';
+import 'package:smooth_app/pages/preferences/user_preferences_choose_text_color_contrast.dart';
+import 'package:smooth_app/pages/preferences/user_preferences_country_selector.dart';
+import 'package:smooth_app/pages/preferences/user_preferences_crash_reporting.dart';
+import 'package:smooth_app/pages/preferences/user_preferences_haptic_feedback.dart';
+import 'package:smooth_app/pages/preferences/user_preferences_image_source.dart';
+import 'package:smooth_app/pages/preferences/user_preferences_language_selector.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_page.dart';
+import 'package:smooth_app/pages/preferences/user_preferences_rate_us.dart';
+import 'package:smooth_app/pages/preferences/user_preferences_send_anonymous.dart';
+import 'package:smooth_app/pages/preferences/user_preferences_share_with_friends.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_widgets.dart';
-import 'package:smooth_app/query/product_query.dart';
-import 'package:smooth_app/services/smooth_services.dart';
-import 'package:smooth_app/themes/color_provider.dart';
-import 'package:smooth_app/themes/color_schemes.dart';
-import 'package:smooth_app/themes/contrast_provider.dart';
 import 'package:smooth_app/themes/theme_provider.dart';
 
 /// Collapsed/expanded display of settings for the preferences page.
 class UserPreferencesSettings extends AbstractUserPreferences {
   UserPreferencesSettings({
-    required final Function(Function()) setState,
     required final BuildContext context,
     required final UserPreferences userPreferences,
     required final AppLocalizations appLocalizations,
     required final ThemeData themeData,
     required this.themeProvider,
   }) : super(
-          setState: setState,
           context: context,
           userPreferences: userPreferences,
           appLocalizations: appLocalizations,
@@ -44,7 +40,7 @@ class UserPreferencesSettings extends AbstractUserPreferences {
   final ThemeProvider themeProvider;
 
   @override
-  PreferencePageType? getPreferencePageType() => PreferencePageType.SETTINGS;
+  PreferencePageType getPreferencePageType() => PreferencePageType.SETTINGS;
 
   @override
   String getTitleString() => appLocalizations.myPreferences_settings_title;
@@ -57,485 +53,26 @@ class UserPreferencesSettings extends AbstractUserPreferences {
   IconData getLeadingIconData() => Icons.handyman;
 
   @override
-  List<Widget> getBody() => const <Widget>[
-        _ApplicationSettings(),
-        _CameraSettings(),
-        _ProductsSettings(),
-        _MiscellaneousSettings(),
-        _PrivacySettings(),
-        _RateUs(),
-        _ShareWithFriends(),
-      ];
-}
-
-class _RateUs extends StatelessWidget {
-  const _RateUs();
-
-  Future<void> _redirect(BuildContext context) async {
-    try {
-      await ApplicationStore.openAppDetails();
-    } on PlatformException {
-      final AppLocalizations appLocalizations = AppLocalizations.of(context);
-      final ThemeData themeData = Theme.of(context);
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(
-            appLocalizations.error_occurred,
-            textAlign: TextAlign.center,
-            style: TextStyle(color: themeData.colorScheme.background),
-          ),
-          behavior: SnackBarBehavior.floating,
-          backgroundColor: themeData.colorScheme.onBackground,
-        ),
-      );
-    }
-  }
-
-  String getImagePath() {
-    String imagePath = '';
-    switch (GlobalVars.storeLabel) {
-      case StoreLabel.FDroid:
-        imagePath = 'assets/app/f-droid.png';
-        break;
-      case StoreLabel.AppleAppStore:
-        imagePath = 'assets/app/app-store.png';
-        break;
-      default:
-        imagePath = 'assets/app/playstore.png';
-    }
-    return imagePath;
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final AppLocalizations appLocalizations = AppLocalizations.of(context);
-
-    final Widget leading = SizedBox(
-      key: const Key('settings.rate_us'),
-      height: DEFAULT_ICON_SIZE,
-      width: DEFAULT_ICON_SIZE,
-      child: Image.asset(getImagePath()),
-    );
-
-    final String title = appLocalizations.rate_app;
-
-    return UserPreferenceListTile(
-      title: title,
-      leading: leading,
-      onTap: _redirect,
-      showDivider: true,
-    );
-  }
-}
-
-class _ShareWithFriends extends StatelessWidget {
-  const _ShareWithFriends();
-
-  Future<void> _shareApp(BuildContext context) async {
-    final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    final ThemeData themeData = Theme.of(context);
-    try {
-      await Share.share(appLocalizations.contribute_share_content);
-    } on PlatformException {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(
-            appLocalizations.error,
-            textAlign: TextAlign.center,
-            style: TextStyle(
-              color: themeData.colorScheme.background,
-            ),
-          ),
-          behavior: SnackBarBehavior.floating,
-          backgroundColor: themeData.colorScheme.onBackground,
-        ),
-      );
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final Widget leading = Icon(
-      key: const Key('settings.share_app'),
-      Icons.adaptive.share,
-    );
-
-    final String title = AppLocalizations.of(context).contribute_share_header;
-
-    return UserPreferenceListTile(
-      title: title,
-      leading: leading,
-      onTap: _shareApp,
-      showDivider: false,
-    );
-  }
-}
-
-class _ApplicationSettings extends StatelessWidget {
-  const _ApplicationSettings({Key? key}) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    final ThemeData themeData = Theme.of(context);
-    final UserPreferences userPreferences = context.watch<UserPreferences>();
-
-    return Column(
-      children: <Widget>[
+  List<Widget> getBody() => <Widget>[
         UserPreferencesTitle.firstItem(
           label: appLocalizations.settings_app_app,
         ),
-        const _ChooseAppTheme(),
+        const UserPreferencesChooseAppTheme(),
+        if (themeProvider.currentTheme == THEME_AMOLED)
+          const UserPreferencesChooseAccentColor(),
+        if (themeProvider.currentTheme == THEME_AMOLED)
+          const UserPreferencesChooseTextColorContrast(),
         const UserPreferencesListItemDivider(),
-        ListTile(
-          title: Text(
-            appLocalizations.country_chooser_label,
-            style: themeData.textTheme.headlineMedium,
+        const UserPreferencesCountrySelector(),
+        const UserPreferencesListItemDivider(),
+        const UserPreferencesLanguageSelector(),
+        const UserPreferencesListItemDivider(),
+        const UserPreferencesImageSource(),
+        if (CameraHelper.hasACamera)
+          UserPreferencesTitle(
+            label: appLocalizations.settings_app_camera,
           ),
-          subtitle: Padding(
-            padding: const EdgeInsetsDirectional.only(
-              top: SMALL_SPACE,
-              bottom: SMALL_SPACE,
-            ),
-            child: CountrySelector(
-              textStyle: themeData.textTheme.bodyMedium,
-              icon: Icons.edit,
-              padding: const EdgeInsetsDirectional.only(
-                start: SMALL_SPACE,
-              ),
-            ),
-          ),
-          minVerticalPadding: MEDIUM_SPACE,
-        ),
-        const UserPreferencesListItemDivider(),
-        ListTile(
-          title: Text(
-            appLocalizations.language_picker_label,
-            style: themeData.textTheme.headlineMedium,
-          ),
-          subtitle: Padding(
-            padding: const EdgeInsetsDirectional.only(
-              top: SMALL_SPACE,
-              bottom: SMALL_SPACE,
-            ),
-            child: LanguageSelector(
-              setLanguage: (final OpenFoodFactsLanguage? language) async {
-                if (language != null) {
-                  ProductQuery.setLanguage(
-                    context,
-                    userPreferences,
-                    languageCode: language.code,
-                  );
-                }
-              },
-              selectedLanguages: <OpenFoodFactsLanguage>[
-                ProductQuery.getLanguage(),
-              ],
-              icon: Icons.edit,
-              padding: const EdgeInsetsDirectional.only(
-                start: SMALL_SPACE,
-              ),
-            ),
-          ),
-          minVerticalPadding: MEDIUM_SPACE,
-        ),
-        const UserPreferencesListItemDivider(),
-        UserPreferencesMultipleChoicesItem<UserPictureSource>(
-          title: appLocalizations.choose_image_source_title,
-          leadingBuilder: <WidgetBuilder>[
-            (_) => const Icon(Icons.edit_note_rounded),
-            (_) => const Icon(Icons.camera),
-            (_) => const Icon(Icons.image),
-          ],
-          labels: <String>[
-            appLocalizations.user_picture_source_select,
-            appLocalizations.settings_app_camera,
-            appLocalizations.gallery_source_label,
-          ],
-          values: const <UserPictureSource>[
-            UserPictureSource.SELECT,
-            UserPictureSource.CAMERA,
-            UserPictureSource.GALLERY,
-          ],
-          currentValue: userPreferences.userPictureSource,
-          onChanged: (final UserPictureSource? newValue) async =>
-              userPreferences.setUserPictureSource(newValue!),
-        ),
-      ],
-    );
-  }
-}
-
-class _ChooseAppTheme extends StatelessWidget {
-  const _ChooseAppTheme();
-
-  @override
-  Widget build(BuildContext context) {
-    final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    final ThemeProvider themeProvider = context.watch<ThemeProvider>();
-
-    final Widget child = UserPreferencesMultipleChoicesItem<String>(
-      title: appLocalizations.darkmode,
-      leadingBuilder: <WidgetBuilder>[
-        (_) => const Icon(Icons.brightness_medium),
-        (_) => const Icon(Icons.light_mode),
-        (_) => const Icon(Icons.dark_mode_outlined),
-        (_) => const Icon(Icons.dark_mode),
-      ],
-      labels: <String>[
-        appLocalizations.darkmode_system_default,
-        appLocalizations.darkmode_light,
-        appLocalizations.darkmode_dark,
-        appLocalizations.theme_amoled,
-      ],
-      values: const <String>[
-        THEME_SYSTEM_DEFAULT,
-        THEME_LIGHT,
-        THEME_DARK,
-        THEME_AMOLED,
-      ],
-      currentValue: themeProvider.currentTheme,
-      onChanged: (String? newValue) {
-        themeProvider.setTheme(newValue!);
-      },
-    );
-
-    if (themeProvider.currentTheme == THEME_AMOLED) {
-      return Column(
-        mainAxisSize: MainAxisSize.min,
-        children: <Widget>[
-          child,
-          const _ChooseAccentColor(),
-          const _ChooseTextColorContrast(),
-        ],
-      );
-    } else {
-      return child;
-    }
-  }
-}
-
-class _ChooseAccentColor extends StatelessWidget {
-  const _ChooseAccentColor();
-
-  @override
-  Widget build(BuildContext context) {
-    final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    final ColorProvider colorProvider = context.watch<ColorProvider>();
-    final Map<String, String> labels = localizedNames(appLocalizations);
-
-    return UserPreferencesMultipleChoicesItem<String>(
-      title: appLocalizations.select_accent_color,
-      leadingBuilder: labels.keys.map(
-        (String key) => (_) => CircleAvatar(
-              backgroundColor: getColorValue(key),
-              radius: SMALL_SPACE,
-            ),
-      ),
-      labels: labels.values,
-      values: labels.keys,
-      currentValue: colorProvider.currentColor,
-      onChanged: (String? newValue) {
-        colorProvider.setColor(newValue!);
-      },
-    );
-  }
-
-  Map<String, String> localizedNames(AppLocalizations appLocalizations) =>
-      <String, String>{
-        'Blue': appLocalizations.color_blue,
-        'Cyan': appLocalizations.color_cyan,
-        'Green': appLocalizations.color_green,
-        'Default': appLocalizations.color_light_brown,
-        'Magenta': appLocalizations.color_magenta,
-        'Orange': appLocalizations.color_orange,
-        'Pink': appLocalizations.color_pink,
-        'Red': appLocalizations.color_red,
-        'Rust': appLocalizations.color_rust,
-        'Teal': appLocalizations.color_teal,
-      };
-}
-
-class _ChooseTextColorContrast extends StatelessWidget {
-  const _ChooseTextColorContrast();
-
-  @override
-  Widget build(BuildContext context) {
-    final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    final TextContrastProvider textContrastProvider =
-        context.watch<TextContrastProvider>();
-
-    return UserPreferencesMultipleChoicesItem<String>(
-      title: appLocalizations.text_contrast_mode,
-      values: const <String>[
-        CONTRAST_HIGH,
-        CONTRAST_MEDIUM,
-        CONTRAST_LOW,
-      ],
-      labels: <String>[
-        appLocalizations.contrast_high,
-        appLocalizations.contrast_medium,
-        appLocalizations.contrast_low,
-      ],
-      currentValue: textContrastProvider.currentContrastLevel,
-      onChanged: (String? contrast) =>
-          textContrastProvider.setContrast(contrast!),
-    );
-  }
-}
-
-class _PrivacySettings extends StatelessWidget {
-  const _PrivacySettings({Key? key}) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    final AppLocalizations appLocalizations = AppLocalizations.of(context);
-
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: <Widget>[
-        UserPreferencesTitle(
-          label: appLocalizations.settings_app_data,
-        ),
-        const _CrashReportingSetting(),
-        const UserPreferencesListItemDivider(),
-        const _SendAnonymousDataSetting(),
-        const UserPreferencesListItemDivider(),
-        const _AdvancedSettings(),
-        const UserPreferencesListItemDivider(),
-      ],
-    );
-  }
-}
-
-class _AdvancedSettings extends StatelessWidget {
-  const _AdvancedSettings({
-    Key? key,
-  }) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    final AppLocalizations appLocalizations = AppLocalizations.of(context);
-
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-      children: <Widget>[
-        Expanded(
-          child: UserPreferenceListTile(
-            onTap: (_) async {
-              await AppSettings.openAppSettings();
-            },
-            title: appLocalizations.native_app_settings,
-            subTitle: appLocalizations.native_app_description,
-            leading: const Icon(CupertinoIcons.settings_solid),
-            showDivider: true,
-          ),
-        ),
-      ],
-    );
-  }
-}
-
-class _SendAnonymousDataSetting extends StatefulWidget {
-  const _SendAnonymousDataSetting({Key? key}) : super(key: key);
-
-  @override
-  State<_SendAnonymousDataSetting> createState() =>
-      _SendAnonymousDataSettingState();
-}
-
-class _SendAnonymousDataSettingState extends State<_SendAnonymousDataSetting> {
-  @override
-  Widget build(BuildContext context) {
-    final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    final UserPreferences userPreferences = context.watch<UserPreferences>();
-
-    return UserPreferencesSwitchItem(
-      title: appLocalizations.send_anonymous_data_toggle_title,
-      subtitle: appLocalizations.send_anonymous_data_toggle_subtitle,
-      value: userPreferences.userTracking,
-      onChanged: (final bool allow) async {
-        await userPreferences.setUserTracking(allow);
-      },
-    );
-  }
-}
-
-class _CrashReportingSetting extends StatelessWidget {
-  const _CrashReportingSetting({Key? key}) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    final UserPreferences userPreferences = context.watch<UserPreferences>();
-
-    return UserPreferencesSwitchItem(
-      title: appLocalizations.crash_reporting_toggle_title,
-      subtitle: appLocalizations.crash_reporting_toggle_subtitle,
-      value: userPreferences.crashReports,
-      onChanged: (final bool value) async {
-        await userPreferences.setCrashReports(value);
-      },
-    );
-  }
-}
-
-class _CameraSettings extends StatelessWidget {
-  const _CameraSettings({Key? key}) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    if (!CameraHelper.hasACamera) {
-      return EMPTY_WIDGET;
-    }
-
-    final AppLocalizations appLocalizations = AppLocalizations.of(context);
-
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: <Widget>[
-        UserPreferencesTitle(
-          label: appLocalizations.settings_app_camera,
-        ),
-        const _CameraPlayScanSoundSetting(),
-      ],
-    );
-  }
-}
-
-class _CameraPlayScanSoundSetting extends StatelessWidget {
-  const _CameraPlayScanSoundSetting({Key? key}) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    final UserPreferences userPreferences = context.watch<UserPreferences>();
-
-    return UserPreferencesSwitchItem(
-      title: appLocalizations.camera_play_sound_title,
-      subtitle: appLocalizations.camera_play_sound_subtitle,
-      value: userPreferences.playCameraSound,
-      onChanged: (final bool value) async {
-        await userPreferences.setPlayCameraSound(value);
-      },
-    );
-  }
-}
-
-class _ProductsSettings extends StatelessWidget {
-  const _ProductsSettings({Key? key}) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    if (!CameraHelper.hasACamera) {
-      return EMPTY_WIDGET;
-    }
-
-    final AppLocalizations appLocalizations = AppLocalizations.of(context);
-
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: <Widget>[
+        if (CameraHelper.hasACamera) const UserPreferencesCameraSound(),
         UserPreferencesTitle(
           label: appLocalizations.settings_app_products,
         ),
@@ -550,51 +87,21 @@ class _ProductsSettings extends StatelessWidget {
           subtitle: appLocalizations.expand_ingredients_body,
           panelId: KnowledgePanelCard.PANEL_INGREDIENTS_ID,
         ),
-      ],
-    );
-  }
-}
-
-class _MiscellaneousSettings extends StatelessWidget {
-  const _MiscellaneousSettings({Key? key}) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    if (!CameraHelper.hasACamera) {
-      return EMPTY_WIDGET;
-    }
-
-    final AppLocalizations appLocalizations = AppLocalizations.of(context);
-
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: <Widget>[
-        UserPreferencesTitle(
-          label: appLocalizations.settings_app_miscellaneous,
-        ),
-        const _HapticFeedbackSetting(),
-      ],
-    );
-  }
-}
-
-class _HapticFeedbackSetting extends StatelessWidget {
-  const _HapticFeedbackSetting();
-
-  @override
-  Widget build(BuildContext context) {
-    final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    final UserPreferences userPreferences = context.watch<UserPreferences>();
-
-    return UserPreferencesSwitchItem(
-      title: appLocalizations.app_haptic_feedback_title,
-      subtitle: appLocalizations.app_haptic_feedback_subtitle,
-      value: userPreferences.hapticFeedbackEnabled,
-      onChanged: (final bool value) async {
-        await userPreferences.setHapticFeedbackEnabled(value);
-      },
-    );
-  }
+        if (CameraHelper.hasACamera)
+          UserPreferencesTitle(
+            label: appLocalizations.settings_app_miscellaneous,
+          ),
+        if (CameraHelper.hasACamera) const UserPreferencesHapticFeedback(),
+        UserPreferencesTitle(label: appLocalizations.settings_app_data),
+        const UserPreferencesCrashReporting(),
+        const UserPreferencesListItemDivider(),
+        const UserPreferencesSendAnonymous(),
+        const UserPreferencesListItemDivider(),
+        const UserPreferencesAdvancedSettings(),
+        const UserPreferencesListItemDivider(),
+        const UserPreferencesRateUs(),
+        const UserPreferencesShareWithFriends(),
+      ];
 }
 
 class _ExpandPanelHelper extends StatelessWidget {

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_share_with_friends.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_share_with_friends.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:share_plus/share_plus.dart';
+import 'package:smooth_app/pages/preferences/user_preferences_widgets.dart';
+
+class UserPreferencesShareWithFriends extends StatelessWidget {
+  const UserPreferencesShareWithFriends();
+
+  @override
+  Widget build(BuildContext context) => UserPreferenceListTile(
+        title: AppLocalizations.of(context).contribute_share_header,
+        leading: Icon(
+          key: const Key('settings.share_app'),
+          Icons.adaptive.share,
+        ),
+        showDivider: false,
+        onTap: (final BuildContext context) async {
+          final AppLocalizations appLocalizations =
+              AppLocalizations.of(context);
+          final ThemeData themeData = Theme.of(context);
+          try {
+            await Share.share(appLocalizations.contribute_share_content);
+          } on PlatformException {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text(
+                  appLocalizations.error,
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    color: themeData.colorScheme.background,
+                  ),
+                ),
+                behavior: SnackBarBehavior.floating,
+                backgroundColor: themeData.colorScheme.onBackground,
+              ),
+            );
+          }
+        },
+      );
+}


### PR DESCRIPTION
### What
- This is a preliminary refactoring PR towards #4513.
- This PR does not change anything to the current display.
- The general idea of this PR is to clean the code a bit.
- More specifically, the idea is to flatten the preference tree - especially in `user_preferences_settings.dart` that was too big a file.
- The next steps would be to OOP a bit more the preference items we display, for instance attaching labels to them, so that a "preference search" would be able to filter only the items that involve "screen" or "mustard". But that would be in a next PR.

### Part of 
- #4513

### Files
New files:
* `user_preferences_advanced_settings.dart`: used to be `_AdvancedSettings` in `user_preferences_settings.dart`
* `user_preferences_camera_sound.dart`: used to be `_CameraPlayScanSoundSetting` in `user_preferences_settings.dart`
* `user_preferences_choose_accent_color.dart`: used to be `_ChooseAccentColor` in `user_preferences_settings.dart`
* `user_preferences_choose_app_theme.dart`: used to be more or less `_ChooseAppTheme` in `user_preferences_settings.dart`
* `user_preferences_choose_text_color_contrast.dart`: used to be `_ChooseTextColorContrast` in `user_preferences_settings.dart`
* `user_preferences_country_selector.dart`: used to be coded in `user_preferences_settings.dart`
* `user_preferences_crash_reporting.dart`: used to be `_CrashReportingSetting` in `user_preferences_settings.dart`
* `user_preferences_haptic_feedback.dart`: used to be `_HapticFeedbackSetting` in `user_preferences_settings.dart`
* `user_preferences_image_source.dart`: used to be coded in `user_preferences_settings.dart`
* `user_preferences_language_selector.dart`: used to be coded in `user_preferences_settings.dart`
* `user_preferences_rate_us.dart`: used to be `_RateUs` in `user_preferences_settings.dart`
* `user_preferences_send_anonymous.dart`: used to be `_SendAnonymousDataSetting` in `user_preferences_settings.dart`
* `user_preferences_share_with_friends.dart`: used to be `_ShareWithFriends` in `user_preferences_settings.dart`

Impacted files:
* `abstract_user_preferences.dart`: minor refactoring
* `preferences_page.dart`: minor refactoring
* `user_preferences.dart`: minor refactoring
* `user_preferences_account.dart`: removed `UserPreferencesSection` and `_UserPreferencesAccountSubTitleSignOut` for simplification
* `user_preferences_attribute_group.dart`: refactored as not `AbstractUserPreferences`
* `user_preferences_connect.dart`: minor refactoring
* `user_preferences_contribute.dart`: minor refactoring
* `user_preferences_dev_mode.dart`: minor refactoring
* `user_preferences_faq.dart`: minor refactoring
* `user_preferences_food.dart`: minor refactoring
* `user_preferences_page.dart`: minor refactoring
* `user_preferences_settings.dart`: file was too big - moved code to new files+classes