### PR TITLE
ci: change the iOS runner

### DIFF
--- a/.github/workflows/ios-release-to-org-openfoodfacts-scanner.yml
+++ b/.github/workflows/ios-release-to-org-openfoodfacts-scanner.yml
@@ -40,7 +40,7 @@ env:
 jobs:
   testflight-release:
     name: Build and deploy to TestFlight testers (org.openfoodfacts.scanner)
-    runs-on: macos-12 #macos-12-xl
+    runs-on: macos-14 #macos-12-xl
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4


### PR DESCRIPTION


### What
ci: change the iOS runner
https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/

### Possible side effects
- check if XCode still runs

### Part of 
- #525 <!-- Add the most granular issue possible -->
