### PR TITLE
fix: 5121 - more relevant choice of nutrients to display (edit page)

### DIFF
--- a/packages/smooth_app/lib/pages/product/nutrition_container.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_container.dart
@@ -74,7 +74,7 @@ class NutritionContainer {
   bool _isNotRelevant(final OrderedNutrient orderedNutrient) {
     final Nutrient nutrient = getNutrient(orderedNutrient)!;
     return getValue(nutrient) == null &&
-        (!orderedNutrient.important) &&
+        (!orderedNutrient.displayInEditForm) &&
         (!_added.contains(nutrient));
   }
 


### PR DESCRIPTION
### What
- Now we display the same set of nutrients by default as on the website. We use the nutrients flagged as `"display_in_edit_form": true` - instead of `"important": true`.
- Of course, that still depends on the selected country.
- Europe is a special case, where we have about the same nutrients for `"display_in_edit_form": true`  and `"important": true`, but in other countries like Russia or Canada the counts are now about 15 nutrients (instead of about 5).
- As a side-effect, we now display by default all the nutrients used for the nutriscore computation.

### Screenshots
For Canada, from 4 (`"important"`) nutrients to 16 (`"display_in_edit_form"`).
| before | after |
| -- | -- |
| ![CA Screenshot_1712850469](https://github.com/openfoodfacts/smooth-app/assets/11576431/d45aae21-792f-4488-ae1e-5ba42f529a21) | ![Screenshot_1712854352](https://github.com/openfoodfacts/smooth-app/assets/11576431/573570e1-a9f5-4e80-a5a2-3a6d9d61869d) |


### Fixes bug(s)
- Fixes: #5121

### Impacted file
* `nutrition_container.dart`: always displaying nutrients flagged as `"display_in_edit_form": true` (instead of `"important": true`)