### PR TITLE
fix: Support for photos in a different language than the default one (green buttons)

### DIFF
--- a/packages/smooth_app/lib/pages/product/add_new_product_helper.dart
+++ b/packages/smooth_app/lib/pages/product/add_new_product_helper.dart
@@ -225,12 +225,8 @@ class AddNewProductHelper {
     final ProductImageData productImageData,
     final String barcode,
   ) =>
-      TransientFile.fromProductImageData(
-        productImageData,
-        barcode,
-        ProductQuery.getLanguage(),
-      ).getImageProvider() !=
-      null;
+      TransientFile.getImageLanguages(productImageData.imageField, barcode)
+          .isNotEmpty;
 
   bool isOneMainImagePopulated(final Product product) {
     final List<ProductImageData> productImagesData = getProductMainImagesData(

--- a/packages/smooth_app/lib/pages/product/add_new_product_helper.dart
+++ b/packages/smooth_app/lib/pages/product/add_new_product_helper.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/data_models/product_image_data.dart';
-import 'package:smooth_app/database/transient_file.dart';
 import 'package:smooth_app/generic_lib/buttons/smooth_large_button_with_icon.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/svg_icon_chip.dart';
@@ -223,10 +222,12 @@ class _AddNewProductNutriScoreIcon extends StatelessWidget {
 class AddNewProductHelper {
   bool isMainImagePopulated(
     final ProductImageData productImageData,
-    final String barcode,
+    final Product product,
   ) =>
-      TransientFile.getImageLanguages(productImageData.imageField, barcode)
-          .isNotEmpty;
+      getProductImageLanguages(
+        product,
+        productImageData.imageField,
+      ).isNotEmpty;
 
   bool isOneMainImagePopulated(final Product product) {
     final List<ProductImageData> productImagesData = getProductMainImagesData(
@@ -235,7 +236,7 @@ class AddNewProductHelper {
       ProductQuery.getLanguage(),
     );
     for (final ProductImageData productImageData in productImagesData) {
-      if (isMainImagePopulated(productImageData, product.barcode!)) {
+      if (isMainImagePopulated(productImageData, product)) {
         return true;
       }
     }

--- a/packages/smooth_app/lib/pages/product/add_new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_new_product_page.dart
@@ -564,7 +564,7 @@ class _AddNewProductPageState extends State<AddNewProductPage>
     );
     for (final ProductImageData data in productImagesData) {
       // Everything else can only be uploaded once
-      rows.add(_buildMainImageButton(context, data));
+      rows.add(_buildMainImageButton(context, upToDateProduct, data));
       rows.add(
         const Padding(
           padding: EdgeInsets.symmetric(vertical: 10.0),
@@ -609,9 +609,10 @@ class _AddNewProductPageState extends State<AddNewProductPage>
   /// Button specific to one of the main 4 images.
   Widget _buildMainImageButton(
     final BuildContext context,
+    final Product product,
     final ProductImageData productImageData,
   ) {
-    final bool done = _helper.isMainImagePopulated(productImageData, barcode);
+    final bool done = _helper.isMainImagePopulated(productImageData, product);
     return AddNewProductButton(
       productImageData.imageField
           .getAddPhotoButtonText(AppLocalizations.of(context)),


### PR DESCRIPTION
Hi everyone,

In the "Fast-track" screen, if the photo is uploaded in a different language than the default one, the button stays gray.
The fix here is to check if at least one photo is pending for the given field.