### PR TITLE
chore: Use new GitHub hosted image for devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.224.3/containers/ubuntu
 {
-    "image": "docker.io/cirrusci/flutter:stable",
+    "image": "ghcr.io/cirruslabs/flutter:3.16.7",
 	"forwardPorts": [
 		3000
 	],


### PR DESCRIPTION
### What

The container image previously referenced for the configured devcontainer is deprecated. Let's use the current one hosted on GitHub's registry instead.