### PR TITLE
chore: upgraded flutter_custom_tabs to 2.0.0

### DIFF
--- a/packages/smooth_app/lib/pages/navigator/external_page.dart
+++ b/packages/smooth_app/lib/pages/navigator/external_page.dart
@@ -59,10 +59,10 @@ class _ExternalPageState extends State<ExternalPage> {
       }
 
       if (Platform.isAndroid) {
-        await tabs.launch(
-          url,
-          customTabsOption: const tabs.CustomTabsOption(
-            showPageTitle: true,
+        await tabs.launchUrl(
+          Uri.parse(url),
+          customTabsOptions: const tabs.CustomTabsOptions(
+            showTitle: true,
           ),
         );
       } else {

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -534,26 +534,42 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_custom_tabs
-      sha256: bebb9552438eb3aea8f8511d48e41abdd0d05ff3e9a74622a4d1acd2bffd242c
+      sha256: "961fe962ae55e9e41097c34e68c6d7d2de10e9a71034f83834919e31a891e728"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.0+1"
+  flutter_custom_tabs_android:
+    dependency: transitive
+    description:
+      name: flutter_custom_tabs_android
+      sha256: "5701a3e38117dfc59e5fa9e84a29eea9203e0062de7be56d1f775845c34456d9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0+1"
+  flutter_custom_tabs_ios:
+    dependency: transitive
+    description:
+      name: flutter_custom_tabs_ios
+      sha256: b29f687f7f366159d37347f888369fcd1259adac8ca6c7f07d356a80b091e08a
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   flutter_custom_tabs_platform_interface:
     dependency: transitive
     description:
       name: flutter_custom_tabs_platform_interface
-      sha256: "1d6b9eb6c5671b21511fdb47babf18aa65982784373986c003aaf67ca78798ad"
+      sha256: "13531a743486695d87b462b151801e11476b1b5a15274caec092420cc1943064"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "2.0.0"
   flutter_custom_tabs_web:
     dependency: transitive
     description:
       name: flutter_custom_tabs_web
-      sha256: dbb5689a97c2398aa5dbcfc9cd59cffea5518ec815e9d23def448dc143cb02be
+      sha256: "3114b511d3942ed42c502cc57ad47eaef9622ac06dd036e2b21b19d8876f6498"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "2.0.0"
   flutter_driver:
     dependency: "direct dev"
     description: flutter

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -63,7 +63,7 @@ dependencies:
   rive: 0.12.4
   sensors_plus: 3.1.0
   webview_flutter: 3.0.4
-  flutter_custom_tabs: 1.0.4
+  flutter_custom_tabs: 2.0.0+1
   flutter_image_compress: 2.1.0
   connectivity_plus: 5.0.2
   dart_ping: 9.0.1


### PR DESCRIPTION
### What
- In order to upgrade [flutter_custom_tabs](https://pub.dev/packages/flutter_custom_tabs) there are little changes to perform.

### Fixes bug(s)
- Fixes: #5023