### PR TITLE
feat: Customized language picker UI for the onboarding

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -777,7 +777,11 @@
     },
     "country_chooser_label": "Please choose a country",
     "@country_chooser_label": {
-        "description": "Label shown above a selector where the user can select their country (in the onboarding)"
+        "description": "Label shown above a selector where the user can select their country (in the preferences)"
+    },
+    "onboarding_country_chooser_label": "Please choose a country:",
+    "@onboarding_country_chooser_label": {
+        "description": "The label shown above a selector where the user can select their country (in the onboarding)"
     },
     "country_chooser_label_from_settings": "Your country",
     "@country_chooser_label_from_settings": {

--- a/packages/smooth_app/lib/pages/onboarding/country_selector.dart
+++ b/packages/smooth_app/lib/pages/onboarding/country_selector.dart
@@ -18,11 +18,15 @@ class CountrySelector extends StatefulWidget {
     this.textStyle,
     this.padding,
     this.icon,
+    this.iconDecoration,
+    this.inkWellBorderRadius,
   });
 
   final TextStyle? textStyle;
   final EdgeInsetsGeometry? padding;
-  final IconData? icon;
+  final BorderRadius? inkWellBorderRadius;
+  final Icon? icon;
+  final BoxDecoration? iconDecoration;
 
   @override
   State<CountrySelector> createState() => _CountrySelectorState();
@@ -76,8 +80,12 @@ class _CountrySelectorState extends State<CountrySelector> {
         final Country selectedCountry = _getSelectedCountry(
           userPreferences.userCountryCode,
         );
+        final EdgeInsetsGeometry innerPadding = const EdgeInsets.symmetric(
+          vertical: SMALL_SPACE,
+        ).add(widget.padding ?? EdgeInsets.zero);
+
         return InkWell(
-          borderRadius: ANGULAR_BORDER_RADIUS,
+          borderRadius: widget.inkWellBorderRadius ?? ANGULAR_BORDER_RADIUS,
           onTap: () async {
             _reorderCountries(selectedCountry);
             List<Country> filteredList = List<Country>.from(_countryList);
@@ -168,32 +176,43 @@ class _CountrySelectorState extends State<CountrySelector> {
               );
             }
           },
-          child: Container(
+          child: DecoratedBox(
             decoration: const BoxDecoration(
               borderRadius: BorderRadius.all(Radius.circular(10)),
             ),
-            padding: const EdgeInsets.symmetric(
-              vertical: SMALL_SPACE,
-            ).add(widget.padding ?? EdgeInsets.zero),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: <Widget>[
-                const Icon(Icons.public),
-                Expanded(
-                  flex: 1,
-                  child: Padding(
-                    padding:
-                        const EdgeInsets.symmetric(horizontal: LARGE_SPACE),
-                    child: Text(
-                      selectedCountry.name,
-                      style: widget.textStyle ??
-                          Theme.of(context).textTheme.displaySmall,
+            child: IntrinsicHeight(
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: <Widget>[
+                  Padding(
+                    padding: innerPadding,
+                    child: const Icon(Icons.public),
+                  ),
+                  Expanded(
+                    flex: 1,
+                    child: Padding(
+                      padding:
+                          const EdgeInsets.symmetric(horizontal: LARGE_SPACE),
+                      child: Text(
+                        selectedCountry.name,
+                        style: Theme.of(context)
+                            .textTheme
+                            .displaySmall
+                            ?.merge(widget.textStyle),
+                      ),
                     ),
                   ),
-                ),
-                Icon(widget.icon ?? Icons.arrow_drop_down),
-              ],
+                  Container(
+                    height: double.infinity,
+                    decoration: widget.iconDecoration ?? const BoxDecoration(),
+                    child: AspectRatio(
+                      aspectRatio: 1.0,
+                      child: widget.icon ?? const Icon(Icons.arrow_drop_down),
+                    ),
+                  ),
+                ],
+              ),
             ),
           ),
         );

--- a/packages/smooth_app/lib/pages/onboarding/welcome_page.dart
+++ b/packages/smooth_app/lib/pages/onboarding/welcome_page.dart
@@ -19,10 +19,9 @@ class WelcomePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    final TextStyle headlineStyle =
-        Theme.of(context).textTheme.displayMedium!.wellSpaced;
-    final TextStyle bodyTextStyle =
-        Theme.of(context).textTheme.bodyLarge!.wellSpaced;
+    final ThemeData theme = Theme.of(context);
+    final TextStyle headlineStyle = theme.textTheme.displayMedium!.wellSpaced;
+    final TextStyle bodyTextStyle = theme.textTheme.bodyLarge!.wellSpaced;
     final Size screenSize = MediaQuery.of(context).size;
 
     return SmoothScaffold(
@@ -74,7 +73,7 @@ class WelcomePage extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: <Widget>[
                       Text(
-                        appLocalizations.country_chooser_label,
+                        appLocalizations.onboarding_country_chooser_label,
                         style: bodyTextStyle,
                       ),
                       Padding(
@@ -82,16 +81,33 @@ class WelcomePage extends StatelessWidget {
                             const EdgeInsets.symmetric(vertical: MEDIUM_SPACE),
                         child: Ink(
                           decoration: BoxDecoration(
-                            border: const Border.fromBorderSide(
+                            border: Border.fromBorderSide(
                               BorderSide(
-                                color: Colors.black,
+                                color: theme.colorScheme.inversePrimary,
                                 width: 1,
                               ),
                             ),
-                            borderRadius: ANGULAR_BORDER_RADIUS,
-                            color: Theme.of(context).cardColor,
+                            borderRadius: ROUNDED_BORDER_RADIUS,
+                            color: theme.colorScheme.onPrimary,
                           ),
-                          child: const CountrySelector(),
+                          child: SizedBox(
+                            width: double.infinity,
+                            child: CountrySelector(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: SMALL_SPACE,
+                              ),
+                              inkWellBorderRadius: ROUNDED_BORDER_RADIUS,
+                              icon: Icon(
+                                Icons.edit,
+                                color: Colors.white.withOpacity(0.9),
+                              ),
+                              iconDecoration: BoxDecoration(
+                                color: theme.primaryColor,
+                                borderRadius: ROUNDED_BORDER_RADIUS,
+                              ),
+                              textStyle: TextStyle(color: theme.primaryColor),
+                            ),
+                          ),
                         ),
                       ),
                       Padding(

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_country_selector.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_country_selector.dart
@@ -35,7 +35,7 @@ class UserPreferencesCountrySelector extends StatelessWidget {
         ),
         child: CountrySelector(
           textStyle: themeData.textTheme.bodyMedium,
-          icon: Icons.edit,
+          icon: const Icon(Icons.edit),
           padding: const EdgeInsetsDirectional.only(
             start: SMALL_SPACE,
           ),


### PR DESCRIPTION
Hi everyone,

I've tweaked a little bit the UI of the language picker in the onboarding.
It won't stay with the redesigned one, so it's just some minor fixes:
- An edit button, instead of a chevron (it's not a dropdown)
- Really weird paddings
- Same UI as the search bar in the redesign.

The UI is OK both in dark/light modes + the widget used in the preferences is still OK.
I've also checked the a11n is OK.

Some screenshots:
Current UI: 
<img width="768" alt="Screenshot 2023-11-20 at 02 28 27" src="https://github.com/openfoodfacts/smooth-app/assets/246838/40da9e4c-bc2c-4531-bec9-f0ef8cf81311">

New UI:
<img width="608" alt="Screenshot 2023-11-20 at 02 56 11" src="https://github.com/openfoodfacts/smooth-app/assets/246838/3059e970-f478-41ff-9fc0-5117186beb41">
<img width="608" alt="Screenshot 2023-11-20 at 02 56 27" src="https://github.com/openfoodfacts/smooth-app/assets/246838/c9715d59-da56-4d61-a35e-7983e32cc8cf">
