### PR TITLE
feat: 4789 - new "add ingredients" button for nutriscore

### DIFF
--- a/packages/smooth_app/lib/pages/product/add_new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_new_product_page.dart
@@ -412,6 +412,12 @@ class _AddNewProductPageState extends State<AddNewProductPage>
                 ),
         done: _nutritionEditor.isPopulated(upToDateProduct),
       ),
+      _buildIngredientsButton(
+        context,
+        forceIconData: Icons.filter_3,
+        disabled: (!_categoryEditor.isPopulated(upToDateProduct)) ||
+            (!_nutritionEditor.isPopulated(upToDateProduct)),
+      ),
       Center(
         child: AddNewProductScoreIcon(
           iconUrl: attribute?.iconUrl,


### PR DESCRIPTION
### What
- Added the "add ingredients" button for the computation of nutriscore of new products.

### Screenshot
![Screenshot_1700139619](https://github.com/openfoodfacts/smooth-app/assets/11576431/b51891df-592f-4e9d-b9e2-9d50d7a1b723)

### Fixes bug(s)
- Closes: #4789