### PR TITLE
fix: Tagline url opening inconsistency

### DIFF
--- a/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
+++ b/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
@@ -27,7 +27,6 @@ import 'package:smooth_app/pages/preferences/user_preferences_widgets.dart';
 import 'package:smooth_app/pages/scan/scan_product_card_loader.dart';
 import 'package:smooth_app/pages/scan/search_page.dart';
 import 'package:smooth_app/services/smooth_services.dart';
-import 'package:url_launcher/url_launcher_string.dart';
 
 class SmoothProductCarousel extends StatefulWidget {
   const SmoothProductCarousel({
@@ -387,11 +386,7 @@ class _SearchCardContentTagLine extends StatelessWidget {
             borderRadius: ANGULAR_BORDER_RADIUS,
             onTap: tagLine.hasLink
                 ? () async {
-                    await launchUrlString(
-                      tagLine.url,
-                      // forms.gle links are not handled by the WebView
-                      mode: LaunchMode.externalApplication,
-                    );
+                    await LaunchUrlHelper.launchURL(tagLine.url, false);
                   }
                 : null,
             child: Center(


### PR DESCRIPTION
### What
Change how tagline url is opened. I presume we should use `LaunchUrlHelper` to open urls, like it's done on other places in the app.

### Screenshot
![image](https://github.com/openfoodfacts/smooth-app/assets/5972966/3db86bc2-3766-4db0-9902-a84334fb2a93)

### Fixes bug(s)
Fixes #4667
