### PR TITLE
fix: 5247 - now "unselect"ing for the correct language

### DIFF
--- a/packages/smooth_app/lib/background/background_task_unselect.dart
+++ b/packages/smooth_app/lib/background/background_task_unselect.dart
@@ -17,6 +17,7 @@ class BackgroundTaskUnselect extends BackgroundTaskBarcode
   BackgroundTaskUnselect._({
     required super.processName,
     required super.uniqueId,
+    required OpenFoodFactsLanguage super.language,
     required super.barcode,
     required super.stamp,
     required this.imageField,
@@ -81,6 +82,7 @@ class BackgroundTaskUnselect extends BackgroundTaskBarcode
       BackgroundTaskUnselect._(
         uniqueId: uniqueId,
         barcode: barcode,
+        language: language,
         processName: _operationType.processName,
         imageField: imageField.offTag,
         // same stamp as image upload


### PR DESCRIPTION
### What
- We passed the correct language to the "unselect" task, but we didn't use this language as "the task" language.
- As a consequence, we used the default language and unselected the wrong image.
- Now it's fixed.

### Fixes bug(s)
- Fixes: #5247

### Impacted file
* `background_task_unselect.dart`: use of explicit language instead of default language.