### PR TITLE
fix: 5437 - fine-tuning about price result display

### DIFF
--- a/packages/smooth_app/lib/pages/prices/price_product_widget.dart
+++ b/packages/smooth_app/lib/pages/prices/price_product_widget.dart
@@ -27,7 +27,8 @@ class PriceProductWidget extends StatelessWidget {
     final bool unknown = priceProduct.name == null;
     final String? imageURL = priceProduct.imageURL;
     final int priceCount = priceProduct.priceCount;
-    final List<String>? brands = priceProduct.brands?.split(',');
+    final List<String>? brands =
+        priceProduct.brands == '' ? null : priceProduct.brands?.split(',');
     final String? quantity = priceProduct.quantity == null
         ? null
         : '${priceProduct.quantity} ${priceProduct.quantityUnit ?? 'g'}';

--- a/packages/smooth_app/lib/pages/prices/product_prices_list.dart
+++ b/packages/smooth_app/lib/pages/prices/product_prices_list.dart
@@ -99,14 +99,15 @@ class _ProductPricesListState extends State<ProductPricesList>
           }
           final AppLocalizations appLocalizations =
               AppLocalizations.of(context);
-          final String title = result.numberOfPages == 1
-              ? appLocalizations.prices_list_length_one_page(
-                  result.items!.length,
-                )
-              : appLocalizations.prices_list_length_many_pages(
-                  widget.model.parameters.pageSize!,
-                  result.total!,
-                );
+          final String title =
+              result.numberOfPages != null && result.numberOfPages! <= 1
+                  ? appLocalizations.prices_list_length_one_page(
+                      result.items!.length,
+                    )
+                  : appLocalizations.prices_list_length_many_pages(
+                      widget.model.parameters.pageSize!,
+                      result.total!,
+                    );
           children.insert(
             0,
             SmoothCard(child: ListTile(title: Text(title))),


### PR DESCRIPTION
### What
* Fixed the case when the price product brand is empty. In that case, we used to display an empty brand widget. Now we display nothing.
* Fixed the case when there are no prices for a product. In that case, we used to display a clumsy message. Now we display an explicit "no result" message.
* For the record I managed to get a "no result" for the same product in TEST env, instead of PROD.

### Screenshot
| before | after |
| -- | -- |
| ![Screenshot_1723465509](https://github.com/user-attachments/assets/739a6dd4-764d-4d03-8a3f-a8fa59d9339d) | ![Screenshot_1723466474](https://github.com/user-attachments/assets/93672a72-a035-45f5-889d-f8e98d60cc9a) |
| ![Screenshot_1723466565](https://github.com/user-attachments/assets/f6b3e1c3-9bb2-48f0-a8d0-9d56971d7d2c) | ![Screenshot_1723466656](https://github.com/user-attachments/assets/1a9a793e-0561-4dc4-93a6-56eec665d4e8) |

### Fixes bug(s)
- Fixes: #5437

### Impacted files
* `price_product_widget.dart`: fixed to "if no brand, don't display an empty brand widget"
* `product_prices_list.dart`: fixed to "if no price result, print 'no result'"