### PR TITLE
ci: tentative fix for set-output deprecation

### DIFF
--- a/.github/workflows/internal-release.yml
+++ b/.github/workflows/internal-release.yml
@@ -66,8 +66,7 @@ jobs:
 
       - name: Set output
         id: set_output
-        run: echo "VERSION_CODE=${{ env.VERSION_CODE }}" >> $GITHUB_OUTPUT
-        run: echo "VERSION_NAME=${{ env.VERSION_NAME }}" >> $GITHUB_OUTPUT
+        run: echo "VERSION_CODE=${{ env.VERSION_CODE }}" >> $GITHUB_OUTPUT && echo "VERSION_NAME=${{ env.VERSION_NAME }}" >> $GITHUB_OUTPUT
   android-release:
     concurrency: 
       group: android-release

--- a/.github/workflows/internal-release.yml
+++ b/.github/workflows/internal-release.yml
@@ -66,8 +66,8 @@ jobs:
 
       - name: Set output
         id: set_output
-        run: echo "::set-output name=VERSION_NAME::${{ env.VERSION_NAME }}" && echo "::set-output name=VERSION_CODE::${{ env.VERSION_CODE }}"
-
+        run: echo "VERSION_CODE=${{ env.VERSION_CODE }}" >> $GITHUB_OUTPUT
+        run: echo "VERSION_NAME=${{ env.VERSION_NAME }}" >> $GITHUB_OUTPUT
   android-release:
     concurrency: 
       group: android-release


### PR DESCRIPTION
### What
- ci: tentative fix for set-output deprecation
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

![image](https://github.com/user-attachments/assets/fab90b51-8367-4505-a59a-b745894fc332)
