### PR TITLE
fix: 4900 - backup_scheme.xml type fix

### DIFF
--- a/packages/smooth_app/android/app/src/main/res/xml/backup_scheme.xml
+++ b/packages/smooth_app/android/app/src/main/res/xml/backup_scheme.xml
@@ -10,7 +10,7 @@
                 domain="sharedpref"
                 path="com.google.mlkit.internal.xml" />
         <include
-                domain="databases"
+                domain="database"
                 path="app_flutter/smoothie.db" />
         <exclude domain="root" />
         <include


### PR DESCRIPTION
### What
- Typo in backup_scheme.xml, which crashes the build on FDroid.
- Detected by @licaon-kter

### Fixes bug(s)
- Fixes: #4900