### PR TITLE
chore: Allow `LaunchUrlHelper` to follow deep links

### DIFF
--- a/packages/smooth_app/lib/helpers/launch_url_helper.dart
+++ b/packages/smooth_app/lib/helpers/launch_url_helper.dart
@@ -1,10 +1,26 @@
 import 'dart:io';
 
+import 'package:flutter/widgets.dart';
+import 'package:go_router/go_router.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class LaunchUrlHelper {
-  LaunchUrlHelper._();
+  const LaunchUrlHelper._();
+
+  static Future<void> launchURLAndFollowDeepLinks(
+    BuildContext context,
+    String url,
+  ) async {
+    assert(url.isNotEmpty);
+
+    if (url.startsWith(RegExp('http(s)?://[a-z]*.openfoodfacts.(net|org)'))) {
+      AnalyticsHelper.trackOutlink(url: url);
+      GoRouter.of(context).go(url);
+    } else {
+      return launchURL(url);
+    }
+  }
 
   /// Launches the url in an external browser.
   static Future<void> launchURL(String url) async {

--- a/packages/smooth_app/lib/pages/scan/carousel/main_card/scan_tagline.dart
+++ b/packages/smooth_app/lib/pages/scan/carousel/main_card/scan_tagline.dart
@@ -368,7 +368,10 @@ class _TagLineContentButton extends StatelessWidget {
           ),
         ],
       ),
-      onPressed: () => LaunchUrlHelper.launchURL(link),
+      onPressed: () => LaunchUrlHelper.launchURLAndFollowDeepLinks(
+        context,
+        link,
+      ),
     );
   }
 }


### PR DESCRIPTION
Hi everyone,

As is, the `url_launcher` dependency ignores deep links. 
To prevent this from happening (and avoid breaking things), there is now a second method redirecting to `GoRouter`