### PR TITLE
fix: properly refresh food preferences language

### DIFF
--- a/packages/smooth_app/lib/pages/preferences/user_preferences_language_selector.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_language_selector.dart
@@ -3,6 +3,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/preferences/user_preferences.dart';
+import 'package:smooth_app/data_models/product_preferences.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/language_selector.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_item.dart';
@@ -23,6 +24,17 @@ class UserPreferencesLanguageSelector extends StatelessWidget {
     );
   }
 
+  Future<void> _changeAppLanguage(
+      BuildContext context, UserPreferences userPreferences,
+      {required OpenFoodFactsLanguage language}) async {
+    ProductQuery.setLanguage(
+      context,
+      userPreferences,
+      languageCode: language.code,
+    );
+    await context.read<ProductPreferences>().refresh();
+  }
+
   @override
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
@@ -39,13 +51,11 @@ class UserPreferencesLanguageSelector extends StatelessWidget {
         ),
         child: LanguageSelector(
           setLanguage: (final OpenFoodFactsLanguage? language) async {
-            if (language != null) {
-              ProductQuery.setLanguage(
-                context,
-                userPreferences,
-                languageCode: language.code,
-              );
+            if (language == null) {
+              return;
             }
+
+            _changeAppLanguage(context, userPreferences, language: language);
           },
           selectedLanguages: <OpenFoodFactsLanguage>[
             ProductQuery.getLanguage(),

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_language_selector.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_language_selector.dart
@@ -25,8 +25,10 @@ class UserPreferencesLanguageSelector extends StatelessWidget {
   }
 
   Future<void> _changeAppLanguage(
-      BuildContext context, UserPreferences userPreferences,
-      {required OpenFoodFactsLanguage language}) async {
+    BuildContext context,
+    UserPreferences userPreferences, {
+    required OpenFoodFactsLanguage language,
+  }) async {
     ProductQuery.setLanguage(
       context,
       userPreferences,
@@ -55,7 +57,11 @@ class UserPreferencesLanguageSelector extends StatelessWidget {
               return;
             }
 
-            _changeAppLanguage(context, userPreferences, language: language);
+            _changeAppLanguage(
+              context,
+              userPreferences,
+              language: language,
+            );
           },
           selectedLanguages: <OpenFoodFactsLanguage>[
             ProductQuery.getLanguage(),


### PR DESCRIPTION
### What
- Update the `LanguageSelector` callback to refresh the `ProductPreferences` as well.

### Fixes bug(s)
- Fixes: #4878 