### PR TITLE
fix: Use the email variant of the virtual keyboard for the login page

### DIFF
--- a/packages/smooth_app/lib/pages/user_management/login_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/login_page.dart
@@ -162,7 +162,7 @@ class _LoginPageState extends State<LoginPage> with TraceableClientMixin {
                       //Login
                       SmoothTextFormField(
                         type: TextFieldTypes.PLAIN_TEXT,
-                        textInputType: TextInputType.name,
+                        textInputType: TextInputType.emailAddress,
                         controller: userIdController,
                         hintText: appLocalizations.username_or_email,
                         prefixIcon: const Icon(Icons.person),


### PR DESCRIPTION
Hi everyone,

This issue was only noticed on iOS, but on the login form we ask for a username or an email address, but by default the iOS keyboard won't show the `@` sign.

It will fix #4711