### PR TITLE
fix: 4812 - check mounted before setState

### DIFF
--- a/packages/smooth_app/lib/pages/product/common/product_query_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_query_page.dart
@@ -73,11 +73,15 @@ class _ProductQueryPageState extends State<ProductQueryPage>
         if (_scrollController.offset >= 400) {
           if (!_showBackToTopButton) {
             _showBackToTopButton = true;
-            setState(() {});
+            if (mounted) {
+              setState(() {});
+            }
           }
         } else if (_showBackToTopButton) {
           _showBackToTopButton = false;
-          setState(() {});
+          if (mounted) {
+            setState(() {});
+          }
         }
       });
   }
@@ -427,8 +431,11 @@ class _ProductQueryPageState extends State<ProductQueryPage>
         ),
       );
 
-  void retryConnection() =>
+  void retryConnection() {
+    if (mounted) {
       setState(() => _model = _getModel(widget.productListSupplier));
+    }
+  }
 
   ProductQueryModel _getModel(final ProductListSupplier supplier) =>
       ProductQueryModel(supplier);
@@ -448,7 +455,9 @@ class _ProductQueryPageState extends State<ProductQueryPage>
       if (successfullyLoaded) {
         _scrollToTop(instant: true);
       }
-      setState(() {});
+      if (mounted) {
+        setState(() {});
+      }
     }
   }
 
@@ -476,7 +485,9 @@ class _ProductQueryPageState extends State<ProductQueryPage>
     try {
       final bool result = await _model.loadNextPage();
       if (result) {
-        setState(() {});
+        if (mounted) {
+          setState(() {});
+        }
       }
     } catch (e) {
       //


### PR DESCRIPTION
### What
- Especially for long operations, we need to check `mounted` before calling `setState`.
- If not, we may get `_TypeError: Null check operator used on a null value` if the user goes back one page while an operation is still pending.

### Fixes bug(s)
- Fixes: #4812