### PR TITLE
fix: When there is no browser, the app shouldn't crash

### DIFF
--- a/packages/smooth_app/lib/generic_lib/smooth_html_widget.dart
+++ b/packages/smooth_app/lib/generic_lib/smooth_html_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_widget_from_html_core/flutter_widget_from_html_core.dart';
 import 'package:fwfh_selectable_text/fwfh_selectable_text.dart';
 import 'package:smooth_app/helpers/launch_url_helper.dart';
@@ -20,7 +21,19 @@ class SmoothHtmlWidget extends StatelessWidget {
       htmlString,
       textStyle: textStyle,
       onTapUrl: (String url) async {
-        await LaunchUrlHelper.launchURL(url, false);
+        try {
+          await LaunchUrlHelper.launchURL(url, false);
+        } catch (_) {
+          if (context.mounted) {
+            final AppLocalizations appLocalizations =
+                AppLocalizations.of(context);
+
+            ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+              SnackBar(content: appLocalizations.link_cant_be_opened),
+            );
+          }
+        }
+
         return true;
       },
       factoryBuilder: () =>

--- a/packages/smooth_app/lib/generic_lib/smooth_html_widget.dart
+++ b/packages/smooth_app/lib/generic_lib/smooth_html_widget.dart
@@ -29,7 +29,9 @@ class SmoothHtmlWidget extends StatelessWidget {
                 AppLocalizations.of(context);
 
             ScaffoldMessenger.maybeOf(context)?.showSnackBar(
-              SnackBar(content: appLocalizations.link_cant_be_opened),
+              SnackBar(
+                content: Text(appLocalizations.link_cant_be_opened),
+              ),
             );
           }
         }

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -2475,5 +2475,9 @@
     "hunger_games_loading_line1": "Please let us a few seconds…",
     "hunger_games_loading_line2": "We're downloading the questions!",
     "hunger_games_error_label": "Argh! Something went wrong… and we couldn't load the questions.",
-    "hunger_games_error_retry_button": "Let's retry!"
+    "hunger_games_error_retry_button": "Let's retry!",
+    "link_cant_be_opened": "This link can't be opened on your device. Please check that you have a browser installed.",
+    "@link_cant_be_opened": {
+        "description": "An error may happen if the device doesn't have a browser installed."
+    }
 }


### PR DESCRIPTION
Hi everyone,

When a link can't be opened, an `Exception` is triggered, but was never caught in `SmoothHtmlWidget`.
We now show a message to inform the user.

It will fix #4719