### PR TITLE
fix: 5145 - bold style for unknown ingredients in KP

### DIFF
--- a/packages/smooth_app/lib/generic_lib/smooth_html_widget.dart
+++ b/packages/smooth_app/lib/generic_lib/smooth_html_widget.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_widget_from_html_core/flutter_widget_from_html_core.dart';
 import 'package:fwfh_selectable_text/fwfh_selectable_text.dart';
+import 'package:html/dom.dart' as dom;
 import 'package:smooth_app/helpers/launch_url_helper.dart';
 
 class SmoothHtmlWidget extends StatelessWidget {
@@ -20,6 +21,12 @@ class SmoothHtmlWidget extends StatelessWidget {
     return HtmlWidget(
       htmlString,
       textStyle: textStyle,
+      customStylesBuilder: (dom.Element element) =>
+          element.classes.contains('unknown_ingredient')
+              ? <String, String>{
+                  'font-weight': 'bold',
+                }
+              : null,
       onTapUrl: (String url) async {
         try {
           await LaunchUrlHelper.launchURL(url);

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -828,7 +828,7 @@ packages:
     source: hosted
     version: "1.1.0"
   html:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: html
       sha256: "3a7812d5bcd2894edf53dfaf8cd640876cf6cef50a8f238745c8b8120ea74d3a"

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   device_preview: 1.1.0
   flutter_svg: 2.0.10+1
   flutter_map: 6.1.0
+  html: 0.15.4
   flutter_widget_from_html_core: 0.8.5+3
   fwfh_selectable_text: 0.8.3+1
   flutter_secure_storage: 9.0.0


### PR DESCRIPTION
### What
* Applied an [_ad-hoc_](https://en.wikipedia.org/wiki/Captain_Haddock) bold CSS style to unknown ingredients in KP
* Example of html code for
  * a known ingredient: `<span>raisins secs</span>`
  * an unknown ingredient: `<span class=\"text_info unknown_ingredient\">raisins de sultane</span>`

### Screenshots
Example on "raisins de sultane" for 5010477348678.
| before | after |
| -- | -- |
| ![Screenshot_1712737593](https://github.com/openfoodfacts/smooth-app/assets/11576431/57d3f676-a27a-4133-9d12-3eb46bbbe32e) | ![Screenshot_1712737746](https://github.com/openfoodfacts/smooth-app/assets/11576431/001a88b4-38f7-4576-82d1-0bf1b22963cb) |

### Fixes bug(s)
- Fixes: #5145

### Impacted files
* `pubspec.lock`: wtf
* `pubspec.yaml`: added a needed dependency to `html` (already implicitly there anyway because of `flutter_widget_from_html_core`)
* `smooth_html_widget.dart`: specific "bold" effect for css class name `unknown_ingredient`