### PR TITLE
fix: The image is zoomed in the gallery

### DIFF
--- a/packages/smooth_app/lib/pages/image/product_image_other_page.dart
+++ b/packages/smooth_app/lib/pages/image/product_image_other_page.dart
@@ -114,7 +114,7 @@ class _ProductImageViewer extends StatelessWidget {
                     uriHelper: ProductQuery.uriProductHelper,
                   ),
                 ),
-                fit: BoxFit.cover,
+                fit: BoxFit.contain,
                 loadingBuilder: (
                   _,
                   final Widget child,


### PR DESCRIPTION
Hi everyone!

In the current release, we can swipe between "Others" photos.
However, the image is too zoomed:
<img width="800" alt="Screenshot 2024-09-25 at 10 10 52" src="https://github.com/user-attachments/assets/f524586f-6bfe-4781-8aa8-17d27bc1f02d">

And this is just a one-line fix