### PR TITLE
feat: Replace all `MediaQuery.of(context).size` with `MediaQuery.sizeOf(context)`

### DIFF
--- a/packages/smooth_app/lib/cards/data_cards/product_image_carousel_item.dart
+++ b/packages/smooth_app/lib/cards/data_cards/product_image_carousel_item.dart
@@ -31,7 +31,7 @@ class ProductImageCarouselItem extends StatefulWidget {
 class _ProductImageCarouselItemState extends State<ProductImageCarouselItem> {
   @override
   Widget build(BuildContext context) {
-    final Size screenSize = MediaQuery.of(context).size;
+    final Size screenSize = MediaQuery.sizeOf(context);
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     context.watch<LocalDatabase>();
     final ImageProvider? imageProvider = TransientFile.fromProductImageData(

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
@@ -35,7 +35,7 @@ class SmoothProductCardFound extends StatelessWidget {
     final UserPreferences userPreferences = context.watch<UserPreferences>();
     final ProductPreferences productPreferences =
         context.watch<ProductPreferences>();
-    final Size screenSize = MediaQuery.of(context).size;
+    final Size screenSize = MediaQuery.sizeOf(context);
     final ThemeData themeData = Theme.of(context);
     final bool isDarkMode = themeData.colorScheme.brightness == Brightness.dark;
     final List<String> excludedAttributeIds =

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_template.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_template.dart
@@ -24,7 +24,7 @@ class SmoothProductCardTemplate extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final Size screenSize = MediaQuery.of(context).size;
+    final Size screenSize = MediaQuery.sizeOf(context);
     final ThemeData themeData = Theme.of(context);
     final bool isDarkMode = themeData.colorScheme.brightness == Brightness.dark;
     final Color itemColor = isDarkMode ? PRIMARY_GREY_COLOR : LIGHT_GREY_COLOR;

--- a/packages/smooth_app/lib/generic_lib/dialogs/smooth_alert_dialog.dart
+++ b/packages/smooth_app/lib/generic_lib/dialogs/smooth_alert_dialog.dart
@@ -670,9 +670,9 @@ class SmoothListAlertDialog extends StatelessWidget {
         vertical: SMALL_SPACE,
       ),
       body: SizedBox(
-        height: MediaQuery.of(context).size.height /
+        height: MediaQuery.sizeOf(context).height /
             (context.keyboardVisible ? 1.0 : 1.5),
-        width: MediaQuery.of(context).size.width,
+        width: MediaQuery.sizeOf(context).width,
         child: Column(
           children: <Widget>[
             Container(

--- a/packages/smooth_app/lib/helpers/ui_helpers.dart
+++ b/packages/smooth_app/lib/helpers/ui_helpers.dart
@@ -16,7 +16,7 @@ class IconWidgetSizer {
   static const double _ICON_WIDGET_SIZE_RATIO = 1 / 10;
 
   static double getIconSizeFromContext(BuildContext context) {
-    final Size screenSize = MediaQuery.of(context).size;
+    final Size screenSize = MediaQuery.sizeOf(context);
     return screenSize.width * _ICON_WIDGET_SIZE_RATIO;
   }
 

--- a/packages/smooth_app/lib/pages/crop_page.dart
+++ b/packages/smooth_app/lib/pages/crop_page.dart
@@ -141,7 +141,7 @@ class _CropPageState extends State<CropPage> {
 
   @override
   Widget build(final BuildContext context) {
-    _screenSize = MediaQuery.of(context).size;
+    _screenSize = MediaQuery.sizeOf(context);
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     return WillPopScope2(
       onWillPop: _onWillPop,

--- a/packages/smooth_app/lib/pages/hunger_games/congrats.dart
+++ b/packages/smooth_app/lib/pages/hunger_games/congrats.dart
@@ -167,7 +167,7 @@ class _Header extends StatelessWidget {
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final double multiplier =
-        math.min(350, MediaQuery.of(context).size.height * 0.3) / 235;
+        math.min(350, MediaQuery.sizeOf(context).height * 0.3) / 235;
 
     return Semantics(
       enabled: true,

--- a/packages/smooth_app/lib/pages/hunger_games/question_answers_options.dart
+++ b/packages/smooth_app/lib/pages/hunger_games/question_answers_options.dart
@@ -23,7 +23,7 @@ class QuestionAnswersOptions extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final double yesNoHeight = MediaQuery.of(context).size.width / (3 * 1.25);
+    final double yesNoHeight = MediaQuery.sizeOf(context).width / (3 * 1.25);
 
     return Column(
       mainAxisSize: MainAxisSize.min,

--- a/packages/smooth_app/lib/pages/hunger_games/question_card.dart
+++ b/packages/smooth_app/lib/pages/hunger_games/question_card.dart
@@ -30,7 +30,7 @@ class QuestionCard extends StatelessWidget {
       context.read<LocalDatabase>(),
     );
 
-    final Size screenSize = MediaQuery.of(context).size;
+    final Size screenSize = MediaQuery.sizeOf(context);
 
     return FutureBuilder<FetchedProduct>(
       future: productFuture,

--- a/packages/smooth_app/lib/pages/locations/location_query_page.dart
+++ b/packages/smooth_app/lib/pages/locations/location_query_page.dart
@@ -44,7 +44,7 @@ class _LocationQueryPageState extends State<LocationQueryPage>
   @override
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    final Size screenSize = MediaQuery.of(context).size;
+    final Size screenSize = MediaQuery.sizeOf(context);
     final ThemeData themeData = Theme.of(context);
 
     return ChangeNotifierProvider<LocationQueryModel>.value(

--- a/packages/smooth_app/lib/pages/offline_data_page.dart
+++ b/packages/smooth_app/lib/pages/offline_data_page.dart
@@ -32,7 +32,7 @@ class _OfflineDataPageState extends State<OfflineDataPage> {
     // TODO(ashaman999): replaace the header asset with a custom one for this page
     const String headerAsset = 'assets/preferences/main.svg';
     final bool dark = Theme.of(context).brightness == Brightness.dark;
-    final double backgroundHeight = MediaQuery.of(context).size.height * .20;
+    final double backgroundHeight = MediaQuery.sizeOf(context).height * .20;
     final LocalDatabase localDatabase = context.watch<LocalDatabase>();
     final DaoProduct daoProduct = DaoProduct(localDatabase);
     final DaoProductLastAccess daoProductLastAccess =

--- a/packages/smooth_app/lib/pages/onboarding/consent_analytics_page.dart
+++ b/packages/smooth_app/lib/pages/onboarding/consent_analytics_page.dart
@@ -20,7 +20,7 @@ class ConsentAnalyticsPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final Size screenSize = MediaQuery.of(context).size;
+    final Size screenSize = MediaQuery.sizeOf(context);
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     return ColoredBox(
       color: backgroundColor,

--- a/packages/smooth_app/lib/pages/onboarding/knowledge_panel_page_template.dart
+++ b/packages/smooth_app/lib/pages/onboarding/knowledge_panel_page_template.dart
@@ -103,8 +103,7 @@ class _KnowledgePanelPageTemplateState
                             children: <Widget>[
                               SvgPicture.asset(
                                 widget.svgAsset,
-                                height:
-                                    MediaQuery.of(context).size.height * .25,
+                                height: MediaQuery.sizeOf(context).height * .25,
                                 package: AppHelper.APP_PACKAGE,
                               ),
                               Padding(

--- a/packages/smooth_app/lib/pages/onboarding/onboarding_bottom_bar.dart
+++ b/packages/smooth_app/lib/pages/onboarding/onboarding_bottom_bar.dart
@@ -24,7 +24,7 @@ class OnboardingBottomBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final Size screenSize = MediaQuery.of(context).size;
+    final Size screenSize = MediaQuery.sizeOf(context);
     // Side padding is 8% of total width.
     final double sidePadding = screenSize.width * .08;
     final bool hasPrevious = rightButton != null;

--- a/packages/smooth_app/lib/pages/onboarding/preferences_page.dart
+++ b/packages/smooth_app/lib/pages/onboarding/preferences_page.dart
@@ -82,7 +82,7 @@ class _HelperState extends State<_Helper> {
     final List<Widget> pageData = <Widget>[
       SvgPicture.asset(
         'assets/onboarding/preferences.svg',
-        height: MediaQuery.of(context).size.height * .25,
+        height: MediaQuery.sizeOf(context).height * .25,
         package: AppHelper.APP_PACKAGE,
       ),
       Padding(

--- a/packages/smooth_app/lib/pages/onboarding/reinvention_page.dart
+++ b/packages/smooth_app/lib/pages/onboarding/reinvention_page.dart
@@ -25,7 +25,7 @@ class ReinventionPage extends StatelessWidget {
         .textTheme
         .displayMedium!
         .copyWith(fontSize: muchTooBigFontSize);
-    final Size screenSize = MediaQuery.of(context).size;
+    final Size screenSize = MediaQuery.sizeOf(context);
     final double animHeight = 352.0 * screenSize.width / 375.0;
 
     return Container(

--- a/packages/smooth_app/lib/pages/onboarding/scan_example.dart
+++ b/packages/smooth_app/lib/pages/onboarding/scan_example.dart
@@ -17,7 +17,7 @@ class ScanExample extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    final Size screenSize = MediaQuery.of(context).size;
+    final Size screenSize = MediaQuery.sizeOf(context);
     return Container(
       color: backgroundColor,
       child: Column(

--- a/packages/smooth_app/lib/pages/onboarding/welcome_page.dart
+++ b/packages/smooth_app/lib/pages/onboarding/welcome_page.dart
@@ -22,7 +22,7 @@ class WelcomePage extends StatelessWidget {
     final ThemeData theme = Theme.of(context);
     final TextStyle headlineStyle = theme.textTheme.displayMedium!.wellSpaced;
     final TextStyle bodyTextStyle = theme.textTheme.bodyLarge!.wellSpaced;
-    final Size screenSize = MediaQuery.of(context).size;
+    final Size screenSize = MediaQuery.sizeOf(context);
 
     return SmoothScaffold(
       backgroundColor: backgroundColor,

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_account.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_account.dart
@@ -97,7 +97,7 @@ class UserPreferencesAccount extends AbstractUserPreferences {
       return null;
     }
     final ThemeData theme = Theme.of(context);
-    final Size size = MediaQuery.of(context).size;
+    final Size size = MediaQuery.sizeOf(context);
     return Container(
       margin: EdgeInsets.only(
         left: size.width / 4,
@@ -131,7 +131,7 @@ class UserPreferencesAccount extends AbstractUserPreferences {
   List<UserPreferencesItem> getChildren() {
     if (OpenFoodAPIConfiguration.globalUser == null) {
       // No credentials
-      final Size size = MediaQuery.of(context).size;
+      final Size size = MediaQuery.sizeOf(context);
       return <UserPreferencesItem>[
         UserPreferencesItemSimple(
           labels: <String>[appLocalizations.sign_in],

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_faq.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_faq.dart
@@ -239,7 +239,7 @@ class UserPreferencesFaq extends AbstractUserPreferences {
                 children: <Widget>[
                   SvgPicture.asset(
                     logo,
-                    width: MediaQuery.of(context).size.width * 0.1,
+                    width: MediaQuery.sizeOf(context).width * 0.1,
                     package: AppHelper.APP_PACKAGE,
                   ),
                   const SizedBox(width: SMALL_SPACE),
@@ -320,7 +320,7 @@ class UserPreferencesFaq extends AbstractUserPreferences {
                           applicationVersion: packageInfo.version,
                           applicationIcon: SvgPicture.asset(
                             logo,
-                            height: MediaQuery.of(context).size.height * 0.1,
+                            height: MediaQuery.sizeOf(context).height * 0.1,
                           ),
                         ),
                         label: appLocalizations.licenses,

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_page.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_page.dart
@@ -228,7 +228,7 @@ class _UserPreferencesPageState extends State<UserPreferencesPage>
       );
     }
     final bool dark = Theme.of(context).brightness == Brightness.dark;
-    final double backgroundHeight = MediaQuery.of(context).size.height * .20;
+    final double backgroundHeight = MediaQuery.sizeOf(context).height * .20;
     children.insert(
       0,
       Container(

--- a/packages/smooth_app/lib/pages/product/add_new_product_helper.dart
+++ b/packages/smooth_app/lib/pages/product/add_new_product_helper.dart
@@ -169,7 +169,7 @@ class AddNewProductScoreIcon extends StatelessWidget {
   Widget build(BuildContext context) {
     final String url = iconUrl ?? defaultIconUrl;
     final String fileName = Uri.parse(url).pathSegments.last;
-    final double height = MediaQuery.of(context).size.height * .2;
+    final double height = MediaQuery.sizeOf(context).height * .2;
 
     if (fileName.startsWith('nutriscore')) {
       return _AddNewProductNutriScoreIcon(

--- a/packages/smooth_app/lib/pages/product/add_other_details_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_other_details_page.dart
@@ -52,7 +52,7 @@ class _AddOtherDetailsPageState extends State<AddOtherDetailsPage> {
 
   @override
   Widget build(BuildContext context) {
-    final Size size = MediaQuery.of(context).size;
+    final Size size = MediaQuery.sizeOf(context);
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     return WillPopScope2(
       onWillPop: () async => (await _mayExitPage(saving: false), null),

--- a/packages/smooth_app/lib/pages/product/common/product_dialog_helper.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_dialog_helper.dart
@@ -60,7 +60,7 @@ class ProductDialogHelper {
   void _openProductNotFoundDialog() => showDialog<Widget>(
       context: context,
       builder: (BuildContext context) {
-        final double availableWidth = MediaQuery.of(context).size.width -
+        final double availableWidth = MediaQuery.sizeOf(context).width -
             SmoothAlertDialog.defaultMargin.horizontal -
             SmoothAlertDialog.defaultContentPadding(context).horizontal;
 

--- a/packages/smooth_app/lib/pages/product/common/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_page.dart
@@ -261,7 +261,7 @@ class _ProductListPageState extends State<ProductListPage>
                     SvgPicture.asset(
                       'assets/misc/empty-list.svg',
                       package: AppHelper.APP_PACKAGE,
-                      width: MediaQuery.of(context).size.width / 2,
+                      width: MediaQuery.sizeOf(context).width / 2,
                     ),
                     Text(
                       appLocalizations.product_list_empty_message,

--- a/packages/smooth_app/lib/pages/product/common/product_query_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_query_page.dart
@@ -96,7 +96,7 @@ class _ProductQueryPageState extends State<ProductQueryPage>
   @override
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    final Size screenSize = MediaQuery.of(context).size;
+    final Size screenSize = MediaQuery.sizeOf(context);
     final ThemeData themeData = Theme.of(context);
 
     return ChangeNotifierProvider<ProductQueryModel>.value(
@@ -264,7 +264,7 @@ class _ProductQueryPageState extends State<ProductQueryPage>
                     return const Center(child: CircularProgressIndicator());
                   }
                   return SizedBox(
-                    height: MediaQuery.of(context).size.height / 4,
+                    height: MediaQuery.sizeOf(context).height / 4,
                   );
                 }
                 return ProductListItemSimple(

--- a/packages/smooth_app/lib/pages/product/common/product_refresher.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_refresher.dart
@@ -37,7 +37,7 @@ class ProductRefresher {
             children: <Widget>[
               SvgPicture.asset(
                 'assets/onboarding/globe.svg',
-                height: MediaQuery.of(context).size.height * .5,
+                height: MediaQuery.sizeOf(context).height * .5,
               ),
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 25),

--- a/packages/smooth_app/lib/pages/product/compare_products3_page.dart
+++ b/packages/smooth_app/lib/pages/product/compare_products3_page.dart
@@ -104,7 +104,7 @@ class _CompareProducts3PageState extends State<CompareProducts3Page> {
     final List<String> brands = <String>[];
     final List<String> quantities = <String>[];
     final List<Widget> pictures = <Widget>[];
-    final Size screenSize = MediaQuery.of(context).size;
+    final Size screenSize = MediaQuery.sizeOf(context);
     for (final Product product in widget.products) {
       names.add(getProductName(product, appLocalizations));
       brands.add(getProductBrands(product, appLocalizations));

--- a/packages/smooth_app/lib/pages/product/edit_ocr_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_ocr_page.dart
@@ -156,7 +156,7 @@ class _EditOcrPageState extends State<EditOcrPage> with UpToDateMixin {
       );
 
   Widget _getImageWidget(final TransientFile transientFile) {
-    final Size size = MediaQuery.of(context).size;
+    final Size size = MediaQuery.sizeOf(context);
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final ImageProvider? imageProvider = transientFile.getImageProvider();
 

--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -386,7 +386,7 @@ class _ProductBarcodeState extends State<_ProductBarcode> {
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final Brightness brightness = Theme.of(context).brightness;
-    final Size screenSize = MediaQuery.of(context).size;
+    final Size screenSize = MediaQuery.sizeOf(context);
 
     return BarcodeWidget(
       padding: EdgeInsets.symmetric(

--- a/packages/smooth_app/lib/pages/product/product_question_answers_options.dart
+++ b/packages/smooth_app/lib/pages/product/product_question_answers_options.dart
@@ -22,7 +22,7 @@ class ProductQuestionAnswersOptions extends StatelessWidget {
     const Color yesNoTextColor = Colors.white;
     final Color maybeTextColor = Colors.grey.shade700;
 
-    final double yesNoHeight = MediaQuery.of(context).size.width / (6);
+    final double yesNoHeight = MediaQuery.sizeOf(context).width / (6);
 
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/packages/smooth_app/lib/pages/user_management/forgot_password_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/forgot_password_page.dart
@@ -69,7 +69,7 @@ class _ForgotPasswordPageState extends State<ForgotPasswordPage>
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    final Size size = MediaQuery.of(context).size;
+    final Size size = MediaQuery.sizeOf(context);
 
     return SmoothScaffold(
       appBar: SmoothAppBar(

--- a/packages/smooth_app/lib/pages/user_management/login_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/login_page.dart
@@ -87,7 +87,7 @@ class _LoginPageState extends State<LoginPage> with TraceableClientMixin {
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    final Size size = MediaQuery.of(context).size;
+    final Size size = MediaQuery.sizeOf(context);
 
     return SmoothScaffold(
       statusBarBackgroundColor: SmoothScaffold.semiTranslucentStatusBar,
@@ -121,7 +121,7 @@ class _LoginPageState extends State<LoginPage> with TraceableClientMixin {
                     children: <Widget>[
                       SvgPicture.asset(
                         'assets/preferences/login.svg',
-                        height: MediaQuery.of(context).size.height * .15,
+                        height: MediaQuery.sizeOf(context).height * .15,
                         package: AppHelper.APP_PACKAGE,
                       ),
                       Text(

--- a/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
@@ -53,7 +53,7 @@ class _SignUpPageState extends State<SignUpPage> with TraceableClientMixin {
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    final Size size = MediaQuery.of(context).size;
+    final Size size = MediaQuery.sizeOf(context);
 
     Color getCheckBoxColor(Set<MaterialState> states) {
       const Set<MaterialState> interactiveStates = <MaterialState>{

--- a/packages/smooth_app/lib/widgets/attribute_button.dart
+++ b/packages/smooth_app/lib/widgets/attribute_button.dart
@@ -30,7 +30,7 @@ class AttributeButton extends StatelessWidget {
         productPreferences.getImportanceIdForAttributeId(attribute.id!);
     const double horizontalPadding = LARGE_SPACE;
     final double widgetWidth =
-        MediaQuery.of(context).size.width - 2 * horizontalPadding;
+        MediaQuery.sizeOf(context).width - 2 * horizontalPadding;
     final double importanceWidth = widgetWidth / 4;
     final TextStyle style = themeData.textTheme.headlineMedium!;
     final String? info = attribute.settingNote;

--- a/packages/smooth_app/lib/widgets/ranking_floating_action_button.dart
+++ b/packages/smooth_app/lib/widgets/ranking_floating_action_button.dart
@@ -22,7 +22,7 @@ class RankingFloatingActionButton extends StatelessWidget {
         child: Container(
           height: MINIMUM_TOUCH_SIZE,
           margin:
-              EdgeInsets.only(left: MediaQuery.of(context).size.width * 0.09),
+              EdgeInsets.only(left: MediaQuery.sizeOf(context).width * 0.09),
           alignment: Alignment.center,
           child: SizedBox(
             height: MINIMUM_TOUCH_SIZE,

--- a/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
+++ b/packages/smooth_app/lib/widgets/smooth_product_carousel.dart
@@ -203,7 +203,7 @@ class _SmoothProductCarouselState extends State<SmoothProductCarousel> {
   }
 
   double _computeViewPortFraction() {
-    final double screenWidth = MediaQuery.of(context).size.width;
+    final double screenWidth = MediaQuery.sizeOf(context).width;
     return (screenWidth -
             (SmoothBarcodeScannerVisor.CORNER_PADDING * 2) -
             (SmoothBarcodeScannerVisor.STROKE_WIDTH * 2) +


### PR DESCRIPTION
Hi everyone,

An `InheritedModel` is far more efficient than an `InheritedWidget`.
With that change, we should remove a few unnecessary draws.