### PR TITLE
chore: Hide the NutriScore V2 guide in France

### DIFF
--- a/packages/smooth_app/lib/pages/preferences/user_preferences_faq.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_faq.dart
@@ -65,24 +65,25 @@ class UserPreferencesFaq extends AbstractUserPreferences {
             false,
           ),
         ),
-        _getListTile(
-          title: appLocalizations.faq_nutriscore_nutriscore,
-          leadingSvg: SvgCache.getAssetsCacheForNutriscore(
-            NutriScoreValue.b,
-            true,
-          ),
-          onTap: () => Navigator.of(context, rootNavigator: true).push(
-            MaterialPageRoute<void>(
-              builder: (BuildContext context) => const GuideNutriscoreV2(),
+        if (userPreferences.userCountryCode != 'fr')
+          _getListTile(
+            title: appLocalizations.faq_nutriscore_nutriscore,
+            leadingSvg: SvgCache.getAssetsCacheForNutriscore(
+              NutriScoreValue.b,
+              true,
+            ),
+            onTap: () => Navigator.of(context, rootNavigator: true).push(
+              MaterialPageRoute<void>(
+                builder: (BuildContext context) => const GuideNutriscoreV2(),
+              ),
+            ),
+
+            /// Hide the icon
+            icon: const Icon(
+              Icons.info,
+              size: 0.0,
             ),
           ),
-
-          /// Hide the icon
-          icon: const Icon(
-            Icons.info,
-            size: 0.0,
-          ),
-        ),
         _getNutriListTile(
           title: appLocalizations.ecoscore_generic,
           url: 'https://world.openfoodfacts.org/ecoscore',


### PR DESCRIPTION
Hi everyone,

A small change to only hide the NutriScore V2 guide from the FAQ, when the country is set to France.