### PR TITLE
feat: prices - barcode reader for additional products

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1688,6 +1688,7 @@
             }
         }
     },
+    "prices_barcode_reader_action": "Barcode reader",
     "prices_view_prices": "View the prices",
     "prices_list_length_one_page": "{count,plural, =0{No price yet} =1{Only one price} other{All {count} prices}}",
     "@prices_list_length_one_page": {

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -1688,6 +1688,7 @@
             }
         }
     },
+    "prices_barcode_reader_action": "Lecteur de code-barres",
     "prices_view_prices": "Voir les prix",
     "prices_list_length_one_page": "{count,plural, =0{Aucun prix} =1{Un seul prix} other{Tous les {count} prix}}",
     "@prices_list_length_one_page": {

--- a/packages/smooth_app/lib/pages/prices/price_scan_page.dart
+++ b/packages/smooth_app/lib/pages/prices/price_scan_page.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
+import 'package:smooth_app/helpers/analytics_helper.dart';
+import 'package:smooth_app/helpers/camera_helper.dart';
+import 'package:smooth_app/helpers/global_vars.dart';
+import 'package:smooth_app/helpers/haptic_feedback_helper.dart';
+import 'package:smooth_app/pages/scan/camera_scan_page.dart';
+import 'package:smooth_app/widgets/smooth_scaffold.dart';
+
+/// Page showing the camera feed and decoding the first barcode, for Prices.
+class PriceScanPage extends StatefulWidget {
+  const PriceScanPage();
+
+  @override
+  State<PriceScanPage> createState() => _PriceScanPageState();
+}
+
+class _PriceScanPageState extends State<PriceScanPage>
+    with TraceableClientMixin {
+  // Mutual exclusion needed: we typically receive several times the same
+  // barcode and the `pop` would be called several times and cause an error like
+  // `Failed assertion: line 5277 pos 12: '!_debugLocked': is not true.`
+  bool _mutex = false;
+
+  @override
+  String get actionName =>
+      'Opened ${GlobalVars.barcodeScanner.getType()}_page for price';
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    return SmoothScaffold(
+      body: GlobalVars.barcodeScanner.getScanner(
+        onScan: (final String barcode) async {
+          if (_mutex) {
+            return false;
+          }
+          _mutex = true;
+          Navigator.of(context).pop(barcode);
+          return true;
+        },
+        hapticFeedback: () => SmoothHapticFeedback.click(),
+        onCameraFlashError: CameraScannerPage.onCameraFlashError,
+        trackCustomEvent: AnalyticsHelper.trackCustomEvent,
+        hasMoreThanOneCamera: CameraHelper.hasMoreThanOneCamera,
+        toggleCameraModeTooltip: appLocalizations.camera_toggle_camera,
+        toggleFlashModeTooltip: appLocalizations.camera_toggle_flash,
+        contentPadding: null,
+      ),
+    );
+  }
+}

--- a/packages/smooth_app/lib/pages/scan/camera_scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/camera_scan_page.dart
@@ -19,10 +19,21 @@ class CameraScannerPage extends StatefulWidget {
   const CameraScannerPage();
 
   @override
-  CameraScannerPageState createState() => CameraScannerPageState();
+  State<CameraScannerPage> createState() => _CameraScannerPageState();
+
+  static Future<void> onCameraFlashError(BuildContext context) async {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    return showDialog<void>(
+      context: context,
+      builder: (_) => SmoothAlertDialog(
+        title: appLocalizations.camera_flash_error_dialog_title,
+        body: Text(appLocalizations.camera_flash_error_dialog_message),
+      ),
+    );
+  }
 }
 
-class CameraScannerPageState extends State<CameraScannerPage>
+class _CameraScannerPageState extends State<CameraScannerPage>
     with TraceableClientMixin {
   final GlobalKey<State<StatefulWidget>> _headerKey = GlobalKey();
 
@@ -87,7 +98,7 @@ class CameraScannerPageState extends State<CameraScannerPage>
           GlobalVars.barcodeScanner.getScanner(
             onScan: _onNewBarcodeDetected,
             hapticFeedback: () => SmoothHapticFeedback.click(),
-            onCameraFlashError: _onCameraFlashError,
+            onCameraFlashError: CameraScannerPage.onCameraFlashError,
             trackCustomEvent: AnalyticsHelper.trackCustomEvent,
             hasMoreThanOneCamera: CameraHelper.hasMoreThanOneCamera,
             toggleCameraModeTooltip: appLocalizations.camera_toggle_camera,
@@ -114,17 +125,5 @@ class CameraScannerPageState extends State<CameraScannerPage>
 
     _userPreferences.incrementScanCount();
     return true;
-  }
-
-  void _onCameraFlashError(BuildContext context) {
-    final AppLocalizations appLocalizations = AppLocalizations.of(context);
-
-    showDialog<void>(
-      context: context,
-      builder: (_) => SmoothAlertDialog(
-        title: appLocalizations.camera_flash_error_dialog_title,
-        body: Text(appLocalizations.camera_flash_error_dialog_message),
-      ),
-    );
   }
 }


### PR DESCRIPTION
### What
- Now we can scan a barcode when adding a product to prices.

### Screenshots
| barcode search: new button | new barcode reader page |
| -- | -- |
| ![Screenshot_20240615_153933](https://github.com/openfoodfacts/smooth-app/assets/11576431/3c68bdcc-b644-4975-b786-15d5d512b8e3) | ![Screenshot_20240615_154251](https://github.com/openfoodfacts/smooth-app/assets/11576431/b59b07e0-8048-4faf-990a-3020b036160d) |

| product found | product added |
| -- | -- |
| ![Screenshot_20240615_154013](https://github.com/openfoodfacts/smooth-app/assets/11576431/9764a4a9-fc7a-4da5-8a1f-aa49a33f3f5a) | ![Screenshot_20240615_154024](https://github.com/openfoodfacts/smooth-app/assets/11576431/68f0980b-e3e6-41fc-8da0-0baa69957db7) |

### Files
New file:
* `price_scan_page.dart`: Page showing the camera feed and decoding the first barcode, for Prices.

Impacted files:
* `app_en.arb`: added 1 "barcode reader" label
* `app_fr.arb`: added 1 "barcode reader" label
* `camera_scan_page.dart`: minor refactoring
* `price_product_search_page.dart`: added a FAB towards the new barcode reader page