### PR TITLE
fix: Hotfix for the onboarding blocking the whole app

### DIFF
--- a/packages/smooth_app/lib/data_models/preferences/migration/user_preferences_migration.dart
+++ b/packages/smooth_app/lib/data_models/preferences/migration/user_preferences_migration.dart
@@ -78,7 +78,7 @@ class _UserPreferencesMigrationV2 extends UserPreferencesMigration {
         null) {
       await preferences._sharedPreferences.setInt(
         UserPreferences._TAG_USER_GROUP,
-        Random().nextInt(10),
+        math.Random().nextInt(10),
       );
     }
   }

--- a/packages/smooth_app/lib/data_models/preferences/user_preferences.dart
+++ b/packages/smooth_app/lib/data_models/preferences/user_preferences.dart
@@ -1,4 +1,4 @@
-import 'dart:math';
+import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
@@ -189,7 +189,7 @@ class UserPreferences extends ChangeNotifier {
     if (result != null) {
       return result;
     }
-    result = Random().nextInt(1 << 32);
+    result = math.Random().nextInt(1 << 32);
     await _sharedPreferences.setInt(tag, result);
     return result;
   }
@@ -251,7 +251,8 @@ class UserPreferences extends ChangeNotifier {
         _sharedPreferences.getInt(_TAG_LAST_VISITED_ONBOARDING_PAGE);
     return pageIndex == null
         ? OnboardingPage.NOT_STARTED
-        : OnboardingPage.values[pageIndex];
+        : OnboardingPage
+            .values[math.min(pageIndex, OnboardingPage.values.length - 1)];
   }
 
   Future<void> incrementScanCount() async {


### PR DESCRIPTION
Hi everyone,

Following the removal of one of the pages of the onboarding (#5420), the app can't be launched, depending on the previous state. Here is the error:
<img width="800" alt="Screenshot 2024-06-22 at 01 15 26" src="https://github.com/openfoodfacts/smooth-app/assets/246838/48e11f4b-2a75-4c72-a219-df5dd6ded0e8">
