### PR TITLE
feat: 5526 - new Prices prod/test url flag

### DIFF
--- a/packages/smooth_app/lib/background/background_task_add_price.dart
+++ b/packages/smooth_app/lib/background/background_task_add_price.dart
@@ -14,6 +14,7 @@ import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/pages/crop_parameters.dart';
 import 'package:smooth_app/pages/prices/eraser_model.dart';
 import 'package:smooth_app/pages/prices/eraser_painter.dart';
+import 'package:smooth_app/query/product_query.dart';
 
 // TODO(monsieurtanuki): use transient file, in order to have instant access to proof image?
 /// Background task about adding a product price.
@@ -344,7 +345,7 @@ class BackgroundTaskAddPrice extends BackgroundTask {
         await OpenPricesAPIClient.getAuthenticationToken(
       username: user.userId,
       password: user.password,
-      uriHelper: uriProductHelper,
+      uriHelper: ProductQuery.uriPricesHelper,
     );
     if (token.isError) {
       throw Exception('Could not get token: ${token.error}');
@@ -367,7 +368,7 @@ class BackgroundTaskAddPrice extends BackgroundTask {
       imageUri: initialImageUri,
       mediaType: initialMediaType,
       bearerToken: bearerToken,
-      uriHelper: uriProductHelper,
+      uriHelper: ProductQuery.uriPricesHelper,
     );
     if (uploadProof.isError) {
       throw Exception('Could not upload proof: ${uploadProof.error}');
@@ -390,7 +391,7 @@ class BackgroundTaskAddPrice extends BackgroundTask {
           await OpenPricesAPIClient.createPrice(
         price: newPrice,
         bearerToken: bearerToken,
-        uriHelper: uriProductHelper,
+        uriHelper: ProductQuery.uriPricesHelper,
       );
       if (addedPrice.isError) {
         throw Exception('Could not add price: ${addedPrice.error}');
@@ -400,7 +401,7 @@ class BackgroundTaskAddPrice extends BackgroundTask {
     // close session
     final MaybeError<bool> closedSession =
         await OpenPricesAPIClient.deleteUserSession(
-      uriHelper: uriProductHelper,
+      uriHelper: ProductQuery.uriPricesHelper,
       bearerToken: bearerToken,
     );
     if (closedSession.isError) {

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_account.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_account.dart
@@ -276,7 +276,7 @@ class UserPreferencesAccount extends AbstractUserPreferences {
                 displayProduct: true,
                 uri: OpenPricesAPIClient.getUri(
                   path: 'app/prices',
-                  uriHelper: ProductQuery.uriProductHelper,
+                  uriHelper: ProductQuery.uriPricesHelper,
                 ),
                 title: appLocalizations.all_search_prices_latest_title,
               ),
@@ -363,7 +363,7 @@ class UserPreferencesAccount extends AbstractUserPreferences {
         () async => LaunchUrlHelper.launchURL(
           OpenPricesAPIClient.getUri(
             path: path,
-            uriHelper: ProductQuery.uriProductHelper,
+            uriHelper: ProductQuery.uriPricesHelper,
           ).toString(),
         ),
         Icons.open_in_new,
@@ -425,7 +425,7 @@ class UserPreferencesAccount extends AbstractUserPreferences {
       GetPricesParameters()
         ..owner = owner
         ..pageSize = 1,
-      uriHelper: ProductQuery.uriProductHelper,
+      uriHelper: ProductQuery.uriPricesHelper,
     );
     if (result.isError) {
       return null;

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_dev_mode.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_dev_mode.dart
@@ -48,6 +48,7 @@ class UserPreferencesDevMode extends AbstractUserPreferences {
         );
 
   static const String userPreferencesFlagProd = '__devWorkingOnProd';
+  static const String userPreferencesFlagPriceProd = '__devWorkingOnPricesProd';
   static const String userPreferencesTestEnvDomain = '__testEnvHost';
   static const String userPreferencesFlagEditIngredients = '__editIngredients';
   static const String userPreferencesFlagBoostedComparison =
@@ -268,6 +269,34 @@ class UserPreferencesDevMode extends AbstractUserPreferences {
                 .toString(),
           ),
           onTap: () async => _changeTestEnvDomain(),
+        ),
+        const UserPreferencesItemSection(
+          label: 'Prices Server configuration',
+        ),
+        UserPreferencesItemTile(
+          title: 'Switch between prices.openfoodfacts.org (PROD) and test env',
+          trailing: DropdownButton<bool>(
+            value:
+                userPreferences.getFlag(userPreferencesFlagPriceProd) ?? true,
+            elevation: 16,
+            onChanged: (bool? newValue) async {
+              await userPreferences.setFlag(
+                userPreferencesFlagPriceProd,
+                newValue,
+              );
+              ProductQuery.setQueryType(userPreferences);
+            },
+            items: const <DropdownMenuItem<bool>>[
+              DropdownMenuItem<bool>(
+                value: true,
+                child: Text('PROD'),
+              ),
+              DropdownMenuItem<bool>(
+                value: false,
+                child: Text('TEST'),
+              ),
+            ],
+          ),
         ),
         UserPreferencesItemSection(
           label: appLocalizations.dev_mode_section_news,

--- a/packages/smooth_app/lib/pages/prices/get_prices_model.dart
+++ b/packages/smooth_app/lib/pages/prices/get_prices_model.dart
@@ -57,7 +57,7 @@ class GetPricesModel {
   ) =>
       OpenPricesAPIClient.getUri(
         path: 'app/products/$barcode',
-        uriHelper: ProductQuery.uriProductHelper,
+        uriHelper: ProductQuery.uriPricesHelper,
       );
 
   /// Query parameters.

--- a/packages/smooth_app/lib/pages/prices/price_user_button.dart
+++ b/packages/smooth_app/lib/pages/prices/price_user_button.dart
@@ -42,7 +42,7 @@ class PriceUserButton extends StatelessWidget {
               displayProduct: true,
               uri: OpenPricesAPIClient.getUri(
                 path: 'app/users/$user',
-                uriHelper: ProductQuery.uriProductHelper,
+                uriHelper: ProductQuery.uriPricesHelper,
               ),
               title: showUserTitle(user: user, context: context),
               subtitle: user,

--- a/packages/smooth_app/lib/pages/prices/prices_proofs_page.dart
+++ b/packages/smooth_app/lib/pages/prices/prices_proofs_page.dart
@@ -47,7 +47,7 @@ class _PricesProofsPageState extends State<PricesProofsPage>
             onPressed: () async => LaunchUrlHelper.launchURL(
               OpenPricesAPIClient.getUri(
                 path: 'app/dashboard/proofs',
-                uriHelper: ProductQuery.uriProductHelper,
+                uriHelper: ProductQuery.uriPricesHelper,
               ).toString(),
             ),
           ),
@@ -152,7 +152,7 @@ class _PricesProofsPageState extends State<PricesProofsPage>
         await OpenPricesAPIClient.getAuthenticationToken(
       username: user.userId,
       password: user.password,
-      uriHelper: ProductQuery.uriProductHelper,
+      uriHelper: ProductQuery.uriPricesHelper,
     );
     final String bearerToken = token.value;
 
@@ -167,12 +167,12 @@ class _PricesProofsPageState extends State<PricesProofsPage>
         ]
         ..pageSize = _pageSize
         ..pageNumber = 1,
-      uriHelper: ProductQuery.uriProductHelper,
+      uriHelper: ProductQuery.uriPricesHelper,
       bearerToken: bearerToken,
     );
 
     await OpenPricesAPIClient.deleteUserSession(
-      uriHelper: ProductQuery.uriProductHelper,
+      uriHelper: ProductQuery.uriPricesHelper,
       bearerToken: bearerToken,
     );
 

--- a/packages/smooth_app/lib/pages/prices/prices_users_page.dart
+++ b/packages/smooth_app/lib/pages/prices/prices_users_page.dart
@@ -46,7 +46,7 @@ class _PricesUsersPageState extends State<PricesUsersPage>
             onPressed: () async => LaunchUrlHelper.launchURL(
               OpenPricesAPIClient.getUri(
                 path: 'app/users',
-                uriHelper: ProductQuery.uriProductHelper,
+                uriHelper: ProductQuery.uriPricesHelper,
               ).toString(),
             ),
           ),
@@ -140,6 +140,6 @@ class _PricesUsersPageState extends State<PricesUsersPage>
           ]
           ..pageSize = _pageSize
           ..pageNumber = 1,
-        uriHelper: ProductQuery.uriProductHelper,
+        uriHelper: ProductQuery.uriPricesHelper,
       );
 }

--- a/packages/smooth_app/lib/pages/prices/product_prices_list.dart
+++ b/packages/smooth_app/lib/pages/prices/product_prices_list.dart
@@ -126,6 +126,6 @@ class _ProductPricesListState extends State<ProductPricesList>
   ) async =>
       OpenPricesAPIClient.getPrices(
         parameters,
-        uriHelper: ProductQuery.uriProductHelper,
+        uriHelper: ProductQuery.uriPricesHelper,
       );
 }

--- a/packages/smooth_app/lib/query/product_query.dart
+++ b/packages/smooth_app/lib/query/product_query.dart
@@ -166,16 +166,24 @@ abstract class ProductQuery {
 
   static late UriProductHelper uriProductHelper;
 
+  /// Product helper only for prices.
+  static late UriProductHelper uriPricesHelper;
+
   static bool isLoggedIn() => OpenFoodAPIConfiguration.globalUser != null;
 
   /// Sets the query type according to the current [UserPreferences]
   static void setQueryType(final UserPreferences userPreferences) {
-    final bool queryTypeProd = userPreferences
-            .getFlag(UserPreferencesDevMode.userPreferencesFlagProd) ??
-        true;
-    uriProductHelper = queryTypeProd
-        ? uriHelperFoodProd
-        : getTestUriProductHelper(userPreferences);
+    UriProductHelper getProductHelper(final String flagProd) =>
+        userPreferences.getFlag(flagProd) ?? true
+            ? uriHelperFoodProd
+            : getTestUriProductHelper(userPreferences);
+
+    uriProductHelper = getProductHelper(
+      UserPreferencesDevMode.userPreferencesFlagProd,
+    );
+    uriPricesHelper = getProductHelper(
+      UserPreferencesDevMode.userPreferencesFlagPriceProd,
+    );
   }
 
   /// Returns the standard test env, or the custom test env if relevant.


### PR DESCRIPTION
### What
- Now we can make Prices point to the TEST env, while OFF still points to PROD env.

### Screenshot
![Screenshot_1723233887](https://github.com/user-attachments/assets/f8297d73-9109-447f-ae2b-5943f32c4a9b)

### Fixes bug(s)
- Closes: #5526

### Impacted files
* `background_task_add_prices.dart`: Prices API called using new Prices prod/test url
* `get_prices_model.dart`: Prices API called using new Prices prod/test url
* `price_user_button.dart`: Prices API called using new Prices prod/test url
* `prices_proofs_page.dart`: Prices API called using new Prices prod/test url
* `prices_users_page.dart`: Prices API called using new Prices prod/test url
* `product_prices_list.dart`: Prices API called using new Prices prod/test url
* `product_query.dart`: new Prices prod/test url
* `user_preferences_account.dart`: Prices API called using new Prices prod/test url
* `user_preferences_dev_mode.dart`: new prod/test flag for Prices url