### PR TITLE
fix: 5288 - added svg files to asset cache

### DIFF
--- a/packages/smooth_app/assets/cache/info.svg
+++ b/packages/smooth_app/assets/cache/info.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="icon" aria-hidden="true" focusable="false"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"/></svg>

--- a/packages/smooth_app/assets/cache/points-negative-0-20.svg
+++ b/packages/smooth_app/assets/cache/points-negative-0-20.svg
@@ -1,0 +1,1 @@
+<svg width="70" height="36" xmlns="http://www.w3.org/2000/svg"><path fill="#BDBDBD" d="M0 11h6v6H0zM7 11h6v6H7zM14 11h6v6h-6zM21 11h6v6h-6zM28 11h6v6h-6zM35 11h6v6h-6zM42 11h6v6h-6zM49 11h6v6h-6zM56 11h6v6h-6zM63 11h6v6h-6zM0 18h6v6H0zM7 18h6v6H7zM14 18h6v6h-6zM21 18h6v6h-6zM28 18h6v6h-6zM35 18h6v6h-6zM42 18h6v6h-6zM49 18h6v6h-6zM56 18h6v6h-6zM63 18h6v6h-6z"/></svg>

--- a/packages/smooth_app/assets/cache/points-negative-15-15.svg
+++ b/packages/smooth_app/assets/cache/points-negative-15-15.svg
@@ -1,0 +1,1 @@
+<svg width="70" height="36" xmlns="http://www.w3.org/2000/svg"><path fill="#EB5757" d="M0 11h6v6H0zM7 11h6v6H7zM14 11h6v6h-6zM21 11h6v6h-6zM28 11h6v6h-6zM35 11h6v6h-6zM42 11h6v6h-6zM49 11h6v6h-6zM56 11h6v6h-6zM63 11h6v6h-6zM0 18h6v6H0zM7 18h6v6H7zM14 18h6v6h-6zM21 18h6v6h-6zM28 18h6v6h-6z"/></svg>

--- a/packages/smooth_app/assets/cache/points-negative-3-10.svg
+++ b/packages/smooth_app/assets/cache/points-negative-3-10.svg
@@ -1,0 +1,1 @@
+<svg width="70" height="36" xmlns="http://www.w3.org/2000/svg"><path fill="#EB5757" d="M0 14h6v6H0zM7 14h6v6H7zM14 14h6v6h-6z"/><path fill="#BDBDBD" d="M21 14h6v6h-6zM28 14h6v6h-6zM35 14h6v6h-6zM42 14h6v6h-6zM49 14h6v6h-6zM56 14h6v6h-6zM63 14h6v6h-6z"/></svg>

--- a/packages/smooth_app/assets/cache/points-negative-5-10.svg
+++ b/packages/smooth_app/assets/cache/points-negative-5-10.svg
@@ -1,0 +1,1 @@
+<svg width="70" height="36" xmlns="http://www.w3.org/2000/svg"><path fill="#EB5757" d="M0 14h6v6H0zM7 14h6v6H7zM14 14h6v6h-6zM21 14h6v6h-6zM28 14h6v6h-6z"/><path fill="#BDBDBD" d="M35 14h6v6h-6zM42 14h6v6h-6zM49 14h6v6h-6zM56 14h6v6h-6zM63 14h6v6h-6z"/></svg>

--- a/packages/smooth_app/assets/cache/points-positive-0-5.svg
+++ b/packages/smooth_app/assets/cache/points-positive-0-5.svg
@@ -1,0 +1,1 @@
+<svg width="70" height="36" xmlns="http://www.w3.org/2000/svg"><path fill="#BDBDBD" d="M0 14h6v6H0zM7 14h6v6H7zM14 14h6v6h-6zM21 14h6v6h-6zM28 14h6v6h-6z"/></svg>


### PR DESCRIPTION
### What
- Added svg files to asset cache
- There will probably be more files given the naming of the files (e.g. `points-negative-5-10.svg`), but let's see first if we really need all of them (in case some ratings are never given).

### Part of 
- #5288
