### PR TITLE
fix: Let's try to fix a crash with a null variable in the `CameraScannerPageState`

### DIFF
--- a/packages/smooth_app/lib/pages/scan/camera_scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/camera_scan_page.dart
@@ -62,6 +62,8 @@ class CameraScannerPageState extends State<CameraScannerPage>
 
       if (_headerHeight == null) {
         _detectHeaderHeight(retries + 1);
+      } else {
+        setState(() {});
       }
     });
   }

--- a/packages/smooth_app/lib/pages/scan/camera_scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/camera_scan_page.dart
@@ -39,13 +39,30 @@ class CameraScannerPageState extends State<CameraScannerPage>
       _userPreferences = context.watch<UserPreferences>();
     }
 
+    _detectHeaderHeight();
+  }
+
+  /// In some cases, the size may be null
+  /// (Mainly when the app is launched for the first time AND in release mode)
+  void _detectHeaderHeight([int retries = 0]) {
+    // Let's try during 5 frames (should be enough, as 2 or 3 seems to be an average)
+    if (retries > 5) {
+      return;
+    }
+
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      setState(() {
+      try {
         _headerHeight =
             (_headerKey.currentContext?.findRenderObject() as RenderBox?)
                 ?.size
                 .height;
-      });
+      } catch (_) {
+        _headerHeight = null;
+      }
+
+      if (_headerHeight == null) {
+        _detectHeaderHeight(retries + 1);
+      }
     });
   }
 


### PR DESCRIPTION
Hi everyone,

Following #4696 and with my tests during the POC, it seems that in release mode and the first time the screen is displayed, the size of the screen is set to zero. We simply have to wait a few frames.

I'm not sure if it will fix #4696, but now the algorithm retries to fetch the value + add a `try/catch`.