### PR TITLE
feat: Custom domain + environment support for the TagLine

### DIFF
--- a/packages/smooth_app/lib/data_models/tagline/tagline_provider.dart
+++ b/packages/smooth_app/lib/data_models/tagline/tagline_provider.dart
@@ -100,8 +100,8 @@ class TagLineProvider extends ChangeNotifier {
     }
   }
 
-  /// API URL: [https://world.openfoodfacts.[org/net]/files/tagline-off-ios-v3.json]
-  /// or [https://world.openfoodfacts.[org/net]/files/tagline-off-android-v3.json]
+  /// API URL: [https://world.openfoodfacts.[org/net]/resources/files/tagline-off-ios-v3.json]
+  /// or [https://world.openfoodfacts.[org/net]/resources/files/tagline-off-android-v3.json]
   Future<String?> _fetchTagLine() async {
     try {
       final UriProductHelper uriProductHelper = ProductQuery.uriProductHelper;

--- a/packages/smooth_app/lib/main.dart
+++ b/packages/smooth_app/lib/main.dart
@@ -106,7 +106,6 @@ late TextContrastProvider _textContrastProvider;
 final ContinuousScanModel _continuousScanModel = ContinuousScanModel();
 final PermissionListener _permissionListener =
     PermissionListener(permission: Permission.camera);
-final TagLineProvider _tagLineProvider = TagLineProvider();
 bool _init1done = false;
 
 // Had to split init in 2 methods, for test/screenshots reasons.
@@ -224,15 +223,20 @@ class _SmoothAppState extends State<SmoothApp> {
             provide<UserManagementProvider>(_userManagementProvider),
             provide<ContinuousScanModel>(_continuousScanModel),
             provide<PermissionListener>(_permissionListener),
-            provide<TagLineProvider>(_tagLineProvider, lazy: true),
           ],
-          child: AnimationsLoader(
-            child: AppNavigator(
-              observers: <NavigatorObserver>[
-                SentryNavigatorObserver(),
-                matomoObserver,
-              ],
-              child: Builder(builder: _buildApp),
+          child: ChangeNotifierProvider<TagLineProvider>(
+            create: (BuildContext context) => TagLineProvider(
+              context.read<UserPreferences>(),
+            ),
+            lazy: true,
+            child: AnimationsLoader(
+              child: AppNavigator(
+                observers: <NavigatorObserver>[
+                  SentryNavigatorObserver(),
+                  matomoObserver,
+                ],
+                child: Builder(builder: _buildApp),
+              ),
             ),
           ),
         );

--- a/packages/smooth_app/lib/pages/scan/scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/scan_page.dart
@@ -8,7 +8,6 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/continuous_scan_model.dart';
 import 'package:smooth_app/data_models/preferences/user_preferences.dart';
-import 'package:smooth_app/data_models/tagline/tagline_provider.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
@@ -61,88 +60,84 @@ class _ScanPageState extends State<ScanPage> {
           Theme.of(context).brightness == Brightness.light && Platform.isIOS
               ? Brightness.dark
               : null,
-      body: ChangeNotifierProvider<TagLineProvider>(
-        lazy: true,
-        create: (_) => TagLineProvider(),
-        child: Container(
-          color: Colors.white,
-          child: SafeArea(
-            child: Container(
-              color: Theme.of(context).colorScheme.background,
-              child: Column(
-                children: <Widget>[
-                  if (hasACamera)
-                    Expanded(
-                      flex: 100 - _carouselHeightPct,
-                      child: Consumer<PermissionListener>(
-                        builder: (
-                          BuildContext context,
-                          PermissionListener listener,
-                          _,
-                        ) {
-                          switch (listener.value.status) {
-                            case DevicePermissionStatus.checking:
-                              return EMPTY_WIDGET;
-                            case DevicePermissionStatus.granted:
-                              // TODO(m123): change
-                              return const CameraScannerPage();
-                            default:
-                              return const _PermissionDeniedCard();
-                          }
-                        },
-                      ),
-                    ),
+      body: Container(
+        color: Colors.white,
+        child: SafeArea(
+          child: Container(
+            color: Theme.of(context).colorScheme.background,
+            child: Column(
+              children: <Widget>[
+                if (hasACamera)
                   Expanded(
-                    flex: _carouselHeightPct,
-                    child: Padding(
-                      padding: const EdgeInsetsDirectional.only(bottom: 10.0),
-                      child: SmoothProductCarousel(
-                        containSearchCard: true,
-                        onPageChangedTo: (int page, String? barcode) async {
-                          if (barcode == null) {
-                            // We only notify for new products
-                            return;
-                          }
-
-                          // Both are Future methods, but it doesn't matter to wait here
-                          SmoothHapticFeedback.lightNotification();
-
-                          if (_userPreferences.playCameraSound) {
-                            await _initSoundManagerIfNecessary();
-                            await _musicPlayer!.stop();
-                            await _musicPlayer!.play(
-                              AssetSource('audio/beep.wav'),
-                              volume: 0.5,
-                              ctx: const AudioContext(
-                                android: AudioContextAndroid(
-                                  isSpeakerphoneOn: false,
-                                  stayAwake: false,
-                                  contentType: AndroidContentType.sonification,
-                                  usageType: AndroidUsageType.notification,
-                                  audioFocus:
-                                      AndroidAudioFocus.gainTransientMayDuck,
-                                ),
-                                iOS: AudioContextIOS(
-                                  category: AVAudioSessionCategory.soloAmbient,
-                                  options: <AVAudioSessionOptions>[
-                                    AVAudioSessionOptions.mixWithOthers,
-                                  ],
-                                ),
-                              ),
-                            );
-                          }
-
-                          SemanticsService.announce(
-                            appLocalizations.scan_announce_new_barcode(barcode),
-                            direction,
-                            assertiveness: Assertiveness.assertive,
-                          );
-                        },
-                      ),
+                    flex: 100 - _carouselHeightPct,
+                    child: Consumer<PermissionListener>(
+                      builder: (
+                        BuildContext context,
+                        PermissionListener listener,
+                        _,
+                      ) {
+                        switch (listener.value.status) {
+                          case DevicePermissionStatus.checking:
+                            return EMPTY_WIDGET;
+                          case DevicePermissionStatus.granted:
+                            // TODO(m123): change
+                            return const CameraScannerPage();
+                          default:
+                            return const _PermissionDeniedCard();
+                        }
+                      },
                     ),
                   ),
-                ],
-              ),
+                Expanded(
+                  flex: _carouselHeightPct,
+                  child: Padding(
+                    padding: const EdgeInsetsDirectional.only(bottom: 10.0),
+                    child: SmoothProductCarousel(
+                      containSearchCard: true,
+                      onPageChangedTo: (int page, String? barcode) async {
+                        if (barcode == null) {
+                          // We only notify for new products
+                          return;
+                        }
+
+                        // Both are Future methods, but it doesn't matter to wait here
+                        SmoothHapticFeedback.lightNotification();
+
+                        if (_userPreferences.playCameraSound) {
+                          await _initSoundManagerIfNecessary();
+                          await _musicPlayer!.stop();
+                          await _musicPlayer!.play(
+                            AssetSource('audio/beep.wav'),
+                            volume: 0.5,
+                            ctx: const AudioContext(
+                              android: AudioContextAndroid(
+                                isSpeakerphoneOn: false,
+                                stayAwake: false,
+                                contentType: AndroidContentType.sonification,
+                                usageType: AndroidUsageType.notification,
+                                audioFocus:
+                                    AndroidAudioFocus.gainTransientMayDuck,
+                              ),
+                              iOS: AudioContextIOS(
+                                category: AVAudioSessionCategory.soloAmbient,
+                                options: <AVAudioSessionOptions>[
+                                  AVAudioSessionOptions.mixWithOthers,
+                                ],
+                              ),
+                            ),
+                          );
+                        }
+
+                        SemanticsService.announce(
+                          appLocalizations.scan_announce_new_barcode(barcode),
+                          direction,
+                          assertiveness: Assertiveness.assertive,
+                        );
+                      },
+                    ),
+                  ),
+                ),
+              ],
             ),
           ),
         ),


### PR DESCRIPTION
Hi everyone!

The `TagLine` fetcher now supports custom domains + test/prod environments.
When one of the two is updated, the tagline is forced to be resynced with the new URL.

+ In the case where the JSON is invalid, an error is not sent to Sentry