### PR TITLE
feat: Add the outdated indicator to the photo grid

### DIFF
--- a/packages/smooth_app/lib/data_models/product_image_data.dart
+++ b/packages/smooth_app/lib/data_models/product_image_data.dart
@@ -2,11 +2,13 @@ import 'package:openfoodfacts/openfoodfacts.dart';
 
 class ProductImageData {
   const ProductImageData({
+    required this.imageId,
     required this.imageField,
     required this.imageUrl,
     required this.language,
   });
 
+  final String? imageId;
   final ImageField imageField;
   final String? imageUrl;
   final OpenFoodFactsLanguage? language;

--- a/packages/smooth_app/lib/database/transient_file.dart
+++ b/packages/smooth_app/lib/database/transient_file.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/data_models/product_image_data.dart';
@@ -11,34 +12,48 @@ class TransientFile {
   TransientFile(
     this.imageField,
     this.barcode,
-    this.language,
-  ) : url = null;
+    this.language, [
+    this.uploadedDate,
+  ]) : url = null;
 
   TransientFile.fromProductImageData(
     final ProductImageData productImageData,
     this.barcode,
-    this.language,
-  )   : imageField = productImageData.imageField,
+    this.language, [
+    this.uploadedDate,
+  ])  : imageField = productImageData.imageField,
         url = productImageData.imageUrl;
 
-  TransientFile.fromProduct(
+  factory TransientFile.fromProduct(
     final Product product,
     final ImageField imageField,
     final OpenFoodFactsLanguage language,
-  ) : this.fromProductImageData(
-          getProductImageData(
-            product,
-            imageField,
-            language,
-          ),
-          product.barcode!,
-          language,
-        );
+  ) {
+    final ProductImageData productImageData = getProductImageData(
+      product,
+      imageField,
+      language,
+    );
+
+    return TransientFile.fromProductImageData(
+      productImageData,
+      product.barcode!,
+      language,
+      product
+          .getRawImages()
+          ?.firstWhereOrNull(
+            (final ProductImage productImage) =>
+                productImage.imgid == productImageData.imageId,
+          )
+          ?.uploaded,
+    );
+  }
 
   final ImageField imageField;
   final String barcode;
   final OpenFoodFactsLanguage language;
   final String? url;
+  final DateTime? uploadedDate;
 
   /// {File "key": file path} map.
   static final Map<String, String> _transientFiles = <String, String>{};

--- a/packages/smooth_app/lib/helpers/product_cards_helper.dart
+++ b/packages/smooth_app/lib/helpers/product_cards_helper.dart
@@ -266,6 +266,7 @@ ProductImageData getProductImageData(
   if (productImage != null) {
     // we found a localized version for this image
     return ProductImageData(
+      imageId: productImage.imgid,
       imageField: imageField,
       imageUrl: productImage.getUrl(
         product.barcode!,
@@ -281,6 +282,7 @@ ProductImageData getProductImageData(
 ProductImageData getEmptyProductImageData(final ImageField imageField) =>
     ProductImageData(
       imageField: imageField,
+      imageId: null,
       imageUrl: null,
       language: null,
     );

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -512,7 +512,7 @@
     },
     "outdated_image_accessibility_label": "{imageType} (this image may be outdated)",
     "@outdated_image_accessibility_label": {
-        "description": "Accessibility label for images that are outdated",
+        "description": "Accessibility label for images that are outdated (image type may be front/ingredients/nutrition…)",
         "placeholders": {
             "imageType": {}
         }

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -510,6 +510,13 @@
     "@front_photo": {
         "description": "Button label: For adding a picture of the front of a product"
     },
+    "outdated_image_accessibility_label": "{imageType} (this image may be outdated)",
+    "@outdated_image_accessibility_label": {
+        "description": "Accessibility label for images that are outdated",
+        "placeholders": {
+            "imageType": {}
+        }
+    },
     "ingredients": "Ingredients",
     "@ingredients": {},
     "ingredients_editing_instructions": "Keep the original order. Indicate the percentage when specified. Separate with a comma or hyphen, use parentheses for ingredients of an ingredient, and indicate allergens between underscores.",

--- a/packages/smooth_app/lib/pages/image/product_image_helper.dart
+++ b/packages/smooth_app/lib/pages/image/product_image_helper.dart
@@ -1,0 +1,21 @@
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/database/transient_file.dart';
+
+class _ProductImageHelper {
+  const _ProductImageHelper._();
+
+  static bool isExpired(final DateTime? uploadedDate) {
+    if (uploadedDate == null) {
+      return false;
+    }
+    return DateTime.now().difference(uploadedDate).inDays > 365;
+  }
+}
+
+extension ProductImageExtension on ProductImage {
+  bool get expired => _ProductImageHelper.isExpired(uploaded);
+}
+
+extension TransientFileExtension on TransientFile {
+  bool get expired => _ProductImageHelper.isExpired(uploadedDate);
+}

--- a/packages/smooth_app/lib/pages/image/product_image_helper.dart
+++ b/packages/smooth_app/lib/pages/image/product_image_helper.dart
@@ -4,6 +4,8 @@ import 'package:smooth_app/database/transient_file.dart';
 class _ProductImageHelper {
   const _ProductImageHelper._();
 
+  /// An image is considered outdated/expired after 1 year.
+  /// Note: the value will be sent in the future by the backend.
   static bool isExpired(final DateTime? uploadedDate) {
     if (uploadedDate == null) {
       return false;

--- a/packages/smooth_app/lib/pages/image/product_image_widget.dart
+++ b/packages/smooth_app/lib/pages/image/product_image_widget.dart
@@ -6,8 +6,9 @@ import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/images/smooth_image.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
+import 'package:smooth_app/pages/image/product_image_helper.dart';
 import 'package:smooth_app/query/product_query.dart';
-import 'package:smooth_app/resources/app_icons.dart';
+import 'package:smooth_app/resources/app_icons.dart' as icons;
 import 'package:smooth_app/themes/smooth_theme_colors.dart';
 
 /// Displays a product image thumbnail with the upload date on top.
@@ -52,7 +53,7 @@ class ProductImageWidget extends StatelessWidget {
     if (uploaded == null) {
       return image;
     }
-    final bool expired = DateTime.now().difference(uploaded).inDays > 365;
+    final bool expired = productImage.expired;
     final String date = dateFormat.format(uploaded);
 
     return Semantics(
@@ -94,7 +95,7 @@ class ProductImageWidget extends StatelessWidget {
                           end: 0.0,
                           height: 20.0,
                           textDirection: Directionality.of(context),
-                          child: Outdated(
+                          child: icons.Outdated(
                             size: 18.0,
                             color: colors.red,
                           ),


### PR DESCRIPTION
Hi everyone,

The outdated icon is visible in the "Other interesting photos" section, but not the top grid.
It requires a bit of work to get the date for the 4 main photos, as it's not directly available.

<img width="461" alt="Screenshot 2024-07-19 at 13 28 13" src="https://github.com/user-attachments/assets/53c24a3b-a286-4c0a-9d6a-191e3c966094">



