### PR TITLE
feat: If a search string only have digits BUT with spaces, we remove them

### DIFF
--- a/packages/smooth_app/lib/helpers/string_extension.dart
+++ b/packages/smooth_app/lib/helpers/string_extension.dart
@@ -1,3 +1,7 @@
 extension StringExtension on String {
   String capitalize() => isEmpty ? this : this[0].toUpperCase() + substring(1);
+
+  String removeSpaces() => replaceAll(RegExp(r' |\n|\r|\s|\t'), '');
+
+  bool hasOnlyDigits() => int.tryParse(this) != null;
 }

--- a/packages/smooth_app/lib/pages/scan/search_page.dart
+++ b/packages/smooth_app/lib/pages/scan/search_page.dart
@@ -7,6 +7,7 @@ import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/duration_constants.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
+import 'package:smooth_app/helpers/string_extension.dart';
 import 'package:smooth_app/pages/navigator/app_navigator.dart';
 import 'package:smooth_app/pages/product/common/product_dialog_helper.dart';
 import 'package:smooth_app/pages/product/common/product_query_page_helper.dart';
@@ -23,6 +24,9 @@ void _performSearch(
   query = query.trim();
   if (query.isEmpty) {
     return;
+  } else if (query.removeSpaces().hasOnlyDigits()) {
+    // This maybe a barcode => remove spaces within the string
+    query = query.removeSpaces();
   }
 
   final LocalDatabase localDatabase = context.read<LocalDatabase>();

--- a/packages/smooth_app/test/utils/string_extensions_test.dart
+++ b/packages/smooth_app/test/utils/string_extensions_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:smooth_app/helpers/string_extension.dart';
 import 'package:smooth_app/helpers/strings_helper.dart';
 
 void main() {
@@ -116,5 +117,17 @@ void main() {
         equals('1.234'),
       ),
     );
+  });
+
+  group('removeEmptySpaces tests', () {
+    test('Empty string', () => expect(''.removeSpaces(), equals('')));
+    test('String with only spaces',
+        () => expect('   '.removeSpaces(), equals('')));
+    test('String with spaces at the beginning',
+        () => expect('  123'.removeSpaces(), equals('123')));
+    test('String with spaces at the middle',
+        () => expect('1 2  3'.removeSpaces(), equals('123')));
+    test('String with spaces at the end',
+        () => expect('123   '.removeSpaces(), equals('123')));
   });
 }


### PR DESCRIPTION
Hi everyone,

As noticed in #5002, when the user inputs a search containing a barcode but with spaces, the request always fails.
Here is a simple fix, to check if there are only digits and in that case, remove all spaces. (the server will then accept the query)

Before:
<img width="277" alt="Screenshot 2024-01-29 at 08 13 17" src="https://github.com/openfoodfacts/smooth-app/assets/246838/ec16cdb9-4deb-4833-a1aa-596261b81ea5">

After:
<img width="224" alt="Screenshot 2024-01-29 at 08 13 52" src="https://github.com/openfoodfacts/smooth-app/assets/246838/537e4069-4d2f-4f97-959e-1e24b5d71fb5">
