### PR TITLE
fix: Raster cache should support `ErrorBuilder`

### DIFF
--- a/packages/smooth_app/lib/cards/category_cards/raster_cache.dart
+++ b/packages/smooth_app/lib/cards/category_cards/raster_cache.dart
@@ -31,29 +31,25 @@ class RasterCache extends AbstractCache {
         if (loadingProgress == null) {
           return child;
         }
-        return RasterAsyncAsset(
-          AssetCacheHelper(
-            fullFilenames,
-            iconUrl!,
-            width: width,
-            height: height,
-          ),
-        );
+        return _localAssetWidget(fullFilenames);
       },
       errorBuilder: (
         final BuildContext context,
         final Object error,
         final StackTrace? stackTrace,
-      ) {
-        return RasterAsyncAsset(
-          AssetCacheHelper(
-            fullFilenames,
-            iconUrl!,
-            width: width,
-            height: height,
-          ),
-        );
-      },
+      ) =>
+          _localAssetWidget(fullFilenames),
+    );
+  }
+
+  RasterAsyncAsset _localAssetWidget(List<String> fullFilenames) {
+    return RasterAsyncAsset(
+      AssetCacheHelper(
+        fullFilenames,
+        iconUrl!,
+        width: width,
+        height: height,
+      ),
     );
   }
 }

--- a/packages/smooth_app/lib/cards/category_cards/raster_cache.dart
+++ b/packages/smooth_app/lib/cards/category_cards/raster_cache.dart
@@ -17,6 +17,7 @@ class RasterCache extends AbstractCache {
     if (fullFilenames.isEmpty) {
       return getDefaultUnknown();
     }
+
     return Image.network(
       iconUrl!,
       width: width,
@@ -30,6 +31,20 @@ class RasterCache extends AbstractCache {
         if (loadingProgress == null) {
           return child;
         }
+        return RasterAsyncAsset(
+          AssetCacheHelper(
+            fullFilenames,
+            iconUrl!,
+            width: width,
+            height: height,
+          ),
+        );
+      },
+      errorBuilder: (
+        final BuildContext context,
+        final Object error,
+        final StackTrace? stackTrace,
+      ) {
         return RasterAsyncAsset(
           AssetCacheHelper(
             fullFilenames,


### PR DESCRIPTION
Hi everyone!

As noticed by @monsieurtanuki, the Signal Conso logo is not working offline, even if it's in the cache assets.
The reason was that the error callback was not fetching the image in the cache