### PR TITLE
fix: 4957 - SVG icons are now correctly refreshed when their URL change

### DIFF
--- a/packages/smooth_app/lib/cards/category_cards/asset_cache_helper.dart
+++ b/packages/smooth_app/lib/cards/category_cards/asset_cache_helper.dart
@@ -31,4 +31,7 @@ class AssetCacheHelper {
 
   Exception loadException() =>
       Exception('could not load any cached file ($cachedFilenames)');
+
+  /// Kind of [ObjectKey].
+  Key getKey() => Key('$url/$width/$height/$color/$cachedFilenames');
 }

--- a/packages/smooth_app/lib/cards/category_cards/svg_cache.dart
+++ b/packages/smooth_app/lib/cards/category_cards/svg_cache.dart
@@ -51,14 +51,16 @@ class SvgCache extends AbstractCache {
           ? Colors.white
           : Colors.black;
     }
+    final AssetCacheHelper helper = AssetCacheHelper(
+      cachedFilenames,
+      iconUrl!,
+      width: width,
+      height: height,
+      color: forcedColor,
+    );
     return SvgSafeNetwork(
-      AssetCacheHelper(
-        cachedFilenames,
-        iconUrl!,
-        width: width,
-        height: height,
-        color: forcedColor,
-      ),
+      helper,
+      key: helper.getKey(),
     );
   }
 

--- a/packages/smooth_app/lib/cards/category_cards/svg_safe_network.dart
+++ b/packages/smooth_app/lib/cards/category_cards/svg_safe_network.dart
@@ -13,8 +13,12 @@ import 'package:smooth_app/services/smooth_services.dart';
 ///
 /// We could use SvgPicture.network, but it sends tons of errors if there in no
 /// internet connection. That's why we download the data ourselves.
+/// We do need the [key] for cases like "We updated the categories and then the
+/// ecoscore changed, as an impact". Without a key, flutter may not refresh the
+/// ecoscore svg widget when the URL changes.
+/// cf. https://api.flutter.dev/flutter/foundation/Key-class.html
 class SvgSafeNetwork extends StatefulWidget {
-  const SvgSafeNetwork(this.helper);
+  const SvgSafeNetwork(this.helper, {required super.key});
 
   final AssetCacheHelper helper;
 
@@ -61,12 +65,16 @@ class _SvgSafeNetworkState extends State<SvgSafeNetwork> {
       _networkCache[_url] = cached = response1.body;
       return cached;
     }
-    if (response1.statusCode == statusNotFound && alternateUrl != null) {
-      // try with the alternate url
-      final http.Response response2 = await http.get(Uri.parse(alternateUrl));
-      if (response2.statusCode == statusOk) {
-        _networkCache[alternateUrl] = cached = response2.body;
-        return cached;
+    if (response1.statusCode == statusNotFound) {
+      if (alternateUrl != null) {
+        // try with the alternate url
+        final http.Response response2 = await http.get(Uri.parse(alternateUrl));
+        if (response2.statusCode == statusOk) {
+          _networkCache[alternateUrl] = cached = response2.body;
+          return cached;
+        }
+        throw Exception(
+            'Failed to load SVG: $_url ${response1.statusCode} $alternateUrl ${response2.statusCode}');
       }
     }
 


### PR DESCRIPTION
### What
- The SVG icons were not refreshed when the underlying URL changed (e.g. after a product category change).
- The fix is to use the SVG icon widget with a URL-related key. That will trigger the refresh of the `StatefulWidget` when relevant.

### Fixes bug(s)
- Fixes: #4957

### Impacted files
* `asset_cache_helper.dart`: added a relevant `key`
* `svg_cache.dart`: used the helper `key` so that flutter does refresh the widget for different URLs
* `svg_safe_network.dart`: used a `key`; unrelated error message improvement