### PR TITLE
feat: Spellchecker for OCR screens

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1819,6 +1819,14 @@
     "@dev_mode_hide_ecoscore_title": {
         "description": "User dev preferences - Disable Ecoscore - Title"
     },
+    "dev_mode_spellchecker_for_ocr_title": "Use a spellchecker for OCR screens",
+    "@dev_mode_spellchecker_for_ocr_title": {
+        "description": "User dev preferences - Enable Spellchecker on OCR screens - Title"
+    },
+    "dev_mode_spellchecker_for_ocr_subtitle": "(Ingredients and packaging)",
+    "@dev_mode_spellchecker_for_ocr_subtitle": {
+        "description": "User dev preferences - Enable Spellchecker on OCR screens - Subtitle"
+    },
     "search_history_item_edit_tooltip": "Reuse and edit this search",
     "@search_history_item_edit_tooltip": {
         "description": "A tooltip to explain the Pen button near a search term -> it allows to reuse the item"

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_dev_mode.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_dev_mode.dart
@@ -333,7 +333,7 @@ class UserPreferencesDevMode extends AbstractUserPreferences {
           value:
               userPreferences.getFlag(userPreferencesFlagSpellCheckerOnOcr) ??
                   false,
-          onChanged: (bool value) => userPreferences.setFlag(
+          onChanged: (bool value) async => userPreferences.setFlag(
             userPreferencesFlagSpellCheckerOnOcr,
             value,
           ),

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_dev_mode.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_dev_mode.dart
@@ -333,12 +333,10 @@ class UserPreferencesDevMode extends AbstractUserPreferences {
           value:
               userPreferences.getFlag(userPreferencesFlagSpellCheckerOnOcr) ??
                   false,
-          onChanged: (bool value) async {
-            await userPreferences.setFlag(
-              userPreferencesFlagSpellCheckerOnOcr,
-              value,
-            );
-          },
+          onChanged: (bool value) => userPreferences.setFlag(
+            userPreferencesFlagSpellCheckerOnOcr,
+            value,
+          ),
         ),
         UserPreferencesItemSection(
           label: appLocalizations.dev_mode_section_experimental_features,

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_dev_mode.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_dev_mode.dart
@@ -57,6 +57,8 @@ class UserPreferencesDevMode extends AbstractUserPreferences {
   static const String userPreferencesFlagAccessibilityEmoji =
       '__accessibilityEmoji';
   static const String userPreferencesFlagUserOrderedKP = '__userOrderedKP';
+  static const String userPreferencesFlagSpellCheckerOnOcr =
+      '__spellcheckerOcr';
 
   final TextEditingController _textFieldController = TextEditingController();
 
@@ -323,6 +325,19 @@ class UserPreferencesDevMode extends AbstractUserPreferences {
             await userPreferences.setFlag(
                 userPreferencesFlagAccessibilityEmoji, value);
             _showSuccessMessage();
+          },
+        ),
+        UserPreferencesItemSwitch(
+          title: appLocalizations.dev_mode_spellchecker_for_ocr_title,
+          subtitle: appLocalizations.dev_mode_spellchecker_for_ocr_subtitle,
+          value:
+              userPreferences.getFlag(userPreferencesFlagSpellCheckerOnOcr) ??
+                  false,
+          onChanged: (bool value) async {
+            await userPreferences.setFlag(
+              userPreferencesFlagSpellCheckerOnOcr,
+              value,
+            );
           },
         ),
         UserPreferencesItemSection(


### PR DESCRIPTION
Hi everyone,

Here is the implementation for #5398, that is to say, a dev mode flag to enable spellchecker on ingredients.
In light mode, our theme defines an `onSurface` white color.

Unless we want to rewrite everything, the easier thing is just to redefine locally this color, to prevent a white-on-white color.

To investigate: I think the `ThemeProvider` still has issues.

Screenshots:
![Screenshot_1718780020](https://github.com/openfoodfacts/smooth-app/assets/246838/1185c2e2-d9c2-470c-89d5-a89b82406b1c)
![Screenshot_1718781981](https://github.com/openfoodfacts/smooth-app/assets/246838/ad09e24d-2f8e-4f50-ab2c-1bc8060db3bc)
![Screenshot_1718781984](https://github.com/openfoodfacts/smooth-app/assets/246838/1ce4776f-9f2c-4687-97f8-fc51766b86f8)
![Screenshot_1718782113](https://github.com/openfoodfacts/smooth-app/assets/246838/8597a650-4c31-4f8f-a725-ac90e44bf7ec)
