### PR TITLE
feat: 5198 - added a local "latest prices" page

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1706,6 +1706,7 @@
     "prices_add_validation_error": "Validation error",
     "prices_privacy_warning_title": "Privacy warning",
     "prices_privacy_warning_message": "Prices will be public, along with the store they refer to.\nThat might allow people who know about your Open Food Facts pseudonym to:\n* infer in which area you live\n* know what you are buying\nIf you are uneasy with that, please change your pseudonym, or create a new Open Food Facts account and log into the app with it.",
+    "prices_unknown_product": "Unknown product",
     "dev_preferences_import_history_result_success": "Done",
     "@dev_preferences_import_history_result_success": {
         "description": "User dev preferences - Import history - Result successful"

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1707,6 +1707,9 @@
     "prices_privacy_warning_title": "Privacy warning",
     "prices_privacy_warning_message": "Prices will be public, along with the store they refer to.\nThat might allow people who know about your Open Food Facts pseudonym to:\n* infer in which area you live\n* know what you are buying\nIf you are uneasy with that, please change your pseudonym, or create a new Open Food Facts account and log into the app with it.",
     "prices_unknown_product": "Unknown product",
+    "@prices_unknown_product": {
+        "description": "Very small text, in the context of prices, to say that the product is unknown"
+    },
     "dev_preferences_import_history_result_success": "Done",
     "@dev_preferences_import_history_result_success": {
         "description": "User dev preferences - Import history - Result successful"

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -1706,6 +1706,7 @@
     "prices_add_validation_error": "Erreur de validation",
     "prices_privacy_warning_title": "Avertissement de confidentialité",
     "prices_privacy_warning_message": "Les prix seront publics, ainsi que le magasin auquel ils font référence.\nCela pourrait permettre aux personnes qui connaissent votre pseudonyme Open Food Facts de :\n* déduire dans quelle région vous habitez\n* savoir ce que vous achetez\nSi vous êtes pas à l'aise avec cela, veuillez changer votre pseudonyme ou créer un nouveau compte Open Food Facts et vous connecter à l'application avec celui-ci.",
+    "prices_unknown_product": "Produit inconnu",
     "dev_preferences_import_history_result_success": "Fait",
     "@dev_preferences_import_history_result_success": {
         "description": "User dev preferences - Import history - Result successful"

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -1707,6 +1707,9 @@
     "prices_privacy_warning_title": "Avertissement de confidentialité",
     "prices_privacy_warning_message": "Les prix seront publics, ainsi que le magasin auquel ils font référence.\nCela pourrait permettre aux personnes qui connaissent votre pseudonyme Open Food Facts de :\n* déduire dans quelle région vous habitez\n* savoir ce que vous achetez\nSi vous êtes pas à l'aise avec cela, veuillez changer votre pseudonyme ou créer un nouveau compte Open Food Facts et vous connecter à l'application avec celui-ci.",
     "prices_unknown_product": "Produit inconnu",
+    "@prices_unknown_product": {
+        "description": "Very small text, in the context of prices, to say that the product is unknown"
+    },
     "dev_preferences_import_history_result_success": "Fait",
     "@dev_preferences_import_history_result_success": {
         "description": "User dev preferences - Import history - Result successful"

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_account.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_account.dart
@@ -244,9 +244,33 @@ class UserPreferencesAccount extends AbstractUserPreferences {
         CupertinoIcons.money_dollar_circle,
         myCount: _getMyPricesCount(),
       ),
-      _getPriceListTile(
+      _getListTile(
         appLocalizations.all_search_prices_latest_title,
-        'app/prices',
+        () async => Navigator.of(context).push(
+          MaterialPageRoute<void>(
+            builder: (BuildContext context) => PricesPage(
+              GetPricesModel(
+                parameters: GetPricesParameters()
+                  ..orderBy = <OrderBy<GetPricesOrderField>>[
+                    const OrderBy<GetPricesOrderField>(
+                      field: GetPricesOrderField.created,
+                      ascending: false,
+                    ),
+                  ]
+                  ..pageSize = GetPricesModel.pageSize
+                  ..pageNumber = 1,
+                displayOwner: true,
+                displayProduct: true,
+                uri: OpenPricesAPIClient.getUri(
+                  path: 'app/prices',
+                  uriHelper: ProductQuery.uriProductHelper,
+                ),
+                title: appLocalizations.all_search_prices_latest_title,
+              ),
+            ),
+          ),
+        ),
+        CupertinoIcons.money_dollar_circle,
       ),
       _getPriceListTile(
         appLocalizations.all_search_prices_top_user_title,

--- a/packages/smooth_app/lib/pages/prices/price_data_widget.dart
+++ b/packages/smooth_app/lib/pages/prices/price_data_widget.dart
@@ -36,6 +36,9 @@ class PriceDataWidget extends StatelessWidget {
       if (price.product == null) {
         return null;
       }
+      if (price.product!.quantity == null) {
+        return null;
+      }
       if ((price.product!.quantityUnit ?? 'g') != 'g') {
         return null;
       }

--- a/packages/smooth_app/lib/pages/prices/price_product_widget.dart
+++ b/packages/smooth_app/lib/pages/prices/price_product_widget.dart
@@ -1,5 +1,6 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/images/smooth_image.dart';
@@ -16,7 +17,9 @@ class PriceProductWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final String? name = priceProduct.name;
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final String name = priceProduct.name ?? priceProduct.code;
+    final bool unknown = priceProduct.name == null;
     final String? imageURL = priceProduct.imageURL;
     final int priceCount = priceProduct.priceCount;
     final List<String>? brands = priceProduct.brands?.split(',');
@@ -32,30 +35,31 @@ class PriceProductWidget extends StatelessWidget {
         mainAxisAlignment: MainAxisAlignment.start,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
-          if (imageURL != null)
-            SizedBox(
-              width: _imageSize,
-              child: SmoothImage(
-                width: _imageSize,
-                height: _imageSize,
-                imageProvider: NetworkImage(imageURL),
-              ),
-            ),
-          if (imageURL != null) const SizedBox(width: SMALL_SPACE),
           SizedBox(
-            width: imageURL == null
-                ? constraints.maxWidth
-                : constraints.maxWidth - _imageSize - SMALL_SPACE,
+            width: _imageSize,
+            child: imageURL == null
+                ? const Icon(
+                    Icons.question_mark,
+                    size: _imageSize / 2,
+                  )
+                : SmoothImage(
+                    width: _imageSize,
+                    height: _imageSize,
+                    imageProvider: NetworkImage(imageURL),
+                  ),
+          ),
+          const SizedBox(width: SMALL_SPACE),
+          SizedBox(
+            width: constraints.maxWidth - _imageSize - SMALL_SPACE,
             child: Column(
               mainAxisAlignment: MainAxisAlignment.start,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
-                if (name != null)
-                  AutoSizeText(
-                    name,
-                    maxLines: 2,
-                    style: Theme.of(context).textTheme.titleMedium,
-                  ),
+                AutoSizeText(
+                  name,
+                  maxLines: 2,
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
                 Wrap(
                   spacing: VERY_SMALL_SPACE,
                   crossAxisAlignment: WrapCrossAlignment.center,
@@ -69,6 +73,16 @@ class PriceProductWidget extends StatelessWidget {
                           onPressed: () {},
                         ),
                     if (quantity != null) Text(quantity),
+                    if (unknown)
+                      PriceButton(
+                        title: appLocalizations.prices_unknown_product,
+                        iconData: Icons.warning,
+                        onPressed: null,
+                        buttonStyle: ElevatedButton.styleFrom(
+                          disabledForegroundColor: Colors.red,
+                          disabledBackgroundColor: Colors.red[100],
+                        ),
+                      ),
                   ],
                 ),
               ],


### PR DESCRIPTION
### What
- Added a local "latest prices" page, from the user page.

### Screenshots
| latest prices page | from user page |
| -- | -- |
| ![Screenshot_1718000938](https://github.com/openfoodfacts/smooth-app/assets/11576431/b8ee24bb-d862-44df-92b6-8701ab53a2f8) | ![Screenshot_1718000921](https://github.com/openfoodfacts/smooth-app/assets/11576431/1cf1ad5b-4cda-4c87-8bd9-5c34453e8208) |

### Fixes bug(s)
- Closes: #5198

### Impacted files
* `app_en.arb`: added 1 "product unknown" label
* `app_fr.arb`: added 1 "product unknown" label
* `price_data_widget.dart`: minor fix
* `price_product_widget.dart`: minor improvements
* `user_preferences_account.dart`: added a call to a "latest prices" page