### PR TITLE
chore: Upgrade GoRouter to the latest version (7.x -> 12.x)

### DIFF
--- a/packages/smooth_app/lib/pages/navigator/app_navigator.dart
+++ b/packages/smooth_app/lib/pages/navigator/app_navigator.dart
@@ -242,7 +242,8 @@ class _SmoothGoRouter {
               // Support cgi/product.pl?type=edit&code=XXXX
               final String? barcode = state.uri.queryParameters['code'];
 
-              if (barcode != null && state.uri.queryParameters['type'] == 'edit') {
+              if (barcode != null &&
+                  state.uri.queryParameters['type'] == 'edit') {
                 return AppRoutes.PRODUCT_LOADER(barcode, edit: true);
               } else {
                 externalLink = true;

--- a/packages/smooth_app/lib/pages/navigator/app_navigator.dart
+++ b/packages/smooth_app/lib/pages/navigator/app_navigator.dart
@@ -131,8 +131,8 @@ class _SmoothGoRouter {
                 final Widget widget = ProductPage(
                   product,
                   withHeroAnimation:
-                      state.queryParameters['heroAnimation'] != 'false',
-                  heroTag: state.queryParameters['heroTag'],
+                      state.uri.queryParameters['heroAnimation'] != 'false',
+                  heroTag: state.uri.queryParameters['heroTag'],
                 );
 
                 if (ExternalCarouselManager.find(context) == null) {
@@ -162,7 +162,7 @@ class _SmoothGoRouter {
                 final String barcode = state.pathParameters['productId']!;
                 return ProductLoaderPage(
                   barcode: barcode,
-                  mode: state.queryParameters['edit'] == 'true'
+                  mode: state.uri.queryParameters['edit'] == 'true'
                       ? ProductLoaderMode.editProduct
                       : ProductLoaderMode.viewProduct,
                 );
@@ -201,7 +201,7 @@ class _SmoothGoRouter {
             GoRoute(
               path: _InternalAppRoutes.EXTERNAL_PAGE,
               builder: (BuildContext context, GoRouterState state) {
-                return ExternalPage(path: state.queryParameters['path']!);
+                return ExternalPage(path: state.uri.queryParameters['path']!);
               },
             ),
           ],
@@ -211,7 +211,7 @@ class _SmoothGoRouter {
         final String path = state.matchedLocation;
 
         // Ignore deep links if the onboarding is not yet completed
-        if (state.location != _InternalAppRoutes.HOME_PAGE &&
+        if (state.uri.toString() != _InternalAppRoutes.HOME_PAGE &&
             !_isOnboardingComplete(context)) {
           return _InternalAppRoutes.HOME_PAGE;
         } else if (_isAnInternalRoute(path)) {
@@ -240,9 +240,9 @@ class _SmoothGoRouter {
               }
             } else if (path == _ExternalRoutes.PRODUCT_EDITION) {
               // Support cgi/product.pl?type=edit&code=XXXX
-              final String? barcode = state.queryParameters['code'];
+              final String? barcode = state.uri.queryParameters['code'];
 
-              if (barcode != null && state.queryParameters['type'] == 'edit') {
+              if (barcode != null && state.uri.queryParameters['type'] == 'edit') {
                 return AppRoutes.PRODUCT_LOADER(barcode, edit: true);
               } else {
                 externalLink = true;
@@ -260,11 +260,11 @@ class _SmoothGoRouter {
         if (externalLink) {
           return _openExternalLink(path);
         } else {
-          return state.location;
+          return state.uri.toString();
         }
       },
       errorBuilder: (_, GoRouterState state) => ErrorPage(
-        url: state.location,
+        url: state.uri.toString(),
       ),
     );
   }

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -759,10 +759,10 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: b185cf91b5a6861f4c2a92ddaa65f8919909416ee033e00751f7c67ebee1588d
+      sha256: c247a4f76071c3b97bb5ae8912968870d5565644801c5e09f3bc961b4d874895
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.2"
+    version: "12.1.1"
   graphs:
     dependency: transitive
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
 
   async: 2.11.0
-  go_router: 7.0.2
+  go_router: 12.1.1
   barcode_widget: 2.0.4
   carousel_slider: 4.2.1
   cupertino_icons: 1.0.6


### PR DESCRIPTION
Hi everyone,

We have a bit of lag with the latest version of GoRouter (5 versions in less than 6 months 🤯).
Some minor tweaks were needed for the upgrade.