### PR TITLE
fix: Fix iOS build

### DIFF
--- a/packages/smooth_app/ios/Podfile.lock
+++ b/packages/smooth_app/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - "app_settings (3.0.0+1)":
+  - app_settings (5.1.1):
     - Flutter
   - audioplayers_darwin (0.0.1):
     - Flutter
@@ -267,7 +267,7 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/webview_flutter_wkwebview/ios"
 
 SPEC CHECKSUMS:
-  app_settings: d103828c9f5d515c4df9ee754dabd443f7cedcf3
+  app_settings: 017320c6a680cdc94c799949d95b84cb69389ebc
   audioplayers_darwin: 877d9a4d06331c5c374595e46e16453ac7eafa40
   camera_avfoundation: 3125e8cd1a4387f6f31c6c63abb8a55892a9eeeb
   connectivity_plus: bf0076dd84a130856aa636df1c71ccaff908fa1d
@@ -320,4 +320,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: a2ded99d2ba03f677e98efb8fb92d57b3a65b96f
 
-COCOAPODS: 1.14.2
+COCOAPODS: 1.14.3

--- a/packages/smooth_app/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/smooth_app/ios/Runner.xcodeproj/project.pbxproj
@@ -37,7 +37,6 @@
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		3B866D492A81BDDB00CEE82C /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D4B2A81BE5A00CEE82C /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		3B866D4C2A81BF3D00CEE82C /* ach */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ach; path = ach.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D4D2A81BF3F00CEE82C /* aa */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = aa; path = aa.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D4E2A81BF4200CEE82C /* af */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = af; path = af.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D4F2A81BF5700CEE82C /* ak */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ak; path = ak.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -45,21 +44,18 @@
 		3B866D512A81BF5900CEE82C /* am */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = am; path = am.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D522A81BF5900CEE82C /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D532A81BF5A00CEE82C /* hy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hy; path = hy.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		3B866D542A81BF5B00CEE82C /* ast */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ast; path = ast.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D552A81BF5B00CEE82C /* as */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = as; path = as.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D562A81BF5C00CEE82C /* az */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = az; path = az.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D572A81BF5D00CEE82C /* bm */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bm; path = bm.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D582A81BF5E00CEE82C /* bn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bn; path = bn.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D592A81BF5E00CEE82C /* eu */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = eu; path = eu.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D5A2A81BF5F00CEE82C /* be */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = be; path = be.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		3B866D5B2A81BF5F00CEE82C /* ber */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ber; path = ber.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D5C2A81BF6000CEE82C /* bs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bs; path = bs.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D5D2A81BF6100CEE82C /* br */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = br; path = br.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D5E2A81BF6100CEE82C /* bg */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bg; path = bg.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D5F2A81BF6200CEE82C /* my */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = my; path = my.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D602A81BF6200CEE82C /* ca */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ca; path = ca.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D612A81BF6300CEE82C /* ce */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ce; path = ce.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		3B866D622A81BF6300CEE82C /* chr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = chr; path = chr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D632A81BF6400CEE82C /* zh */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = zh; path = zh.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D642A81BF6400CEE82C /* cv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cv; path = cv.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D652A81BF6500CEE82C /* kw */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kw; path = kw.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -72,7 +68,6 @@
 		3B866D6D2A81BF6C00CEE82C /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D6E2A81BF6D00CEE82C /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D6F2A81BF6D00CEE82C /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		3B866D712A81BF6F00CEE82C /* fil */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fil; path = fil.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D722A81BF7100CEE82C /* gl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = gl; path = gl.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D732A81BF7200CEE82C /* ka */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ka; path = ka.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D742A81BF7200CEE82C /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -90,7 +85,6 @@
 		3B866D802A81BF7B00CEE82C /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D812A81BF7C00CEE82C /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D822A81BF7C00CEE82C /* jv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = jv; path = jv.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		3B866D832A81BF7D00CEE82C /* kab */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kab; path = kab.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D842A81BF7D00CEE82C /* kn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kn; path = kn.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D852A81BF7E00CEE82C /* kk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kk; path = kk.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D862A81BF7F00CEE82C /* km */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = km; path = km.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -102,23 +96,18 @@
 		3B866D8C2A81BF8200CEE82C /* lv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lv; path = lv.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D8D2A81BF8300CEE82C /* lt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lt; path = lt.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D8E2A81BF8600CEE82C /* zu */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = zu; path = zu.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		3B866D8F2A81BF8700CEE82C /* zea */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = zea; path = zea.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D902A81BF8700CEE82C /* yo */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = yo; path = yo.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D912A81BF8800CEE82C /* yi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = yi; path = yi.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D922A81BF8800CEE82C /* xh */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = xh; path = xh.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D932A81BF8900CEE82C /* wo */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = wo; path = wo.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		3B866D942A81BF8900CEE82C /* vls */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vls; path = vls.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D952A81BF8A00CEE82C /* cy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cy; path = cy.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D962A81BF8A00CEE82C /* wa */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = wa; path = wa.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D972A81BF8B00CEE82C /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		3B866D982A81BF8C00CEE82C /* vec */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vec; path = vec.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D992A81BF8C00CEE82C /* ve */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ve; path = ve.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		3B866D9A2A81BF8D00CEE82C /* val */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = val; path = val.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D9B2A81BF8D00CEE82C /* uz */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uz; path = uz.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D9C2A81BF8E00CEE82C /* ug */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ug; path = ug.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D9D2A81BF8F00CEE82C /* ur */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ur; path = ur.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866D9E2A81BF8F00CEE82C /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		3B866D9F2A81BF9000CEE82C /* tzl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tzl; path = tzl.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866DA02A81BF9000CEE82C /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866DA12A81BF9100CEE82C /* tn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tn; path = tn.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866DA22A81BF9100CEE82C /* ts */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ts; path = ts.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -135,9 +124,7 @@
 		3B866DAE2A81BF9D00CEE82C /* sw */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sw; path = sw.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866DAF2A81BF9E00CEE82C /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866DB02A81BF9E00CEE82C /* st */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = st; path = st.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		3B866DB12A81BF9F00CEE82C /* sma */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sma; path = sma.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866DB22A81BF9F00CEE82C /* nr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nr; path = nr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		3B866DB32A81BFA000CEE82C /* son */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = son; path = son.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866DB42A81BFA000CEE82C /* so */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = so; path = so.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866DB52A81BFA100CEE82C /* sl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sl; path = sl.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866DB62A81BFA100CEE82C /* sk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sk; path = sk.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -145,12 +132,9 @@
 		3B866DB82A81BFA300CEE82C /* sd */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sd; path = sd.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866DB92A81BFA400CEE82C /* ii */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ii; path = ii.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866DBA2A81BFA400CEE82C /* sn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sn; path = sn.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		3B866DBB2A81BFA400CEE82C /* crs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = crs; path = crs.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866DBC2A81BFA500CEE82C /* sr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sr; path = sr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866DBD2A81BFA500CEE82C /* gd */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = gd; path = gd.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		3B866DBE2A81BFA700CEE82C /* sco */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sco; path = sco.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866DBF2A81BFA700CEE82C /* sc */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sc; path = sc.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		3B866DC02A81BFA800CEE82C /* sat */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sat; path = sat.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866DC12A81BFA800CEE82C /* sa */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sa; path = sa.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866DC22A81BFA900CEE82C /* sg */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sg; path = sg.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866DC32A81BFAA00CEE82C /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -167,7 +151,6 @@
 		3B866DCE2A81BFB300CEE82C /* nn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nn; path = nn.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866DCF2A81BFB300CEE82C /* ne */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ne; path = ne.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866DD02A81BFB400CEE82C /* mn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = mn; path = mn.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		3B866DD12A81BFB500CEE82C /* lol */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lol; path = lol.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866DD22A81BFB500CEE82C /* mr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = mr; path = mr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866DD32A81BFB600CEE82C /* mi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = mi; path = mi.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3B866DD42A81BFB600CEE82C /* mt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = mt; path = mt.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -316,16 +299,13 @@
 				en,
 				Base,
 				aa,
-				ach,
 				af,
 				ak,
 				am,
 				ar,
 				as,
-				ast,
 				az,
 				be,
-				ber,
 				bg,
 				bm,
 				bn,
@@ -334,9 +314,7 @@
 				bs,
 				ca,
 				ce,
-				chr,
 				co,
-				crs,
 				cs,
 				cv,
 				cy,
@@ -349,7 +327,6 @@
 				eu,
 				fa,
 				fi,
-				fil,
 				fo,
 				ga,
 				gd,
@@ -370,7 +347,6 @@
 				ja,
 				jv,
 				ka,
-				kab,
 				kk,
 				km,
 				kn,
@@ -381,7 +357,6 @@
 				la,
 				lb,
 				lo,
-				lol,
 				lt,
 				lv,
 				mg,
@@ -408,18 +383,14 @@
 				ro,
 				ru,
 				sa,
-				sat,
 				sc,
-				sco,
 				sd,
 				sg,
 				si,
 				sk,
 				sl,
-				sma,
 				sn,
 				so,
-				son,
 				sq,
 				sr,
 				ss,
@@ -438,22 +409,17 @@
 				tt,
 				tw,
 				ty,
-				tzl,
 				ug,
 				uk,
 				ur,
 				uz,
-				val,
 				ve,
-				vec,
 				vi,
-				vls,
 				wa,
 				wo,
 				xh,
 				yi,
 				yo,
-				zea,
 				zh,
 				zu,
 				fr,
@@ -574,7 +540,6 @@
 			children = (
 				3B866D492A81BDDB00CEE82C /* en */,
 				3B866D4B2A81BE5A00CEE82C /* fr */,
-				3B866D4C2A81BF3D00CEE82C /* ach */,
 				3B866D4D2A81BF3F00CEE82C /* aa */,
 				3B866D4E2A81BF4200CEE82C /* af */,
 				3B866D4F2A81BF5700CEE82C /* ak */,
@@ -582,21 +547,18 @@
 				3B866D512A81BF5900CEE82C /* am */,
 				3B866D522A81BF5900CEE82C /* ar */,
 				3B866D532A81BF5A00CEE82C /* hy */,
-				3B866D542A81BF5B00CEE82C /* ast */,
 				3B866D552A81BF5B00CEE82C /* as */,
 				3B866D562A81BF5C00CEE82C /* az */,
 				3B866D572A81BF5D00CEE82C /* bm */,
 				3B866D582A81BF5E00CEE82C /* bn */,
 				3B866D592A81BF5E00CEE82C /* eu */,
 				3B866D5A2A81BF5F00CEE82C /* be */,
-				3B866D5B2A81BF5F00CEE82C /* ber */,
 				3B866D5C2A81BF6000CEE82C /* bs */,
 				3B866D5D2A81BF6100CEE82C /* br */,
 				3B866D5E2A81BF6100CEE82C /* bg */,
 				3B866D5F2A81BF6200CEE82C /* my */,
 				3B866D602A81BF6200CEE82C /* ca */,
 				3B866D612A81BF6300CEE82C /* ce */,
-				3B866D622A81BF6300CEE82C /* chr */,
 				3B866D632A81BF6400CEE82C /* zh */,
 				3B866D642A81BF6400CEE82C /* cv */,
 				3B866D652A81BF6500CEE82C /* kw */,
@@ -609,7 +571,6 @@
 				3B866D6D2A81BF6C00CEE82C /* nl */,
 				3B866D6E2A81BF6D00CEE82C /* da */,
 				3B866D6F2A81BF6D00CEE82C /* cs */,
-				3B866D712A81BF6F00CEE82C /* fil */,
 				3B866D722A81BF7100CEE82C /* gl */,
 				3B866D732A81BF7200CEE82C /* ka */,
 				3B866D742A81BF7200CEE82C /* de */,
@@ -627,7 +588,6 @@
 				3B866D802A81BF7B00CEE82C /* it */,
 				3B866D812A81BF7C00CEE82C /* ja */,
 				3B866D822A81BF7C00CEE82C /* jv */,
-				3B866D832A81BF7D00CEE82C /* kab */,
 				3B866D842A81BF7D00CEE82C /* kn */,
 				3B866D852A81BF7E00CEE82C /* kk */,
 				3B866D862A81BF7F00CEE82C /* km */,
@@ -639,7 +599,6 @@
 				3B866D8C2A81BF8200CEE82C /* lv */,
 				3B866D8D2A81BF8300CEE82C /* lt */,
 				3B866D8E2A81BF8600CEE82C /* zu */,
-				3B866D8F2A81BF8700CEE82C /* zea */,
 				3B866D902A81BF8700CEE82C /* yo */,
 				3B866D912A81BF8800CEE82C /* yi */,
 				3B866D922A81BF8800CEE82C /* xh */,
@@ -650,12 +609,10 @@
 				3B866D972A81BF8B00CEE82C /* vi */,
 				3B866D982A81BF8C00CEE82C /* vec */,
 				3B866D992A81BF8C00CEE82C /* ve */,
-				3B866D9A2A81BF8D00CEE82C /* val */,
 				3B866D9B2A81BF8D00CEE82C /* uz */,
 				3B866D9C2A81BF8E00CEE82C /* ug */,
 				3B866D9D2A81BF8F00CEE82C /* ur */,
 				3B866D9E2A81BF8F00CEE82C /* uk */,
-				3B866D9F2A81BF9000CEE82C /* tzl */,
 				3B866DA02A81BF9000CEE82C /* tr */,
 				3B866DA12A81BF9100CEE82C /* tn */,
 				3B866DA22A81BF9100CEE82C /* ts */,
@@ -672,9 +629,7 @@
 				3B866DAE2A81BF9D00CEE82C /* sw */,
 				3B866DAF2A81BF9E00CEE82C /* es */,
 				3B866DB02A81BF9E00CEE82C /* st */,
-				3B866DB12A81BF9F00CEE82C /* sma */,
 				3B866DB22A81BF9F00CEE82C /* nr */,
-				3B866DB32A81BFA000CEE82C /* son */,
 				3B866DB42A81BFA000CEE82C /* so */,
 				3B866DB52A81BFA100CEE82C /* sl */,
 				3B866DB62A81BFA100CEE82C /* sk */,
@@ -682,12 +637,9 @@
 				3B866DB82A81BFA300CEE82C /* sd */,
 				3B866DB92A81BFA400CEE82C /* ii */,
 				3B866DBA2A81BFA400CEE82C /* sn */,
-				3B866DBB2A81BFA400CEE82C /* crs */,
 				3B866DBC2A81BFA500CEE82C /* sr */,
 				3B866DBD2A81BFA500CEE82C /* gd */,
-				3B866DBE2A81BFA700CEE82C /* sco */,
 				3B866DBF2A81BFA700CEE82C /* sc */,
-				3B866DC02A81BFA800CEE82C /* sat */,
 				3B866DC12A81BFA800CEE82C /* sa */,
 				3B866DC22A81BFA900CEE82C /* sg */,
 				3B866DC32A81BFAA00CEE82C /* ru */,
@@ -704,7 +656,6 @@
 				3B866DCE2A81BFB300CEE82C /* nn */,
 				3B866DCF2A81BFB300CEE82C /* ne */,
 				3B866DD02A81BFB400CEE82C /* mn */,
-				3B866DD12A81BFB500CEE82C /* lol */,
 				3B866DD22A81BFB500CEE82C /* mr */,
 				3B866DD32A81BFB600CEE82C /* mi */,
 				3B866DD42A81BFB600CEE82C /* mt */,


### PR DESCRIPTION
Hi everyone,

On iOS, Crowdin injects invalid languages with 3 characters.
The previous fix (https://github.com/openfoodfacts/smooth-app/commit/059ca727a687ab42fb67f57dd200d5f4e7bd31b0) was not enough and the app doesn't build on the latest version of Xcode.

This PR ensures the removal of all references.

Note: I really love the "lol" language 🤭