### PR TITLE
fix: 4820 - ChangeNotifierProvider already disposes

### DIFF
--- a/packages/smooth_app/lib/pages/product/common/product_list_item_simple.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_item_simple.dart
@@ -40,12 +40,6 @@ class _ProductListItemSimpleState extends State<ProductListItemSimple> {
   }
 
   @override
-  void dispose() {
-    _model.dispose();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) => ChangeNotifierProvider<ProductModel>(
         create: (final BuildContext context) => _model,
         builder: (final BuildContext context, final Widget? wtf) {


### PR DESCRIPTION
### What
- In `ProductListItemSimple` we disposed the `ProductModel` instance in the `dispose` method.
- But the `ChangeNotifierProvider` already disposed automatically the `ProductModel`.
- Therefore the model was disposed twice, hence the issue.
- Now it's fixed.

### Fixes bug(s)
- Fixes: #4820