### PR TITLE
fix: Guide: Rewrite newline character from translations

### DIFF
--- a/packages/smooth_app/lib/helpers/strings_helper.dart
+++ b/packages/smooth_app/lib/helpers/strings_helper.dart
@@ -58,6 +58,8 @@ class TextHelper {
     required TextStyle? defaultStyle,
     required TextStyle? highlightedStyle,
   }) {
+    text = text.replaceAll(r'\n', '\n');
+
     final Iterable<RegExpMatch> highlightedParts =
         RegExp('$symbol[^$symbol]+$symbol').allMatches(text);
 
@@ -108,7 +110,6 @@ class FormattedText extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final TextStyle defaultTextStyle = textStyle ?? const TextStyle();
-
     return RichText(
       text: TextSpan(
         style: DefaultTextStyle.of(context).style,


### PR DESCRIPTION
Hi everyone!

Translations for guides may contain "illegal" backslash characters.
This is just a one line fix

<img width="799" alt="Screenshot 2024-06-13 at 09 51 56" src="https://github.com/openfoodfacts/smooth-app/assets/246838/9d15f23f-292e-4ff3-be29-d7fd9cbe7a1c">
