### PR TITLE
feat: Popup Menu now uses the iOS actions sheet

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -2956,5 +2956,9 @@
     "prices_feedback_form": "Click here to send us your feedback about this new feature!",
     "@prices_feedback_form": {
         "description": "A button to send feedback about the prices feature"
+    },
+    "menu_button_list_actions": "Select an action",
+    "@menu_button_list_actions": {
+        "description": "Button to select an action in a list (eg: Share, Delete, …)"
     }
 }

--- a/packages/smooth_app/lib/pages/personalized_ranking_page.dart
+++ b/packages/smooth_app/lib/pages/personalized_ranking_page.dart
@@ -16,6 +16,7 @@ import 'package:smooth_app/pages/product/common/loading_status.dart';
 import 'package:smooth_app/pages/product/common/product_list_item_simple.dart';
 import 'package:smooth_app/pages/product_list_user_dialog_helper.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
+import 'package:smooth_app/widgets/smooth_menu_button.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
 class PersonalizedRankingPage extends StatefulWidget {
@@ -97,13 +98,13 @@ class _PersonalizedRankingPageState extends State<PersonalizedRankingPage>
       appBar: SmoothAppBar(
         title: Text(widget.title, overflow: TextOverflow.fade),
         actions: <Widget>[
-          PopupMenuButton<String>(
+          SmoothPopupMenuButton<String>(
             onSelected: _handlePopUpClick,
             itemBuilder: (BuildContext context) {
-              return <PopupMenuEntry<String>>[
-                PopupMenuItem<String>(
+              return <SmoothPopupMenuItem<String>>[
+                SmoothPopupMenuItem<String>(
                   value: 'add_to_list',
-                  child: Text(appLocalizations.user_list_button_add_product),
+                  label: appLocalizations.user_list_button_add_product,
                 ),
               ];
             },

--- a/packages/smooth_app/lib/pages/product/common/product_list_item_popup_items.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_item_popup_items.dart
@@ -10,6 +10,7 @@ import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/pages/personalized_ranking_page.dart';
 import 'package:smooth_app/pages/product/compare_products3_page.dart';
 import 'package:smooth_app/pages/product/ordered_nutrients_cache.dart';
+import 'package:smooth_app/widgets/smooth_menu_button.dart';
 
 /// Popup menu item entries for the product list page, for selected items.
 enum ProductListItemPopupMenuEntry {
@@ -26,6 +27,9 @@ abstract class ProductListItemPopupItem {
   /// IconData of the popup menu item.
   IconData getIconData();
 
+  /// Is-it a destructive action?
+  bool isDestructive() => false;
+
   /// Action of the popup menu item.
   ///
   /// Returns true if the caller must refresh (setState) (e.g. after deleting).
@@ -37,17 +41,16 @@ abstract class ProductListItemPopupItem {
   });
 
   /// Returns the popup menu item.
-  PopupMenuItem<ProductListItemPopupItem> getMenuItem(
+  SmoothPopupMenuItem<ProductListItemPopupItem> getMenuItem(
     final AppLocalizations appLocalizations,
     final bool enabled,
   ) =>
-      PopupMenuItem<ProductListItemPopupItem>(
+      SmoothPopupMenuItem<ProductListItemPopupItem>(
         value: this,
+        icon: getIconData(),
+        label: getTitle(appLocalizations),
         enabled: enabled,
-        child: ListTile(
-          leading: Icon(getIconData()),
-          title: Text(getTitle(appLocalizations)),
-        ),
+        type: isDestructive() ? SmoothPopupMenuItemType.destructive : null,
       );
 }
 
@@ -138,6 +141,9 @@ class ProductListItemPopupDelete extends ProductListItemPopupItem {
 
   @override
   IconData getIconData() => Icons.delete;
+
+  @override
+  bool isDestructive() => true;
 
   @override
   Future<bool> doSomething({

--- a/packages/smooth_app/lib/pages/product/common/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_page.dart
@@ -31,6 +31,7 @@ import 'package:smooth_app/pages/product_list_user_dialog_helper.dart';
 import 'package:smooth_app/pages/scan/carousel/scan_carousel_manager.dart';
 import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
+import 'package:smooth_app/widgets/smooth_menu_button.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 import 'package:smooth_app/widgets/will_pop_scope.dart';
 
@@ -181,7 +182,7 @@ class _ProductListPageState extends State<ProductListPage>
                 }
               },
             ),
-          PopupMenuButton<ProductListPopupItem>(
+          SmoothPopupMenuButton<ProductListPopupItem>(
             onSelected: (final ProductListPopupItem action) async {
               final ProductList? differentProductList =
                   await action.doSomething(
@@ -193,8 +194,7 @@ class _ProductListPageState extends State<ProductListPage>
                 setState(() => productList = differentProductList);
               }
             },
-            itemBuilder: (BuildContext context) =>
-                <PopupMenuEntry<ProductListPopupItem>>[
+            itemBuilder: (_) => <SmoothPopupMenuItem<ProductListPopupItem>>[
               if (enableRename) _rename.getMenuItem(appLocalizations),
               _share.getMenuItem(appLocalizations),
               _openInWeb.getMenuItem(appLocalizations),
@@ -215,7 +215,7 @@ class _ProductListPageState extends State<ProductListPage>
         },
         actionModeTitle: Text('${_selectedBarcodes.length}'),
         actionModeActions: <Widget>[
-          PopupMenuButton<ProductListItemPopupItem>(
+          SmoothPopupMenuButton<ProductListItemPopupItem>(
             onSelected: (final ProductListItemPopupItem action) async {
               final bool andThenSetState = await action.doSomething(
                 productList: productList,
@@ -229,8 +229,7 @@ class _ProductListPageState extends State<ProductListPage>
                 }
               }
             },
-            itemBuilder: (BuildContext context) =>
-                <PopupMenuEntry<ProductListItemPopupItem>>[
+            itemBuilder: (_) => <SmoothPopupMenuItem<ProductListItemPopupItem>>[
               if (userPreferences.getFlag(UserPreferencesDevMode
                       .userPreferencesFlagBoostedComparison) ==
                   true)

--- a/packages/smooth_app/lib/pages/product/common/product_list_popup_items.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_popup_items.dart
@@ -8,6 +8,7 @@ import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/temp_product_list_share_helper.dart';
 import 'package:smooth_app/pages/product_list_user_dialog_helper.dart';
+import 'package:smooth_app/widgets/smooth_menu_button.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 /// Popup menu item entries for the product list page.
@@ -30,6 +31,9 @@ abstract class ProductListPopupItem {
   /// Popup menu entry of the popup menu item.
   ProductListPopupMenuEntry getEntry();
 
+  /// Is-it a destructive action?
+  bool isDestructive() => false;
+
   /// Action of the popup menu item.
   ///
   /// Returns a different product list if there are changes, else null.
@@ -40,15 +44,14 @@ abstract class ProductListPopupItem {
   });
 
   /// Returns the popup menu item.
-  PopupMenuItem<ProductListPopupItem> getMenuItem(
+  SmoothPopupMenuItem<ProductListPopupItem> getMenuItem(
     final AppLocalizations appLocalizations,
   ) =>
-      PopupMenuItem<ProductListPopupItem>(
+      SmoothPopupMenuItem<ProductListPopupItem>(
         value: this,
-        child: ListTile(
-          leading: Icon(getIconData()),
-          title: Text(getTitle(appLocalizations)),
-        ),
+        icon: getIconData(),
+        label: getTitle(appLocalizations),
+        type: isDestructive() ? SmoothPopupMenuItemType.destructive : null,
       );
 }
 
@@ -63,6 +66,9 @@ class ProductListPopupClear extends ProductListPopupItem {
 
   @override
   ProductListPopupMenuEntry getEntry() => ProductListPopupMenuEntry.clear;
+
+  @override
+  bool isDestructive() => true;
 
   @override
   Future<ProductList?> doSomething({

--- a/packages/smooth_app/lib/widgets/smooth_menu_button.dart
+++ b/packages/smooth_app/lib/widgets/smooth_menu_button.dart
@@ -1,0 +1,112 @@
+import 'dart:io';
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+class SmoothPopupMenuButton<T> extends StatefulWidget {
+  const SmoothPopupMenuButton({
+    required this.onSelected,
+    required this.itemBuilder,
+    this.actionsTitle,
+    this.buttonIcon,
+    this.buttonLabel,
+  })  : assert(buttonLabel == null || buttonLabel.length > 0),
+        assert(actionsTitle == null || actionsTitle.length > 0);
+
+  final Icon? buttonIcon;
+  final String? buttonLabel;
+  final String? actionsTitle;
+  final void Function(T value) onSelected;
+  final Iterable<SmoothPopupMenuItem<T>> Function(BuildContext context)
+      itemBuilder;
+
+  @override
+  State<SmoothPopupMenuButton<T>> createState() =>
+      _SmoothPopupMenuButtonState<T>();
+}
+
+class _SmoothPopupMenuButtonState<T> extends State<SmoothPopupMenuButton<T>> {
+  @override
+  Widget build(BuildContext context) {
+    if (Platform.isIOS || Platform.isMacOS) {
+      return IconButton(
+        icon: widget.buttonIcon ?? Icon(Icons.adaptive.more),
+        tooltip: widget.buttonLabel ??
+            MaterialLocalizations.of(context).showMenuTooltip,
+        onPressed: _openModalSheet,
+      );
+    } else {
+      return PopupMenuButton<T>(
+        icon: widget.buttonIcon ?? Icon(Icons.adaptive.more),
+        tooltip: widget.buttonLabel ??
+            MaterialLocalizations.of(context).showMenuTooltip,
+        onSelected: widget.onSelected,
+        itemBuilder: (BuildContext context) {
+          return widget.itemBuilder(context).map((SmoothPopupMenuItem<T> item) {
+            return PopupMenuItem<T>(
+              value: item.value,
+              enabled: item.enabled,
+              child: ListTile(
+                leading: Icon(item.icon),
+                title: Text(item.label),
+              ),
+            );
+          }).toList(growable: false);
+        },
+      );
+    }
+  }
+
+  // iOS and macOS behavior
+  void _openModalSheet() {
+    showCupertinoModalPopup(
+        context: context,
+        builder: (BuildContext context) {
+          return CupertinoActionSheet(
+            title: Text(
+              widget.actionsTitle ??
+                  AppLocalizations.of(context).menu_button_list_actions,
+            ),
+            actions: widget
+                .itemBuilder(context)
+                .where((SmoothPopupMenuItem<T> item) => item.enabled)
+                .map((SmoothPopupMenuItem<T> item) {
+              return CupertinoActionSheetAction(
+                isDefaultAction:
+                    item.type == SmoothPopupMenuItemType.highlighted,
+                isDestructiveAction:
+                    item.type == SmoothPopupMenuItemType.destructive,
+                onPressed: () {
+                  widget.onSelected(item.value);
+                  Navigator.of(context).maybePop();
+                },
+                child: Text(item.label),
+              );
+            }).toList(growable: false),
+          );
+        });
+  }
+}
+
+class SmoothPopupMenuItem<T> {
+  const SmoothPopupMenuItem({
+    required this.value,
+    required this.label,
+    this.icon,
+    this.type,
+    this.enabled = true,
+  }) : assert(label.length > 0);
+
+  final T value;
+  final String label;
+  final IconData? icon;
+  final SmoothPopupMenuItemType? type;
+  final bool enabled;
+}
+
+enum SmoothPopupMenuItemType {
+  normal,
+  highlighted,
+  destructive,
+}

--- a/packages/smooth_app/lib/widgets/smooth_menu_button.dart
+++ b/packages/smooth_app/lib/widgets/smooth_menu_button.dart
@@ -4,6 +4,9 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
+/// A Button similar to a [PopupMenuButton] for non Apple platforms.
+/// On iOS and macOS, it's still an [IconButton], but that opens a
+/// [CupertinoActionSheet].
 class SmoothPopupMenuButton<T> extends StatefulWidget {
   const SmoothPopupMenuButton({
     required this.onSelected,
@@ -105,6 +108,9 @@ class SmoothPopupMenuItem<T> {
   final bool enabled;
 }
 
+/// The style of an item in the menu
+/// On Material platforms, all values behave the same.
+/// On iOS, the [highlighted] value is in black and [destructive] in red.
 enum SmoothPopupMenuItemType {
   normal,
   highlighted,

--- a/packages/smooth_app/lib/widgets/smooth_menu_button.dart
+++ b/packages/smooth_app/lib/widgets/smooth_menu_button.dart
@@ -14,12 +14,12 @@ class SmoothPopupMenuButton<T> extends StatefulWidget {
   })  : assert(buttonLabel == null || buttonLabel.length > 0),
         assert(actionsTitle == null || actionsTitle.length > 0);
 
-  final Icon? buttonIcon;
-  final String? buttonLabel;
-  final String? actionsTitle;
   final void Function(T value) onSelected;
   final Iterable<SmoothPopupMenuItem<T>> Function(BuildContext context)
       itemBuilder;
+  final Icon? buttonIcon;
+  final String? buttonLabel;
+  final String? actionsTitle;
 
   @override
   State<SmoothPopupMenuButton<T>> createState() =>

--- a/packages/smooth_app/macos/Podfile.lock
+++ b/packages/smooth_app/macos/Podfile.lock
@@ -114,7 +114,7 @@ SPEC CHECKSUMS:
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
   in_app_review: a850789fad746e89bce03d4aeee8078b45a53fd0
   mobile_scanner: 54ceceae0c8da2457e26a362a6be5c61154b1829
-  package_info_plus: 02d7a575e80f194102bef286361c6c326e4c29ce
+  package_info_plus: fa739dd842b393193c5ca93c26798dff6e3d0e0c
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
   ReachabilitySwift: 2128f3a8c9107e1ad33574c6e58e8285d460b149
   rive_common: cf5ab646aa576b2d742d0e2d528126fbf032c856


### PR DESCRIPTION
Hi everyone,

We have a "three dots" menu item containing actions on the screen with lists.
On Android, we use the `PopupMenuButton` from Material, but on iOS, it looks really… Android.

I've created a custom Widget that shows the Cupertino component on iOS and macOS. Otherwise, it's Material.

Android:
<img width="461" alt="Screenshot 2024-07-20 at 03 14 16" src="https://github.com/user-attachments/assets/aeb5e88b-05a0-4260-8185-511f5ac7306e">

iOS:
<img width="461" alt="Screenshot 2024-07-20 at 03 13 54" src="https://github.com/user-attachments/assets/85637df1-aac7-4b57-a1fd-f41a7bbd7abd">