### PR TITLE
chore: Save the date when the country is changed

### DIFF
--- a/packages/smooth_app/lib/data_models/preferences/user_preferences.dart
+++ b/packages/smooth_app/lib/data_models/preferences/user_preferences.dart
@@ -68,6 +68,8 @@ class UserPreferences extends ChangeNotifier {
   static const String _TAG_CURRENT_COLOR_SCHEME = 'currentColorScheme';
   static const String _TAG_CURRENT_CONTRAST_MODE = 'contrastMode';
   static const String _TAG_USER_COUNTRY_CODE = 'userCountry';
+  static const String _TAG_USER_COUNTRY_CODE_LAST_UPDATE =
+      'userCountryLastUpdate';
   static const String _TAG_USER_CURRENCY_CODE = 'userCurrency';
   static const String _TAG_LAST_VISITED_ONBOARDING_PAGE =
       'lastVisitedOnboardingPage';
@@ -227,6 +229,10 @@ class UserPreferences extends ChangeNotifier {
   /// Please use [ProductQuery.setCountry] as interface
   Future<void> setUserCountryCode(final String countryCode) async {
     await _sharedPreferences.setString(_TAG_USER_COUNTRY_CODE, countryCode);
+    await _sharedPreferences.setInt(
+      _TAG_USER_COUNTRY_CODE_LAST_UPDATE,
+      DateTime.now().millisecondsSinceEpoch,
+    );
     notifyListeners();
   }
 


### PR DESCRIPTION
Hi everyone!

As we wait for 4.15.0, I'll add a small change I will use later.
It saves the date when the country is changed.

This will allow us to display a message when the user is abroad.