### PR TITLE
fix: Fix UK flag in the country picker

### DIFF
--- a/packages/smooth_app/lib/pages/prices/emoji_helper.dart
+++ b/packages/smooth_app/lib/pages/prices/emoji_helper.dart
@@ -17,7 +17,10 @@ class EmojiHelper {
   static String? getEmojiByCountryCode(final String countryCode) {
     if (countryCode.isEmpty) {
       return null;
+    } else if (countryCode.toUpperCase() == 'UK') {
+      return _getCountryEmojiFromUnicode('GB');
     }
+
     return _getCountryEmojiFromUnicode(countryCode);
   }
 


### PR DESCRIPTION
There is no UK flag, but the GB one is OK.
<img width="800" alt="Screenshot 2024-08-02 at 11 46 12" src="https://github.com/user-attachments/assets/d6760c9f-5ba2-4620-91c5-9b01899dc008">
