### PR TITLE
fix: 4725 - refresh of the ios folder for background tasks

### DIFF
--- a/packages/smooth_app/lib/background/background_task_crop.dart
+++ b/packages/smooth_app/lib/background/background_task_crop.dart
@@ -137,7 +137,7 @@ class BackgroundTaskCrop extends BackgroundTaskUpload {
         images: <ProductImage>[_getProductImage()],
       ),
     );
-    putTransientImage(localDatabase);
+    await putTransientImage(localDatabase);
   }
 
   /// Returns the actual crop parameters.
@@ -163,7 +163,7 @@ class BackgroundTaskCrop extends BackgroundTaskUpload {
   ) async {
     await super.postExecute(localDatabase, success);
     try {
-      File(croppedPath).deleteSync();
+      (await getFile(croppedPath)).deleteSync();
     } catch (e) {
       // not likely, but let's not spoil the task for that either.
     }

--- a/packages/smooth_app/lib/background/background_task_image.dart
+++ b/packages/smooth_app/lib/background/background_task_image.dart
@@ -153,7 +153,7 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
         images: <ProductImage>[_getProductImage()],
       ),
     );
-    putTransientImage(localDatabase);
+    await putTransientImage(localDatabase);
   }
 
   /// Returns a fake value that means: "remove the previous value when merging".
@@ -176,17 +176,17 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
   ) async {
     await super.postExecute(localDatabase, success);
     try {
-      File(fullPath).deleteSync();
+      (await getFile(fullPath)).deleteSync();
     } catch (e) {
       // not likely, but let's not spoil the task for that either.
     }
     try {
-      File(croppedPath).deleteSync();
+      (await getFile(croppedPath)).deleteSync();
     } catch (e) {
       // not likely, but let's not spoil the task for that either.
     }
     try {
-      File(_getCroppedPath()).deleteSync();
+      (await getFile(_getCroppedPath())).deleteSync();
     } catch (e) {
       // possible, but let's not spoil the task for that either.
     }
@@ -226,7 +226,8 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
   /// Returns false if no crop operation is needed.
   /// Returns null if the image (cropped or not) is too small.
   Future<bool?> _crop(final File file) async {
-    final ui.Image full = await loadUiImage(await File(fullPath).readAsBytes());
+    final ui.Image full =
+        await loadUiImage(await (await getFile(fullPath)).readAsBytes());
     if (cropX1 == 0 &&
         cropY1 == 0 &&
         cropX2 == cropConversionFactor &&
@@ -296,7 +297,7 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
   Future<void> upload() async {
     final String path;
     final String croppedPath = _getCroppedPath();
-    final bool? neededCrop = await _crop(File(croppedPath));
+    final bool? neededCrop = await _crop(await getFile(croppedPath));
     if (neededCrop == null) {
       // TODO(monsieurtanuki): maybe something more refined when we dismiss the picture, like alerting the user, though it's not supposed to happen anymore from upstream.
       return;

--- a/packages/smooth_app/lib/background/background_task_upload.dart
+++ b/packages/smooth_app/lib/background/background_task_upload.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:smooth_app/background/background_task_barcode.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/database/transient_file.dart';
@@ -71,10 +72,10 @@ abstract class BackgroundTaskUpload extends BackgroundTaskBarcode {
       );
 
   @protected
-  void putTransientImage(final LocalDatabase localDatabase) =>
+  Future<void> putTransientImage(final LocalDatabase localDatabase) async =>
       _getTransientFile().putImage(
         localDatabase,
-        File(croppedPath),
+        await getFile(croppedPath),
       );
 
   @protected
@@ -87,7 +88,7 @@ abstract class BackgroundTaskUpload extends BackgroundTaskBarcode {
   Future<void> recover(final LocalDatabase localDatabase) async {
     final File? transientFile = _getTransientImage();
     if (transientFile == null) {
-      putTransientImage(localDatabase);
+      await putTransientImage(localDatabase);
     }
   }
 
@@ -97,4 +98,25 @@ abstract class BackgroundTaskUpload extends BackgroundTaskBarcode {
     final String language,
   ) =>
       '$barcode;image;$imageField;$language';
+
+  static Future<Directory> getDirectory() async =>
+      getApplicationSupportDirectory();
+
+  /// Returns a "safe" [File] from a given [path].
+  ///
+  /// iOS sometimes changes the path of its standard app folders, like the one
+  /// we use in [getDirectory].
+  /// With this method we refresh the path for iOS.
+  /// cf. https://github.com/openfoodfacts/smooth-app/issues/4725
+  @protected
+  Future<File> getFile(String path) async {
+    if (Platform.isIOS) {
+      final int lastSeparator = path.lastIndexOf('/');
+      final String filename =
+          lastSeparator == -1 ? path : path.substring(lastSeparator + 1);
+      final Directory directory = await getDirectory();
+      path = '${directory.path}/$filename';
+    }
+    return File(path);
+  }
 }

--- a/packages/smooth_app/lib/pages/crop_page.dart
+++ b/packages/smooth_app/lib/pages/crop_page.dart
@@ -7,10 +7,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
-import 'package:path_provider/path_provider.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/background/background_task_crop.dart';
 import 'package:smooth_app/background/background_task_image.dart';
+import 'package:smooth_app/background/background_task_upload.dart';
 import 'package:smooth_app/data_models/continuous_scan_model.dart';
 import 'package:smooth_app/database/dao_int.dart';
 import 'package:smooth_app/database/local_database.dart';
@@ -318,7 +318,7 @@ class _CropPageState extends State<CropPage> {
     final DaoInt daoInt = DaoInt(localDatabase);
     final int sequenceNumber =
         await getNextSequenceNumber(daoInt, _CROP_PAGE_SEQUENCE_KEY);
-    final Directory directory = await getApplicationSupportDirectory();
+    final Directory directory = await BackgroundTaskUpload.getDirectory();
 
     final File croppedFile = await _getCroppedImageFile(
       directory,


### PR DESCRIPTION
### What
- On ios, the standard app folders change regularly. The files are still there, but the folder is different.
- This PR fixes a top sentry issue, where in background tasks we cannot find temporary files because the folder name changed.

### Fixes bug(s)
- Fixes: #4725

### Impacted files
* `background_task_crop.dart`: now using new safe method `getFile` instead of just `File`
* `background_task_image.dart`: now using new safe method `getFile` instead of just `File`
* `background_task_upload.dart`: now fixing the ios directory
* `crop_page.dart`: now using a shared directory