### PR TITLE
refactor: 5075 - explicit localization of OFF world links

### DIFF
--- a/packages/smooth_app/lib/generic_lib/loading_dialog.dart
+++ b/packages/smooth_app/lib/generic_lib/loading_dialog.dart
@@ -78,7 +78,6 @@ class LoadingDialog<T> {
                         recognizer: TapGestureRecognizer()
                           ..onTap = () => LaunchUrlHelper.launchURL(
                                 Status.openNewIssueUrl,
-                                false,
                               ),
                       ),
                     ),

--- a/packages/smooth_app/lib/generic_lib/smooth_html_widget.dart
+++ b/packages/smooth_app/lib/generic_lib/smooth_html_widget.dart
@@ -22,7 +22,7 @@ class SmoothHtmlWidget extends StatelessWidget {
       textStyle: textStyle,
       onTapUrl: (String url) async {
         try {
-          await LaunchUrlHelper.launchURL(url, false);
+          await LaunchUrlHelper.launchURL(url);
         } catch (_) {
           if (context.mounted) {
             final AppLocalizations appLocalizations =

--- a/packages/smooth_app/lib/helpers/launch_url_helper.dart
+++ b/packages/smooth_app/lib/helpers/launch_url_helper.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'dart:ui';
 
 import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -7,16 +6,8 @@ import 'package:url_launcher/url_launcher.dart';
 class LaunchUrlHelper {
   LaunchUrlHelper._();
 
-  /// ifOFF true adds the users country code in front of the url
-  /// Throws a error when already populated
-  /// YES https://   openfoodfacts.org/...
-  /// NO  https://de.openfoodfacts.org/...
-  ///
-  static Future<void> launchURL(String url, bool isOFF) async {
-    if (isOFF) {
-      url = _replaceSubdomainWithCodes(url);
-    }
-
+  /// Launches the url in an external browser.
+  static Future<void> launchURL(String url) async {
     AnalyticsHelper.trackOutlink(url: url);
 
     try {
@@ -29,25 +20,5 @@ class LaunchUrlHelper {
     } catch (e) {
       throw 'Could not launch $url,Error: $e';
     }
-  }
-
-  static String _replaceSubdomainWithCodes(String url) {
-    if (!url.contains('https://openfoodfacts.')) {
-      throw 'Error do not use local identifier in url';
-    }
-
-    String? countryCode =
-        PlatformDispatcher.instance.locale.countryCode?.toLowerCase();
-
-    if (countryCode == null) {
-      countryCode = 'world.';
-    } else {
-      countryCode = '$countryCode.';
-    }
-
-    url = url.replaceAll(
-        'https://openfoodfacts.', 'https://${countryCode}openfoodfacts.');
-
-    return url;
   }
 }

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_text_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_text_card.dart
@@ -46,7 +46,6 @@ class KnowledgePanelTextCard extends StatelessWidget {
             iconData: null,
             onPressed: () async => LaunchUrlHelper.launchURL(
               textElement.sourceUrl!,
-              false,
             ),
           ),
         ),

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_world_map_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_world_map_card.dart
@@ -76,7 +76,6 @@ class KnowledgePanelWorldMapCard extends StatelessWidget {
                   'OpenStreetMap contributors',
                   onTap: () => LaunchUrlHelper.launchURL(
                     'https://www.openstreetmap.org/copyright',
-                    false,
                   ),
                 ),
               ],

--- a/packages/smooth_app/lib/pages/navigator/external_page.dart
+++ b/packages/smooth_app/lib/pages/navigator/external_page.dart
@@ -66,7 +66,7 @@ class _ExternalPageState extends State<ExternalPage> {
           ),
         );
       } else {
-        await LaunchUrlHelper.launchURL(url, false);
+        await LaunchUrlHelper.launchURL(url);
       }
 
       if (mounted) {

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_account.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_account.dart
@@ -220,8 +220,9 @@ class UserPreferencesAccount extends AbstractUserPreferences {
       _getListTile(
         appLocalizations.view_profile,
         () async => LaunchUrlHelper.launchURL(
-          'https://openfoodfacts.org/editor/$userId',
-          true,
+          ProductQuery.replaceSubdomain(
+            'https://world.openfoodfacts.org/editor/$userId',
+          ),
         ),
         Icons.open_in_new,
       ),

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_connect.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_connect.dart
@@ -216,7 +216,7 @@ class UserPreferencesConnect extends AbstractUserPreferences {
         labels: <String>[title],
         builder: (_) => UserPreferencesListTile(
           title: Text(title),
-          onTap: onTap ?? () async => LaunchUrlHelper.launchURL(url!, false),
+          onTap: onTap ?? () async => LaunchUrlHelper.launchURL(url!),
           trailing:
               UserPreferencesListTile.getTintedIcon(Icons.open_in_new, context),
           leading: leadingIconData != null

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_contribute.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_contribute.dart
@@ -81,7 +81,6 @@ class UserPreferencesContribute extends AbstractUserPreferences {
             ProductQuery.replaceSubdomain(
               'https://world.openfoodfacts.org/contribute',
             ),
-            false,
           ),
           Icons.volunteer_activism_outlined,
           externalLink: true,
@@ -90,7 +89,6 @@ class UserPreferencesContribute extends AbstractUserPreferences {
           appLocalizations.contribute_join_skill_pool,
           () async => LaunchUrlHelper.launchURL(
             'https://docs.google.com/forms/d/e/1FAIpQLSfGHAn5KxW7ko3_GlDfQpVGKpPAMHMbDvY2IjtxfJSXxKJQ2A/viewform?usp=sf_link',
-            false,
           ),
           Icons.group,
           externalLink: true,
@@ -104,7 +102,6 @@ class UserPreferencesContribute extends AbstractUserPreferences {
           appLocalizations.contribute_donate_header,
           () async => LaunchUrlHelper.launchURL(
             AppLocalizations.of(context).donate_url,
-            false,
           ),
           Icons.volunteer_activism,
           icon:
@@ -133,7 +130,6 @@ class UserPreferencesContribute extends AbstractUserPreferences {
               if (result == true) {
                 await LaunchUrlHelper.launchURL(
                   GlobalVars.appStore.getEnrollInBetaURL()!,
-                  false,
                 );
               }
             },
@@ -216,15 +212,17 @@ class UserPreferencesContribute extends AbstractUserPreferences {
                 SmoothAlertContentButton(
                   label: 'Slack',
                   icon: Icons.open_in_new,
-                  onPressed: () => LaunchUrlHelper.launchURL(
-                      'https://slack.openfoodfacts.org/', false),
+                  onPressed: () async => LaunchUrlHelper.launchURL(
+                    'https://slack.openfoodfacts.org/',
+                  ),
                 ),
                 const SizedBox(height: SMALL_SPACE),
                 SmoothAlertContentButton(
                   label: 'GitHub',
                   icon: Icons.open_in_new,
-                  onPressed: () => LaunchUrlHelper.launchURL(
-                      'https://github.com/openfoodfacts', false),
+                  onPressed: () async => LaunchUrlHelper.launchURL(
+                    'https://github.com/openfoodfacts',
+                  ),
                 ),
                 const SizedBox(height: 10),
                 UserPreferencesSwitchWidget(
@@ -266,8 +264,9 @@ class UserPreferencesContribute extends AbstractUserPreferences {
               ],
             ),
             positiveAction: SmoothActionButton(
-              onPressed: () => LaunchUrlHelper.launchURL(
-                  'https://translate.openfoodfacts.org/', false),
+              onPressed: () async => LaunchUrlHelper.launchURL(
+                'https://translate.openfoodfacts.org/',
+              ),
               text: appLocalizations.contribute_translate_link_text,
             ),
             negativeAction: SmoothActionButton(
@@ -376,12 +375,9 @@ class _ContributorsDialog extends StatelessWidget {
                           message: contributor.login,
                           child: InkWell(
                             customBorder: const CircleBorder(),
-                            onTap: () {
-                              LaunchUrlHelper.launchURL(
-                                contributor.profilePath,
-                                false,
-                              );
-                            },
+                            onTap: () async => LaunchUrlHelper.launchURL(
+                              contributor.profilePath,
+                            ),
                             child: Ink(
                               decoration: BoxDecoration(
                                 borderRadius:
@@ -413,8 +409,9 @@ class _ContributorsDialog extends StatelessWidget {
         },
       ),
       positiveAction: SmoothActionButton(
-        onPressed: () => LaunchUrlHelper.launchURL(
-            'https://github.com/openfoodfacts/smooth-app', false),
+        onPressed: () async => LaunchUrlHelper.launchURL(
+          'https://github.com/openfoodfacts/smooth-app',
+        ),
         text: AppLocalizations.of(context).contribute,
         minWidth: 150,
       ),

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_faq.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_faq.dart
@@ -288,8 +288,9 @@ class UserPreferencesFaq extends AbstractUserPreferences {
                       const SizedBox(height: VERY_SMALL_SPACE),
                       SmoothAlertContentButton(
                         onPressed: () => LaunchUrlHelper.launchURL(
-                          'https://openfoodfacts.org/privacy',
-                          true,
+                          ProductQuery.replaceSubdomain(
+                            'https://world.openfoodfacts.org/privacy',
+                          ),
                         ),
                         label: appLocalizations.privacy_policy,
                         icon: Icons.open_in_new,

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_faq.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_faq.dart
@@ -162,7 +162,7 @@ class UserPreferencesFaq extends AbstractUserPreferences {
         labels: <String>[title],
         builder: (_) => UserPreferencesListTile(
           title: Text(title),
-          onTap: onTap ?? () async => LaunchUrlHelper.launchURL(url!, false),
+          onTap: onTap ?? () async => LaunchUrlHelper.launchURL(url!),
           trailing: icon ??
               UserPreferencesListTile.getTintedIcon(Icons.open_in_new, context),
           leading: SizedBox(
@@ -257,25 +257,30 @@ class UserPreferencesFaq extends AbstractUserPreferences {
                       ),
                       const SizedBox(height: VERY_SMALL_SPACE),
                       SmoothAlertContentButton(
-                        onPressed: () => LaunchUrlHelper.launchURL(
-                            'https://openfoodfacts.org/who-we-are', true),
+                        onPressed: () async => LaunchUrlHelper.launchURL(
+                          ProductQuery.replaceSubdomain(
+                            'https://world.openfoodfacts.org/who-we-are',
+                          ),
+                        ),
                         label: appLocalizations.learnMore,
                         icon: Icons.open_in_new,
                       ),
                       const SizedBox(height: VERY_SMALL_SPACE),
                       SmoothAlertContentButton(
-                        onPressed: () => LaunchUrlHelper.launchURL(
-                          'https://openfoodfacts.org/terms-of-use',
-                          true,
+                        onPressed: () async => LaunchUrlHelper.launchURL(
+                          ProductQuery.replaceSubdomain(
+                            'https://world.openfoodfacts.org/terms-of-use',
+                          ),
                         ),
                         label: appLocalizations.termsOfUse,
                         icon: Icons.open_in_new,
                       ),
                       const SizedBox(height: VERY_SMALL_SPACE),
                       SmoothAlertContentButton(
-                        onPressed: () => LaunchUrlHelper.launchURL(
-                          'https://openfoodfacts.org/legal',
-                          true,
+                        onPressed: () async => LaunchUrlHelper.launchURL(
+                          ProductQuery.replaceSubdomain(
+                            'https://world.openfoodfacts.org/legal',
+                          ),
                         ),
                         label: appLocalizations.legalNotices,
                         icon: Icons.open_in_new,

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -249,7 +249,6 @@ class _ProductPageState extends State<ProductPage>
                 icon: CupertinoIcons.tag_fill,
                 onPressed: () async => LaunchUrlHelper.launchURL(
                   'https://prices.openfoodfacts.org/app/products/${upToDateProduct.barcode!}',
-                  false,
                 ),
               ),
             ),

--- a/packages/smooth_app/lib/pages/product/website_card.dart
+++ b/packages/smooth_app/lib/pages/product/website_card.dart
@@ -15,7 +15,7 @@ class WebsiteCard extends StatelessWidget {
     final String website = _getWebsite();
     return buildProductSmoothCard(
       body: InkWell(
-        onTap: () => LaunchUrlHelper.launchURL(website, false),
+        onTap: () async => LaunchUrlHelper.launchURL(website),
         borderRadius: ROUNDED_BORDER_RADIUS,
         child: Container(
           width: double.infinity,

--- a/packages/smooth_app/lib/pages/user_management/login_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/login_page.dart
@@ -381,7 +381,7 @@ class _LoginPageState extends State<LoginPage> with TraceableClientMixin {
             text: appLocalizations.okay,
             onPressed: () async {
               final String formLink = UserFeedbackHelper.getFeedbackFormLink();
-              LaunchUrlHelper.launchURL(formLink, false);
+              LaunchUrlHelper.launchURL(formLink);
               Navigator.of(context).pop();
             },
           ),

--- a/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
+++ b/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
@@ -385,9 +385,7 @@ class _SearchCardContentTagLine extends StatelessWidget {
           return InkWell(
             borderRadius: ANGULAR_BORDER_RADIUS,
             onTap: tagLine.hasLink
-                ? () async {
-                    await LaunchUrlHelper.launchURL(tagLine.url, false);
-                  }
+                ? () async => LaunchUrlHelper.launchURL(tagLine.url)
                 : null,
             child: Center(
               child: AutoSizeText(
@@ -527,7 +525,7 @@ class _SearchCardContentAppReview extends StatelessWidget {
             text: localizations.app_review_negative_modal_positive_button,
             onPressed: () {
               final String formLink = UserFeedbackHelper.getFeedbackFormLink();
-              LaunchUrlHelper.launchURL(formLink, false);
+              LaunchUrlHelper.launchURL(formLink);
               Navigator.of(context).pop();
             },
           ),


### PR DESCRIPTION
### What
- There was some confusion and redundancy with the `isOFF` parameter of method `LaunchUrlHelper.launchURL`.
- Given that there were only a few cases where we localize OFF world links - e.g. `https://world.openfoodfacts.org/legal` becoming `https://be-fr.openfoodfacts.org/legal`, it was safer to remove the `isOFF` parameter and to explicitly localize the world link when needed.
- Actually that was done that way in other `launchURL` calls. In this PR we bring more code coherency.

### Fixes bug(s)
- Closes: #5075

### Impacted files
* `external_page.dart`: removed useless parameter
* `knowledge_panel_text_card.dart`: removed useless parameter
* `knowledge_panel_world_map_card.dart`: removed useless parameter
* `launch_url_helper.dart`: removed useless parameter; removed redundant method
* `loading_dialog.dart`: removed useless parameter
* `login_page.dart`: removed useless parameter
* `new_product_page.dart`: removed useless parameter
* `smooth_html_widget.dart`: removed useless parameter
* `smooth_product_carousel.dart`: removed useless parameter
* `user_preferences_account.dart`: explicitly localized the OFF world subdomain
* `user_preferences_connect.dart`: removed useless parameter
* `user_preferences_contribute.dart`: removed useless parameter
* `user_preferences_faq.dart`: explicitly localized the OFF world subdomain; removed useless parameter
* `website_card.dart`: removed useless parameter