### PR TITLE
feat: Snap scrolling for guides

### DIFF
--- a/packages/smooth_app/lib/helpers/physics.dart
+++ b/packages/smooth_app/lib/helpers/physics.dart
@@ -239,7 +239,6 @@ mixin _VerticalSnapScrollPhysicsHelper on ScrollPhysics {
 
   double? _lastPixels;
 
-  @override
   Simulation? createBallisticSimulation2(
     ScrollMetrics position,
     double velocity,

--- a/packages/smooth_app/lib/helpers/physics.dart
+++ b/packages/smooth_app/lib/helpers/physics.dart
@@ -59,7 +59,7 @@ class _VerticalClampScrollState extends State<VerticalClampScroll> {
 
           return true;
         },
-        child: ChangeNotifierProvider(
+        child: ChangeNotifierProvider<VerticalClampScrollLimiter>(
           create: (_) => _limiter,
           child: widget.child,
         ),
@@ -83,7 +83,7 @@ class _VerticalClampScrollState extends State<VerticalClampScroll> {
       }
 
       if (scrollTo != null) {
-        Future.delayed(Duration.zero, () {
+        Future<void>.delayed(Duration.zero, () {
           context.read<ScrollController>().animateTo(
                 scrollTo!,
                 curve: Curves.easeOutCubic,

--- a/packages/smooth_app/lib/helpers/physics.dart
+++ b/packages/smooth_app/lib/helpers/physics.dart
@@ -160,6 +160,7 @@ class VerticalSnapScrollPhysics extends ClampingScrollPhysics {
     return VerticalSnapScrollPhysics(
       parent: buildParent(ancestor),
       steps: steps,
+      lastStepBlocking: lastStepBlocking,
     );
   }
 
@@ -228,7 +229,7 @@ class VerticalSnapScrollPhysics extends ClampingScrollPhysics {
     }
 
     /// Smooth scroll to a step
-    if (hasChanged && position.pixels < steps.last) {
+    if (hasChanged && (lastStepBlocking || position.pixels < steps.last)) {
       return ScrollSpringSimulation(
         spring,
         position.pixels,

--- a/packages/smooth_app/lib/helpers/physics.dart
+++ b/packages/smooth_app/lib/helpers/physics.dart
@@ -1,0 +1,356 @@
+import 'dart:math' as math;
+
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+import 'package:provider/provider.dart';
+
+class VerticalClampScroll extends StatefulWidget {
+  const VerticalClampScroll({
+    required this.steps,
+    required this.child,
+    super.key,
+  }) : assert(steps.length >= 2);
+
+  final List<double> steps;
+  final Widget child;
+
+  @override
+  State<VerticalClampScroll> createState() => _VerticalClampScrollState();
+}
+
+class _VerticalClampScrollState extends State<VerticalClampScroll> {
+  late final Iterable<double> _reversedSteps;
+  final VerticalClampScrollLimiter _limiter = VerticalClampScrollLimiter();
+  ScrollDirection? _direction;
+  ScrollMetrics? _startMetrics;
+
+  @override
+  void initState() {
+    super.initState();
+    _reversedSteps = widget.steps.reversed;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ScrollConfiguration(
+      behavior: _CustomScrollBehavior(
+        VerticalSnapScrollPhysics(
+          steps: widget.steps,
+        ),
+      ),
+      child: NotificationListener<ScrollNotification>(
+        onNotification: (ScrollNotification notif) {
+          if (notif.metrics.axisDirection == AxisDirection.left ||
+              notif.metrics.axisDirection == AxisDirection.right) {
+            return false;
+          }
+
+          if (notif is UserScrollNotification) {
+            _direction = notif.direction;
+
+            if (notif.direction != ScrollDirection.idle) {
+              _startMetrics = notif.metrics;
+            }
+          } else if (notif is ScrollUpdateNotification) {
+            _onScrollUpdate(notif);
+          } else if (notif is ScrollEndNotification) {
+            _onScrollEnd(notif);
+          }
+
+          return true;
+        },
+        child: ChangeNotifierProvider(
+          create: (_) => _limiter,
+          child: widget.child,
+        ),
+      ),
+    );
+  }
+
+  void _onScrollEnd(ScrollEndNotification notif) {
+    if (notif.dragDetails != null) {
+      final (double? min, double? max) = _getRange(
+        widget.steps,
+        notif.metrics.pixels,
+      );
+
+      double? scrollTo;
+      // Down
+      if (_direction == ScrollDirection.reverse && max != null) {
+        scrollTo = max;
+      } else if (_direction == ScrollDirection.forward && min != null) {
+        scrollTo = min;
+      }
+
+      if (scrollTo != null) {
+        Future.delayed(Duration.zero, () {
+          context.read<ScrollController>().animateTo(
+                scrollTo!,
+                curve: Curves.easeOutCubic,
+                duration: const Duration(milliseconds: 500),
+              );
+        });
+      }
+    }
+  }
+
+  void _onScrollUpdate(ScrollUpdateNotification notif) {
+    if (_direction != ScrollDirection.forward || _startMetrics == null) {
+      return;
+    }
+
+    if (_limiter.value != null && notif.metrics.pixels > _limiter.value!) {
+      context.read<ScrollController>().position.correctPixels(_limiter.value!);
+      return;
+    }
+
+    for (int i = 0; i != _reversedSteps.length; i++) {
+      if (_blockScrollIfNecessary(
+          notif, _reversedSteps.elementAt(i), i == _reversedSteps.length - 1)) {
+        break;
+      }
+    }
+  }
+
+  bool _blockScrollIfNecessary(
+    ScrollUpdateNotification notif,
+    double step,
+    bool isLast,
+  ) {
+    if (isLast) {
+      if (_startMetrics!.extentBefore >= step) {
+        if (notif.metrics.pixels <= step) {
+          context.read<ScrollController>().position.correctPixels(step);
+        }
+        return true;
+      }
+    }
+
+    return false;
+  }
+}
+
+class VerticalClampScrollLimiter extends ValueNotifier<double?> {
+  VerticalClampScrollLimiter() : super(null);
+
+  void limitScroll(double height) {
+    value = height;
+  }
+}
+
+/// A custom [ScrollPhysics] that snaps to specific [steps].
+/// ignore: must_be_immutable
+class VerticalSnapScrollPhysics extends ClampingScrollPhysics {
+  VerticalSnapScrollPhysics({
+    required List<double> steps,
+    this.lastStepBlocking = true,
+    super.parent,
+  })  : steps = steps.toList()..sort(),
+        ignoreNextScroll = false;
+
+  final List<double> steps;
+
+  // If true, scrolling from the bottom with be blocked at the last step
+  // If false, scrolling from the bottom will continue
+  final bool lastStepBlocking;
+  bool ignoreNextScroll;
+
+  @override
+  ClampingScrollPhysics applyTo(ScrollPhysics? ancestor) {
+    return VerticalSnapScrollPhysics(
+      parent: buildParent(ancestor),
+      steps: steps,
+    );
+  }
+
+  double? _lastPixels;
+
+  @override
+  Simulation? createBallisticSimulation(
+    ScrollMetrics position,
+    double velocity,
+  ) {
+    final Tolerance tolerance = toleranceFor(position);
+    if (velocity.abs() < tolerance.velocity) {
+      return null;
+    }
+    if (velocity > 0.0 && position.pixels >= position.maxScrollExtent) {
+      ignoreNextScroll = false;
+      return null;
+    }
+    if (velocity < 0.0 && position.pixels <= position.minScrollExtent) {
+      ignoreNextScroll = false;
+      return null;
+    }
+
+    final Simulation? simulation =
+        super.createBallisticSimulation(position, velocity);
+    double? proposedPixels = simulation?.x(double.infinity);
+
+    if (simulation == null || proposedPixels == null) {
+      final (double? min, _) = _getRange(steps, position.pixels);
+
+      if (min != null && min != steps.last && ignoreNextScroll) {
+        return ScrollSpringSimulation(
+          spring,
+          position.pixels,
+          min,
+          velocity,
+          tolerance: toleranceFor(position),
+        );
+      } else {
+        ignoreNextScroll = false;
+        return null;
+      }
+    }
+
+    ignoreNextScroll = false;
+    final (double? min, double? max) = _getRange(steps, position.pixels);
+    bool hasChanged = false;
+    if (min != null && max == null) {
+      if (proposedPixels < min) {
+        proposedPixels = min;
+        hasChanged = true;
+      }
+    } else if (min != null && max != null) {
+      if (position.pixels - proposedPixels > 0) {
+        proposedPixels = min;
+      } else {
+        proposedPixels = max;
+      }
+      hasChanged = true;
+    }
+
+    if (_lastPixels == null) {
+      _lastPixels = proposedPixels;
+    } else {
+      _lastPixels = _fixInconsistency(proposedPixels);
+    }
+
+    /// Smooth scroll to a step
+    if (hasChanged && position.pixels < steps.last) {
+      return ScrollSpringSimulation(
+        spring,
+        position.pixels,
+        _lastPixels!,
+        velocity,
+        tolerance: tolerance,
+      );
+    }
+
+    /// Normal scrolling
+    return simulation;
+  }
+
+  // In some cases, the proposed pixels have a giant space and finding the range
+  // is incorrect. In that case, we ensure to have a contiguous range.
+  double _fixInconsistency(double proposedPixels) {
+    return fixInconsistency(steps, proposedPixels, _lastPixels!);
+  }
+
+  static double fixInconsistency(
+    List<double> steps,
+    double proposedPixels,
+    double initialPixelPosition,
+  ) {
+    final int newPosition = _getStepPosition(steps, proposedPixels);
+    final int oldPosition = _getStepPosition(steps, initialPixelPosition);
+
+    if (newPosition - oldPosition >= 2) {
+      return steps[math.min(newPosition - 1, 0)];
+    } else if (newPosition - oldPosition <= -2) {
+      return steps[math.min(newPosition + 1, steps.length - 1)];
+    }
+
+    return proposedPixels;
+  }
+
+  static int _getStepPosition(List<double> steps, double pixels) {
+    for (int i = steps.length - 1; i >= 0; i--) {
+      final double step = steps.elementAt(i);
+
+      if (pixels >= step) {
+        return i;
+      }
+    }
+
+    return 0;
+  }
+}
+
+(double?, double?) _getRange(List<double> steps, double position) {
+  for (int i = steps.length - 1; i >= 0; i--) {
+    final double step = steps[i];
+
+    if (i == steps.length - 1 && position > step) {
+      return (step, null);
+    } else if (position > step && position < steps[i + 1]) {
+      return (step, steps[i + 1]);
+    }
+  }
+
+  return (null, null);
+}
+
+class _CustomScrollBehavior extends ScrollBehavior {
+  const _CustomScrollBehavior(this.physics);
+
+  final ScrollPhysics physics;
+
+  @override
+  ScrollPhysics getScrollPhysics(BuildContext context) => physics;
+}
+
+class HorizontalSnapScrollPhysics extends ScrollPhysics {
+  const HorizontalSnapScrollPhysics({super.parent, required this.snapSize});
+
+  final double snapSize;
+
+  @override
+  HorizontalSnapScrollPhysics applyTo(ScrollPhysics? ancestor) {
+    return HorizontalSnapScrollPhysics(
+        parent: buildParent(ancestor), snapSize: snapSize);
+  }
+
+  double _getPage(ScrollMetrics position) {
+    return position.pixels / snapSize;
+  }
+
+  double _getPixels(ScrollMetrics position, double page) {
+    return page * snapSize;
+  }
+
+  double _getTargetPixels(
+      ScrollMetrics position, Tolerance tolerance, double velocity) {
+    double page = _getPage(position);
+    if (velocity < -tolerance.velocity) {
+      page -= 0.5;
+    } else if (velocity > tolerance.velocity) {
+      page += 0.5;
+    }
+    return _getPixels(position, page.roundToDouble());
+  }
+
+  @override
+  Simulation? createBallisticSimulation(
+    ScrollMetrics position,
+    double velocity,
+  ) {
+    // If we're out of range and not headed back in range, defer to the parent
+    // ballistics, which should put us back in range at a page boundary.
+    if ((velocity <= 0.0 && position.pixels <= position.minScrollExtent) ||
+        (velocity >= 0.0 && position.pixels >= position.maxScrollExtent)) {
+      return super.createBallisticSimulation(position, velocity);
+    }
+    final Tolerance tolerance = toleranceFor(position);
+    final double target = _getTargetPixels(position, tolerance, velocity);
+    if (target != position.pixels) {
+      return ScrollSpringSimulation(spring, position.pixels, target, velocity,
+          tolerance: tolerance);
+    }
+    return null;
+  }
+
+  @override
+  bool get allowImplicitScrolling => false;
+}

--- a/packages/smooth_app/lib/helpers/physics.dart
+++ b/packages/smooth_app/lib/helpers/physics.dart
@@ -139,9 +139,7 @@ class VerticalClampScrollLimiter extends ValueNotifier<double?> {
   }
 }
 
-class VerticalSnapScrollPhysics {
-  const VerticalSnapScrollPhysics._();
-
+class VerticalSnapScrollPhysics extends ScrollPhysics {
   static ScrollPhysics get({
     required List<double> steps,
     bool lastStepBlocking = true,
@@ -161,6 +159,36 @@ class VerticalSnapScrollPhysics {
 }
 
 //ignore: must_be_immutable
+class _VerticalSnapClampingScrollPhysics extends ClampingScrollPhysics
+    with _VerticalSnapScrollPhysicsHelper {
+  _VerticalSnapClampingScrollPhysics({
+    required List<double> steps,
+    bool lastStepBlocking = true,
+  }) {
+    _init(
+      steps: steps,
+      lastStepBlocking: lastStepBlocking,
+    );
+  }
+
+  @override
+  _VerticalSnapClampingScrollPhysics applyTo(ScrollPhysics? ancestor) {
+    return _VerticalSnapClampingScrollPhysics(
+      steps: _steps,
+      lastStepBlocking: _lastStepBlocking,
+    );
+  }
+
+  @override
+  Simulation? createBallisticSimulation(
+    ScrollMetrics position,
+    double velocity,
+  ) {
+    return createBallisticSimulation2(position, velocity);
+  }
+}
+
+//ignore: must_be_immutable
 class _VerticalSnapBouncingScrollPhysics extends BouncingScrollPhysics
     with _VerticalSnapScrollPhysicsHelper {
   _VerticalSnapBouncingScrollPhysics({
@@ -172,19 +200,21 @@ class _VerticalSnapBouncingScrollPhysics extends BouncingScrollPhysics
       lastStepBlocking: lastStepBlocking,
     );
   }
-}
 
-//ignore: must_be_immutable
-class _VerticalSnapClampingScrollPhysics extends ClampingScrollPhysics
-    with _VerticalSnapScrollPhysicsHelper {
-  _VerticalSnapClampingScrollPhysics({
-    required List<double> steps,
-    bool lastStepBlocking = true,
-  }) {
-    _init(
-      steps: steps,
-      lastStepBlocking: lastStepBlocking,
+  @override
+  _VerticalSnapBouncingScrollPhysics applyTo(ScrollPhysics? ancestor) {
+    return _VerticalSnapBouncingScrollPhysics(
+      steps: _steps,
+      lastStepBlocking: _lastStepBlocking,
     );
+  }
+
+  @override
+  Simulation? createBallisticSimulation(
+    ScrollMetrics position,
+    double velocity,
+  ) {
+    return createBallisticSimulation2(position, velocity);
   }
 }
 
@@ -210,7 +240,7 @@ mixin _VerticalSnapScrollPhysicsHelper on ScrollPhysics {
   double? _lastPixels;
 
   @override
-  Simulation? createBallisticSimulation(
+  Simulation? createBallisticSimulation2(
     ScrollMetrics position,
     double velocity,
   ) {

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -2527,6 +2527,7 @@
             }
         }
     },
+    "nutriscore_new_formula_title": "Nutri-Score (New calculation)",
     "nutriscore_unknown": "Unknown Nutri-Score",
     "nutriscore_unknown_new_formula": "Unknown Nutri-Score (New calculation)",
     "nutriscore_not_applicable": "Nutri-Score is not applicable",

--- a/packages/smooth_app/lib/pages/guides/guide/guide_nutriscore_v2.dart
+++ b/packages/smooth_app/lib/pages/guides/guide/guide_nutriscore_v2.dart
@@ -4,7 +4,6 @@ import 'package:smooth_app/pages/guides/helpers/guides_content.dart';
 import 'package:smooth_app/pages/guides/helpers/guides_footer.dart';
 import 'package:smooth_app/pages/guides/helpers/guides_header.dart';
 import 'package:smooth_app/pages/guides/helpers/guides_translations.dart';
-import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/resources/app_icons.dart';
 
 class GuideNutriscoreV2 extends StatelessWidget {
@@ -12,40 +11,17 @@ class GuideNutriscoreV2 extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: FutureBuilder<void>(
-        future: GuidesTranslations.init(
-          Locale(ProductQuery.getLanguage().offTag),
-        ),
-        builder: (BuildContext context, AsyncSnapshot<void> snapshot) {
-          if (snapshot.connectionState == ConnectionState.done) {
-            return const _GuideNutriscoreV2Content();
-          }
-          return const Center(child: CircularProgressIndicator());
-        },
-      ),
-    );
-  }
-}
-
-class _GuideNutriscoreV2Content extends StatelessWidget {
-  const _GuideNutriscoreV2Content();
-
-  @override
-  Widget build(BuildContext context) {
-    return const Scaffold(
-      body: CustomScrollView(
-        slivers: <Widget>[
-          _NutriscoreHeader(),
-          _NutriScoreSection1(),
-          _NutriScoreSection2(),
-          _NutriScoreSection3(),
-          _NutriScoreSection4(),
-          _NutriScoreSection5(),
-          SliverToBoxAdapter(
-            child: GuidesFooter(),
-          )
-        ],
+    return const GuidesPage(
+      header: _NutriscoreHeader(),
+      body: <Widget>[
+        _NutriScoreSection1(),
+        _NutriScoreSection2(),
+        _NutriScoreSection3(),
+        _NutriScoreSection4(),
+        _NutriScoreSection5(),
+      ],
+      footer: SliverToBoxAdapter(
+        child: GuidesFooter(),
       ),
     );
   }

--- a/packages/smooth_app/lib/pages/guides/helpers/guides_content.dart
+++ b/packages/smooth_app/lib/pages/guides/helpers/guides_content.dart
@@ -82,7 +82,7 @@ class _GuidesPageBody extends StatelessWidget {
         },
         child: CustomScrollView(
           controller: _controller,
-          physics: VerticalSnapScrollPhysics(
+          physics: VerticalSnapScrollPhysics.get(
             lastStepBlocking: false,
             steps: const <double>[
               0,

--- a/packages/smooth_app/lib/pages/guides/helpers/guides_content.dart
+++ b/packages/smooth_app/lib/pages/guides/helpers/guides_content.dart
@@ -83,7 +83,7 @@ class _GuidesPageBody extends StatelessWidget {
         child: CustomScrollView(
           controller: _controller,
           physics: VerticalSnapScrollPhysics(
-            lastStepBlocking: true,
+            lastStepBlocking: false,
             steps: const <double>[
               0,
               GuidesHeader.HEADER_HEIGHT - kToolbarHeight,

--- a/packages/smooth_app/lib/pages/guides/helpers/guides_content.dart
+++ b/packages/smooth_app/lib/pages/guides/helpers/guides_content.dart
@@ -61,6 +61,10 @@ class _GuidesPageBody extends StatelessWidget {
         onNotification: (ScrollNotification notification) {
           /// Snap to positions when the user stops scrolling.
           if (notification is ScrollEndNotification) {
+            if (notification.dragDetails == null) {
+              return true;
+            }
+
             if (notification.metrics.pixels < 125) {
               Future<void>.delayed(Duration.zero, () {
                 _controller.animateTo(0,

--- a/packages/smooth_app/lib/pages/guides/helpers/guides_content.dart
+++ b/packages/smooth_app/lib/pages/guides/helpers/guides_content.dart
@@ -60,8 +60,7 @@ class _GuidesPageBody extends StatelessWidget {
       child: NotificationListener<ScrollNotification>(
         onNotification: (ScrollNotification notification) {
           /// Snap to positions when the user stops scrolling.
-          if (notification is ScrollEndNotification &&
-              notification.dragDetails != null) {
+          if (notification is ScrollEndNotification) {
             if (notification.metrics.pixels < 125) {
               Future<void>.delayed(Duration.zero, () {
                 _controller.animateTo(0,


### PR DESCRIPTION
Better than words, a video:
https://github.com/openfoodfacts/smooth-app/assets/246838/ff3c3a31-8d8f-4b62-acaa-2980382932f6

Or in plain text, if we scroll within the header, it will automatically scroll at the beginning/end (depending on the position).


This PR also includes all custom `ScrollPhysics` from the new design.