### PR TITLE
feat: 4836 - clickable link to "open new issue" when relevant

### DIFF
--- a/packages/smooth_app/lib/generic_lib/loading_dialog.dart
+++ b/packages/smooth_app/lib/generic_lib/loading_dialog.dart
@@ -1,9 +1,12 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/helpers/app_helper.dart';
+import 'package:smooth_app/helpers/launch_url_helper.dart';
 
 /// Dialog with a stop button, while a future is running.
 ///
@@ -36,6 +39,7 @@ class LoadingDialog<T> {
   static Future<void> error({
     required final BuildContext context,
     final String? title,
+    final bool shouldOpenNewIssue = false,
   }) async =>
       showDialog<void>(
         context: context,
@@ -53,11 +57,32 @@ class LoadingDialog<T> {
                 Padding(
                   padding: const EdgeInsets.symmetric(vertical: MEDIUM_SPACE),
                   child: Text(
-                    title ??
-                        appLocalizations.loading_dialog_default_error_message,
+                    shouldOpenNewIssue
+                        ? appLocalizations.server_error_open_new_issue
+                        : title ??
+                            appLocalizations
+                                .loading_dialog_default_error_message,
                     textAlign: TextAlign.center,
                   ),
                 ),
+                if (shouldOpenNewIssue)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: MEDIUM_SPACE),
+                    child: RichText(
+                      textAlign: TextAlign.center,
+                      text: TextSpan(
+                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                              color: Colors.blue,
+                            ),
+                        text: Status.openNewIssueUrl,
+                        recognizer: TapGestureRecognizer()
+                          ..onTap = () => LaunchUrlHelper.launchURL(
+                                Status.openNewIssueUrl,
+                                false,
+                              ),
+                      ),
+                    ),
+                  ),
               ],
             ),
             positiveAction: SmoothActionButton(

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -141,6 +141,7 @@
     "@ecoCardUtility": {
         "description": "Description of what a user can use the Eco data in a product for."
     },
+    "server_error_open_new_issue": "No server response! You may open an issue with the following link.",
     "@user_management": {},
     "sign_in_text": "Sign in to your Open Food Facts account to save your contributions",
     "incorrect_credentials": "Incorrect username or password.",

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -141,6 +141,7 @@
     "@ecoCardUtility": {
         "description": "Description of what a user can use the Eco data in a product for."
     },
+    "server_error_open_new_issue": "Pas de réponse du serveur ! Vous pouvez ouvrir un incident avec le lien ci-dessous.",
     "@user_management": {},
     "sign_in_text": "Connectez-vous à votre compte Open Food Facts pour enregistrer vos contributions",
     "incorrect_credentials": "Nom d'utilisateur ou mot de passe incorrect.",

--- a/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
@@ -395,7 +395,11 @@ class _SignUpPageState extends State<SignUpPage> with TraceableClientMixin {
       }
 
       if (context.mounted) {
-        await LoadingDialog.error(context: context, title: errorMessage);
+        await LoadingDialog.error(
+          context: context,
+          title: errorMessage,
+          shouldOpenNewIssue: status.shouldOpenNewIssue(),
+        );
       }
       return;
     }

--- a/packages/smooth_app/lib/query/paged_to_be_completed_product_query.dart
+++ b/packages/smooth_app/lib/query/paged_to_be_completed_product_query.dart
@@ -16,7 +16,7 @@ class PagedToBeCompletedProductQuery extends PagedProductQuery {
         parametersList: <Parameter>[
           PageSize(size: pageSize),
           PageNumber(page: pageNumber),
-          StatesTagsParameter(
+          const StatesTagsParameter(
             map: <ProductState, bool>{
               ProductState.CATEGORIES_COMPLETED: false,
             },

--- a/packages/smooth_app/lib/query/paged_user_product_query.dart
+++ b/packages/smooth_app/lib/query/paged_user_product_query.dart
@@ -38,7 +38,7 @@ enum UserSearchType {
           PageSize(size: pageSize),
           PageNumber(page: pageNumber),
           if (toBeCompleted)
-            StatesTagsParameter(
+            const StatesTagsParameter(
               map: <ProductState, bool>{
                 ProductState.COMPLETED: false,
               },

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -1076,10 +1076,10 @@ packages:
     dependency: "direct main"
     description:
       name: openfoodfacts
-      sha256: "4a3a331ad0abc3bbea189ced88a426a4a9955a59e28df5f773d0697bef06ccfc"
+      sha256: "47436d0d647700327b8df45d02658a5e6e8d89b328e0b3d95c3fc3c34d5aebb7"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.2.1"
   openfoodfacts_flutter_lints:
     dependency: "direct dev"
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -97,7 +97,7 @@ dependencies:
     path: ../scanner/zxing
 
 
-  openfoodfacts: 3.1.0
+  openfoodfacts: 3.2.1
   # openfoodfacts:
   #   path: ../../../openfoodfacts-dart
 


### PR DESCRIPTION
### What
- With the latest off-dart version we have access to method `bool shouldOpenNewIssue()` for `Status`.
- When appropriate (e.g. `500` server error), we display a localized label and a clickable link to open a new issue.

### Screenshot
![Screenshot_1701712820](https://github.com/openfoodfacts/smooth-app/assets/11576431/43200583-af36-4956-b86f-12ed6e9f82d7)

### Fixes bug(s)
- Closes: #4836

### Impacted files
* `app_en.arb`: added an "open new issue if relevant" label.
* `app_fr.arb`: added an "open new issue if relevant" label.
* `loading_dialog.dart`: added an optional `shouldOpenNewIssue` parameter with appropriate display
* `pubspec.lock`: wtf
* `pubspec.yaml`: upgraded openfoodfacts to 3.2.1
* `sign_up_page.dart`: use the new `shouldOpenNewIssue` parameter when server error