### PR TITLE
fix: Navigator: if the path is empty -> force the homepage

### DIFF
--- a/packages/smooth_app/lib/pages/navigator/app_navigator.dart
+++ b/packages/smooth_app/lib/pages/navigator/app_navigator.dart
@@ -260,6 +260,9 @@ class _SmoothGoRouter {
 
         if (externalLink) {
           return _openExternalLink(path);
+        } else if (path.isEmpty) {
+          // Force the Homepage
+          return _InternalAppRoutes.HOME_PAGE;
         } else {
           return state.uri.toString();
         }


### PR DESCRIPTION
Hi everyone,

As noticed in #4983, the Navigator is broken when:
1. The app is killed AND
2. We want to open the homepage
(All other links are OK)