### PR TITLE
chore: Remove unnecessary `MediaQuery.of()`

### DIFF
--- a/packages/smooth_app/lib/generic_lib/bottom_sheets/smooth_draggable_bottom_sheet.dart
+++ b/packages/smooth_app/lib/generic_lib/bottom_sheets/smooth_draggable_bottom_sheet.dart
@@ -84,7 +84,7 @@ class SmoothDraggableBottomSheetState
                               : widget.initHeightFraction,
                           scrollController: controller,
                           cacheExtent: _calculateCacheExtent(
-                            MediaQuery.of(context).viewInsets.bottom,
+                            MediaQuery.viewInsetsOf(context).bottom,
                           ),
                         ),
                       ),

--- a/packages/smooth_app/lib/helpers/keyboard_helper.dart
+++ b/packages/smooth_app/lib/helpers/keyboard_helper.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/widgets.dart';
 
 extension KeyboardContextExtention on BuildContext {
-  bool get keyboardVisible => MediaQuery.of(this).viewInsets.bottom > 0.0;
+  bool get keyboardVisible => MediaQuery.viewInsetsOf(this).bottom > 0.0;
 }

--- a/packages/smooth_app/lib/pages/image/uploaded_image_gallery.dart
+++ b/packages/smooth_app/lib/pages/image/uploaded_image_gallery.dart
@@ -38,8 +38,8 @@ class UploadedImageGallery extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    final MediaQueryData mediaQueryData = MediaQuery.of(context);
-    final double columnWidth = mediaQueryData.size.width / 2;
+    final double columnWidth = MediaQuery.sizeOf(context).width / 2;
+
     return SmoothScaffold(
       backgroundColor: Colors.black,
       appBar: SmoothAppBar(

--- a/packages/smooth_app/lib/pages/onboarding/reinvention_page.dart
+++ b/packages/smooth_app/lib/pages/onboarding/reinvention_page.dart
@@ -20,7 +20,7 @@ class OnboardingHomePage extends StatelessWidget {
     return Scaffold(
       backgroundColor: const Color(0xFFE3F3FE),
       body: Provider<OnboardingConfig>.value(
-        value: OnboardingConfig._(MediaQuery.of(context)),
+        value: OnboardingConfig._(MediaQuery.sizeOf(context)),
         child: Stack(
           children: <Widget>[
             const _OnboardingWelcomePageContent(),
@@ -186,7 +186,7 @@ class OnboardingText extends StatelessWidget {
       fontMultiplier = OnboardingConfig.of(context).fontMultiplier;
     } catch (_) {
       fontMultiplier =
-          OnboardingConfig.computeFontMultiplier(MediaQuery.of(context));
+          OnboardingConfig.computeFontMultiplier(MediaQuery.sizeOf(context));
     }
 
     final Color backgroundColor =
@@ -265,12 +265,12 @@ class OnboardingText extends StatelessWidget {
 
 // TODO(g123k): Move elsewhere when the onboarding will be redesigned
 class OnboardingConfig {
-  OnboardingConfig._(MediaQueryData mediaQuery)
-      : fontMultiplier = computeFontMultiplier(mediaQuery);
+  OnboardingConfig._(Size screenSize)
+      : fontMultiplier = computeFontMultiplier(screenSize);
   final double fontMultiplier;
 
-  static double computeFontMultiplier(MediaQueryData mediaQuery) =>
-      ((mediaQuery.size.width * 45) / 428) / 45;
+  static double computeFontMultiplier(Size screenSize) =>
+      ((screenSize.width * 45) / 428) / 45;
 
   static OnboardingConfig of(BuildContext context) =>
       context.watch<OnboardingConfig>();

--- a/packages/smooth_app/lib/pages/product/portion_calculator.dart
+++ b/packages/smooth_app/lib/pages/product/portion_calculator.dart
@@ -37,7 +37,6 @@ class _PortionCalculatorState extends State<PortionCalculator> {
 
   @override
   Widget build(BuildContext context) {
-    final MediaQueryData data = MediaQuery.of(context);
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final bool isQuantityValid = _isInputValid();
 
@@ -66,7 +65,7 @@ class _PortionCalculatorState extends State<PortionCalculator> {
             textBaseline: TextBaseline.alphabetic,
             children: <Widget>[
               SizedBox(
-                width: data.size.width * 0.3,
+                width: MediaQuery.sizeOf(context).width * 0.3,
                 child: Semantics(
                   value:
                       '${_quantityController.text} ${UnitHelper.unitToString(Unit.G)}',

--- a/packages/smooth_app/lib/widgets/smooth_scaffold.dart
+++ b/packages/smooth_app/lib/widgets/smooth_scaffold.dart
@@ -66,7 +66,7 @@ class SmoothScaffoldState extends ScaffoldState {
   Widget build(BuildContext context) {
     Widget child = super.build(context);
 
-    final MediaQueryData mediaQuery = MediaQuery.of(context);
+    final EdgeInsets viewPadding = MediaQuery.viewPaddingOf(context);
 
     if (_contentBehindStatusBar) {
       final Color statusBarColor =
@@ -79,7 +79,7 @@ class SmoothScaffoldState extends ScaffoldState {
           children: <Widget>[
             SizedBox(
               width: double.infinity,
-              height: mediaQuery.viewPadding.top,
+              height: viewPadding.top,
               child: ColoredBox(
                 color: statusBarColor,
               ),
@@ -98,7 +98,7 @@ class SmoothScaffoldState extends ScaffoldState {
             child,
             SizedBox(
               width: double.infinity,
-              height: mediaQuery.viewPadding.top,
+              height: viewPadding.top,
               child: ColoredBox(
                 color: statusBarColor,
               ),
@@ -109,8 +109,8 @@ class SmoothScaffoldState extends ScaffoldState {
     }
 
     if ((widget as SmoothScaffold).fixKeyboard) {
-      final double padding = MediaQuery.of(context).viewInsets.bottom -
-          MediaQuery.of(context).viewPadding.bottom;
+      final double padding = MediaQuery.viewInsetsOf(context).bottom -
+          MediaQuery.viewPaddingOf(context).bottom;
 
       if (padding > 0.0) {
         child = Padding(


### PR DESCRIPTION
Hi everyone!

Calling `MediaQuery.of()` means that when one of the items inside the `MediaQuery` changes, it forces a rebuild.
Using `MediaQuery.sizeOf()` for example will reduce unnecessary builds.