### PR TITLE
chore: NewsProvider - Allow the URL of a translated image to be null

### DIFF
--- a/packages/smooth_app/lib/data_models/news_feed/newsfeed_json.dart
+++ b/packages/smooth_app/lib/data_models/news_feed/newsfeed_json.dart
@@ -121,7 +121,9 @@ class _TagLineItemNewsItem {
       startDate: startDate,
       endDate: endDate,
       style: style?.toTagLineStyle(),
-      image: translation.image?.toTagLineImage(),
+      image: translation.image?.overridesContent == true
+          ? translation.image?.toTagLineImage()
+          : null,
     );
   }
 
@@ -210,20 +212,22 @@ class _TagLineItemNewsTranslationDefault extends _TagLineItemNewsTranslation {
   _TagLineItemNewsTranslationDefault.fromJson(Map<dynamic, dynamic> json)
       : assert((json['title'] as String).isNotEmpty),
         assert((json['message'] as String).isNotEmpty),
+        assert(json['image'] == null ||
+            ((json['image'] as Map<String, dynamic>)['url'] as String)
+                .isNotEmpty),
         super.fromJson(json);
 }
 
 class _TagLineNewsImage {
   _TagLineNewsImage.fromJson(Map<dynamic, dynamic> json)
-      : assert((json['url'] as String).isNotEmpty),
-        assert(json['width'] == null ||
+      : assert(json['width'] == null ||
             ((json['width'] as num) >= 0.0 && (json['width'] as num) <= 1.0)),
         assert(json['alt'] == null || (json['alt'] as String).isNotEmpty),
         url = json['url'],
         width = json['width'],
         alt = json['alt'];
 
-  final String url;
+  final String? url;
   final double? width;
   final String? alt;
 
@@ -234,6 +238,8 @@ class _TagLineNewsImage {
       alt: alt,
     );
   }
+
+  bool get overridesContent => url != null || width != null || alt != null;
 }
 
 class _TagLineNewsStyle {

--- a/packages/smooth_app/lib/data_models/news_feed/newsfeed_model.dart
+++ b/packages/smooth_app/lib/data_models/news_feed/newsfeed_model.dart
@@ -118,7 +118,7 @@ class AppNewsImage {
     this.alt,
   });
 
-  final String src;
+  final String? src;
   final double? width;
   final String? alt;
 

--- a/packages/smooth_app/lib/pages/scan/carousel/main_card/scan_tagline.dart
+++ b/packages/smooth_app/lib/pages/scan/carousel/main_card/scan_tagline.dart
@@ -302,7 +302,7 @@ class _TagLineContentBodyState extends State<_TagLineContentBody> {
   }
 
   Widget _image() {
-    if (widget.image!.src.endsWith('svg')) {
+    if (widget.image!.src?.endsWith('svg') == true) {
       return SvgCache(
         widget.image!.src,
         semanticsLabel: widget.image!.alt,
@@ -323,7 +323,7 @@ class _TagLineContentBodyState extends State<_TagLineContentBody> {
 
           return EMPTY_WIDGET;
         },
-        widget.image!.src,
+        widget.image!.src ?? '-',
       );
     }
   }


### PR DESCRIPTION
Hi everyone,

Here is a small improvement for the tagline/news, to allow empty URL on translated images.
It will reduce the size of the JSON.