### PR TITLE
feat: 5079 - new deeplink to the Country Eco-Score

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1686,6 +1686,10 @@
     "@all_search_to_be_completed_title": {
         "description": "All products to be completed: list tile title"
     },
+    "categorize_products_country_title": "Help categorize products in your country",
+    "@categorize_products_country_title": {
+        "description": "Help categorize products in your country: list tile title"
+    },
     "edit_product_action_retake_picture": "Retake photo",
     "@edit_product_action_retake_picture": {
         "description": "Product edition - FAB actions - retake a picture"

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -1686,6 +1686,10 @@
     "@all_search_to_be_completed_title": {
         "description": "All products to be completed: list tile title"
     },
+    "categorize_products_country_title": "Aidez-nous pour les catégories des produits dans votre pays",
+    "@categorize_products_country_title": {
+        "description": "Help categorize products in your country: list tile title"
+    },
     "edit_product_action_retake_picture": "Reprendre une photo",
     "@edit_product_action_retake_picture": {
         "description": "Product edition - FAB actions - retake a picture"

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_account.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_account.dart
@@ -218,6 +218,13 @@ class UserPreferencesAccount extends AbstractUserPreferences {
         localDatabase: localDatabase,
       ),
       _getListTile(
+        appLocalizations.categorize_products_country_title,
+        () async => LaunchUrlHelper.launchURL(
+          'https://hunger.openfoodfacts.org/eco-score?cc=${ProductQuery.getCountry().offTag}',
+        ),
+        Icons.open_in_new,
+      ),
+      _getListTile(
         appLocalizations.view_profile,
         () async => LaunchUrlHelper.launchURL(
           ProductQuery.replaceSubdomain(


### PR DESCRIPTION
### What
- Added a link to country-related eco-score hunger games page on user welcome page.

### Screenshot
![Screenshot_1713005214](https://github.com/openfoodfacts/smooth-app/assets/11576431/b11b6810-6dba-47e4-bc20-478d5647afac)

### Fixes bug(s)
- Closes: #5079

### Impacted files
* `app_en.arb`: 1 label added
* `app_fr.arb`: 1 label added
* `user_preferences_account.dart`: added a link to country eco-score on user welcome page