### PR TITLE
feat: Better error message for search screen

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -764,6 +764,16 @@
     "@could_not_refresh": {
         "description": "The product data couldn't be refreshed"
     },
+    "product_internet_error_modal_title": "An error has occurred!",
+    "product_internet_error_modal_message": "We are unable to fetch information about this product due to a network error. Please check your internet connection and try again.\n\nInternal error:\n{error}",
+    "@product_internet_error_modal_message": {
+        "placeholders": {
+            "error": {
+                "type": "String",
+                "description": "The error message"
+            }
+        }
+    },
     "product_internet_error": "Impossible to fetch information about this product due to a network error.",
     "cached_results_from": "Show results from:",
     "@cached_results_from": {

--- a/packages/smooth_app/lib/pages/product/common/product_dialog_helper.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_dialog_helper.dart
@@ -165,23 +165,21 @@ class ProductDialogHelper {
         ],
       );
 
-  void _openErrorMessage(final String message) {
-    showDialog<void>(
-      context: context,
-      builder: (BuildContext context) {
-        final AppLocalizations localizations = AppLocalizations.of(context);
+  void _openErrorMessage(final String message) => showDialog<void>(
+        context: context,
+        builder: (BuildContext context) {
+          final AppLocalizations localizations = AppLocalizations.of(context);
 
-        return SmoothAlertDialog(
-          title: localizations.product_internet_error_modal_title,
-          body: getErrorMessage(message),
-          positiveAction: SmoothActionButton(
-            text: localizations.close,
-            onPressed: () => Navigator.pop(context),
-          ),
-        );
-      },
-    );
-  }
+          return SmoothAlertDialog(
+            title: localizations.product_internet_error_modal_title,
+            body: getErrorMessage(message),
+            positiveAction: SmoothActionButton(
+              text: localizations.close,
+              onPressed: () => Navigator.pop(context),
+            ),
+          );
+        },
+      );
 
   /// Opens an error dialog; to be used only if the status is not ok.
   void openError(final FetchedProduct fetchedProduct) {

--- a/packages/smooth_app/lib/pages/product/common/product_dialog_helper.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_dialog_helper.dart
@@ -165,16 +165,23 @@ class ProductDialogHelper {
         ],
       );
 
-  void _openErrorMessage(final String message) => showDialog<void>(
-        context: context,
-        builder: (BuildContext context) => SmoothAlertDialog(
+  void _openErrorMessage(final String message) {
+    showDialog<void>(
+      context: context,
+      builder: (BuildContext context) {
+        final AppLocalizations localizations = AppLocalizations.of(context);
+
+        return SmoothAlertDialog(
+          title: localizations.product_internet_error_modal_title,
           body: getErrorMessage(message),
           positiveAction: SmoothActionButton(
-            text: AppLocalizations.of(context).close,
+            text: localizations.close,
             onPressed: () => Navigator.pop(context),
           ),
-        ),
-      );
+        );
+      },
+    );
+  }
 
   /// Opens an error dialog; to be used only if the status is not ok.
   void openError(final FetchedProduct fetchedProduct) {
@@ -185,7 +192,10 @@ class ProductDialogHelper {
       case FetchedProductStatus.userCancelled:
         return;
       case FetchedProductStatus.internetError:
-        _openErrorMessage(appLocalizations.product_internet_error);
+        _openErrorMessage(
+          appLocalizations.product_internet_error_modal_message(
+              fetchedProduct.exceptionString ?? '-'),
+        );
         return;
       case FetchedProductStatus.internetNotFound:
         _openProductNotFoundDialog();


### PR DESCRIPTION
Hi everyone,

We're having server problems at the moment.
I'd like to take this opportunity to explain the errors in a little more detail and potentially allow users to send them to us:

After:
<img width="443" alt="Screenshot 2024-05-27 at 20 00 43" src="https://github.com/openfoodfacts/smooth-app/assets/246838/2c63ac80-9a9a-497a-9a28-e56607bbd466">

Before (in French sorry):
<img width="443" alt="Screenshot 2024-05-27 at 19 55 10" src="https://github.com/openfoodfacts/smooth-app/assets/246838/be40438b-f7a6-4b49-8a7f-f736b1066e1d">
