### PR TITLE
feat: Shortcut for the Nutri-Score V2 guide in the FAQ (+ some utils)

### DIFF
--- a/packages/smooth_app/lib/cards/category_cards/svg_cache.dart
+++ b/packages/smooth_app/lib/cards/category_cards/svg_cache.dart
@@ -3,6 +3,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:smooth_app/cards/category_cards/abstract_cache.dart';
 import 'package:smooth_app/cards/category_cards/asset_cache_helper.dart';
 import 'package:smooth_app/cards/category_cards/svg_safe_network.dart';
+import 'package:smooth_app/query/product_query.dart';
 
 /// Widget that displays a svg from network (and cache while waiting).
 class SvgCache extends AbstractCache {
@@ -133,4 +134,46 @@ class SvgCache extends AbstractCache {
       return localizations.nutriscore_new_formula(letter);
     }
   }
+
+  static String getAssetsCacheForNutriscore(
+    NutriScoreValue nutriScore,
+    bool newNutriScore,
+  ) {
+    String suffix = '';
+    if (newNutriScore) {
+      final StringBuffer buffer = StringBuffer('-new-');
+
+      buffer.write(switch (ProductQuery.getLanguage().offTag) {
+        'de' => 'de',
+        'en' => 'en',
+        'fr' => 'fr',
+        'lb' => 'lb',
+        'nl' => 'nl',
+        _ => 'en',
+      });
+
+      suffix = buffer.toString();
+    }
+
+    return switch (nutriScore) {
+      NutriScoreValue.a => 'assets/cache/nutriscore-a$suffix.svg',
+      NutriScoreValue.b => 'assets/cache/nutriscore-b$suffix.svg',
+      NutriScoreValue.c => 'assets/cache/nutriscore-c$suffix.svg',
+      NutriScoreValue.d => 'assets/cache/nutriscore-d$suffix.svg',
+      NutriScoreValue.e => 'assets/cache/nutriscore-e$suffix.svg',
+      NutriScoreValue.notApplicable =>
+        'assets/cache/nutriscore-not-applicable$suffix.svg',
+      NutriScoreValue.unknown => 'assets/cache/nutriscore-unknown$suffix.svg',
+    };
+  }
+}
+
+enum NutriScoreValue {
+  a,
+  b,
+  c,
+  d,
+  e,
+  unknown,
+  notApplicable,
 }

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_faq.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_faq.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:package_info_plus/package_info_plus.dart';
+import 'package:smooth_app/cards/category_cards/svg_cache.dart';
 import 'package:smooth_app/data_models/preferences/user_preferences.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
@@ -11,6 +12,7 @@ import 'package:smooth_app/helpers/app_helper.dart';
 import 'package:smooth_app/helpers/global_vars.dart';
 import 'package:smooth_app/helpers/launch_url_helper.dart';
 import 'package:smooth_app/helpers/user_feedback_helper.dart';
+import 'package:smooth_app/pages/guides/guide/guide_nutriscore_v2.dart';
 import 'package:smooth_app/pages/preferences/abstract_user_preferences.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_item.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_list_tile.dart';
@@ -58,7 +60,22 @@ class UserPreferencesFaq extends AbstractUserPreferences {
         _getNutriListTile(
           title: appLocalizations.nutriscore_generic,
           url: 'https://world.openfoodfacts.org/nutriscore',
-          svg: 'assets/cache/nutriscore-b.svg',
+          svg: SvgCache.getAssetsCacheForNutriscore(
+            NutriScoreValue.b,
+            false,
+          ),
+        ),
+        _getListTile(
+          title: appLocalizations.nutriscore_generic,
+          leadingSvg: SvgCache.getAssetsCacheForNutriscore(
+            NutriScoreValue.b,
+            true,
+          ),
+          onTap: () => Navigator.of(context).push(
+            MaterialPageRoute<void>(
+              builder: (BuildContext context) => const GuideNutriscoreV2(),
+            ),
+          ),
         ),
         _getNutriListTile(
           title: appLocalizations.ecoscore_generic,

--- a/packages/smooth_app/lib/pages/product/add_new_product_helper.dart
+++ b/packages/smooth_app/lib/pages/product/add_new_product_helper.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/cards/category_cards/svg_cache.dart';
 import 'package:smooth_app/data_models/product_image_data.dart';
 import 'package:smooth_app/database/transient_file.dart';
 import 'package:smooth_app/generic_lib/buttons/smooth_large_button_with_icon.dart';
@@ -191,22 +192,22 @@ class _AddNewProductNutriScoreIcon extends StatelessWidget {
     required this.height,
   }) : nutriScore = extractValue(fileName);
 
-  final NutriScoreAnimationValue nutriScore;
+  final NutriScoreValue nutriScore;
   final double height;
 
-  static NutriScoreAnimationValue extractValue(String fileName) {
+  static NutriScoreValue extractValue(String fileName) {
     if (fileName.startsWith('nutriscore-a')) {
-      return NutriScoreAnimationValue.a;
+      return NutriScoreValue.a;
     } else if (fileName.startsWith('nutriscore-b')) {
-      return NutriScoreAnimationValue.b;
+      return NutriScoreValue.b;
     } else if (fileName.startsWith('nutriscore-c')) {
-      return NutriScoreAnimationValue.c;
+      return NutriScoreValue.c;
     } else if (fileName.startsWith('nutriscore-d')) {
-      return NutriScoreAnimationValue.d;
+      return NutriScoreValue.d;
     } else if (fileName.startsWith('nutriscore-e')) {
-      return NutriScoreAnimationValue.e;
+      return NutriScoreValue.e;
     } else {
-      return NutriScoreAnimationValue.unknown;
+      return NutriScoreValue.unknown;
     }
   }
 

--- a/packages/smooth_app/lib/resources/app_animations.dart
+++ b/packages/smooth_app/lib/resources/app_animations.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
 import 'package:rive/rive.dart';
+import 'package:smooth_app/cards/category_cards/svg_cache.dart';
 import 'package:smooth_app/services/smooth_services.dart';
 import 'package:smooth_app/themes/theme_provider.dart';
 
@@ -345,16 +346,16 @@ class _TorchAnimationState extends State<TorchAnimation> {
 
 class NutriScoreAnimation extends StatefulWidget {
   factory NutriScoreAnimation({
-    required NutriScoreAnimationValue value,
+    required NutriScoreValue value,
     Size? size,
     Key? key,
   }) {
     return switch (value) {
-      NutriScoreAnimationValue.a => NutriScoreAnimation.A(size: size, key: key),
-      NutriScoreAnimationValue.b => NutriScoreAnimation.B(size: size, key: key),
-      NutriScoreAnimationValue.c => NutriScoreAnimation.C(size: size, key: key),
-      NutriScoreAnimationValue.d => NutriScoreAnimation.D(size: size, key: key),
-      NutriScoreAnimationValue.e => NutriScoreAnimation.E(size: size, key: key),
+      NutriScoreValue.a => NutriScoreAnimation.A(size: size, key: key),
+      NutriScoreValue.b => NutriScoreAnimation.B(size: size, key: key),
+      NutriScoreValue.c => NutriScoreAnimation.C(size: size, key: key),
+      NutriScoreValue.d => NutriScoreAnimation.D(size: size, key: key),
+      NutriScoreValue.e => NutriScoreAnimation.E(size: size, key: key),
       _ => NutriScoreAnimation.unknown(size: size, key: key),
     };
   }
@@ -466,14 +467,4 @@ class _NutriScoreAnimationState extends State<NutriScoreAnimation> {
     _controller?.dispose();
     super.dispose();
   }
-}
-
-enum NutriScoreAnimationValue {
-  a,
-  b,
-  c,
-  d,
-  e,
-  unknown,
-  notApplicable,
 }


### PR DESCRIPTION
Hi everyone,

In the FAQ, we have a link to the NutriScore (V1) guide on the website.
I've added the one for V2.

There is also a method to get the correct SVG file depending on NutriScore V1 or V2 and language.

<img width="661" alt="Screenshot 2024-05-24 at 08 33 01" src="https://github.com/openfoodfacts/smooth-app/assets/246838/a046ee4a-db77-4863-b1eb-1f1fd0e4a1bd">
