### PR TITLE
chore: Ensure that error logs sent to Sentry via Fimber are always considered as exceptions

### DIFF
--- a/packages/smooth_app/lib/services/logs/fimber/trees/sentry_fimber_tree.dart
+++ b/packages/smooth_app/lib/services/logs/fimber/trees/sentry_fimber_tree.dart
@@ -17,18 +17,23 @@ class SentryFimberTree extends BaseFimberTree {
     StackTrace? stacktrace,
     String? tag,
   }) {
-    if (ex != null) {
+    final SentryLevel sentryLevel = _convertLevel(level);
+
+    if (ex != null || sentryLevel == SentryLevel.error) {
       Sentry.captureException(
         ex,
         stackTrace: stacktrace,
-        hint: tag != null ? Hint.withMap(<String, Object>{'tag': tag}) : null,
+        hint: Hint.withMap(<String, Object>{
+          'tag': tag ?? '-',
+          'message': message,
+        }),
       );
     } else {
       Sentry.addBreadcrumb(
         Breadcrumb(
           message: message,
           timestamp: DateTime.now(),
-          level: _convertLevel(level),
+          level: sentryLevel,
         ),
         hint: tag != null ? Hint.withMap(<String, Object>{'tag': tag}) : null,
       );


### PR DESCRIPTION
Hi everyone,

When we use the `LogsService` mechanism, in release mode, events are sent to Sentry.
However, if we have an error without an exception, an event is not created in Sentry, it's just a breadcrumb in the timeline.

To better filter that kind of errors, now all "errors" logs will be considered as exceptions.