### PR TITLE
fix: 4943 - new nutrients, including polyols

### DIFF
--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -1084,10 +1084,10 @@ packages:
     dependency: "direct main"
     description:
       name: openfoodfacts
-      sha256: c3c778d2ccdf4862ea91abdc4d20c3a759d0ee21a22cef4cb5206fb7a0110537
+      sha256: d7042d65f9082785b10cd7b3d894f50e25da9ef35d8b4530dc311c5e00905c1f
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.0"
+    version: "3.3.2"
   openfoodfacts_flutter_lints:
     dependency: "direct dev"
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -98,7 +98,7 @@ dependencies:
     path: ../scanner/zxing
 
 
-  openfoodfacts: 3.3.0
+  openfoodfacts: 3.3.2
   # openfoodfacts:
   #   path: ../../../openfoodfacts-dart
 


### PR DESCRIPTION
### What
- Upgraded to the latest off-dart package.
- That package includes new nutrients, including polyols.

### Screenshot
| before | after |
| -- | -- |
| ![Screenshot_1706255574](https://github.com/openfoodfacts/smooth-app/assets/11576431/c15115be-e9b2-4a0c-8aa5-35bc38127a12) | ![Screenshot_1706256222](https://github.com/openfoodfacts/smooth-app/assets/11576431/1519a78c-7177-4186-9db2-a70577db03c2) |

### Fixes bug(s)
- Fixes: #4943

### Impacted files
* `pubspec.lock`: wtf
* `pubspec.yaml`: upgraded to more recent off-dart version