### PR TITLE
chore: bump in_app_review dependency to 2.0.9

### DIFF
--- a/packages/app_store/apple_app_store/pubspec.yaml
+++ b/packages/app_store/apple_app_store/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  in_app_review: 2.0.4
+  in_app_review: 2.0.9
 
   app_store_shared:
     path: ../shared
@@ -18,6 +18,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: 2.0.2
+  flutter_lints: 2.0.3
   openfoodfacts_flutter_lints:
     git: https://github.com/openfoodfacts/openfoodfacts_flutter_lints.git

--- a/packages/app_store/google_play/pubspec.yaml
+++ b/packages/app_store/google_play/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  in_app_review: 2.0.4
+  in_app_review: 2.0.9
 
   app_store_shared:
     path: ../shared
@@ -18,7 +18,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: 2.0.2
+  flutter_lints: 2.0.3
   openfoodfacts_flutter_lints:
     git: https://github.com/openfoodfacts/openfoodfacts_flutter_lints.git
 

--- a/packages/app_store/shared/pubspec.yaml
+++ b/packages/app_store/shared/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: 2.0.2
+  flutter_lints: 2.0.3
   openfoodfacts_flutter_lints:
     git: https://github.com/openfoodfacts/openfoodfacts_flutter_lints.git
 

--- a/packages/app_store/uri_store/pubspec.yaml
+++ b/packages/app_store/uri_store/pubspec.yaml
@@ -18,6 +18,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: 2.0.2
+  flutter_lints: 2.0.3
   openfoodfacts_flutter_lints:
     git: https://github.com/openfoodfacts/openfoodfacts_flutter_lints.git


### PR DESCRIPTION
Will be mandatory at the end of September on Android:
<img width="662" alt="Screenshot 2024-07-01 at 09 00 30" src="https://github.com/openfoodfacts/smooth-app/assets/246838/37514add-c566-4cb8-9692-7aa7a922b5b7">
