### PR TITLE
fix: 4925 - consistency for "edit product" app bars

### DIFF
--- a/packages/smooth_app/lib/helpers/product_cards_helper.dart
+++ b/packages/smooth_app/lib/helpers/product_cards_helper.dart
@@ -10,15 +10,26 @@ import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/helpers/image_field_extension.dart';
 import 'package:smooth_app/helpers/ui_helpers.dart';
 import 'package:smooth_app/query/product_query.dart';
+import 'package:smooth_app/widgets/smooth_app_bar.dart';
 
-Widget buildProductTitle(
-  final Product product,
-  final AppLocalizations appLocalizations,
-) =>
-    Text(
-      getProductNameAndBrands(product, appLocalizations),
-      overflow: TextOverflow.ellipsis,
-      maxLines: 1,
+SmoothAppBar buildEditProductAppBar({
+  required final BuildContext context,
+  required final String title,
+  required final Product product,
+}) =>
+    SmoothAppBar(
+      centerTitle: false,
+      title: Text(
+        title,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      subTitle: Text(
+        getProductNameAndBrands(product, AppLocalizations.of(context)),
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      ignoreSemanticsForSubtitle: true,
     );
 
 String getProductNameAndBrands(

--- a/packages/smooth_app/lib/pages/image/product_image_other_page.dart
+++ b/packages/smooth_app/lib/pages/image/product_image_other_page.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
-import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
 /// Full page display of a raw product image.
@@ -19,10 +18,10 @@ class ProductImageOtherPage extends StatelessWidget {
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     return SmoothScaffold(
-      appBar: SmoothAppBar(
-        centerTitle: false,
-        title: Text(appLocalizations.edit_product_form_item_photos_title),
-        subTitle: buildProductTitle(product, appLocalizations),
+      appBar: buildEditProductAppBar(
+        context: context,
+        title: appLocalizations.edit_product_form_item_photos_title,
+        product: product,
       ),
       body: Image(
         image: NetworkImage(

--- a/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
@@ -15,7 +15,6 @@ import 'package:smooth_app/pages/product/common/product_refresher.dart';
 import 'package:smooth_app/pages/product/may_exit_page_helper.dart';
 import 'package:smooth_app/pages/product/multilingual_helper.dart';
 import 'package:smooth_app/pages/text_field_helper.dart';
-import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
 /// Input of a product's basic details, like name, quantity and brands.
@@ -91,10 +90,10 @@ class _AddBasicDetailsPageState extends State<AddBasicDetailsPage> {
       child: UnfocusWhenTapOutside(
         child: SmoothScaffold(
           fixKeyboard: true,
-          appBar: SmoothAppBar(
-            centerTitle: false,
-            title: Text(appLocalizations.basic_details),
-            subTitle: buildProductTitle(widget.product, appLocalizations),
+          appBar: buildEditProductAppBar(
+            context: context,
+            title: appLocalizations.basic_details,
+            product: widget.product,
           ),
           body: Form(
             key: _formKey,

--- a/packages/smooth_app/lib/pages/product/add_other_details_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_other_details_page.dart
@@ -9,7 +9,6 @@ import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/pages/product/common/product_buttons.dart';
 import 'package:smooth_app/pages/product/may_exit_page_helper.dart';
 import 'package:smooth_app/pages/text_field_helper.dart';
-import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
 /// Input of a product's less significant details, like website.
@@ -58,12 +57,10 @@ class _AddOtherDetailsPageState extends State<AddOtherDetailsPage> {
       onWillPop: () async => _mayExitPage(saving: false),
       child: SmoothScaffold(
         fixKeyboard: true,
-        appBar: SmoothAppBar(
-          centerTitle: false,
-          title:
-              Text(appLocalizations.edit_product_form_item_other_details_title),
-          subTitle: buildProductTitle(widget.product, appLocalizations),
-          ignoreSemanticsForSubtitle: true,
+        appBar: buildEditProductAppBar(
+          context: context,
+          title: appLocalizations.edit_product_form_item_other_details_title,
+          product: widget.product,
         ),
         body: Form(
           key: _formKey,
@@ -75,15 +72,6 @@ class _AddOtherDetailsPageState extends State<AddOtherDetailsPage> {
                   padding: EdgeInsets.symmetric(horizontal: size.width * 0.05),
                   child: Column(
                     children: <Widget>[
-                      ExcludeSemantics(
-                        child: Text(
-                          appLocalizations.barcode_barcode(_product.barcode!),
-                          style:
-                              Theme.of(context).textTheme.bodyMedium?.copyWith(
-                                    fontWeight: FontWeight.bold,
-                                  ),
-                        ),
-                      ),
                       SizedBox(height: _heightSpace),
                       SmoothTextFormField(
                         controller: _websiteController,

--- a/packages/smooth_app/lib/pages/product/edit_new_packagings.dart
+++ b/packages/smooth_app/lib/pages/product/edit_new_packagings.dart
@@ -20,7 +20,6 @@ import 'package:smooth_app/pages/product/may_exit_page_helper.dart';
 import 'package:smooth_app/pages/product/simple_input_number_field.dart';
 import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/themes/color_schemes.dart';
-import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
 /// Edit display of a product packagings (the new api V3 version).
@@ -188,9 +187,11 @@ class _EditNewPackagingsState extends State<EditNewPackagings>
       child: UnfocusWhenTapOutside(
         child: SmoothScaffold(
           fixKeyboard: true,
-          appBar: SmoothAppBar(
-              title: Text(appLocalizations.edit_packagings_title),
-              subTitle: buildProductTitle(upToDateProduct, appLocalizations)),
+          appBar: buildEditProductAppBar(
+            context: context,
+            title: appLocalizations.edit_packagings_title,
+            product: upToDateProduct,
+          ),
           body: ListView(
             padding: const EdgeInsets.only(top: LARGE_SPACE),
             children: children,

--- a/packages/smooth_app/lib/pages/product/edit_ocr_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_ocr_page.dart
@@ -1,5 +1,3 @@
-import 'dart:ui' show ImageFilter;
-
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
@@ -21,7 +19,6 @@ import 'package:smooth_app/pages/product/multilingual_helper.dart';
 import 'package:smooth_app/pages/product/ocr_helper.dart';
 import 'package:smooth_app/pages/product/product_image_local_button.dart';
 import 'package:smooth_app/pages/product/product_image_server_button.dart';
-import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
 /// Editing with OCR a product field and the corresponding image.
@@ -131,37 +128,13 @@ class _EditOcrPageState extends State<EditOcrPage> with UpToDateMixin {
       _multilingualHelper.getCurrentLanguage(),
     );
 
-    final TextStyle appbarTextStyle = TextStyle(shadows: <Shadow>[
-      Shadow(
-        color: Theme.of(context).colorScheme.brightness == Brightness.light
-            ? Colors.white
-            : Colors.black,
-        offset: const Offset(0.5, 0.5),
-        blurRadius: 5.0,
-      )
-    ]);
-
     // TODO(monsieurtanuki): add WillPopScope / MayExitPage system
     return SmoothScaffold(
       extendBodyBehindAppBar: true,
-      appBar: SmoothAppBar(
-        centerTitle: false,
-        title: Text(
-          _helper.getTitle(appLocalizations),
-          style: appbarTextStyle,
-        ),
-        subTitle: DefaultTextStyle(
-            style: appbarTextStyle,
-            child: buildProductTitle(upToDateProduct, appLocalizations)),
-        backgroundColor: Colors.transparent,
-        flexibleSpace: ClipRect(
-          child: BackdropFilter(
-            filter: ImageFilter.blur(sigmaX: 5.0, sigmaY: 5.0),
-            child: Container(
-              color: Colors.transparent,
-            ),
-          ),
-        ),
+      appBar: buildEditProductAppBar(
+        context: context,
+        title: _helper.getTitle(appLocalizations),
+        product: upToDateProduct,
       ),
       body: Stack(
         children: <Widget>[

--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -154,7 +154,6 @@ class _EditProductPageState extends State<EditProductPage> with UpToDateMixin {
                           ProductImageGalleryView(
                         product: upToDateProduct,
                       ),
-                      fullscreenDialog: true,
                     ),
                   );
                 },
@@ -250,7 +249,6 @@ class _EditProductPageState extends State<EditProductPage> with UpToDateMixin {
                     context,
                     MaterialPageRoute<void>(
                       builder: (_) => AddOtherDetailsPage(upToDateProduct),
-                      fullscreenDialog: true,
                     ),
                   );
                 },
@@ -308,7 +306,6 @@ class _EditProductPageState extends State<EditProductPage> with UpToDateMixin {
               helpers: helpers,
               product: upToDateProduct,
             ),
-            fullscreenDialog: true,
           ),
         );
       },

--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -22,7 +22,6 @@ import 'package:smooth_app/pages/product/nutrition_container.dart';
 import 'package:smooth_app/pages/product/ordered_nutrients_cache.dart';
 import 'package:smooth_app/pages/product/simple_input_number_field.dart';
 import 'package:smooth_app/pages/text_field_helper.dart';
-import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
 /// Actual nutrition page, with data already loaded.
@@ -74,7 +73,6 @@ class NutritionPageLoaded extends StatefulWidget {
               cache.orderedNutrients,
               isLoggedInMandatory: isLoggedInMandatory,
             ),
-            fullscreenDialog: true,
           ),
         );
       }
@@ -194,12 +192,10 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded>
       onWillPop: () async => _mayExitPage(saving: false),
       child: SmoothScaffold(
         fixKeyboard: true,
-        appBar: SmoothAppBar(
-          title: AutoSizeText(
-            appLocalizations.nutrition_page_title,
-            maxLines: 1,
-          ),
-          subTitle: buildProductTitle(upToDateProduct, appLocalizations),
+        appBar: buildEditProductAppBar(
+          context: context,
+          title: appLocalizations.nutrition_page_title,
+          product: upToDateProduct,
         ),
         body: Padding(
           padding: const EdgeInsets.symmetric(

--- a/packages/smooth_app/lib/pages/product/product_field_editor.dart
+++ b/packages/smooth_app/lib/pages/product/product_field_editor.dart
@@ -72,7 +72,6 @@ class ProductFieldSimpleEditor extends ProductFieldEditor {
           helper: helper,
           product: product,
         ),
-        fullscreenDialog: true,
       ),
     );
   }
@@ -163,7 +162,6 @@ class ProductFieldPackagingEditor extends ProductFieldEditor {
           product: product,
           isLoggedInMandatory: isLoggedInMandatory,
         ),
-        fullscreenDialog: true,
       ),
     );
   }
@@ -229,7 +227,6 @@ abstract class ProductFieldOcrEditor extends ProductFieldEditor {
           helper: helper,
           isLoggedInMandatory: isLoggedInMandatory,
         ),
-        fullscreenDialog: true,
       ),
     );
   }

--- a/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
@@ -18,7 +18,6 @@ import 'package:smooth_app/pages/product/common/product_refresher.dart';
 import 'package:smooth_app/pages/product/product_image_swipeable_view.dart';
 import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/widgets/slivers.dart';
-import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
 /// Display of the main 4 pictures of a product, with edit options.
@@ -52,10 +51,10 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView>
     context.watch<LocalDatabase>();
     refreshUpToDate();
     return SmoothScaffold(
-      appBar: SmoothAppBar(
-        centerTitle: false,
-        title: Text(appLocalizations.edit_product_form_item_photos_title),
-        subTitle: buildProductTitle(upToDateProduct, appLocalizations),
+      appBar: buildEditProductAppBar(
+        context: context,
+        title: appLocalizations.edit_product_form_item_photos_title,
+        product: upToDateProduct,
       ),
       floatingActionButton: FloatingActionButton.extended(
         onPressed: () async {

--- a/packages/smooth_app/lib/pages/product/simple_input_page.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page.dart
@@ -13,7 +13,6 @@ import 'package:smooth_app/pages/product/common/product_buttons.dart';
 import 'package:smooth_app/pages/product/may_exit_page_helper.dart';
 import 'package:smooth_app/pages/product/simple_input_page_helpers.dart';
 import 'package:smooth_app/pages/product/simple_input_widget.dart';
-import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
 /// Simple input page: we have a list of terms, we add, we remove, we save.
@@ -54,8 +53,10 @@ class _SimpleInputPageState extends State<SimpleInputPage> {
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final List<Widget> simpleInputs = <Widget>[];
+    final List<String> titles = <String>[];
 
     for (int i = 0; i < widget.helpers.length; i++) {
+      titles.add(widget.helpers[i].getTitle(appLocalizations));
       simpleInputs.add(
         Padding(
           padding: i == 0
@@ -79,6 +80,7 @@ class _SimpleInputPageState extends State<SimpleInputPage> {
                 helper: widget.helpers[i],
                 product: widget.product,
                 controller: _controllers[i],
+                displayTitle: widget.helpers.length > 1,
               ),
             ),
           ),
@@ -91,13 +93,10 @@ class _SimpleInputPageState extends State<SimpleInputPage> {
       child: UnfocusWhenTapOutside(
         child: SmoothScaffold(
           fixKeyboard: true,
-          appBar: SmoothAppBar(
-            centerTitle: false,
-            title: buildProductTitle(widget.product, appLocalizations),
-            subTitle: widget.product.barcode != null
-                ? ExcludeSemantics(
-                    excluding: true, child: Text(widget.product.barcode!))
-                : null,
+          appBar: buildEditProductAppBar(
+            context: context,
+            title: titles.join(', '),
+            product: widget.product,
           ),
           body: Padding(
             padding: const EdgeInsets.all(SMALL_SPACE),

--- a/packages/smooth_app/lib/pages/product/simple_input_widget.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_widget.dart
@@ -14,11 +14,13 @@ class SimpleInputWidget extends StatefulWidget {
     required this.helper,
     required this.product,
     required this.controller,
+    required this.displayTitle,
   });
 
   final AbstractSimpleInputPageHelper helper;
   final Product product;
   final TextEditingController controller;
+  final bool displayTitle;
 
   @override
   State<SimpleInputWidget> createState() => _SimpleInputWidgetState();
@@ -64,15 +66,16 @@ class _SimpleInputWidgetState extends State<SimpleInputWidget> {
       mainAxisAlignment: MainAxisAlignment.start,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        ListTile(
-          leading: widget.helper.getIcon(),
-          minLeadingWidth: 0.0,
-          horizontalTitleGap: 12.0,
-          title: Text(
-            widget.helper.getTitle(appLocalizations),
-            style: themeData.textTheme.displaySmall,
+        if (widget.displayTitle)
+          ListTile(
+            leading: widget.helper.getIcon(),
+            minLeadingWidth: 0.0,
+            horizontalTitleGap: 12.0,
+            title: Text(
+              widget.helper.getTitle(appLocalizations),
+              style: themeData.textTheme.displaySmall,
+            ),
           ),
-        ),
         if (explanations != null) ExplanationWidget(explanations),
         LayoutBuilder(
           builder: (_, BoxConstraints constraints) {


### PR DESCRIPTION
### What
- Now all the edit product pages use the same app bar and are called as real pages (i.e. without `fullScreenDialog: true`)

### Screenshots
| col 1 | col 2 |
| -- | -- |
| ![Screenshot_1703752667](https://github.com/openfoodfacts/smooth-app/assets/11576431/0fb7e027-1400-4af7-b4c7-069a9db11018) | ![Screenshot_1703752674](https://github.com/openfoodfacts/smooth-app/assets/11576431/af2e9e87-830d-4344-a7f5-d423a2fa4ebf) |
| ![Screenshot_1703752687](https://github.com/openfoodfacts/smooth-app/assets/11576431/c75cc558-80b3-4f47-9c5f-6ab19f8bb787) | ![Screenshot_1703752695](https://github.com/openfoodfacts/smooth-app/assets/11576431/bc23771e-0dcc-4fa1-b5d7-444ff027cecc) |
| ![Screenshot_1703752701](https://github.com/openfoodfacts/smooth-app/assets/11576431/bb794578-1fd5-40f1-9aea-c9296c260ec2) | ![Screenshot_1703752711](https://github.com/openfoodfacts/smooth-app/assets/11576431/460b7bc6-f1bd-4f84-8515-0549d7638815) |
| ![Screenshot_1703752721](https://github.com/openfoodfacts/smooth-app/assets/11576431/334c5ec2-5cbb-4bb8-8512-b89f76e481bf) | ![Screenshot_1703752736](https://github.com/openfoodfacts/smooth-app/assets/11576431/94100e45-7a6d-4983-90a9-92507a05981f) |
| ![Screenshot_1703752743](https://github.com/openfoodfacts/smooth-app/assets/11576431/c543f597-53cb-4621-87b7-79db941ee0d7) | ![Screenshot_1703752752](https://github.com/openfoodfacts/smooth-app/assets/11576431/d046e152-a835-4f6c-bd13-592b6f1177f7) |
| ![Screenshot_1703752760](https://github.com/openfoodfacts/smooth-app/assets/11576431/cce8196f-6786-45b7-83a3-d71b0f6d4e97) | ![Screenshot_1703752766](https://github.com/openfoodfacts/smooth-app/assets/11576431/236d30fb-bb95-47c0-ba3d-75d24a02f219) |
| ![Screenshot_1703752773](https://github.com/openfoodfacts/smooth-app/assets/11576431/2e27789b-5e02-4b08-a26d-7a4f723bed0a) | ![Screenshot_1703752782](https://github.com/openfoodfacts/smooth-app/assets/11576431/d6528d5f-05b9-4e3c-9836-13ce06ee8e62) |


### Fixes bug(s)
- Fixes: #4925
- Fixes: #4182

### Impacted files
* `add_basic_details_page.dart`: now using new method `buildEditProductAppBar`
* `add_other_details_page.dart`: now using new method `buildEditProductAppBar`; removed an irrelevant barcode display
* `edit_new_packagings.dart`: now using new method `buildEditProductAppBar`
* `edit_ocr_page.dart`: now using new method `buildEditProductAppBar`
* `edit_product_page.dart`: removed inconsistent `fullScreenDialog:true` parameters
* `nutrition_page_loaded.dart`: now using new method `buildEditProductAppBar`; removed inconsistent `fullScreenDialog:true` parameters
* `product_cards_helper.dart`: new method `buildEditProductAppBar` instead of `buildProductTitle`
* `product_field_editor.dart`: removed inconsistent `fullScreenDialog:true` parameters
* `product_image_gallery_view.dart`: now using new method `buildEditProductAppBar`
* `product_image_other_page.dart`: now using new method `buildEditProductAppBar`
* `simple_input_page.dart`: now using new method `buildEditProductAppBar`
* `simple_input_widget.dart`: now we don't display the widget title on a single widget page - in order to avoid title redundancy