### PR TITLE
feat: 5301 - added an erasing tool for proofs

### DIFF
--- a/packages/smooth_app/lib/background/background_task_add_price.dart
+++ b/packages/smooth_app/lib/background/background_task_add_price.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:crop_image/crop_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:http_parser/http_parser.dart';
@@ -11,6 +12,8 @@ import 'package:smooth_app/background/background_task_upload.dart';
 import 'package:smooth_app/background/operation_type.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/pages/crop_parameters.dart';
+import 'package:smooth_app/pages/prices/eraser_model.dart';
+import 'package:smooth_app/pages/prices/eraser_painter.dart';
 
 // TODO(monsieurtanuki): use transient file, in order to have instant access to proof image?
 // TODO(monsieurtanuki): add source
@@ -33,6 +36,8 @@ class BackgroundTaskAddPrice extends BackgroundTask {
     required this.currency,
     required this.locationOSMId,
     required this.locationOSMType,
+    // lines
+    required this.eraserCoordinates,
     // multi
     required this.barcode,
     required this.priceIsDiscounted,
@@ -53,11 +58,24 @@ class BackgroundTaskAddPrice extends BackgroundTask {
         locationOSMId = json[_jsonTagOSMId] as int,
         locationOSMType =
             LocationOSMType.fromOffTag(json[_jsonTagOSMType] as String)!,
+        eraserCoordinates =
+            _fromJsonListDouble(json[_jsonTagEraserCoordinates]),
         barcode = json[_jsonTagBarcode] as String,
         priceIsDiscounted = json[_jsonTagIsDiscounted] as bool,
         price = json[_jsonTagPrice] as double,
         priceWithoutDiscount = json[_jsonTagPriceWithoutDiscount] as double?,
         super.fromJson(json);
+
+  static List<double>? _fromJsonListDouble(final List<dynamic>? input) {
+    if (input == null) {
+      return null;
+    }
+    final List<double> result = <double>[];
+    for (final dynamic item in input) {
+      result.add(item as double);
+    }
+    return result;
+  }
 
   static const String _jsonTagImagePath = 'imagePath';
   static const String _jsonTagRotation = 'rotation';
@@ -67,6 +85,7 @@ class BackgroundTaskAddPrice extends BackgroundTask {
   static const String _jsonTagY2 = 'y2';
   static const String _jsonTagProofType = 'proofType';
   static const String _jsonTagDate = 'date';
+  static const String _jsonTagEraserCoordinates = 'eraserCoordinates';
   static const String _jsonTagCurrency = 'currency';
   static const String _jsonTagOSMId = 'osmId';
   static const String _jsonTagOSMType = 'osmType';
@@ -88,6 +107,7 @@ class BackgroundTaskAddPrice extends BackgroundTask {
   final Currency currency;
   final int locationOSMId;
   final LocationOSMType locationOSMType;
+  final List<double>? eraserCoordinates;
   final String barcode;
   final bool priceIsDiscounted;
   final double price;
@@ -107,6 +127,7 @@ class BackgroundTaskAddPrice extends BackgroundTask {
     result[_jsonTagCurrency] = currency.name;
     result[_jsonTagOSMId] = locationOSMId;
     result[_jsonTagOSMType] = locationOSMType.offTag;
+    result[_jsonTagEraserCoordinates] = eraserCoordinates;
     result[_jsonTagBarcode] = barcode;
     result[_jsonTagIsDiscounted] = priceIsDiscounted;
     result[_jsonTagPrice] = price;
@@ -185,6 +206,7 @@ class BackgroundTaskAddPrice extends BackgroundTask {
         currency: currency,
         locationOSMId: locationOSMId,
         locationOSMType: locationOSMType,
+        eraserCoordinates: cropObject.eraserCoordinates,
         barcode: barcode,
         priceIsDiscounted: priceIsDiscounted,
         price: price,
@@ -238,6 +260,16 @@ class BackgroundTaskAddPrice extends BackgroundTask {
       ..priceWithoutDiscount = priceWithoutDiscount
       ..productCode = barcode;
 
+    final List<Offset> offsets = <Offset>[];
+    if (eraserCoordinates != null) {
+      for (int i = 0; i < eraserCoordinates!.length; i += 2) {
+        final Offset offset = Offset(
+          eraserCoordinates![i],
+          eraserCoordinates![i + 1],
+        );
+        offsets.add(offset);
+      }
+    }
     final String? path = await BackgroundTaskImage.cropIfNeeded(
       fullPath: fullPath,
       croppedPath: BackgroundTaskImage.getCroppedPath(fullPath),
@@ -246,6 +278,20 @@ class BackgroundTaskAddPrice extends BackgroundTask {
       cropY1: cropY1,
       cropX2: cropX2,
       cropY2: cropY2,
+      overlayPainter: offsets.isEmpty
+          ? null
+          : EraserPainter(
+              eraserModel: EraserModel(
+                rotation: CropRotationExtension.fromDegrees(rotationDegrees)!,
+                offsets: offsets,
+              ),
+              cropRect: BackgroundTaskImage.getDownsizedRect(
+                cropX1,
+                cropY1,
+                cropX2,
+                cropY2,
+              ),
+            ),
     );
     if (path == null) {
       // TODO(monsieurtanuki): maybe something more refined when we dismiss the picture, like alerting the user, though it's not supposed to happen anymore from upstream.

--- a/packages/smooth_app/lib/background/background_task_image.dart
+++ b/packages/smooth_app/lib/background/background_task_image.dart
@@ -202,7 +202,7 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
   static Rect getUpsizedRect(final Rect source) =>
       getResizedRect(source, _cropConversionFactor);
 
-  static Rect _getDownsizedRect(
+  static Rect getDownsizedRect(
     final int cropX1,
     final int cropY1,
     final int cropX2,
@@ -234,6 +234,7 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
     required final int cropY1,
     required final int cropX2,
     required final int cropY2,
+    final CustomPainter? overlayPainter,
   }) async {
     final ui.Image full = await loadUiImage(
         await (await BackgroundTaskUpload.getFile(fullPath)).readAsBytes());
@@ -246,11 +247,13 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
         return null;
       }
       // in that case, no need to crop
-      return fullPath;
+      if (overlayPainter == null) {
+        return fullPath;
+      }
     }
 
     Size getCroppedSize() {
-      final Rect cropRect = _getDownsizedRect(cropX1, cropY1, cropX2, cropY2);
+      final Rect cropRect = getDownsizedRect(cropX1, cropY1, cropX2, cropY2);
       switch (CropRotationExtension.fromDegrees(rotationDegrees)!) {
         case CropRotation.up:
         case CropRotation.down:
@@ -272,11 +275,12 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
       return null;
     }
     final ui.Image cropped = await CropController.getCroppedBitmap(
-      crop: _getDownsizedRect(cropX1, cropY1, cropX2, cropY2),
+      crop: getDownsizedRect(cropX1, cropY1, cropX2, cropY2),
       rotation: CropRotationExtension.fromDegrees(rotationDegrees)!,
       image: full,
       maxSize: null,
       quality: FilterQuality.high,
+      overlayPainter: overlayPainter,
     );
     await saveJpeg(
       file: await BackgroundTaskUpload.getFile(croppedPath),

--- a/packages/smooth_app/lib/background/operation_type.dart
+++ b/packages/smooth_app/lib/background/operation_type.dart
@@ -67,66 +67,41 @@ enum OperationType {
         '$_transientHeaderSeparator${work ?? ''}';
   }
 
-  BackgroundTask fromJson(Map<String, dynamic> map) {
-    switch (this) {
-      case crop:
-        return BackgroundTaskCrop.fromJson(map);
-      case addPrice:
-        return BackgroundTaskAddPrice.fromJson(map);
-      case details:
-        return BackgroundTaskDetails.fromJson(map);
-      case hungerGames:
-        return BackgroundTaskHungerGames.fromJson(map);
-      case image:
-        return BackgroundTaskImage.fromJson(map);
-      case refreshLater:
-        return BackgroundTaskRefreshLater.fromJson(map);
-      case unselect:
-        return BackgroundTaskUnselect.fromJson(map);
-      case offline:
-        return BackgroundTaskOffline.fromJson(map);
-      case offlineBarcodes:
-        return BackgroundTaskTopBarcodes.fromJson(map);
-      case offlineProducts:
-        return BackgroundTaskDownloadProducts.fromJson(map);
-      case fullRefresh:
-        return BackgroundTaskFullRefresh.fromJson(map);
-      case languageRefresh:
-        return BackgroundTaskLanguageRefresh.fromJson(map);
-    }
-  }
+  BackgroundTask fromJson(Map<String, dynamic> map) => switch (this) {
+        crop => BackgroundTaskCrop.fromJson(map),
+        addPrice => BackgroundTaskAddPrice.fromJson(map),
+        details => BackgroundTaskDetails.fromJson(map),
+        hungerGames => BackgroundTaskHungerGames.fromJson(map),
+        image => BackgroundTaskImage.fromJson(map),
+        refreshLater => BackgroundTaskRefreshLater.fromJson(map),
+        unselect => BackgroundTaskUnselect.fromJson(map),
+        offline => BackgroundTaskOffline.fromJson(map),
+        offlineBarcodes => BackgroundTaskTopBarcodes.fromJson(map),
+        offlineProducts => BackgroundTaskDownloadProducts.fromJson(map),
+        fullRefresh => BackgroundTaskFullRefresh.fromJson(map),
+        languageRefresh => BackgroundTaskLanguageRefresh.fromJson(map),
+      };
 
   bool matches(final TransientOperation action) =>
       action.key.startsWith('$header$_transientHeaderSeparator');
 
-  String getLabel(final AppLocalizations appLocalizations) {
-    switch (this) {
-      case OperationType.details:
-        return appLocalizations.background_task_operation_details;
-      case OperationType.addPrice:
-        return 'Add price';
-      case OperationType.image:
-        return appLocalizations.background_task_operation_image;
-      case OperationType.unselect:
-        return 'Unselect a product image';
-      case OperationType.hungerGames:
-        return 'Answering to a Hunger Games question';
-      case OperationType.crop:
-        return 'Crop an existing image';
-      case OperationType.refreshLater:
-        return 'Waiting 10 min before refreshing product to get all automatic edits';
-      case OperationType.offline:
-        return 'Downloading top n products for offline usage';
-      case OperationType.offlineBarcodes:
-        return 'Downloading top n barcodes';
-      case OperationType.offlineProducts:
-        return 'Downloading products';
-      case OperationType.fullRefresh:
-        return 'Refreshing the full local database';
-      case OperationType.languageRefresh:
-        return 'Refreshing the local database to a new language';
-    }
-  }
+  String getLabel(final AppLocalizations appLocalizations) => switch (this) {
+        OperationType.details =>
+          appLocalizations.background_task_operation_details,
+        OperationType.addPrice => 'Add price',
+        OperationType.image => appLocalizations.background_task_operation_image,
+        OperationType.unselect => 'Unselect a product image',
+        OperationType.hungerGames => 'Answering to a Hunger Games question',
+        OperationType.crop => 'Crop an existing image',
+        OperationType.refreshLater =>
+          'Waiting 10 min before refreshing product to get all automatic edits',
+        OperationType.offline => 'Downloading top n products for offline usage',
+        OperationType.offlineBarcodes => 'Downloading top n barcodes',
+        OperationType.offlineProducts => 'Downloading products',
+        OperationType.fullRefresh => 'Refreshing the full local database',
+        OperationType.languageRefresh =>
+          'Refreshing the local database to a new language',
+      };
 
   static int getSequentialId(final TransientOperation operation) {
     final List<String> keyItems =

--- a/packages/smooth_app/lib/pages/crop_helper.dart
+++ b/packages/smooth_app/lib/pages/crop_helper.dart
@@ -31,7 +31,11 @@ abstract class CropHelper {
     required final File smallCroppedFile,
     required final Directory directory,
     required final int sequenceNumber,
+    final List<Offset>? offsets,
   });
+
+  /// Should we display the eraser with the crop grid?
+  bool get enableEraser;
 
   /// Returns the crop rect according to local cropping method * factor.
   @protected
@@ -43,8 +47,16 @@ abstract class CropHelper {
     required final CropController controller,
     required final File? fullFile,
     required final File smallCroppedFile,
+    final List<Offset>? offsets,
   }) {
     final Rect cropRect = getLocalCropRect(controller);
+    final List<double> eraserCoordinates = <double>[];
+    if (offsets != null) {
+      for (final Offset offset in offsets) {
+        eraserCoordinates.add(offset.dx);
+        eraserCoordinates.add(offset.dy);
+      }
+    }
     return CropParameters(
       fullFile: fullFile,
       smallCroppedFile: smallCroppedFile,
@@ -53,6 +65,7 @@ abstract class CropHelper {
       y1: cropRect.top.ceil(),
       x2: cropRect.right.floor(),
       y2: cropRect.bottom.floor(),
+      eraserCoordinates: eraserCoordinates,
     );
   }
 

--- a/packages/smooth_app/lib/pages/crop_parameters.dart
+++ b/packages/smooth_app/lib/pages/crop_parameters.dart
@@ -10,6 +10,7 @@ class CropParameters {
     required this.y1,
     required this.x2,
     required this.y2,
+    this.eraserCoordinates,
   });
 
   /// File of the full image.
@@ -23,4 +24,6 @@ class CropParameters {
   final int y1;
   final int x2;
   final int y2;
+
+  final List<double>? eraserCoordinates;
 }

--- a/packages/smooth_app/lib/pages/prices/eraser_model.dart
+++ b/packages/smooth_app/lib/pages/prices/eraser_model.dart
@@ -1,0 +1,130 @@
+import 'package:crop_image/crop_image.dart';
+import 'package:flutter/rendering.dart';
+
+/// Model about the eraser tool: coordinate computations.
+class EraserModel {
+  EraserModel({
+    this.rotation = CropRotation.up,
+    final List<Offset>? offsets,
+  }) : offsets = offsets ?? <Offset>[];
+
+  CropRotation rotation;
+
+  final List<Offset> offsets;
+
+  Rect? cropRect;
+
+  late double _imageWidth;
+  late double _imageHeight;
+
+  // Canvas size.
+  set size(final Size value) {
+    _imageWidth = value.width;
+    _imageHeight = value.height;
+  }
+
+  // Full displayed image dimensions. For screen crop grid only.
+  late double _fullWidth;
+  late double _fullHeight;
+
+  set _boxConstraints(final BoxConstraints value) {
+    _fullWidth = value.maxWidth;
+    _fullHeight = value.maxHeight;
+  }
+
+  double get _deltaX => (_fullWidth - _imageWidth) / 2;
+  double get _deltaY => (_fullHeight - _imageHeight) / 2;
+
+  Offset? _latestStart;
+  Offset? _latestUpdate;
+
+  bool get isEmpty => offsets.isEmpty;
+
+  int get length => offsets.length ~/ 2;
+
+  static const Rect _fullImageCropRect = Rect.fromLTRB(0, 0, 1, 1);
+
+  // From full image [0,1] to possibly cropped
+  Offset _fromPct(final Offset offset) {
+    final Rect rect = cropRect ?? _fullImageCropRect;
+    return switch (rotation) {
+      CropRotation.down => Offset(
+          (1 - offset.dx - rect.left) / rect.width * _imageWidth,
+          (1 - offset.dy - rect.top) / rect.height * _imageHeight,
+        ),
+      CropRotation.left => Offset(
+          (offset.dy - rect.left) / rect.width * _imageWidth,
+          (1 - offset.dx - rect.top) / rect.height * _imageHeight,
+        ),
+      CropRotation.right => Offset(
+          (1 - offset.dy - rect.left) / rect.width * _imageWidth,
+          (offset.dx - rect.top) / rect.height * _imageHeight,
+        ),
+      CropRotation.up => Offset(
+          (offset.dx - rect.left) / rect.width * _imageWidth,
+          (offset.dy - rect.top) / rect.height * _imageHeight,
+        ),
+    };
+  }
+
+  // From screen offset to full image [0,1] offset
+  Offset _toPct(final Offset offset) => switch (rotation) {
+        CropRotation.down => Offset(
+            (_imageWidth - (offset.dx - _deltaX)) / _imageWidth,
+            (_imageHeight - (offset.dy - _deltaY)) / _imageHeight,
+          ),
+        CropRotation.left => Offset(
+            (_imageHeight - (offset.dy - _deltaY)) / _imageHeight,
+            (0 + (offset.dx - _deltaX)) / _imageWidth,
+          ),
+        CropRotation.right => Offset(
+            (offset.dy - _deltaY) / _imageHeight,
+            (_imageWidth - (offset.dx - _deltaX)) / _imageWidth,
+          ),
+        _ => Offset(
+            (offset.dx - _deltaX) / _imageWidth,
+            (offset.dy - _deltaY) / _imageHeight,
+          ),
+      };
+
+  Offset getStart(final int index) => _fromPct(offsets[2 * index]);
+
+  Offset getEnd(final int index) => _fromPct(offsets[2 * index + 1]);
+
+  Offset? getCurrentStart() =>
+      _latestStart == null ? null : _fromPct(_latestStart!);
+
+  Offset? getCurrentEnd() =>
+      _latestUpdate == null ? null : _fromPct(_latestUpdate!);
+
+  void panStart(
+    final Offset offset,
+    final BoxConstraints constraints,
+  ) {
+    _boxConstraints = constraints;
+    _latestStart = _latestUpdate = _toPct(offset);
+  }
+
+  void panUpdate(
+    final Offset offset,
+    final BoxConstraints constraints,
+  ) {
+    _boxConstraints = constraints;
+    _latestUpdate = _toPct(offset);
+  }
+
+  void panEnd() {
+    if (_latestStart != _latestUpdate) {
+      if (_latestStart != null && _latestUpdate != null) {
+        offsets.add(_latestStart!);
+        offsets.add(_latestUpdate!);
+      }
+    }
+    _latestStart = _latestUpdate = null;
+  }
+
+  void undo() {
+    offsets.removeLast();
+    offsets.removeLast();
+  }
+}

--- a/packages/smooth_app/lib/pages/prices/eraser_painter.dart
+++ b/packages/smooth_app/lib/pages/prices/eraser_painter.dart
@@ -1,0 +1,62 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:smooth_app/pages/prices/eraser_model.dart';
+
+/// Painter of the eraser tool: displaying thick lines.
+class EraserPainter extends CustomPainter {
+  EraserPainter({
+    required this.eraserModel,
+    this.cropRect,
+  });
+
+  final EraserModel eraserModel;
+  final Rect? cropRect;
+
+  static const Color color = Colors.black;
+
+  final Paint _paint = Paint()
+    ..color = color
+    ..style = PaintingStyle.stroke
+    ..strokeCap = StrokeCap.round;
+
+  final Path _path = Path();
+
+  void _addToPath(final Offset start, final Offset end) {
+    _path.moveTo(start.dx, start.dy);
+    _path.lineTo(end.dx, end.dy);
+  }
+
+  static const double _strokeWidthFactor = .03;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    eraserModel.size = size;
+
+    eraserModel.cropRect = cropRect;
+
+    if (cropRect == null) {
+      _paint.strokeWidth = _strokeWidthFactor * sqrt(size.width * size.height);
+    } else {
+      _paint.strokeWidth = _strokeWidthFactor *
+          sqrt(size.width * size.height / cropRect!.width / cropRect!.height);
+    }
+
+    _path.reset();
+    for (int i = 0; i < eraserModel.length; i++) {
+      _addToPath(eraserModel.getStart(i), eraserModel.getEnd(i));
+    }
+    final Offset? currentStart = eraserModel.getCurrentStart();
+    final Offset? currentEnd = eraserModel.getCurrentEnd();
+    if (currentStart != null && currentEnd != null) {
+      _addToPath(currentStart, currentEnd);
+    }
+
+    eraserModel.cropRect = null;
+
+    canvas.drawPath(_path, _paint);
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => true;
+}

--- a/packages/smooth_app/lib/pages/prices/product_price_item.dart
+++ b/packages/smooth_app/lib/pages/prices/product_price_item.dart
@@ -96,10 +96,16 @@ class ProductPriceItem extends StatelessWidget {
             ),
             if (price.proof?.filePath != null)
               ElevatedButton(
-                onPressed: () async => LaunchUrlHelper.launchURL(
-                  // TODO(monsieurtanuki): probably won't work in TEST env
-                  'https://prices.openfoodfacts.org/img/${price.proof?.filePath}',
-                ),
+                onPressed: () async {
+                  final UriProductHelper uriProductHelper =
+                      ProductQuery.uriProductHelper;
+                  final Uri uri = Uri(
+                    scheme: uriProductHelper.scheme,
+                    host: uriProductHelper.getHost('prices'),
+                    path: 'img/${price.proof?.filePath}',
+                  );
+                  return LaunchUrlHelper.launchURL(uri.toString());
+                },
                 child: const Icon(Icons.image),
               ),
           ],

--- a/packages/smooth_app/lib/pages/product_crop_helper.dart
+++ b/packages/smooth_app/lib/pages/product_crop_helper.dart
@@ -38,6 +38,9 @@ abstract class ProductCropHelper extends CropHelper {
   String getProcessLabel(final AppLocalizations appLocalizations) =>
       appLocalizations.send_image_button_label;
 
+  @override
+  bool get enableEraser => false;
+
   @protected
   Future<void> refresh(final BuildContext context) async {
     final LocalDatabase localDatabase = context.read<LocalDatabase>();
@@ -67,6 +70,7 @@ class ProductCropNewHelper extends ProductCropHelper {
     required final File smallCroppedFile,
     required final Directory directory,
     required final int sequenceNumber,
+    final List<Offset>? offsets,
   }) async {
     // in this case, it's a brand new picture, with crop parameters.
     // for performance reasons, we do not crop the image full-size here,
@@ -130,6 +134,7 @@ class ProductCropAgainHelper extends ProductCropHelper {
     required final File smallCroppedFile,
     required final Directory directory,
     required final int sequenceNumber,
+    final List<Offset>? offsets,
   }) async {
     // in this case, it's an existing picture, with crop parameters.
     // we let the server do everything: better performance, and no privacy

--- a/packages/smooth_app/lib/pages/proof_crop_helper.dart
+++ b/packages/smooth_app/lib/pages/proof_crop_helper.dart
@@ -37,6 +37,9 @@ class ProofCropHelper extends CropHelper {
       appLocalizations.okay;
 
   @override
+  bool get enableEraser => true;
+
+  @override
   Future<CropParameters?> process({
     required final BuildContext context,
     required final CropController controller,
@@ -45,6 +48,7 @@ class ProofCropHelper extends CropHelper {
     required final File smallCroppedFile,
     required final Directory directory,
     required final int sequenceNumber,
+    final List<Offset>? offsets,
   }) async {
     // It's a brand new picture, with crop parameters.
     // For performance reasons, we do not crop the image full-size here,
@@ -63,6 +67,7 @@ class ProofCropHelper extends CropHelper {
       controller: controller,
       fullFile: fullFile,
       smallCroppedFile: smallCroppedFile,
+      offsets: offsets,
     );
   }
 }

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -329,10 +329,10 @@ packages:
     dependency: "direct main"
     description:
       name: crop_image
-      sha256: "67d379ea927f4a9e48bf3d314a74bff7d86cdefd4a58af4554b37daa3c10bb9c"
+      sha256: "6cf20655ecbfba99c369d43ec7adcfa49bf135af88fb75642173d6224a95d3f1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.12"
+    version: "1.0.13"
   cross_file:
     dependency: transitive
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -51,7 +51,7 @@ dependencies:
   flutter_native_splash: 2.4.0
   image: 4.1.7
   auto_size_text: 3.0.0
-  crop_image: 1.0.12
+  crop_image: 1.0.13
   shared_preferences: 2.2.3
   intl: 0.18.1
   collection: 1.18.0


### PR DESCRIPTION
### What
- Added an "eraser tool" when the user crops the proof image. The typical use case is barring sensitive data in a receipt, e.g. name or account number.

### Screenshots
| `CropImage` |`getCroppedBitmap` |
| -- | -- |
| ![Screenshot_1717592735](https://github.com/deakjahn/crop_image/assets/11576431/f566e524-c87a-497e-88a6-9a6b81aa5c52) | ![Screenshot_1717592857](https://github.com/deakjahn/crop_image/assets/11576431/9fb584ad-3047-4ef6-b936-54f7a2c2eb5d) |

Uploaded image: https://prices.openfoodfacts.net/img/0003/pRFjLvNol8.jpg

### Part of 
- #5301

### Files
New files:
* `eraser_model.dart`: Model about the eraser tool: coordinate computations.
* `eraser_painter.dart`:  Painter of the eraser tool: displaying thick lines.

Impacted files:
* `background_task_add_price.dart`: displaying the eraser bars if relevant; new `eraserCoordinates` field
* `background_task_image.dart`: minor refactoring
* `crop_helper.dart`: new `enableEraser` field `offsets` parameters
* `crop_page.dart`: added an erasing tool for proofs; refactored
* `crop_parameters.dart`: new `eraserCoordinates` parameter
* `operation_type.dart` unrelated minor refactoring
* `product_crop_helper.dart`: minor refactoring
* `product_price_item.dart`: unrelated fix for TEST env
* `proof_crop_helper.dart`: minor refactoring
* `pubspec.lock`: wtf
* `pubspec.yaml`: needed upgrade of `crop_image` to `1.0.13`