### PR TITLE
feat: 5204 - preliminary step for multi-product price addition

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1676,6 +1676,16 @@
     "prices_generic_title": "Prices",
     "prices_add_a_price": "Add a price",
     "prices_send_the_price": "Send the price",
+    "prices_barcode_search_title": "Product search",
+    "prices_barcode_search_running": "Looking for {barcode}",
+    "@prices_barcode_search_running": {
+        "description": "Dialog title about barcode look-up",
+        "placeholders": {
+            "barcode": {
+                "type": "String"
+            }
+        }
+    },
     "prices_view_prices": "View the prices",
     "prices_list_length_one_page": "{count,plural, =0{No price yet} =1{Only one price} other{All {count} prices}}",
     "@prices_list_length_one_page": {

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -1676,6 +1676,16 @@
     "prices_generic_title": "Prix",
     "prices_add_a_price": "Ajouter un prix",
     "prices_send_the_price": "Envoyer le prix",
+    "prices_barcode_search_title": "Recherche de produit",
+    "prices_barcode_search_running": "À la recherche de {barcode}",
+    "@prices_barcode_search_running": {
+        "description": "Dialog title about barcode look-up",
+        "placeholders": {
+            "barcode": {
+                "type": "String"
+            }
+        }
+    },
     "prices_view_prices": "Voir les prix",
     "prices_list_length_one_page": "{count,plural, =0{Aucun prix} =1{Un seul prix} other{Tous les {count} prix}}",
     "@prices_list_length_one_page": {

--- a/packages/smooth_app/lib/pages/prices/get_prices_model.dart
+++ b/packages/smooth_app/lib/pages/prices/get_prices_model.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
-import 'package:smooth_app/helpers/product_cards_helper.dart';
+import 'package:smooth_app/pages/prices/price_meta_product.dart';
 import 'package:smooth_app/pages/prices/product_price_add_page.dart';
 import 'package:smooth_app/query/product_query.dart';
 
@@ -20,43 +20,19 @@ class GetPricesModel {
 
   /// Gets latest prices for a product.
   factory GetPricesModel.product({
-    required final Product product,
+    required final PriceMetaProduct product,
     required final BuildContext context,
   }) =>
       GetPricesModel(
-        parameters: _getProductPricesParameters(product.barcode!),
+        parameters: _getProductPricesParameters(product.barcode),
         displayOwner: true,
         displayProduct: false,
-        uri: _getProductPricesUri(product.barcode!),
-        title: getProductNameAndBrands(
-          product,
-          AppLocalizations.of(context),
-        ),
+        uri: _getProductPricesUri(product.barcode),
+        title: product.getName(AppLocalizations.of(context)),
         subtitle: product.barcode,
         addButton: () async => ProductPriceAddPage.showProductPage(
           context: context,
           product: product,
-        ),
-        enableCountButton: false,
-      );
-
-  /// Gets latest prices for a barcode.
-  factory GetPricesModel.barcode({
-    required final String barcode,
-    required final String name,
-    required final BuildContext context,
-  }) =>
-      GetPricesModel(
-        parameters: _getProductPricesParameters(barcode),
-        displayOwner: true,
-        displayProduct: false,
-        uri: _getProductPricesUri(barcode),
-        title: name,
-        subtitle: barcode,
-        addButton: () async => ProductPriceAddPage.showBarcodePage(
-          context: context,
-          barcode: barcode,
-          title: name,
         ),
         enableCountButton: false,
       );

--- a/packages/smooth_app/lib/pages/prices/price_amount_card.dart
+++ b/packages/smooth_app/lib/pages/prices/price_amount_card.dart
@@ -1,15 +1,19 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:provider/provider.dart';
 import 'package:smooth_app/generic_lib/buttons/smooth_large_button_with_icon.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/pages/prices/price_amount_field.dart';
-import 'package:smooth_app/pages/prices/price_model.dart';
+import 'package:smooth_app/pages/prices/price_amount_model.dart';
+import 'package:smooth_app/pages/prices/price_meta_product.dart';
+import 'package:smooth_app/pages/prices/price_product_list_tile.dart';
+import 'package:smooth_app/pages/prices/price_product_search_page.dart';
 
 /// Card that displays the amounts (discounted or not) for price adding.
 class PriceAmountCard extends StatefulWidget {
-  const PriceAmountCard();
+  const PriceAmountCard(this.model);
+
+  final PriceAmountModel model;
 
   @override
   State<PriceAmountCard> createState() => _PriceAmountCardState();
@@ -22,16 +26,39 @@ class _PriceAmountCardState extends State<PriceAmountCard> {
 
   @override
   Widget build(BuildContext context) {
-    final PriceModel model = context.watch<PriceModel>();
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     return SmoothCard(
       child: Column(
         children: <Widget>[
           Text(appLocalizations.prices_amount_subtitle),
+          PriceProductListTile(
+            product: widget.model.product,
+            trailingIconData: Icons.edit,
+            onPressed: () async {
+              final PriceMetaProduct? product =
+                  await Navigator.of(context).push(
+                MaterialPageRoute<PriceMetaProduct>(
+                  builder: (BuildContext context) => PriceProductSearchPage(
+                    widget.model.product,
+                  ),
+                ),
+              );
+              if (product == null) {
+                return;
+              }
+              setState(
+                () => widget.model.product = product,
+              );
+            },
+          ),
           SmoothLargeButtonWithIcon(
-            icon: model.promo ? Icons.check_box : Icons.check_box_outline_blank,
+            icon: widget.model.promo
+                ? Icons.check_box
+                : Icons.check_box_outline_blank,
             text: appLocalizations.prices_amount_is_discounted,
-            onPressed: () => model.promo = !model.promo,
+            onPressed: () => setState(
+              () => widget.model.promo = !widget.model.promo,
+            ),
           ),
           const SizedBox(height: SMALL_SPACE),
           LayoutBuilder(
@@ -46,10 +73,10 @@ class _PriceAmountCardState extends State<PriceAmountCard> {
                 child: PriceAmountField(
                   controller: _controllerPaid,
                   isPaidPrice: true,
-                  model: model,
+                  model: widget.model,
                 ),
               );
-              if (!model.promo) {
+              if (!widget.model.promo) {
                 return Align(
                   alignment: Alignment.centerLeft,
                   child: columnPaid,
@@ -60,7 +87,7 @@ class _PriceAmountCardState extends State<PriceAmountCard> {
                 child: PriceAmountField(
                   controller: _controllerWithoutDiscount,
                   isPaidPrice: false,
-                  model: model,
+                  model: widget.model,
                 ),
               );
               return Row(

--- a/packages/smooth_app/lib/pages/prices/price_amount_card.dart
+++ b/packages/smooth_app/lib/pages/prices/price_amount_card.dart
@@ -5,9 +5,7 @@ import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/pages/prices/price_amount_field.dart';
 import 'package:smooth_app/pages/prices/price_amount_model.dart';
-import 'package:smooth_app/pages/prices/price_meta_product.dart';
 import 'package:smooth_app/pages/prices/price_product_list_tile.dart';
-import 'package:smooth_app/pages/prices/price_product_search_page.dart';
 
 /// Card that displays the amounts (discounted or not) for price adding.
 class PriceAmountCard extends StatefulWidget {
@@ -33,23 +31,6 @@ class _PriceAmountCardState extends State<PriceAmountCard> {
           Text(appLocalizations.prices_amount_subtitle),
           PriceProductListTile(
             product: widget.model.product,
-            trailingIconData: Icons.edit,
-            onPressed: () async {
-              final PriceMetaProduct? product =
-                  await Navigator.of(context).push(
-                MaterialPageRoute<PriceMetaProduct>(
-                  builder: (BuildContext context) => PriceProductSearchPage(
-                    widget.model.product,
-                  ),
-                ),
-              );
-              if (product == null) {
-                return;
-              }
-              setState(
-                () => widget.model.product = product,
-              );
-            },
           ),
           SmoothLargeButtonWithIcon(
             icon: widget.model.promo

--- a/packages/smooth_app/lib/pages/prices/price_amount_field.dart
+++ b/packages/smooth_app/lib/pages/prices/price_amount_field.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_text_form_field.dart';
-import 'package:smooth_app/pages/prices/price_model.dart';
+import 'package:smooth_app/pages/prices/price_amount_model.dart';
 
 /// Text field that displays a single amount for price adding.
 class PriceAmountField extends StatelessWidget {
@@ -11,7 +11,7 @@ class PriceAmountField extends StatelessWidget {
     required this.controller,
   });
 
-  final PriceModel model;
+  final PriceAmountModel model;
   final bool isPaidPrice;
   final TextEditingController controller;
 
@@ -46,7 +46,7 @@ class PriceAmountField extends StatelessWidget {
           if (value == null || value.isEmpty) {
             return appLocalizations.prices_amount_price_mandatory;
           }
-          final double? doubleValue = model.validateDouble(value);
+          final double? doubleValue = PriceAmountModel.validateDouble(value);
           if (doubleValue == null) {
             return appLocalizations.prices_amount_price_incorrect;
           }
@@ -57,7 +57,7 @@ class PriceAmountField extends StatelessWidget {
         if (value == null || value.isEmpty) {
           return null;
         }
-        final double? doubleValue = model.validateDouble(value);
+        final double? doubleValue = PriceAmountModel.validateDouble(value);
         if (doubleValue == null) {
           return appLocalizations.prices_amount_price_incorrect;
         }

--- a/packages/smooth_app/lib/pages/prices/price_amount_model.dart
+++ b/packages/smooth_app/lib/pages/prices/price_amount_model.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:smooth_app/pages/prices/price_meta_product.dart';
+
+/// Model for the price of a single product.
+class PriceAmountModel {
+  PriceAmountModel({
+    required this.product,
+  });
+
+  PriceMetaProduct product;
+
+  String _paidPrice = '';
+  String _priceWithoutDiscount = '';
+
+  set paidPrice(final String value) => _paidPrice = value;
+
+  set priceWithoutDiscount(final String value) => _priceWithoutDiscount = value;
+
+  late double _checkedPaidPrice;
+  double? _checkedPriceWithoutDiscount;
+
+  double get checkedPaidPrice => _checkedPaidPrice;
+
+  double? get checkedPriceWithoutDiscount => _checkedPriceWithoutDiscount;
+
+  bool promo = false;
+
+  static double? validateDouble(final String value) =>
+      double.tryParse(value) ??
+      double.tryParse(
+        value.replaceAll(',', '.'),
+      );
+
+  String? checkParameters(final BuildContext context) {
+    _checkedPaidPrice = validateDouble(_paidPrice)!;
+    _checkedPriceWithoutDiscount = null;
+    if (promo) {
+      if (_priceWithoutDiscount.isNotEmpty) {
+        _checkedPriceWithoutDiscount = validateDouble(_priceWithoutDiscount);
+        if (_checkedPriceWithoutDiscount == null) {
+          return AppLocalizations.of(context).prices_amount_price_incorrect;
+        }
+      }
+    }
+    return null;
+  }
+}

--- a/packages/smooth_app/lib/pages/prices/price_count_widget.dart
+++ b/packages/smooth_app/lib/pages/prices/price_count_widget.dart
@@ -5,23 +5,19 @@ import 'package:smooth_app/database/dao_product.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/pages/prices/get_prices_model.dart';
 import 'package:smooth_app/pages/prices/price_button.dart';
+import 'package:smooth_app/pages/prices/price_meta_product.dart';
 import 'package:smooth_app/pages/prices/prices_page.dart';
 
 /// Price Count display.
 class PriceCountWidget extends StatelessWidget {
   const PriceCountWidget(
     this.count, {
-    required this.barcode,
-    required this.name,
+    required this.priceProduct,
     required this.enableCountButton,
   });
 
   final int count;
-  final String barcode;
-
-  /// Product name to display in case we have only the barcode, not the product.
-  final String name;
-
+  final PriceProduct priceProduct;
   final bool enableCountButton;
 
   @override
@@ -31,24 +27,20 @@ class PriceCountWidget extends StatelessWidget {
             : () async {
                 final LocalDatabase localDatabase =
                     context.read<LocalDatabase>();
-                final Product? product =
-                    await DaoProduct(localDatabase).get(barcode);
+                final Product? newProduct =
+                    await DaoProduct(localDatabase).get(priceProduct.code);
                 if (!context.mounted) {
                   return;
                 }
                 return Navigator.of(context).push<void>(
                   MaterialPageRoute<void>(
                     builder: (BuildContext context) => PricesPage(
-                      product != null
-                          ? GetPricesModel.product(
-                              product: product,
-                              context: context,
-                            )
-                          : GetPricesModel.barcode(
-                              barcode: barcode,
-                              name: name,
-                              context: context,
-                            ),
+                      GetPricesModel.product(
+                        product: newProduct != null
+                            ? PriceMetaProduct.product(newProduct)
+                            : PriceMetaProduct.priceProduct(priceProduct),
+                        context: context,
+                      ),
                     ),
                   ),
                 );

--- a/packages/smooth_app/lib/pages/prices/price_meta_product.dart
+++ b/packages/smooth_app/lib/pages/prices/price_meta_product.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/helpers/product_cards_helper.dart';
+
+/// Meta version of a product, coming from OFF or from Prices.
+class PriceMetaProduct {
+  PriceMetaProduct.product(Product this.product) : priceProduct = null;
+  PriceMetaProduct.priceProduct(PriceProduct this.priceProduct)
+      : product = null;
+
+  final Product? product;
+  final PriceProduct? priceProduct;
+
+  String get barcode =>
+      product != null ? product!.barcode! : priceProduct!.code;
+
+  String getName(final AppLocalizations appLocalizations) => product != null
+      ? getProductNameAndBrands(
+          product!,
+          appLocalizations,
+        )
+      : priceProduct!.name ?? priceProduct!.code;
+
+  String? get imageUrl => product != null ? null : priceProduct!.imageURL;
+}

--- a/packages/smooth_app/lib/pages/prices/price_model.dart
+++ b/packages/smooth_app/lib/pages/prices/price_model.dart
@@ -7,18 +7,21 @@ import 'package:smooth_app/data_models/preferences/user_preferences.dart';
 import 'package:smooth_app/pages/crop_parameters.dart';
 import 'package:smooth_app/pages/locations/osm_location.dart';
 import 'package:smooth_app/pages/onboarding/currency_selector_helper.dart';
+import 'package:smooth_app/pages/prices/price_amount_model.dart';
+import 'package:smooth_app/pages/prices/price_meta_product.dart';
 
 /// Price Model (checks and background task call) for price adding.
 class PriceModel with ChangeNotifier {
   PriceModel({
     required final ProofType proofType,
     required final List<OsmLocation> locations,
-    required this.barcode,
+    required final PriceMetaProduct product,
   })  : _proofType = proofType,
         _date = DateTime.now(),
-        _locations = locations;
+        _locations = locations,
+        priceAmountModel = PriceAmountModel(product: product);
 
-  final String barcode;
+  final PriceAmountModel priceAmountModel;
 
   CropParameters? _cropParameters;
 
@@ -61,33 +64,10 @@ class PriceModel with ChangeNotifier {
 
   OsmLocation? get location => _locations.firstOrNull;
 
-  bool _promo = false;
-
-  bool get promo => _promo;
-
-  set promo(final bool promo) {
-    _promo = promo;
-    notifyListeners();
-  }
-
-  String _paidPrice = '';
-  String _priceWithoutDiscount = '';
-
-  set paidPrice(final String value) => _paidPrice = value;
-  set priceWithoutDiscount(final String value) => _priceWithoutDiscount = value;
-
   late Currency _checkedCurrency;
-  late double _checkedPaidPrice;
-  double? _checkedPriceWithoutDiscount;
-
-  double? validateDouble(final String value) =>
-      double.tryParse(value) ??
-      double.tryParse(
-        value.replaceAll(',', '.'),
-      );
 
   /// Returns the error message of the parameter check, or null if OK.
-  Future<String?> checkParameters(final BuildContext context) async {
+  String? checkParameters(final BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     if (cropParameters == null) {
       return appLocalizations.prices_proof_mandatory;
@@ -97,15 +77,9 @@ class PriceModel with ChangeNotifier {
     _checkedCurrency =
         CurrencySelectorHelper().getSelected(userPreferences.userCurrencyCode);
 
-    _checkedPaidPrice = validateDouble(_paidPrice)!;
-    _checkedPriceWithoutDiscount = null;
-    if (promo) {
-      if (_priceWithoutDiscount.isNotEmpty) {
-        _checkedPriceWithoutDiscount = validateDouble(_priceWithoutDiscount);
-        if (_checkedPriceWithoutDiscount == null) {
-          return appLocalizations.prices_amount_price_incorrect;
-        }
-      }
+    final String? checkParameters = priceAmountModel.checkParameters(context);
+    if (checkParameters != null) {
+      return checkParameters;
     }
 
     if (location == null) {
@@ -118,16 +92,18 @@ class PriceModel with ChangeNotifier {
   /// Adds the related background task.
   Future<void> addTask(final BuildContext context) async =>
       BackgroundTaskAddPrice.addTask(
+        context: context,
+        // per receipt
         cropObject: cropParameters!,
         locationOSMId: location!.osmId,
         locationOSMType: location!.osmType,
         date: date,
         proofType: proofType,
         currency: _checkedCurrency,
-        barcode: barcode,
-        priceIsDiscounted: promo,
-        price: _checkedPaidPrice,
-        priceWithoutDiscount: _checkedPriceWithoutDiscount,
-        context: context,
+        // per item
+        barcode: priceAmountModel.product.barcode,
+        priceIsDiscounted: priceAmountModel.promo,
+        price: priceAmountModel.checkedPaidPrice,
+        priceWithoutDiscount: priceAmountModel.checkedPriceWithoutDiscount,
       );
 }

--- a/packages/smooth_app/lib/pages/prices/price_product_list_tile.dart
+++ b/packages/smooth_app/lib/pages/prices/price_product_list_tile.dart
@@ -9,55 +9,59 @@ import 'package:smooth_app/pages/prices/price_meta_product.dart';
 class PriceProductListTile extends StatelessWidget {
   const PriceProductListTile({
     required this.product,
-    required this.trailingIconData,
-    required this.onPressed,
+    this.trailingIconData,
+    this.onPressed,
   });
 
   final PriceMetaProduct product;
-  final IconData trailingIconData;
-  final VoidCallback onPressed;
+  final IconData? trailingIconData;
+  final VoidCallback? onPressed;
 
   @override
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final Size screenSize = MediaQuery.sizeOf(context);
     final double size = screenSize.width * 0.20;
+    final Widget child = Row(
+      mainAxisAlignment: MainAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: <Widget>[
+        SizedBox(
+          width: size,
+          child: product.product != null
+              ? SmoothMainProductImage(
+                  product: product.product!,
+                  width: size,
+                  height: size,
+                )
+              : SmoothImage(
+                  width: size,
+                  height: size,
+                  imageProvider: product.imageUrl == null
+                      ? null
+                      : NetworkImage(product.imageUrl!),
+                ),
+        ),
+        const SizedBox(width: SMALL_SPACE),
+        Expanded(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.start,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Text(product.getName(appLocalizations)),
+              Text(product.barcode),
+            ],
+          ),
+        ),
+        if (trailingIconData != null) Icon(trailingIconData),
+      ],
+    );
+    if (onPressed == null) {
+      return child;
+    }
     return InkWell(
       onTap: onPressed,
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.start,
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: <Widget>[
-          SizedBox(
-            width: size,
-            child: product.product != null
-                ? SmoothMainProductImage(
-                    product: product.product!,
-                    width: size,
-                    height: size,
-                  )
-                : SmoothImage(
-                    width: size,
-                    height: size,
-                    imageProvider: product.imageUrl == null
-                        ? null
-                        : NetworkImage(product.imageUrl!),
-                  ),
-          ),
-          const SizedBox(width: SMALL_SPACE),
-          Expanded(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.start,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                Text(product.getName(appLocalizations)),
-                Text(product.barcode),
-              ],
-            ),
-          ),
-          Icon(trailingIconData),
-        ],
-      ),
+      child: child,
     );
   }
 }

--- a/packages/smooth_app/lib/pages/prices/price_product_list_tile.dart
+++ b/packages/smooth_app/lib/pages/prices/price_product_list_tile.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/generic_lib/widgets/images/smooth_image.dart';
+import 'package:smooth_app/generic_lib/widgets/smooth_product_image.dart';
+import 'package:smooth_app/pages/prices/price_meta_product.dart';
+
+/// Displays a meta product with an action button, as a ListTile.
+class PriceProductListTile extends StatelessWidget {
+  const PriceProductListTile({
+    required this.product,
+    required this.trailingIconData,
+    required this.onPressed,
+  });
+
+  final PriceMetaProduct product;
+  final IconData trailingIconData;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final Size screenSize = MediaQuery.sizeOf(context);
+    final double size = screenSize.width * 0.20;
+    return InkWell(
+      onTap: onPressed,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: <Widget>[
+          SizedBox(
+            width: size,
+            child: product.product != null
+                ? SmoothMainProductImage(
+                    product: product.product!,
+                    width: size,
+                    height: size,
+                  )
+                : SmoothImage(
+                    width: size,
+                    height: size,
+                    imageProvider: product.imageUrl == null
+                        ? null
+                        : NetworkImage(product.imageUrl!),
+                  ),
+          ),
+          const SizedBox(width: SMALL_SPACE),
+          Expanded(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.start,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(product.getName(appLocalizations)),
+                Text(product.barcode),
+              ],
+            ),
+          ),
+          Icon(trailingIconData),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/smooth_app/lib/pages/prices/price_product_search_page.dart
+++ b/packages/smooth_app/lib/pages/prices/price_product_search_page.dart
@@ -1,0 +1,178 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:provider/provider.dart';
+import 'package:smooth_app/data_models/fetched_product.dart';
+import 'package:smooth_app/database/dao_product.dart';
+import 'package:smooth_app/database/local_database.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/generic_lib/loading_dialog.dart';
+import 'package:smooth_app/generic_lib/widgets/smooth_back_button.dart';
+import 'package:smooth_app/generic_lib/widgets/smooth_text_form_field.dart';
+import 'package:smooth_app/pages/prices/price_meta_product.dart';
+import 'package:smooth_app/pages/prices/price_product_list_tile.dart';
+import 'package:smooth_app/pages/product/common/product_refresher.dart';
+import 'package:smooth_app/widgets/smooth_app_bar.dart';
+import 'package:smooth_app/widgets/smooth_scaffold.dart';
+
+/// Product Search Page, for Prices.
+class PriceProductSearchPage extends StatefulWidget {
+  const PriceProductSearchPage(
+    this.product,
+  );
+
+  final PriceMetaProduct product;
+  // TODO(monsieurtanuki): as a parameter, add a list of barcodes already there: we're not supposed to select twice the same product
+
+  @override
+  State<PriceProductSearchPage> createState() => _PriceProductSearchPageState();
+}
+
+class _PriceProductSearchPageState extends State<PriceProductSearchPage> {
+  final TextEditingController _controller = TextEditingController();
+
+  late PriceMetaProduct? _product = widget.product;
+
+  // TODO(monsieurtanuki): TextInputAction + focus
+  static const TextInputType _textInputType = TextInputType.number;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.text = _product?.barcode ?? '';
+  }
+
+  static const String _barcodeHint = '7300400481588';
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final LocalDatabase localDatabase = context.read<LocalDatabase>();
+    // TODO(monsieurtanuki): add WillPopScope2
+    return SmoothScaffold(
+      appBar: SmoothAppBar(
+        centerTitle: false,
+        leading: const SmoothBackButton(),
+        title: Text(appLocalizations.prices_barcode_search_title),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(LARGE_SPACE),
+        child: Column(
+          children: <Widget>[
+            // TODO(monsieurtanuki): add a "clear" button
+            // TODO(monsieurtanuki): add an automatic "validate barcode" feature (cf. https://en.wikipedia.org/wiki/International_Article_Number#Check_digit)
+            SmoothTextFormField(
+              type: TextFieldTypes.PLAIN_TEXT,
+              controller: _controller,
+              hintText: _barcodeHint,
+              textInputType: _textInputType,
+              onChanged: (_) async {
+                final String barcode = _controller.text;
+                final String cleanBarcode = _getCleanBarcode(barcode);
+                if (barcode != cleanBarcode) {
+                  setState(() => _controller.text = cleanBarcode);
+                  return;
+                }
+
+                if (_product != null) {
+                  setState(
+                    () => _product = null,
+                  );
+                }
+
+                final Product? product = await _localSearch(
+                  barcode,
+                  localDatabase,
+                );
+                if (product != null) {
+                  setState(
+                    () => _product = PriceMetaProduct.product(product),
+                  );
+                  return;
+                }
+              },
+              onFieldSubmitted: (_) async {
+                final String barcode = _controller.text;
+                if (barcode.isEmpty) {
+                  return;
+                }
+
+                final Product? product = await _serverSearch(
+                  barcode,
+                  localDatabase,
+                  context,
+                );
+                if (product != null) {
+                  setState(() => _product = PriceMetaProduct.product(product));
+                }
+              },
+              prefixIcon: const Icon(CupertinoIcons.barcode),
+              textInputAction: TextInputAction.search,
+            ),
+            if (_product != null)
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: LARGE_SPACE),
+                child: PriceProductListTile(
+                  product: _product!,
+                  trailingIconData: Icons.check_circle,
+                  onPressed: () => Navigator.of(context).pop(_product),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<Product?> _localSearch(
+    final String barcode,
+    final LocalDatabase localDatabase,
+  ) async =>
+      DaoProduct(localDatabase).get(barcode);
+
+  Future<Product?> _serverSearch(
+    final String barcode,
+    final LocalDatabase localDatabase,
+    final BuildContext context,
+  ) async {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final FetchedProduct? fetchAndRefreshed =
+        await LoadingDialog.run<FetchedProduct>(
+      future: ProductRefresher().silentFetchAndRefresh(
+        localDatabase: localDatabase,
+        barcode: barcode,
+      ),
+      context: context,
+      title: appLocalizations.prices_barcode_search_running(barcode),
+    );
+    if (fetchAndRefreshed == null) {
+      // the user probably cancelled
+      return null;
+    }
+    if (fetchAndRefreshed.product == null) {
+      if (context.mounted) {
+        await LoadingDialog.error(
+          context: context,
+          title: fetchAndRefreshed.getErrorTitle(appLocalizations),
+        );
+      }
+    }
+    return fetchAndRefreshed.product;
+  }
+
+  // Probably there's a regexp for that, but at least it's readable code.
+  String _getCleanBarcode(final String input) {
+    const int ascii0 = 48;
+    const int ascii9 = 48 + 10 - 1;
+
+    final StringBuffer buffer = StringBuffer();
+    for (int i = 0; i < input.length; i++) {
+      final int charCode = input.codeUnitAt(i);
+      if (charCode >= ascii0 && charCode <= ascii9) {
+        buffer.writeCharCode(charCode);
+      }
+    }
+    return buffer.toString();
+  }
+}

--- a/packages/smooth_app/lib/pages/prices/price_product_widget.dart
+++ b/packages/smooth_app/lib/pages/prices/price_product_widget.dart
@@ -18,10 +18,10 @@ class PriceProductWidget extends StatelessWidget {
   final PriceProduct priceProduct;
   final GetPricesModel model;
 
-  static const double _imageSize = 75;
-
   @override
   Widget build(BuildContext context) {
+    final Size screenSize = MediaQuery.sizeOf(context);
+    final double size = screenSize.width * 0.20;
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final String name = priceProduct.name ?? priceProduct.code;
     final bool unknown = priceProduct.name == null;
@@ -31,75 +31,62 @@ class PriceProductWidget extends StatelessWidget {
     final String? quantity = priceProduct.quantity == null
         ? null
         : '${priceProduct.quantity} ${priceProduct.quantityUnit ?? 'g'}';
-    return LayoutBuilder(
-      builder: (
-        final BuildContext context,
-        final BoxConstraints constraints,
-      ) =>
-          Row(
-        mainAxisAlignment: MainAxisAlignment.start,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          SizedBox(
-            width: _imageSize,
-            child: imageURL == null
-                ? const Icon(
-                    Icons.question_mark,
-                    size: _imageSize / 2,
-                  )
-                : SmoothImage(
-                    width: _imageSize,
-                    height: _imageSize,
-                    imageProvider: NetworkImage(imageURL),
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        SizedBox(
+          width: size,
+          child: SmoothImage(
+            width: size,
+            height: size,
+            imageProvider: imageURL == null ? null : NetworkImage(imageURL),
+          ),
+        ),
+        const SizedBox(width: SMALL_SPACE),
+        Expanded(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.start,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              AutoSizeText(
+                name,
+                maxLines: 2,
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              Wrap(
+                spacing: VERY_SMALL_SPACE,
+                crossAxisAlignment: WrapCrossAlignment.center,
+                runSpacing: 0,
+                children: <Widget>[
+                  PriceCountWidget(
+                    priceCount,
+                    priceProduct: priceProduct,
+                    enableCountButton: model.enableCountButton,
                   ),
-          ),
-          const SizedBox(width: SMALL_SPACE),
-          SizedBox(
-            width: constraints.maxWidth - _imageSize - SMALL_SPACE,
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.start,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                AutoSizeText(
-                  name,
-                  maxLines: 2,
-                  style: Theme.of(context).textTheme.titleMedium,
-                ),
-                Wrap(
-                  spacing: VERY_SMALL_SPACE,
-                  crossAxisAlignment: WrapCrossAlignment.center,
-                  runSpacing: 0,
-                  children: <Widget>[
-                    PriceCountWidget(
-                      priceCount,
-                      barcode: priceProduct.code,
-                      name: name,
-                      enableCountButton: model.enableCountButton,
-                    ),
-                    if (brands != null)
-                      for (final String brand in brands)
-                        PriceButton(
-                          title: brand,
-                          onPressed: () {},
-                        ),
-                    if (quantity != null) Text(quantity),
-                    if (unknown)
+                  if (brands != null)
+                    for (final String brand in brands)
                       PriceButton(
-                        title: appLocalizations.prices_unknown_product,
-                        iconData: Icons.warning,
-                        onPressed: null,
-                        buttonStyle: ElevatedButton.styleFrom(
-                          disabledForegroundColor: Colors.red,
-                          disabledBackgroundColor: Colors.red[100],
-                        ),
+                        title: brand,
+                        onPressed: () {},
                       ),
-                  ],
-                ),
-              ],
-            ),
+                  if (quantity != null) Text(quantity),
+                  if (unknown)
+                    PriceButton(
+                      title: appLocalizations.prices_unknown_product,
+                      iconData: Icons.warning,
+                      onPressed: null,
+                      buttonStyle: ElevatedButton.styleFrom(
+                        disabledForegroundColor: Colors.red,
+                        disabledBackgroundColor: Colors.red[100],
+                      ),
+                    ),
+                ],
+              ),
+            ],
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 }

--- a/packages/smooth_app/lib/pages/prices/prices_card.dart
+++ b/packages/smooth_app/lib/pages/prices/prices_card.dart
@@ -6,6 +6,7 @@ import 'package:smooth_app/generic_lib/buttons/smooth_large_button_with_icon.dar
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/pages/prices/get_prices_model.dart';
+import 'package:smooth_app/pages/prices/price_meta_product.dart';
 import 'package:smooth_app/pages/prices/prices_page.dart';
 import 'package:smooth_app/pages/prices/product_price_add_page.dart';
 
@@ -40,7 +41,7 @@ class PricesCard extends StatelessWidget {
                   MaterialPageRoute<void>(
                     builder: (BuildContext context) => PricesPage(
                       GetPricesModel.product(
-                        product: product,
+                        product: PriceMetaProduct.product(product),
                         context: context,
                       ),
                     ),
@@ -55,7 +56,7 @@ class PricesCard extends StatelessWidget {
                 icon: Icons.add,
                 onPressed: () async => ProductPriceAddPage.showProductPage(
                   context: context,
-                  product: product,
+                  product: PriceMetaProduct.product(product),
                 ),
               ),
             ),

--- a/packages/smooth_app/lib/pages/prices/product_price_add_page.dart
+++ b/packages/smooth_app/lib/pages/prices/product_price_add_page.dart
@@ -8,12 +8,12 @@ import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_back_button.dart';
-import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/pages/locations/osm_location.dart';
 import 'package:smooth_app/pages/prices/price_amount_card.dart';
 import 'package:smooth_app/pages/prices/price_currency_card.dart';
 import 'package:smooth_app/pages/prices/price_date_card.dart';
 import 'package:smooth_app/pages/prices/price_location_card.dart';
+import 'package:smooth_app/pages/prices/price_meta_product.dart';
 import 'package:smooth_app/pages/prices/price_model.dart';
 import 'package:smooth_app/pages/prices/price_proof_card.dart';
 import 'package:smooth_app/pages/product/common/product_refresher.dart';
@@ -23,43 +23,16 @@ import 'package:smooth_app/widgets/smooth_scaffold.dart';
 /// Single page that displays all the elements of price adding.
 class ProductPriceAddPage extends StatefulWidget {
   const ProductPriceAddPage({
-    required this.barcode,
-    required this.title,
+    required this.product,
     required this.latestOsmLocations,
   });
 
-  final String barcode;
-  final String title;
+  final PriceMetaProduct product;
   final List<OsmLocation> latestOsmLocations;
-
-  static Future<void> showBarcodePage({
-    required final BuildContext context,
-    required final String barcode,
-    required final String title,
-  }) async =>
-      _showPage(
-        context: context,
-        barcode: barcode,
-        title: title,
-      );
 
   static Future<void> showProductPage({
     required final BuildContext context,
-    required final Product product,
-  }) async =>
-      _showPage(
-        context: context,
-        barcode: product.barcode!,
-        title: getProductNameAndBrands(
-          product,
-          AppLocalizations.of(context),
-        ),
-      );
-
-  static Future<void> _showPage({
-    required final BuildContext context,
-    required final String barcode,
-    required final String title,
+    required final PriceMetaProduct product,
   }) async {
     if (!await ProductRefresher().checkIfLoggedIn(
       context,
@@ -79,8 +52,7 @@ class ProductPriceAddPage extends StatefulWidget {
     await Navigator.of(context).push(
       MaterialPageRoute<void>(
         builder: (BuildContext context) => ProductPriceAddPage(
-          barcode: barcode,
-          title: title,
+          product: product,
           latestOsmLocations: osmLocations,
         ),
       ),
@@ -95,7 +67,7 @@ class _ProductPriceAddPageState extends State<ProductPriceAddPage> {
   late final PriceModel _model = PriceModel(
     proofType: ProofType.priceTag,
     locations: widget.latestOsmLocations,
-    barcode: widget.barcode,
+    product: widget.product,
   );
 
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
@@ -113,10 +85,8 @@ class _ProductPriceAddPageState extends State<ProductPriceAddPage> {
             centerTitle: false,
             leading: const SmoothBackButton(),
             title: Text(
-              widget.title,
-              maxLines: 1,
+              appLocalizations.prices_add_a_price,
             ),
-            subTitle: Text(widget.barcode),
             actions: <Widget>[
               IconButton(
                 icon: const Icon(Icons.info),
@@ -124,48 +94,27 @@ class _ProductPriceAddPageState extends State<ProductPriceAddPage> {
               ),
             ],
           ),
-          body: const SingleChildScrollView(
-            padding: EdgeInsets.all(LARGE_SPACE),
+          body: SingleChildScrollView(
+            padding: const EdgeInsets.all(LARGE_SPACE),
             child: Column(
               children: <Widget>[
-                PriceProofCard(),
-                SizedBox(height: LARGE_SPACE),
-                PriceDateCard(),
-                SizedBox(height: LARGE_SPACE),
-                PriceLocationCard(),
-                SizedBox(height: LARGE_SPACE),
-                PriceCurrencyCard(),
-                SizedBox(height: LARGE_SPACE),
-                PriceAmountCard(),
+                const PriceProofCard(),
+                const SizedBox(height: LARGE_SPACE),
+                const PriceDateCard(),
+                const SizedBox(height: LARGE_SPACE),
+                const PriceLocationCard(),
+                const SizedBox(height: LARGE_SPACE),
+                const PriceCurrencyCard(),
+                const SizedBox(height: LARGE_SPACE),
+                PriceAmountCard(_model.priceAmountModel),
                 // so that the last items don't get hidden by the FAB
-                SizedBox(height: MINIMUM_TOUCH_SIZE * 2),
+                const SizedBox(height: MINIMUM_TOUCH_SIZE * 2),
               ],
             ),
           ),
           floatingActionButton: FloatingActionButton.extended(
             onPressed: () async {
-              if (!_formKey.currentState!.validate()) {
-                return;
-              }
-
-              String? error;
-              try {
-                error = await _model.checkParameters(context);
-              } catch (e) {
-                error = e.toString();
-              }
-              if (error != null) {
-                if (!context.mounted) {
-                  return;
-                }
-                await showDialog<void>(
-                  context: context,
-                  builder: (BuildContext context) =>
-                      SmoothSimpleErrorAlertDialog(
-                    title: appLocalizations.prices_add_validation_error,
-                    message: error!,
-                  ),
-                );
+              if (!await _check(context)) {
                 return;
               }
               if (!context.mounted) {
@@ -221,5 +170,33 @@ class _ProductPriceAddPageState extends State<ProductPriceAddPage> {
               ),
       ),
     );
+  }
+
+  /// Returns true if the basic checks passed.
+  Future<bool> _check(final BuildContext context) async {
+    if (!_formKey.currentState!.validate()) {
+      return false;
+    }
+
+    String? error;
+    try {
+      error = _model.checkParameters(context);
+    } catch (e) {
+      error = e.toString();
+    }
+    if (error != null) {
+      if (!context.mounted) {
+        return false;
+      }
+      await showDialog<void>(
+        context: context,
+        builder: (BuildContext context) => SmoothSimpleErrorAlertDialog(
+          title: AppLocalizations.of(context).prices_add_validation_error,
+          message: error!,
+        ),
+      );
+      return false;
+    }
+    return true;
   }
 }

--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -13,6 +13,7 @@ import 'package:smooth_app/generic_lib/widgets/smooth_list_tile_card.dart';
 import 'package:smooth_app/generic_lib/widgets/svg_icon.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
+import 'package:smooth_app/pages/prices/price_meta_product.dart';
 import 'package:smooth_app/pages/prices/product_price_add_page.dart';
 import 'package:smooth_app/pages/product/add_other_details_page.dart';
 import 'package:smooth_app/pages/product/common/product_refresher.dart';
@@ -259,7 +260,7 @@ class _EditProductPageState extends State<EditProductPage> with UpToDateMixin {
                 leading: const Icon(Icons.add),
                 onTap: () async => ProductPriceAddPage.showProductPage(
                   context: context,
-                  product: upToDateProduct,
+                  product: PriceMetaProduct.product(upToDateProduct),
                 ),
               ),
             ],


### PR DESCRIPTION
### What
This is the first step towards multi-product price addition:
- improved flexibility in the "add price page" as now we can change the product (coming next: adding receipt lines, with their own products and amounts)
- creation of a "meta" product, in order to treat in a similar way products from "off" and products from "prices"
- creation of a "product search" page (barcode search), currently with local and server look-ups, with room for many new features

### Screenshots
| add a price | search a product |
| -- | -- |
| ![Screenshot_1718266980](https://github.com/openfoodfacts/smooth-app/assets/11576431/0fff00c3-3aa1-4c4f-a3ed-e3252dea8880) | ![Screenshot_1718266995](https://github.com/openfoodfacts/smooth-app/assets/11576431/d8008db9-552f-4524-8e54-d8c95e007027) |

### Part of 
- #5204

### Files
New files:
* `price_amount_model.dart`: Model for the price of a single product.
* `price_meta_product.dart`: Meta version of a product, coming from OFF or from Prices.
* `price_product_search_page.dart`: Product Search Page, for Prices.
* `price_product_list_tile.dart`: Displays a meta product with an action button, as a ListTile.

Impacted files:
* `app_en.arb`: added 2 labels for the new "price product search" page
* `app_fr.arb`: added 2 labels for the new "price product search" page
* `edit_product_page.dart`: minor refactoring
* `get_prices_model.dart`: minor refactoring
* `price_amount_card.dart`: minor refactoring
* `price_amount_field.dart`: minor refactoring
* `price_count_widget.dart`: minor refactoring
* `price_model.dart`: moved product amount code to new class `PriceAmountModel`
* `price_product_widget.dart`: unrelated UI refactoring
* `prices_card.dart`: minor refactoring
* `product_price_add_page.dart`: minor refactoring