### PR TITLE
fix: 4923 - added a padding for banner

### DIFF
--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -251,6 +251,9 @@ class _ProductPageState extends State<ProductPage>
                 ),
               ),
             ),
+          if (questionsLayout == ProductQuestionsLayout.banner)
+            // assuming it's tall enough in order to go above the banner
+            const SizedBox(height: 4 * VERY_LARGE_SPACE),
         ],
       ),
     );


### PR DESCRIPTION
### What
- Added a lousy padding so that the banner doesn't hide the last item of the product page's list view.

### Screenshot
| before | after |
| -- | -- |
| ![Screenshot_1703519139](https://github.com/openfoodfacts/smooth-app/assets/11576431/d4de732a-805b-4bf2-8bce-f122f35ddbb8) | ![Screenshot_1703519094](https://github.com/openfoodfacts/smooth-app/assets/11576431/800d5810-446d-4253-ac34-39c0eb06d6c9) |

### Fixes bug(s)
- Fixes: #4923