### PR TITLE
chore: upgrade to flutter_map 4.0.0

### DIFF
--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_world_map_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_world_map_card.dart
@@ -30,48 +30,27 @@ class KnowledgePanelWorldMapCard extends StatelessWidget {
             ),
             zoom: 6.0,
           ),
-          layers: <LayerOptions>[
-            TileLayerOptions(
-              urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-            ),
-            MarkerLayerOptions(
-              markers: getMarkers(mapElement.pointers),
+          nonRotatedChildren: <Widget>[
+            RichAttributionWidget(
+              popupInitialDisplayDuration: const Duration(seconds: 5),
+              animationConfig: const ScaleRAWA(),
+              attributions: <SourceAttribution>[
+                TextSourceAttribution(
+                  'OpenStreetMap contributors',
+                  onTap: () => LaunchUrlHelper.launchURL(
+                    'https://www.openstreetmap.org/copyright',
+                    false,
+                  ),
+                ),
+              ],
             ),
           ],
-          nonRotatedChildren: <Widget>[
-            AttributionWidget(
-              attributionBuilder: (BuildContext context) {
-                return Align(
-                  alignment: AlignmentDirectional.bottomEnd,
-                  child: ColoredBox(
-                    color: const Color(0xCCFFFFFF),
-                    child: GestureDetector(
-                      onTap: () => LaunchUrlHelper.launchURL(
-                        'https://www.openstreetmap.org/copyright',
-                        false,
-                      ),
-                      child: Padding(
-                        padding: const EdgeInsets.all(3),
-                        child: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: <Widget>[
-                            Text(
-                              '© OpenStreetMap contributors',
-                              style: Theme.of(context)
-                                  .textTheme
-                                  .bodyMedium!
-                                  .copyWith(
-                                    color: Colors.blue,
-                                  ),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ),
-                  ),
-                );
-              },
-            )
+          children: <Widget>[
+            TileLayer(
+              urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+              userAgentPackageName: 'org.openfoodfacts.app',
+            ),
+            MarkerLayer(markers: getMarkers(mapElement.pointers)),
           ],
         ),
       ),

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -622,10 +622,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_map
-      sha256: "09010e452bcd8c57ade1b936b79643c4fd599f93b00d1696630f0b919b6f374a"
+      sha256: "52c65a977daae42f9aae6748418dd1535eaf27186e9bac9bf431843082bc75a3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "4.0.0"
   flutter_native_splash:
     dependency: "direct main"
     description:
@@ -1264,14 +1264,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
-  positioned_tap_detector_2:
-    dependency: transitive
-    description:
-      name: positioned_tap_detector_2
-      sha256: "52e06863ad3e1f82b058fd05054fc8c9caeeb3b47d5cea7a24bd9320746059c1"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.4"
   process:
     dependency: transitive
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   cupertino_icons: 1.0.5
   device_preview: 1.1.0
   flutter_svg: 2.0.8
-  flutter_map: 2.2.0
+  flutter_map: 4.0.0
   flutter_widget_from_html_core: 0.8.3+1
   fwfh_selectable_text: 0.8.3+1
   flutter_secure_storage: 8.0.0


### PR DESCRIPTION
### What
- The upgrade to flutter_map 4.0.0 required some minor code change.

### Screenshot
For the record, the new attribution display in flutter_map 4.0.0:
| before clicking on the attribution icon | after clicking on the attribution icon |
| -- | -- |
| ![Screenshot_1698740284](https://github.com/openfoodfacts/smooth-app/assets/11576431/790cc8cf-360c-48fb-8415-08687b34f6cd) | ![Screenshot_1698740293](https://github.com/openfoodfacts/smooth-app/assets/11576431/491fe160-fd08-46b6-a399-69372deb98ea) |

### Part of 
- #4751

### Impacted files
* `knowledge_panel_world_map_card.dart`: recoded with flutter_map 4.0.0 syntax
* `pubspec.lock`: wtf
* `pubspec.yaml`: upgraded to flutter_map 4.0.0