### PR TITLE
feat: 5077 - "open prices" button available for all users

### DIFF
--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -239,20 +239,17 @@ class _ProductPageState extends State<ProductPage>
           if (upToDateProduct.website != null &&
               upToDateProduct.website!.trim().isNotEmpty)
             WebsiteCard(upToDateProduct.website!),
-          if (userPreferences.getFlag(
-                  UserPreferencesDevMode.userPreferencesFlagShortcutToPrices) ??
-              false)
-            Padding(
-              padding: const EdgeInsets.all(SMALL_SPACE),
-              child: SmoothLargeButtonWithIcon(
-                text: appLocalizations.prices_app_button,
-                icon: CupertinoIcons.tag_fill,
-                onPressed: () async => LaunchUrlHelper.launchURL(
-                  'https://prices.openfoodfacts.org/app/products/${upToDateProduct.barcode!}',
-                  false,
-                ),
+          Padding(
+            padding: const EdgeInsets.all(SMALL_SPACE),
+            child: SmoothLargeButtonWithIcon(
+              text: appLocalizations.prices_app_button,
+              icon: CupertinoIcons.tag_fill,
+              onPressed: () async => LaunchUrlHelper.launchURL(
+                'https://prices.openfoodfacts.org/app/products/${upToDateProduct.barcode!}',
+                false,
               ),
             ),
+          ),
           if (userPreferences.getFlag(
                   UserPreferencesDevMode.userPreferencesFlagUserOrderedKP) ??
               false)


### PR DESCRIPTION
### What
- Now the button that goes to "open prices" from the product page is available for all users, and not only the users that checked that option.

### Fixes bug(s)
- Closes: #5077