### PR TITLE
fix: 5217 - no check on cookie as it's always null

### DIFF
--- a/packages/smooth_app/lib/data_models/user_management_provider.dart
+++ b/packages/smooth_app/lib/data_models/user_management_provider.dart
@@ -45,7 +45,7 @@ class UserManagementProvider with ChangeNotifier {
     try {
       effectiveUserId = userId ?? await DaoSecuredString.get(_USER_ID);
       effectivePassword = password ?? await DaoSecuredString.get(_PASSWORD);
-      effectiveCookie = password ?? await DaoSecuredString.get(_COOKIE);
+      effectiveCookie = await DaoSecuredString.get(_COOKIE);
     } on PlatformException {
       /// Decrypting the values can go wrong if, for example, the app was
       /// manually overwritten from an external apk.
@@ -55,9 +55,7 @@ class UserManagementProvider with ChangeNotifier {
       Logs.e('Credentials query failed, you have been logged out');
     }
 
-    if (effectiveUserId == null ||
-        effectivePassword == null ||
-        effectiveCookie == null) {
+    if (effectiveUserId == null || effectivePassword == null) {
       return;
     }
 


### PR DESCRIPTION
### What
- Recent changes rely on a cookie field being populated.
- Unfortunately, that field is not populated by `OpenFoodAPIClient.login2`
- As a consequence, when returning to the app, the fact that cookie was null erased all local user configuration.

### Fixes bug(s)
- Fixes: #5217