### PR TITLE
feat: Add the name of the contributor (photo)

### DIFF
--- a/packages/smooth_app/lib/pages/image/product_image_other_page.dart
+++ b/packages/smooth_app/lib/pages/image/product_image_other_page.dart
@@ -243,10 +243,11 @@ class _ProductImageDetailsButton extends StatelessWidget {
                     body: Column(
                       children: <Widget>[
                         ListTile(
-                          title: Text(appLocalizations
-                              .photo_viewer_details_contributor_title),
-                          // TODO(g123k): add contributor
-                          subtitle: const Text('TODO'),
+                          title: Text(
+                            appLocalizations
+                                .photo_viewer_details_contributor_title,
+                          ),
+                          subtitle: Text(image.contributor ?? '-'),
                         ),
                         ListTile(
                           title: Text(


### PR DESCRIPTION
Hi everyone!

Thanks to the latest version of the dart package, we now have the contributor's name.
We use it in the following section:
<img width="475" alt="Screenshot 2024-08-30 at 19 46 47" src="https://github.com/user-attachments/assets/d9501222-285b-4405-b4a9-b492850e65f5">

(The field may be empty until the product is refreshed)
