### PR TITLE
feat: new parameters for uploadProof

### DIFF
--- a/packages/smooth_app/lib/background/background_task_add_price.dart
+++ b/packages/smooth_app/lib/background/background_task_add_price.dart
@@ -360,6 +360,10 @@ class BackgroundTaskAddPrice extends BackgroundTask {
         HttpHelper().imagineMediaType(initialImageUri.path)!;
     final MaybeError<Proof> uploadProof = await OpenPricesAPIClient.uploadProof(
       proofType: proofType,
+      date: date,
+      currency: currency,
+      locationOSMId: locationOSMId,
+      locationOSMType: locationOSMType,
       imageUri: initialImageUri,
       mediaType: initialMediaType,
       bearerToken: bearerToken,

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -1108,10 +1108,10 @@ packages:
     dependency: "direct main"
     description:
       name: openfoodfacts
-      sha256: "90a853e7536d0f97a665b18cd602055215520bf424765ef06930e4be25b760ba"
+      sha256: b8e90057fc04ecb407bdd48758172fc8200483ae15e926d6825fc3bd6a4d2468
       url: "https://pub.dev"
     source: hosted
-    version: "3.11.0"
+    version: "3.12.0"
   openfoodfacts_flutter_lints:
     dependency: "direct dev"
     description:
@@ -1853,4 +1853,4 @@ packages:
     version: "3.1.2"
 sdks:
   dart: ">=3.4.0 <4.0.0"
-  flutter: ">=3.19.0"
+  flutter: ">=3.22.0"

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -100,7 +100,7 @@ dependencies:
     path: ../scanner/zxing
 
 
-  openfoodfacts: 3.11.0
+  openfoodfacts: 3.12.0
   # openfoodfacts:
   #   path: ../../../openfoodfacts-dart
 


### PR DESCRIPTION
### What
- Using the latest Prices and off-dart code, we're now able to set location, date and currency for a proof (and not just for each individual price)

### Screenshot
From the Prices app, about a proof created from Smoothie with the current PR code:
<img width="391" alt="image" src="https://github.com/openfoodfacts/smooth-app/assets/11576431/f9ba4ef3-dae0-4829-9751-7cf75dcd521e">
As opposed to a proof without location, date and currency
<img width="345" alt="image" src="https://github.com/openfoodfacts/smooth-app/assets/11576431/e49d626a-4a3c-40dc-aaee-8b405db6ad8d">

### Impacted files
* `background_task_add_prices.dart`: 4 new parameters for `uploadProof`
* `pubspec.lock`: wtf
* `pubspec.yaml`: upgraded to off-dart 3.12.0