### PR TITLE
fix: 4853 - new "dist" subfolder for server attribute images

### DIFF
--- a/packages/smooth_app/assets/metadata/init_attribute_groups_en.json
+++ b/packages/smooth_app/assets/metadata/init_attribute_groups_en.json
@@ -1,6 +1,6 @@
 [{
   "attributes": [{
-    "icon_url": "https://static.openfoodfacts.org/images/attributes/nutriscore-a.svg",
+    "icon_url": "https://static.openfoodfacts.org/images/attributes/dist/nutriscore-a.svg",
     "setting_note": "The Nutri-Score is computed and can be taken into account for all products, even if is not displayed on the packaging.",
     "name": "Nutri-Score",
     "default": "very_important",
@@ -11,22 +11,22 @@
     "setting_name": "Salt in low quantity",
     "id": "low_salt",
     "setting_note": "The salt level is taken into account by the Nutri-Score. Use this setting only if you are specifically on a low salt diet.",
-    "icon_url": "https://static.openfoodfacts.org/images/attributes/nutrient-level-salt-low.svg"
+    "icon_url": "https://static.openfoodfacts.org/images/attributes/dist/nutrient-level-salt-low.svg"
   }, {
     "setting_note": "The sugars level is taken into account by the Nutri-Score. Use this setting only if you are specifically on a low sugars diet.",
-    "icon_url": "https://static.openfoodfacts.org/images/attributes/nutrient-level-sugars-low.svg",
+    "icon_url": "https://static.openfoodfacts.org/images/attributes/dist/nutrient-level-sugars-low.svg",
     "id": "low_sugars",
     "setting_name": "Sugars in low quantity",
     "name": "Sugars"
   }, {
-    "icon_url": "https://static.openfoodfacts.org/images/attributes/nutrient-level-fat-low.svg",
+    "icon_url": "https://static.openfoodfacts.org/images/attributes/dist/nutrient-level-fat-low.svg",
     "setting_note": "The fat level is taken into account by the Nutri-Score. Use this setting only if you are specifically on a low fat diet.",
     "id": "low_fat",
     "setting_name": "Fat in low quantity",
     "name": "Fat"
   }, {
     "setting_note": "The saturated fat level is taken into account by the Nutri-Score. Use this setting only if you are specifically on a low saturated fat diet.",
-    "icon_url": "https://static.openfoodfacts.org/images/attributes/nutrient-level-saturated-fat-low.svg",
+    "icon_url": "https://static.openfoodfacts.org/images/attributes/dist/nutrient-level-saturated-fat-low.svg",
     "name": "Saturated fat",
     "id": "low_saturated_fat",
     "setting_name": "Saturated fat in low quantity"
@@ -37,13 +37,13 @@
   "id": "processing",
   "name": "Food processing",
   "attributes": [{
-    "icon_url": "https://static.openfoodfacts.org/images/attributes/nova-group-1.svg",
+    "icon_url": "https://static.openfoodfacts.org/images/attributes/dist/nova-group-1.svg",
     "name": "NOVA group",
     "default": "important",
     "setting_name": "No or little food processing (NOVA group)",
     "id": "nova"
   }, {
-    "icon_url": "https://static.openfoodfacts.org/images/attributes/0-additives.svg",
+    "icon_url": "https://static.openfoodfacts.org/images/attributes/dist/0-additives.svg",
     "setting_name": "No or few additives",
     "id": "additives",
     "name": "Additives"
@@ -54,14 +54,14 @@
     "name": "Gluten",
     "id": "allergens_no_gluten",
     "setting_name": "Without Gluten",
-    "icon_url": "https://static.openfoodfacts.org/images/attributes/no-gluten.svg"
+    "icon_url": "https://static.openfoodfacts.org/images/attributes/dist/no-gluten.svg"
   }, {
     "name": "Milk",
     "id": "allergens_no_milk",
     "setting_name": "Without Milk",
-    "icon_url": "https://static.openfoodfacts.org/images/attributes/no-milk.svg"
+    "icon_url": "https://static.openfoodfacts.org/images/attributes/dist/no-milk.svg"
   }, {
-    "icon_url": "https://static.openfoodfacts.org/images/attributes/no-eggs.svg",
+    "icon_url": "https://static.openfoodfacts.org/images/attributes/dist/no-eggs.svg",
     "name": "Eggs",
     "setting_name": "Without Eggs",
     "id": "allergens_no_eggs"
@@ -69,14 +69,14 @@
     "setting_name": "Without Nuts",
     "id": "allergens_no_nuts",
     "name": "Nuts",
-    "icon_url": "https://static.openfoodfacts.org/images/attributes/no-nuts.svg"
+    "icon_url": "https://static.openfoodfacts.org/images/attributes/dist/no-nuts.svg"
   }, {
     "name": "Peanuts",
     "id": "allergens_no_peanuts",
     "setting_name": "Without Peanuts",
-    "icon_url": "https://static.openfoodfacts.org/images/attributes/no-peanuts.svg"
+    "icon_url": "https://static.openfoodfacts.org/images/attributes/dist/no-peanuts.svg"
   }, {
-    "icon_url": "https://static.openfoodfacts.org/images/attributes/no-sesame-seeds.svg",
+    "icon_url": "https://static.openfoodfacts.org/images/attributes/dist/no-sesame-seeds.svg",
     "setting_name": "Without Sesame seeds",
     "id": "allergens_no_sesame_seeds",
     "name": "Sesame seeds"
@@ -84,34 +84,34 @@
     "setting_name": "Without Soybeans",
     "id": "allergens_no_soybeans",
     "name": "Soybeans",
-    "icon_url": "https://static.openfoodfacts.org/images/attributes/no-soybeans.svg"
+    "icon_url": "https://static.openfoodfacts.org/images/attributes/dist/no-soybeans.svg"
   }, {
     "name": "Celery",
     "id": "allergens_no_celery",
     "setting_name": "Without Celery",
-    "icon_url": "https://static.openfoodfacts.org/images/attributes/no-celery.svg"
+    "icon_url": "https://static.openfoodfacts.org/images/attributes/dist/no-celery.svg"
   }, {
     "id": "allergens_no_mustard",
     "setting_name": "Without Mustard",
     "name": "Mustard",
-    "icon_url": "https://static.openfoodfacts.org/images/attributes/no-mustard.svg"
+    "icon_url": "https://static.openfoodfacts.org/images/attributes/dist/no-mustard.svg"
   }, {
     "setting_name": "Without Lupin",
     "id": "allergens_no_lupin",
     "name": "Lupin",
-    "icon_url": "https://static.openfoodfacts.org/images/attributes/no-lupin.svg"
+    "icon_url": "https://static.openfoodfacts.org/images/attributes/dist/no-lupin.svg"
   }, {
     "id": "allergens_no_fish",
     "setting_name": "Without Fish",
     "name": "Fish",
-    "icon_url": "https://static.openfoodfacts.org/images/attributes/no-fish.svg"
+    "icon_url": "https://static.openfoodfacts.org/images/attributes/dist/no-fish.svg"
   }, {
     "name": "Crustaceans",
     "setting_name": "Without Crustaceans",
     "id": "allergens_no_crustaceans",
-    "icon_url": "https://static.openfoodfacts.org/images/attributes/no-crustaceans.svg"
+    "icon_url": "https://static.openfoodfacts.org/images/attributes/dist/no-crustaceans.svg"
   }, {
-    "icon_url": "https://static.openfoodfacts.org/images/attributes/no-molluscs.svg",
+    "icon_url": "https://static.openfoodfacts.org/images/attributes/dist/no-molluscs.svg",
     "id": "allergens_no_molluscs",
     "setting_name": "Without Molluscs",
     "name": "Molluscs"
@@ -119,13 +119,13 @@
     "name": "Sulphur dioxide and sulphites",
     "id": "allergens_no_sulphur_dioxide_and_sulphites",
     "setting_name": "Without Sulphur dioxide and sulphites",
-    "icon_url": "https://static.openfoodfacts.org/images/attributes/no-sulphur-dioxide-and-sulphites.svg"
+    "icon_url": "https://static.openfoodfacts.org/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg"
   }],
   "id": "allergens",
   "name": "Allergens"
 }, {
   "attributes": [{
-    "icon_url": "https://static.openfoodfacts.org/images/attributes/vegan.svg",
+    "icon_url": "https://static.openfoodfacts.org/images/attributes/dist/vegan.svg",
     "setting_name": "Vegan",
     "id": "vegan",
     "name": "Vegan"
@@ -133,9 +133,9 @@
     "id": "vegetarian",
     "setting_name": "Vegetarian",
     "name": "Vegetarian",
-    "icon_url": "https://static.openfoodfacts.org/images/attributes/vegetarian.svg"
+    "icon_url": "https://static.openfoodfacts.org/images/attributes/dist/vegetarian.svg"
   }, {
-    "icon_url": "https://static.openfoodfacts.org/images/attributes/palm-oil-free.svg",
+    "icon_url": "https://static.openfoodfacts.org/images/attributes/dist/palm-oil-free.svg",
     "name": "Palm oil free",
     "id": "palm_oil_free",
     "setting_name": "Palm oil free"
@@ -145,14 +145,14 @@
 }, {
   "attributes": [{
     "description_short": "Organic products promote ecological sustainability and biodiversity.",
-    "icon_url": "https://static.openfoodfacts.org/images/attributes/organic.svg",
+    "icon_url": "https://static.openfoodfacts.org/images/attributes/dist/organic.svg",
     "description": "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
     "name": "Organic farming",
     "setting_name": "Organic farming",
     "id": "labels_organic"
   }, {
     "description_short": "Fair trade products help producers in developing countries.",
-    "icon_url": "https://static.openfoodfacts.org/images/attributes/fair-trade.svg",
+    "icon_url": "https://static.openfoodfacts.org/images/attributes/dist/fair-trade.svg",
     "name": "Fair trade",
     "description": "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
     "id": "labels_fair_trade",
@@ -162,7 +162,7 @@
   "id": "labels"
 }, {
   "attributes": [{
-    "icon_url": "https://static.openfoodfacts.org/images/attributes/ecoscore-a.svg",
+    "icon_url": "https://static.openfoodfacts.org/images/attributes/dist/ecoscore-a.svg",
     "name": "Eco-Score",
     "id": "ecoscore",
     "setting_name": "Low environmental impact (Eco-Score)",
@@ -171,7 +171,7 @@
     "id": "forest_footprint",
     "setting_name": "Low risk of deforestation (Forest footprint)",
     "name": "Forest footprint",
-    "icon_url": "https://static.openfoodfacts.org/images/attributes/forest-footprint-a.svg"
+    "icon_url": "https://static.openfoodfacts.org/images/attributes/dist/forest-footprint-a.svg"
   }],
   "name": "Environment",
   "id": "environment"

--- a/packages/smooth_app/assets/onboarding/sample_product_data.json
+++ b/packages/smooth_app/assets/onboarding/sample_product_data.json
@@ -9,7 +9,7 @@
                   "description" : "",
                   "description_short" : "Very good nutritional quality",
                   "grade" : "a",
-                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/nutriscore-a.svg",
+                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/dist/nutriscore-a.svg",
                   "id" : "nutriscore",
                   "match" : 85.0714285714286,
                   "name" : "Nutri-Score",
@@ -20,7 +20,7 @@
                {
                   "description_short" : "0.4 g / 100 g",
                   "grade" : "b",
-                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/nutrient-level-salt-medium.svg",
+                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/dist/nutrient-level-salt-medium.svg",
                   "id" : "low_salt",
                   "match" : 75,
                   "name" : "Salt",
@@ -30,7 +30,7 @@
                {
                   "description_short" : "0.5 g / 100 g",
                   "grade" : "a",
-                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/nutrient-level-fat-low.svg",
+                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/dist/nutrient-level-fat-low.svg",
                   "id" : "low_fat",
                   "match" : 96.6666666666667,
                   "name" : "Fat",
@@ -40,7 +40,7 @@
                {
                   "description_short" : "0.5 g / 100 g",
                   "grade" : "a",
-                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/nutrient-level-sugars-low.svg",
+                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/dist/nutrient-level-sugars-low.svg",
                   "id" : "low_sugars",
                   "match" : 98,
                   "name" : "Sugars",
@@ -50,7 +50,7 @@
                {
                   "description_short" : "0.2 g / 100 g",
                   "grade" : "a",
-                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/nutrient-level-saturated-fat-low.svg",
+                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/dist/nutrient-level-saturated-fat-low.svg",
                   "id" : "low_saturated_fat",
                   "match" : 97.3333333333333,
                   "name" : "Saturated fat",
@@ -66,7 +66,7 @@
                {
                   "debug" : "7 ingredients (0 unknown)",
                   "grade" : "a",
-                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/no-gluten.svg",
+                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/dist/no-gluten.svg",
                   "id" : "allergens_no_gluten",
                   "match" : 100,
                   "name" : "Gluten",
@@ -76,7 +76,7 @@
                {
                   "debug" : "7 ingredients (0 unknown)",
                   "grade" : "a",
-                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/no-milk.svg",
+                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/dist/no-milk.svg",
                   "id" : "allergens_no_milk",
                   "match" : 100,
                   "name" : "Milk",
@@ -86,7 +86,7 @@
                {
                   "debug" : "7 ingredients (0 unknown)",
                   "grade" : "a",
-                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/no-eggs.svg",
+                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/dist/no-eggs.svg",
                   "id" : "allergens_no_eggs",
                   "match" : 100,
                   "name" : "Eggs",
@@ -96,7 +96,7 @@
                {
                   "debug" : "7 ingredients (0 unknown)",
                   "grade" : "a",
-                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/no-nuts.svg",
+                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/dist/no-nuts.svg",
                   "id" : "allergens_no_nuts",
                   "match" : 100,
                   "name" : "Nuts",
@@ -106,7 +106,7 @@
                {
                   "debug" : "7 ingredients (0 unknown)",
                   "grade" : "a",
-                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/no-peanuts.svg",
+                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/dist/no-peanuts.svg",
                   "id" : "allergens_no_peanuts",
                   "match" : 100,
                   "name" : "Peanuts",
@@ -116,7 +116,7 @@
                {
                   "debug" : "7 ingredients (0 unknown)",
                   "grade" : "a",
-                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/no-sesame-seeds.svg",
+                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/dist/no-sesame-seeds.svg",
                   "id" : "allergens_no_sesame_seeds",
                   "match" : 100,
                   "name" : "Sesame seeds",
@@ -126,7 +126,7 @@
                {
                   "debug" : "7 ingredients (0 unknown)",
                   "grade" : "a",
-                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/no-soybeans.svg",
+                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/dist/no-soybeans.svg",
                   "id" : "allergens_no_soybeans",
                   "match" : 100,
                   "name" : "Soybeans",
@@ -136,7 +136,7 @@
                {
                   "debug" : "7 ingredients (0 unknown)",
                   "grade" : "a",
-                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/no-celery.svg",
+                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/dist/no-celery.svg",
                   "id" : "allergens_no_celery",
                   "match" : 100,
                   "name" : "Celery",
@@ -146,7 +146,7 @@
                {
                   "debug" : "7 ingredients (0 unknown)",
                   "grade" : "a",
-                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/no-mustard.svg",
+                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/dist/no-mustard.svg",
                   "id" : "allergens_no_mustard",
                   "match" : 100,
                   "name" : "Mustard",
@@ -156,7 +156,7 @@
                {
                   "debug" : "7 ingredients (0 unknown)",
                   "grade" : "a",
-                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/no-lupin.svg",
+                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/dist/no-lupin.svg",
                   "id" : "allergens_no_lupin",
                   "match" : 100,
                   "name" : "Lupin",
@@ -166,7 +166,7 @@
                {
                   "debug" : "7 ingredients (0 unknown)",
                   "grade" : "a",
-                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/no-fish.svg",
+                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/dist/no-fish.svg",
                   "id" : "allergens_no_fish",
                   "match" : 100,
                   "name" : "Fish",
@@ -176,7 +176,7 @@
                {
                   "debug" : "7 ingredients (0 unknown)",
                   "grade" : "a",
-                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/no-crustaceans.svg",
+                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/dist/no-crustaceans.svg",
                   "id" : "allergens_no_crustaceans",
                   "match" : 100,
                   "name" : "Crustaceans",
@@ -186,7 +186,7 @@
                {
                   "debug" : "7 ingredients (0 unknown)",
                   "grade" : "a",
-                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/no-molluscs.svg",
+                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/dist/no-molluscs.svg",
                   "id" : "allergens_no_molluscs",
                   "match" : 100,
                   "name" : "Molluscs",
@@ -196,7 +196,7 @@
                {
                   "debug" : "7 ingredients (0 unknown)",
                   "grade" : "a",
-                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/no-sulphur-dioxide-and-sulphites.svg",
+                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/dist/no-sulphur-dioxide-and-sulphites.svg",
                   "id" : "allergens_no_sulphur_dioxide_and_sulphites",
                   "match" : 100,
                   "name" : "Sulphur dioxide and sulphites",
@@ -212,7 +212,7 @@
             "attributes" : [
                {
                   "grade" : "a",
-                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/vegan.svg",
+                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/dist/vegan.svg",
                   "id" : "vegan",
                   "match" : 100,
                   "name" : "Vegan",
@@ -222,7 +222,7 @@
                },
                {
                   "grade" : "a",
-                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/vegetarian.svg",
+                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/dist/vegetarian.svg",
                   "id" : "vegetarian",
                   "match" : 100,
                   "name" : "Vegetarian",
@@ -232,7 +232,7 @@
                },
                {
                   "grade" : "a",
-                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/palm-oil-free.svg",
+                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/dist/palm-oil-free.svg",
                   "id" : "palm_oil_free",
                   "match" : 100,
                   "name" : "Palm oil free",
@@ -250,7 +250,7 @@
                   "description" : "",
                   "description_short" : "Processed foods",
                   "grade" : "b",
-                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/nova-group-3.svg",
+                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/dist/nova-group-3.svg",
                   "id" : "nova",
                   "match" : 75,
                   "name" : "NOVA group",
@@ -260,7 +260,7 @@
                },
                {
                   "grade" : "a",
-                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/0-additives.svg",
+                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/dist/0-additives.svg",
                   "id" : "additives",
                   "match" : 100,
                   "name" : "Additives",
@@ -278,7 +278,7 @@
                   "description" : "",
                   "description_short" : "Very low environmental impact",
                   "grade" : "a",
-                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/ecoscore-a.svg",
+                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/dist/ecoscore-a.svg",
                   "id" : "ecoscore",
                   "match" : 100,
                   "name" : "Eco-Score",
@@ -290,7 +290,7 @@
                   "description" : "",
                   "description_short" : "Currently only for products with chicken or eggs",
                   "grade" : "e",
-                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/forest-footprint-not-computed.svg",
+                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/dist/forest-footprint-not-computed.svg",
                   "id" : "forest_footprint",
                   "match" : 0,
                   "name" : "Forest footprint",
@@ -307,7 +307,7 @@
                   "description" : "Organic farming aims to protect the environment and to conserve biodiversity by prohibiting or limiting the use of synthetic fertilizers, pesticides and food additives.",
                   "description_short" : "Promotes ecological sustainability and biodiversity.",
                   "grade" : "a",
-                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/organic.svg",
+                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/dist/organic.svg",
                   "id" : "labels_organic",
                   "match" : 100,
                   "name" : "Organic farming",
@@ -318,7 +318,7 @@
                   "description" : "When you buy fair trade products, producers in developing countries are paid an higher and fairer price, which helps them improve and sustain higher social and often environmental standards.",
                   "description_short" : "Helps producers in developing countries.",
                   "grade" : "a",
-                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/fair-trade.svg",
+                  "icon_url" : "https://static.openfoodfacts.org/images/attributes/dist/fair-trade.svg",
                   "id" : "labels_fair_trade",
                   "match" : 100,
                   "name" : "Fair trade",
@@ -957,7 +957,7 @@
             "level" : "info",
             "title_element" : {
                "grade" : "a",
-               "icon_url" : "https://static.openfoodfacts.org/images/attributes/ecoscore-a.svg",
+               "icon_url" : "https://static.openfoodfacts.org/images/attributes/dist/ecoscore-a.svg",
                "title" : "Eco-Score A - Very low environmental impact",
                "type" : "grade"
             },
@@ -1276,7 +1276,7 @@
             "level" : "info",
             "title_element" : {
                "grade" : "a",
-               "icon_url" : "https://static.openfoodfacts.org/images/attributes/ecoscore-a.svg",
+               "icon_url" : "https://static.openfoodfacts.org/images/attributes/dist/ecoscore-a.svg",
                "subtitle" : "Product: A good product for you - Open Food Facts - 100 g",
                "title" : "Impact for this product: A (Score: 115/100)",
                "type" : "grade"
@@ -1638,7 +1638,7 @@
             ],
             "level" : "info",
             "title_element" : {
-               "icon_url" : "https://static.openfoodfacts.org/images/attributes/nova-group-3.svg",
+               "icon_url" : "https://static.openfoodfacts.org/images/attributes/dist/nova-group-3.svg",
                "title" : "Processed foods"
             },
             "topics" : [
@@ -1808,7 +1808,7 @@
             "level" : "info",
             "title_element" : {
                "grade" : "a",
-               "icon_url" : "https://static.openfoodfacts.org/images/attributes/nutriscore-a.svg",
+               "icon_url" : "https://static.openfoodfacts.org/images/attributes/dist/nutriscore-a.svg",
                "title" : "Very good nutritional quality",
                "type" : "grade"
             },

--- a/packages/smooth_app/lib/cards/category_cards/svg_safe_network.dart
+++ b/packages/smooth_app/lib/cards/category_cards/svg_safe_network.dart
@@ -61,6 +61,7 @@ class _SvgSafeNetworkState extends State<SvgSafeNetwork> {
             }
           }
           if (snapshot.error != null) {
+            // TODO(monsieurtanuki): rather put the real host
             final bool serverOrConnectionIssue = snapshot.error.toString() ==
                 "Failed host lookup: 'static.openfoodfacts.org'";
             if (!serverOrConnectionIssue) {

--- a/packages/smooth_app/lib/pages/product/common/product_dialog_helper.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_dialog_helper.dart
@@ -25,11 +25,11 @@ class ProductDialogHelper {
   });
 
   static const String unknownSvgNutriscore =
-      'https://static.openfoodfacts.org/images/attributes/nutriscore-unknown.svg';
+      'https://static.openfoodfacts.org/images/attributes/dist/nutriscore-unknown.svg';
   static const String unknownSvgEcoscore =
-      'https://static.openfoodfacts.org/images/attributes/ecoscore-unknown.svg';
+      'https://static.openfoodfacts.org/images/attributes/dist/ecoscore-unknown.svg';
   static const String unknownSvgNova =
-      'https://static.openfoodfacts.org/images/attributes/nova-group-unknown.svg';
+      'https://static.openfoodfacts.org/images/attributes/dist/nova-group-unknown.svg';
 
   final String barcode;
   final BuildContext context;

--- a/packages/smooth_app/lib/pages/product/product_incomplete_card.dart
+++ b/packages/smooth_app/lib/pages/product/product_incomplete_card.dart
@@ -61,7 +61,7 @@ class ProductIncompleteCard extends StatelessWidget {
 
   static bool _isScoreNotApplicable(final Product product, final String tag) =>
       _getAttribute(product, tag)?.iconUrl ==
-      'https://static.openfoodfacts.org/images/attributes/$tag-not-applicable.svg';
+      'https://static.openfoodfacts.org/images/attributes/dist/$tag-not-applicable.svg';
 
   // TODO(monsieurtanuki): move to off-dart (or find it there)
   static Attribute? _getAttribute(final Product product, final String id) {


### PR DESCRIPTION
### What
Changed `https://static.openfoodfacts.org/images/attributes/` into `https://static.openfoodfacts.org/images/attributes/dist/`

### Fixes bug(s)
- Fixes: #4853

### Part of 
- #4850