### PR TITLE
feat: Popup Menu now uses the iOS actions sheet

### DIFF
--- a/packages/smooth_app/ios/Podfile.lock
+++ b/packages/smooth_app/ios/Podfile.lock
@@ -121,22 +121,20 @@ PODS:
   - qr_code_scanner (0.2.0):
     - Flutter
     - MTBBarcodeScanner
-  - ReachabilitySwift (5.2.2)
+  - ReachabilitySwift (5.2.3)
   - rive_common (0.0.1):
     - Flutter
-  - SDWebImage (5.19.2):
-    - SDWebImage/Core (= 5.19.2)
-  - SDWebImage/Core (5.19.2)
+  - SDWebImage (5.19.4):
+    - SDWebImage/Core (= 5.19.4)
+  - SDWebImage/Core (5.19.4)
   - SDWebImageWebPCoder (0.14.6):
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.17)
-  - Sentry/HybridSDK (8.21.0):
-    - SentryPrivate (= 8.21.0)
-  - sentry_flutter (0.0.1):
+  - Sentry/HybridSDK (8.29.0)
+  - sentry_flutter (8.3.0):
     - Flutter
     - FlutterMacOS
-    - Sentry/HybridSDK (= 8.21.0)
-  - SentryPrivate (8.21.0)
+    - Sentry/HybridSDK (= 8.29.0)
   - share_plus (0.0.1):
     - Flutter
   - shared_preferences_foundation (0.0.1):
@@ -201,7 +199,6 @@ SPEC REPOS:
     - SDWebImage
     - SDWebImageWebPCoder
     - Sentry
-    - SentryPrivate
 
 EXTERNAL SOURCES:
   app_settings:
@@ -298,13 +295,12 @@ SPEC CHECKSUMS:
   permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   qr_code_scanner: bb67d64904c3b9658ada8c402e8b4d406d5d796e
-  ReachabilitySwift: 2128f3a8c9107e1ad33574c6e58e8285d460b149
+  ReachabilitySwift: 7f151ff156cea1481a8411701195ac6a984f4979
   rive_common: cbbac3192af00d7341f19dae2f26298e9e37d99e
-  SDWebImage: dfe95b2466a9823cf9f0c6d01217c06550d7b29a
+  SDWebImage: 066c47b573f408f18caa467d71deace7c0f8280d
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
-  Sentry: ebc12276bd17613a114ab359074096b6b3725203
-  sentry_flutter: dff1df05dc39c83d04f9330b36360fc374574c5e
-  SentryPrivate: d651efb234cf385ec9a1cdd3eff94b5e78a0e0fe
+  Sentry: 016de45ee5ce5fca2a829996f1bfafeb5e62e8b4
+  sentry_flutter: 5fb57c5b7e6427a9dc1fedde4269eb65823982d4
   share_plus: c3fef564749587fc939ef86ffb283ceac0baf9f5
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
   sqflite: 673a0e54cc04b7d6dba8d24fb8095b31c3a99eec

--- a/packages/smooth_app/lib/helpers/analytics_helper.dart
+++ b/packages/smooth_app/lib/helpers/analytics_helper.dart
@@ -286,7 +286,7 @@ class AnalyticsHelper {
     try {
       await MatomoTracker.instance.initialize(
         url: 'https://analytics.openfoodfacts.org/matomo.php',
-        siteId: 2,
+        siteId: '2',
         visitorId: _visitorId,
       );
     } catch (err) {

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -2956,5 +2956,9 @@
     "prices_feedback_form": "Click here to send us your feedback about this new feature!",
     "@prices_feedback_form": {
         "description": "A button to send feedback about the prices feature"
+    },
+    "menu_button_list_actions": "Select an action",
+    "@menu_button_list_actions": {
+        "description": "Button to select an action in a list (eg: Share, Delete, …)"
     }
 }

--- a/packages/smooth_app/lib/pages/personalized_ranking_page.dart
+++ b/packages/smooth_app/lib/pages/personalized_ranking_page.dart
@@ -16,6 +16,7 @@ import 'package:smooth_app/pages/product/common/loading_status.dart';
 import 'package:smooth_app/pages/product/common/product_list_item_simple.dart';
 import 'package:smooth_app/pages/product_list_user_dialog_helper.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
+import 'package:smooth_app/widgets/smooth_menu_button.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
 class PersonalizedRankingPage extends StatefulWidget {
@@ -97,13 +98,13 @@ class _PersonalizedRankingPageState extends State<PersonalizedRankingPage>
       appBar: SmoothAppBar(
         title: Text(widget.title, overflow: TextOverflow.fade),
         actions: <Widget>[
-          PopupMenuButton<String>(
+          SmoothPopupMenuButton<String>(
             onSelected: _handlePopUpClick,
             itemBuilder: (BuildContext context) {
-              return <PopupMenuEntry<String>>[
-                PopupMenuItem<String>(
+              return <SmoothPopupMenuItem<String>>[
+                SmoothPopupMenuItem<String>(
                   value: 'add_to_list',
-                  child: Text(appLocalizations.user_list_button_add_product),
+                  label: appLocalizations.user_list_button_add_product,
                 ),
               ];
             },

--- a/packages/smooth_app/lib/pages/product/common/product_list_item_popup_items.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_item_popup_items.dart
@@ -10,6 +10,7 @@ import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/pages/personalized_ranking_page.dart';
 import 'package:smooth_app/pages/product/compare_products3_page.dart';
 import 'package:smooth_app/pages/product/ordered_nutrients_cache.dart';
+import 'package:smooth_app/widgets/smooth_menu_button.dart';
 
 /// Popup menu item entries for the product list page, for selected items.
 enum ProductListItemPopupMenuEntry {
@@ -26,6 +27,9 @@ abstract class ProductListItemPopupItem {
   /// IconData of the popup menu item.
   IconData getIconData();
 
+  /// Is-it a destructive action?
+  bool isDestructive() => false;
+
   /// Action of the popup menu item.
   ///
   /// Returns true if the caller must refresh (setState) (e.g. after deleting).
@@ -37,17 +41,16 @@ abstract class ProductListItemPopupItem {
   });
 
   /// Returns the popup menu item.
-  PopupMenuItem<ProductListItemPopupItem> getMenuItem(
+  SmoothPopupMenuItem<ProductListItemPopupItem> getMenuItem(
     final AppLocalizations appLocalizations,
     final bool enabled,
   ) =>
-      PopupMenuItem<ProductListItemPopupItem>(
+      SmoothPopupMenuItem<ProductListItemPopupItem>(
         value: this,
+        icon: getIconData(),
+        label: getTitle(appLocalizations),
         enabled: enabled,
-        child: ListTile(
-          leading: Icon(getIconData()),
-          title: Text(getTitle(appLocalizations)),
-        ),
+        type: isDestructive() ? SmoothPopupMenuItemType.destructive : null,
       );
 }
 
@@ -138,6 +141,9 @@ class ProductListItemPopupDelete extends ProductListItemPopupItem {
 
   @override
   IconData getIconData() => Icons.delete;
+
+  @override
+  bool isDestructive() => true;
 
   @override
   Future<bool> doSomething({

--- a/packages/smooth_app/lib/pages/product/common/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_page.dart
@@ -31,6 +31,7 @@ import 'package:smooth_app/pages/product_list_user_dialog_helper.dart';
 import 'package:smooth_app/pages/scan/carousel/scan_carousel_manager.dart';
 import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
+import 'package:smooth_app/widgets/smooth_menu_button.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 import 'package:smooth_app/widgets/will_pop_scope.dart';
 
@@ -181,7 +182,7 @@ class _ProductListPageState extends State<ProductListPage>
                 }
               },
             ),
-          PopupMenuButton<ProductListPopupItem>(
+          SmoothPopupMenuButton<ProductListPopupItem>(
             onSelected: (final ProductListPopupItem action) async {
               final ProductList? differentProductList =
                   await action.doSomething(
@@ -193,8 +194,7 @@ class _ProductListPageState extends State<ProductListPage>
                 setState(() => productList = differentProductList);
               }
             },
-            itemBuilder: (BuildContext context) =>
-                <PopupMenuEntry<ProductListPopupItem>>[
+            itemBuilder: (_) => <SmoothPopupMenuItem<ProductListPopupItem>>[
               if (enableRename) _rename.getMenuItem(appLocalizations),
               _share.getMenuItem(appLocalizations),
               _openInWeb.getMenuItem(appLocalizations),
@@ -215,7 +215,7 @@ class _ProductListPageState extends State<ProductListPage>
         },
         actionModeTitle: Text('${_selectedBarcodes.length}'),
         actionModeActions: <Widget>[
-          PopupMenuButton<ProductListItemPopupItem>(
+          SmoothPopupMenuButton<ProductListItemPopupItem>(
             onSelected: (final ProductListItemPopupItem action) async {
               final bool andThenSetState = await action.doSomething(
                 productList: productList,
@@ -229,8 +229,7 @@ class _ProductListPageState extends State<ProductListPage>
                 }
               }
             },
-            itemBuilder: (BuildContext context) =>
-                <PopupMenuEntry<ProductListItemPopupItem>>[
+            itemBuilder: (_) => <SmoothPopupMenuItem<ProductListItemPopupItem>>[
               if (userPreferences.getFlag(UserPreferencesDevMode
                       .userPreferencesFlagBoostedComparison) ==
                   true)

--- a/packages/smooth_app/lib/pages/product/common/product_list_popup_items.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_popup_items.dart
@@ -8,6 +8,7 @@ import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/temp_product_list_share_helper.dart';
 import 'package:smooth_app/pages/product_list_user_dialog_helper.dart';
+import 'package:smooth_app/widgets/smooth_menu_button.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 /// Popup menu item entries for the product list page.
@@ -30,6 +31,9 @@ abstract class ProductListPopupItem {
   /// Popup menu entry of the popup menu item.
   ProductListPopupMenuEntry getEntry();
 
+  /// Is-it a destructive action?
+  bool isDestructive() => false;
+
   /// Action of the popup menu item.
   ///
   /// Returns a different product list if there are changes, else null.
@@ -40,15 +44,14 @@ abstract class ProductListPopupItem {
   });
 
   /// Returns the popup menu item.
-  PopupMenuItem<ProductListPopupItem> getMenuItem(
+  SmoothPopupMenuItem<ProductListPopupItem> getMenuItem(
     final AppLocalizations appLocalizations,
   ) =>
-      PopupMenuItem<ProductListPopupItem>(
+      SmoothPopupMenuItem<ProductListPopupItem>(
         value: this,
-        child: ListTile(
-          leading: Icon(getIconData()),
-          title: Text(getTitle(appLocalizations)),
-        ),
+        icon: getIconData(),
+        label: getTitle(appLocalizations),
+        type: isDestructive() ? SmoothPopupMenuItemType.destructive : null,
       );
 }
 
@@ -63,6 +66,9 @@ class ProductListPopupClear extends ProductListPopupItem {
 
   @override
   ProductListPopupMenuEntry getEntry() => ProductListPopupMenuEntry.clear;
+
+  @override
+  bool isDestructive() => true;
 
   @override
   Future<ProductList?> doSomething({

--- a/packages/smooth_app/lib/widgets/smooth_menu_button.dart
+++ b/packages/smooth_app/lib/widgets/smooth_menu_button.dart
@@ -1,0 +1,112 @@
+import 'dart:io';
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+class SmoothPopupMenuButton<T> extends StatefulWidget {
+  const SmoothPopupMenuButton({
+    required this.onSelected,
+    required this.itemBuilder,
+    this.actionsTitle,
+    this.buttonIcon,
+    this.buttonLabel,
+  })  : assert(buttonLabel == null || buttonLabel.length > 0),
+        assert(actionsTitle == null || actionsTitle.length > 0);
+
+  final Icon? buttonIcon;
+  final String? buttonLabel;
+  final String? actionsTitle;
+  final void Function(T value) onSelected;
+  final Iterable<SmoothPopupMenuItem<T>> Function(BuildContext context)
+      itemBuilder;
+
+  @override
+  State<SmoothPopupMenuButton<T>> createState() =>
+      _SmoothPopupMenuButtonState<T>();
+}
+
+class _SmoothPopupMenuButtonState<T> extends State<SmoothPopupMenuButton<T>> {
+  @override
+  Widget build(BuildContext context) {
+    if (Platform.isIOS || Platform.isMacOS) {
+      return IconButton(
+        icon: widget.buttonIcon ?? Icon(Icons.adaptive.more),
+        tooltip: widget.buttonLabel ??
+            MaterialLocalizations.of(context).showMenuTooltip,
+        onPressed: _openModalSheet,
+      );
+    } else {
+      return PopupMenuButton<T>(
+        icon: widget.buttonIcon ?? Icon(Icons.adaptive.more),
+        tooltip: widget.buttonLabel ??
+            MaterialLocalizations.of(context).showMenuTooltip,
+        onSelected: widget.onSelected,
+        itemBuilder: (BuildContext context) {
+          return widget.itemBuilder(context).map((SmoothPopupMenuItem<T> item) {
+            return PopupMenuItem<T>(
+              value: item.value,
+              enabled: item.enabled,
+              child: ListTile(
+                leading: Icon(item.icon),
+                title: Text(item.label),
+              ),
+            );
+          }).toList(growable: false);
+        },
+      );
+    }
+  }
+
+  // iOS and macOS behavior
+  void _openModalSheet() {
+    showCupertinoModalPopup(
+        context: context,
+        builder: (BuildContext context) {
+          return CupertinoActionSheet(
+            title: Text(
+              widget.actionsTitle ??
+                  AppLocalizations.of(context).menu_button_list_actions,
+            ),
+            actions: widget
+                .itemBuilder(context)
+                .where((SmoothPopupMenuItem<T> item) => item.enabled)
+                .map((SmoothPopupMenuItem<T> item) {
+              return CupertinoActionSheetAction(
+                isDefaultAction:
+                    item.type == SmoothPopupMenuItemType.highlighted,
+                isDestructiveAction:
+                    item.type == SmoothPopupMenuItemType.destructive,
+                onPressed: () {
+                  widget.onSelected(item.value);
+                  Navigator.of(context).maybePop();
+                },
+                child: Text(item.label),
+              );
+            }).toList(growable: false),
+          );
+        });
+  }
+}
+
+class SmoothPopupMenuItem<T> {
+  const SmoothPopupMenuItem({
+    required this.value,
+    required this.label,
+    this.icon,
+    this.type,
+    this.enabled = true,
+  }) : assert(label.length > 0);
+
+  final T value;
+  final String label;
+  final IconData? icon;
+  final SmoothPopupMenuItemType? type;
+  final bool enabled;
+}
+
+enum SmoothPopupMenuItemType {
+  normal,
+  highlighted,
+  destructive,
+}

--- a/packages/smooth_app/macos/Podfile.lock
+++ b/packages/smooth_app/macos/Podfile.lock
@@ -22,16 +22,14 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - ReachabilitySwift (5.2.2)
+  - ReachabilitySwift (5.2.3)
   - rive_common (0.0.1):
     - FlutterMacOS
-  - Sentry/HybridSDK (8.21.0):
-    - SentryPrivate (= 8.21.0)
-  - sentry_flutter (0.0.1):
+  - Sentry/HybridSDK (8.29.0)
+  - sentry_flutter (8.3.0):
     - Flutter
     - FlutterMacOS
-    - Sentry/HybridSDK (= 8.21.0)
-  - SentryPrivate (8.21.0)
+    - Sentry/HybridSDK (= 8.29.0)
   - share_plus (0.0.1):
     - FlutterMacOS
   - shared_preferences_foundation (0.0.1):
@@ -66,7 +64,6 @@ SPEC REPOS:
   trunk:
     - ReachabilitySwift
     - Sentry
-    - SentryPrivate
 
 EXTERNAL SOURCES:
   audioplayers_darwin:
@@ -116,11 +113,10 @@ SPEC CHECKSUMS:
   mobile_scanner: 54ceceae0c8da2457e26a362a6be5c61154b1829
   package_info_plus: 02d7a575e80f194102bef286361c6c326e4c29ce
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
-  ReachabilitySwift: 2128f3a8c9107e1ad33574c6e58e8285d460b149
+  ReachabilitySwift: 7f151ff156cea1481a8411701195ac6a984f4979
   rive_common: cf5ab646aa576b2d742d0e2d528126fbf032c856
-  Sentry: ebc12276bd17613a114ab359074096b6b3725203
-  sentry_flutter: dff1df05dc39c83d04f9330b36360fc374574c5e
-  SentryPrivate: d651efb234cf385ec9a1cdd3eff94b5e78a0e0fe
+  Sentry: 016de45ee5ce5fca2a829996f1bfafeb5e62e8b4
+  sentry_flutter: 5fb57c5b7e6427a9dc1fedde4269eb65823982d4
   share_plus: 76dd39142738f7a68dd57b05093b5e8193f220f7
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
   sqflite: 673a0e54cc04b7d6dba8d24fb8095b31c3a99eec

--- a/packages/smooth_app/macos/Podfile.lock
+++ b/packages/smooth_app/macos/Podfile.lock
@@ -111,7 +111,7 @@ SPEC CHECKSUMS:
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
   in_app_review: a850789fad746e89bce03d4aeee8078b45a53fd0
   mobile_scanner: 54ceceae0c8da2457e26a362a6be5c61154b1829
-  package_info_plus: 02d7a575e80f194102bef286361c6c326e4c29ce
+  package_info_plus: fa739dd842b393193c5ca93c26798dff6e3d0e0c
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
   ReachabilitySwift: 7f151ff156cea1481a8411701195ac6a984f4979
   rive_common: cf5ab646aa576b2d742d0e2d528126fbf032c856

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -329,10 +329,10 @@ packages:
     dependency: transitive
     description:
       name: cross_file
-      sha256: fedaadfa3a6996f75211d835aaeb8fede285dae94262485698afd832371b9a5e
+      sha256: "55d7b444feb71301ef6b8838dbc1ae02e63dd48c8773f3810ff53bb1e2945b32"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.3+8"
+    version: "0.3.4+1"
   crypto:
     dependency: transitive
     description:
@@ -807,10 +807,10 @@ packages:
     dependency: "direct main"
     description:
       name: http
-      sha256: a2bbf9d017fcced29139daa8ed2bba4ece450ab222871df93ca9eec6f80c34ba
+      sha256: b9c29a161230ee03d3ccf545097fccd9b87a5264228c5d348202e0f0c28f9010
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.2"
   http_parser:
     dependency: "direct main"
     description:
@@ -1028,10 +1028,10 @@ packages:
     dependency: "direct main"
     description:
       name: matomo_tracker
-      sha256: de5c08e80b566f8d1f0edf47f5704fe855fbef52377acb2796d28c2a3e36ea41
+      sha256: b7950a0d8e8a8533e451b54de8ab1005bd72af6a209e198a3b8cd58ff106ff46
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.1"
+    version: "5.0.0+1"
   meta:
     dependency: transitive
     description:
@@ -1117,18 +1117,18 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: "88bc797f44a94814f2213db1c9bd5badebafdfb8290ca9f78d4b9ee2a3db4d79"
+      sha256: b93d8b4d624b4ea19b0a5a208b2d6eff06004bc3ce74c06040b120eeadd00ce0
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.1"
+    version: "8.0.0"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
       name: package_info_plus_platform_interface
-      sha256: "9bc8ba46813a4cc42c66ab781470711781940780fd8beddd0c3da62506d3a6c6"
+      sha256: f49918f3433a3146047372f9d4f1f847511f2acd5cd030e1f44fe5a50036b70e
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.0"
   path:
     dependency: "direct main"
     description:
@@ -1442,10 +1442,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_web
-      sha256: "7b15ffb9387ea3e237bb7a66b8a23d2147663d391cafc5c8f37b2e7b4bde5d21"
+      sha256: "9aee1089b36bd2aafe06582b7d7817fd317ef05fc30e6ba14bff247d0933042a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.2"
+    version: "2.3.0"
   shared_preferences_windows:
     dependency: transitive
     description:
@@ -1491,6 +1491,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.0"
+  sprintf:
+    dependency: transitive
+    description:
+      name: sprintf
+      sha256: "1fc9ffe69d4df602376b52949af107d8f5703b77cda567c4d7d86a0693120f23"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
   sqflite:
     dependency: "direct main"
     description:
@@ -1663,10 +1671,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_web
-      sha256: fff0932192afeedf63cdd50ecbb1bc825d31aed259f02bb8dba0f3b729a5e88b
+      sha256: "8d9e750d8c9338601e709cd0885f95825086bd8b642547f26bda435aade95d8a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.3"
+    version: "2.3.1"
   url_launcher_windows:
     dependency: transitive
     description:
@@ -1679,10 +1687,10 @@ packages:
     dependency: "direct main"
     description:
       name: uuid
-      sha256: "648e103079f7c64a36dc7d39369cabb358d377078a051d6ae2ad3aa539519313"
+      sha256: "83d37c7ad7aaf9aa8e275490669535c8080377cfa7a7004c24dfac53afffaa90"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.7"
+    version: "4.4.2"
   vector_graphics:
     dependency: transitive
     description:
@@ -1743,10 +1751,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: "4188706108906f002b3a293509234588823c8c979dc83304e229ff400c996b05"
+      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.2"
+    version: "0.5.1"
   webdriver:
     dependency: transitive
     description:
@@ -1836,5 +1844,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.4.0 <4.0.0"
+  dart: ">=3.4.1 <4.0.0"
   flutter: ">=3.22.0"

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -25,17 +25,17 @@ dependencies:
   flutter_secure_storage: 9.2.2
   hive: 2.2.3
   hive_flutter: 1.1.0
-  http: 1.2.0
+  http: 1.2.2
   http_parser: 4.0.2
   image_picker: 1.1.1
   iso_countries: 2.2.0
   latlong2: 0.9.1
-  matomo_tracker: 4.1.1
-  package_info_plus: 5.0.1
+  matomo_tracker: 5.0.0+1
+  package_info_plus: 8.0.0
   device_info_plus: 9.1.2
   permission_handler: 11.3.1
   photo_view: 0.15.0
-  uuid: 3.0.7
+  uuid: 4.4.2
   provider: 6.1.2
   sentry_flutter: 8.3.0
   sqflite: 2.3.3+1


### PR DESCRIPTION
Hi everyone,

We have a "three dots" menu item containing actions on the screen with lists.
On Android, we use the `PopupMenuButton` from Material, but on iOS, it looks really… Android.

I've created a custom Widget that shows the Cupertino component on iOS and macOS. Otherwise, it's Material.

Android:
<img width="461" alt="Screenshot 2024-07-20 at 03 14 16" src="https://github.com/user-attachments/assets/aeb5e88b-05a0-4260-8185-511f5ac7306e">

iOS:
<img width="461" alt="Screenshot 2024-07-20 at 03 13 54" src="https://github.com/user-attachments/assets/85637df1-aac7-4b57-a1fd-f41a7bbd7abd">
