### PR TITLE
feat: Improve photo gallery accessibility + internationalization

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -750,16 +750,12 @@
     "@product_refreshed": {
         "description": "Confirmation, that the product data refresh is done"
     },
-    "product_image_date_format": "yyyy-MM-dd",
-    "@product_image_date_format": {
-        "description": "'yyyy' means year (= 2024) / MM means month (= January) / dd means day of the week = 20)"
-    },
     "product_image_accessibility_label": "Image taken on {date}",
     "@product_image_accessibility_label": {
         "placeholders": {
             "date": {
                 "type": "String",
-                "description": "The date of picture (formatted with product_image_date_format key)"
+                "description": "The date of picture (in localized format for YYYY-MM-DD)"
             }
         }
     },
@@ -768,7 +764,7 @@
         "placeholders": {
             "date": {
                 "type": "String",
-                "description": "The date of picture (formatted with product_image_date_format key)"
+                "description": "The date of picture (in localized format for YYYY-MM-DD)"
             }
         }
     },

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -752,9 +752,9 @@
     },
     "product_image_date_format": "yyyy-MM-dd",
     "@product_image_date_format": {
-        "description": "'yyyy' means year (= 2024) / MM means month (= January) / dd means day of the week '= 20)"
+        "description": "'yyyy' means year (= 2024) / MM means month (= January) / dd means day of the week = 20)"
     },
-    "product_image_accessibility_label": "Image taken the {date}",
+    "product_image_accessibility_label": "Image taken on {date}",
     "@product_image_accessibility_label": {
         "placeholders": {
             "date": {
@@ -763,7 +763,7 @@
             }
         }
     },
-    "product_image_outdated_accessibility_label": "Image taken the {date}. This image may be outdated",
+    "product_image_outdated_accessibility_label": "Image taken on {date}. This image may be outdated",
     "@product_image_outdated_accessibility_label": {
         "placeholders": {
             "date": {

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -750,6 +750,28 @@
     "@product_refreshed": {
         "description": "Confirmation, that the product data refresh is done"
     },
+    "product_image_date_format": "yyyy-MM-dd",
+    "@product_image_date_format": {
+        "description": "'yyyy' means year (= 2024) / MM means month (= January) / dd means day of the week '= 20)"
+    },
+    "product_image_accessibility_label": "Image taken the {date}",
+    "@product_image_accessibility_label": {
+        "placeholders": {
+            "date": {
+                "type": "String",
+                "description": "The date of picture (formatted with product_image_date_format key)"
+            }
+        }
+    },
+    "product_image_outdated_accessibility_label": "Image taken the {date}. This image may be outdated",
+    "@product_image_outdated_accessibility_label": {
+        "placeholders": {
+            "date": {
+                "type": "String",
+                "description": "The date of picture (formatted with product_image_date_format key)"
+            }
+        }
+    },
     "homepage_main_card_logo_description": "Welcome to Open Food Facts",
     "@homepage_main_card_logo_description": {
         "description": "Description for accessibility of the Open Food Facts logo on the homepage"

--- a/packages/smooth_app/lib/pages/image/product_image_gallery_other_view.dart
+++ b/packages/smooth_app/lib/pages/image/product_image_gallery_other_view.dart
@@ -4,6 +4,7 @@ import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/fetched_product.dart';
 import 'package:smooth_app/database/local_database.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/pages/image/product_image_other_page.dart';
 import 'package:smooth_app/pages/image/product_image_widget.dart';
@@ -116,20 +117,27 @@ class _RawGridGallery extends StatelessWidget {
           // order by descending ids
           index = rawImages.length - 1 - index;
           final ProductImage productImage = rawImages[index];
-          return InkWell(
-            onTap: () async => Navigator.push<void>(
-              context,
-              MaterialPageRoute<bool>(
-                builder: (BuildContext context) => ProductImageOtherPage(
-                  product,
-                  int.parse(productImage.imgid!),
+          return Padding(
+            padding: EdgeInsetsDirectional.only(
+              start: VERY_SMALL_SPACE,
+              end: index % _columns == 0 ? VERY_SMALL_SPACE : 0.0,
+              bottom: VERY_SMALL_SPACE,
+            ),
+            child: InkWell(
+              onTap: () async => Navigator.push<void>(
+                context,
+                MaterialPageRoute<bool>(
+                  builder: (BuildContext context) => ProductImageOtherPage(
+                    product,
+                    int.parse(productImage.imgid!),
+                  ),
                 ),
               ),
-            ),
-            child: ProductImageWidget(
-              productImage: productImage,
-              barcode: product.barcode!,
-              squareSize: squareSize,
+              child: ProductImageWidget(
+                productImage: productImage,
+                barcode: product.barcode!,
+                squareSize: squareSize,
+              ),
             ),
           );
         },

--- a/packages/smooth_app/lib/pages/image/product_image_widget.dart
+++ b/packages/smooth_app/lib/pages/image/product_image_widget.dart
@@ -7,7 +7,6 @@ import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/images/smooth_image.dart';
 import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/resources/app_icons.dart';
-import 'package:smooth_app/services/smooth_services.dart';
 import 'package:smooth_app/themes/smooth_theme_colors.dart';
 
 /// Displays a product image thumbnail with the upload date on top.
@@ -25,15 +24,8 @@ class ProductImageWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    DateFormat dateFormat;
-
-    try {
-      dateFormat = DateFormat(appLocalizations.product_image_date_format);
-    } catch (_) {
-      dateFormat = DateFormat('yyyy-MM-dd');
-      Logs.e(
-          'Invalid date format detected: ${appLocalizations.product_image_date_format}');
-    }
+    final DateFormat dateFormat =
+        DateFormat.yMd(ProductQuery.getLanguage().offTag);
 
     final Widget image = SmoothImage(
       width: squareSize,

--- a/packages/smooth_app/lib/pages/image/product_image_widget.dart
+++ b/packages/smooth_app/lib/pages/image/product_image_widget.dart
@@ -5,12 +5,13 @@ import 'package:intl/intl.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/images/smooth_image.dart';
+import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/resources/app_icons.dart';
 import 'package:smooth_app/themes/smooth_theme_colors.dart';
 
 /// Displays a product image thumbnail with the upload date on top.
-class ProductImageWidget extends StatelessWidget {
+class ProductImageWidget extends StatefulWidget {
   const ProductImageWidget({
     required this.productImage,
     required this.barcode,
@@ -22,23 +23,54 @@ class ProductImageWidget extends StatelessWidget {
   final double squareSize;
 
   @override
+  State<ProductImageWidget> createState() => _ProductImageWidgetState();
+}
+
+class _ProductImageWidgetState extends State<ProductImageWidget> {
+  @override
+  void initState() {
+    super.initState();
+    _loadImagePalette();
+  }
+
+  Future<void> _loadImagePalette() async {
+    final ColorScheme palette = await ColorScheme.fromImageProvider(
+        provider: NetworkImage(widget.productImage.getUrl(
+      widget.barcode,
+      uriHelper: ProductQuery.uriProductHelper,
+    )));
+
+    setState(() {
+      backgroundColor = palette.primaryContainer;
+      darkBackground = backgroundColor!.computeLuminance() < 0.5;
+    });
+  }
+
+  Color? backgroundColor;
+  bool? darkBackground;
+
+  @override
   Widget build(BuildContext context) {
+    final SmoothColorsThemeExtension colors =
+        Theme.of(context).extension<SmoothColorsThemeExtension>()!;
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final DateFormat dateFormat =
         DateFormat.yMd(ProductQuery.getLanguage().offTag);
 
+    darkBackground = darkBackground ?? true;
+
     final Widget image = SmoothImage(
-      width: squareSize,
-      height: squareSize,
+      width: widget.squareSize,
+      height: widget.squareSize,
       imageProvider: NetworkImage(
-        productImage.getUrl(
-          barcode,
+        widget.productImage.getUrl(
+          widget.barcode,
           uriHelper: ProductQuery.uriProductHelper,
         ),
       ),
       rounded: false,
     );
-    final DateTime? uploaded = productImage.uploaded;
+    final DateTime? uploaded = widget.productImage.uploaded;
     if (uploaded == null) {
       return image;
     }
@@ -51,43 +83,55 @@ class ProductImageWidget extends StatelessWidget {
           : appLocalizations.product_image_accessibility_label(date),
       excludeSemantics: true,
       button: true,
-      child: Column(
-        children: <Widget>[
-          Expanded(
-            child: image,
-          ),
-          SizedBox(
-            width: double.infinity,
-            child: Padding(
-              padding: const EdgeInsets.symmetric(
-                horizontal: SMALL_SPACE,
-                vertical: VERY_SMALL_SPACE,
+      child: SmoothCard(
+        padding: EdgeInsets.zero,
+        color: backgroundColor ?? colors.primaryBlack,
+        borderRadius: ANGULAR_BORDER_RADIUS,
+        margin: EdgeInsets.zero,
+        child: ClipRRect(
+          borderRadius: ANGULAR_BORDER_RADIUS,
+          child: Column(
+            children: <Widget>[
+              Expanded(
+                child: image,
               ),
-              child: Stack(
-                children: <Widget>[
-                  Center(
-                    child: AutoSizeText(
-                      date,
-                      maxLines: 1,
-                    ),
+              SizedBox(
+                width: double.infinity,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: SMALL_SPACE,
+                    vertical: VERY_SMALL_SPACE,
                   ),
-                  if (expired)
-                    Positioned.directional(
-                      end: 0.0,
-                      height: 20.0,
-                      textDirection: Directionality.of(context),
-                      child: Outdated(
-                        size: 18.0,
-                        color: Theme.of(context)
-                            .extension<SmoothColorsThemeExtension>()!
-                            .red,
+                  child: Stack(
+                    children: <Widget>[
+                      Center(
+                        child: AutoSizeText(
+                          date,
+                          maxLines: 1,
+                          style: TextStyle(
+                            color: darkBackground!
+                                ? Colors.white
+                                : colors.primaryDark,
+                          ),
+                        ),
                       ),
-                    ),
-                ],
-              ),
-            ),
-          )
-        ],
+                      if (expired)
+                        Positioned.directional(
+                          end: 0.0,
+                          height: 20.0,
+                          textDirection: Directionality.of(context),
+                          child: Outdated(
+                            size: 18.0,
+                            color: colors.red,
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+              )
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/packages/smooth_app/lib/pages/image/product_image_widget.dart
+++ b/packages/smooth_app/lib/pages/image/product_image_widget.dart
@@ -1,10 +1,14 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:intl/intl.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/images/smooth_image.dart';
 import 'package:smooth_app/query/product_query.dart';
+import 'package:smooth_app/resources/app_icons.dart';
+import 'package:smooth_app/services/smooth_services.dart';
+import 'package:smooth_app/themes/smooth_theme_colors.dart';
 
 /// Displays a product image thumbnail with the upload date on top.
 class ProductImageWidget extends StatelessWidget {
@@ -18,10 +22,19 @@ class ProductImageWidget extends StatelessWidget {
   final String barcode;
   final double squareSize;
 
-  static final DateFormat _dateFormat = DateFormat('yyyy-MM-dd');
-
   @override
   Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    DateFormat dateFormat;
+
+    try {
+      dateFormat = DateFormat(appLocalizations.product_image_date_format);
+    } catch (_) {
+      dateFormat = DateFormat('yyyy-MM-dd');
+      Logs.e(
+          'Invalid date format detected: ${appLocalizations.product_image_date_format}');
+    }
+
     final Widget image = SmoothImage(
       width: squareSize,
       height: squareSize,
@@ -37,35 +50,53 @@ class ProductImageWidget extends StatelessWidget {
     if (uploaded == null) {
       return image;
     }
-    final DateTime now = DateTime.now();
-    final String date = _dateFormat.format(uploaded);
-    final bool expired = now.difference(uploaded).inDays > 365;
-    return Stack(
-      children: <Widget>[
-        image,
-        SizedBox(
-          width: squareSize,
-          height: squareSize,
-          child: Align(
-            alignment: Alignment.bottomCenter,
+    final bool expired = DateTime.now().difference(uploaded).inDays > 365;
+    final String date = dateFormat.format(uploaded);
+
+    return Semantics(
+      label: expired
+          ? appLocalizations.product_image_outdated_accessibility_label(date)
+          : appLocalizations.product_image_accessibility_label(date),
+      excludeSemantics: true,
+      button: true,
+      child: Column(
+        children: <Widget>[
+          Expanded(
+            child: image,
+          ),
+          SizedBox(
+            width: double.infinity,
             child: Padding(
-              padding: const EdgeInsets.all(SMALL_SPACE),
-              child: Container(
-                height: VERY_LARGE_SPACE,
-                color: expired
-                    ? Colors.red.withAlpha(128)
-                    : Colors.white.withAlpha(128),
-                child: Center(
-                  child: AutoSizeText(
-                    date,
-                    maxLines: 1,
+              padding: const EdgeInsets.symmetric(
+                horizontal: SMALL_SPACE,
+                vertical: VERY_SMALL_SPACE,
+              ),
+              child: Stack(
+                children: <Widget>[
+                  Center(
+                    child: AutoSizeText(
+                      date,
+                      maxLines: 1,
+                    ),
                   ),
-                ),
+                  if (expired)
+                    Positioned.directional(
+                      end: 0.0,
+                      height: 20.0,
+                      textDirection: Directionality.of(context),
+                      child: Outdated(
+                        size: 18.0,
+                        color: Theme.of(context)
+                            .extension<SmoothColorsThemeExtension>()!
+                            .red,
+                      ),
+                    ),
+                ],
               ),
             ),
-          ),
-        ),
-      ],
+          )
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
HI everyone,

Here is the current layout for the gallery:
<img width="566" alt="Screenshot 2024-06-13 at 10 16 47" src="https://github.com/openfoodfacts/smooth-app/assets/246838/efe6276c-f59d-42a4-bdd2-a270cd42e9dd">

There are three issues:
- Text is poorly readable (and thus accessible)
- No accessibility node
- The date format is not translated

I've fixed all of them + added the icon from the POC:

<img width="566" alt="Screenshot 2024-06-13 at 12 13 29" src="https://github.com/openfoodfacts/smooth-app/assets/246838/1890ca29-c5d4-435b-9984-5a7a8852636d">
