### PR TITLE
fix: If a "panel summary widget" is incomplete, the app shouldn't crash

### DIFF
--- a/packages/smooth_app/lib/helpers/product_cards_helper.dart
+++ b/packages/smooth_app/lib/helpers/product_cards_helper.dart
@@ -97,13 +97,16 @@ Widget buildProductSmoothCard({
     SmoothCard(
       margin: margin,
       padding: padding,
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: <Widget>[
-          if (header != null) header,
-          body,
-        ],
-      ),
+      child: switch (header) {
+        Object _ => Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              if (header != null) header,
+              body,
+            ],
+          ),
+        _ => body
+      },
     );
 
 // used to be in now defunct `AttributeListExpandable`

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_card.dart
@@ -67,7 +67,7 @@ class KnowledgePanelCard extends StatelessWidget {
               isClickable: isClickable,
               margin: EdgeInsets.zero,
             ) ??
-            SizedBox(),
+            const SizedBox(),
       ),
     );
   }

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_card.dart
@@ -63,10 +63,11 @@ class KnowledgePanelCard extends StatelessWidget {
                   ),
                 ),
         child: KnowledgePanelsBuilder.getPanelSummaryWidget(
-          panel,
-          isClickable: isClickable,
-          margin: EdgeInsets.zero,
-        ),
+              panel,
+              isClickable: isClickable,
+              margin: EdgeInsets.zero,
+            ) ??
+            SizedBox(),
       ),
     );
   }


### PR DESCRIPTION
Hi everyone,

This is a fix for #4948, but I won't link to the issue, as I'm not fully sure if it answers correctly the problem for the final user.
But basically this PR ensures the product page won't crash when there is no `titleElement`.
I have also improved a bit the code to only use a Column when there is at least 2 children.