### PR TITLE
feat: 3297 - added an "add pics" button to the "edit origins" widget

### DIFF
--- a/packages/smooth_app/lib/generic_lib/buttons/smooth_large_button_with_icon.dart
+++ b/packages/smooth_app/lib/generic_lib/buttons/smooth_large_button_with_icon.dart
@@ -57,7 +57,7 @@ class SmoothLargeButtonWithIcon extends StatelessWidget {
             flex: 10,
             child: AutoSizeText(
               text,
-              maxLines: 2,
+              maxLines: 3,
               minFontSize: 10,
               textAlign: textAlign,
               style: style,

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1890,6 +1890,10 @@
     "@add_packaging_photo_button_label": {
         "description": "Label for the add PACKAGING photo button"
     },
+    "add_origin_photo_button_label": "Take photos of any origin information",
+    "@add_origin_photo_button_label": {
+        "description": "Label for the add ORIGIN photo button"
+    },
     "choose_image_source_title": "Choose image source",
     "@choose_image_source_title": {
         "description": "Title for the image source chooser"

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1894,6 +1894,14 @@
     "@add_origin_photo_button_label": {
         "description": "Label for the add ORIGIN photo button"
     },
+    "add_emb_photo_button_label": "Take photos of any traceability code information",
+    "@add_emb_photo_button_label": {
+        "description": "Label for the add EMB photo button"
+    },
+    "add_label_photo_button_label": "Take photos of any labels & certifications information",
+    "@add_label_photo_button_label": {
+        "description": "Label for the add LABELS photo button"
+    },
     "choose_image_source_title": "Choose image source",
     "@choose_image_source_title": {
         "description": "Title for the image source chooser"

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -1890,6 +1890,10 @@
     "@add_packaging_photo_button_label": {
         "description": "Label for the add PACKAGING photo button"
     },
+    "add_origin_photo_button_label": "Prenez des photos de toute information sur les origines",
+    "@add_origin_photo_button_label": {
+        "description": "Label for the add ORIGIN photo button"
+    },
     "choose_image_source_title": "Choisissez la source de l'image",
     "@choose_image_source_title": {
         "description": "Title for the image source chooser"

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -1894,6 +1894,14 @@
     "@add_origin_photo_button_label": {
         "description": "Label for the add ORIGIN photo button"
     },
+    "add_emb_photo_button_label": "Prenez des photos de toute information sur les codes de traçabilité",
+    "@add_emb_photo_button_label": {
+        "description": "Label for the add EMB photo button"
+    },
+    "add_label_photo_button_label": "Prenez des photos de toute information sur les labels & certifications",
+    "@add_label_photo_button_label": {
+        "description": "Label for the add LABELS photo button"
+    },
     "choose_image_source_title": "Choisissez la source de l'image",
     "@choose_image_source_title": {
         "description": "Title for the image source chooser"

--- a/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
@@ -112,6 +112,32 @@ abstract class AbstractSimpleInputPageHelper extends ChangeNotifier {
   ) =>
       null;
 
+  /// Typical extra widget for the "add other pics" button.
+  @protected
+  Widget getExtraPhotoWidget(
+    final BuildContext context,
+    final Product product,
+    final String title,
+  ) =>
+      Padding(
+        padding: const EdgeInsets.symmetric(
+          vertical: VERY_LARGE_SPACE,
+          horizontal: SMALL_SPACE,
+        ),
+        child: addPanelButton(
+          title.toUpperCase(),
+          onPressed: () async => confirmAndUploadNewPicture(
+            context,
+            imageField: ImageField.OTHER,
+            barcode: product.barcode!,
+            language: ProductQuery.getLanguage(),
+            // we're already logged in if needed
+            isLoggedInMandatory: false,
+          ),
+          iconData: Icons.add_a_photo,
+        ),
+      );
+
   /// Returns true if changes were made.
   bool getChangedProduct(final Product product) {
     if (!_changed) {
@@ -244,25 +270,10 @@ class SimpleInputPageOriginHelper extends AbstractSimpleInputPageHelper {
     final BuildContext context,
     final Product product,
   ) =>
-      Padding(
-        padding: const EdgeInsets.symmetric(
-          vertical: VERY_LARGE_SPACE,
-          horizontal: SMALL_SPACE,
-        ),
-        child: addPanelButton(
-          AppLocalizations.of(context)
-              .add_origin_photo_button_label
-              .toUpperCase(),
-          onPressed: () async => confirmAndUploadNewPicture(
-            context,
-            imageField: ImageField.OTHER,
-            barcode: product.barcode!,
-            language: ProductQuery.getLanguage(),
-            // we're already logged in if needed
-            isLoggedInMandatory: false,
-          ),
-          iconData: Icons.add_a_photo,
-        ),
+      getExtraPhotoWidget(
+        context,
+        product,
+        AppLocalizations.of(context).add_origin_photo_button_label,
       );
 }
 
@@ -308,6 +319,17 @@ class SimpleInputPageEmbCodeHelper extends AbstractSimpleInputPageHelper {
   @override
   AnalyticsEditEvents getAnalyticsEditEvent() =>
       AnalyticsEditEvents.traceabilityCodes;
+
+  @override
+  Widget? getExtraWidget(
+    final BuildContext context,
+    final Product product,
+  ) =>
+      getExtraPhotoWidget(
+        context,
+        product,
+        AppLocalizations.of(context).add_emb_photo_button_label,
+      );
 }
 
 /// Implementation for "Labels" of an [AbstractSimpleInputPageHelper].
@@ -357,6 +379,17 @@ class SimpleInputPageLabelHelper extends AbstractSimpleInputPageHelper {
   @override
   AnalyticsEditEvents getAnalyticsEditEvent() =>
       AnalyticsEditEvents.labelsAndCertifications;
+
+  @override
+  Widget? getExtraWidget(
+    final BuildContext context,
+    final Product product,
+  ) =>
+      getExtraPhotoWidget(
+        context,
+        product,
+        AppLocalizations.of(context).add_label_photo_button_label,
+      );
 }
 
 /// Implementation for "Categories" of an [AbstractSimpleInputPageHelper].

--- a/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
@@ -2,7 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/background/background_task_details.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
+import 'package:smooth_app/helpers/product_cards_helper.dart';
+import 'package:smooth_app/pages/image_crop_page.dart';
 import 'package:smooth_app/query/product_query.dart';
 
 /// Abstract helper for Simple Input Page.
@@ -100,7 +103,14 @@ abstract class AbstractSimpleInputPageHelper extends ChangeNotifier {
   TagType? getTagType();
 
   /// Returns the icon data for the list tile.
-  Widget? getIcon() => null;
+  Widget getIcon();
+
+  /// Extra widget to be displayed after the list.
+  Widget? getExtraWidget(
+    final BuildContext context,
+    final Product product,
+  ) =>
+      null;
 
   /// Returns true if changes were made.
   bool getChangedProduct(final Product product) {
@@ -177,7 +187,7 @@ class SimpleInputPageStoreHelper extends AbstractSimpleInputPageHelper {
   TagType? getTagType() => null;
 
   @override
-  Widget? getIcon() => const Icon(Icons.shopping_cart);
+  Widget getIcon() => const Icon(Icons.shopping_cart);
 
   @override
   BackgroundTaskDetailsStamp getStamp() => BackgroundTaskDetailsStamp.stores;
@@ -221,13 +231,39 @@ class SimpleInputPageOriginHelper extends AbstractSimpleInputPageHelper {
   TagType? getTagType() => TagType.ORIGINS;
 
   @override
-  Widget? getIcon() => const Icon(Icons.travel_explore);
+  Widget getIcon() => const Icon(Icons.travel_explore);
 
   @override
   BackgroundTaskDetailsStamp getStamp() => BackgroundTaskDetailsStamp.origins;
 
   @override
   AnalyticsEditEvents getAnalyticsEditEvent() => AnalyticsEditEvents.origins;
+
+  @override
+  Widget? getExtraWidget(
+    final BuildContext context,
+    final Product product,
+  ) =>
+      Padding(
+        padding: const EdgeInsets.symmetric(
+          vertical: VERY_LARGE_SPACE,
+          horizontal: SMALL_SPACE,
+        ),
+        child: addPanelButton(
+          AppLocalizations.of(context)
+              .add_origin_photo_button_label
+              .toUpperCase(),
+          onPressed: () async => confirmAndUploadNewPicture(
+            context,
+            imageField: ImageField.OTHER,
+            barcode: product.barcode!,
+            language: ProductQuery.getLanguage(),
+            // we're already logged in if needed
+            isLoggedInMandatory: false,
+          ),
+          iconData: Icons.add_a_photo,
+        ),
+      );
 }
 
 /// Implementation for "Emb Code" of an [AbstractSimpleInputPageHelper].
@@ -264,7 +300,7 @@ class SimpleInputPageEmbCodeHelper extends AbstractSimpleInputPageHelper {
   TagType? getTagType() => TagType.EMB_CODES;
 
   @override
-  Widget? getIcon() => const Icon(Icons.factory);
+  Widget getIcon() => const Icon(Icons.factory);
 
   @override
   BackgroundTaskDetailsStamp getStamp() => BackgroundTaskDetailsStamp.embCodes;
@@ -313,7 +349,7 @@ class SimpleInputPageLabelHelper extends AbstractSimpleInputPageHelper {
   TagType? getTagType() => TagType.LABELS;
 
   @override
-  Widget? getIcon() => const Icon(Icons.local_offer);
+  Widget getIcon() => const Icon(Icons.local_offer);
 
   @override
   BackgroundTaskDetailsStamp getStamp() => BackgroundTaskDetailsStamp.labels;
@@ -366,7 +402,7 @@ class SimpleInputPageCategoryHelper extends AbstractSimpleInputPageHelper {
   TagType? getTagType() => TagType.CATEGORIES;
 
   @override
-  Widget? getIcon() => const Icon(Icons.restaurant);
+  Widget getIcon() => const Icon(Icons.restaurant);
 
   @override
   BackgroundTaskDetailsStamp getStamp() =>
@@ -415,7 +451,7 @@ class SimpleInputPageCountryHelper extends AbstractSimpleInputPageHelper {
   TagType? getTagType() => TagType.COUNTRIES;
 
   @override
-  Widget? getIcon() => const Icon(Icons.public);
+  Widget getIcon() => const Icon(Icons.public);
 
   @override
   BackgroundTaskDetailsStamp getStamp() => BackgroundTaskDetailsStamp.countries;

--- a/packages/smooth_app/lib/pages/product/simple_input_widget.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_widget.dart
@@ -55,6 +55,10 @@ class _SimpleInputWidgetState extends State<SimpleInputWidget> {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final String? explanations =
         widget.helper.getAddExplanations(appLocalizations);
+    final Widget? extraWidget = widget.helper.getExtraWidget(
+      context,
+      widget.product,
+    );
 
     return Column(
       mainAxisAlignment: MainAxisAlignment.start,
@@ -142,6 +146,7 @@ class _SimpleInputWidgetState extends State<SimpleInputWidget> {
           shrinkWrap: true,
           physics: const NeverScrollableScrollPhysics(),
         ),
+        if (extraWidget != null) extraWidget,
       ],
     );
   }


### PR DESCRIPTION
### What
- Added an "add pics" button to the "edit origins" widget.

### Screenshot
![Screenshot_1701251016](https://github.com/openfoodfacts/smooth-app/assets/11576431/232dc3ee-95fc-4927-832e-de4212f2dad0)

### Related issues
- #3297

### Impacted files
* `app_en.arb`: added label for "add origin pics"
* `app_fr.arb`: added label for "add origin pics"
* `simple_input_page_helpers.dart`: added an "extra widget" for simple inputs, and implemented it for "origins" with an "add photo" button; minor refactoring on `getIcon`
* `simple_input_widget.dart`: minor refactoring