### PR TITLE
fix: Remove an unnecessary ending comma on `Share` or `View on the web`

### DIFF
--- a/packages/smooth_app/lib/helpers/temp_product_list_share_helper.dart
+++ b/packages/smooth_app/lib/helpers/temp_product_list_share_helper.dart
@@ -3,15 +3,11 @@ import 'package:smooth_app/query/product_query.dart';
 
 // TODO(m123): Move this to off-dart
 Uri shareProductList(List<String> barcodes) {
-  final StringBuffer buffer = StringBuffer();
-
-  for (final String i in barcodes) {
-    buffer.write('$i,');
-  }
+  final String barcodesString = barcodes.join(',');
 
   return UriHelper.replaceSubdomain(
     ProductQuery.uriProductHelper.getUri(
-      path: 'products/$buffer',
+      path: 'products/$barcodesString',
       addUserAgentParameters: false,
     ),
     language: OpenFoodAPIConfiguration.globalLanguages?.first,


### PR DESCRIPTION
### What

On `Lists` tab, thanks to the top right three dots, it is possible to `Share` or `View on the web` the scanned products. For instance for `Share` it results in a message like:

> Have a look at my list of products on Open Food Facts: https://world-en.openfoodfacts.org/products/BARCODE_0,...,BARCODE_N,

Note the useless ending comma, as https://world.openfoodfacts.org/products/BARCODE_0,...,BARCODE_N, works as good as https://world.openfoodfacts.org/products/BARCODE_0,...,BARCODE_N.

This PR aim is to change the URL to https://world-en.openfoodfacts.org/products/BARCODE_0,...,BARCODE_N