### PR TITLE
chore: upgrade to off-dart 3.0.0

### DIFF
--- a/packages/smooth_app/lib/background/background_task.dart
+++ b/packages/smooth_app/lib/background/background_task.dart
@@ -7,6 +7,7 @@ import 'package:smooth_app/background/background_task_manager.dart';
 import 'package:smooth_app/background/background_task_refresh_later.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/duration_constants.dart';
+import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/widgets/smooth_floating_message.dart';
 
 /// Abstract background task.
@@ -142,7 +143,8 @@ abstract class BackgroundTask {
   OpenFoodFactsLanguage getLanguage() => LanguageHelper.fromJson(languageCode);
 
   @protected
-  OpenFoodFactsCountry? getCountry() => CountryHelper.fromJson(country);
+  OpenFoodFactsCountry? getCountry() =>
+      OpenFoodFactsCountry.fromOffTag(country);
 
   @protected
   User getUser() => User.fromJson(jsonDecode(user) as Map<String, dynamic>);
@@ -160,4 +162,6 @@ abstract class BackgroundTask {
   /// We return true only in rare cases. Typically, when we split an task in
   /// subtasks that call the next one at the end.
   bool get hasImmediateNextTask => false;
+
+  UriProductHelper get uriProductHelper => ProductQuery.uriProductHelper;
 }

--- a/packages/smooth_app/lib/background/background_task_crop.dart
+++ b/packages/smooth_app/lib/background/background_task_crop.dart
@@ -191,6 +191,7 @@ class BackgroundTaskCrop extends BackgroundTaskUpload {
       x2: productImage.x2!,
       y2: productImage.y2!,
       user: getUser(),
+      uriHelper: uriProductHelper,
     );
     if (imageUrl == null) {
       throw Exception('Could not select picture');

--- a/packages/smooth_app/lib/background/background_task_details.dart
+++ b/packages/smooth_app/lib/background/background_task_details.dart
@@ -141,6 +141,7 @@ class BackgroundTaskDetails extends BackgroundTaskBarcode {
         packagingsComplete: product.packagingsComplete,
         language: getLanguage(),
         country: getCountry(),
+        uriHelper: uriProductHelper,
       );
       if (result.status != ProductResultV3.statusSuccess &&
           result.status != ProductResultV3.statusWarning) {
@@ -153,6 +154,7 @@ class BackgroundTaskDetails extends BackgroundTaskBarcode {
       product,
       language: getLanguage(),
       country: getCountry(),
+      uriHelper: uriProductHelper,
     );
     if (status.status != 1) {
       throw Exception('Could not save product - ${status.error}');

--- a/packages/smooth_app/lib/background/background_task_download_products.dart
+++ b/packages/smooth_app/lib/background/background_task_download_products.dart
@@ -133,6 +133,7 @@ class BackgroundTaskDownloadProducts extends BackgroundTaskProgressing {
         country: ProductQuery.getCountry(),
         version: ProductQuery.productQueryVersion,
       ),
+      uriHelper: uriProductHelper,
     );
     final List<Product>? downloadedProducts = searchResult.products;
     if (downloadedProducts == null) {

--- a/packages/smooth_app/lib/background/background_task_image.dart
+++ b/packages/smooth_app/lib/background/background_task_image.dart
@@ -321,7 +321,11 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
       imageUri: Uri.parse(path),
     );
 
-    final Status status = await OpenFoodAPIClient.addProductImage(user, image);
+    final Status status = await OpenFoodAPIClient.addProductImage(
+      user,
+      image,
+      uriHelper: uriProductHelper,
+    );
     if (status.status == 'status ok') {
       // successfully uploaded a new picture and set it as field+language
       return;
@@ -337,6 +341,7 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
         imgid: '$imageId',
         angle: ImageAngle.NOON,
         user: user,
+        uriHelper: uriProductHelper,
       );
       if (imageUrl == null) {
         throw Exception('Could not select picture');

--- a/packages/smooth_app/lib/background/background_task_top_barcodes.dart
+++ b/packages/smooth_app/lib/background/background_task_top_barcodes.dart
@@ -112,6 +112,7 @@ class BackgroundTaskTopBarcodes extends BackgroundTaskProgressing {
         country: ProductQuery.getCountry(),
         version: ProductQuery.productQueryVersion,
       ),
+      uriHelper: uriProductHelper,
     );
     if (searchResult.products == null || searchResult.count == null) {
       throw Exception('Cannot download top barcodes');

--- a/packages/smooth_app/lib/background/background_task_unselect.dart
+++ b/packages/smooth_app/lib/background/background_task_unselect.dart
@@ -129,6 +129,7 @@ class BackgroundTaskUnselect extends BackgroundTaskBarcode {
         imageField: ImageField.fromOffTag(imageField)!,
         language: getLanguage(),
         user: getUser(),
+        uriHelper: uriProductHelper,
       );
 
   /// Returns a product with "unselected" image.

--- a/packages/smooth_app/lib/data_models/onboarding_data_product.dart
+++ b/packages/smooth_app/lib/data_models/onboarding_data_product.dart
@@ -6,6 +6,7 @@ import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/duration_constants.dart';
 import 'package:smooth_app/helpers/app_helper.dart';
 import 'package:smooth_app/pages/product/common/product_refresher.dart';
+import 'package:smooth_app/query/product_query.dart';
 
 /// Helper around a product we download, store and reuse at onboarding.
 class OnboardingDataProduct extends AbstractOnboardingData<Product> {
@@ -38,6 +39,7 @@ class OnboardingDataProduct extends AbstractOnboardingData<Product> {
         ProductRefresher().getBarcodeQueryConfiguration(
           AbstractOnboardingData.barcode,
         ),
+        uriHelper: ProductQuery.uriProductHelper,
       ).timeout(SnackBarDuration.long);
 
   @override

--- a/packages/smooth_app/lib/data_models/user_management_provider.dart
+++ b/packages/smooth_app/lib/data_models/user_management_provider.dart
@@ -14,7 +14,10 @@ class UserManagementProvider with ChangeNotifier {
   Future<bool> login(User user) async {
     final LoginStatus? loginStatus;
     try {
-      loginStatus = await OpenFoodAPIClient.login2(user);
+      loginStatus = await OpenFoodAPIClient.login2(
+        user,
+        uriHelper: ProductQuery.uriProductHelper,
+      );
     } catch (e) {
       throw Exception(e);
     }
@@ -107,6 +110,7 @@ class UserManagementProvider with ChangeNotifier {
             userId: user.userId,
             password: user.password,
           ),
+          uriHelper: ProductQuery.uriProductHelper,
         );
         if (loginStatus == null) {
           // No internet or sever down

--- a/packages/smooth_app/lib/helpers/data_importer/product_list_import_export.dart
+++ b/packages/smooth_app/lib/helpers/data_importer/product_list_import_export.dart
@@ -72,6 +72,7 @@ class ProductListImportExport {
       ProductRefresher().getBarcodeListQueryConfiguration(
         barcodes.toList(growable: false),
       ),
+      uriHelper: ProductQuery.uriProductHelper,
     );
 
     return searchResult.products ?? <Product>[];

--- a/packages/smooth_app/lib/helpers/product_cards_helper.dart
+++ b/packages/smooth_app/lib/helpers/product_cards_helper.dart
@@ -231,7 +231,11 @@ ProductImageData getProductImageData(
   if (productImage != null) {
     // we found a localized version for this image
     imageLanguage = language;
-    imageUrl = getLocalizedProductImageUrl(product, productImage);
+    imageUrl = ImageHelper.getLocalizedProductImageUrl(
+      product.barcode!,
+      productImage,
+      imageSize: ImageSize.DISPLAY,
+    );
   } else {
     imageLanguage = null;
     imageUrl = forceLanguage ? null : imageField.getUrl(product);
@@ -280,19 +284,6 @@ List<MapEntry<ProductImageData, ImageProvider?>> getSelectedImages(
   }
   return result.entries.toList();
 }
-
-String _getImageRoot() =>
-    OpenFoodAPIConfiguration.globalQueryType == QueryType.PROD
-        ? 'https://images.openfoodfacts.org/images/products'
-        : 'https://images.openfoodfacts.net/images/products';
-
-String getLocalizedProductImageUrl(
-  final Product product,
-  final ProductImage productImage,
-) =>
-    '${_getImageRoot()}/'
-    '${ImageHelper.getBarcodeSubPath(product.barcode!)}/'
-    '${ImageHelper.getProductImageFilename(productImage, imageSize: ImageSize.DISPLAY)}';
 
 /// Returns the languages for which [imageField] has images for that [product].
 Iterable<OpenFoodFactsLanguage> getProductImageLanguages(

--- a/packages/smooth_app/lib/helpers/temp_product_list_share_helper.dart
+++ b/packages/smooth_app/lib/helpers/temp_product_list_share_helper.dart
@@ -1,4 +1,5 @@
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/query/product_query.dart';
 
 // TODO(m123): Move this to off-dart
 Uri shareProductList(List<String> barcodes) {
@@ -9,7 +10,7 @@ Uri shareProductList(List<String> barcodes) {
   }
 
   return UriHelper.replaceSubdomain(
-    UriHelper.getUri(
+    ProductQuery.uriProductHelper.getUri(
       path: 'products/$buffer',
       addUserAgentParameters: false,
     ),

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_account.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_account.dart
@@ -291,7 +291,7 @@ class UserPreferencesAccount extends AbstractUserPreferences {
       final SearchResult result = await OpenFoodAPIClient.searchProducts(
         user,
         configuration,
-        queryType: OpenFoodAPIConfiguration.globalQueryType,
+        uriHelper: ProductQuery.uriProductHelper,
       );
       return result.count;
     } catch (e) {

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_dev_debug_info.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_dev_debug_info.dart
@@ -27,7 +27,10 @@ class _UserPreferencesDebugInfoState extends State<UserPreferencesDebugInfo> {
     'IsLoggedIn': ProductQuery.isLoggedIn().toString(),
     'UUID': OpenFoodAPIConfiguration.uuid.toString(),
     'Matomo Visitor ID': AnalyticsHelper.matomoVisitorId,
-    'QueryType': OpenFoodAPIConfiguration.globalQueryType.toString(),
+    'QueryType': ProductQuery.uriProductHelper.isTestMode
+        ? 'QueryType.TEST'
+        : 'QueryType.PROD',
+    'Domain': ProductQuery.uriProductHelper.domain,
     'UserAgent-name': '${OpenFoodAPIConfiguration.userAgent?.name}',
     'UserAgent-system': '${OpenFoodAPIConfiguration.userAgent?.system}',
   };

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_dev_mode.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_dev_mode.dart
@@ -41,7 +41,7 @@ class UserPreferencesDevMode extends AbstractUserPreferences {
         );
 
   static const String userPreferencesFlagProd = '__devWorkingOnProd';
-  static const String userPreferencesTestEnvHost = '__testEnvHost';
+  static const String userPreferencesTestEnvDomain = '__testEnvHost';
   static const String userPreferencesFlagEditIngredients = '__editIngredients';
   static const String userPreferencesFlagBoostedComparison =
       '__boostedComparison';
@@ -102,7 +102,7 @@ class UserPreferencesDevMode extends AbstractUserPreferences {
         UserPreferencesItemTile(
           title: appLocalizations.dev_preferences_environment_switch_title,
           trailing: DropdownButton<bool>(
-            value: OpenFoodAPIConfiguration.globalQueryType == QueryType.PROD,
+            value: userPreferences.getFlag(userPreferencesFlagProd) ?? true,
             elevation: 16,
             onChanged: (bool? newValue) async {
               await userPreferences.setFlag(userPreferencesFlagProd, newValue);
@@ -123,9 +123,11 @@ class UserPreferencesDevMode extends AbstractUserPreferences {
         UserPreferencesItemTile(
           title: appLocalizations.dev_preferences_test_environment_title,
           subtitle: appLocalizations.dev_preferences_test_environment_subtitle(
-            '${OpenFoodAPIConfiguration.uriScheme}://${OpenFoodAPIConfiguration.uriTestHost}/',
+            ProductQuery.getTestUriProductHelper(userPreferences)
+                .getPostUri(path: '')
+                .toString(),
           ),
-          onTap: () async => _changeTestEnvHost(),
+          onTap: () async => _changeTestEnvDomain(),
         ),
         UserPreferencesItemSwitch(
           title: appLocalizations.dev_preferences_edit_ingredients_title,
@@ -362,10 +364,10 @@ class UserPreferencesDevMode extends AbstractUserPreferences {
             ),
           );
 
-  Future<void> _changeTestEnvHost() async {
+  Future<void> _changeTestEnvDomain() async {
     _textFieldController.text =
-        userPreferences.getDevModeString(userPreferencesTestEnvHost) ??
-            OpenFoodAPIConfiguration.uriTestHost;
+        userPreferences.getDevModeString(userPreferencesTestEnvDomain) ??
+            uriHelperFoodTest.domain;
     final bool? result = await showDialog<bool>(
       context: context,
       builder: (final BuildContext context) => SmoothAlertDialog(
@@ -383,7 +385,7 @@ class UserPreferencesDevMode extends AbstractUserPreferences {
     );
     if (result == true) {
       await userPreferences.setDevModeString(
-          userPreferencesTestEnvHost, _textFieldController.text);
+          userPreferencesTestEnvDomain, _textFieldController.text);
       ProductQuery.setQueryType(userPreferences);
     }
   }

--- a/packages/smooth_app/lib/pages/product/common/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_page.dart
@@ -483,6 +483,7 @@ class _ProductListPageState extends State<ProductListPage>
       final SearchResult searchResult = await OpenFoodAPIClient.searchProducts(
         ProductQuery.getUser(),
         ProductRefresher().getBarcodeListQueryConfiguration(barcodes),
+        uriHelper: ProductQuery.uriProductHelper,
       );
       final List<Product>? freshProducts = searchResult.products;
       if (freshProducts == null) {

--- a/packages/smooth_app/lib/pages/product/common/product_refresher.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_refresher.dart
@@ -162,6 +162,7 @@ class ProductRefresher {
     try {
       final ProductResultV3 result = await OpenFoodAPIClient.getProductV3(
         getBarcodeQueryConfiguration(barcode),
+        uriHelper: ProductQuery.uriProductHelper,
       );
       if (result.product != null) {
         await DaoProduct(localDatabase).put(result.product!);
@@ -180,11 +181,7 @@ class ProductRefresher {
           connectivityResult: connectivityResult,
         );
       }
-      // TODO(monsieurtanuki): make things cleaner with off-dart
-      final String host =
-          OpenFoodAPIConfiguration.globalQueryType == QueryType.PROD
-              ? OpenFoodAPIConfiguration.uriProdHost
-              : OpenFoodAPIConfiguration.uriTestHost;
+      final String host = ProductQuery.uriProductHelper.host;
       final PingData result = await Ping(host, count: 1).stream.first;
       return FetchedProduct.error(
         exceptionString: e.toString(),
@@ -205,6 +202,7 @@ class ProductRefresher {
       final SearchResult searchResult = await OpenFoodAPIClient.searchProducts(
         ProductQuery.getUser(),
         getBarcodeListQueryConfiguration(barcodes),
+        uriHelper: ProductQuery.uriProductHelper,
       );
       if (searchResult.products == null) {
         return null;

--- a/packages/smooth_app/lib/pages/product/ocr_ingredients_helper.dart
+++ b/packages/smooth_app/lib/pages/product/ocr_ingredients_helper.dart
@@ -3,6 +3,7 @@ import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/background/background_task_details.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/pages/product/ocr_helper.dart';
+import 'package:smooth_app/query/product_query.dart';
 
 /// OCR Helper for ingredients.
 class OcrIngredientsHelper extends OcrHelper {
@@ -73,6 +74,7 @@ class OcrIngredientsHelper extends OcrHelper {
       getUser(),
       product.barcode!,
       language,
+      uriHelper: ProductQuery.uriProductHelper,
     );
     return result.ingredientsTextFromImage;
   }

--- a/packages/smooth_app/lib/pages/product/ocr_packaging_helper.dart
+++ b/packages/smooth_app/lib/pages/product/ocr_packaging_helper.dart
@@ -5,6 +5,7 @@ import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/background/background_task_details.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/pages/product/ocr_helper.dart';
+import 'package:smooth_app/query/product_query.dart';
 
 /// OCR Helper for packaging.
 class OcrPackagingHelper extends OcrHelper {
@@ -75,6 +76,7 @@ class OcrPackagingHelper extends OcrHelper {
       getUser(),
       product.barcode!,
       language,
+      uriHelper: ProductQuery.uriProductHelper,
     );
     return result.textFromImage;
   }

--- a/packages/smooth_app/lib/pages/product/ordered_nutrients_cache.dart
+++ b/packages/smooth_app/lib/pages/product/ordered_nutrients_cache.dart
@@ -55,6 +55,7 @@ class OrderedNutrientsCache {
     final String string = await OpenFoodAPIClient.getOrderedNutrientsJsonString(
       country: ProductQuery.getCountry(),
       language: ProductQuery.getLanguage(),
+      uriHelper: ProductQuery.uriProductHelper,
     );
     final OrderedNutrients result = OrderedNutrients.fromJson(
       jsonDecode(string) as Map<String, dynamic>,
@@ -70,6 +71,6 @@ class OrderedNutrientsCache {
     return 'nutrients.pl'
         '/${country.offTag}'
         '/${language.code}'
-        '/${OpenFoodAPIConfiguration.globalQueryType}';
+        '/${ProductQuery.uriProductHelper.domain}';
   }
 }

--- a/packages/smooth_app/lib/pages/product/product_image_server_button.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_server_button.dart
@@ -59,6 +59,7 @@ class ProductImageServerButton extends StatelessWidget {
         future: OpenFoodAPIClient.getProductImageIds(
           barcode,
           user: ProductQuery.getUser(),
+          uriHelper: ProductQuery.uriProductHelper,
         ),
         context: context,
         title: appLocalizations.edit_photo_select_existing_download_label,

--- a/packages/smooth_app/lib/pages/user_management/forgot_password_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/forgot_password_page.dart
@@ -37,6 +37,7 @@ class _ForgotPasswordPageState extends State<ForgotPasswordPage>
         _userIdController.text,
         country: ProductQuery.getCountry(),
         language: ProductQuery.getLanguage(),
+        uriHelper: ProductQuery.uriProductHelper,
       );
       if (status.status == 200) {
         _send = true;

--- a/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
@@ -337,6 +337,7 @@ class _SignUpPageState extends State<SignUpPage> with TraceableClientMixin {
         orgName: _foodProducer ? _brandController.trimmedText : null,
         country: ProductQuery.getCountry(),
         language: ProductQuery.getLanguage(),
+        uriHelper: ProductQuery.uriProductHelper,
       ),
       title: appLocalisations.sign_up_page_action_doing_it,
     );

--- a/packages/smooth_app/lib/query/paged_product_query.dart
+++ b/packages/smooth_app/lib/query/paged_product_query.dart
@@ -38,7 +38,7 @@ abstract class PagedProductQuery {
       OpenFoodAPIClient.searchProducts(
         ProductQuery.getUser(),
         getQueryConfiguration(),
-        queryType: OpenFoodAPIConfiguration.globalQueryType,
+        uriHelper: ProductQuery.uriProductHelper,
       );
 
   AbstractQueryConfiguration getQueryConfiguration();

--- a/packages/smooth_app/lib/query/random_questions_query.dart
+++ b/packages/smooth_app/lib/query/random_questions_query.dart
@@ -14,7 +14,7 @@ class RandomQuestionsQuery extends QuestionsQuery {
     final RobotoffQuestionResult result = await RobotoffAPIClient.getQuestions(
       ProductQuery.getLanguage(),
       user: ProductQuery.getUser(),
-      country: ProductQuery.getCountry(),
+      countries: <OpenFoodFactsCountry>[ProductQuery.getCountry()],
       count: count,
       questionOrder: RobotoffQuestionOrder.random,
     );

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -1067,10 +1067,10 @@ packages:
     dependency: "direct main"
     description:
       name: openfoodfacts
-      sha256: fa136e570e5751286882d4e62bcbfe1173df75f98c12dc7247eb89c7aeba8fa5
+      sha256: afd34c76e60dddc614ebf1e370985548d58d5e15a007118f3c3e9d95a2728c6a
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.1"
+    version: "3.0.0"
   openfoodfacts_flutter_lints:
     dependency: "direct dev"
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -100,7 +100,7 @@ dependencies:
     path: ../scanner/zxing
 
 
-  openfoodfacts: 2.10.1
+  openfoodfacts: 3.0.0
   # openfoodfacts:
   #   path: ../../../openfoodfacts-dart
 


### PR DESCRIPTION
### What
- Upgrade to off-dart 3.0.0

### Impacted files
* `background_task.dart`: minor refactoring
* `background_task_crop.dart`: added the `UriProductHelper` parameter
* `background_task_details.dart`: added the `UriProductHelper` parameter
* `background_task_download_products.dart`: added the `UriProductHelper` parameter
* `background_task_image.dart`: added the `UriProductHelper` parameter
* `background_task_top_barcodes.dart`: added the `UriProductHelper` parameter
* `background_task_unselect.dart`: added the `UriProductHelper` parameter
* `forgot_password_page.dart`: added the `UriProductHelper` parameter
* `ocr_ingredients_helper.dart`: added the `UriProductHelper` parameter
* `ocr_packaging_helper.dart`: added the `UriProductHelper` parameter
* `onboarding_data_product.dart`: added the `UriProductHelper` parameter
* `ordered_nutrients_cache.dart`: added the `UriProductHelper` parameter
* `paged_product_query.dart`: added the `UriProductHelper` parameter
* `product_cards_helper.dart`: now using an off-dart method
* `product_image_server_button.dart`: added the `UriProductHelper` parameter
* `product_list_import_export.dart`: added the `UriProductHelper` parameter
* `product_list_page.dart`: added the `UriProductHelper` parameter
* `product_query.dart`: added a static `UriProductHelper` that more or less replaces the `QueryType`; minor refactoring
* `product_refresher.dart`: added the `UriProductHelper` parameter
* `pubspec.lock`: wtf
* `pubspec.yaml`: upgraded off-dart to 3.0.0
* `random_questions_query.dart`: `countries` instead of `country`
* `sign_up_page.dart`: added the `UriProductHelper` parameter
* `temp_product_list_share_helper.dart`: now using a `UriProductHelper`
* `user_management_provider.dart`: added the `UriProductHelper` parameter
* `user_preferences_account.dart`: added the `UriProductHelper` parameter
* `user_preferences_dev_debug_info.dart`: minor refactoring
* `user_preferences_dev_mode.dart`: minor refactoring