### PR TITLE
fix: 4697 - no more redundant "complete category" button

### DIFF
--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -17,14 +17,12 @@ import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/helpers/ui_helpers.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_page.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels_builder.dart';
-import 'package:smooth_app/pages/product/add_simple_input_button.dart';
 import 'package:smooth_app/pages/product/common/product_query_page_helper.dart';
 import 'package:smooth_app/pages/product/hideable_container.dart';
 import 'package:smooth_app/pages/product/product_compatibility_header.dart';
 import 'package:smooth_app/pages/product/product_field_editor.dart';
 import 'package:smooth_app/pages/product/product_incomplete_card.dart';
 import 'package:smooth_app/pages/product/product_questions_widget.dart';
-import 'package:smooth_app/pages/product/simple_input_page_helpers.dart';
 import 'package:smooth_app/pages/product/summary_attribute_group.dart';
 import 'package:smooth_app/query/category_product_query.dart';
 import 'package:smooth_app/query/product_query.dart';
@@ -294,17 +292,6 @@ class _SummaryCardState extends State<SummaryCard> with UpToDateMixin {
     final List<Widget> summaryCardButtons = <Widget>[];
 
     if (widget.isFullVersion) {
-      // Complete category
-      if (statesTags
-          .contains(ProductState.CATEGORIES_COMPLETED.toBeCompletedTag)) {
-        summaryCardButtons.add(
-          AddSimpleInputButton(
-            product: upToDateProduct,
-            helper: SimpleInputPageCategoryHelper(),
-          ),
-        );
-      }
-
       // Compare to category
       if (categoryTag != null && categoryLabel != null) {
         summaryCardButtons.add(


### PR DESCRIPTION
### What
- Removed the redundant "complete category" button in product summary card (redundant with the fast-track button).

### Screenshot
| before | after |
| -- | -- |
| ![Screenshot_1704114355](https://github.com/openfoodfacts/smooth-app/assets/11576431/321e54a5-7f31-4ed0-880b-3c6de13486d5) | ![Screenshot_1704114509](https://github.com/openfoodfacts/smooth-app/assets/11576431/e699b3da-98da-40a5-88c3-e5d488bcd1ff) |

### Fixes bug(s)
- Fixes: #4697
