### PR TITLE
chore: Remove the package name from the quick tile

### DIFF
--- a/packages/smooth_app/android/app/src/main/AndroidManifest.xml
+++ b/packages/smooth_app/android/app/src/main/AndroidManifest.xml
@@ -565,7 +565,7 @@
                 android:value="2"/>
 
         <!-- Quick tile / setting (only available on Android 24+ / Nougat) -->
-        <service android:name="org.openfoodfacts.app.AppMainTile"
+        <service android:name=".AppMainTile"
                  android:exported="true"
                  android:icon="@drawable/ic_launcher_foreground"
                  android:label="@string/app_name"

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_product_cards.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_product_cards.dart
@@ -21,6 +21,8 @@ class KnowledgePanelProductCards extends StatelessWidget {
             ))
         .toList(growable: false);
 
+    //print(widgetsWrappedInSmoothCards.elementAt(1));
+
     return Center(
       child: Padding(
         padding: const EdgeInsetsDirectional.only(


### PR DESCRIPTION
Hi everyone,

The `Quick Tile` entry the AndroidManifest was hardcoded.
As the package name is different on F-Droid, I wonder if it may not cause #4974, but I'm not sure of that.