### PR TITLE
fix: 4627 - no more nutrients wiped out

### DIFF
--- a/packages/smooth_app/lib/data_models/up_to_date_changes.dart
+++ b/packages/smooth_app/lib/data_models/up_to_date_changes.dart
@@ -80,7 +80,10 @@ class UpToDateChanges {
     if (change.noNutritionData != null) {
       initial.noNutritionData = change.noNutritionData;
     }
-    if (change.nutriments != null) {
+    // cf. https://github.com/openfoodfacts/smooth-app/issues/4627
+    // If we don't check if nutriments is empty, most of the time we overwrite
+    // potentially existing nutriments with an empty map.
+    if (change.nutriments != null && !change.nutriments!.isEmpty()) {
       initial.nutriments = change.nutriments;
     }
     if (change.servingSize != null) {

--- a/packages/smooth_app/lib/pages/product/ordered_nutrients_cache.dart
+++ b/packages/smooth_app/lib/pages/product/ordered_nutrients_cache.dart
@@ -24,7 +24,7 @@ class OrderedNutrientsCache {
     cache._orderedNutrients = await cache._get();
     if (cache._orderedNutrients == null) {
       if (context.mounted) {
-        await LoadingDialog.run<OrderedNutrients>(
+        cache._orderedNutrients = await LoadingDialog.run<OrderedNutrients>(
           context: context,
           future: cache._download(),
         );


### PR DESCRIPTION
### What
- 2 bugs fixed in this PR.
- Minor fixed bug: there was a "cannot load" error that prevented the user from entering the nutrition facts page the very first time (then it was OK).
- The "Empty nutrition facts" bug is also fixed here:
  - when background tasks are piling up, we sent the request to the server and meanwhile we compute the local product as the initial product with all the local-and-not-server-committed changes on top.
  - the problem was that in those changes we overwrote existing nutrition facts with empty nutrition facts (from a product change that had no nutrition facts and it was transformed into existing but empty nutrition facts).

### Fixes bug(s)
- Fixes: #4627

### Impacted files
* `ordered_nutrients_cache.dart`: removed a bug I introduced in #4768.
* `up_to_date_changes.dart`: now nutriments are safer when background tasks are running.