### PR TITLE
feat: When there is no picture, the whole placeholder is clickable

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -624,6 +624,7 @@
     "ingredients_photo_title": "Ingredients Photo",
     "nutritional_facts_photo_title": "Nutrition Facts Photo",
     "recycling_photo_title": "Recycling Photo",
+    "take_photo_title": "Take a picture",
     "take_more_photo_title": "Take more pictures",
     "front_photo_uploaded": "Front photo uploaded",
     "@front_photo_uploaded": {},

--- a/packages/smooth_app/lib/pages/product/product_image_viewer.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_viewer.dart
@@ -11,6 +11,7 @@ import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/language_selector.dart';
 import 'package:smooth_app/generic_lib/widgets/picture_not_found.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
+import 'package:smooth_app/pages/image_crop_page.dart';
 import 'package:smooth_app/pages/product/product_image_button.dart';
 
 /// Displays a full-screen image with an "edit" floating button.
@@ -94,6 +95,25 @@ class _ProductImageViewerState extends State<ProductImageViewer>
                                     ?.copyWith(color: Colors.black) ??
                                 const TextStyle(color: Colors.black),
                             textAlign: TextAlign.center,
+                          ),
+                        ),
+                        Positioned.fill(
+                          child: Material(
+                            type: MaterialType.transparency,
+                            child: Semantics(
+                              label: appLocalizations.take_photo_title,
+                              child: InkWell(
+                                onTap: () async {
+                                  await confirmAndUploadNewPicture(
+                                    context,
+                                    imageField: widget.imageField,
+                                    barcode: barcode,
+                                    language: widget.language,
+                                    isLoggedInMandatory: true,
+                                  );
+                                },
+                              ),
+                            ),
                           ),
                         ),
                       ],


### PR DESCRIPTION
Hi everyone,

When the placeholder says `No image yet` or `No image in that language yet`, the whole placeholder is now clickable
![Screenshot 2024-05-24 at 05 31 47](https://github.com/openfoodfacts/smooth-app/assets/246838/8356d0e0-0671-4ca9-b2dc-c949e85565c2)
