### PR TITLE
feat: 4996 - reordering product languages

### DIFF
--- a/packages/smooth_app/lib/database/dao_string_list.dart
+++ b/packages/smooth_app/lib/database/dao_string_list.dart
@@ -13,10 +13,15 @@ class DaoStringList extends AbstractDao {
   /// Key for the list of task ids.
   static const String keyTasks = 'tasks';
 
+  /// Key for the list of latest languages used in the app.
+  static const String keyLanguages = 'languages';
+
   /// Max lengths of each key (null means no limit).
   static const Map<String, int?> _maxLengths = <String, int?>{
     keySearchHistory: 10,
     keyTasks: null,
+    // TODO(monsieurtanuki): more "latest" languages are possible if we create a page to remove some of them
+    keyLanguages: 1,
   };
 
   @override

--- a/packages/smooth_app/lib/generic_lib/widgets/language_priority.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/language_priority.dart
@@ -1,0 +1,92 @@
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/database/dao_string_list.dart';
+import 'package:smooth_app/query/product_query.dart';
+
+/// Helper around the language priority.
+///
+/// cf. https://github.com/openfoodfacts/smooth-app/issues/4996
+class LanguagePriority {
+  LanguagePriority({
+    required final Product? product,
+    required final Iterable<OpenFoodFactsLanguage>? selectedLanguages,
+    required final DaoStringList daoStringList,
+  }) {
+    _addAll(selectedLanguages);
+    _addStringList(daoStringList.getAll(DaoStringList.keyLanguages));
+    _add(ProductQuery.getLanguage());
+    if (product == null) {
+      return;
+    }
+    _add(product.lang);
+    _addMap(product.productNameInLanguages);
+    _addImages(product.images);
+    _addMap(product.packagingTextInLanguages);
+    _addMap(product.ingredientsTextInLanguages);
+    _addMap(product.labelsTagsInLanguages);
+    _addMap(product.categoriesTagsInLanguages);
+    _addMap(product.countriesTagsInLanguages);
+  }
+
+  final List<OpenFoodFactsLanguage> _languages = <OpenFoodFactsLanguage>[];
+
+  void _addMap(final Map<OpenFoodFactsLanguage, dynamic>? map) {
+    if (map == null) {
+      return;
+    }
+    _addAll(map.keys);
+  }
+
+  void _addImages(final Iterable<ProductImage>? productImages) {
+    if (productImages == null) {
+      return;
+    }
+    for (final ProductImage productImage in productImages) {
+      _add(productImage.language);
+    }
+  }
+
+  void _add(final OpenFoodFactsLanguage? language) {
+    if (language == null) {
+      return;
+    }
+    if (_languages.contains(language)) {
+      return;
+    }
+    _languages.add(language);
+  }
+
+  void _addString(final String languageCode) {
+    try {
+      final OpenFoodFactsLanguage? language =
+          OpenFoodFactsLanguage.fromOffTag(languageCode);
+      _add(language);
+    } catch (e) {
+      // just ignore
+    }
+  }
+
+  void _addStringList(final List<String> languageCodes) =>
+      languageCodes.forEach(_addString);
+
+  void _addAll(final Iterable<OpenFoodFactsLanguage>? languages) {
+    if (languages == null) {
+      return;
+    }
+    languages.forEach(_add);
+  }
+
+  int? compare(final OpenFoodFactsLanguage a, final OpenFoodFactsLanguage b) {
+    final bool selectedA = _languages.contains(a);
+    final bool selectedB = _languages.contains(b);
+    if (selectedA) {
+      if (!selectedB) {
+        return -1;
+      }
+    } else {
+      if (selectedB) {
+        return 1;
+      }
+    }
+    return null;
+  }
+}

--- a/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
@@ -133,8 +133,10 @@ class _AddBasicDetailsPageState extends State<AddBasicDetailsPage> {
                           Card(
                             child: Column(
                               children: <Widget>[
-                                _multilingualHelper
-                                    .getLanguageSelector(setState),
+                                _multilingualHelper.getLanguageSelector(
+                                  setState: setState,
+                                  product: _product,
+                                ),
                                 Padding(
                                   padding: const EdgeInsets.all(8.0),
                                   child: SmoothTextFormField(

--- a/packages/smooth_app/lib/pages/product/edit_ocr_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_ocr_page.dart
@@ -265,7 +265,10 @@ class _EditOcrPageState extends State<EditOcrPage> with UpToDateMixin {
                   child: Column(
                     children: <Widget>[
                       if (!_multilingualHelper.isMonolingual())
-                        _multilingualHelper.getLanguageSelector(setState),
+                        _multilingualHelper.getLanguageSelector(
+                          setState: setState,
+                          product: upToDateProduct,
+                        ),
                       if (transientFile.isServerImage())
                         SmoothActionButtonsBar.single(
                           action: SmoothActionButton(

--- a/packages/smooth_app/lib/pages/product/multilingual_helper.dart
+++ b/packages/smooth_app/lib/pages/product/multilingual_helper.dart
@@ -109,8 +109,12 @@ class MultilingualHelper {
   // TODO(monsieurtanuki): we would be better off always never monolingual
   bool isMonolingual() => _initialMultilingualTexts.isEmpty;
 
-  Widget getLanguageSelector(void Function(void Function()) setState) =>
+  Widget getLanguageSelector({
+    required void Function(void Function()) setState,
+    required Product product,
+  }) =>
       LanguageSelector(
+        product: product,
         setLanguage: (
           final OpenFoodFactsLanguage? newLanguage,
         ) async {


### PR DESCRIPTION
### What
Now we sort the product languages so that the more interesting languages are displayed first in the language selector:
1. the languages that are currently used for this product field
1. the latest languages used locally in the app
1. the current app language
1. the product main language
1. the languages used for the product
   1. names
   1. images
   1. packages
   2. ingredients
   3. labels
   4. categories
   5. countries

### Screenshot
Spanish is close to the top as it's the app language:
![Screenshot_1706556912](https://github.com/openfoodfacts/smooth-app/assets/11576431/a86ae7d2-7c88-4439-be3c-0ec1b35287f8)

### Fixes bug(s)
- Closes: #4996

### Impacted files
New file:
* `language_priority.dart`: Helper around the language priority.

Impacted files:
* `add_basic_details_page.dart`: minor refactoring
* `dao_string_list.dart`: now storing the latest languages used locally in the app
* `edit_ocr_page.dart`: minor refactoring
* `language_selector.dart`: now showing app and product languages as first languages
* `multilingual_helper.dart`: minor refactoring