### PR TITLE
fix: If we dismiss the Fast track screen, the dialog shouldn't be visible anymore

### DIFF
--- a/packages/smooth_app/lib/pages/product/common/product_dialog_helper.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_dialog_helper.dart
@@ -134,9 +134,15 @@ class ProductDialogHelper {
           actionsAxis: Axis.vertical,
           positiveAction: SmoothActionButton(
             text: AppLocalizations.of(context).contribute,
-            onPressed: () => AppNavigator.of(context).push(
-              AppRoutes.PRODUCT_CREATOR(barcode),
-            ),
+            onPressed: () async {
+              await AppNavigator.of(context).push(
+                AppRoutes.PRODUCT_CREATOR(barcode),
+              );
+
+              if (context.mounted) {
+                Navigator.pop(context);
+              }
+            },
           ),
           negativeAction: SmoothActionButton(
             text: AppLocalizations.of(context).close,


### PR DESCRIPTION
Hi everyone,

When a product is not found, we show a `Dialog` to explain the issue.
If we open the "fast-track" screen and then we dismiss it, the Dialog is still there.

Issue: https://github.com/openfoodfacts/smooth-app/assets/246838/39bd9a6f-f1ff-4c52-98dc-1788d93df871

