### PR TITLE
chore: "Take a picture" button now distinguishes "Take a picture" VS "Take a new picture"

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -2156,7 +2156,7 @@
             }
         }
     },
-    "capture": "Capture New",
+    "capture": "Take a new picture",
     "@capture": {
         "description": "Button label for taking a new photo (= there's already one)"
     },

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -2158,7 +2158,11 @@
     },
     "capture": "Capture New",
     "@capture": {
-        "description": "Button label for taking a photo"
+        "description": "Button label for taking a new photo (= there's already one)"
+    },
+    "capture_new_picture": "Take a picture",
+    "@capture_new_picture": {
+        "description": "Button label for taking a new photo (= the first one)"
     },
     "choose_from_gallery": "Choose from gallery",
     "@choose_from_gallery": {

--- a/packages/smooth_app/lib/pages/product/edit_ocr/edit_ocr_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_ocr/edit_ocr_page.dart
@@ -151,11 +151,16 @@ class _EditOcrPageState extends State<EditOcrPage> with UpToDateMixin {
     );
   }
 
-  Widget _getImageButton(final ProductImageButtonType type) => Padding(
+  Widget _getImageButton(
+    final ProductImageButtonType type,
+    final bool imageExists,
+  ) =>
+      Padding(
         padding: const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
         child: type.getButton(
           product: upToDateProduct,
           imageField: _helper.getImageField(),
+          imageExists: imageExists,
           language: _multilingualHelper.getCurrentLanguage(),
           isLoggedInMandatory: widget.isLoggedInMandatory,
           borderWidth: 2,
@@ -217,6 +222,8 @@ class _EditOcrPageState extends State<EditOcrPage> with UpToDateMixin {
     final OpenFoodFactsLanguage language =
         _multilingualHelper.getCurrentLanguage();
     final ImageProvider? imageProvider = transientFile.getImageProvider();
+    final bool imageExists = imageProvider != null;
+
     return Align(
       alignment: AlignmentDirectional.bottomStart,
       child: Column(
@@ -239,10 +246,16 @@ class _EditOcrPageState extends State<EditOcrPage> with UpToDateMixin {
                     mainAxisSize: MainAxisSize.max,
                     children: <Widget>[
                       Expanded(
-                        child: _getImageButton(ProductImageButtonType.server),
+                        child: _getImageButton(
+                          ProductImageButtonType.server,
+                          imageExists,
+                        ),
                       ),
                       Expanded(
-                        child: _getImageButton(ProductImageButtonType.local),
+                        child: _getImageButton(
+                          ProductImageButtonType.local,
+                          imageExists,
+                        ),
                       ),
                     ],
                   ),
@@ -253,11 +266,16 @@ class _EditOcrPageState extends State<EditOcrPage> with UpToDateMixin {
                       mainAxisSize: MainAxisSize.max,
                       children: <Widget>[
                         Expanded(
-                          child:
-                              _getImageButton(ProductImageButtonType.unselect),
+                          child: _getImageButton(
+                            ProductImageButtonType.unselect,
+                            imageExists,
+                          ),
                         ),
                         Expanded(
-                          child: _getImageButton(ProductImageButtonType.edit),
+                          child: _getImageButton(
+                            ProductImageButtonType.edit,
+                            imageExists,
+                          ),
                         ),
                       ],
                     ),

--- a/packages/smooth_app/lib/pages/product/product_image_button.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_button.dart
@@ -65,6 +65,7 @@ enum ProductImageButtonType {
     required final OpenFoodFactsLanguage language,
     required final bool isLoggedInMandatory,
     final double? borderWidth,
+    required bool imageExists,
   }) =>
       switch (this) {
         ProductImageButtonType.local => ProductImageLocalButton(
@@ -73,6 +74,7 @@ enum ProductImageButtonType {
             language: language,
             isLoggedInMandatory: isLoggedInMandatory,
             borderWidth: borderWidth,
+            imageExists: imageExists,
           ),
         ProductImageButtonType.server => ProductImageServerButton(
             product: product,

--- a/packages/smooth_app/lib/pages/product/product_image_local_button.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_local_button.dart
@@ -11,15 +11,19 @@ class ProductImageLocalButton extends ProductImageButton {
     required super.imageField,
     required super.language,
     required super.isLoggedInMandatory,
+    required this.imageExists,
     super.borderWidth,
   });
+
+  final bool imageExists;
 
   @override
   IconData getIconData() => Icons.add_a_photo;
 
   @override
-  String getLabel(final AppLocalizations appLocalizations) =>
-      appLocalizations.capture;
+  String getLabel(final AppLocalizations appLocalizations) => imageExists
+      ? appLocalizations.capture
+      : appLocalizations.capture_new_picture;
 
   @override
   Future<void> action(final BuildContext context) async {

--- a/packages/smooth_app/lib/pages/product/product_image_viewer.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_viewer.dart
@@ -44,11 +44,16 @@ class _ProductImageViewerState extends State<ProductImageViewer>
     initUpToDate(widget.product, context.read<LocalDatabase>());
   }
 
-  Widget _getImageButton(final ProductImageButtonType type) => Padding(
+  Widget _getImageButton(
+    final ProductImageButtonType type,
+    final bool imageExists,
+  ) =>
+      Padding(
         padding: const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
         child: type.getButton(
           product: upToDateProduct,
           imageField: widget.imageField,
+          imageExists: imageExists,
           language: widget.language,
           isLoggedInMandatory: widget.isLoggedInMandatory,
         ),
@@ -65,6 +70,7 @@ class _ProductImageViewerState extends State<ProductImageViewer>
       widget.language,
     );
     final ImageProvider? imageProvider = _getTransientFile().getImageProvider();
+    final bool imageExists = imageProvider != null;
     final Iterable<OpenFoodFactsLanguage> selectedLanguages =
         getProductImageLanguages(
       upToDateProduct,
@@ -193,10 +199,16 @@ class _ProductImageViewerState extends State<ProductImageViewer>
             mainAxisSize: MainAxisSize.max,
             children: <Widget>[
               Expanded(
-                child: _getImageButton(ProductImageButtonType.server),
+                child: _getImageButton(
+                  ProductImageButtonType.server,
+                  imageExists,
+                ),
               ),
               Expanded(
-                child: _getImageButton(ProductImageButtonType.local),
+                child: _getImageButton(
+                  ProductImageButtonType.local,
+                  imageExists,
+                ),
               ),
             ],
           ),
@@ -207,10 +219,16 @@ class _ProductImageViewerState extends State<ProductImageViewer>
               mainAxisSize: MainAxisSize.max,
               children: <Widget>[
                 Expanded(
-                  child: _getImageButton(ProductImageButtonType.unselect),
+                  child: _getImageButton(
+                    ProductImageButtonType.unselect,
+                    imageExists,
+                  ),
                 ),
                 Expanded(
-                  child: _getImageButton(ProductImageButtonType.edit),
+                  child: _getImageButton(
+                    ProductImageButtonType.edit,
+                    imageExists,
+                  ),
                 ),
               ],
             ),


### PR DESCRIPTION
Hi everyone,

As explained in #5393, the button to take a picture asks for a **new** photo, which may be confusing.
Now, there's a distinction between "taking the first photo" and "taking a new photo".

Existing picture:
<img width="546" alt="Screenshot 2024-06-17 at 18 40 13" src="https://github.com/openfoodfacts/smooth-app/assets/246838/5b36bd53-e8a2-4ebe-82c9-643b6d349720">

No picture:
<img width="546" alt="Screenshot 2024-06-17 at 18 39 51" src="https://github.com/openfoodfacts/smooth-app/assets/246838/e49c1197-de74-4392-9d48-5b0bdc20e6cf">
