### PR TITLE
chore: upgrade to connectivity_plus v6.0.3

### DIFF
--- a/packages/smooth_app/lib/data_models/fetched_product.dart
+++ b/packages/smooth_app/lib/data_models/fetched_product.dart
@@ -1,4 +1,3 @@
-import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 
@@ -17,7 +16,7 @@ class FetchedProduct {
   const FetchedProduct._({
     required this.status,
     this.product,
-    this.connectivityResult,
+    this.isConnected,
     this.exceptionString,
     this.failedPingedHost,
   });
@@ -41,11 +40,11 @@ class FetchedProduct {
   /// When the "fetch product" operation had an internet error.
   const FetchedProduct.error({
     required final String exceptionString,
-    required final ConnectivityResult connectivityResult,
+    required final bool isConnected,
     final String? failedPingedHost,
   }) : this._(
           status: FetchedProductStatus.internetError,
-          connectivityResult: connectivityResult,
+          isConnected: isConnected,
           exceptionString: exceptionString,
           failedPingedHost: failedPingedHost,
         );
@@ -53,8 +52,8 @@ class FetchedProduct {
   final Product? product;
   final FetchedProductStatus status;
 
-  /// When relevant, result of the connectivity check.
-  final ConnectivityResult? connectivityResult;
+  /// When relevant, returns true if connected.
+  final bool? isConnected;
 
   /// When relevant, string of the exception.
   final String? exceptionString;
@@ -73,7 +72,7 @@ class FetchedProduct {
       case FetchedProductStatus.internetNotFound:
         return appLocalizations.product_refresher_internet_not_found;
       case FetchedProductStatus.internetError:
-        if (connectivityResult == ConnectivityResult.none) {
+        if (isConnected == false) {
           return appLocalizations.product_refresher_internet_not_connected;
         }
         if (failedPingedHost != null) {

--- a/packages/smooth_app/lib/pages/product/common/product_refresher.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_refresher.dart
@@ -178,19 +178,19 @@ class ProductRefresher {
       return const FetchedProduct.internetNotFound();
     } catch (e) {
       Logs.e('Refresh from server error', ex: e);
-      final ConnectivityResult connectivityResult =
+      final List<ConnectivityResult> connectivityResults =
           await Connectivity().checkConnectivity();
-      if (connectivityResult == ConnectivityResult.none) {
+      if (connectivityResults.contains(ConnectivityResult.none)) {
         return FetchedProduct.error(
           exceptionString: e.toString(),
-          connectivityResult: connectivityResult,
+          isConnected: false,
         );
       }
       final String host = ProductQuery.uriProductHelper.host;
       final PingData result = await Ping(host, count: 1).stream.first;
       return FetchedProduct.error(
         exceptionString: e.toString(),
-        connectivityResult: connectivityResult,
+        isConnected: true,
         failedPingedHost: result.error == null ? null : host,
       );
     }

--- a/packages/smooth_app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/smooth_app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -24,7 +24,7 @@ import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AudioplayersDarwinPlugin.register(with: registry.registrar(forPlugin: "AudioplayersDarwinPlugin"))
-  ConnectivityPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlugin"))
+  ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FlutterImageCompressMacosPlugin.register(with: registry.registrar(forPlugin: "FlutterImageCompressMacosPlugin"))

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -305,18 +305,18 @@ packages:
     dependency: "direct main"
     description:
       name: connectivity_plus
-      sha256: "224a77051d52a11fbad53dd57827594d3bd24f945af28bd70bab376d68d437f0"
+      sha256: db7a4e143dc72cc3cb2044ef9b052a7ebfe729513e6a82943bc3526f784365b8
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.2"
+    version: "6.0.3"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
       name: connectivity_plus_platform_interface
-      sha256: cf1d1c28f4416f8c654d7dc3cd638ec586076255d407cef3ddbdaf178272a71a
+      sha256: b6a56efe1e6675be240de39107281d4034b64ac23438026355b4234042a35adb
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.4"
+    version: "2.0.0"
   convert:
     dependency: transitive
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -66,7 +66,7 @@ dependencies:
   webview_flutter: 3.0.4
   flutter_custom_tabs: 2.0.0+1
   flutter_image_compress: 2.2.0
-  connectivity_plus: 5.0.2
+  connectivity_plus: 6.0.3
   dart_ping: 9.0.1
   dart_ping_ios: 4.0.2
   flutter_animation_progress_bar: 2.3.1


### PR DESCRIPTION
### What
- Upgrade to connectivity_plus v6.0.3.

### Part of 
- #5176

### Impacted files
* `fetched_product.dart`: simplified the code with just the notion of "is connected?"
* `GeneratedPluginRegistrant.swift`: wtf
* `product_refresher.dart`: upgraded to `connectivity_plus` v6.0.3 - in our case we eventually just want to check `ConnectivityResult.none`
* `pubspec.lock`: wtf
* `pubspec.yaml`: upgraded to `connectivity_plus` v6.0.3