### PR TITLE
fix: If there is a network error in an SVG file, we should consider it as an error

### DIFF
--- a/packages/smooth_app/lib/cards/category_cards/svg_safe_network.dart
+++ b/packages/smooth_app/lib/cards/category_cards/svg_safe_network.dart
@@ -33,6 +33,9 @@ class _SvgSafeNetworkState extends State<SvgSafeNetwork> {
       return cached;
     }
     final http.Response response = await http.get(Uri.parse(_url));
+    if (response.statusCode != 200) {
+      throw Exception('Failed to load SVG: $_url ${response.statusCode}');
+    }
     _networkCache[_url] = cached = response.body;
     return cached;
   }


### PR DESCRIPTION
Hi everyone,

We currently have an issue on the product page and the carousel.
If an SVG doesn't exist (e.g.: https://static.openfoodfacts.org/images/attributes/nutriscore-c.svg), the Widget will crash.

Basically, it will pass a `String` containing '404 Not found' to the `SvgPicture` => hence an `Exception`.