### PR TITLE
feat: A deeplink to open the NutriScore Guide

### DIFF
--- a/packages/smooth_app/ios/Podfile.lock
+++ b/packages/smooth_app/ios/Podfile.lock
@@ -147,6 +147,8 @@ PODS:
   - sqflite (0.0.3):
     - Flutter
     - FlutterMacOS
+  - uni_links (0.0.1):
+    - Flutter
   - url_launcher_ios (0.0.1):
     - Flutter
   - webview_flutter_wkwebview (0.0.1):
@@ -180,6 +182,7 @@ DEPENDENCIES:
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - sqflite (from `.symlinks/plugins/sqflite/darwin`)
+  - uni_links (from `.symlinks/plugins/uni_links/ios`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
   - webview_flutter_wkwebview (from `.symlinks/plugins/webview_flutter_wkwebview/ios`)
 
@@ -261,6 +264,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
   sqflite:
     :path: ".symlinks/plugins/sqflite/darwin"
+  uni_links:
+    :path: ".symlinks/plugins/uni_links/ios"
   url_launcher_ios:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
   webview_flutter_wkwebview:
@@ -314,6 +319,7 @@ SPEC CHECKSUMS:
   share_plus: c3fef564749587fc939ef86ffb283ceac0baf9f5
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
   sqflite: 673a0e54cc04b7d6dba8d24fb8095b31c3a99eec
+  uni_links: d97da20c7701486ba192624d99bffaaffcfc298a
   url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
   webview_flutter_wkwebview: be0f0d33777f1bfd0c9fdcb594786704dbf65f36
 

--- a/packages/smooth_app/lib/pages/navigator/app_navigator.dart
+++ b/packages/smooth_app/lib/pages/navigator/app_navigator.dart
@@ -8,6 +8,7 @@ import 'package:smooth_app/data_models/product_preferences.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/extension_on_text_helper.dart';
 import 'package:smooth_app/pages/carousel_manager.dart';
+import 'package:smooth_app/pages/guides/guide/guide_nutriscore_v2.dart';
 import 'package:smooth_app/pages/navigator/error_page.dart';
 import 'package:smooth_app/pages/navigator/external_page.dart';
 import 'package:smooth_app/pages/onboarding/onboarding_flow_navigator.dart';
@@ -82,6 +83,7 @@ class AppNavigator extends InheritedWidget {
 /// -   _product_creator      Create a new product
 /// -   _preferences          User preferences
 /// -   _search               Search for a product
+/// -   _guides/              List of guides
 /// -   _external             Open an external link on the OFF website
 ///
 /// All our routes are prefixed with an underscore, as the [redirect] method
@@ -115,6 +117,7 @@ class _SmoothGoRouter {
 
             return _findLastOnboardingPage(context);
           },
+
           // We use sub-routes to allow the back button to work correctly
           // for deep links to go back to the homepage
           routes: <GoRoute>[
@@ -181,10 +184,6 @@ class _SmoothGoRouter {
               },
             ),
             GoRoute(
-              path: _InternalAppRoutes.SEARCH_PAGE,
-              builder: (_, __) => const SearchPage(SearchProductHelper()),
-            ),
-            GoRoute(
               path: '${_InternalAppRoutes.PREFERENCES_PAGE}/:preferenceType',
               builder: (BuildContext context, GoRouterState state) {
                 final String? type = state.pathParameters['preferenceType'];
@@ -199,6 +198,27 @@ class _SmoothGoRouter {
                 return UserPreferencesPage(
                   type: pageType,
                 );
+              },
+            ),
+            GoRoute(
+              path: _InternalAppRoutes.SEARCH_PAGE,
+              builder: (_, __) => const SearchPage(SearchProductHelper()),
+            ),
+            GoRoute(
+              path: _InternalAppRoutes._GUIDES,
+              routes: <GoRoute>[
+                GoRoute(
+                  path: _InternalAppRoutes.GUIDE_NUTRISCORE_V2_PAGE,
+                  builder: (_, __) => const GuideNutriscoreV2(),
+                ),
+              ],
+              redirect: (_, GoRouterState state) {
+                if (state.uri.pathSegments.last !=
+                    _InternalAppRoutes.GUIDE_NUTRISCORE_V2_PAGE) {
+                  return AppRoutes.EXTERNAL(state.path ?? '');
+                } else {
+                  return null;
+                }
               },
             ),
             GoRoute(
@@ -256,6 +276,8 @@ class _SmoothGoRouter {
             }
           } else if (path == _ExternalRoutes.MOBILE_APP_DOWNLOAD) {
             return AppRoutes.HOME;
+          } else if (path == _ExternalRoutes.GUIDE_NUTRISCORE_V2) {
+            return AppRoutes.GUIDE_NUTRISCORE_V2;
           } else if (path != _InternalAppRoutes.HOME_PAGE) {
             externalLink = true;
           }
@@ -365,11 +387,15 @@ class _InternalAppRoutes {
   static const String PREFERENCES_PAGE = '_preferences';
   static const String SEARCH_PAGE = '_search';
   static const String EXTERNAL_PAGE = '_external';
+
+  static const String _GUIDES = '_guides';
+  static const String GUIDE_NUTRISCORE_V2_PAGE = '_nutriscore-v2';
 }
 
 class _ExternalRoutes {
   static const String MOBILE_APP_DOWNLOAD = '/open-food-facts-mobile-app';
   static const String PRODUCT_EDITION = '/cgi/product.pl';
+  static const String GUIDE_NUTRISCORE_V2 = '/nutriscore-v2';
 }
 
 /// A list of internal routes to use with [AppNavigator]
@@ -409,6 +435,10 @@ class AppRoutes {
 
   // Search view
   static String get SEARCH => '/${_InternalAppRoutes.SEARCH_PAGE}';
+
+  // Guide for NutriScore (TODO: If we have more guides, we should use a more generic algorithm)
+  static String get GUIDE_NUTRISCORE_V2 =>
+      '/${_InternalAppRoutes._GUIDES}/${_InternalAppRoutes.GUIDE_NUTRISCORE_V2_PAGE}';
 
   // Open an external link (where path is relative to the OFF website)
   static String EXTERNAL(String path) =>


### PR DESCRIPTION
To test the screen before releasing it, a deep link is now available: https://fr.openfoodfacts.org/nutriscore-v2