### PR TITLE
fix: Exception when product brands are null

### DIFF
--- a/packages/smooth_app/lib/helpers/product_cards_helper.dart
+++ b/packages/smooth_app/lib/helpers/product_cards_helper.dart
@@ -11,14 +11,32 @@ import 'package:smooth_app/helpers/image_field_extension.dart';
 import 'package:smooth_app/helpers/ui_helpers.dart';
 import 'package:smooth_app/query/product_query.dart';
 
+Widget buildProductTitle(
+  final Product product,
+  final AppLocalizations appLocalizations,
+) =>
+    Text(
+      getProductNameAndBrands(product, appLocalizations),
+      overflow: TextOverflow.ellipsis,
+      maxLines: 1,
+    );
+
+String getProductNameAndBrands(
+    Product product, AppLocalizations appLocalizations) {
+  final String name =
+      product.productName?.trim() ?? appLocalizations.unknownProductName;
+  final String brands = product.brands?.trim() ?? appLocalizations.unknownBrand;
+  return '$name, $brands';
+}
+
 String getProductName(Product product, AppLocalizations appLocalizations) =>
     product.productName ??
     product.productNameInLanguages?[ProductQuery.getLanguage()] ??
     appLocalizations.unknownProductName;
 
 String getProductBrands(Product product, AppLocalizations appLocalizations) {
-  final String? brands = product.brands;
-  if (brands == null) {
+  final String? brands = product.brands?.trim();
+  if (brands == null || brands.isEmpty) {
     return appLocalizations.unknownBrand;
   } else {
     return formatProductBrands(brands);

--- a/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
@@ -84,17 +84,9 @@ class _AddBasicDetailsPageState extends State<AddBasicDetailsPage> {
       child: SmoothScaffold(
         fixKeyboard: true,
         appBar: SmoothAppBar(
-          centerTitle: false,
-          title: Text(appLocalizations.basic_details),
-          subTitle: widget.product.productName != null
-              ? Text(
-                  '${widget.product.productName!.trim()}'
-                  ', ${widget.product.brands?.trim() ?? appLocalizations.unknownBrand}',
-                  overflow: TextOverflow.ellipsis,
-                  maxLines: 1,
-                )
-              : null,
-        ),
+            centerTitle: false,
+            title: Text(appLocalizations.basic_details),
+            subTitle: buildProductTitle(widget.product, appLocalizations)),
         body: Form(
           key: _formKey,
           child: Scrollbar(

--- a/packages/smooth_app/lib/pages/product/add_other_details_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_other_details_page.dart
@@ -5,6 +5,7 @@ import 'package:smooth_app/background/background_task_details.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_text_form_field.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
+import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/pages/product/common/product_buttons.dart';
 import 'package:smooth_app/pages/product/may_exit_page_helper.dart';
 import 'package:smooth_app/pages/text_field_helper.dart';
@@ -61,12 +62,7 @@ class _AddOtherDetailsPageState extends State<AddOtherDetailsPage> {
           centerTitle: false,
           title:
               Text(appLocalizations.edit_product_form_item_other_details_title),
-          subTitle: widget.product.productName != null
-              ? Text(
-                  '${widget.product.productName!.trim()}, ${widget.product.brands!.trim()}',
-                  overflow: TextOverflow.ellipsis,
-                  maxLines: 1)
-              : null,
+          subTitle: buildProductTitle(widget.product, appLocalizations),
           ignoreSemanticsForSubtitle: true,
         ),
         body: Form(

--- a/packages/smooth_app/lib/pages/product/edit_new_packagings.dart
+++ b/packages/smooth_app/lib/pages/product/edit_new_packagings.dart
@@ -189,15 +189,8 @@ class _EditNewPackagingsState extends State<EditNewPackagings>
         child: SmoothScaffold(
           fixKeyboard: true,
           appBar: SmoothAppBar(
-            title: Text(appLocalizations.edit_packagings_title),
-            subTitle: upToDateProduct.productName != null
-                ? Text(
-                    '${upToDateProduct.productName!.trim()}, ${upToDateProduct.brands!.trim()}',
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  )
-                : null,
-          ),
+              title: Text(appLocalizations.edit_packagings_title),
+              subTitle: buildProductTitle(upToDateProduct, appLocalizations)),
           body: ListView(
             padding: const EdgeInsets.only(top: LARGE_SPACE),
             children: children,

--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -12,6 +12,7 @@ import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/image_field_extension.dart';
+import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/helpers/text_input_formatters_helper.dart';
 import 'package:smooth_app/pages/product/common/product_buttons.dart';
 import 'package:smooth_app/pages/product/common/product_refresher.dart';
@@ -198,13 +199,7 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded>
             appLocalizations.nutrition_page_title,
             maxLines: upToDateProduct.productName?.isNotEmpty == true ? 1 : 2,
           ),
-          subTitle: upToDateProduct.productName != null
-              ? Text(
-                  '${upToDateProduct.productName!.trim()}, ${upToDateProduct.brands!.trim()}',
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                )
-              : null,
+          subTitle: buildProductTitle(upToDateProduct, appLocalizations),
         ),
         body: Padding(
           padding: const EdgeInsets.symmetric(

--- a/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
@@ -53,13 +53,7 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView>
       appBar: SmoothAppBar(
         centerTitle: false,
         title: Text(appLocalizations.edit_product_form_item_photos_title),
-        subTitle: upToDateProduct.productName == null
-            ? null
-            : Text(
-                '${upToDateProduct.productName!.trim()}, ${upToDateProduct.brands!.trim()}',
-                overflow: TextOverflow.ellipsis,
-                maxLines: 1,
-              ),
+        subTitle: buildProductTitle(upToDateProduct, appLocalizations),
       ),
       floatingActionButton: FloatingActionButton.extended(
         onPressed: () async {

--- a/packages/smooth_app/lib/pages/product/simple_input_page.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page.dart
@@ -85,10 +85,6 @@ class _SimpleInputPageState extends State<SimpleInputPage> {
         ),
       );
     }
-    final String productName = getProductName(
-      widget.product,
-      appLocalizations,
-    );
 
     return WillPopScope(
       onWillPop: () async => _mayExitPage(saving: false),
@@ -97,11 +93,7 @@ class _SimpleInputPageState extends State<SimpleInputPage> {
           fixKeyboard: true,
           appBar: SmoothAppBar(
             centerTitle: false,
-            title: Text(
-              '${productName.trim()}, ${widget.product.brands!.trim()}',
-              maxLines: widget.product.barcode?.isNotEmpty == true ? 1 : 2,
-              overflow: TextOverflow.ellipsis,
-            ),
+            title: buildProductTitle(widget.product, appLocalizations),
             subTitle: widget.product.barcode != null
                 ? ExcludeSemantics(
                     excluding: true, child: Text(widget.product.barcode!))


### PR DESCRIPTION
### What
Fixing some null exception, that I randomly found while working on other issues, due to this bang operator: `widget.product.brands!`

### Fixes bug(s)
Fixes #4692, #4693, #4694

