### PR TITLE
chore: capitalize method for String

### DIFF
--- a/packages/smooth_app/lib/helpers/string_extension.dart
+++ b/packages/smooth_app/lib/helpers/string_extension.dart
@@ -1,5 +1,3 @@
 extension StringExtension on String {
-  String capitalize() => isEmpty
-      ? this
-      : this[0].toUpperCase() + (length == 1 ? '' : substring(1));
+  String capitalize() => isEmpty ? this : this[0].toUpperCase() + substring(1);
 }

--- a/packages/smooth_app/lib/helpers/string_extension.dart
+++ b/packages/smooth_app/lib/helpers/string_extension.dart
@@ -1,0 +1,5 @@
+extension StringExtension on String {
+  String capitalize() => isEmpty
+      ? this
+      : this[0].toUpperCase() + (length == 1 ? '' : substring(1));
+}

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_languages_list.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_languages_list.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
-import 'package:flutter_native_splash/cli_commands.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/helpers/string_extension.dart';
 
 class Languages {
   const Languages();


### PR DESCRIPTION
### What
- We used a `capitalize` method for `String` from an outdated package, and that prevents us from upgrading package `flutter_native_splash`.
- The fix is just to implement the same method, as a `String` extension.
- When this PR is merged, we can upgrade `flutter_native_splash`.

### Part of 
- #4715

### Files
New file:
* `string_extension.dart`: extension for `String`

Impacted file:
* `user_preferences_languages_list.dart`: now using the new `String` extension instead of deprecated library