### PR TITLE
fix: Ensure there is a visible button in the Existing photos screen

### DIFF
--- a/packages/smooth_app/lib/pages/image/uploaded_image_gallery.dart
+++ b/packages/smooth_app/lib/pages/image/uploaded_image_gallery.dart
@@ -8,6 +8,7 @@ import 'package:smooth_app/database/dao_int.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/images/smooth_image.dart';
+import 'package:smooth_app/generic_lib/widgets/smooth_back_button.dart';
 import 'package:smooth_app/pages/crop_page.dart';
 import 'package:smooth_app/pages/image_crop_page.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
@@ -43,6 +44,9 @@ class UploadedImageGallery extends StatelessWidget {
         backgroundColor: Colors.black,
         foregroundColor: WHITE_COLOR,
         elevation: 0,
+        leading: const SmoothBackButton(
+          iconColor: Colors.white,
+        ),
       ),
       body: GridView.builder(
         itemCount: imageIds.length,


### PR DESCRIPTION
Hi everyone,

In the "Existing photos" screen, the back button is invisible (black on black).
This PR ensure we force a white color

<img width="335" alt="Screenshot 2023-12-04 at 17 03 18" src="https://github.com/openfoodfacts/smooth-app/assets/246838/6e18ebbc-359b-4a0f-aa97-4cf5f541940e">
