### PR TITLE
feat: 5204 - multi-product price addition

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1674,8 +1674,10 @@
     "prices_app_dev_mode_flag": "Shortcut to Prices app on product page",
     "prices_app_button": "Go to Prices app",
     "prices_generic_title": "Prices",
+    "prices_add_n_prices": "{count,plural, =1{Add a price} other{App {count} prices}}",
+    "prices_send_n_prices": "{count,plural, =1{Send the price} other{Send {count} prices}}",
+    "prices_add_an_item": "Add an item",
     "prices_add_a_price": "Add a price",
-    "prices_send_the_price": "Send the price",
     "prices_barcode_search_title": "Product search",
     "prices_barcode_search_running": "Looking for {barcode}",
     "@prices_barcode_search_running": {

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -1674,8 +1674,10 @@
     "prices_app_dev_mode_flag": "Raccourci vers l'application Prix sur la page produit",
     "prices_app_button": "Accéder à l'application Prix",
     "prices_generic_title": "Prix",
+    "prices_add_n_prices": "{count,plural, =1{Ajouter un prix} other{Ajouter {count} prix}}",
+    "prices_send_n_prices": "{count,plural, =1{Envoyer le prix} other{Envoyer {count} prix}}",
+    "prices_add_an_item": "Ajouter un article",
     "prices_add_a_price": "Ajouter un prix",
-    "prices_send_the_price": "Envoyer le prix",
     "prices_barcode_search_title": "Recherche de produit",
     "prices_barcode_search_running": "À la recherche de {barcode}",
     "@prices_barcode_search_running": {

--- a/packages/smooth_app/lib/pages/prices/price_model.dart
+++ b/packages/smooth_app/lib/pages/prices/price_model.dart
@@ -105,7 +105,7 @@ class PriceModel with ChangeNotifier {
       prices.add(priceAmountModel.checkedPaidPrice);
       pricesWithoutDiscount.add(priceAmountModel.checkedPriceWithoutDiscount);
     }
-    BackgroundTaskAddPrice.addTask(
+    return BackgroundTaskAddPrice.addTask(
       context: context,
       // per receipt
       cropObject: cropParameters!,

--- a/packages/smooth_app/lib/pages/prices/price_product_search_page.dart
+++ b/packages/smooth_app/lib/pages/prices/price_product_search_page.dart
@@ -18,11 +18,11 @@ import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
 /// Product Search Page, for Prices.
 class PriceProductSearchPage extends StatefulWidget {
-  const PriceProductSearchPage(
+  const PriceProductSearchPage({
     this.product,
-  );
+  });
 
-  final PriceMetaProduct product;
+  final PriceMetaProduct? product;
   // TODO(monsieurtanuki): as a parameter, add a list of barcodes already there: we're not supposed to select twice the same product
 
   @override

--- a/packages/smooth_app/lib/pages/prices/product_price_add_page.dart
+++ b/packages/smooth_app/lib/pages/prices/product_price_add_page.dart
@@ -5,16 +5,20 @@ import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/preferences/user_preferences.dart';
 import 'package:smooth_app/database/dao_osm_location.dart';
 import 'package:smooth_app/database/local_database.dart';
+import 'package:smooth_app/generic_lib/buttons/smooth_large_button_with_icon.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_back_button.dart';
+import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/pages/locations/osm_location.dart';
 import 'package:smooth_app/pages/prices/price_amount_card.dart';
+import 'package:smooth_app/pages/prices/price_amount_model.dart';
 import 'package:smooth_app/pages/prices/price_currency_card.dart';
 import 'package:smooth_app/pages/prices/price_date_card.dart';
 import 'package:smooth_app/pages/prices/price_location_card.dart';
 import 'package:smooth_app/pages/prices/price_meta_product.dart';
 import 'package:smooth_app/pages/prices/price_model.dart';
+import 'package:smooth_app/pages/prices/price_product_search_page.dart';
 import 'package:smooth_app/pages/prices/price_proof_card.dart';
 import 'package:smooth_app/pages/product/common/product_refresher.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
@@ -85,7 +89,9 @@ class _ProductPriceAddPageState extends State<ProductPriceAddPage> {
             centerTitle: false,
             leading: const SmoothBackButton(),
             title: Text(
-              appLocalizations.prices_add_a_price,
+              appLocalizations.prices_add_n_prices(
+                _model.priceAmountModels.length,
+              ),
             ),
             actions: <Widget>[
               IconButton(
@@ -106,7 +112,37 @@ class _ProductPriceAddPageState extends State<ProductPriceAddPage> {
                 const SizedBox(height: LARGE_SPACE),
                 const PriceCurrencyCard(),
                 const SizedBox(height: LARGE_SPACE),
-                PriceAmountCard(_model.priceAmountModel),
+                for (int i = 0; i < _model.priceAmountModels.length; i++)
+                  PriceAmountCard(
+                    priceModel: _model,
+                    index: i,
+                    refresh: () => setState(() {}),
+                  ),
+                SmoothCard(
+                  child: SmoothLargeButtonWithIcon(
+                    text: appLocalizations.prices_add_an_item,
+                    icon: Icons.add,
+                    onPressed: () async {
+                      final PriceMetaProduct? product =
+                          await Navigator.of(context).push<PriceMetaProduct>(
+                        MaterialPageRoute<PriceMetaProduct>(
+                          builder: (BuildContext context) =>
+                              const PriceProductSearchPage(),
+                        ),
+                      );
+                      if (product == null) {
+                        return;
+                      }
+                      setState(
+                        () => _model.priceAmountModels.add(
+                          PriceAmountModel(
+                            product: product,
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                ),
                 // so that the last items don't get hidden by the FAB
                 const SizedBox(height: MINIMUM_TOUCH_SIZE * 2),
               ],
@@ -143,7 +179,11 @@ class _ProductPriceAddPageState extends State<ProductPriceAddPage> {
               Navigator.of(context).pop();
             },
             icon: const Icon(Icons.send),
-            label: Text(appLocalizations.prices_send_the_price),
+            label: Text(
+              appLocalizations.prices_send_n_prices(
+                _model.priceAmountModels.length,
+              ),
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
### What
- Now we can add several product prices in one shot, and even offline.
- For the time being, it's just that on all the "add a single price" pages we can add and remove products (and their prices).
- The products are found by barcodes, locally, and from the server if needed.
- Many possible improvements in next PRs:
  - more obvious "Add prices" / "Add receipt" buttons - but I don't know where to put them in the app
  - more refined product selection - scanner, list of previous "price" products, list of local products, full text search, ...

### Screenshots
| top | middle | bottom |
| -- | -- | -- |
| ![Screenshot_1718384964](https://github.com/openfoodfacts/smooth-app/assets/11576431/39a38d18-8738-4409-b964-15384e0c6074) | ![Screenshot_1718385144](https://github.com/openfoodfacts/smooth-app/assets/11576431/c2c8f56f-034b-460e-bb94-c3e65abf271a) | ![Screenshot_1718385155](https://github.com/openfoodfacts/smooth-app/assets/11576431/1ca2bf47-9bfc-4697-a29a-b31ead9ae142) |

Et voilà:
![Capture d’écran 2024-06-14 à 19 14 02](https://github.com/openfoodfacts/smooth-app/assets/11576431/6f3d463e-f20c-45ce-ad91-10c8e639de79)


### Fixes bug(s)
- Fixes: #5204

### Impacted files
* `app_en.arb`: added 3 labels and removed one redundant one
* `app_fr.arb`: added 3 labels and removed one redundant one
* `background_task_add_price.dart`: now we manage multiple products, in `List`s
* `price_amount_card.dart`: small UI/UX differences for a single product among several products; minor code simplification
* `price_model.dart`: now we manage multiple products
* `price_product_search_page.dart`: added "no initial product" case
* `product_price_add_page.dart`: now we manage multiple products