### PR TITLE
feat: added deeplinking for the sign up page #4169

### DIFF
--- a/packages/smooth_app/ios/Podfile.lock
+++ b/packages/smooth_app/ios/Podfile.lock
@@ -130,8 +130,6 @@ PODS:
   - SDWebImageWebPCoder (0.14.6):
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.17)
-  - sensors_plus (0.0.1):
-    - Flutter
   - Sentry/HybridSDK (8.21.0):
     - SentryPrivate (= 8.21.0)
   - sentry_flutter (0.0.1):
@@ -175,7 +173,6 @@ DEPENDENCIES:
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - qr_code_scanner (from `.symlinks/plugins/qr_code_scanner/ios`)
   - rive_common (from `.symlinks/plugins/rive_common/ios`)
-  - sensors_plus (from `.symlinks/plugins/sensors_plus/ios`)
   - sentry_flutter (from `.symlinks/plugins/sentry_flutter/ios`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
@@ -251,8 +248,6 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/qr_code_scanner/ios"
   rive_common:
     :path: ".symlinks/plugins/rive_common/ios"
-  sensors_plus:
-    :path: ".symlinks/plugins/sensors_plus/ios"
   sentry_flutter:
     :path: ".symlinks/plugins/sentry_flutter/ios"
   share_plus:
@@ -307,7 +302,6 @@ SPEC CHECKSUMS:
   rive_common: cbbac3192af00d7341f19dae2f26298e9e37d99e
   SDWebImage: dfe95b2466a9823cf9f0c6d01217c06550d7b29a
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
-  sensors_plus: 4ee32bc7d61a055f27f88d3215ad6b6fb96a2b8e
   Sentry: ebc12276bd17613a114ab359074096b6b3725203
   sentry_flutter: dff1df05dc39c83d04f9330b36360fc374574c5e
   SentryPrivate: d651efb234cf385ec9a1cdd3eff94b5e78a0e0fe

--- a/packages/smooth_app/lib/pages/navigator/app_navigator.dart
+++ b/packages/smooth_app/lib/pages/navigator/app_navigator.dart
@@ -283,6 +283,8 @@ class _SmoothGoRouter {
             return AppRoutes.HOME;
           } else if (path == _ExternalRoutes.GUIDE_NUTRISCORE_V2) {
             return AppRoutes.GUIDE_NUTRISCORE_V2;
+          } else if (path == _ExternalRoutes.SIGNUP) {
+            return AppRoutes.SIGNUP;
           } else if (path != _InternalAppRoutes.HOME_PAGE) {
             externalLink = true;
           }
@@ -402,6 +404,7 @@ class _ExternalRoutes {
   static const String MOBILE_APP_DOWNLOAD = '/open-food-facts-mobile-app';
   static const String PRODUCT_EDITION = '/cgi/product.pl';
   static const String GUIDE_NUTRISCORE_V2 = '/nutriscore-v2';
+  static const String SIGNUP = '/signup';
 }
 
 /// A list of internal routes to use with [AppNavigator]
@@ -446,6 +449,7 @@ class AppRoutes {
   static String get GUIDE_NUTRISCORE_V2 =>
       '/${_InternalAppRoutes._GUIDES}/${_InternalAppRoutes.GUIDE_NUTRISCORE_V2_PAGE}';
 
+  static String get SIGNUP => '/${_InternalAppRoutes.SIGNUP_PAGE}';
   // Open an external link (where path is relative to the OFF website)
   static String EXTERNAL(String path) =>
       '/${_InternalAppRoutes.EXTERNAL_PAGE}/?path=$path';

--- a/packages/smooth_app/lib/pages/navigator/app_navigator.dart
+++ b/packages/smooth_app/lib/pages/navigator/app_navigator.dart
@@ -19,6 +19,7 @@ import 'package:smooth_app/pages/product/new_product_page.dart';
 import 'package:smooth_app/pages/product/product_loader_page.dart';
 import 'package:smooth_app/pages/scan/search_page.dart';
 import 'package:smooth_app/pages/scan/search_product_helper.dart';
+import 'package:smooth_app/pages/user_management/sign_up_page.dart';
 import 'package:smooth_app/query/product_query.dart';
 
 /// A replacement for the [Navigator], where we internally use [GoRouter].
@@ -227,6 +228,10 @@ class _SmoothGoRouter {
                 return ExternalPage(path: state.uri.queryParameters['path']!);
               },
             ),
+            GoRoute(
+              path: _InternalAppRoutes.SIGNUP_PAGE,
+              builder:(_, __) => const SignUpPage(),
+              )
           ],
         ),
       ],
@@ -387,6 +392,7 @@ class _InternalAppRoutes {
   static const String PREFERENCES_PAGE = '_preferences';
   static const String SEARCH_PAGE = '_search';
   static const String EXTERNAL_PAGE = '_external';
+  static const String SIGNUP_PAGE = '_signup';
 
   static const String _GUIDES = '_guides';
   static const String GUIDE_NUTRISCORE_V2_PAGE = '_nutriscore-v2';

--- a/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
+import 'package:smooth_app/data_models/preferences/user_preferences.dart';
 import 'package:smooth_app/data_models/user_management_provider.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
@@ -46,8 +47,20 @@ class _SignUpPageState extends State<SignUpPage> with TraceableClientMixin {
   bool _subscribe = false;
   bool _disagreed = false;
 
+  late UserPreferences _userPreferences;
+
   @override
   String get actionName => 'Opened sign_up_page';
+  
+  @override
+  void initState() {
+  super.initState();
+  getUserPreferences();
+  }
+
+  Future<void> getUserPreferences() async {
+    _userPreferences = await UserPreferences.getUserPreferences();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -314,6 +327,7 @@ class _SignUpPageState extends State<SignUpPage> with TraceableClientMixin {
   }
 
   Future<void> _signUp() async {
+    ///add and make complete onboarding false at signup.
     final AppLocalizations appLocalisations = AppLocalizations.of(context);
     _disagreed = !_agree;
     setState(() {});
@@ -411,6 +425,8 @@ class _SignUpPageState extends State<SignUpPage> with TraceableClientMixin {
     if (!mounted) {
       return;
     }
+    debugPrint('Reseting Onboarding');
+    _userPreferences.resetOnboarding();
     await showDialog<void>(
       context: context,
       builder: (BuildContext context) => SmoothAlertDialog(

--- a/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
@@ -47,21 +47,9 @@ class _SignUpPageState extends State<SignUpPage> with TraceableClientMixin {
   bool _subscribe = false;
   bool _disagreed = false;
 
-  late UserPreferences _userPreferences;
-
   @override
   String get actionName => 'Opened sign_up_page';
   
-  @override
-  void initState() {
-  super.initState();
-  getUserPreferences();
-  }
-
-  Future<void> getUserPreferences() async {
-    _userPreferences = await UserPreferences.getUserPreferences();
-  }
-
   @override
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
@@ -425,8 +413,8 @@ class _SignUpPageState extends State<SignUpPage> with TraceableClientMixin {
     if (!mounted) {
       return;
     }
-    debugPrint('Reseting Onboarding');
-    _userPreferences.resetOnboarding();
+    final UserPreferences userPreferences = await UserPreferences.getUserPreferences();
+    userPreferences.resetOnboarding();
     await showDialog<void>(
       context: context,
       builder: (BuildContext context) => SmoothAlertDialog(


### PR DESCRIPTION
[###](url) What
 Added deep linking for the sign-up page. Also, reset the users onboarding settings so that it shows them onboarding right after they sign up. 

To test the screen before releasing it, a deep link is now available: https://fr.openfoodfacts.org/_signup/

- <!-- Changed x to achieve y -->
<!-- 
Please name your pull request following this scheme: `type: What you did` this allows us to automatically generate the changelog
Following `type`s are allowed:
  - `feat`, for Features
  - `fix`, for Bug Fixes
  - `docs`, for Documentation
  - `ci`, for Automation
  - `refactor`, for code Refactoring
  - `chore`, for Miscellaneous things
-->
### Screenshot

https://github.com/openfoodfacts/smooth-app/assets/32947267/68117d2c-5410-4c5d-ac4f-0552e3909728

<!-- Insert a screenshot to provide visual record of your changes, if visible -->

### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes: <!-- #1 Note: you can also use Closes: -->

### Part of 
- #525 <!-- Add the most granular issue possible -->
