### PR TITLE
feat: 5318 - added a "price privacy warning" dialog

### DIFF
--- a/packages/smooth_app/lib/background/background_task_add_price.dart
+++ b/packages/smooth_app/lib/background/background_task_add_price.dart
@@ -52,9 +52,9 @@ class BackgroundTaskAddPrice extends BackgroundTask {
         cropY1 = json[_jsonTagY1] as int? ?? 0,
         cropX2 = json[_jsonTagX2] as int? ?? 0,
         cropY2 = json[_jsonTagY2] as int? ?? 0,
-        proofType = getProofTypeFromOffTag(json[_jsonTagProofType] as String)!,
+        proofType = ProofType.fromOffTag(json[_jsonTagProofType] as String)!,
         date = JsonHelper.stringTimestampToDate(json[_jsonTagDate] as String),
-        currency = getCurrencyFromName(json[_jsonTagCurrency] as String)!,
+        currency = Currency.fromName(json[_jsonTagCurrency] as String)!,
         locationOSMId = json[_jsonTagOSMId] as int,
         locationOSMType =
             LocationOSMType.fromOffTag(json[_jsonTagOSMType] as String)!,
@@ -356,26 +356,6 @@ class BackgroundTaskAddPrice extends BackgroundTask {
       // throw Exception('Could not really close session');
       return;
     }
-  }
-
-  // TODO(monsieurtanuki): move it to off-dart
-  static Currency? getCurrencyFromName(final String name) {
-    for (final Currency currency in Currency.values) {
-      if (currency.name == name) {
-        return currency;
-      }
-    }
-    return null;
-  }
-
-  // TODO(monsieurtanuki): move it to off-dart
-  static ProofType? getProofTypeFromOffTag(final String offTag) {
-    for (final ProofType value in ProofType.values) {
-      if (value.offTag == offTag) {
-        return value;
-      }
-    }
-    return null;
   }
 
   @override

--- a/packages/smooth_app/lib/data_models/preferences/user_preferences.dart
+++ b/packages/smooth_app/lib/data_models/preferences/user_preferences.dart
@@ -89,6 +89,9 @@ class UserPreferences extends ChangeNotifier {
   /// Vibrations / haptic feedback
   static const String _TAG_HAPTIC_FEEDBACK_IN_APP = 'haptic_feedback_enabled';
 
+  /// Price privacy warning
+  static const String TAG_PRICE_PRIVACY_WARNING = 'price_privacy_warning';
+
   /// Attribute group that is not collapsed
   static const String _TAG_ACTIVE_ATTRIBUTE_GROUP = 'activeAttributeGroup';
 

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_action_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_action_card.dart
@@ -31,7 +31,7 @@ class KnowledgePanelActionCard extends StatelessWidget {
       mainAxisAlignment: MainAxisAlignment.start,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        SmoothHtmlWidget(element.html),
+        if (element.html != null) SmoothHtmlWidget(element.html!),
         const SizedBox(height: SMALL_SPACE),
         ...actionWidgets,
       ],

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1704,6 +1704,8 @@
     "prices_proof_price_tag": "Price tag",
     "prices_proof_mandatory": "You need to select a proof!",
     "prices_add_validation_error": "Validation error",
+    "prices_privacy_warning_title": "Privacy warning",
+    "prices_privacy_warning_message": "Prices will be public, along with the store they refer to.\nThat might allow people who know about your Open Food Facts pseudonym to:\n* infer in which area you live\n* know what you are buying\nIf you are uneasy with that, please change your pseudonym, or create a new Open Food Facts account and log into the app with it.",
     "dev_preferences_import_history_result_success": "Done",
     "@dev_preferences_import_history_result_success": {
         "description": "User dev preferences - Import history - Result successful"

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_account.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_account.dart
@@ -289,20 +289,15 @@ class UserPreferencesAccount extends AbstractUserPreferences {
   }) =>
       _getListTile(
         title,
-        () async => LaunchUrlHelper.launchURL(_getPriceUrl(path)),
+        () async => LaunchUrlHelper.launchURL(
+          OpenPricesAPIClient.getUri(
+            path: path,
+            uriHelper: ProductQuery.uriProductHelper,
+          ).toString(),
+        ),
         Icons.open_in_new,
         myCount: myCount,
       );
-
-  String _getPriceUrl(final String path) {
-    final UriProductHelper uriProductHelper = ProductQuery.uriProductHelper;
-    final Uri uri = Uri(
-      scheme: uriProductHelper.scheme,
-      host: uriProductHelper.getHost('prices'),
-      path: path,
-    );
-    return uri.toString();
-  }
 
   Future<bool?> _confirmLogout() async => showDialog<bool>(
         context: context,

--- a/packages/smooth_app/lib/pages/prices/product_price_item.dart
+++ b/packages/smooth_app/lib/pages/prices/product_price_item.dart
@@ -96,16 +96,13 @@ class ProductPriceItem extends StatelessWidget {
             ),
             if (price.proof?.filePath != null)
               ElevatedButton(
-                onPressed: () async {
-                  final UriProductHelper uriProductHelper =
-                      ProductQuery.uriProductHelper;
-                  final Uri uri = Uri(
-                    scheme: uriProductHelper.scheme,
-                    host: uriProductHelper.getHost('prices'),
-                    path: 'img/${price.proof?.filePath}',
-                  );
-                  return LaunchUrlHelper.launchURL(uri.toString());
-                },
+                onPressed: () async => LaunchUrlHelper.launchURL(
+                  price.proof!
+                      .getFileUrl(
+                        uriProductHelper: ProductQuery.uriProductHelper,
+                      )
+                      .toString(),
+                ),
                 child: const Icon(Icons.image),
               ),
           ],

--- a/packages/smooth_app/lib/pages/prices/product_prices_page.dart
+++ b/packages/smooth_app/lib/pages/prices/product_prices_page.dart
@@ -49,16 +49,12 @@ class _ProductPricesPageState extends State<ProductPricesPage>
           IconButton(
             tooltip: appLocalizations.prices_app_button,
             icon: const Icon(Icons.open_in_new),
-            onPressed: () async {
-              final UriProductHelper uriProductHelper =
-                  ProductQuery.uriProductHelper;
-              final Uri uri = Uri(
-                scheme: uriProductHelper.scheme,
-                host: uriProductHelper.getHost('prices'),
+            onPressed: () async => LaunchUrlHelper.launchURL(
+              OpenPricesAPIClient.getUri(
                 path: 'app/products/${upToDateProduct.barcode!}',
-              );
-              return LaunchUrlHelper.launchURL(uri.toString());
-            },
+                uriHelper: ProductQuery.uriProductHelper,
+              ).toString(),
+            ),
           ),
         ],
       ),

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -1108,10 +1108,10 @@ packages:
     dependency: "direct main"
     description:
       name: openfoodfacts
-      sha256: ab05acea8a91a4cef6cbed9064af261a8921c60c5cc253298d9024c1b0ff8674
+      sha256: "90a853e7536d0f97a665b18cd602055215520bf424765ef06930e4be25b760ba"
       url: "https://pub.dev"
     source: hosted
-    version: "3.10.0"
+    version: "3.11.0"
   openfoodfacts_flutter_lints:
     dependency: "direct dev"
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -99,7 +99,7 @@ dependencies:
     path: ../scanner/zxing
 
 
-  openfoodfacts: 3.10.0
+  openfoodfacts: 3.11.0
   # openfoodfacts:
   #   path: ../../../openfoodfacts-dart
 


### PR DESCRIPTION
### What
- Added a "price privacy warning" dialog.
- This dialog is displayed the first time the user tries to add a price.
- This dialog is also displayed when the user taps on the app bar "info" button.

### Screenshots
| As "first time" | As "info" button |
| -- | -- |
| ![Screenshot_1717772402](https://github.com/openfoodfacts/smooth-app/assets/11576431/9dc8749f-d2c2-4d70-ada2-51ca734a22fc) | ![Screenshot_1717772375](https://github.com/openfoodfacts/smooth-app/assets/11576431/c8a9c9ae-833f-4978-a4c3-3fc26411dd78) |

### Fixes bug(s)
- Closes: #5318

### Impacted files
* `app_en.arb`: added 2 labels for the "price privacy warning" dialog
* `background_task_add_price.dart`: now using new off-dart methods
* `knowledge_panel_action_card.dart`: minor off-dart impact
* `price_model.dart`: refactored
* `product_price_add_page.dart`: added the "price privacy warning" dialog the very first time and in an app bar button
* `product_price_item.dart`: now using new off-dart method
* `product_prices_page.dart`: now using new off-dart method
* `pubspec.lock`: wtf
* `pubspec.yaml`: upgraded of `openfoodfacts` to `3.11.0`
* `user_preferences.dart`: added flag for "price privacy warning"
* `user_preferences_account.dart`: now using new off-dart method