### PR TITLE
feat: 5191 - knowledge panel image card now clickable

### DIFF
--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_image_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_image_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/helpers/launch_url_helper.dart';
 
 /// Card that displays a Knowledge Panel _Image_ element.
 class KnowledgePanelImageCard extends StatelessWidget {
@@ -12,11 +13,21 @@ class KnowledgePanelImageCard extends StatelessWidget {
 
   // TODO(g123k): It would be nice to provide a Placeholder
   @override
-  Widget build(BuildContext context) => Image.network(
-        imageElement.url,
-        width: imageElement.width?.toDouble(),
-        height: imageElement.height?.toDouble(),
-      );
+  Widget build(BuildContext context) {
+    final Widget image = Image.network(
+      imageElement.url,
+      width: imageElement.width?.toDouble(),
+      height: imageElement.height?.toDouble(),
+    );
+    final String? linkUrl = imageElement.linkUrl;
+    if (linkUrl == null) {
+      return image;
+    }
+    return InkWell(
+      onTap: () => LaunchUrlHelper.launchURL(linkUrl),
+      child: image,
+    );
+  }
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -1132,10 +1132,10 @@ packages:
     dependency: "direct main"
     description:
       name: openfoodfacts
-      sha256: "1b9954e093ead9c314e21e25a92e89540adae2212ae0535f6e69804b312ff972"
+      sha256: dd2e19905a00eba37f67b5c8a52612e93d0f6758a96986ee0afe3723da7e41d5
       url: "https://pub.dev"
     source: hosted
-    version: "3.6.1"
+    version: "3.7.0"
   openfoodfacts_flutter_lints:
     dependency: "direct dev"
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -100,7 +100,7 @@ dependencies:
     path: ../scanner/zxing
 
 
-  openfoodfacts: 3.6.1
+  openfoodfacts: 3.7.0
   # openfoodfacts:
   #   path: ../../../openfoodfacts-dart
 


### PR DESCRIPTION
### What
- The knowledge panel image card is now clickable, but only if the `linkUrl` field is populated.
- This applies in particular to "signal conso" image.
- Products need to be refreshed, because before off-dart 3.7.0 we didn't store the `linkUrl` field.

### Screenshots
| smoothie page | linked page |
| -- | -- |
| ![Screenshot_20240505_112852](https://github.com/openfoodfacts/smooth-app/assets/11576431/61ed425e-a9c1-41dd-b698-0040283fcf5c) | ![Screenshot_20240505_112528_Chrome](https://github.com/openfoodfacts/smooth-app/assets/11576431/9dc54c9b-80ee-4227-89d8-32f581bde66b) |

### Fixes bug(s)
- Closes: #5191

### Impacted files
* `knowledge_panel_image_card.dart`: now using the optional `linkUrl` field for click operation
* `pubspec.lock`: wtf
* `pubspec.yaml`: upgraded to off-dart 3.7.0