### PR TITLE
feat: 5195 - new "add one product price" page with background task

### DIFF
--- a/packages/smooth_app/lib/background/background_task_add_price.dart
+++ b/packages/smooth_app/lib/background/background_task_add_price.dart
@@ -1,0 +1,291 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:http_parser/http_parser.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:provider/provider.dart';
+import 'package:smooth_app/background/background_task_barcode.dart';
+import 'package:smooth_app/background/background_task_upload.dart';
+import 'package:smooth_app/background/operation_type.dart';
+import 'package:smooth_app/database/local_database.dart';
+
+// TODO(monsieurtanuki): use transient file, in order to have instant access to proof image?
+// TODO(monsieurtanuki): add crop
+// TODO(monsieurtanuki): check "is picture big enough?"
+// TODO(monsieurtanuki): add source
+// TODO(monsieurtanuki): make it work for several products
+/// Background task about adding a product price.
+class BackgroundTaskAddPrice extends BackgroundTaskBarcode {
+  BackgroundTaskAddPrice._({
+    required super.processName,
+    required super.uniqueId,
+    required super.barcode,
+    required super.stamp,
+    // single
+    required this.fullPath,
+    required this.proofType,
+    required this.date,
+    required this.currency,
+    // multi
+    required this.priceIsDiscounted,
+    required this.price,
+    required this.priceWithoutDiscount,
+    required this.locationOSMId,
+    required this.locationOSMType,
+  });
+
+  BackgroundTaskAddPrice.fromJson(Map<String, dynamic> json)
+      : fullPath = json[_jsonTagImagePath] as String,
+        proofType = getProofTypeFromOffTag(json[_jsonTagProofType] as String)!,
+        date = JsonHelper.stringTimestampToDate(json[_jsonTagDate] as String),
+        currency = getCurrencyFromName(json[_jsonTagCurrency] as String)!,
+        priceIsDiscounted = json[_jsonTagIsDiscounted] as bool,
+        price = json[_jsonTagPrice] as double,
+        priceWithoutDiscount = json[_jsonTagPriceWithoutDiscount] as double?,
+        locationOSMId = json[_jsonTagOSMId] as int,
+        locationOSMType =
+            LocationOSMType.fromOffTag(json[_jsonTagOSMType] as String)!,
+        super.fromJson(json);
+
+  static const String _jsonTagImagePath = 'imagePath';
+  static const String _jsonTagProofType = 'proofType';
+  static const String _jsonTagDate = 'date';
+  static const String _jsonTagCurrency = 'currency';
+  static const String _jsonTagIsDiscounted = 'isDiscounted';
+  static const String _jsonTagPrice = 'price';
+  static const String _jsonTagPriceWithoutDiscount = 'priceWithoutDiscount';
+  static const String _jsonTagOSMId = 'osmId';
+  static const String _jsonTagOSMType = 'osmType';
+
+  static const OperationType _operationType = OperationType.addPrice;
+
+  final String fullPath;
+  final ProofType proofType;
+  final DateTime date;
+  final Currency currency;
+  final bool priceIsDiscounted;
+  final double price;
+  final double? priceWithoutDiscount;
+  final int locationOSMId;
+  final LocationOSMType locationOSMType;
+
+  @override
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> result = super.toJson();
+    result[_jsonTagImagePath] = fullPath;
+    result[_jsonTagProofType] = proofType.offTag;
+    result[_jsonTagDate] = date.toIso8601String();
+    result[_jsonTagCurrency] = currency.name;
+    result[_jsonTagIsDiscounted] = priceIsDiscounted;
+    result[_jsonTagPrice] = price;
+    result[_jsonTagPriceWithoutDiscount] = priceWithoutDiscount;
+    result[_jsonTagOSMId] = locationOSMId;
+    result[_jsonTagOSMType] = locationOSMType.offTag;
+    return result;
+  }
+
+  /// Adds the background task about uploading a product image.
+  static Future<void> addTask(
+    final String barcode, {
+    required final File fullFile,
+    required final ProofType proofType,
+    required final DateTime date,
+    required final Currency currency,
+    required final bool priceIsDiscounted,
+    required final double price,
+    required final double? priceWithoutDiscount,
+    required final int locationOSMId,
+    required final LocationOSMType locationOSMType,
+    required final BuildContext context,
+  }) async {
+    final LocalDatabase localDatabase = context.read<LocalDatabase>();
+    final String uniqueId = await _operationType.getNewKey(
+      localDatabase,
+      barcode: barcode,
+    );
+    final BackgroundTaskBarcode task = _getNewTask(
+      barcode,
+      fullFile: fullFile,
+      proofType: proofType,
+      date: date,
+      currency: currency,
+      priceIsDiscounted: priceIsDiscounted,
+      price: price,
+      priceWithoutDiscount: priceWithoutDiscount,
+      locationOSMId: locationOSMId,
+      locationOSMType: locationOSMType,
+      uniqueId: uniqueId,
+    );
+    if (!context.mounted) {
+      return;
+    }
+    await task.addToManager(localDatabase, context: context);
+  }
+
+  @override
+  (String, AlignmentGeometry)? getFloatingMessage(
+          final AppLocalizations appLocalizations) =>
+      (
+        appLocalizations.add_price_queued,
+        AlignmentDirectional.center,
+      );
+
+  /// Returns a new background task about changing a product.
+  static BackgroundTaskAddPrice _getNewTask(
+    final String barcode, {
+    required final File fullFile,
+    required final ProofType proofType,
+    required final DateTime date,
+    required final Currency currency,
+    required final bool priceIsDiscounted,
+    required final double price,
+    required final double? priceWithoutDiscount,
+    required final int locationOSMId,
+    required final LocationOSMType locationOSMType,
+    required final String uniqueId,
+  }) =>
+      BackgroundTaskAddPrice._(
+        uniqueId: uniqueId,
+        barcode: barcode,
+        processName: _operationType.processName,
+        fullPath: fullFile.path,
+        proofType: proofType,
+        date: date,
+        currency: currency,
+        priceIsDiscounted: priceIsDiscounted,
+        price: price,
+        priceWithoutDiscount: priceWithoutDiscount,
+        locationOSMId: locationOSMId,
+        locationOSMType: locationOSMType,
+        stamp: _getStamp(
+          barcode: barcode,
+          date: date,
+          locationOSMId: locationOSMId,
+          locationOSMType: locationOSMType,
+        ),
+      );
+
+  static String _getStamp({
+    required final String barcode,
+    required final DateTime date,
+    required final int locationOSMId,
+    required final LocationOSMType locationOSMType,
+  }) =>
+      '$barcode;price;$date;$locationOSMId;$locationOSMType';
+
+  @override
+  Future<void> postExecute(
+    final LocalDatabase localDatabase,
+    final bool success,
+  ) async {
+    await super.postExecute(localDatabase, success);
+    try {
+      (await BackgroundTaskUpload.getFile(fullPath)).deleteSync();
+    } catch (e) {
+      // not likely, but let's not spoil the task for that either.
+    }
+  }
+
+  @override
+  Future<void> preExecute(final LocalDatabase localDatabase) async {}
+
+  // Here we don't need the product refresh
+  @override
+  Future<void> execute(final LocalDatabase localDatabase) async => upload();
+
+  /// Sends the product price to the server
+  @override
+  Future<void> upload() async {
+    final Price newPrice = Price()
+      ..date = date
+      ..currency = currency
+      ..priceIsDiscounted = priceIsDiscounted
+      ..price = price
+      ..priceWithoutDiscount = priceWithoutDiscount
+      ..productCode = barcode
+      ..locationOSMId = locationOSMId
+      ..locationOSMType = locationOSMType;
+
+    // authentication
+    final User user = getUser();
+    final MaybeError<String> token =
+        await OpenPricesAPIClient.getAuthenticationToken(
+      username: user.userId,
+      password: user.password,
+      uriHelper: uriProductHelper,
+    );
+    if (token.isError) {
+      throw Exception('Could not get token: ${token.error}');
+    }
+    if (token.value.isEmpty) {
+      throw Exception('Unexpected empty token');
+    }
+    final String bearerToken = token.value;
+
+    // proof upload
+    final File file = File(fullPath);
+    final Uri initialImageUri = Uri.parse(file.path);
+    final MediaType initialMediaType =
+        HttpHelper().imagineMediaType(initialImageUri.path)!;
+    final MaybeError<Proof> uploadProof = await OpenPricesAPIClient.uploadProof(
+      proofType: proofType,
+      imageUri: initialImageUri,
+      mediaType: initialMediaType,
+      bearerToken: bearerToken,
+      uriHelper: uriProductHelper,
+    );
+    if (uploadProof.isError) {
+      throw Exception('Could not upload proof: ${uploadProof.error}');
+    }
+    newPrice.proofId = uploadProof.value.id;
+
+    // create price
+    final MaybeError<Price> addedPrice = await OpenPricesAPIClient.createPrice(
+      price: newPrice,
+      bearerToken: bearerToken,
+      uriHelper: uriProductHelper,
+    );
+    if (addedPrice.isError) {
+      throw Exception('Could not add price: ${addedPrice.error}');
+    }
+
+    // close session
+    final MaybeError<bool> closedSession =
+        await OpenPricesAPIClient.deleteUserSession(
+      uriHelper: uriProductHelper,
+      bearerToken: bearerToken,
+    );
+    if (closedSession.isError) {
+      // TODO(monsieurtanuki): do we really care?
+      // throw Exception('Could not close session: ${closedSession.error}');
+      return;
+    }
+    if (!closedSession.value) {
+      // TODO(monsieurtanuki): do we really care?
+      // throw Exception('Could not really close session');
+      return;
+    }
+  }
+
+  // TODO(monsieurtanuki): move it to off-dart
+  static Currency? getCurrencyFromName(final String name) {
+    for (final Currency currency in Currency.values) {
+      if (currency.name == name) {
+        return currency;
+      }
+    }
+    return null;
+  }
+
+  // TODO(monsieurtanuki): move it to off-dart
+  static ProofType? getProofTypeFromOffTag(final String offTag) {
+    for (final ProofType value in ProofType.values) {
+      if (value.offTag == offTag) {
+        return value;
+      }
+    }
+    return null;
+  }
+}

--- a/packages/smooth_app/lib/background/background_task_crop.dart
+++ b/packages/smooth_app/lib/background/background_task_crop.dart
@@ -149,7 +149,7 @@ class BackgroundTaskCrop extends BackgroundTaskUpload {
   ) async {
     await super.postExecute(localDatabase, success);
     try {
-      (await getFile(croppedPath)).deleteSync();
+      (await BackgroundTaskUpload.getFile(croppedPath)).deleteSync();
     } catch (e) {
       // not likely, but let's not spoil the task for that either.
     }

--- a/packages/smooth_app/lib/background/background_task_image.dart
+++ b/packages/smooth_app/lib/background/background_task_image.dart
@@ -162,17 +162,17 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
   ) async {
     await super.postExecute(localDatabase, success);
     try {
-      (await getFile(fullPath)).deleteSync();
+      (await BackgroundTaskUpload.getFile(fullPath)).deleteSync();
     } catch (e) {
       // not likely, but let's not spoil the task for that either.
     }
     try {
-      (await getFile(croppedPath)).deleteSync();
+      (await BackgroundTaskUpload.getFile(croppedPath)).deleteSync();
     } catch (e) {
       // not likely, but let's not spoil the task for that either.
     }
     try {
-      (await getFile(_getCroppedPath())).deleteSync();
+      (await BackgroundTaskUpload.getFile(_getCroppedPath())).deleteSync();
     } catch (e) {
       // possible, but let's not spoil the task for that either.
     }
@@ -212,8 +212,8 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
   /// Returns false if no crop operation is needed.
   /// Returns null if the image (cropped or not) is too small.
   Future<bool?> _crop(final File file) async {
-    final ui.Image full =
-        await loadUiImage(await (await getFile(fullPath)).readAsBytes());
+    final ui.Image full = await loadUiImage(
+        await (await BackgroundTaskUpload.getFile(fullPath)).readAsBytes());
     if (cropX1 == 0 &&
         cropY1 == 0 &&
         cropX2 == cropConversionFactor &&
@@ -283,7 +283,8 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
   Future<void> upload() async {
     final String path;
     final String croppedPath = _getCroppedPath();
-    final bool? neededCrop = await _crop(await getFile(croppedPath));
+    final bool? neededCrop =
+        await _crop(await BackgroundTaskUpload.getFile(croppedPath));
     if (neededCrop == null) {
       // TODO(monsieurtanuki): maybe something more refined when we dismiss the picture, like alerting the user, though it's not supposed to happen anymore from upstream.
       return;

--- a/packages/smooth_app/lib/background/background_task_upload.dart
+++ b/packages/smooth_app/lib/background/background_task_upload.dart
@@ -108,8 +108,7 @@ abstract class BackgroundTaskUpload extends BackgroundTaskBarcode
   /// we use in [getDirectory].
   /// With this method we refresh the path for iOS.
   /// cf. https://github.com/openfoodfacts/smooth-app/issues/4725
-  @protected
-  Future<File> getFile(String path) async {
+  static Future<File> getFile(String path) async {
     if (Platform.isIOS) {
       final int lastSeparator = path.lastIndexOf('/');
       final String filename =

--- a/packages/smooth_app/lib/background/operation_type.dart
+++ b/packages/smooth_app/lib/background/operation_type.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:smooth_app/background/background_task.dart';
+import 'package:smooth_app/background/background_task_add_price.dart';
 import 'package:smooth_app/background/background_task_crop.dart';
 import 'package:smooth_app/background/background_task_details.dart';
 import 'package:smooth_app/background/background_task_download_products.dart';
@@ -35,6 +36,7 @@ enum OperationType {
   offlineProducts('P', 'OFFLINE_PRODUCTS'),
   fullRefresh('F', 'FULL_REFRESH'),
   languageRefresh('L', 'LANGUAGE_REFRESH'),
+  addPrice('A', 'ADD_PRICE'),
   details('D', 'PRODUCT_EDIT');
 
   const OperationType(this.header, this.processName);
@@ -69,6 +71,8 @@ enum OperationType {
     switch (this) {
       case crop:
         return BackgroundTaskCrop.fromJson(map);
+      case addPrice:
+        return BackgroundTaskAddPrice.fromJson(map);
       case details:
         return BackgroundTaskDetails.fromJson(map);
       case hungerGames:
@@ -99,6 +103,8 @@ enum OperationType {
     switch (this) {
       case OperationType.details:
         return appLocalizations.background_task_operation_details;
+      case OperationType.addPrice:
+        return 'Add price';
       case OperationType.image:
         return appLocalizations.background_task_operation_image;
       case OperationType.unselect:

--- a/packages/smooth_app/lib/data_models/location_list_supplier.dart
+++ b/packages/smooth_app/lib/data_models/location_list_supplier.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/pages/locations/osm_location.dart';
+import 'package:smooth_app/query/product_query.dart';
 
 /// Asynchronously loads locations.
 class LocationListSupplier {
@@ -16,6 +17,17 @@ class LocationListSupplier {
 
   /// Returns null if OK, or the message error
   Future<String?> asyncLoad() async {
+    // don't ask me why, but it looks like we need to explicitly set a language,
+    // or else we get different (and not relevant) results
+    // and only en,fr,de can be used.
+    OpenFoodFactsLanguage getQueryLanguage() =>
+        switch (ProductQuery.getLanguage()) {
+          OpenFoodFactsLanguage.FRENCH => OpenFoodFactsLanguage.FRENCH,
+          OpenFoodFactsLanguage.GERMAN => OpenFoodFactsLanguage.GERMAN,
+          OpenFoodFactsLanguage.ENGLISH => OpenFoodFactsLanguage.ENGLISH,
+          _ => OpenFoodFactsLanguage.ENGLISH,
+        };
+
     try {
       locations.clear();
       final http.Response response = await http.get(
@@ -25,6 +37,7 @@ class LocationListSupplier {
           path: 'api',
           queryParameters: <String, String>{
             'q': query,
+            'lang': getQueryLanguage().offTag,
           },
         ),
       );

--- a/packages/smooth_app/lib/database/dao_osm_location.dart
+++ b/packages/smooth_app/lib/database/dao_osm_location.dart
@@ -86,19 +86,6 @@ class DaoOsmLocation extends AbstractSqlDao {
     return result;
   }
 
-  Future<int> updateLastAccess(
-    final int osmId,
-    final LocationOSMType osmType,
-  ) async =>
-      localDatabase.database.update(
-        _table,
-        <String, Object?>{
-          _columnLastAccess: LocalDatabase.nowInMillis(),
-        },
-        where: '$_columnId = ? AND $_columnType = ?',
-        whereArgs: <Object>[osmId, osmType.offTag],
-      );
-
   Future<int> put(final OsmLocation osmLocation) async =>
       localDatabase.database.insert(
         _table,

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1653,7 +1653,29 @@
     "prices_app_button": "Go to Prices app",
     "prices_generic_title": "Prices",
     "prices_add_a_price": "Add a price",
+    "prices_send_the_price": "Send the price",
     "prices_view_prices": "View the prices",
+    "prices_list_length_one_page": "{count,plural, =0{No price yet} =1{Only one price} other{All {count} prices}}",
+    "@prices_list_length_one_page": {
+        "description": "Number of prices for one-page result",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "prices_list_length_many_pages": "Latest {pageSize} prices (total: {total})",
+    "@prices_list_length_many_pages": {
+        "description": "Number of prices for one-page result",
+        "placeholders": {
+            "pageSize": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
     "prices_amount_subtitle": "Amount",
     "prices_amount_is_discounted": "Is discounted?",
     "prices_amount_price_normal": "Price",

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1653,6 +1653,24 @@
     "prices_generic_title": "Prices",
     "prices_add_a_price": "Add a price",
     "prices_view_prices": "View the prices",
+    "prices_amount_subtitle": "Amount",
+    "prices_amount_is_discounted": "Is discounted?",
+    "prices_amount_price_normal": "Price",
+    "prices_amount_price_discounted": "Discounted price",
+    "prices_amount_price_not_discounted": "Original price",
+    "prices_amount_price_incorrect": "Incorrect value",
+    "prices_amount_price_mandatory": "Mandatory value",
+    "prices_currency_subtitle": "Currency",
+    "prices_date_subtitle": "Date",
+    "prices_location_subtitle": "Shop",
+    "prices_location_find": "Find a shop",
+    "prices_location_mandatory": "You need to select a shop!",
+    "prices_proof_subtitle": "Proof",
+    "prices_proof_find": "Select a proof",
+    "prices_proof_receipt": "Receipt",
+    "prices_proof_price_tag": "Price tag",
+    "prices_proof_mandatory": "You need to select a proof!",
+    "prices_add_validation_error": "Validation error",
     "dev_preferences_import_history_result_success": "Done",
     "@dev_preferences_import_history_result_success": {
         "description": "User dev preferences - Import history - Result successful"
@@ -1977,6 +1995,10 @@
     "image_upload_queued": "The image will be uploaded in the background as soon as possible.",
     "@image_upload_queued": {
         "description": "Message when a photo is queued for upload"
+    },
+    "add_price_queued": "The price will be sent to the server as soon as possible.",
+    "@add_price_queued": {
+        "description": "Message when an added price is queued for the server"
     },
     "background_task_title_full_refresh": "Starting the refresh of all the products locally stored",
     "@background_task_title_full_refresh": {

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -1626,7 +1626,29 @@
     "prices_app_button": "Accéder à l'application Prix",
     "prices_generic_title": "Prix",
     "prices_add_a_price": "Ajouter un prix",
+    "prices_send_the_price": "Envoyer le prix",
     "prices_view_prices": "Voir les prix",
+    "prices_list_length_one_page": "{count,plural, =0{Aucun prix} =1{Un seul prix} other{Tous les {count} prix}}",
+    "@prices_list_length_one_page": {
+        "description": "Number of prices for one-page result",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "prices_list_length_many_pages": "{pageSize} prix les plus récents (total : {total})",
+    "@prices_list_length_many_pages": {
+        "description": "Number of prices for one-page result",
+        "placeholders": {
+            "pageSize": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
     "prices_amount_subtitle": "Montant",
     "prices_amount_is_discounted": "En promotion ?",
     "prices_amount_price_normal": "Prix",

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -1627,6 +1627,24 @@
     "prices_generic_title": "Prix",
     "prices_add_a_price": "Ajouter un prix",
     "prices_view_prices": "Voir les prix",
+    "prices_amount_subtitle": "Montant",
+    "prices_amount_is_discounted": "En promotion ?",
+    "prices_amount_price_normal": "Prix",
+    "prices_amount_price_discounted": "Prix en promotion",
+    "prices_amount_price_not_discounted": "Prix d'origine",
+    "prices_amount_price_incorrect": "Valeur incorrecte",
+    "prices_amount_price_mandatory": "Valeur obligatoire",
+    "prices_currency_subtitle": "Devise",
+    "prices_date_subtitle": "Date",
+    "prices_location_subtitle": "Magasin",
+    "prices_location_find": "Chercher un magasin",
+    "prices_location_mandatory": "Vous devez choisir un magasin !",
+    "prices_proof_subtitle": "Preuve",
+    "prices_proof_find": "Choisir une preuve",
+    "prices_proof_receipt": "Facture",
+    "prices_proof_price_tag": "Étiquette",
+    "prices_proof_mandatory": "Vous devez choisir une preuve !",
+    "prices_add_validation_error": "Erreur de validation",
     "dev_preferences_import_history_result_success": "Fait",
     "@dev_preferences_import_history_result_success": {
         "description": "User dev preferences - Import history - Result successful"
@@ -1951,6 +1969,10 @@
     "image_upload_queued": "L'image va être envoyée en arrière-plan dès que possible.",
     "@image_upload_queued": {
         "description": "Message when a photo is queued for upload"
+    },
+    "add_price_queued": "Le prix sera envoyé en arrière-plan dès que possible.",
+    "@add_price_queued": {
+        "description": "Message when an added price is queued for the server"
     },
     "background_task_title_full_refresh": "Démarrage de la mise à jour de tous les produits stockés localement",
     "@background_task_title_full_refresh": {

--- a/packages/smooth_app/lib/pages/locations/location_map_page.dart
+++ b/packages/smooth_app/lib/pages/locations/location_map_page.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
@@ -8,9 +9,13 @@ import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
 /// Page that displays a map centered on a location.
 class LocationMapPage extends StatelessWidget {
-  const LocationMapPage(this.osmLocation);
+  const LocationMapPage(
+    this.osmLocation, {
+    required this.popFirst,
+  });
 
   final OsmLocation osmLocation;
+  final bool popFirst;
 
   @override
   Widget build(BuildContext context) {
@@ -22,6 +27,46 @@ class LocationMapPage extends StatelessWidget {
       appBar: SmoothAppBar(
         title: title == null ? null : Text(title),
         subTitle: subtitle == null ? null : Text(subtitle),
+        actions: <Widget>[
+          IconButton(
+            icon: const Icon(Icons.check),
+            onPressed: () {
+              // pops that map page
+              Navigator.of(context).pop();
+              if (popFirst) {
+                // pops the result page
+                Navigator.of(context).pop();
+              }
+              // returns the result
+              Navigator.of(context).pop(osmLocation);
+            },
+          ),
+          IconButton(
+            icon: const Icon(Icons.info),
+            onPressed: () => showCupertinoModalPopup<void>(
+              context: context,
+              builder: (final BuildContext context) => CupertinoActionSheet(
+                actions: <Widget>[
+                  if (osmLocation.name != null)
+                    _getItem(context, osmLocation.name!, 'Name'),
+                  if (osmLocation.street != null)
+                    _getItem(context, osmLocation.street!, 'Street'),
+                  if (osmLocation.city != null)
+                    _getItem(context, osmLocation.city!, 'City'),
+                  if (osmLocation.postcode != null)
+                    _getItem(context, osmLocation.postcode!, 'Postcode'),
+                  if (osmLocation.country != null)
+                    _getItem(context, osmLocation.country!, 'Country'),
+                  _getItem(
+                    context,
+                    '${osmLocation.latitude}, ${osmLocation.longitude}',
+                    'Coordinates',
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
       ),
       body: FlutterMap(
         options: MapOptions(
@@ -64,4 +109,14 @@ class LocationMapPage extends StatelessWidget {
       ),
     );
   }
+
+  Widget _getItem(
+    final BuildContext context,
+    final String value,
+    final String label,
+  ) =>
+      CupertinoActionSheetAction(
+        onPressed: () => Navigator.of(context).pop(),
+        child: Text('$label: $value'),
+      );
 }

--- a/packages/smooth_app/lib/pages/locations/search_location_preloaded_item.dart
+++ b/packages/smooth_app/lib/pages/locations/search_location_preloaded_item.dart
@@ -38,7 +38,10 @@ class SearchLocationPreloadedItem extends SearchPreloadedItem {
           onPressed: () async => Navigator.push<OsmLocation>(
             context,
             MaterialPageRoute<OsmLocation>(
-              builder: (BuildContext context) => LocationMapPage(osmLocation),
+              builder: (BuildContext context) => LocationMapPage(
+                osmLocation,
+                popFirst: popFirst,
+              ),
             ),
           ),
           icon: const Icon(Icons.map),

--- a/packages/smooth_app/lib/pages/onboarding/currency_selector.dart
+++ b/packages/smooth_app/lib/pages/onboarding/currency_selector.dart
@@ -1,16 +1,13 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/preferences/user_preferences.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
-import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
-import 'package:smooth_app/generic_lib/widgets/smooth_text_form_field.dart';
-import 'package:smooth_app/widgets/smooth_text.dart';
+import 'package:smooth_app/pages/onboarding/currency_selector_helper.dart';
 
 /// A selector for selecting user's currency.
-class CurrencySelector extends StatefulWidget {
-  const CurrencySelector({
+class CurrencySelector extends StatelessWidget {
+  CurrencySelector({
     this.textStyle,
     this.padding,
     this.icon,
@@ -20,179 +17,59 @@ class CurrencySelector extends StatefulWidget {
   final EdgeInsetsGeometry? padding;
   final Icon? icon;
 
-  @override
-  State<CurrencySelector> createState() => _CurrencySelectorState();
-}
-
-class _CurrencySelectorState extends State<CurrencySelector> {
-  final ScrollController _scrollController = ScrollController();
-  final TextEditingController _currencyController = TextEditingController();
-  final List<Currency> _currencyList = List<Currency>.from(Currency.values);
+  final CurrencySelectorHelper helper = CurrencySelectorHelper();
 
   @override
   Widget build(BuildContext context) {
-    final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    return Selector<UserPreferences, String?>(
-      selector: (BuildContext buildContext, UserPreferences userPreferences) =>
-          userPreferences.appLanguageCode,
-      builder: (BuildContext context, String? appLanguageCode, _) {
-        final UserPreferences userPreferences =
-            context.watch<UserPreferences>();
-        final Currency selected = _getSelected(
-          userPreferences.userCurrencyCode,
+    final UserPreferences userPreferences = context.watch<UserPreferences>();
+    final Currency selected = helper.getSelected(
+      userPreferences.userCurrencyCode,
+    );
+
+    return InkWell(
+      borderRadius: ANGULAR_BORDER_RADIUS,
+      onTap: () async {
+        final Currency? currency = await helper.openCurrencySelector(
+          context: context,
+          selected: selected,
         );
-        final EdgeInsetsGeometry innerPadding = const EdgeInsets.symmetric(
-          vertical: SMALL_SPACE,
-        ).add(widget.padding ?? EdgeInsets.zero);
-
-        return InkWell(
-          borderRadius: ANGULAR_BORDER_RADIUS,
-          onTap: () async {
-            _reorderCurrencies(selected);
-            List<Currency> filteredList = List<Currency>.from(_currencyList);
-            final Currency? currency = await showDialog<Currency>(
-              context: context,
-              builder: (BuildContext context) {
-                return StatefulBuilder(
-                  builder: (BuildContext context,
-                      void Function(VoidCallback fn) setState) {
-                    const double horizontalPadding = 16.0 + SMALL_SPACE;
-
-                    return SmoothListAlertDialog(
-                      title: appLocalizations.currency_selector_title,
-                      header: SmoothTextFormField(
-                        type: TextFieldTypes.PLAIN_TEXT,
-                        prefixIcon: const Icon(Icons.search),
-                        controller: _currencyController,
-                        onChanged: (String? query) {
-                          query = query!.trim()..getComparisonSafeString();
-
-                          setState(
-                            () {
-                              filteredList = _currencyList
-                                  .where((Currency item) => item.name
-                                      .getComparisonSafeString()
-                                      .contains(
-                                        query!,
-                                      ))
-                                  .toList(growable: false);
-                            },
-                          );
-                        },
-                        hintText: appLocalizations.search,
-                      ),
-                      scrollController: _scrollController,
-                      list: ListView.separated(
-                        controller: _scrollController,
-                        itemBuilder: (BuildContext context, int index) {
-                          final Currency currency = filteredList[index];
-                          final bool isSelected = currency == selected;
-                          return ListTile(
-                            dense: true,
-                            contentPadding: const EdgeInsets.symmetric(
-                              horizontal: horizontalPadding,
-                            ),
-                            trailing:
-                                isSelected ? const Icon(Icons.check) : null,
-                            title: TextHighlighter(
-                              text: currency.name,
-                              filter: _currencyController.text,
-                              selected: isSelected,
-                            ),
-                            onTap: () {
-                              Navigator.of(context).pop(currency);
-                              _currencyController.clear();
-                            },
-                          );
-                        },
-                        separatorBuilder: (_, __) => const Divider(
-                          height: 1.0,
-                        ),
-                        itemCount: filteredList.length,
-                        shrinkWrap: true,
-                      ),
-                      positiveAction: SmoothActionButton(
-                        onPressed: () {
-                          Navigator.pop(context);
-                          _currencyController.clear();
-                        },
-                        text: appLocalizations.cancel,
-                      ),
-                    );
-                  },
-                );
-              },
-            );
-            if (currency != null) {
-              await userPreferences.setUserCurrencyCode(currency.name);
-            }
-          },
-          child: DecoratedBox(
-            decoration: const BoxDecoration(
-              borderRadius: BorderRadius.all(Radius.circular(10)),
-            ),
-            child: IntrinsicHeight(
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: <Widget>[
-                  Padding(
-                    padding: innerPadding,
-                    child: const Icon(Icons.currency_exchange),
-                  ),
-                  Expanded(
-                    flex: 1,
-                    child: Padding(
-                      padding:
-                          const EdgeInsets.symmetric(horizontal: LARGE_SPACE),
-                      child: Text(
-                        selected.name,
-                        style: Theme.of(context)
-                            .textTheme
-                            .displaySmall
-                            ?.merge(widget.textStyle),
-                      ),
-                    ),
-                  ),
-                  widget.icon ?? const Icon(Icons.arrow_drop_down),
-                ],
+        if (currency != null) {
+          await userPreferences.setUserCurrencyCode(currency.name);
+        }
+      },
+      child: DecoratedBox(
+        decoration: const BoxDecoration(
+          borderRadius: BorderRadius.all(Radius.circular(10)),
+        ),
+        child: IntrinsicHeight(
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: <Widget>[
+              Padding(
+                padding: const EdgeInsets.symmetric(
+                  vertical: SMALL_SPACE,
+                ).add(padding ?? EdgeInsets.zero),
+                child: const Icon(Icons.currency_exchange),
               ),
-            ),
+              Expanded(
+                flex: 1,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: LARGE_SPACE),
+                  child: Text(
+                    selected.name,
+                    style: Theme.of(context)
+                        .textTheme
+                        .displaySmall
+                        ?.merge(textStyle),
+                  ),
+                ),
+              ),
+              icon ?? const Icon(Icons.arrow_drop_down),
+            ],
           ),
-        );
-      },
+        ),
+      ),
     );
-  }
-
-  Currency _getSelected(final String? code) {
-    if (code != null) {
-      for (final Currency currency in _currencyList) {
-        if (currency.name == code) {
-          return currency;
-        }
-      }
-    }
-    return _currencyList[0];
-  }
-
-  /// Reorder currencies alphabetically, bring user's selected one to top.
-  void _reorderCurrencies(final Currency selected) {
-    _currencyList.sort(
-      (final Currency a, final Currency b) {
-        if (a == selected) {
-          return -1;
-        }
-        if (b == selected) {
-          return 1;
-        }
-        return a.name.compareTo(b.name);
-      },
-    );
-  }
-
-  @override
-  void dispose() {
-    _currencyController.dispose();
-    super.dispose();
   }
 }

--- a/packages/smooth_app/lib/pages/onboarding/currency_selector_helper.dart
+++ b/packages/smooth_app/lib/pages/onboarding/currency_selector_helper.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
+import 'package:smooth_app/generic_lib/widgets/smooth_text_form_field.dart';
+import 'package:smooth_app/widgets/smooth_text.dart';
+
+/// Helper for currency selection.
+class CurrencySelectorHelper {
+  CurrencySelectorHelper();
+
+  final List<Currency> _currencyList = List<Currency>.from(Currency.values);
+
+  Future<Currency?> openCurrencySelector({
+    required final BuildContext context,
+    required final Currency selected,
+  }) async {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final ScrollController scrollController = ScrollController();
+    final TextEditingController currencyController = TextEditingController();
+    _reorderCurrencies(selected);
+    List<Currency> filteredList = List<Currency>.from(_currencyList);
+    return showDialog<Currency>(
+      context: context,
+      builder: (BuildContext context) {
+        return StatefulBuilder(
+          builder:
+              (BuildContext context, void Function(VoidCallback fn) setState) {
+            const double horizontalPadding = 16.0 + SMALL_SPACE;
+
+            return SmoothListAlertDialog(
+              title: appLocalizations.currency_selector_title,
+              header: SmoothTextFormField(
+                type: TextFieldTypes.PLAIN_TEXT,
+                prefixIcon: const Icon(Icons.search),
+                controller: currencyController,
+                onChanged: (String? query) {
+                  query = query!.trim()..getComparisonSafeString();
+
+                  setState(
+                    () {
+                      filteredList = _currencyList
+                          .where((Currency item) =>
+                              item.name.getComparisonSafeString().contains(
+                                    query!,
+                                  ))
+                          .toList(growable: false);
+                    },
+                  );
+                },
+                hintText: appLocalizations.search,
+              ),
+              scrollController: scrollController,
+              list: ListView.separated(
+                controller: scrollController,
+                itemBuilder: (BuildContext context, int index) {
+                  final Currency currency = filteredList[index];
+                  final bool isSelected = currency == selected;
+                  return ListTile(
+                    dense: true,
+                    contentPadding: const EdgeInsets.symmetric(
+                      horizontal: horizontalPadding,
+                    ),
+                    trailing: isSelected ? const Icon(Icons.check) : null,
+                    title: TextHighlighter(
+                      text: currency.name,
+                      filter: currencyController.text,
+                      selected: isSelected,
+                    ),
+                    onTap: () {
+                      Navigator.of(context).pop(currency);
+                      currencyController.clear();
+                    },
+                  );
+                },
+                separatorBuilder: (_, __) => const Divider(
+                  height: 1.0,
+                ),
+                itemCount: filteredList.length,
+                shrinkWrap: true,
+              ),
+              positiveAction: SmoothActionButton(
+                onPressed: () {
+                  Navigator.pop(context);
+                  currencyController.clear();
+                },
+                text: appLocalizations.cancel,
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  Currency getSelected(final String? code) {
+    if (code != null) {
+      for (final Currency currency in _currencyList) {
+        if (currency.name == code) {
+          return currency;
+        }
+      }
+    }
+    return _currencyList[0];
+  }
+
+  /// Reorder currencies alphabetically, bring user's selected one to top.
+  void _reorderCurrencies(final Currency selected) {
+    _currencyList.sort(
+      (final Currency a, final Currency b) {
+        if (a == selected) {
+          return -1;
+        }
+        if (b == selected) {
+          return 1;
+        }
+        return a.name.compareTo(b.name);
+      },
+    );
+  }
+}

--- a/packages/smooth_app/lib/pages/prices/price_amount_card.dart
+++ b/packages/smooth_app/lib/pages/prices/price_amount_card.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:provider/provider.dart';
+import 'package:smooth_app/generic_lib/buttons/smooth_large_button_with_icon.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
+import 'package:smooth_app/pages/prices/price_amount_field.dart';
+import 'package:smooth_app/pages/prices/price_model.dart';
+
+/// Card that displays the amounts (discounted or not) for price adding.
+class PriceAmountCard extends StatefulWidget {
+  const PriceAmountCard();
+
+  @override
+  State<PriceAmountCard> createState() => _PriceAmountCardState();
+}
+
+class _PriceAmountCardState extends State<PriceAmountCard> {
+  final TextEditingController _controllerPaid = TextEditingController();
+  final TextEditingController _controllerWithoutDiscount =
+      TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    final PriceModel model = context.watch<PriceModel>();
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    return SmoothCard(
+      child: Column(
+        children: <Widget>[
+          Text(appLocalizations.prices_amount_subtitle),
+          SmoothLargeButtonWithIcon(
+            icon: model.promo ? Icons.check_box : Icons.check_box_outline_blank,
+            text: appLocalizations.prices_amount_is_discounted,
+            onPressed: () => model.promo = !model.promo,
+          ),
+          const SizedBox(height: SMALL_SPACE),
+          LayoutBuilder(
+            builder: (
+              final BuildContext context,
+              final BoxConstraints boxConstraints,
+            ) {
+              final double columnWidth =
+                  (boxConstraints.maxWidth - LARGE_SPACE) / 2;
+              final Widget columnPaid = SizedBox(
+                width: columnWidth,
+                child: PriceAmountField(
+                  controller: _controllerPaid,
+                  isPaidPrice: true,
+                  model: model,
+                ),
+              );
+              if (!model.promo) {
+                return Align(
+                  alignment: Alignment.centerLeft,
+                  child: columnPaid,
+                );
+              }
+              final Widget columnWithoutDiscount = SizedBox(
+                width: columnWidth,
+                child: PriceAmountField(
+                  controller: _controllerWithoutDiscount,
+                  isPaidPrice: false,
+                  model: model,
+                ),
+              );
+              return Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: <Widget>[
+                  columnPaid,
+                  columnWithoutDiscount,
+                ],
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/smooth_app/lib/pages/prices/price_amount_field.dart
+++ b/packages/smooth_app/lib/pages/prices/price_amount_field.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:smooth_app/generic_lib/widgets/smooth_text_form_field.dart';
+import 'package:smooth_app/pages/prices/price_model.dart';
+
+/// Text field that displays a single amount for price adding.
+class PriceAmountField extends StatelessWidget {
+  const PriceAmountField({
+    required this.model,
+    required this.isPaidPrice,
+    required this.controller,
+  });
+
+  final PriceModel model;
+  final bool isPaidPrice;
+  final TextEditingController controller;
+
+  // TODO(monsieurtanuki): TextInputAction + focus
+  static const TextInputType _priceTextInputType =
+      TextInputType.numberWithOptions(
+    signed: false,
+    decimal: true,
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    return SmoothTextFormField(
+      type: TextFieldTypes.PLAIN_TEXT,
+      controller: controller,
+      hintText: !isPaidPrice
+          ? appLocalizations.prices_amount_price_not_discounted
+          : model.promo
+              ? appLocalizations.prices_amount_price_discounted
+              : appLocalizations.prices_amount_price_normal,
+      textInputType: _priceTextInputType,
+      onChanged: (final String? value) {
+        if (isPaidPrice) {
+          model.paidPrice = value ?? '';
+          return;
+        }
+        model.priceWithoutDiscount = value ?? '';
+      },
+      validator: (String? value) {
+        if (isPaidPrice) {
+          if (value == null || value.isEmpty) {
+            return appLocalizations.prices_amount_price_mandatory;
+          }
+          final double? doubleValue = model.validateDouble(value);
+          if (doubleValue == null) {
+            return appLocalizations.prices_amount_price_incorrect;
+          }
+          return null;
+        }
+
+        // price without discount: only visible if discounted.
+        if (value == null || value.isEmpty) {
+          return null;
+        }
+        final double? doubleValue = model.validateDouble(value);
+        if (doubleValue == null) {
+          return appLocalizations.prices_amount_price_incorrect;
+        }
+        return null;
+      },
+    );
+  }
+}

--- a/packages/smooth_app/lib/pages/prices/price_currency_card.dart
+++ b/packages/smooth_app/lib/pages/prices/price_currency_card.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
+import 'package:smooth_app/pages/prices/price_currency_selector.dart';
+
+/// Card that displays the currency for price adding.
+class PriceCurrencyCard extends StatelessWidget {
+  const PriceCurrencyCard();
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    return SmoothCard(
+      child: Column(
+        children: <Widget>[
+          Text(appLocalizations.prices_currency_subtitle),
+          PriceCurrencySelector(),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/smooth_app/lib/pages/prices/price_currency_selector.dart
+++ b/packages/smooth_app/lib/pages/prices/price_currency_selector.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:provider/provider.dart';
+import 'package:smooth_app/data_models/preferences/user_preferences.dart';
+import 'package:smooth_app/generic_lib/buttons/smooth_large_button_with_icon.dart';
+import 'package:smooth_app/pages/onboarding/currency_selector_helper.dart';
+
+/// Button that displays the currency for price adding.
+class PriceCurrencySelector extends StatelessWidget {
+  PriceCurrencySelector();
+
+  final CurrencySelectorHelper helper = CurrencySelectorHelper();
+
+  @override
+  Widget build(BuildContext context) {
+    // TODO(monsieurtanuki): use PriceModel for currency?
+    final UserPreferences userPreferences = context.watch<UserPreferences>();
+    final Currency selected = helper.getSelected(
+      userPreferences.userCurrencyCode,
+    );
+    return SmoothLargeButtonWithIcon(
+      onPressed: () async {
+        final Currency? currency = await helper.openCurrencySelector(
+          context: context,
+          selected: selected,
+        );
+        if (currency != null) {
+          await userPreferences.setUserCurrencyCode(currency.name);
+        }
+      },
+      text: selected.name,
+      icon: Icons.currency_exchange,
+    );
+  }
+}

--- a/packages/smooth_app/lib/pages/prices/price_date_card.dart
+++ b/packages/smooth_app/lib/pages/prices/price_date_card.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+import 'package:smooth_app/generic_lib/buttons/smooth_large_button_with_icon.dart';
+import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
+import 'package:smooth_app/pages/prices/price_model.dart';
+import 'package:smooth_app/query/product_query.dart';
+
+/// Card that displays the date for price adding.
+class PriceDateCard extends StatelessWidget {
+  const PriceDateCard();
+
+  @override
+  Widget build(BuildContext context) {
+    final PriceModel model = context.watch<PriceModel>();
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final String locale = ProductQuery.getLocaleString();
+    final DateFormat dateFormat = DateFormat.yMd(locale);
+    return SmoothCard(
+      child: Column(
+        children: <Widget>[
+          Text(appLocalizations.prices_date_subtitle),
+          SmoothLargeButtonWithIcon(
+            text: dateFormat.format(model.date),
+            icon: Icons.calendar_month,
+            onPressed: () async {
+              final DateTime? newDate = await showDatePicker(
+                context: context,
+                locale: Locale(ProductQuery.getLanguage().offTag),
+                firstDate: model.firstDate,
+                lastDate: model.today,
+                builder: (final BuildContext context, final Widget? child) {
+                  // for some reason we don't have a fine display without that theme.
+                  // cf. https://stackoverflow.com/questions/50321182/how-to-customize-a-date-picker
+                  final ThemeData themeData =
+                      Theme.of(context).brightness == Brightness.light
+                          ? ThemeData.light()
+                          : ThemeData.dark();
+                  return Theme(
+                    data: themeData.copyWith(),
+                    child: child!,
+                  );
+                },
+              );
+              if (newDate == null) {
+                return;
+              }
+              model.date = newDate;
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/smooth_app/lib/pages/prices/price_location_card.dart
+++ b/packages/smooth_app/lib/pages/prices/price_location_card.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:provider/provider.dart';
+import 'package:smooth_app/database/dao_osm_location.dart';
+import 'package:smooth_app/database/local_database.dart';
+import 'package:smooth_app/generic_lib/buttons/smooth_large_button_with_icon.dart';
+import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
+import 'package:smooth_app/pages/locations/osm_location.dart';
+import 'package:smooth_app/pages/locations/search_location_helper.dart';
+import 'package:smooth_app/pages/locations/search_location_preloaded_item.dart';
+import 'package:smooth_app/pages/prices/price_model.dart';
+import 'package:smooth_app/pages/scan/search_page.dart';
+
+/// Card that displays the location for price adding.
+class PriceLocationCard extends StatelessWidget {
+  const PriceLocationCard();
+
+  static const IconData _iconTodo = CupertinoIcons.exclamationmark;
+  static const IconData _iconDone = Icons.place;
+
+  @override
+  Widget build(BuildContext context) {
+    final PriceModel model = context.watch<PriceModel>();
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final OsmLocation? location = model.location;
+    return SmoothCard(
+      child: Column(
+        children: <Widget>[
+          Text(appLocalizations.prices_location_subtitle),
+          SmoothLargeButtonWithIcon(
+            text: location == null
+                ? appLocalizations.prices_location_find
+                : location.getTitle() ??
+                    location.getSubtitle() ??
+                    location.getLatLng().toString(),
+            icon: location == null ? _iconTodo : _iconDone,
+            onPressed: () async {
+              final LocalDatabase localDatabase = context.read<LocalDatabase>();
+              final List<SearchLocationPreloadedItem> preloadedList =
+                  <SearchLocationPreloadedItem>[];
+              for (final OsmLocation osmLocation in model.locations) {
+                preloadedList.add(
+                  SearchLocationPreloadedItem(
+                    osmLocation,
+                    popFirst: false,
+                  ),
+                );
+              }
+              final OsmLocation? osmLocation =
+                  await Navigator.push<OsmLocation>(
+                context,
+                MaterialPageRoute<OsmLocation>(
+                  builder: (BuildContext context) => SearchPage(
+                    const SearchLocationHelper(),
+                    preloadedList: preloadedList,
+                    autofocus: false,
+                  ),
+                ),
+              );
+              if (osmLocation == null) {
+                return;
+              }
+              final DaoOsmLocation daoOsmLocation =
+                  DaoOsmLocation(localDatabase);
+              await daoOsmLocation.put(osmLocation);
+              final List<OsmLocation> newOsmLocations =
+                  await daoOsmLocation.getAll();
+              model.locations = newOsmLocations;
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/smooth_app/lib/pages/prices/price_model.dart
+++ b/packages/smooth_app/lib/pages/prices/price_model.dart
@@ -1,0 +1,127 @@
+import 'dart:io';
+
+import 'package:camera/camera.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:provider/provider.dart';
+import 'package:smooth_app/background/background_task_add_price.dart';
+import 'package:smooth_app/data_models/preferences/user_preferences.dart';
+import 'package:smooth_app/pages/locations/osm_location.dart';
+import 'package:smooth_app/pages/onboarding/currency_selector_helper.dart';
+
+/// Price Model (checks and background task call) for price adding.
+class PriceModel with ChangeNotifier {
+  PriceModel({
+    required final ProofType proofType,
+    required final List<OsmLocation> locations,
+    required this.barcode,
+  })  : _proofType = proofType,
+        _date = DateTime.now(),
+        _locations = locations;
+
+  final String barcode;
+
+  XFile? _xFile;
+
+  XFile? get xFile => _xFile;
+
+  set xFile(final XFile? xFile) {
+    _xFile = xFile;
+    notifyListeners();
+  }
+
+  ProofType _proofType;
+
+  ProofType get proofType => _proofType;
+
+  set proofType(final ProofType proofType) {
+    _proofType = proofType;
+    notifyListeners();
+  }
+
+  DateTime _date;
+
+  DateTime get date => _date;
+
+  set date(final DateTime date) {
+    _date = date;
+    notifyListeners();
+  }
+
+  final DateTime today = DateTime.now();
+  final DateTime firstDate = DateTime.utc(2020, 1, 1);
+
+  late List<OsmLocation> _locations;
+
+  List<OsmLocation> get locations => _locations;
+
+  set locations(final List<OsmLocation> locations) {
+    _locations = locations;
+    notifyListeners();
+  }
+
+  OsmLocation? get location => _locations.firstOrNull;
+
+  bool _promo = false;
+
+  bool get promo => _promo;
+
+  set promo(final bool promo) {
+    _promo = promo;
+    notifyListeners();
+  }
+
+  String _paidPrice = '';
+  String _priceWithoutDiscount = '';
+
+  set paidPrice(final String value) => _paidPrice = value;
+  set priceWithoutDiscount(final String value) => _priceWithoutDiscount = value;
+
+  double? validateDouble(final String value) =>
+      double.tryParse(value) ??
+      double.tryParse(
+        value.replaceAll(',', '.'),
+      );
+
+  Future<String?> addPrice(final BuildContext context) async {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    if (xFile == null) {
+      return appLocalizations.prices_proof_mandatory;
+    }
+
+    final UserPreferences userPreferences = context.read<UserPreferences>();
+    final Currency currency =
+        CurrencySelectorHelper().getSelected(userPreferences.userCurrencyCode);
+
+    final double paidPrice = validateDouble(_paidPrice)!;
+    double? priceWithoutDiscount;
+    if (promo) {
+      if (_priceWithoutDiscount.isNotEmpty) {
+        priceWithoutDiscount = validateDouble(_priceWithoutDiscount);
+        if (priceWithoutDiscount == null) {
+          return appLocalizations.prices_amount_price_incorrect;
+        }
+      }
+    }
+
+    if (location == null) {
+      return appLocalizations.prices_location_mandatory;
+    }
+
+    await BackgroundTaskAddPrice.addTask(
+      barcode,
+      fullFile: File(xFile!.path),
+      date: date,
+      proofType: proofType,
+      currency: currency,
+      priceIsDiscounted: promo,
+      price: paidPrice,
+      priceWithoutDiscount: priceWithoutDiscount,
+      locationOSMId: location!.osmId,
+      locationOSMType: location!.osmType,
+      context: context,
+    );
+    return null;
+  }
+}

--- a/packages/smooth_app/lib/pages/prices/price_proof_card.dart
+++ b/packages/smooth_app/lib/pages/prices/price_proof_card.dart
@@ -1,0 +1,73 @@
+import 'package:camera/camera.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:provider/provider.dart';
+import 'package:smooth_app/generic_lib/buttons/smooth_large_button_with_icon.dart';
+import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
+import 'package:smooth_app/pages/image_crop_page.dart';
+import 'package:smooth_app/pages/prices/price_model.dart';
+
+/// Card that displays the proof for price adding.
+class PriceProofCard extends StatelessWidget {
+  const PriceProofCard();
+
+  static const IconData _iconTodo = CupertinoIcons.exclamationmark;
+  static const IconData _iconDone = Icons.receipt;
+
+  @override
+  Widget build(BuildContext context) {
+    final PriceModel model = context.watch<PriceModel>();
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    return SmoothCard(
+      child: Column(
+        children: <Widget>[
+          Text(appLocalizations.prices_proof_subtitle),
+          SmoothLargeButtonWithIcon(
+            text: model.xFile == null
+                ? appLocalizations.prices_proof_find
+                : model.proofType == ProofType.receipt
+                    ? appLocalizations.prices_proof_receipt
+                    : appLocalizations.prices_proof_price_tag,
+            icon: model.xFile == null ? _iconTodo : _iconDone,
+            onPressed: () async {
+              // TODO(monsieurtanuki): add the crop feature
+              final XFile? xFile = await pickImageFile(context);
+              if (xFile != null) {
+                model.xFile = xFile;
+              }
+            },
+          ),
+          LayoutBuilder(
+            builder: (BuildContext context, BoxConstraints constraints) => Row(
+              children: <Widget>[
+                SizedBox(
+                  width: constraints.maxWidth / 2,
+                  child: RadioListTile<ProofType>(
+                    title: Text(appLocalizations.prices_proof_receipt),
+                    value: ProofType.receipt,
+                    groupValue: model.proofType,
+                    onChanged: (final ProofType? proofType) =>
+                        model.proofType = proofType!,
+                  ),
+                ),
+                SizedBox(
+                  width: constraints.maxWidth / 2,
+                  child: RadioListTile<ProofType>(
+                    title: Text(appLocalizations.prices_proof_price_tag),
+                    value: ProofType.priceTag,
+                    groupValue: model.proofType,
+                    onChanged: (final ProofType? proofType) =>
+                        model.proofType = proofType!,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/smooth_app/lib/pages/prices/prices_card.dart
+++ b/packages/smooth_app/lib/pages/prices/prices_card.dart
@@ -2,16 +2,11 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
-import 'package:provider/provider.dart';
-import 'package:smooth_app/database/dao_osm_location.dart';
-import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/buttons/smooth_large_button_with_icon.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
-import 'package:smooth_app/pages/locations/osm_location.dart';
 import 'package:smooth_app/pages/prices/product_price_add_page.dart';
 import 'package:smooth_app/pages/prices/product_prices_page.dart';
-import 'package:smooth_app/pages/product/common/product_refresher.dart';
 
 /// Card that displays buttons related to prices.
 class PricesCard extends StatelessWidget {
@@ -53,32 +48,10 @@ class PricesCard extends StatelessWidget {
               child: SmoothLargeButtonWithIcon(
                 text: appLocalizations.prices_add_a_price,
                 icon: Icons.add,
-                onPressed: () async {
-                  if (!await ProductRefresher().checkIfLoggedIn(
-                    context,
-                    isLoggedInMandatory: true,
-                  )) {
-                    return;
-                  }
-                  if (!context.mounted) {
-                    return;
-                  }
-                  final LocalDatabase localDatabase =
-                      context.read<LocalDatabase>();
-                  final List<OsmLocation> osmLocations =
-                      await DaoOsmLocation(localDatabase).getAll();
-                  if (!context.mounted) {
-                    return;
-                  }
-                  await Navigator.of(context).push(
-                    MaterialPageRoute<void>(
-                      builder: (BuildContext context) => ProductPriceAddPage(
-                        product,
-                        latestOsmLocations: osmLocations,
-                      ),
-                    ),
-                  );
-                },
+                onPressed: () async => ProductPriceAddPage.showPage(
+                  context: context,
+                  product: product,
+                ),
               ),
             ),
           ],

--- a/packages/smooth_app/lib/pages/prices/prices_card.dart
+++ b/packages/smooth_app/lib/pages/prices/prices_card.dart
@@ -2,11 +2,16 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:provider/provider.dart';
+import 'package:smooth_app/database/dao_osm_location.dart';
+import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/buttons/smooth_large_button_with_icon.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
-import 'package:smooth_app/helpers/launch_url_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
+import 'package:smooth_app/pages/locations/osm_location.dart';
+import 'package:smooth_app/pages/prices/product_price_add_page.dart';
 import 'package:smooth_app/pages/prices/product_prices_page.dart';
+import 'package:smooth_app/pages/product/common/product_refresher.dart';
 
 /// Card that displays buttons related to prices.
 class PricesCard extends StatelessWidget {
@@ -48,12 +53,32 @@ class PricesCard extends StatelessWidget {
               child: SmoothLargeButtonWithIcon(
                 text: appLocalizations.prices_add_a_price,
                 icon: Icons.add,
-                onPressed: () async =>
-                    // TODO(monsieurtanuki): link to the local to-be-developed ProductPriceAddPage page
-                    // TODO(monsieurtanuki): make it work for TEST too
-                    LaunchUrlHelper.launchURL(
-                  'https://prices.openfoodfacts.org/app/add/single?code=${product.barcode}',
-                ),
+                onPressed: () async {
+                  if (!await ProductRefresher().checkIfLoggedIn(
+                    context,
+                    isLoggedInMandatory: true,
+                  )) {
+                    return;
+                  }
+                  if (!context.mounted) {
+                    return;
+                  }
+                  final LocalDatabase localDatabase =
+                      context.read<LocalDatabase>();
+                  final List<OsmLocation> osmLocations =
+                      await DaoOsmLocation(localDatabase).getAll();
+                  if (!context.mounted) {
+                    return;
+                  }
+                  await Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (BuildContext context) => ProductPriceAddPage(
+                        product,
+                        latestOsmLocations: osmLocations,
+                      ),
+                    ),
+                  );
+                },
               ),
             ),
           ],

--- a/packages/smooth_app/lib/pages/prices/product_price_add_page.dart
+++ b/packages/smooth_app/lib/pages/prices/product_price_add_page.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
+import 'package:smooth_app/database/dao_osm_location.dart';
+import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_back_button.dart';
@@ -13,6 +15,7 @@ import 'package:smooth_app/pages/prices/price_date_card.dart';
 import 'package:smooth_app/pages/prices/price_location_card.dart';
 import 'package:smooth_app/pages/prices/price_model.dart';
 import 'package:smooth_app/pages/prices/price_proof_card.dart';
+import 'package:smooth_app/pages/product/common/product_refresher.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
@@ -25,6 +28,35 @@ class ProductPriceAddPage extends StatefulWidget {
 
   final Product product;
   final List<OsmLocation> latestOsmLocations;
+
+  static Future<void> showPage({
+    required final BuildContext context,
+    required final Product product,
+  }) async {
+    if (!await ProductRefresher().checkIfLoggedIn(
+      context,
+      isLoggedInMandatory: true,
+    )) {
+      return;
+    }
+    if (!context.mounted) {
+      return;
+    }
+    final LocalDatabase localDatabase = context.read<LocalDatabase>();
+    final List<OsmLocation> osmLocations =
+        await DaoOsmLocation(localDatabase).getAll();
+    if (!context.mounted) {
+      return;
+    }
+    await Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (BuildContext context) => ProductPriceAddPage(
+          product,
+          latestOsmLocations: osmLocations,
+        ),
+      ),
+    );
+  }
 
   @override
   State<ProductPriceAddPage> createState() => _ProductPriceAddPageState();
@@ -105,8 +137,8 @@ class _ProductPriceAddPageState extends State<ProductPriceAddPage> {
               }
               Navigator.of(context).pop();
             },
-            icon: const Icon(Icons.add),
-            label: Text(appLocalizations.prices_add_a_price),
+            icon: const Icon(Icons.send),
+            label: Text(appLocalizations.prices_send_the_price),
           ),
         ),
       ),

--- a/packages/smooth_app/lib/pages/prices/product_price_add_page.dart
+++ b/packages/smooth_app/lib/pages/prices/product_price_add_page.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:provider/provider.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
+import 'package:smooth_app/generic_lib/widgets/smooth_back_button.dart';
+import 'package:smooth_app/helpers/product_cards_helper.dart';
+import 'package:smooth_app/pages/locations/osm_location.dart';
+import 'package:smooth_app/pages/prices/price_amount_card.dart';
+import 'package:smooth_app/pages/prices/price_currency_card.dart';
+import 'package:smooth_app/pages/prices/price_date_card.dart';
+import 'package:smooth_app/pages/prices/price_location_card.dart';
+import 'package:smooth_app/pages/prices/price_model.dart';
+import 'package:smooth_app/pages/prices/price_proof_card.dart';
+import 'package:smooth_app/widgets/smooth_app_bar.dart';
+import 'package:smooth_app/widgets/smooth_scaffold.dart';
+
+/// Single page that displays all the elements of price adding.
+class ProductPriceAddPage extends StatefulWidget {
+  const ProductPriceAddPage(
+    this.product, {
+    required this.latestOsmLocations,
+  });
+
+  final Product product;
+  final List<OsmLocation> latestOsmLocations;
+
+  @override
+  State<ProductPriceAddPage> createState() => _ProductPriceAddPageState();
+}
+
+class _ProductPriceAddPageState extends State<ProductPriceAddPage> {
+  late final PriceModel _model = PriceModel(
+    proofType: ProofType.priceTag,
+    locations: widget.latestOsmLocations,
+    barcode: widget.product.barcode!,
+  );
+
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    return ChangeNotifierProvider<PriceModel>(
+      create: (_) => _model,
+      child: Form(
+        key: _formKey,
+        child: SmoothScaffold(
+          appBar: SmoothAppBar(
+            centerTitle: false,
+            leading: const SmoothBackButton(),
+            title: Text(
+              getProductNameAndBrands(widget.product, appLocalizations),
+              maxLines: 1,
+            ),
+            subTitle: Text(widget.product.barcode!),
+          ),
+          body: const SingleChildScrollView(
+            padding: EdgeInsets.all(LARGE_SPACE),
+            child: Column(
+              children: <Widget>[
+                PriceProofCard(),
+                SizedBox(height: LARGE_SPACE),
+                PriceDateCard(),
+                SizedBox(height: LARGE_SPACE),
+                PriceLocationCard(),
+                SizedBox(height: LARGE_SPACE),
+                PriceCurrencyCard(),
+                SizedBox(height: LARGE_SPACE),
+                PriceAmountCard(),
+                // so that the last items don't get hidden by the FAB
+                SizedBox(height: MINIMUM_TOUCH_SIZE * 2),
+              ],
+            ),
+          ),
+          floatingActionButton: FloatingActionButton.extended(
+            onPressed: () async {
+              if (!_formKey.currentState!.validate()) {
+                return;
+              }
+
+              String? error;
+              try {
+                error = await _model.addPrice(context);
+              } catch (e) {
+                error = e.toString();
+              }
+              if (error != null) {
+                if (!context.mounted) {
+                  return;
+                }
+                await showDialog<void>(
+                  context: context,
+                  builder: (BuildContext context) =>
+                      SmoothSimpleErrorAlertDialog(
+                    title: appLocalizations.prices_add_validation_error,
+                    message: error!,
+                  ),
+                );
+                return;
+              }
+              if (!context.mounted) {
+                return;
+              }
+              Navigator.of(context).pop();
+            },
+            icon: const Icon(Icons.add),
+            label: Text(appLocalizations.prices_add_a_price),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/smooth_app/lib/pages/prices/product_price_item.dart
+++ b/packages/smooth_app/lib/pages/prices/product_price_item.dart
@@ -119,13 +119,6 @@ class ProductPriceItem extends StatelessWidget {
     return result.toString();
   }
 
-  // TODO(monsieurtanuki): enrich the data or find something more elegant
-  // TODO(monsieurtanuki): wait until https://github.com/openfoodfacts/open-prices/issues/292 is solved
   static OpenFoodFactsCountry? _getCountry(final Location location) =>
-      switch (location.country) {
-        'France' => OpenFoodFactsCountry.FRANCE,
-        'Italia' => OpenFoodFactsCountry.ITALY,
-        'Monaco' => OpenFoodFactsCountry.MONACO,
-        _ => null,
-      };
+      OpenFoodFactsCountry.fromOffTag(location.countryCode);
 }

--- a/packages/smooth_app/lib/pages/prices/product_price_item.dart
+++ b/packages/smooth_app/lib/pages/prices/product_price_item.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:intl/intl.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
@@ -17,6 +18,7 @@ class ProductPriceItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final String locale = ProductQuery.getLocaleString();
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final DateFormat dateFormat = DateFormat.yMd(locale);
     final DateFormat timeFormat = DateFormat.Hms(locale);
     final NumberFormat currencyFormat = NumberFormat.simpleCurrency(
@@ -24,14 +26,40 @@ class ProductPriceItem extends StatelessWidget {
       name: price.currency.name,
     );
     final String? locationTitle = _getLocationTitle(price.location);
-    final double? pricePerKg = _getPricePerKg(price);
+
+    String? getPricePerKg() {
+      if (price.product == null) {
+        return null;
+      }
+      if (price.product!.quantityUnit != 'g') {
+        return null;
+      }
+      return '${currencyFormat.format(price.price / (price.product!.quantity! / 1000))} / kg';
+    }
+
+    String? getNotDiscountedPrice() {
+      if (price.product == null) {
+        return null;
+      }
+      if (price.priceIsDiscounted != true) {
+        return null;
+      }
+      if (price.priceWithoutDiscount == null) {
+        return null;
+      }
+      return '${appLocalizations.prices_amount_price_not_discounted} ${currencyFormat.format(price.priceWithoutDiscount)}';
+    }
+
+    final String? pricePerKg = getPricePerKg();
+    final String? notDiscountedPrice = getNotDiscountedPrice();
     return SmoothCard(
       child: ListTile(
         title: Text(
           '${currencyFormat.format(price.price)}'
-          '${pricePerKg == null ? '' : ' (${currencyFormat.format(pricePerKg)} / kg)'}'
+          '${pricePerKg == null ? '' : ' ($pricePerKg)'}'
           '   '
-          '${dateFormat.format(price.date)}',
+          '${dateFormat.format(price.date)}'
+          '${notDiscountedPrice == null ? '' : '  ($notDiscountedPrice)'}',
         ),
         subtitle: Wrap(
           spacing: MEDIUM_SPACE,
@@ -78,16 +106,6 @@ class ProductPriceItem extends StatelessWidget {
         ),
       ),
     );
-  }
-
-  static double? _getPricePerKg(final Price price) {
-    if (price.product == null) {
-      return null;
-    }
-    if (price.product!.quantityUnit != 'g') {
-      return null;
-    }
-    return price.price / (price.product!.quantity! / 1000);
   }
 
   static String? _getLocationTitle(final Location? location) {

--- a/packages/smooth_app/lib/pages/prices/product_prices_list.dart
+++ b/packages/smooth_app/lib/pages/prices/product_prices_list.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/pages/prices/product_price_item.dart';
 import 'package:smooth_app/query/product_query.dart';
@@ -22,7 +24,6 @@ class _ProductPricesListState extends State<ProductPricesList> {
 
   // TODO(monsieurtanuki): add a refresh gesture
   // TODO(monsieurtanuki): add a "download the next 10" items
-  // TODO(monsieurtanuki): localize
   @override
   Widget build(BuildContext context) =>
       FutureBuilder<MaybeError<GetPricesResult>>(
@@ -53,20 +54,21 @@ class _ProductPricesListState extends State<ProductPricesList> {
           for (final Price price in result.items!) {
             children.add(ProductPriceItem(price));
           }
-          final String title;
-          if (children.isEmpty) {
-            title = 'No price for that product yet!';
-          } else if (result.total == 1) {
-            title = 'Only one price found for that product.';
-          } else if (result.numberOfPages == 1) {
-            title = 'All ${result.total} prices for that product';
-          } else {
-            title =
-                'Latest $_pageSize prices for that product (total: ${result.total})';
-          }
+          final AppLocalizations appLocalizations =
+              AppLocalizations.of(context);
+          final String title = result.numberOfPages == 1
+              ? appLocalizations.prices_list_length_one_page(children.length)
+              : appLocalizations.prices_list_length_many_pages(
+                  _pageSize,
+                  result.total!,
+                );
           children.insert(
             0,
             SmoothCard(child: ListTile(title: Text(title))),
+          );
+          // so that the last content gets not hidden by the FAB
+          children.add(
+            const SizedBox(height: 2 * MINIMUM_TOUCH_SIZE),
           );
           return ListView(
             children: children,

--- a/packages/smooth_app/lib/pages/prices/product_prices_page.dart
+++ b/packages/smooth_app/lib/pages/prices/product_prices_page.dart
@@ -7,6 +7,7 @@ import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_back_button.dart';
 import 'package:smooth_app/helpers/launch_url_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
+import 'package:smooth_app/pages/prices/product_price_add_page.dart';
 import 'package:smooth_app/pages/prices/product_prices_list.dart';
 import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
@@ -62,6 +63,14 @@ class _ProductPricesPageState extends State<ProductPricesPage>
         ],
       ),
       body: ProductPricesList(barcode),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () async => ProductPriceAddPage.showPage(
+          context: context,
+          product: upToDateProduct,
+        ),
+        label: Text(appLocalizations.prices_add_a_price),
+        icon: const Icon(Icons.add),
+      ),
     );
   }
 }

--- a/packages/smooth_app/lib/pages/prices/product_prices_page.dart
+++ b/packages/smooth_app/lib/pages/prices/product_prices_page.dart
@@ -8,6 +8,7 @@ import 'package:smooth_app/generic_lib/widgets/smooth_back_button.dart';
 import 'package:smooth_app/helpers/launch_url_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/pages/prices/product_prices_list.dart';
+import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
@@ -34,29 +35,29 @@ class _ProductPricesPageState extends State<ProductPricesPage>
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     context.watch<LocalDatabase>();
     refreshUpToDate();
-    final String productName = getProductName(
-      upToDateProduct,
-      appLocalizations,
-    );
-    final String productBrand =
-        getProductBrands(upToDateProduct, appLocalizations);
 
     return SmoothScaffold(
       appBar: SmoothAppBar(
         centerTitle: false,
         leading: const SmoothBackButton(),
         title: Text(
-          '${productName.trim()}, ${productBrand.trim()}',
+          getProductNameAndBrands(upToDateProduct, appLocalizations),
           maxLines: 2,
         ),
         actions: <Widget>[
           IconButton(
             tooltip: appLocalizations.prices_app_button,
             icon: const Icon(Icons.open_in_new),
-            onPressed: () async => LaunchUrlHelper.launchURL(
-              // TODO(monsieurtanuki): make it work for TEST too
-              'https://prices.openfoodfacts.org/app/products/${upToDateProduct.barcode!}',
-            ),
+            onPressed: () async {
+              final UriProductHelper uriProductHelper =
+                  ProductQuery.uriProductHelper;
+              final Uri uri = Uri(
+                scheme: uriProductHelper.scheme,
+                host: uriProductHelper.getHost('prices'),
+                path: 'app/products/${upToDateProduct.barcode!}',
+              );
+              return LaunchUrlHelper.launchURL(uri.toString());
+            },
           ),
         ],
       ),

--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -13,6 +13,7 @@ import 'package:smooth_app/generic_lib/widgets/smooth_list_tile_card.dart';
 import 'package:smooth_app/generic_lib/widgets/svg_icon.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
+import 'package:smooth_app/pages/prices/product_price_add_page.dart';
 import 'package:smooth_app/pages/product/add_other_details_page.dart';
 import 'package:smooth_app/pages/product/common/product_refresher.dart';
 import 'package:smooth_app/pages/product/nutrition_page_loaded.dart';
@@ -252,6 +253,14 @@ class _EditProductPageState extends State<EditProductPage> with UpToDateMixin {
                     ),
                   );
                 },
+              ),
+              _ListTitleItem(
+                title: appLocalizations.prices_add_a_price,
+                leading: const Icon(Icons.add),
+                onTap: () async => ProductPriceAddPage.showPage(
+                  context: context,
+                  product: upToDateProduct,
+                ),
               ),
             ],
           ),

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -852,7 +852,7 @@ packages:
     source: hosted
     version: "1.2.0"
   http_parser:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http_parser
       sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
@@ -1148,10 +1148,10 @@ packages:
     dependency: "direct main"
     description:
       name: openfoodfacts
-      sha256: bb9bc36d08bb57c83dc55e44dc52053aeff77e22685b525bf334706d0f20af36
+      sha256: ab05acea8a91a4cef6cbed9064af261a8921c60c5cc253298d9024c1b0ff8674
       url: "https://pub.dev"
     source: hosted
-    version: "3.9.0"
+    version: "3.10.0"
   openfoodfacts_flutter_lints:
     dependency: "direct dev"
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -27,6 +27,7 @@ dependencies:
   hive: 2.2.3
   hive_flutter: 1.1.0
   http: 1.2.0
+  http_parser: 4.0.2
   image_picker: 1.1.1
   iso_countries: 2.2.0
   latlong2: 0.9.1
@@ -102,7 +103,7 @@ dependencies:
     path: ../scanner/zxing
 
 
-  openfoodfacts: 3.9.0
+  openfoodfacts: 3.10.0
   # openfoodfacts:
   #   path: ../../../openfoodfacts-dart
 


### PR DESCRIPTION
### What
- This PR introduces a new page - "add one product price" - accessible from the product page
- In this page we can enter all the needed data - except the barcode as it's implied from the (previous) product page
- A new background task is run, which means that the user immediate gets back the control of the app instead of waiting. It also works offline.
- The UI is as compact as possible: everything fits in one page.

### Screenshot
| page | after the click on "+" |
| -- | -- |
| ![Screenshot_1716647379](https://github.com/openfoodfacts/smooth-app/assets/11576431/b101eda1-d486-4299-b52f-ea098fff3b0f) | ![Screenshot_1716647383](https://github.com/openfoodfacts/smooth-app/assets/11576431/e8978d07-8594-41e0-aa48-be8d962134d4) |

### Fixes bug(s)
- Fixes: #5195

### Files
New files:
* `background_task_add_price.dart`: Background task about adding a product price.
* `currency_selector_helper.dart`: Helper for currency selection.
* `price_amount_card.dart`: Card that displays the amounts (discounted or not) for price adding.
* `price_amount_field.dart`: Text field that displays a single amount for price adding.
* `price_currency_card.dart`: Card that displays the currency for price adding.
* `price_currency_selector.dart`: Button that displays the currency for price adding.
* `price_date_card.dart`: Card that displays the date for price adding.
* `price_location_card.dart`: Card that displays the location for price adding.
* `price_model.dart`: Price Model (checks and background task call) for price adding.
* `price_proof_card.dart`: Card that displays the proof for price adding.
* `product_price_add_page.dart`: Single page that displays all the elements of price adding.

Impacted files:
* `app_en.arb`: added labels related to price adding
* `app_fr.arb`: added labels related to price adding
* `background_task_crop.dart`: minor refactoring
* `background_task_image.dart`: minor refactoring
* `background_task_upload.dart`: minor refactoring
* `currency_selector.dart`: refactored with new class `CurrencySelectorHelper`
* `dao_osm_location.dart`: minor refactoring
* `image_crop_page.dart`: minor refactoring
* `location_list_supplier.dart`: minor refactoring
* `location_map_page.dart`: added action buttons for location description and location confirmation
* `operation_type.dart`: added data for new class `BackgroundTaskAddPrice`
* `prices_card.dart`: now opening new page `ProductPriceAddPage`
* `product_price_item.dart`: minor improvement
* `product_prices_page.dart`: minor improvement
* `pubspec.lock`: wtf
* `pubspec.yaml`: upgraded `openfoodfacts` to `3.10.0`
* `search_location_preloaded_item.dart`: now enabling the map page to confirm a location