### PR TITLE
fix: 5104 - fixed the position of the "Failed lookup" string

### DIFF
--- a/packages/smooth_app/lib/cards/category_cards/svg_safe_network.dart
+++ b/packages/smooth_app/lib/cards/category_cards/svg_safe_network.dart
@@ -116,7 +116,7 @@ class _SvgSafeNetworkState extends State<SvgSafeNetwork> {
           }
           if (snapshot.error != null) {
             final bool serverOrConnectionIssue =
-                snapshot.error.toString().startsWith("Failed host lookup: '");
+                snapshot.error.toString().contains("Failed host lookup: '");
             if (!serverOrConnectionIssue) {
               Logs.e(
                 'Could not download "$_url"',


### PR DESCRIPTION
### What
- Top 3 Sentry error in Smoothie is about the off server being unreachable or DNS kaputt each time we download a SVG file.
- We already detected that case (not very problematic as we have local fallback svg files), but too strictly, as we expected the error message to _start_ with a specific string. And it looks like in some cases, that specific string is part of the error message but doesn't start it.
- The fix is just to check if the error message _contains_ (and not _starts with_) that string.
- For the record, the error message is something like `ClientException with SocketException: Failed host lookup: 'static.openfoodfacts.org' (OS Error: No address associated with hostname, errno = 7), uri=https://static.openfoodfacts.org/images/attributes/dist/nova-group-4.svg` and the "specific string" we're looking for is `Failed host lookup: '`.

### Fixes bug(s)
- Fixes: #5104