### PR TITLE
fix: "Stores" field to not show loading spinner (#4669)

### DIFF
--- a/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
@@ -75,19 +75,22 @@ class _SimpleInputTextFieldState extends State<SimpleInputTextField> {
   Future<_SearchResults> _getSuggestions(String search) async {
     final DateTime start = DateTime.now();
 
-    if (_suggestions[search] == null) {
-      if (_manager == null || search.length < widget.minLengthForSuggestions) {
-        _suggestions[search] = _SearchResults.empty();
-      } else {
-        _setLoading(true);
-        try {
-          _suggestions[search] =
-              _SearchResults(await _manager!.getSuggestions(search));
-        } catch (_) {}
-      }
+    if (_suggestions[search] != null) {
+      return _suggestions[search]!;
+    } else if (_manager == null ||
+        search.length < widget.minLengthForSuggestions) {
+      _suggestions[search] = _SearchResults.empty();
+      return _suggestions[search]!;
     }
 
-    if (_suggestions[search]?.isEmpty == true && search == _searchInput) {
+    _setLoading(true);
+
+    try {
+      _suggestions[search] =
+          _SearchResults(await _manager!.getSuggestions(search));
+    } catch (_) {}
+
+    if (_suggestions[search]?.isEmpty ?? true && search == _searchInput) {
       _setLoading(false);
     }
 
@@ -96,7 +99,7 @@ class _SimpleInputTextFieldState extends State<SimpleInputTextField> {
       // Ignore this request, it's too long and this is not even the current search
       return _SearchResults.empty();
     } else {
-      return _suggestions[search]!;
+      return _suggestions[search] ?? _SearchResults.empty();
     }
   }
 

--- a/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
@@ -79,6 +79,7 @@ class _SimpleInputTextFieldState extends State<SimpleInputTextField> {
       if (_manager == null || search.length < widget.minLengthForSuggestions) {
         _suggestions[search] = _SearchResults.empty();
       } else {
+        _setLoading(true);
         try {
           _suggestions[search] =
               _SearchResults(await _manager!.getSuggestions(search));
@@ -87,7 +88,7 @@ class _SimpleInputTextFieldState extends State<SimpleInputTextField> {
     }
 
     if (_suggestions[search]?.isEmpty == true && search == _searchInput) {
-      _hideLoading();
+      _setLoading(false);
     }
 
     if (_searchInput != search &&
@@ -123,7 +124,6 @@ class _SimpleInputTextFieldState extends State<SimpleInputTextField> {
                       VoidCallback onFieldSubmitted) =>
                   TextField(
                 controller: widget.controller,
-                onChanged: (_) => setState(() => _loading = true),
                 decoration: InputDecoration(
                   filled: true,
                   border: const OutlineInputBorder(
@@ -170,7 +170,7 @@ class _SimpleInputTextFieldState extends State<SimpleInputTextField> {
                 }
 
                 if (input == _searchInput) {
-                  _hideLoading();
+                  _setLoading(false);
                 }
 
                 return AutocompleteOptions<String>(
@@ -199,10 +199,10 @@ class _SimpleInputTextFieldState extends State<SimpleInputTextField> {
 
   String get _searchInput => widget.controller.text.trim();
 
-  void _hideLoading() {
-    if (_loading) {
+  void _setLoading(bool loading) {
+    if (_loading != loading) {
       WidgetsBinding.instance.addPostFrameCallback(
-        (_) => setState(() => _loading = false),
+        (_) => setState(() => _loading = loading),
       );
     }
   }


### PR DESCRIPTION
### What
"simple input text field " was showing loading spinner, even if there were no autocomplete suggestions available.

Any input field, without autocomplete enabled, will now not show loading spinner.

### Screenshot
[untitled.webm](https://github.com/openfoodfacts/smooth-app/assets/5972966/66c62fbf-bd4c-4511-9e75-ea7817ca9904)

### Fixes bug(s)
Fixes #4669
