### PR TITLE
feat: Store user's cookie on startup

### DIFF
--- a/packages/smooth_app/lib/data_models/user_management_provider.dart
+++ b/packages/smooth_app/lib/data_models/user_management_provider.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
@@ -110,14 +112,16 @@ class UserManagementProvider with ChangeNotifier {
         password: user.password,
       ),
     );
-    switch (loginResult.type) {
-      case LoginResultType.successful:
-      case LoginResultType.serverIssue:
-      case LoginResultType.exception:
-        return;
-      case LoginResultType.unsuccessful:
-        // TODO(m123): Notify the user
-        await logout();
+
+    if (loginResult.type == LoginResultType.unsuccessful) {
+      // TODO(m123): Notify the user
+      await logout();
+      return;
+    }
+
+    /// Save the cookie if necessary
+    if (user.cookie == null && loginResult.user?.cookie != null) {
+      putUser(loginResult.user!);
     }
   }
 }

--- a/packages/smooth_app/lib/main.dart
+++ b/packages/smooth_app/lib/main.dart
@@ -136,6 +136,7 @@ Future<bool> _init1() async {
     ),
     daoString: DaoString(_localDatabase),
   );
+  ProductQuery.setQueryType(_userPreferences);
   UserManagementProvider().checkUserLoginValidity();
 
   await AnalyticsHelper.linkPreferences(_userPreferences);
@@ -144,7 +145,6 @@ Future<bool> _init1() async {
   _themeProvider = ThemeProvider(_userPreferences);
   _colorProvider = ColorProvider(_userPreferences);
   _textContrastProvider = TextContrastProvider(_userPreferences);
-  ProductQuery.setQueryType(_userPreferences);
 
   await CameraHelper.init();
   await ProductQuery.setUuid(_localDatabase);


### PR DESCRIPTION
Hi everyone,

In the app, we call on every startup `UserManagerProvider.checkUserLoginValidity`.
However, it always fails due to `ProductQuery.uriProductHelper` not being initialized at this time.

That's why there is a change in the order of `main.dart`.
Once that call is done, if the cookie is available, we update the user accordingly.

In terms of code, I think it's enough: what I mean by that, is the fact that a check before a call to a `getProduct` is not necessary.