### PR TITLE
feat: Help debug KP by providing some debug info

### DIFF
--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_action_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_action_card.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
@@ -107,5 +108,12 @@ class KnowledgePanelActionCard extends StatelessWidget {
       default:
         return false;
     }
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(StringProperty('html', element.html));
+    properties.add(IterableProperty<String>('actions', element.actions));
   }
 }

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_card.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
@@ -90,5 +91,12 @@ class KnowledgePanelCard extends StatelessWidget {
       }
     }
     return false;
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(StringProperty('panelId', panelId));
+    properties.add(DiagnosticsProperty<bool>('clickable', isClickable));
   }
 }

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_expanded_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_expanded_card.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
@@ -50,5 +51,15 @@ class KnowledgePanelExpandedCard extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: elementWidgets,
     );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(StringProperty('panelId', panelId));
+    properties.add(
+      DiagnosticsProperty<bool>('initiallyExpanded', isInitiallyExpanded),
+    );
+    properties.add(DiagnosticsProperty<bool>('clickable', isClickable));
   }
 }

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_group_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_group_card.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
@@ -42,5 +43,13 @@ class KnowledgePanelGroupCard extends StatelessWidget {
         ],
       ),
     );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(StringProperty('groupElement', groupElement.title));
+    properties.add(DiagnosticsProperty<bool>('clickable', isClickable));
+    properties.add(IterableProperty<String>('panelIds', groupElement.panelIds));
   }
 }

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_image_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_image_card.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 
@@ -16,4 +17,12 @@ class KnowledgePanelImageCard extends StatelessWidget {
         width: imageElement.width?.toDouble(),
         height: imageElement.height?.toDouble(),
       );
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(StringProperty('url', imageElement.url));
+    properties.add(IntProperty('width', imageElement.width));
+    properties.add(IntProperty('height', imageElement.height));
+  }
 }

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_page.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_page.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
@@ -123,5 +124,11 @@ class _KnowledgePanelPageState extends State<KnowledgePanelPage>
       return (panel?.titleElement?.title)!;
     }
     return '';
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(StringProperty('panelId', widget.panelId));
   }
 }

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_product_cards.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_product_cards.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
@@ -34,5 +35,11 @@ class KnowledgePanelProductCards extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(IntProperty('count', knowledgePanelWidgets.length));
   }
 }

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_table_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_table_card.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
@@ -272,6 +273,14 @@ class _KnowledgePanelTableCardState extends State<KnowledgePanelTableCard> {
 
     return buffer.toString();
   }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(StringProperty('tableElementId', widget.tableElement.id));
+    properties
+        .add(DiagnosticsProperty<bool>('expanded', widget.isInitiallyExpanded));
+  }
 }
 
 class TableCellWidget extends StatefulWidget {
@@ -403,5 +412,13 @@ class _TableCellWidgetState extends State<TableCellWidget> {
         ),
       ),
     );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+        .add(DiagnosticsProperty<bool>('expanded', widget.isInitiallyExpanded));
+    properties.add(DoubleProperty('cellWidth', widget.cellWidth));
   }
 }

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_text_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_text_card.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
@@ -56,4 +57,11 @@ class KnowledgePanelTextCard extends StatelessWidget {
   bool get _hasSource =>
       textElement.sourceText?.isNotEmpty == true &&
       textElement.sourceUrl?.isNotEmpty == true;
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(StringProperty('text', textElement.sourceText));
+    properties.add(StringProperty('url', textElement.sourceUrl));
+  }
 }

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_title_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_title_card.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
@@ -181,5 +182,24 @@ class KnowledgePanelTitleCard extends StatelessWidget {
     }
 
     return buffer.toString();
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+
+    properties.add(
+      StringProperty('iconUrl', knowledgePanelTitleElement.iconUrl),
+    );
+    properties.add(
+      EnumProperty<TitleElementType>('type', knowledgePanelTitleElement.type),
+    );
+    properties.add(
+      EnumProperty<Grade>('grade', knowledgePanelTitleElement.grade),
+    );
+    properties.add(
+      DiagnosticsProperty<bool>('clickable', isClickable),
+    );
+    properties.add(EnumProperty<Evaluation>('evaluation', evaluation));
   }
 }

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_world_map_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_world_map_card.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
@@ -81,6 +82,20 @@ class KnowledgePanelWorldMapCard extends StatelessWidget {
               ],
             ),
           ],
+        ),
+      ),
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(
+      IterableProperty<String?>(
+        'pointers',
+        mapElement.pointers.map(
+          (KnowledgePanelGeoPointer pointer) =>
+              pointer.geo?.toJson().toString(),
         ),
       ),
     );


### PR DESCRIPTION
Hi everyone,

In the Flutter DevTools, we can inspect the hierarchy of Widgets and add some specific info per Widget.
To help me debug #4948, we now have details for all KP widgets.

Here is an example:
<img width="500" alt="Screenshot 2024-01-08 at 13 58 16" src="https://github.com/openfoodfacts/smooth-app/assets/246838/8256a4cb-0858-4948-81c2-7f1d76480133">
