### PR TITLE
fix: Null check operator used on a null value on Line 46 using null traverse operator

### DIFF
--- a/packages/smooth_app/lib/pages/scan/camera_scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/camera_scan_page.dart
@@ -43,8 +43,7 @@ class CameraScannerPageState extends State<CameraScannerPage>
       setState(() {
         _headerHeight =
             (_headerKey.currentContext?.findRenderObject() as RenderBox?)
-                ?.size
-                .height;
+                ?.size?.height;
       });
     });
   }


### PR DESCRIPTION
### Resolving
 TypeError: Null check operator used on a null value File "camera_scan_page.dart", line 46, in CameraScannerPageState.didChangeDependencies 

### What
<!-- description of the PR -->
- Null check operator was being used on the Null value in line 46 in camera_scan_page.dart (in set state ) used the Null traverse operator to fix the issue <!-- Changed x to achieve y -->
<!-- 
Please name your pull request following this scheme: `type: What you did` this allows us to automatically generate the changelog
Following `type`s are allowed:
  - `feat`, for Features
  - `fix`, for Bug Fixes
  - `docs`, for Documentation
  - `ci`, for Automation
  - `refactor`, for code Refactoring
  - `chore`, for Miscellaneous things
-->


### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes: #4696