### PR TITLE
fix: Ensure the upload confirmation message is centered

### DIFF
--- a/packages/smooth_app/lib/background/background_task_image.dart
+++ b/packages/smooth_app/lib/background/background_task_image.dart
@@ -98,7 +98,7 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
           final AppLocalizations appLocalizations) =>
       (
         appLocalizations.image_upload_queued,
-        AlignmentDirectional.topCenter,
+        AlignmentDirectional.center,
       );
 
   /// Returns a new background task about changing a product.


### PR DESCRIPTION
Hi everyone,

A confirmation message is displayed when we upload a picture, but it overlaps the `AppBar`.
However, the `context` doesn't contain the info if an `AppBar` is in the hierarchy.

As it requires many changes, for just this, I have moved the message to the center of the screen.

Before:
<img width="347" alt="Screenshot 2024-01-30 at 08 45 40" src="https://github.com/openfoodfacts/smooth-app/assets/246838/114af0b5-d512-4750-a293-96e5809cf2bb">

After:
<img width="313" alt="Screenshot 2024-01-30 at 08 45 44" src="https://github.com/openfoodfacts/smooth-app/assets/246838/5cae7621-408b-475f-b645-7bb5bb68f5a4">
