### PR TITLE
chore: When the app fails to launch, the Exception is dispatched the log service (Sentry…)

### DIFF
--- a/packages/smooth_app/lib/main.dart
+++ b/packages/smooth_app/lib/main.dart
@@ -194,6 +194,11 @@ class _SmoothAppState extends State<SmoothApp> {
       future: _initFuture,
       builder: (BuildContext context, AsyncSnapshot<void> snapshot) {
         if (snapshot.hasError) {
+          Logs.e(
+            'The app initialisation failed',
+            ex: snapshot.error,
+            stacktrace: snapshot.stackTrace,
+          );
           FlutterNativeSplash.remove();
           return _buildError(snapshot);
         }


### PR DESCRIPTION
Hi everyone,

The Hive error (#4807) is a bit hard to debug, as no Exception is exported on Sentry and the logs.
The PRs ensure that if the initialization fails, it will notify the LogService