### PR TITLE
chore: Remove `flutter_map` attribution

### DIFF
--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_world_map_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_world_map_card.dart
@@ -71,6 +71,7 @@ class KnowledgePanelWorldMapCard extends StatelessWidget {
             RichAttributionWidget(
               popupInitialDisplayDuration: const Duration(seconds: 5),
               animationConfig: const ScaleRAWA(),
+              showFlutterMapAttribution: false,
               attributions: <SourceAttribution>[
                 TextSourceAttribution(
                   'OpenStreetMap contributors',


### PR DESCRIPTION
Hi everyone,

The map on the Product Page has an icon similar to the Google Maps icon:
![Screenshot_1722002354](https://github.com/user-attachments/assets/1c67f15d-42fd-43a8-ad75-c212f55f300c)

I prefer to disable it, because it's really misleading and I've clicked many times on it.