### PR TITLE
feat: Use the Slivers mechanism with the Gallery view

### DIFF
--- a/packages/smooth_app/lib/generic_lib/widgets/images/smooth_image.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/images/smooth_image.dart
@@ -16,6 +16,7 @@ class SmoothImage extends StatelessWidget {
     this.color,
     this.decoration,
     this.fit,
+    this.rounded,
     this.heroTag,
   });
 
@@ -26,6 +27,7 @@ class SmoothImage extends StatelessWidget {
   final Decoration? decoration;
   final BoxFit? fit;
   final String? heroTag;
+  final bool? rounded;
 
   @override
   Widget build(BuildContext context) {
@@ -42,16 +44,21 @@ class SmoothImage extends StatelessWidget {
       child = Hero(tag: heroTag!, child: child);
     }
 
-    return ClipRRect(
-      borderRadius: ROUNDED_BORDER_RADIUS,
-      child: Container(
+    child = Container(
         decoration: decoration,
         width: width,
         height: height,
         color: color,
+        child: child);
+
+    if (rounded ?? true) {
+      child = ClipRRect(
+        borderRadius: ROUNDED_BORDER_RADIUS,
         child: child,
-      ),
-    );
+      );
+    }
+
+    return child;
   }
 
   Widget _loadingBuilder(

--- a/packages/smooth_app/lib/pages/image/product_image_gallery_other_view.dart
+++ b/packages/smooth_app/lib/pages/image/product_image_gallery_other_view.dart
@@ -98,6 +98,7 @@ class _ProductImageGalleryOtherViewState
                 ),
               );
             },
+            addAutomaticKeepAlives: false,
             childCount: ids.length,
           ),
 

--- a/packages/smooth_app/lib/pages/image/product_image_gallery_other_view.dart
+++ b/packages/smooth_app/lib/pages/image/product_image_gallery_other_view.dart
@@ -44,16 +44,20 @@ class _ProductImageGalleryOtherViewState
         final AsyncSnapshot<List<int>> snapshot,
       ) {
         if (snapshot.connectionState != ConnectionState.done) {
-          return SizedBox(
-            width: squareSize,
-            height: squareSize,
-            child: const CircularProgressIndicator.adaptive(),
+          return SliverToBoxAdapter(
+            child: SizedBox(
+              width: squareSize,
+              height: squareSize,
+              child: const CircularProgressIndicator.adaptive(),
+            ),
           );
         }
         if (snapshot.data == null) {
-          return Text(
-            snapshot.error?.toString() ??
-                appLocalizations.loading_dialog_default_error_message,
+          return SliverToBoxAdapter(
+            child: Text(
+              snapshot.error?.toString() ??
+                  appLocalizations.loading_dialog_default_error_message,
+            ),
           );
         }
         final List<int> ids = snapshot.data!;
@@ -63,39 +67,42 @@ class _ProductImageGalleryOtherViewState
             appLocalizations.edit_photo_select_existing_downloaded_none,
           );
         }
-        return SizedBox(
-          height: (ids.length / _columns).ceil() * squareSize,
-          child: GridView.builder(
-            physics: const NeverScrollableScrollPhysics(),
-            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-              crossAxisCount: _columns,
-            ),
-            itemBuilder: (final BuildContext context, final int index) =>
-                InkWell(
-              onTap: () async => Navigator.push<void>(
-                context,
-                MaterialPageRoute<bool>(
-                  builder: (BuildContext context) => ProductImageOtherPage(
-                    widget.product,
-                    ids[index],
-                  ),
-                ),
-              ),
-              child: SmoothImage(
-                width: squareSize,
-                height: squareSize,
-                imageProvider: NetworkImage(
-                  ImageHelper.getUploadedImageUrl(
-                    widget.product.barcode!,
-                    ids[index],
-                    ImageSize.DISPLAY,
-                  ),
-                ),
-              ),
-            ),
-            itemCount: ids.length,
-            //scrollDirection: Axis.vertical,
+        return SliverGrid(
+          gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+            crossAxisCount: _columns,
           ),
+          delegate: SliverChildBuilderDelegate(
+            (final BuildContext context, final int index) {
+              print(index);
+              return InkWell(
+                onTap: () async =>
+                    Navigator.push<void>(
+                      context,
+                      MaterialPageRoute<bool>(
+                        builder: (BuildContext context) =>
+                            ProductImageOtherPage(
+                              widget.product,
+                              ids[index],
+                            ),
+                      ),
+                    ),
+                child: SmoothImage(
+                  width: squareSize,
+                  height: squareSize,
+                  imageProvider: NetworkImage(
+                    ImageHelper.getUploadedImageUrl(
+                      widget.product.barcode!,
+                      ids[index],
+                      ImageSize.DISPLAY,
+                    ),
+                  ),
+                ),
+              );
+            },
+            childCount: ids.length,
+          ),
+
+          //scrollDirection: Axis.vertical,
         );
       },
     );

--- a/packages/smooth_app/lib/pages/image/product_image_gallery_other_view.dart
+++ b/packages/smooth_app/lib/pages/image/product_image_gallery_other_view.dart
@@ -74,17 +74,15 @@ class _ProductImageGalleryOtherViewState
           delegate: SliverChildBuilderDelegate(
             (final BuildContext context, final int index) {
               return InkWell(
-                onTap: () async =>
-                    Navigator.push<void>(
-                      context,
-                      MaterialPageRoute<bool>(
-                        builder: (BuildContext context) =>
-                            ProductImageOtherPage(
-                              widget.product,
-                              ids[index],
-                            ),
-                      ),
+                onTap: () async => Navigator.push<void>(
+                  context,
+                  MaterialPageRoute<bool>(
+                    builder: (BuildContext context) => ProductImageOtherPage(
+                      widget.product,
+                      ids[index],
                     ),
+                  ),
+                ),
                 child: SmoothImage(
                   width: squareSize,
                   height: squareSize,

--- a/packages/smooth_app/lib/pages/image/product_image_gallery_other_view.dart
+++ b/packages/smooth_app/lib/pages/image/product_image_gallery_other_view.dart
@@ -73,7 +73,6 @@ class _ProductImageGalleryOtherViewState
           ),
           delegate: SliverChildBuilderDelegate(
             (final BuildContext context, final int index) {
-              print(index);
               return InkWell(
                 onTap: () async =>
                     Navigator.push<void>(

--- a/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
@@ -97,76 +97,66 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView>
                 barcode: barcode,
                 context: context,
               ),
-              child: MultiProvider(
-                providers: [
-                  Provider<Product>.value(
-                    value: upToDateProduct,
+              child: CustomScrollView(
+                slivers: <Widget>[
+                  SliverGrid(
+                    gridDelegate:
+                        SliverGridDelegateWithFixedCrossAxisCountAndFixedHeight(
+                      crossAxisCount: 2,
+                      height: _computeItemHeight(),
+                    ),
+                    delegate: SliverChildBuilderDelegate(
+                      (BuildContext context, int index) {
+                        return _PhotoRow(
+                          position: index,
+                          product: upToDateProduct,
+                          language: _language,
+                        );
+                      },
+                      childCount: 4,
+                    ),
                   ),
-                  Provider<OpenFoodFactsLanguage>.value(
-                    value: _language,
-                  ),
-                ],
-                child: CustomScrollView(
-                  slivers: <Widget>[
-                    SliverGrid(
-                      gridDelegate:
-                          SliverGridDelegateWithFixedCrossAxisCountAndFixedHeight(
-                        crossAxisCount: 2,
-                        height: _computeItemHeight(),
-                      ),
-                      delegate: SliverChildBuilderDelegate(
-                        (BuildContext context, int index) {
-                          return _PhotoRow(
-                            position: index,
-                            product: upToDateProduct,
-                            language: _language,
-                          );
-                        },
-                        childCount: 4,
+                  SliverPadding(
+                    padding: const EdgeInsetsDirectional.symmetric(
+                      vertical: MEDIUM_SPACE,
+                      horizontal: SMALL_SPACE,
+                    ),
+                    sliver: SliverToBoxAdapter(
+                      child: Text(
+                        appLocalizations.more_photos,
+                        style: Theme.of(context).textTheme.displayMedium,
                       ),
                     ),
-                    SliverPadding(
-                      padding: const EdgeInsetsDirectional.symmetric(
-                        vertical: MEDIUM_SPACE,
-                        horizontal: SMALL_SPACE,
-                      ),
-                      sliver: SliverToBoxAdapter(
-                        child: Text(
-                          appLocalizations.more_photos,
-                          style: Theme.of(context).textTheme.displayMedium,
-                        ),
-                      ),
-                    ),
-                    if (!_clickedOtherPictureButton)
-                      SliverToBoxAdapter(
-                        child: Padding(
-                          padding: const EdgeInsets.all(SMALL_SPACE),
-                          child: SmoothLargeButtonWithIcon(
-                            text: appLocalizations.view_more_photo_button,
-                            icon: Icons.photo_camera_rounded,
-                            onPressed: () => setState(
-                              () => _clickedOtherPictureButton = true,
-                            ),
+                  ),
+                  if (!_clickedOtherPictureButton)
+                    SliverToBoxAdapter(
+                      child: Padding(
+                        padding: const EdgeInsets.all(SMALL_SPACE),
+                        child: SmoothLargeButtonWithIcon(
+                          text: appLocalizations.view_more_photo_button,
+                          icon: Icons.photo_camera_rounded,
+                          onPressed: () => setState(
+                            () => _clickedOtherPictureButton = true,
                           ),
                         ),
                       ),
-
-                    if (_clickedOtherPictureButton)
-                      ProductImageGalleryOtherView(product: upToDateProduct),
-                    // Extra space to be above the FAB
-                    SliverFillRemaining(
-                      hasScrollBody: false,
-                      child: SizedBox(
-                        height: (Theme.of(context)
-                                    .floatingActionButtonTheme
-                                    .extendedSizeConstraints
-                                    ?.maxHeight ??
-                                56.0) +
-                            16.0,
-                      ),
                     ),
-                  ],
-                ),
+
+                  if (_clickedOtherPictureButton)
+                    ProductImageGalleryOtherView(product: upToDateProduct),
+                  // Extra space to be above the FAB
+                  SliverFillRemaining(
+                    hasScrollBody: false,
+                    child: SizedBox(
+                      height: (Theme.of(context)
+                                  .floatingActionButtonTheme
+                                  .extendedSizeConstraints
+                                  ?.maxHeight ??
+                              56.0) +
+                          16.0,
+                    ),
+                  ),
+                ],
               ),
             ),
           ),

--- a/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
@@ -17,6 +17,7 @@ import 'package:smooth_app/pages/image_crop_page.dart';
 import 'package:smooth_app/pages/product/common/product_refresher.dart';
 import 'package:smooth_app/pages/product/product_image_swipeable_view.dart';
 import 'package:smooth_app/query/product_query.dart';
+import 'package:smooth_app/widgets/slivers.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
@@ -74,87 +75,166 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView>
         label: Text(appLocalizations.add_photo_button_label),
         icon: const Icon(Icons.add_a_photo),
       ),
-      body: RefreshIndicator(
-        onRefresh: () async => ProductRefresher().fetchAndRefresh(
-          barcode: barcode,
-          context: context,
-        ),
-        child: ListView(
-          children: <Widget>[
-            LanguageSelector(
-              setLanguage: (final OpenFoodFactsLanguage? newLanguage) async {
-                if (newLanguage == null || newLanguage == _language) {
-                  return;
-                }
-                setState(() => _language = newLanguage);
-              },
-              displayedLanguage: _language,
-              selectedLanguages: null,
-              padding: const EdgeInsetsDirectional.symmetric(
-                horizontal: 13.0,
-                vertical: SMALL_SPACE,
+      body: Column(
+        children: <Widget>[
+          LanguageSelector(
+            setLanguage: (final OpenFoodFactsLanguage? newLanguage) async {
+              if (newLanguage == null || newLanguage == _language) {
+                return;
+              }
+              setState(() => _language = newLanguage);
+            },
+            displayedLanguage: _language,
+            selectedLanguages: null,
+            padding: const EdgeInsetsDirectional.symmetric(
+              horizontal: 13.0,
+              vertical: SMALL_SPACE,
+            ),
+          ),
+          Expanded(
+            child: RefreshIndicator(
+              onRefresh: () async => ProductRefresher().fetchAndRefresh(
+                barcode: barcode,
+                context: context,
+              ),
+              child: MultiProvider(
+                providers: [
+                  Provider<Product>.value(
+                    value: upToDateProduct,
+                  ),
+                  Provider<OpenFoodFactsLanguage>.value(
+                    value: _language,
+                  ),
+                ],
+                child: CustomScrollView(
+                  slivers: <Widget>[
+                    SliverGrid(
+                      gridDelegate:
+                          SliverGridDelegateWithFixedCrossAxisCountAndFixedHeight(
+                        crossAxisCount: 2,
+                        height: _computeItemHeight(),
+                      ),
+                      delegate: SliverChildBuilderDelegate(
+                        (BuildContext context, int index) {
+                          return _PhotoRow(
+                            position: index,
+                            product: upToDateProduct,
+                            language: _language,
+                          );
+                        },
+                        childCount: 4,
+                      ),
+                    ),
+                    SliverPadding(
+                      padding: const EdgeInsetsDirectional.symmetric(
+                        vertical: MEDIUM_SPACE,
+                        horizontal: SMALL_SPACE,
+                      ),
+                      sliver: SliverToBoxAdapter(
+                        child: Text(
+                          appLocalizations.more_photos,
+                          style: Theme.of(context).textTheme.displayMedium,
+                        ),
+                      ),
+                    ),
+                    if (!_clickedOtherPictureButton)
+                      SliverToBoxAdapter(
+                        child: Padding(
+                          padding: const EdgeInsets.all(SMALL_SPACE),
+                          child: SmoothLargeButtonWithIcon(
+                            text: appLocalizations.view_more_photo_button,
+                            icon: Icons.photo_camera_rounded,
+                            onPressed: () => setState(
+                              () => _clickedOtherPictureButton = true,
+                            ),
+                          ),
+                        ),
+                      ),
+
+                    if (_clickedOtherPictureButton)
+                      ProductImageGalleryOtherView(product: upToDateProduct),
+                    // Extra space to be above the FAB
+                    SliverFillRemaining(
+                      hasScrollBody: false,
+                      child: SizedBox(
+                        height: (Theme.of(context)
+                                    .floatingActionButtonTheme
+                                    .extendedSizeConstraints
+                                    ?.maxHeight ??
+                                56.0) +
+                            16.0,
+                      ),
+                    ),
+                  ],
+                ),
               ),
             ),
-            _ImageRow(row: 1, product: upToDateProduct, language: _language),
-            _TextRow(row: 1, product: upToDateProduct, language: _language),
-            _ImageRow(row: 2, product: upToDateProduct, language: _language),
-            _TextRow(row: 2, product: upToDateProduct, language: _language),
-            if (!_clickedOtherPictureButton)
-              Padding(
-                padding: const EdgeInsets.all(SMALL_SPACE),
-                child: SmoothLargeButtonWithIcon(
-                  text: appLocalizations.view_more_photo_button,
-                  icon: Icons.photo_camera_rounded,
-                  onPressed: () => setState(
-                    () => _clickedOtherPictureButton = true,
+          ),
+        ],
+      ),
+    );
+  }
+
+  double _computeItemHeight() {
+    final TextStyle? textStyle = Theme.of(context).textTheme.headlineMedium;
+
+    return (MediaQuery.sizeOf(context).width / 2) +
+        SMALL_SPACE +
+        ((textStyle?.fontSize ?? 15.0) * 2) * (textStyle?.height ?? 2.0);
+  }
+}
+
+class _PhotoRow extends StatelessWidget {
+  const _PhotoRow({
+    required this.position,
+    required this.product,
+    required this.language,
+  });
+
+  final int position;
+  final Product product;
+  final OpenFoodFactsLanguage language;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(
+        top: SMALL_SPACE,
+      ),
+      child: InkWell(
+        onTap: () => _openImage(
+          context: context,
+          initialImageIndex: position,
+        ),
+        child: Column(
+          children: <Widget>[
+            AspectRatio(
+              aspectRatio: 1.0,
+              child: SmoothImage(
+                rounded: false,
+                imageProvider: _getTransientFile(
+                  getImageField(position),
+                ).getImageProvider(),
+              ),
+            ),
+            Expanded(
+              child: Center(
+                child: Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Text(
+                    getImageField(position)
+                        .getProductImageTitle(AppLocalizations.of(context)),
+                    style: Theme.of(context).textTheme.headlineMedium,
+                    textAlign: TextAlign.center,
                   ),
                 ),
               ),
-            if (_clickedOtherPictureButton)
-              Padding(
-                padding: const EdgeInsets.all(SMALL_SPACE),
-                child: Text(
-                  appLocalizations.more_photos,
-                  style: _getTextStyle(context),
-                ),
-              ),
-            if (_clickedOtherPictureButton)
-              ProductImageGalleryOtherView(product: upToDateProduct),
-            const SizedBox(height: 2 * VERY_LARGE_SPACE),
+            ),
           ],
         ),
       ),
     );
   }
-}
-
-abstract class _GenericRow extends StatelessWidget {
-  const _GenericRow({
-    required this.row,
-    required this.product,
-    required this.language,
-  });
-
-  /// Displayed row, starting from 1.
-  final int row;
-  final Product product;
-  final OpenFoodFactsLanguage language;
-
-  @protected
-  int get index1 => (row - 1) * 2;
-
-  @protected
-  int get index2 => index1 + 1;
-
-  @protected
-  ImageField getImageField(final int index) =>
-      ImageFieldSmoothieExtension.orderedMain[index];
-
-  static const double _innerPadding = SMALL_SPACE;
-
-  @protected
-  double getSquareSize(final BuildContext context) =>
-      (MediaQuery.of(context).size.width - _innerPadding) / 2;
 
   Future<void> _openImage({
     required BuildContext context,
@@ -171,133 +251,16 @@ abstract class _GenericRow extends StatelessWidget {
           ),
         ),
       );
-}
 
-class _ImageRow extends _GenericRow {
-  const _ImageRow({
-    required super.row,
-    required super.product,
-    required super.language,
-  });
-
-  TransientFile _getTransientFile(final ImageField imageField) =>
+  TransientFile _getTransientFile(
+    final ImageField imageField,
+  ) =>
       TransientFile.fromProductImageData(
         getProductImageData(product, imageField, language),
         product.barcode!,
         language,
       );
 
-  @override
-  Widget build(BuildContext context) => Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: <Widget>[
-          _Image(
-            squareSize: getSquareSize(context),
-            imageProvider:
-                _getTransientFile(getImageField(index1)).getImageProvider(),
-            onTap: () => _openImage(
-              context: context,
-              initialImageIndex: index1,
-            ),
-          ),
-          _Image(
-            squareSize: getSquareSize(context),
-            imageProvider:
-                _getTransientFile(getImageField(index2)).getImageProvider(),
-            onTap: () => _openImage(
-              context: context,
-              initialImageIndex: index2,
-            ),
-          ),
-        ],
-      );
+  ImageField getImageField(final int index) =>
+      ImageFieldSmoothieExtension.orderedMain[index];
 }
-
-class _TextRow extends _GenericRow {
-  const _TextRow({
-    required super.row,
-    required super.product,
-    required super.language,
-  });
-
-  @override
-  Widget build(BuildContext context) => Padding(
-        padding: const EdgeInsets.only(
-          top: SMALL_SPACE,
-          bottom: LARGE_SPACE,
-        ),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: <Widget>[
-            _Text(
-              squareSize: getSquareSize(context),
-              imageField: getImageField(index1),
-              onTap: () => _openImage(
-                context: context,
-                initialImageIndex: index1,
-              ),
-            ),
-            _Text(
-              squareSize: getSquareSize(context),
-              imageField: getImageField(index2),
-              onTap: () => _openImage(
-                context: context,
-                initialImageIndex: index2,
-              ),
-            ),
-          ],
-        ),
-      );
-}
-
-class _Image extends StatelessWidget {
-  const _Image({
-    required this.squareSize,
-    required this.imageProvider,
-    required this.onTap,
-  });
-
-  final double squareSize;
-  final ImageProvider? imageProvider;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) => InkWell(
-        onTap: onTap,
-        child: SmoothImage(
-          width: squareSize,
-          height: squareSize,
-          imageProvider: imageProvider,
-        ),
-      );
-}
-
-class _Text extends StatelessWidget {
-  const _Text({
-    required this.squareSize,
-    required this.imageField,
-    required this.onTap,
-  });
-
-  final double squareSize;
-  final ImageField imageField;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) => InkWell(
-        onTap: onTap,
-        child: SizedBox(
-          width: squareSize,
-          child: Center(
-            child: Text(
-              imageField.getProductImageTitle(AppLocalizations.of(context)),
-              style: _getTextStyle(context),
-              textAlign: TextAlign.center,
-            ),
-          ),
-        ),
-      );
-}
-
-TextStyle? _getTextStyle(final BuildContext context) =>
-    Theme.of(context).textTheme.headlineMedium;

--- a/packages/smooth_app/lib/widgets/slivers.dart
+++ b/packages/smooth_app/lib/widgets/slivers.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/rendering.dart';
+
+class SliverGridDelegateWithFixedCrossAxisCountAndFixedHeight
+    extends SliverGridDelegate {
+  /// Creates a delegate that makes grid layouts with a fixed number of tiles in
+  /// the cross axis.
+  ///
+  /// All of the arguments must not be null. The `mainAxisSpacing` and
+  /// `crossAxisSpacing` arguments must not be negative. The `crossAxisCount`
+  /// and `childAspectRatio` arguments must be greater than zero.
+  const SliverGridDelegateWithFixedCrossAxisCountAndFixedHeight({
+    required this.crossAxisCount,
+    this.mainAxisSpacing = 0.0,
+    this.crossAxisSpacing = 0.0,
+    this.height = 56.0,
+  })  : assert(crossAxisCount > 0),
+        assert(mainAxisSpacing >= 0),
+        assert(crossAxisSpacing >= 0),
+        assert(height >= 0.0);
+
+  /// The number of children in the cross axis.
+  final int crossAxisCount;
+
+  /// The number of logical pixels between each child along the main axis.
+  final double mainAxisSpacing;
+
+  /// The number of logical pixels between each child along the cross axis.
+  final double crossAxisSpacing;
+
+  /// The height of the crossAxis.
+  final double height;
+
+  bool _debugAssertIsValid() {
+    assert(crossAxisCount > 0);
+    assert(mainAxisSpacing >= 0.0);
+    assert(crossAxisSpacing >= 0.0);
+    assert(height > 0.0);
+    return true;
+  }
+
+  @override
+  SliverGridLayout getLayout(SliverConstraints constraints) {
+    assert(_debugAssertIsValid());
+    final double usableCrossAxisExtent =
+        constraints.crossAxisExtent - crossAxisSpacing * (crossAxisCount - 1);
+    final double childCrossAxisExtent = usableCrossAxisExtent / crossAxisCount;
+    final double childMainAxisExtent = height;
+    return SliverGridRegularTileLayout(
+      crossAxisCount: crossAxisCount,
+      mainAxisStride: childMainAxisExtent + mainAxisSpacing,
+      crossAxisStride: childCrossAxisExtent + crossAxisSpacing,
+      childMainAxisExtent: childMainAxisExtent,
+      childCrossAxisExtent: childCrossAxisExtent,
+      reverseCrossAxis: axisDirectionIsReversed(constraints.crossAxisDirection),
+    );
+  }
+
+  @override
+  bool shouldRelayout(
+      SliverGridDelegateWithFixedCrossAxisCountAndFixedHeight oldDelegate) {
+    return oldDelegate.crossAxisCount != crossAxisCount ||
+        oldDelegate.mainAxisSpacing != mainAxisSpacing ||
+        oldDelegate.crossAxisSpacing != crossAxisSpacing ||
+        oldDelegate.height != height;
+  }
+}

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -1499,6 +1499,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.99"
+  sliver_tools:
+    dependency: "direct main"
+    description:
+      name: sliver_tools
+      sha256: eae28220badfb9d0559207badcbbc9ad5331aac829a88cb0964d330d2a4636a6
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.12"
   source_gen:
     dependency: transitive
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -71,6 +71,7 @@ dependencies:
   dart_ping_ios: 4.0.2
   flutter_animation_progress_bar: 2.3.1
   email_validator: 2.1.16
+  sliver_tools: 0.2.12
 
   # According to the build variant, only one "app store" implementation must be added when building a release
   # Call "flutter pub remove xxxx" to remove unused dependencies


### PR DESCRIPTION
Hi everyone,

As explained in #4912, the Box mechanism in Flutter ensures that ALL Widgets are built, even if they are not visible by the user. For that, we have Slivers and their lazy loading capacity.

This PR moves the code to `Slivers` and also simplifies it by not relying on rows of 2 items.

A demo:

https://github.com/openfoodfacts/smooth-app/assets/246838/6081c7eb-5da5-4513-a7fa-70d44b38005b

