### PR TITLE
fix: Tagline/App review: Ensure that all texts are centred

### DIFF
--- a/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
+++ b/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
@@ -463,6 +463,7 @@ class _SearchCardContentAppReview extends StatelessWidget {
                 child: Text(
                   localizations.tagline_app_review_button_positive,
                   style: const TextStyle(fontSize: 17.0),
+                  textAlign: TextAlign.center,
                 ),
               ),
             ),
@@ -479,6 +480,7 @@ class _SearchCardContentAppReview extends StatelessWidget {
                       },
                       child: Text(
                         localizations.tagline_app_review_button_negative,
+                        textAlign: TextAlign.center,
                       ),
                     ),
                   ),
@@ -488,6 +490,7 @@ class _SearchCardContentAppReview extends StatelessWidget {
                       onPressed: () => onHideReview(),
                       child: Text(
                         localizations.tagline_app_review_button_later,
+                        textAlign: TextAlign.center,
                       ),
                     ),
                   ),


### PR DESCRIPTION
Hi everyone,

I've noticed a minor issue in prod with the app review banner in the tagline: all texts are not centered.
This now enforced for the three buttons.

Bug in prod:
![IMG_0464](https://github.com/openfoodfacts/smooth-app/assets/246838/35e34099-1be8-4ca3-a1db-9f6dfaac207d)
