### PR TITLE
feat: Add a feature to paste from the clipboard in the search page

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1974,9 +1974,9 @@
     "@copy_to_clipboard": {
         "description": "Copy to clipboard button description"
     },
-    "copy_from_clipboard": "Copy from clipboard",
-    "@copy_from_clipboard": {
-        "description": "Copy the content of the clipboard"
+    "paste_from_clipboard": "Paste from clipboard",
+    "@paste_from_clipboard": {
+        "description": "Paste the content of the clipboard"
     },
     "no_data_available_in_clipboard": "No data available in your clipboard",
     "@no_data_available_in_clipboard": {

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1974,6 +1974,14 @@
     "@copy_to_clipboard": {
         "description": "Copy to clipboard button description"
     },
+    "copy_from_clipboard": "Copy from clipboard",
+    "@copy_from_clipboard": {
+        "description": "Copy the content of the clipboard"
+    },
+    "no_data_available_in_clipboard": "No data available in your clipboard",
+    "@no_data_available_in_clipboard": {
+        "description": "No data available in your clipboard"
+    },
     "clipboard_barcode_copy": "Copy barcode to clipboard",
     "@clipboard_barcode_copied": {
         "description": "Snackbar label after clipboard copy",

--- a/packages/smooth_app/lib/pages/scan/search_history_view.dart
+++ b/packages/smooth_app/lib/pages/scan/search_history_view.dart
@@ -45,7 +45,7 @@ class _SearchHistoryViewState extends State<SearchHistoryView> {
       child: ListView.builder(
         itemBuilder: (BuildContext context, int i) {
           if (i == 0) {
-            return _SearchItemCopyFromClipboard(
+            return _SearchItemPasteFromClipboard(
               onData: (String data) => widget.onTap?.call(data),
             );
           }
@@ -155,8 +155,8 @@ class _SearchHistoryTile extends StatelessWidget {
   }
 }
 
-class _SearchItemCopyFromClipboard extends StatelessWidget {
-  const _SearchItemCopyFromClipboard({
+class _SearchItemPasteFromClipboard extends StatelessWidget {
+  const _SearchItemPasteFromClipboard({
     required this.onData,
   });
 
@@ -182,7 +182,7 @@ class _SearchItemCopyFromClipboard extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsetsDirectional.only(start: 18.0, end: 13.0),
         child: ListTile(
-          title: Text(localizations.copy_from_clipboard),
+          title: Text(localizations.paste_from_clipboard),
           leading: const Icon(Icons.copy),
           minLeadingWidth: 10.0,
         ),

--- a/packages/smooth_app/lib/pages/scan/search_history_view.dart
+++ b/packages/smooth_app/lib/pages/scan/search_history_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/database/dao_string_list.dart';
@@ -36,21 +37,83 @@ class _SearchHistoryViewState extends State<SearchHistoryView> {
 
   @override
   Widget build(BuildContext context) {
-    return ListView.builder(
-      itemCount: _queries.length,
-      itemBuilder: (BuildContext context, int i) =>
-          _buildSearchHistoryTile(context, _queries[i]),
+    return ListTileTheme(
+      data: const ListTileThemeData(
+        titleTextStyle: TextStyle(fontSize: 20.0),
+        minLeadingWidth: 18.0,
+      ),
+      child: ListView.builder(
+        itemBuilder: (BuildContext context, int i) {
+          if (i == 0) {
+            return _SearchItemCopyFromClipboard(
+              onData: (String data) => widget.onTap?.call(data),
+            );
+          }
+
+          final String query = _queries[i - 1];
+
+          return _SearchHistoryTile(
+            query: query,
+            onTap: () => widget.onTap?.call(query),
+            onEditItem: () => _onEditItem(query),
+            onDismissItem: () async {
+              // we need an immediate action for the display refresh
+              _queries.remove(query);
+              // and we need to impact the database too
+              final LocalDatabase localDatabase = context.read<LocalDatabase>();
+              await DaoStringList(localDatabase)
+                  .remove(DaoStringList.keySearchHistory, query);
+              setState(() {});
+            },
+          );
+        },
+        itemCount: _queries.length + 1, // +1 for the "Copy to clipboard"
+      ),
     );
   }
 
-  Widget _buildSearchHistoryTile(BuildContext context, String query) {
+  void _onEditItem(String query) {
+    final TextEditingController controller = Provider.of<TextEditingController>(
+      context,
+      listen: false,
+    );
+
+    controller.text = query;
+    controller.selection =
+        TextSelection.fromPosition(TextPosition(offset: query.length));
+
+    // If the keyboard is hidden, show it.
+    if (View.of(context).viewInsets.bottom == 0) {
+      widget.focusNode?.unfocus();
+
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        FocusScope.of(context).requestFocus(widget.focusNode);
+      });
+    }
+  }
+}
+
+class _SearchHistoryTile extends StatelessWidget {
+  const _SearchHistoryTile({
+    required this.query,
+    required this.onTap,
+    required this.onEditItem,
+    required this.onDismissItem,
+  });
+
+  final String query;
+  final VoidCallback onTap;
+  final VoidCallback onEditItem;
+  final VoidCallback onDismissItem;
+
+  @override
+  Widget build(BuildContext context) {
     final AppLocalizations localizations = AppLocalizations.of(context);
 
     return Dismissible(
       key: Key(query),
       direction: DismissDirection.endToStart,
-      onDismissed: (DismissDirection direction) async =>
-          _handleDismissed(context, query),
+      onDismissed: (DismissDirection direction) async => onDismissItem(),
       background: Container(
         color: RED_COLOR,
         alignment: AlignmentDirectional.centerEnd,
@@ -61,7 +124,7 @@ class _SearchHistoryViewState extends State<SearchHistoryView> {
         ),
       ),
       child: InkWell(
-        onTap: () => widget.onTap?.call(query),
+        onTap: () => onTap,
         child: Padding(
           padding: const EdgeInsetsDirectional.only(start: 18.0, end: 13.0),
           child: ListTile(
@@ -69,31 +132,11 @@ class _SearchHistoryViewState extends State<SearchHistoryView> {
               padding: EdgeInsetsDirectional.only(top: VERY_SMALL_SPACE),
               child: Icon(
                 Icons.search,
-                size: 18.0,
               ),
             ),
             trailing: InkWell(
               customBorder: const CircleBorder(),
-              onTap: () {
-                final TextEditingController controller =
-                    Provider.of<TextEditingController>(
-                  context,
-                  listen: false,
-                );
-
-                controller.text = query;
-                controller.selection = TextSelection.fromPosition(
-                    TextPosition(offset: query.length));
-
-                // If the keyboard is hidden, show it.
-                if (View.of(context).viewInsets.bottom == 0) {
-                  widget.focusNode?.unfocus();
-
-                  WidgetsBinding.instance.addPostFrameCallback((_) {
-                    FocusScope.of(context).requestFocus(widget.focusNode);
-                  });
-                }
-              },
+              onTap: onEditItem,
               child: Tooltip(
                 message: localizations.search_history_item_edit_tooltip,
                 enableFeedback: true,
@@ -104,20 +147,46 @@ class _SearchHistoryViewState extends State<SearchHistoryView> {
               ),
             ),
             minLeadingWidth: 10.0,
-            title: Text(query, style: const TextStyle(fontSize: 20.0)),
+            title: Text(query),
           ),
         ),
       ),
     );
   }
+}
 
-  Future<void> _handleDismissed(BuildContext context, String query) async {
-    // we need an immediate action for the display refresh
-    _queries.remove(query);
-    // and we need to impact the database too
-    final LocalDatabase localDatabase = context.read<LocalDatabase>();
-    await DaoStringList(localDatabase)
-        .remove(DaoStringList.keySearchHistory, query);
-    setState(() {});
+class _SearchItemCopyFromClipboard extends StatelessWidget {
+  const _SearchItemCopyFromClipboard({
+    required this.onData,
+  });
+
+  final Function(String) onData;
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations localizations = AppLocalizations.of(context);
+
+    return InkWell(
+      onTap: () async {
+        final ClipboardData? data = await Clipboard.getData('text/plain');
+        if (data?.text?.isNotEmpty == true) {
+          onData(data!.text!);
+        } else if (context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(localizations.no_data_available_in_clipboard),
+            ),
+          );
+        }
+      },
+      child: Padding(
+        padding: const EdgeInsetsDirectional.only(start: 18.0, end: 13.0),
+        child: ListTile(
+          title: Text(localizations.copy_from_clipboard),
+          leading: const Icon(Icons.copy),
+          minLeadingWidth: 10.0,
+        ),
+      ),
+    );
   }
 }


### PR DESCRIPTION
Hi everyone,

Here is a UX improvement for the search page to allow to quickly copy the content from the clipboard.
FYI: we can't show directly the content because on iOS, there is a popup ("do you really want to share the content of your clipboard") blocking the UI.

Also the Widget is a Widget, not a method

https://github.com/openfoodfacts/smooth-app/assets/246838/f84fe1c5-a3e2-47d2-b404-a43c7183f3b7


