### PR TITLE
feat: `semanticsLabel` for SVGs cache + implementation for the "Add product" dialog

### DIFF
--- a/packages/smooth_app/lib/cards/category_cards/asset_cache_helper.dart
+++ b/packages/smooth_app/lib/cards/category_cards/asset_cache_helper.dart
@@ -9,6 +9,7 @@ class AssetCacheHelper {
     this.width,
     this.height,
     this.color,
+    this.semanticsLabel,
   });
 
   /// Full asset names, e.g. 'assets/cache/ab-agriculture-biologique.74x90.svg'
@@ -21,9 +22,15 @@ class AssetCacheHelper {
   final double? height;
   final Color? color;
 
-  Widget getEmptySpace() => SizedBox(
-        width: width ?? height,
-        height: height ?? width,
+  final String? semanticsLabel;
+
+  Widget getEmptySpace() => Semantics(
+        label: semanticsLabel,
+        image: true,
+        child: SizedBox(
+          width: width ?? height,
+          height: height ?? width,
+        ),
       );
 
   void notFound() => Logs.d(

--- a/packages/smooth_app/lib/cards/category_cards/svg_cache.dart
+++ b/packages/smooth_app/lib/cards/category_cards/svg_cache.dart
@@ -11,9 +11,11 @@ class SvgCache extends AbstractCache {
     super.width,
     super.height,
     this.color,
+    this.semanticsLabel,
   });
 
   final Color? color;
+  final String? semanticsLabel;
 
   @override
   List<String> getCachedFilenames() {
@@ -57,6 +59,7 @@ class SvgCache extends AbstractCache {
       width: width,
       height: height,
       color: forcedColor,
+      semanticsLabel: semanticsLabel,
     );
     return SvgSafeNetwork(
       helper,

--- a/packages/smooth_app/lib/cards/category_cards/svg_safe_network.dart
+++ b/packages/smooth_app/lib/cards/category_cards/svg_safe_network.dart
@@ -30,6 +30,7 @@ class _SvgSafeNetworkState extends State<SvgSafeNetwork> {
   late final Future<String> _loading = _load();
 
   String get _url => widget.helper.url;
+
 // TODO(monsieurtanuki): Change /dist/ url to be the first try when the majority of products have been updated
   /// Loads the SVG file from url or from alternate url.
   ///
@@ -116,7 +117,8 @@ class _SvgSafeNetworkState extends State<SvgSafeNetwork> {
                         ui.BlendMode.srcIn,
                       ),
                 fit: BoxFit.contain,
-                semanticsLabel: SvgCache.getSemanticsLabel(context, _url),
+                semanticsLabel: widget.helper.semanticsLabel ??
+                    SvgCache.getSemanticsLabel(context, _url),
                 placeholderBuilder: (BuildContext context) =>
                     SvgAsyncAsset(widget.helper),
               );

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -566,6 +566,10 @@
     "@new_product_dialog_description": {
         "description": "Please keep it short, like less than 100 characters. Explanatory text of the dialog when the user searched for an unknown barcode."
     },
+    "new_product_dialog_illustration_description": "An illustration with unknown Nutri-Score and Eco-Score",
+    "@new_product_dialog_illustration_description": {
+        "description": "A description for accessibility of two images side by side: a Nutri-Score and an EcoScore."
+    },
     "front_packaging_photo_button_label": "Front packaging photo",
     "@front_packaging_photo_button_label": {},
     "confirm_front_packaging_photo_button_label": "Confirm upload of Front packaging photo",

--- a/packages/smooth_app/lib/pages/product/common/product_dialog_helper.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_dialog_helper.dart
@@ -87,6 +87,7 @@ class ProductDialogHelper {
               SvgPicture.asset(
                 'assets/onboarding/birthday-cake.svg',
                 package: AppHelper.APP_PACKAGE,
+                excludeFromSemantics: true,
               ),
               SizedBox(height: SMALL_SPACE * heightMultiplier),
               Text(
@@ -101,26 +102,31 @@ class ProductDialogHelper {
                 textAlign: TextAlign.center,
               ),
               SizedBox(height: MEDIUM_SPACE * heightMultiplier),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: <Widget>[
-                  Expanded(
-                    flex: 4,
-                    child: SvgCache(
-                      unknownSvgNutriscore,
-                      height: svgHeight,
+              Semantics(
+                label: appLocalizations
+                    .new_product_dialog_illustration_description,
+                excludeSemantics: true,
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: <Widget>[
+                    Expanded(
+                      flex: 4,
+                      child: SvgCache(
+                        unknownSvgNutriscore,
+                        height: svgHeight,
+                      ),
                     ),
-                  ),
-                  const Spacer(),
-                  Expanded(
-                    flex: 4,
-                    child: SvgCache(
-                      unknownSvgEcoscore,
-                      height: svgHeight,
+                    const Spacer(),
+                    Expanded(
+                      flex: 4,
+                      child: SvgCache(
+                        unknownSvgEcoscore,
+                        height: svgHeight,
+                      ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
               SizedBox(height: SMALL_SPACE * heightMultiplier),
               Text(


### PR DESCRIPTION
Hi everyone,

Currently, we provide forced semantics label for Nutri-Score and EcoScore, but not for the other SVGs.
The class now allows that.

An implementation is a description of this illustration:
![Screenshot 2024-05-24 at 05 54 42](https://github.com/openfoodfacts/smooth-app/assets/246838/54bc8553-816a-4417-a303-5041dabb4334)
