### PR TITLE
feat: Dev mode for app news: custom URI + manual refresh

### DIFF
--- a/packages/smooth_app/lib/data_models/news_feed/newsfeed_provider.dart
+++ b/packages/smooth_app/lib/data_models/news_feed/newsfeed_provider.dart
@@ -26,12 +26,12 @@ class AppNewsProvider extends ChangeNotifier {
   AppNewsProvider(UserPreferences preferences)
       : _state = const AppNewsStateLoading(),
         _preferences = preferences,
+        _uriOverride = preferences.getDevModeString(
+            UserPreferencesDevMode.userPreferencesCustomNewsJSONURI),
         _domain = preferences.getDevModeString(
-                UserPreferencesDevMode.userPreferencesTestEnvDomain) ??
-            '',
+            UserPreferencesDevMode.userPreferencesTestEnvDomain),
         _prodEnv = preferences
-                .getFlag(UserPreferencesDevMode.userPreferencesFlagProd) ??
-            true {
+            .getFlag(UserPreferencesDevMode.userPreferencesFlagProd) {
     _preferences.addListener(_onPreferencesChanged);
     loadLatestNews();
   }
@@ -67,13 +67,13 @@ class AppNewsProvider extends ChangeNotifier {
       return;
     }
 
-    final AppNews? tagLine = await Isolate.run(
+    final AppNews? appNews = await Isolate.run(
         () => _parseJSONAndGetLocalizedContent(jsonString!, locale));
-    if (tagLine == null) {
+    if (appNews == null) {
       _emit(const AppNewsStateError('Unable to parse the JSON news file'));
       Logs.e('Unable to parse the JSON news file');
     } else {
-      _emit(AppNewsStateLoaded(tagLine));
+      _emit(AppNewsStateLoaded(appNews, cacheFile.lastModifiedSync()));
       Logs.i('News ${forceUpdate ? 're' : ''}loaded');
     }
   }
@@ -106,7 +106,13 @@ class AppNewsProvider extends ChangeNotifier {
     try {
       final UriProductHelper uriProductHelper = ProductQuery.uriProductHelper;
       final Map<String, String> headers = <String, String>{};
-      final Uri uri = uriProductHelper.getUri(path: _newsUrl);
+      final Uri uri;
+
+      if (_uriOverride?.isNotEmpty == true) {
+        uri = Uri.parse(_uriOverride!);
+      } else {
+        uri = uriProductHelper.getUri(path: _newsUrl);
+      }
 
       if (uriProductHelper.userInfoForPatch != null) {
         headers['Authorization'] =
@@ -158,10 +164,14 @@ class AppNewsProvider extends ChangeNotifier {
 
   bool? _prodEnv;
   String? _domain;
+  String? _uriOverride;
 
   /// [ProductQuery.uriProductHelper] is not synced yet,
   /// so we have to check it manually
   Future<void> _onPreferencesChanged() async {
+    final String jsonURI = _preferences.getDevModeString(
+            UserPreferencesDevMode.userPreferencesCustomNewsJSONURI) ??
+        '';
     final String domain = _preferences.getDevModeString(
             UserPreferencesDevMode.userPreferencesTestEnvDomain) ??
         '';
@@ -169,9 +179,10 @@ class AppNewsProvider extends ChangeNotifier {
         _preferences.getFlag(UserPreferencesDevMode.userPreferencesFlagProd) ??
             true;
 
-    if (domain != _domain || prodEnv != _prodEnv) {
+    if (domain != _domain || prodEnv != _prodEnv || jsonURI != _uriOverride) {
       _domain = domain;
       _prodEnv = prodEnv;
+      _uriOverride = jsonURI;
       loadLatestNews(forceUpdate: true);
     }
   }
@@ -192,9 +203,10 @@ final class AppNewsStateLoading extends AppNewsState {
 }
 
 class AppNewsStateLoaded extends AppNewsState {
-  const AppNewsStateLoaded(this.content);
+  const AppNewsStateLoaded(this.content, this.lastUpdate);
 
   final AppNews content;
+  final DateTime lastUpdate;
 }
 
 class AppNewsStateError extends AppNewsState {

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1716,6 +1716,31 @@
     "@dev_preferences_import_history_subtitle": {
         "description": "User dev preferences - Import history - Subtitle"
     },
+    "dev_preferences_news_custom_url_title": "Custom URL for news",
+    "@dev_preferences_news_custom_url_title": {
+        "description": "News dev preferences - Custom URL for news - Title"
+    },
+    "dev_preferences_news_custom_url_subtitle": "URL of the JSON file:",
+    "@dev_preferences_news_custom_url_subtitle": {
+        "description": "News dev preferences - Custom URL for news - Title"
+    },
+    "dev_preferences_news_custom_url_empty_value": "Not set",
+    "@dev_preferences_news_custom_url_empty_value": {
+        "description": "Message to show when the custom news URL is not set"
+    },
+    "dev_preferences_news_provider_status_title": "Status",
+    "@dev_preferences_news_provider_status_title": {
+        "description": "News dev preferences - Status - Title"
+    },
+    "dev_preferences_news_provider_status_subtitle": "Last refresh: {date}",
+    "@dev_preferences_news_provider_status_subtitle": {
+        "description": "News dev preferences - Custom URL for news - Subtitle",
+        "placeholders": {
+            "date": {
+                "type": "String"
+            }
+        }
+    },
     "prices_app_dev_mode_flag": "Shortcut to Prices app on product page",
     "prices_app_button": "Go to Prices app",
     "prices_generic_title": "Prices",
@@ -1824,6 +1849,7 @@
         "description": "User dev preferences - Import history - Result successful"
     },
     "dev_mode_section_server": "Server configuration",
+    "dev_mode_section_news": "News provider configuration",
     "dev_mode_section_product_page": "Product page",
     "dev_mode_section_ui": "User Interface",
     "dev_mode_section_data": "Data",

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_widgets.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_widgets.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:provider/provider.dart';
 import 'package:smooth_app/generic_lib/bottom_sheets/smooth_bottom_sheet.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_item.dart';
 import 'package:smooth_app/themes/smooth_theme_colors.dart';
 
@@ -161,6 +164,35 @@ class UserPreferencesItemTile implements UserPreferencesItem {
         onTap: onTap,
         leading: leading,
         trailing: trailing,
+      );
+}
+
+/// Same as [UserPreferencesItemTile] but with [WidgetBuilder].
+class UserPreferencesItemTileBuilder implements UserPreferencesItem {
+  const UserPreferencesItemTileBuilder({
+    required this.title,
+    required this.subtitleBuilder,
+    this.onTap,
+    this.leadingBuilder,
+    this.trailingBuilder,
+  });
+
+  final String title;
+  final WidgetBuilder subtitleBuilder;
+  final VoidCallback? onTap;
+  final WidgetBuilder? leadingBuilder;
+  final WidgetBuilder? trailingBuilder;
+
+  @override
+  List<String> get labels => <String>[title];
+
+  @override
+  WidgetBuilder get builder => (final BuildContext context) => ListTile(
+        title: Text(title),
+        subtitle: subtitleBuilder.call(context),
+        onTap: onTap,
+        leading: leadingBuilder?.call(context),
+        trailing: trailingBuilder?.call(context),
       );
 }
 
@@ -491,6 +523,131 @@ class UserPreferenceListTile extends StatelessWidget {
           ),
         ),
         if (showDivider) const UserPreferencesListItemDivider(),
+      ],
+    );
+  }
+}
+
+class UserPreferencesEditableItemTile extends UserPreferencesItemTile {
+  const UserPreferencesEditableItemTile({
+    required super.title,
+    required String dialogAction,
+    required this.onNewValue,
+    this.subtitleWithEmptyValue,
+    this.validator,
+    this.hint,
+    this.value,
+  })  : assert(dialogAction.length > 0),
+        super(subtitle: dialogAction);
+
+  final String? value;
+  final String? hint;
+  final String? subtitleWithEmptyValue;
+  final bool Function(String)? validator;
+  final Function(String) onNewValue;
+
+  @override
+  WidgetBuilder get builder => (BuildContext context) {
+        return ListTile(
+          title: Text(title),
+          subtitle: Text(value?.isNotEmpty == true
+              ? value!
+              : (subtitleWithEmptyValue ?? '-')),
+          onTap: () async => _showInputTextDialog(context),
+        );
+      };
+
+  Future<void> _showInputTextDialog(BuildContext context) async {
+    final TextEditingController controller =
+        TextEditingController(text: value ?? '');
+
+    final dynamic res = await showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (BuildContext context) {
+        final AppLocalizations appLocalizations = AppLocalizations.of(context);
+
+        return ChangeNotifierProvider<TextEditingController>.value(
+          value: controller,
+          child: Consumer<TextEditingController>(
+            builder:
+                (BuildContext context, TextEditingController controller, _) {
+              return SmoothAlertDialog(
+                title: title,
+                close: true,
+                body: _UserPreferencesEditableDialogContent(
+                  title: subtitle!,
+                  hint: hint,
+                ),
+                positiveAction: SmoothActionButton(
+                  text: appLocalizations.okay,
+                  onPressed: validator?.call(controller.text) != false
+                      ? () => Navigator.of(context).pop(controller.text)
+                      : null,
+                ),
+                negativeAction: SmoothActionButton(
+                  text: appLocalizations.cancel,
+                  onPressed: () => Navigator.of(context).pop(),
+                ),
+              );
+            },
+          ),
+        );
+      },
+    );
+
+    if (res is String && res != value) {
+      onNewValue.call(res);
+    }
+  }
+}
+
+class _UserPreferencesEditableDialogContent extends StatefulWidget {
+  const _UserPreferencesEditableDialogContent({
+    required this.title,
+    this.hint,
+  });
+
+  final String title;
+  final String? hint;
+
+  @override
+  State<_UserPreferencesEditableDialogContent> createState() =>
+      _InputTextDialogBodyState();
+}
+
+class _InputTextDialogBodyState
+    extends State<_UserPreferencesEditableDialogContent> {
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text(widget.title),
+        const SizedBox(height: 10),
+        TextField(
+          controller: Provider.of<TextEditingController>(context),
+          autocorrect: false,
+          autofocus: true,
+          textInputAction: TextInputAction.send,
+          decoration: InputDecoration(
+            hintText: widget.hint,
+            suffix: Semantics(
+              button: true,
+              label: MaterialLocalizations.of(context).deleteButtonTooltip,
+              excludeSemantics: true,
+              child: InkWell(
+                onTap: () => context.read<TextEditingController>().clear(),
+                customBorder: const CircleBorder(),
+                child: const Padding(
+                  padding: EdgeInsetsDirectional.all(SMALL_SPACE),
+                  child: Icon(Icons.clear),
+                ),
+              ),
+            ),
+          ),
+          onSubmitted: (String value) => Navigator.of(context).pop(value),
+        ),
       ],
     );
   }


### PR DESCRIPTION
Hi everyone,

Currently, the JSON for news is handcrafted.
There are 2 new items in the dev mode:
- Allow to set a custom URI
- Manually refresh the content (to bypass the cache)

Video:


https://github.com/openfoodfacts/smooth-app/assets/246838/cbb12725-576b-48aa-a870-80939f4ee587


