### PR TITLE
chore: (Re)Use the public version of mobile_scanner

### DIFF
--- a/packages/scanner/ml_kit/pubspec.yaml
+++ b/packages/scanner/ml_kit/pubspec.yaml
@@ -13,10 +13,7 @@ dependencies:
   visibility_detector: 0.4.0+2
   async: 2.11.0
 
-  mobile_scanner:
-    git:
-      url: https://github.com/openfoodfacts/mobile_scanner.git
-      ref: custom_release
+  mobile_scanner: 3.5.2
   scanner_shared:
     path: ../shared
 

--- a/packages/smooth_app/ios/Podfile.lock
+++ b/packages/smooth_app/ios/Podfile.lock
@@ -105,7 +105,7 @@ PODS:
     - GTMSessionFetcher/Core (< 3.0, >= 1.1)
     - MLImage (= 1.0.0-beta4)
     - MLKitCommon (~> 9.0)
-  - mobile_scanner (3.2.0):
+  - mobile_scanner (3.5.2):
     - Flutter
     - GoogleMLKit/BarcodeScanning (~> 4.0.0)
   - MTBBarcodeScanner (5.0.11)
@@ -314,7 +314,7 @@ SPEC CHECKSUMS:
   MLKitBarcodeScanning: 04e264482c5f3810cb89ebc134ef6b61e67db505
   MLKitCommon: c1b791c3e667091918d91bda4bba69a91011e390
   MLKitVision: 8baa5f46ee3352614169b85250574fde38c36f49
-  mobile_scanner: 47056db0c04027ea5f41a716385542da28574662
+  mobile_scanner: 5090a13b7a35fc1c25b0d97e18e84f271a6eb605
   MTBBarcodeScanner: f453b33c4b7dfe545d8c6484ed744d55671788cb
   nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
   package_info_plus: 6c92f08e1f853dc01228d6f553146438dafcd14e
@@ -340,4 +340,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: aa97d8b016d7264ad0a1ef5c44765133ae787bc4
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.13.0

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -694,10 +694,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_svg
-      sha256: bfc7cc3c75fe1282e8ce2e056d8fd1533f1a6848b65c379b4a5e7a9b623d3371
+      sha256: d39e7f95621fc84376bc0f7d504f05c3a41488c562f4a8ad410569127507402c
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.8"
+    version: "2.0.9"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -1033,12 +1033,11 @@ packages:
   mobile_scanner:
     dependency: transitive
     description:
-      path: "."
-      ref: custom_release
-      resolved-ref: "031ff428687e56e2a1ef94eea8c62a2d43093b56"
-      url: "https://github.com/openfoodfacts/mobile_scanner.git"
-    source: git
-    version: "3.4.1"
+      name: mobile_scanner
+      sha256: cf978740676ba5b0c17399baf117984b31190bb7a6eaa43e51229ed46abc42ee
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.5.2"
   mockito:
     dependency: "direct dev"
     description:


### PR DESCRIPTION
Hi everyone,

A blocking crash on iOS was forcing us to use a forked version of `mobile_scanner`.
But it's now OK to use back the version, as it's fixed (actually it's also a revert of the faulty code)

Will fix #4753 4753