### PR TITLE
ci: Migrate actions to Java 17

### DIFF
--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v4.2.1
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
 
       # Get the flutter version from ./flutter-version.txt
       - run: echo "FLUTTER_VERSION=$(cat flutter-version.txt)" >> $GITHUB_OUTPUT

--- a/.github/workflows/waldo_sessions.yml
+++ b/.github/workflows/waldo_sessions.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/setup-java@v4.2.1
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
 
       # Get the flutter version from ./flutter-version.txt
       - run: echo "FLUTTER_VERSION=$(cat flutter-version.txt)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Hi everyone!

All builds are failing because of a migration to Java 17 on Android.
This should fix the issue.