### PR TITLE
feat: Support for '-' in nutritional values

### DIFF
--- a/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
@@ -34,8 +34,8 @@ class AddBasicDetailsPage extends StatefulWidget {
 
 class _AddBasicDetailsPageState extends State<AddBasicDetailsPage> {
   final TextEditingController _productNameController = TextEditingController();
-  late final TextEditingControllerWithInitialValue _brandNameController;
-  late final TextEditingControllerWithInitialValue _weightController;
+  late final TextEditingControllerWithHistory _brandNameController;
+  late final TextEditingControllerWithHistory _weightController;
 
   final double _heightSpace = LARGE_SPACE;
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
@@ -47,10 +47,10 @@ class _AddBasicDetailsPageState extends State<AddBasicDetailsPage> {
   void initState() {
     super.initState();
     _product = widget.product;
-    _weightController = TextEditingControllerWithInitialValue(
+    _weightController = TextEditingControllerWithHistory(
       text: MultilingualHelper.getCleanText(_product.quantity ?? ''),
     );
-    _brandNameController = TextEditingControllerWithInitialValue(
+    _brandNameController = TextEditingControllerWithHistory(
       text: _formatProductBrands(_product.brands),
     );
     _multilingualHelper = MultilingualHelper(
@@ -230,11 +230,11 @@ class _AddBasicDetailsPageState extends State<AddBasicDetailsPage> {
 
     Product getBasicProduct() => Product(barcode: _product.barcode);
 
-    if (_weightController.valueHasChanged) {
+    if (_weightController.isDifferentFromInitialValue) {
       result ??= getBasicProduct();
       result.quantity = _weightController.text;
     }
-    if (_brandNameController.valueHasChanged) {
+    if (_brandNameController.isDifferentFromInitialValue) {
       result ??= getBasicProduct();
       result.brands = _formatProductBrands(_brandNameController.text);
     }

--- a/packages/smooth_app/lib/pages/product/add_other_details_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_other_details_page.dart
@@ -25,7 +25,7 @@ class AddOtherDetailsPage extends StatefulWidget {
 }
 
 class _AddOtherDetailsPageState extends State<AddOtherDetailsPage> {
-  late final TextEditingControllerWithInitialValue _websiteController;
+  late final TextEditingControllerWithHistory _websiteController;
 
   final double _heightSpace = LARGE_SPACE;
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
@@ -36,7 +36,7 @@ class _AddOtherDetailsPageState extends State<AddOtherDetailsPage> {
     super.initState();
     _product = widget.product;
     _websiteController =
-        TextEditingControllerWithInitialValue(text: _product.website ?? '');
+        TextEditingControllerWithHistory(text: _product.website ?? '');
   }
 
   @override
@@ -111,7 +111,7 @@ class _AddOtherDetailsPageState extends State<AddOtherDetailsPage> {
   }
 
   /// Returns `true` if any value differs with initial state.
-  bool _isEdited() => _websiteController.valueHasChanged;
+  bool _isEdited() => _websiteController.isDifferentFromInitialValue;
 
   /// Exits the page if the [flag] is `true`.
   void _exitPage(final bool flag) {

--- a/packages/smooth_app/lib/pages/product/nutrition_add_nutrient_button.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_add_nutrient_button.dart
@@ -35,8 +35,8 @@ class NutritionAddNutrientButton extends StatelessWidget {
             a.name!.compareTo(b.name!));
         List<OrderedNutrient> filteredList =
             List<OrderedNutrient>.from(leftovers);
-        final TextEditingControllerWithInitialValue nutritionTextController =
-            TextEditingControllerWithInitialValue();
+        final TextEditingControllerWithHistory nutritionTextController =
+            TextEditingControllerWithHistory();
         final ScrollController controller = ScrollController();
 
         final OrderedNutrient? selected = await showDialog<OrderedNutrient>(

--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -606,7 +606,7 @@ class _NutrientUnitVisibility extends StatelessWidget {
         BuildContext context,
         TextEditingControllerWithHistory controller,
       ) {
-        final bool isValueSet = !controller.isNotSet;
+        final bool isValueSet = controller.isSet;
 
         return ElevatedButton(
           onPressed: () {

--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -87,9 +87,9 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded>
   late final NumberFormat _decimalNumberFormat;
   late final NutritionContainer _nutritionContainer;
 
-  final Map<Nutrient, TextEditingControllerWithInitialValue> _controllers =
-      <Nutrient, TextEditingControllerWithInitialValue>{};
-  TextEditingControllerWithInitialValue? _servingController;
+  final Map<Nutrient, TextEditingControllerWithHistory> _controllers =
+      <Nutrient, TextEditingControllerWithHistory>{};
+  TextEditingControllerWithHistory? _servingController;
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
   final List<FocusNode> _focusNodes = <FocusNode>[];
 
@@ -110,7 +110,7 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded>
   void dispose() {
     _focusNodes.clear();
 
-    for (final TextEditingControllerWithInitialValue controller
+    for (final TextEditingControllerWithHistory controller
         in _controllers.values) {
       controller.dispose();
     }
@@ -165,18 +165,20 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded>
         final Nutrient nutrient = _getNutrient(orderedNutrient);
         if (_controllers[nutrient] == null) {
           final double? value = _nutritionContainer.getValue(nutrient);
-          _controllers[nutrient] = TextEditingControllerWithInitialValue(
+          _controllers[nutrient] = TextEditingControllerWithHistory(
             text: value == null ? '' : _decimalNumberFormat.format(value),
           );
         }
 
         children.add(
-          _NutrientRow(
-            _nutritionContainer,
-            _decimalNumberFormat,
-            _controllers[nutrient]!,
-            orderedNutrient,
-            i,
+          ChangeNotifierProvider<TextEditingControllerWithHistory>.value(
+            value: _controllers[nutrient]!,
+            child: _NutrientRow(
+              _nutritionContainer,
+              _decimalNumberFormat,
+              orderedNutrient,
+              i,
+            ),
           ),
         );
       }
@@ -230,13 +232,12 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded>
     final String value = _nutritionContainer.servingSize;
 
     if (_servingController == null) {
-      _servingController = TextEditingControllerWithInitialValue(text: value);
+      _servingController = TextEditingControllerWithHistory(text: value);
       _servingController!.selection =
           TextSelection.collapsed(offset: _servingController!.text.length - 1);
     }
 
-    final TextEditingControllerWithInitialValue controller =
-        _servingController!;
+    final TextEditingControllerWithHistory controller = _servingController!;
 
     return Padding(
       padding: const EdgeInsetsDirectional.only(bottom: VERY_LARGE_SPACE),
@@ -318,15 +319,18 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded>
           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
           crossAxisAlignment: CrossAxisAlignment.center,
           children: <Widget>[
-            Switch(
-              value: _nutritionContainer.noNutritionData,
-              onChanged: (final bool value) =>
-                  setState(() => _nutritionContainer.noNutritionData = value),
-              trackColor: MaterialStateProperty.all(
-                  Theme.of(context).colorScheme.onPrimary),
+            Expanded(
+              flex: 2,
+              child: Switch(
+                value: _nutritionContainer.noNutritionData,
+                onChanged: (final bool value) =>
+                    setState(() => _nutritionContainer.noNutritionData = value),
+                trackColor: MaterialStateProperty.all(
+                    Theme.of(context).colorScheme.onPrimary),
+              ),
             ),
-            SizedBox(
-              width: _getColumnSize(context, 0.6),
+            Expanded(
+              flex: 6,
               child: AutoSizeText(
                 localizations.nutrition_page_unspecified,
                 style: Theme.of(context).primaryTextTheme.bodyMedium?.copyWith(
@@ -342,12 +346,13 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded>
 
   /// Returns `true` if any value differs with initial state.
   bool _isEdited() {
-    if (_servingController != null && _servingController!.valueHasChanged) {
+    if (_servingController != null &&
+        _servingController!.isDifferentFromInitialValue) {
       return true;
     }
-    for (final TextEditingControllerWithInitialValue controller
+    for (final TextEditingControllerWithHistory controller
         in _controllers.values) {
-      if (controller.valueHasChanged) {
+      if (controller.isDifferentFromInitialValue) {
         return true;
       }
     }
@@ -359,7 +364,7 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded>
       return null;
     }
     for (final Nutrient nutrient in _controllers.keys) {
-      final TextEditingControllerWithInitialValue controller =
+      final TextEditingControllerWithHistory controller =
           _controllers[nutrient]!;
       _nutritionContainer.setNutrientValueText(
         nutrient,
@@ -437,51 +442,50 @@ class _NutrientRow extends StatelessWidget {
   const _NutrientRow(
     this.nutritionContainer,
     this.decimalNumberFormat,
-    this.controller,
     this.orderedNutrient,
     this.position,
   );
 
   final NutritionContainer nutritionContainer;
   final NumberFormat decimalNumberFormat;
-  final TextEditingControllerWithInitialValue controller;
   final OrderedNutrient orderedNutrient;
   final int position;
 
   @override
-  Widget build(BuildContext context) => Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: <Widget>[
-          Expanded(
-            child: _NutrientValueCell(
-              decimalNumberFormat,
-              controller,
-              orderedNutrient,
-              position,
-            ),
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: <Widget>[
+        Expanded(
+          flex: 6,
+          child: _NutrientValueCell(
+            decimalNumberFormat,
+            orderedNutrient,
+            position,
           ),
-          SizedBox(
-            width: _getColumnSize(context, 0.3),
-            child: _NutrientUnitCell(
-              nutritionContainer,
-              orderedNutrient,
-            ),
+        ),
+        Expanded(
+          flex: 3,
+          child: _NutrientUnitCell(
+            nutritionContainer,
+            orderedNutrient,
           ),
-        ],
-      );
+        ),
+        const _NutrientUnitVisibility()
+      ],
+    );
+  }
 }
 
 class _NutrientValueCell extends StatelessWidget {
   const _NutrientValueCell(
     this.decimalNumberFormat,
-    this.controller,
     this.orderedNutrient,
     this.position,
   );
 
   final NumberFormat decimalNumberFormat;
-  final TextEditingControllerWithInitialValue controller;
   final OrderedNutrient orderedNutrient;
   final int position;
 
@@ -491,11 +495,13 @@ class _NutrientValueCell extends StatelessWidget {
       context,
       listen: false,
     );
-
+    final TextEditingControllerWithHistory controller =
+        context.watch<TextEditingControllerWithHistory>();
     final bool isLast = position == focusNodes.length - 1;
 
     return TextFormField(
       controller: controller,
+      enabled: controller.isSet,
       focusNode: focusNodes[position],
       decoration: InputDecoration(
         enabledBorder: const UnderlineInputBorder(),
@@ -550,16 +556,29 @@ class _NutrientUnitCellState extends State<_NutrientUnitCell> {
   Widget build(BuildContext context) {
     final Unit unit =
         widget.nutritionContainer.getUnit(_getNutrient(widget.orderedNutrient));
-    return ElevatedButton(
-      onPressed: widget.nutritionContainer.isEditableWeight(unit)
-          ? () => setState(
-                () => widget.nutritionContainer
-                    .setNextWeightUnit(widget.orderedNutrient),
-              )
-          : null,
-      child: Text(
-        _getUnitLabel(unit),
-        style: const TextStyle(fontWeight: FontWeight.bold),
+    return Padding(
+      padding: const EdgeInsetsDirectional.only(
+        start: VERY_SMALL_SPACE,
+        end: SMALL_SPACE,
+      ),
+      child: _NutritionCellTextWatcher(
+        builder: (_, TextEditingControllerWithHistory controller) {
+          return ElevatedButton(
+            onPressed: controller.isNotSet
+                ? null
+                : widget.nutritionContainer.isEditableWeight(unit)
+                    ? () => setState(
+                          () => widget.nutritionContainer
+                              .setNextWeightUnit(widget.orderedNutrient),
+                        )
+                    : null,
+            child: Text(
+              _getUnitLabel(unit),
+              textAlign: TextAlign.center,
+              style: const TextStyle(fontWeight: FontWeight.bold),
+            ),
+          );
+        },
       ),
     );
   }
@@ -577,11 +596,40 @@ class _NutrientUnitCellState extends State<_NutrientUnitCell> {
       _unitLabels[unit] ?? UnitHelper.unitToString(unit)!;
 }
 
-double _getColumnSize(
-  final BuildContext context,
-  final double adjustmentFactor,
-) =>
-    MediaQuery.of(context).size.width * adjustmentFactor;
+class _NutrientUnitVisibility extends StatelessWidget {
+  const _NutrientUnitVisibility();
+
+  @override
+  Widget build(BuildContext context) {
+    return _NutritionCellTextWatcher(
+      builder: (
+        BuildContext context,
+        TextEditingControllerWithHistory controller,
+      ) {
+        final bool isValueSet = !controller.isNotSet;
+
+        return ElevatedButton(
+          onPressed: () {
+            if (isValueSet) {
+              controller.text = '-';
+            } else {
+              if (controller.previousValue != '-') {
+                controller.text = controller.previousValue ?? '-';
+              } else {
+                controller.text = '';
+              }
+            }
+          },
+          child: Icon(
+            isValueSet
+                ? Icons.visibility_rounded
+                : Icons.visibility_off_rounded,
+          ),
+        );
+      },
+    );
+  }
+}
 
 // cf. https://github.com/openfoodfacts/smooth-app/issues/3387
 Nutrient _getNutrient(final OrderedNutrient orderedNutrient) {
@@ -592,4 +640,39 @@ Nutrient _getNutrient(final OrderedNutrient orderedNutrient) {
     return Nutrient.energyKJ;
   }
   throw Exception('unknown nutrient for "${orderedNutrient.id}"');
+}
+
+extension _NutritionTextEditionController on TextEditingController {
+  bool get isSet => text.trim() != '-';
+
+  bool get isNotSet => text.trim() == '-';
+}
+
+/// Use this Widget to be notified when the value is set or not
+class _NutritionCellTextWatcher extends StatelessWidget {
+  const _NutritionCellTextWatcher({
+    required this.builder,
+  });
+
+  final Widget Function(
+    BuildContext context,
+    TextEditingControllerWithHistory value,
+  ) builder;
+
+  @override
+  Widget build(BuildContext context) {
+    return Selector<TextEditingControllerWithHistory,
+        TextEditingControllerWithHistory>(
+      selector: (_, TextEditingControllerWithHistory controller) {
+        return controller;
+      },
+      shouldRebuild: (_, TextEditingControllerWithHistory controller) {
+        return controller.isDifferentFromPreviousValue;
+      },
+      builder: (BuildContext context,
+          TextEditingControllerWithHistory controller, _) {
+        return builder(context, controller);
+      },
+    );
+  }
 }

--- a/packages/smooth_app/lib/pages/text_field_helper.dart
+++ b/packages/smooth_app/lib/pages/text_field_helper.dart
@@ -1,14 +1,27 @@
 import 'package:flutter/material.dart';
 
-/// A [TextEditingController] that saves the value passed to the constructor.
-class TextEditingControllerWithInitialValue extends TextEditingController {
-  TextEditingControllerWithInitialValue({String? text})
+/// A [TextEditingController] that saves the value passed to the constructor
+/// and persists the previous value.
+class TextEditingControllerWithHistory extends TextEditingController {
+  TextEditingControllerWithHistory({String? text})
       : _initialValue = text,
+        _previousValue = text,
         super(text: text);
 
   final String? _initialValue;
+  String? _previousValue;
 
   String? get initialValue => _initialValue;
 
-  bool get valueHasChanged => _initialValue != text;
+  String? get previousValue => _previousValue;
+
+  bool get isDifferentFromInitialValue => _initialValue != text;
+
+  bool get isDifferentFromPreviousValue => _previousValue != text;
+
+  @override
+  set text(String newText) {
+    _previousValue = text;
+    super.text = newText;
+  }
 }


### PR DESCRIPTION
Hi everyone!

Here is an implementation for #4745: the fact that a value is not available on the product.
In addition to this modification, there is also:
- `TextEditingControllerWithInitialValue` renamed to `TextEditingControllerWithHistory`, to also store the previous value
- In the Nutrition Facts screen, calls to `MediaQuery` are replaced by the flex mechanism
- The Controller for each field is passed through a `Provider`
- To limit the number of redraws, a `_NutritionCellTextWatcher` is used to only call when a value is set or not

A video of the implementation:

https://github.com/openfoodfacts/smooth-app/assets/246838/306500f8-281a-43dd-9e1a-9ca52e72b6e4

