### PR TITLE
fix: In the search field, when a suggestion is selected, the loader shouldn't be visible anymore

### DIFF
--- a/packages/smooth_app/lib/pages/input/smooth_autocomplete_text_field.dart
+++ b/packages/smooth_app/lib/pages/input/smooth_autocomplete_text_field.dart
@@ -35,6 +35,7 @@ class _SmoothAutocompleteTextFieldState
     extends State<SmoothAutocompleteTextField> {
   final Map<String, _SearchResults> _suggestions = <String, _SearchResults>{};
   bool _loading = false;
+  String? _selectedSearch;
 
   late _DebouncedTextEditingController _debouncedController;
 
@@ -71,6 +72,7 @@ class _SmoothAutocompleteTextFieldState
               VoidCallback onFieldSubmitted) =>
           TextField(
         controller: widget.controller,
+        onChanged: (_) => setState(() => _selectedSearch = null),
         decoration: InputDecoration(
           filled: true,
           border: const OutlineInputBorder(
@@ -97,6 +99,10 @@ class _SmoothAutocompleteTextFieldState
         autofocus: false,
         focusNode: focusNode,
       ),
+      onSelected: (String search) {
+        _selectedSearch = search;
+        _setLoading(false);
+      },
       optionsViewBuilder: (
         BuildContext lContext,
         AutocompleteOnSelected<String> onSelected,
@@ -140,6 +146,10 @@ class _SmoothAutocompleteTextFieldState
   }
 
   Future<_SearchResults> _getSuggestions(String search) async {
+    if (search == _selectedSearch) {
+      return _SearchResults.empty();
+    }
+
     final DateTime start = DateTime.now();
 
     if (_suggestions[search] != null) {


### PR DESCRIPTION
Hi everyone,

Here is an annoying bug with the loader in a text field.
If the user selects a suggestion, the loader continues to spin, whereas it should be invisible.

Before:

https://github.com/openfoodfacts/smooth-app/assets/246838/dcfec60c-e875-432b-9942-f50ffc927ae1

After:


https://github.com/openfoodfacts/smooth-app/assets/246838/d2e2df6f-b62d-48fd-8f76-6be6fa0580cd

