### PR TITLE
fix: 5371 - less ambiguous currency symbol

### DIFF
--- a/packages/smooth_app/lib/pages/onboarding/currency_selector.dart
+++ b/packages/smooth_app/lib/pages/onboarding/currency_selector.dart
@@ -51,7 +51,7 @@ class CurrencySelector extends StatelessWidget {
                 padding: const EdgeInsets.symmetric(
                   vertical: SMALL_SPACE,
                 ).add(padding ?? EdgeInsets.zero),
-                child: const Icon(Icons.currency_exchange),
+                child: Icon(helper.currencyIconData),
               ),
               Expanded(
                 flex: 1,

--- a/packages/smooth_app/lib/pages/onboarding/currency_selector_helper.dart
+++ b/packages/smooth_app/lib/pages/onboarding/currency_selector_helper.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
@@ -12,6 +13,8 @@ class CurrencySelectorHelper {
   CurrencySelectorHelper();
 
   final List<Currency> _currencyList = List<Currency>.from(Currency.values);
+
+  IconData get currencyIconData => CupertinoIcons.money_dollar_circle;
 
   Future<Currency?> openCurrencySelector({
     required final BuildContext context,

--- a/packages/smooth_app/lib/pages/prices/price_currency_selector.dart
+++ b/packages/smooth_app/lib/pages/prices/price_currency_selector.dart
@@ -30,7 +30,7 @@ class PriceCurrencySelector extends StatelessWidget {
         }
       },
       text: selected.getFullName(),
-      icon: Icons.currency_exchange,
+      icon: helper.currencyIconData,
     );
   }
 }


### PR DESCRIPTION
### What
- The currency symbol we use for currency edit doesn't give the false impression of forex anymore.

### Screenshots
| price | app |
| -- | -- |
| ![Screenshot_1718429919](https://github.com/openfoodfacts/smooth-app/assets/11576431/d16f9b64-4ba8-4c20-8d63-0a3c724e88f4) | ![Screenshot_1718429855](https://github.com/openfoodfacts/smooth-app/assets/11576431/5dbcee17-0692-4b25-9089-7b938645a16c) |

### Fixes bug(s)
- Fixes: #5371