### PR TITLE
chore: upgrade to off-dart 3.3.3

### DIFF
--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -1084,10 +1084,10 @@ packages:
     dependency: "direct main"
     description:
       name: openfoodfacts
-      sha256: d7042d65f9082785b10cd7b3d894f50e25da9ef35d8b4530dc311c5e00905c1f
+      sha256: "2469396e450fd210bb498b8428dace4bdc37e2c7df4cf6eadc61857cbc367ad4"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.2"
+    version: "3.3.3"
   openfoodfacts_flutter_lints:
     dependency: "direct dev"
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -98,7 +98,7 @@ dependencies:
     path: ../scanner/zxing
 
 
-  openfoodfacts: 3.3.2
+  openfoodfacts: 3.3.3
   # openfoodfacts:
   #   path: ../../../openfoodfacts-dart
 


### PR DESCRIPTION
### What
Upgrade to off-dart 3.3.3:
- fixes "per size: serving" bug
- adds `added-sugars` nutrient
