### PR TITLE
fix: Hide Robotoff banner on the onboarding

### DIFF
--- a/packages/smooth_app/lib/pages/onboarding/preferences_page.dart
+++ b/packages/smooth_app/lib/pages/onboarding/preferences_page.dart
@@ -109,6 +109,7 @@ class _HelperState extends State<_Helper> {
           isRemovable: false,
           isSettingVisible: false,
           isProductEditable: false,
+          showQuestionsBanner: false,
         ),
       ),
     ];

--- a/packages/smooth_app/lib/pages/product/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/new_product_page.dart
@@ -217,7 +217,6 @@ class _ProductPageState extends State<ProductPage>
                     upToDateProduct,
                     _productPreferences,
                     isFullVersion: true,
-                    showUnansweredQuestions: true,
                   ),
                 ),
               ),

--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -17,6 +17,7 @@ import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/helpers/ui_helpers.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_page.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels_builder.dart';
+import 'package:smooth_app/pages/hunger_games/question_card.dart';
 import 'package:smooth_app/pages/product/common/product_query_page_helper.dart';
 import 'package:smooth_app/pages/product/hideable_container.dart';
 import 'package:smooth_app/pages/product/product_compatibility_header.dart';
@@ -41,7 +42,7 @@ class SummaryCard extends StatefulWidget {
     this._product,
     this._productPreferences, {
     this.isFullVersion = false,
-    this.showUnansweredQuestions = false,
+    this.showQuestionsBanner = false,
     this.isRemovable = true,
     this.isSettingVisible = true,
     this.isProductEditable = true,
@@ -58,9 +59,8 @@ class SummaryCard extends StatefulWidget {
   /// Buttons should only be visible in full mode
   final bool isFullVersion;
 
-  /// If true, the summary card will try to load unanswered questions about this
-  /// product and give a prompt to answer those questions.
-  final bool showUnansweredQuestions;
+  /// If true, show the [QuestionCard] if there are questions for the product.
+  final bool showQuestionsBanner;
 
   /// If true, there will be a button to remove the product from the carousel.
   final bool isRemovable;
@@ -347,6 +347,7 @@ class _SummaryCardState extends State<SummaryCard> with UpToDateMixin {
           ProductIncompleteCard(product: upToDateProduct),
         ..._getAttributes(scoreAttributes),
         if (widget.isFullVersion &&
+            widget.showQuestionsBanner &&
             _questionsLayout == ProductQuestionsLayout.button)
           ProductQuestionsWidget(
             upToDateProduct,


### PR DESCRIPTION
Hi everyone,

On the onboarding, we quickly have the Robotoff banner appearing.
This PR totally hides it.

Old behavior:

https://github.com/openfoodfacts/smooth-app/assets/246838/22772a47-7f0a-4d47-8f7b-3f72cf267349

