### PR TITLE
fix: Don't rely on `removeDiacritics` to highlight text

### DIFF
--- a/packages/smooth_app/lib/generic_lib/widgets/language_selector.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/language_selector.dart
@@ -1,4 +1,3 @@
-import 'package:diacritic/diacritic.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';

--- a/packages/smooth_app/lib/generic_lib/widgets/language_selector.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/language_selector.dart
@@ -146,19 +146,21 @@ class LanguageSelector extends StatelessWidget {
             prefixIcon: const Icon(Icons.search),
             controller: languageSelectorController,
             onChanged: (String? query) {
-              query = removeDiacritics(query!.trim().toLowerCase());
+              query = query!.trim().toLowerCase().removeDiacritics();
 
               setState(
                 () {
                   filteredList = leftovers
                       .where((OpenFoodFactsLanguage item) =>
-                          removeDiacritics(_languages
-                                  .getNameInEnglish(item)
-                                  .toLowerCase())
+                          _languages
+                              .getNameInEnglish(item)
+                              .toLowerCase()
+                              .removeDiacritics()
                               .contains(query!.toLowerCase()) ||
-                          removeDiacritics(_languages
-                                  .getNameInLanguage(item)
-                                  .toLowerCase())
+                          _languages
+                              .getNameInLanguage(item)
+                              .toLowerCase()
+                              .removeDiacritics()
                               .contains(query.toLowerCase()) ||
                           item.code.contains(query))
                       .toList();

--- a/packages/smooth_app/lib/generic_lib/widgets/language_selector.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/language_selector.dart
@@ -145,7 +145,7 @@ class LanguageSelector extends StatelessWidget {
             prefixIcon: const Icon(Icons.search),
             controller: languageSelectorController,
             onChanged: (String? query) {
-              query = query!.trim().toLowerCase().removeDiacritics();
+              query = query!.trim().getComparisonSafeString();
 
               setState(
                 () {
@@ -153,13 +153,11 @@ class LanguageSelector extends StatelessWidget {
                       .where((OpenFoodFactsLanguage item) =>
                           _languages
                               .getNameInEnglish(item)
-                              .toLowerCase()
-                              .removeDiacritics()
+                              .getComparisonSafeString()
                               .contains(query!.toLowerCase()) ||
                           _languages
                               .getNameInLanguage(item)
-                              .toLowerCase()
-                              .removeDiacritics()
+                              .getComparisonSafeString()
                               .contains(query.toLowerCase()) ||
                           item.code.contains(query))
                       .toList();

--- a/packages/smooth_app/lib/pages/onboarding/country_selector.dart
+++ b/packages/smooth_app/lib/pages/onboarding/country_selector.dart
@@ -1,4 +1,3 @@
-import 'package:diacritic/diacritic.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';

--- a/packages/smooth_app/lib/pages/onboarding/country_selector.dart
+++ b/packages/smooth_app/lib/pages/onboarding/country_selector.dart
@@ -104,23 +104,26 @@ class _CountrySelectorState extends State<CountrySelector> {
                         prefixIcon: const Icon(Icons.search),
                         controller: _countryController,
                         onChanged: (String? query) {
-                          query = removeDiacritics(query!.trim().toLowerCase());
+                          query =
+                              query!.trim().toLowerCase().removeDiacritics();
 
                           setState(
                             () {
                               filteredList = _countryList
                                   .where(
                                     (Country item) =>
-                                        removeDiacritics(
-                                                item.name.toLowerCase())
+                                        item.name
+                                            .toLowerCase()
+                                            .removeDiacritics()
                                             .contains(
-                                          query!,
-                                        ) ||
-                                        removeDiacritics(
-                                                item.countryCode.toLowerCase())
+                                              query!,
+                                            ) ||
+                                        item.countryCode
+                                            .toLowerCase()
+                                            .removeDiacritics()
                                             .contains(
-                                          query,
-                                        ),
+                                              query,
+                                            ),
                                   )
                                   .toList(growable: false);
                             },

--- a/packages/smooth_app/lib/pages/onboarding/country_selector.dart
+++ b/packages/smooth_app/lib/pages/onboarding/country_selector.dart
@@ -104,7 +104,7 @@ class _CountrySelectorState extends State<CountrySelector> {
                         controller: _countryController,
                         onChanged: (String? query) {
                           query =
-                              query!.trim().toLowerCase().removeDiacritics();
+                              query!.trim()..getComparisonSafeString();
 
                           setState(
                             () {
@@ -112,14 +112,12 @@ class _CountrySelectorState extends State<CountrySelector> {
                                   .where(
                                     (Country item) =>
                                         item.name
-                                            .toLowerCase()
-                                            .removeDiacritics()
+                                            .getComparisonSafeString()
                                             .contains(
                                               query!,
                                             ) ||
                                         item.countryCode
-                                            .toLowerCase()
-                                            .removeDiacritics()
+                                            .getComparisonSafeString()
                                             .contains(
                                               query,
                                             ),

--- a/packages/smooth_app/lib/pages/onboarding/country_selector.dart
+++ b/packages/smooth_app/lib/pages/onboarding/country_selector.dart
@@ -103,8 +103,7 @@ class _CountrySelectorState extends State<CountrySelector> {
                         prefixIcon: const Icon(Icons.search),
                         controller: _countryController,
                         onChanged: (String? query) {
-                          query =
-                              query!.trim()..getComparisonSafeString();
+                          query = query!.trim()..getComparisonSafeString();
 
                           setState(
                             () {

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_search_page.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_search_page.dart
@@ -1,4 +1,3 @@
-import 'package:diacritic/diacritic.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/preferences/user_preferences.dart';

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_search_page.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_search_page.dart
@@ -6,6 +6,7 @@ import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/pages/preferences/abstract_user_preferences.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_item.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_page.dart';
+import 'package:smooth_app/widgets/smooth_text.dart';
 
 /// Search page for preferences, with TextField filter.
 class UserPreferencesSearchPage extends StatefulWidget {
@@ -70,7 +71,7 @@ class _UserPreferencesSearchPageState extends State<UserPreferencesSearchPage> {
     final String searchString,
     final UserPreferences userPreferences,
   ) {
-    final String needle = removeDiacritics(searchString.toLowerCase());
+    final String needle = searchString.toLowerCase().removeDiacritics();
     final List<Widget> result = <Widget>[];
     final List<PreferencePageType> types =
         PreferencePageType.getPreferencePageTypes(userPreferences);
@@ -101,7 +102,7 @@ class _UserPreferencesSearchPageState extends State<UserPreferencesSearchPage> {
 
   bool _findLabels(final String needle, final Iterable<String> labels) {
     for (final String label in labels) {
-      if (removeDiacritics(label.toLowerCase()).contains(needle)) {
+      if (label.toLowerCase().removeDiacritics().contains(needle)) {
         return true;
       }
     }

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_search_page.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_search_page.dart
@@ -70,7 +70,7 @@ class _UserPreferencesSearchPageState extends State<UserPreferencesSearchPage> {
     final String searchString,
     final UserPreferences userPreferences,
   ) {
-    final String needle = searchString.toLowerCase().removeDiacritics();
+    final String needle = searchString.getComparisonSafeString();
     final List<Widget> result = <Widget>[];
     final List<PreferencePageType> types =
         PreferencePageType.getPreferencePageTypes(userPreferences);
@@ -101,7 +101,7 @@ class _UserPreferencesSearchPageState extends State<UserPreferencesSearchPage> {
 
   bool _findLabels(final String needle, final Iterable<String> labels) {
     for (final String label in labels) {
-      if (label.toLowerCase().removeDiacritics().contains(needle)) {
+      if (label.getComparisonSafeString().contains(needle)) {
         return true;
       }
     }

--- a/packages/smooth_app/lib/pages/product/nutrition_add_nutrient_button.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_add_nutrient_button.dart
@@ -1,4 +1,3 @@
-import 'package:diacritic/diacritic.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';

--- a/packages/smooth_app/lib/pages/product/nutrition_add_nutrient_button.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_add_nutrient_button.dart
@@ -56,10 +56,10 @@ class NutritionAddNutrientButton extends StatelessWidget {
                   () => filteredList = leftovers
                       .where(
                         (OrderedNutrient item) => item.name!
-                            .removeDiacritics()
-                            .toLowerCase()
+                            .trim()
+                            .getComparisonSafeString()
                             .contains(
-                              query!.removeDiacritics().toLowerCase().trim(),
+                              query!.trim().getComparisonSafeString(),
                             ),
                       )
                       .toList(),

--- a/packages/smooth_app/lib/pages/product/nutrition_add_nutrient_button.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_add_nutrient_button.dart
@@ -55,9 +55,14 @@ class NutritionAddNutrientButton extends StatelessWidget {
                 controller: nutritionTextController,
                 onChanged: (String? query) => setState(
                   () => filteredList = leftovers
-                      .where((OrderedNutrient item) =>
-                          removeDiacritics(item.name!).toLowerCase().contains(
-                              removeDiacritics(query!).toLowerCase().trim()))
+                      .where(
+                        (OrderedNutrient item) => item.name!
+                            .removeDiacritics()
+                            .toLowerCase()
+                            .contains(
+                              query!.removeDiacritics().toLowerCase().trim(),
+                            ),
+                      )
                       .toList(),
                 ),
               ),

--- a/packages/smooth_app/lib/widgets/smooth_text.dart
+++ b/packages/smooth_app/lib/widgets/smooth_text.dart
@@ -24,6 +24,12 @@ extension StringExtension on String {
   String removeDiacritics() {
     return lib.removeDiacritics(this);
   }
+
+  /// Same as [removeDiacritics] but also lowercases the string.
+  /// Prefer this method when you want to compare two strings.
+  String getComparisonSafeString() {
+    return toLowerCase().removeDiacritics();
+  }
 }
 
 /// An extension on [TextStyle] that allows to have "well spaced" variant
@@ -126,12 +132,12 @@ class TextHighlighter extends StatelessWidget {
     required TextStyle? defaultStyle,
     required TextStyle? highlightedStyle,
   }) {
-    final String filterWithoutDiacritics = filter.removeDiacritics();
-    final String textWithoutDiacritics = text.removeDiacritics();
+    final String filterWithoutDiacritics = filter.getComparisonSafeString();
+    final String textWithoutDiacritics = text.getComparisonSafeString();
 
     final Iterable<RegExpMatch> highlightedParts =
-        RegExp(filterWithoutDiacritics.toLowerCase().trim()).allMatches(
-      textWithoutDiacritics.toLowerCase(),
+        RegExp(filterWithoutDiacritics.trim()).allMatches(
+      textWithoutDiacritics,
     );
 
     final List<(String, TextStyle?)> parts = <(String, TextStyle?)>[];

--- a/packages/smooth_app/lib/widgets/smooth_text.dart
+++ b/packages/smooth_app/lib/widgets/smooth_text.dart
@@ -188,7 +188,7 @@ class TextHighlighter extends StatelessWidget {
     int diff = 0;
     for (int pos = 0; pos < endPosition; pos++) {
       if (pos == subText.length - 1) {
-        diff = pos - (subText.length);
+        diff = pos - subText.length;
         break;
       }
 

--- a/packages/smooth_app/lib/widgets/smooth_text.dart
+++ b/packages/smooth_app/lib/widgets/smooth_text.dart
@@ -1,4 +1,3 @@
-import 'package:diacritic/diacritic.dart';
 import 'package:flutter/material.dart';
 
 /// An extension on [TextStyle] that allows to have "well spaced" variant
@@ -92,8 +91,8 @@ class TextHighlighter extends StatelessWidget {
     required TextStyle? highlightedStyle,
   }) {
     final Iterable<RegExpMatch> highlightedParts =
-        RegExp(removeDiacritics(filter).toLowerCase().trim()).allMatches(
-      removeDiacritics(text).toLowerCase(),
+        RegExp(_removeAccents(filter).toLowerCase().trim()).allMatches(
+      _removeAccents(text).toLowerCase(),
     );
 
     final List<(String, TextStyle?)> parts = <(String, TextStyle?)>[];
@@ -122,5 +121,21 @@ class TextHighlighter extends StatelessWidget {
       }
     }
     return parts;
+  }
+
+  /// We can't rely on [removeDiacritics] here, as it replaces some characters
+  /// of 1 letter into 2 or more.
+  /// That's why this simpler algorithm is used instead.
+  String _removeAccents(String str) {
+    const String withAccents =
+        'ÀÁÂÃÄÅàáâãäåÒÓÔÕÕÖØòóôõöøÈÉÊËèéêëðÇçÐÌÍÎÏìíîïÙÚÛÜùúûüÑñŠšŸÿýŽž';
+    const String withoutAccents =
+        'AAAAAAaaaaaaOOOOOOOooooooEEEEeeeeeCcDIIIIiiiiUUUUuuuuNnSsYyyZz';
+
+    for (int i = 0; i < withAccents.length; i++) {
+      str = str.replaceAll(withAccents[i], withoutAccents[i]);
+    }
+
+    return str;
   }
 }

--- a/packages/smooth_app/lib/widgets/smooth_text.dart
+++ b/packages/smooth_app/lib/widgets/smooth_text.dart
@@ -4,21 +4,6 @@ import 'package:smooth_app/services/smooth_services.dart';
 
 /// An extension on [String]
 extension StringExtension on String {
-  /// Simple algorithm to only remove accents AND not diacritics.
-  String removeAccents() {
-    const String withAccents =
-        'ÀÁÂÃÄÅàáâãäåÒÓÔÕÕÖØòóôõöøÈÉÊËèéêëðÇçÐÌÍÎÏìíîïÙÚÛÜùúûüÑñŠšŸÿýŽž';
-    const String withoutAccents =
-        'AAAAAAaaaaaaOOOOOOOooooooEEEEeeeeeCcDIIIIiiiiUUUUuuuuNnSsYyyZz';
-
-    String str = this;
-    for (int i = 0; i < withAccents.length; i++) {
-      str = str.replaceAll(withAccents[i], withoutAccents[i]);
-    }
-
-    return str;
-  }
-
   /// Please use this method instead of directly calling the library.
   /// It will ease the migration if we decide to remove/change it.
   String removeDiacritics() {

--- a/packages/smooth_app/lib/widgets/smooth_text.dart
+++ b/packages/smooth_app/lib/widgets/smooth_text.dart
@@ -20,7 +20,7 @@ extension StringExtension on String {
   }
 
   /// Please use this method instead of directly calling the library.
-  /// It will use the migration if we decide to remove/change it.
+  /// It will ease the migration if we decide to remove/change it.
   String removeDiacritics() {
     return lib.removeDiacritics(this);
   }

--- a/packages/smooth_app/lib/widgets/smooth_text.dart
+++ b/packages/smooth_app/lib/widgets/smooth_text.dart
@@ -127,10 +127,7 @@ class TextHighlighter extends StatelessWidget {
     required TextStyle? highlightedStyle,
   }) {
     final String filterWithoutDiacritics = filter.removeDiacritics();
-    final int filterDiacriticsLength =
-        filterWithoutDiacritics.length - filter.length;
     final String textWithoutDiacritics = text.removeDiacritics();
-    final int textDiacriticsLength = textWithoutDiacritics.length - text.length;
 
     final Iterable<RegExpMatch> highlightedParts =
         RegExp(filterWithoutDiacritics.toLowerCase().trim()).allMatches(

--- a/packages/smooth_app/test/utils/smooth_text_test.dart
+++ b/packages/smooth_app/test/utils/smooth_text_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:smooth_app/widgets/smooth_text.dart' show StringExtension;
+
+void main() {
+  group('Smooth text', () {
+    group('String extension', () {
+      test('Remove accents', () {
+        expect(
+          'àáâãäåéèêëòóôõöìíîïùúûüñšÿýž'.removeAccents(),
+          equals('aaaaaaeeeeoooooiiiiuuuunsyyz'),
+        );
+      });
+      test('Remove diacritics', () {
+        expect(
+          'àáâãäåéèêëòóôõöìíîïùúûüñšÿýž'.removeDiacritics(),
+          equals('aaaaaaeeeeoooooiiiiuuuunsyyz'),
+        );
+      });
+    });
+  });
+}

--- a/packages/smooth_app/test/utils/smooth_text_test.dart
+++ b/packages/smooth_app/test/utils/smooth_text_test.dart
@@ -4,16 +4,16 @@ import 'package:smooth_app/widgets/smooth_text.dart' show StringExtension;
 void main() {
   group('Smooth text', () {
     group('String extension', () {
-      test('Remove accents', () {
+      test('Remove diacritics (oeuf)', () {
         expect(
-          'àáâãäåéèêëòóôõöìíîïùúûüñšÿýž'.removeAccents(),
-          equals('aaaaaaeeeeoooooiiiiuuuunsyyz'),
+          'œuf'.removeDiacritics(),
+          equals('oeuf'),
         );
       });
-      test('Remove diacritics', () {
+      test('Comparison Safe String', () {
         expect(
-          'àáâãäåéèêëòóôõöìíîïùúûüñšÿýž'.removeDiacritics(),
-          equals('aaaaaaeeeeoooooiiiiuuuunsyyz'),
+          'œuF'.getComparisonSafeString(),
+          equals('oeuf'),
         );
       });
     });


### PR DESCRIPTION
Hi everyone,

When we highlight suggestions, we use the `removeDiacritics`method.
However, it replaces some characters (eg: `œ`) by 2 or more letters (eg: `oe`)

I use instead a simpler algorithm to only remove accents.