### PR TITLE
fix: Onboarding: the main button should be selected first by screen readers

### DIFF
--- a/packages/smooth_app/lib/pages/onboarding/consent_analytics_page.dart
+++ b/packages/smooth_app/lib/pages/onboarding/consent_analytics_page.dart
@@ -72,14 +72,14 @@ class ConsentAnalyticsPage extends StatelessWidget {
             ),
           ),
           OnboardingBottomBar(
-            startButton: _buildButton(
+            rightButton: _buildButton(
               context,
               appLocalizations.refuse_button_label,
               false,
               const Color(0xFFA08D84),
               Colors.white,
             ),
-            endButton: _buildButton(
+            leftButton: _buildButton(
               context,
               appLocalizations.authorize_button_label,
               true,
@@ -87,6 +87,7 @@ class ConsentAnalyticsPage extends StatelessWidget {
               Colors.black,
             ),
             backgroundColor: backgroundColor,
+            semanticsHorizontalOrder: false,
           ),
         ],
       ),

--- a/packages/smooth_app/lib/pages/onboarding/next_button.dart
+++ b/packages/smooth_app/lib/pages/onboarding/next_button.dart
@@ -36,7 +36,7 @@ class NextButton extends StatelessWidget {
         OnboardingFlowNavigator(userPreferences);
     final OnboardingPage previousPage = currentPage.getPrevPage();
     return OnboardingBottomBar(
-      startButton: previousPage.isOnboardingNotStarted()
+      rightButton: previousPage.isOnboardingNotStarted()
           ? null
           : OnboardingBottomIcon(
               onPressed: () async => navigator.navigateToPage(
@@ -50,7 +50,7 @@ class NextButton extends StatelessWidget {
                   ? const EdgeInsetsDirectional.only(end: 2.0)
                   : EdgeInsets.zero,
             ),
-      endButton: OnboardingBottomButton(
+      leftButton: OnboardingBottomButton(
         onPressed: () async {
           await OnboardingLoader(localDatabase)
               .runAtNextTime(currentPage, context);

--- a/packages/smooth_app/lib/pages/onboarding/onboarding_bottom_bar.dart
+++ b/packages/smooth_app/lib/pages/onboarding/onboarding_bottom_bar.dart
@@ -1,16 +1,21 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 
 /// Bottom Bar during onboarding. Typical use case: previous/next buttons.
 class OnboardingBottomBar extends StatelessWidget {
   const OnboardingBottomBar({
-    required this.endButton,
+    required this.leftButton,
     required this.backgroundColor,
-    this.startButton,
+    this.rightButton,
+    this.semanticsHorizontalOrder = true,
   });
 
-  final Widget endButton;
-  final Widget? startButton;
+  final Widget leftButton;
+  final Widget? rightButton;
+
+  /// If [true], the [leftButton] will be said first by the screen reader.
+  final bool semanticsHorizontalOrder;
 
   /// Color of the background where we put the buttons.
   ///
@@ -22,7 +27,7 @@ class OnboardingBottomBar extends StatelessWidget {
     final Size screenSize = MediaQuery.of(context).size;
     // Side padding is 8% of total width.
     final double sidePadding = screenSize.width * .08;
-    final bool hasPrevious = startButton != null;
+    final bool hasPrevious = rightButton != null;
     return Column(
       children: <Widget>[
         Container(
@@ -43,8 +48,15 @@ class OnboardingBottomBar extends StatelessWidget {
                 : MainAxisAlignment.end,
             crossAxisAlignment: CrossAxisAlignment.center,
             children: <Widget>[
-              if (startButton != null) startButton!,
-              endButton,
+              if (rightButton != null)
+                Semantics(
+                  sortKey: OrdinalSortKey(semanticsHorizontalOrder ? 1.0 : 2.0),
+                  child: rightButton,
+                ),
+              Semantics(
+                sortKey: OrdinalSortKey(semanticsHorizontalOrder ? 2.0 : 1.0),
+                child: leftButton,
+              ),
             ],
           ),
         ),

--- a/packages/smooth_app/lib/pages/onboarding/permissions_page.dart
+++ b/packages/smooth_app/lib/pages/onboarding/permissions_page.dart
@@ -94,13 +94,14 @@ class _PermissionsPageState extends State<PermissionsPage> {
               ),
             )),
             OnboardingBottomBar(
-              startButton: _IgnoreButton(
+              rightButton: _IgnoreButton(
                 onPermissionIgnored: () => _moveToNextScreen(context),
               ),
-              endButton: _AskPermissionButton(
+              leftButton: _AskPermissionButton(
                 onPermissionIgnored: () => _moveToNextScreen(context),
               ),
               backgroundColor: widget.backgroundColor,
+              semanticsHorizontalOrder: false,
             )
           ],
         ),


### PR DESCRIPTION
Hi everyone,

While I was testing the application for accessibility, I realized that the onboarding was first selecting the negative button for camera and consent pages.

I've reversed this behavior and also given the Widget better names (start/end meant right/left)
Before:
https://github.com/openfoodfacts/smooth-app/assets/246838/2dfa47ee-841d-468c-b442-816d79fd821f

After:

https://github.com/openfoodfacts/smooth-app/assets/246838/4b84a28d-9af2-4d2a-9397-63d3c0d4d0d3