### PR TITLE
feat: 5095 - matomo anonymous visitor id now starts with a persistent letter

### DIFF
--- a/packages/smooth_app/lib/data_models/preferences/user_preferences.dart
+++ b/packages/smooth_app/lib/data_models/preferences/user_preferences.dart
@@ -75,6 +75,7 @@ class UserPreferences extends ChangeNotifier {
   static const String _TAG_CRASH_REPORTS = 'crash_reports';
   static const String _TAG_EXCLUDED_ATTRIBUTE_IDS = 'excluded_attributes';
   static const String _TAG_USER_GROUP = '_user_group';
+  static const String _TAG_UNIQUE_RANDOM = '_unique_random';
 
   /// Camera preferences
 
@@ -170,6 +171,18 @@ class UserPreferences extends ChangeNotifier {
 
   /// A random int between 0 and 10 (a naive implementation to allow A/B testing)
   int get userGroup => _sharedPreferences.getInt(_TAG_USER_GROUP)!;
+
+  /// Returns a huge random value that will be computed just once.
+  Future<int> getUniqueRandom() async {
+    const String tag = _TAG_UNIQUE_RANDOM;
+    int? result = _sharedPreferences.getInt(tag);
+    if (result != null) {
+      return result;
+    }
+    result = Random().nextInt(1 << 32);
+    await _sharedPreferences.setInt(tag, result);
+    return result;
+  }
 
   Future<void> setCrashReports(final bool state) async {
     await _sharedPreferences.setBool(_TAG_CRASH_REPORTS, state);

--- a/packages/smooth_app/lib/main.dart
+++ b/packages/smooth_app/lib/main.dart
@@ -138,7 +138,7 @@ Future<bool> _init1() async {
   );
   UserManagementProvider().checkUserLoginValidity();
 
-  AnalyticsHelper.linkPreferences(_userPreferences);
+  await AnalyticsHelper.linkPreferences(_userPreferences);
 
   await ProductQuery.initCountry(_userPreferences);
   _themeProvider = ThemeProvider(_userPreferences);


### PR DESCRIPTION
### What
- The matomo anonymous visitor id used to be only one value: `0000000000000000`.
- As a consequence, matomo skewed the way it worked because of very numerous (anonymous) visitor ids that started with `0`
- The solution implemented here is to make the anonymous visitor id start with a random (capital) letter, e.g. `F000000000000000`. 26 times smaller anonymous buckets.
- If needed we can add more possible starting characters, e.g. lower case letters and digits.

### Fixes bug(s)
- Closes: #5095

### Impacted files:
* `analytics_helper.dart`: new getter `_anonymousVisitorId`; refactoring
* `main.dart`: minor refactoring
* `user_preferences.dart`: new method `getUniqueRandom()` that is used to compute and store the first letter of the anonymous visitor ID.