### PR TITLE
feat: Use 'OpenSans' font by default

### DIFF
--- a/packages/smooth_app/lib/themes/smooth_theme.dart
+++ b/packages/smooth_app/lib/themes/smooth_theme.dart
@@ -40,6 +40,7 @@ class SmoothTheme {
 
     return ThemeData(
       useMaterial3: false,
+      fontFamily: 'OpenSans',
       primaryColor: DARK_BROWN_COLOR,
       extensions: <SmoothColorsThemeExtension>[
         SmoothColorsThemeExtension.defaultValues(),


### PR DESCRIPTION
Hi!
I don't know why the default font was not set, but it's now fixed