### PR TITLE
fix: 4228 - max lines 2 and tooltip for edit image buttons

### DIFF
--- a/packages/smooth_app/lib/pages/product/edit_image_button.dart
+++ b/packages/smooth_app/lib/pages/product/edit_image_button.dart
@@ -1,3 +1,4 @@
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 
@@ -18,28 +19,35 @@ class EditImageButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ColorScheme colorScheme = Theme.of(context).colorScheme;
-    return OutlinedButton.icon(
-      icon: Icon(iconData),
-      style: ButtonStyle(
-        backgroundColor: MaterialStateProperty.all(colorScheme.onPrimary),
-        shape: MaterialStateProperty.all(
-          const RoundedRectangleBorder(borderRadius: ROUNDED_BORDER_RADIUS),
-        ),
-        side: borderWidth == null
-            ? null
-            : MaterialStateBorderSide.resolveWith(
-                (_) => BorderSide(
-                  color: colorScheme.primary,
-                  width: borderWidth!,
+    return Tooltip(
+      message: label,
+      child: OutlinedButton.icon(
+        icon: Icon(iconData),
+        style: ButtonStyle(
+          backgroundColor: MaterialStateProperty.all(colorScheme.onPrimary),
+          shape: MaterialStateProperty.all(
+            const RoundedRectangleBorder(borderRadius: ROUNDED_BORDER_RADIUS),
+          ),
+          side: borderWidth == null
+              ? null
+              : MaterialStateBorderSide.resolveWith(
+                  (_) => BorderSide(
+                    color: colorScheme.primary,
+                    width: borderWidth!,
+                  ),
                 ),
-              ),
-      ),
-      onPressed: onPressed,
-      label: SizedBox(
-        width: double.infinity,
-        child: Padding(
-          padding: EdgeInsets.all(borderWidth ?? 0),
-          child: Text(label),
+        ),
+        onPressed: onPressed,
+        label: SizedBox(
+          width: double.infinity,
+          child: Padding(
+            padding: EdgeInsets.all(borderWidth ?? 0),
+            child: AutoSizeText(
+              label,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
         ),
       ),
     );


### PR DESCRIPTION
### What
- For the edit image buttons, we now use an `AutoSizeText` with max lines 2 and a tooltip (on long press).
- That will prevent us from having abnormally tall buttons, while providing the full description of the button if needed.

### Screenshot
| long text with ellipsis | ... and tooltip |
| -- | -- |
| ![Screenshot_1704118168](https://github.com/openfoodfacts/smooth-app/assets/11576431/92ad4be5-eeb5-483e-bf40-e18211a91c77) | ![Screenshot_1704118172](https://github.com/openfoodfacts/smooth-app/assets/11576431/55daaa06-053e-4622-b798-f64711c042a7) |

### Fixes bug(s)
- Fixes: #4228