### PR TITLE
fix: 5560 - proof files from PROD/DEV

### DIFF
--- a/packages/smooth_app/lib/pages/prices/price_proof_page.dart
+++ b/packages/smooth_app/lib/pages/prices/price_proof_page.dart
@@ -40,6 +40,6 @@ class PriceProofPage extends StatelessWidget {
   }
 
   String _getUrl() => proof
-      .getFileUrl(uriProductHelper: ProductQuery.uriProductHelper)
+      .getFileUrl(uriProductHelper: ProductQuery.uriPricesHelper)
       .toString();
 }

--- a/packages/smooth_app/lib/pages/prices/prices_proofs_page.dart
+++ b/packages/smooth_app/lib/pages/prices/prices_proofs_page.dart
@@ -203,7 +203,7 @@ class _PriceProofImage extends StatelessWidget {
           imageProvider: NetworkImage(
             proof
                 .getFileUrl(
-                  uriProductHelper: ProductQuery.uriProductHelper,
+                  uriProductHelper: ProductQuery.uriPricesHelper,
                 )
                 .toString(),
           ),


### PR DESCRIPTION
### What
- When _displaying_ the proof image files, we used the _product_ PROD/DEV settings instead of the _prices_ PROD/DEV settings
- That's now fixed here. Didn't test it, though, in order to push a quick fix.

### Fixes bug(s)
- Fixes: #5560

### Impacted files
* `price_proof_page.dart`: used prices PROD/DEV instead of product PROD/DEV settings
* `prices_proofs_page.dart`: used prices PROD/DEV instead of product PROD/DEV settings