### PR TITLE
feat: Dev mode with sections + reordered

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1726,6 +1726,11 @@
     "@dev_preferences_import_history_result_success": {
         "description": "User dev preferences - Import history - Result successful"
     },
+    "dev_mode_section_server": "Server configuration",
+    "dev_mode_section_product_page": "Product page",
+    "dev_mode_section_ui": "User Interface",
+    "dev_mode_section_data": "Data",
+    "dev_mode_section_experimental_features": "Experimental features",
     "dev_mode_hide_ecoscore_title": "Exclude Eco-Score",
     "@dev_mode_hide_ecoscore_title": {
         "description": "User dev preferences - Disable Ecoscore - Title"

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_item.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_item.dart
@@ -17,5 +17,5 @@ class UserPreferencesItemSimple implements UserPreferencesItem {
   final Iterable<String> labels;
 
   @override
-  final Widget Function(BuildContext) builder;
+  final WidgetBuilder builder;
 }

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_widgets.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_widgets.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:smooth_app/generic_lib/bottom_sheets/smooth_bottom_sheet.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_item.dart';
+import 'package:smooth_app/themes/smooth_theme_colors.dart';
 
 /// A dashed line
 class UserPreferencesListItemDivider extends StatelessWidget {
@@ -123,7 +124,7 @@ class UserPreferencesItemSwitch implements UserPreferencesItem {
       ];
 
   @override
-  Widget Function(BuildContext) get builder =>
+  WidgetBuilder get builder =>
       (final BuildContext context) => UserPreferencesSwitchWidget(
             title: title,
             subtitle: subtitle,
@@ -154,14 +155,59 @@ class UserPreferencesItemTile implements UserPreferencesItem {
       ];
 
   @override
-  Widget Function(BuildContext) get builder =>
-      (final BuildContext context) => ListTile(
-            title: Text(title),
-            subtitle: subtitle == null ? null : Text(subtitle!),
-            onTap: onTap,
-            leading: leading,
-            trailing: trailing,
-          );
+  WidgetBuilder get builder => (final BuildContext context) => ListTile(
+        title: Text(title),
+        subtitle: subtitle == null ? null : Text(subtitle!),
+        onTap: onTap,
+        leading: leading,
+        trailing: trailing,
+      );
+}
+
+class UserPreferencesItemSection implements UserPreferencesItem {
+  const UserPreferencesItemSection({
+    required this.label,
+    this.icon,
+  }) : assert(label.length > 0);
+
+  final String label;
+  final Widget? icon;
+
+  @override
+  WidgetBuilder get builder => (BuildContext context) {
+        final SmoothColorsThemeExtension colors =
+            Theme.of(context).extension<SmoothColorsThemeExtension>()!;
+
+        return Container(
+          color: colors.primaryDark,
+          padding: const EdgeInsets.symmetric(
+            horizontal: LARGE_SPACE,
+            vertical: SMALL_SPACE,
+          ),
+          child: Row(
+            children: <Widget>[
+              Expanded(
+                child: Text(
+                  label,
+                  style: TextStyle(
+                    color: colors.primaryLight,
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+              if (icon != null)
+                IconTheme(
+                  data: IconThemeData(color: colors.primaryLight),
+                  child: icon!,
+                ),
+            ],
+          ),
+        );
+      };
+
+  @override
+  Iterable<String> get labels => <String>[label];
 }
 
 /// A preference allowing to choose between a list of items.


### PR DESCRIPTION
Hi everyone,

The dev mode page has a lot of text and it isn't easy to find things.
That's why, I've reordered everything + added some sections:

<img width="497" alt="Screenshot 2024-06-13 at 17 53 37" src="https://github.com/openfoodfacts/smooth-app/assets/246838/53fc5455-5749-4f72-8b59-fbf487c7b018">
