### PR TITLE
chore: A better name for NutriScore v2 guide in the FAQ

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -2666,6 +2666,7 @@
     "faq_title_install_beauty": "Install Open Beauty Facts to create a cosmetic database",
     "faq_title_install_pet": "Install Open Pet Food Facts to create a pet food database",
     "faq_title_install_product": "Install Open Products Facts to create a products database to extend the life of objects",
+    "faq_nutriscore_nutriscore": "Nutri-Score New calculation: what's new?",
     "contact_title_pro_page": "Pro? Import your products in Open Food Facts",
     "contact_title_pro_email": "Producer Contact",
     "contact_title_press_page": "Press Page",

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -2666,7 +2666,7 @@
     "faq_title_install_beauty": "Install Open Beauty Facts to create a cosmetic database",
     "faq_title_install_pet": "Install Open Pet Food Facts to create a pet food database",
     "faq_title_install_product": "Install Open Products Facts to create a products database to extend the life of objects",
-    "faq_nutriscore_nutriscore": "Nutri-Score New calculation: what's new?",
+    "faq_nutriscore_nutriscore": "New calculation of the Nutri-Score: what's new?",
     "contact_title_pro_page": "Pro? Import your products in Open Food Facts",
     "contact_title_pro_email": "Producer Contact",
     "contact_title_press_page": "Press Page",

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_faq.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_faq.dart
@@ -66,7 +66,7 @@ class UserPreferencesFaq extends AbstractUserPreferences {
           ),
         ),
         _getListTile(
-          title: appLocalizations.nutriscore_generic,
+          title: appLocalizations.faq_nutriscore_nutriscore,
           leadingSvg: SvgCache.getAssetsCacheForNutriscore(
             NutriScoreValue.b,
             true,
@@ -76,6 +76,7 @@ class UserPreferencesFaq extends AbstractUserPreferences {
               builder: (BuildContext context) => const GuideNutriscoreV2(),
             ),
           ),
+          icon: null,
         ),
         _getNutriListTile(
           title: appLocalizations.ecoscore_generic,

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_faq.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_faq.dart
@@ -76,7 +76,12 @@ class UserPreferencesFaq extends AbstractUserPreferences {
               builder: (BuildContext context) => const GuideNutriscoreV2(),
             ),
           ),
-          icon: null,
+
+          /// Hide the icon
+          icon: const Icon(
+            Icons.info,
+            size: 0.0,
+          ),
         ),
         _getNutriListTile(
           title: appLocalizations.ecoscore_generic,


### PR DESCRIPTION
Before:
![IMG_35C0228BC5F3-1](https://github.com/openfoodfacts/smooth-app/assets/246838/64f68a43-2627-491b-aa83-5f5a0c78fe7b)

After:
<img width="509" alt="Screenshot 2024-06-15 at 15 33 39" src="https://github.com/openfoodfacts/smooth-app/assets/246838/b8fc32ce-e50e-433c-bc3f-d19320b8ceab">
