### PR TITLE
chore: Add `TraceableClientMixin` to prices pages

### DIFF
--- a/packages/smooth_app/lib/pages/prices/price_product_search_page.dart
+++ b/packages/smooth_app/lib/pages/prices/price_product_search_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/fetched_product.dart';
@@ -26,13 +27,15 @@ class PriceProductSearchPage extends StatefulWidget {
   });
 
   final PriceMetaProduct? product;
+
   // TODO(monsieurtanuki): as a parameter, add a list of barcodes already there: we're not supposed to select twice the same product
 
   @override
   State<PriceProductSearchPage> createState() => _PriceProductSearchPageState();
 }
 
-class _PriceProductSearchPageState extends State<PriceProductSearchPage> {
+class _PriceProductSearchPageState extends State<PriceProductSearchPage>
+    with TraceableClientMixin {
   final TextEditingController _controller = TextEditingController();
 
   late PriceMetaProduct? _product = widget.product;

--- a/packages/smooth_app/lib/pages/prices/prices_proofs_page.dart
+++ b/packages/smooth_app/lib/pages/prices/prices_proofs_page.dart
@@ -2,6 +2,7 @@ import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:intl/intl.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/images/smooth_image.dart';
@@ -21,7 +22,8 @@ class PricesProofsPage extends StatefulWidget {
   State<PricesProofsPage> createState() => _PricesProofsPageState();
 }
 
-class _PricesProofsPageState extends State<PricesProofsPage> {
+class _PricesProofsPageState extends State<PricesProofsPage>
+    with TraceableClientMixin {
   late final Future<MaybeError<GetProofsResult>> _results = _download();
 
   static const int _columns = 3;

--- a/packages/smooth_app/lib/pages/prices/prices_users_page.dart
+++ b/packages/smooth_app/lib/pages/prices/prices_users_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_back_button.dart';
@@ -20,7 +21,8 @@ class PricesUsersPage extends StatefulWidget {
   State<PricesUsersPage> createState() => _PricesUsersPageState();
 }
 
-class _PricesUsersPageState extends State<PricesUsersPage> {
+class _PricesUsersPageState extends State<PricesUsersPage>
+    with TraceableClientMixin {
   late final Future<MaybeError<GetUsersResult>> _users = _showTopUsers();
 
   // In this specific page, let's never try to go beyond the top 10.

--- a/packages/smooth_app/lib/pages/prices/product_price_add_page.dart
+++ b/packages/smooth_app/lib/pages/prices/product_price_add_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/preferences/user_preferences.dart';
@@ -56,6 +57,7 @@ class ProductPriceAddPage extends StatefulWidget {
     if (!context.mounted) {
       return;
     }
+
     await Navigator.of(context).push(
       MaterialPageRoute<void>(
         builder: (BuildContext context) => ProductPriceAddPage(
@@ -71,7 +73,8 @@ class ProductPriceAddPage extends StatefulWidget {
   State<ProductPriceAddPage> createState() => _ProductPriceAddPageState();
 }
 
-class _ProductPriceAddPageState extends State<ProductPriceAddPage> {
+class _ProductPriceAddPageState extends State<ProductPriceAddPage>
+    with TraceableClientMixin {
   late final PriceModel _model = PriceModel(
     proofType: widget.proofType,
     locations: widget.latestOsmLocations,
@@ -244,4 +247,7 @@ class _ProductPriceAddPageState extends State<ProductPriceAddPage> {
     }
     return true;
   }
+
+  @override
+  String get actionName => 'Opened price_page with ${widget.proofType.offTag}';
 }

--- a/packages/smooth_app/lib/pages/prices/product_prices_list.dart
+++ b/packages/smooth_app/lib/pages/prices/product_prices_list.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
@@ -20,7 +21,8 @@ class ProductPricesList extends StatefulWidget {
   State<ProductPricesList> createState() => _ProductPricesListState();
 }
 
-class _ProductPricesListState extends State<ProductPricesList> {
+class _ProductPricesListState extends State<ProductPricesList>
+    with TraceableClientMixin {
   late final Future<MaybeError<GetPricesResult>> _prices =
       _showProductPrices(widget.model.parameters);
 


### PR DESCRIPTION
Hi everyone!

Before shipping the Prices feature, we need to instrument user behavior more.