### PR TITLE
feat: 5586 - OxF filter for term searches

### DIFF
--- a/packages/smooth_app/lib/data_models/product_list.dart
+++ b/packages/smooth_app/lib/data_models/product_list.dart
@@ -47,6 +47,7 @@ class ProductList {
     this.pageNumber = 0,
     this.language,
     this.country,
+    this.productType,
   });
 
   ProductList.keywordSearch(
@@ -55,6 +56,7 @@ class ProductList {
     required int pageNumber,
     required OpenFoodFactsLanguage language,
     required OpenFoodFactsCountry? country,
+    required ProductType productType,
   }) : this._(
           listType: ProductListType.HTTP_SEARCH_KEYWORDS,
           parameters: keywords,
@@ -62,6 +64,7 @@ class ProductList {
           pageNumber: pageNumber,
           language: language,
           country: country,
+          productType: productType,
         );
 
   ProductList.categorySearch(
@@ -70,6 +73,7 @@ class ProductList {
     required int pageNumber,
     required OpenFoodFactsLanguage language,
     required OpenFoodFactsCountry? country,
+    required ProductType productType,
   }) : this._(
           listType: ProductListType.HTTP_SEARCH_CATEGORY,
           parameters: category,
@@ -77,6 +81,7 @@ class ProductList {
           pageNumber: pageNumber,
           language: language,
           country: country,
+          productType: productType,
         );
 
   ProductList.contributor(
@@ -84,12 +89,14 @@ class ProductList {
     required int pageSize,
     required int pageNumber,
     required OpenFoodFactsLanguage language,
+    required ProductType productType,
   }) : this._(
           listType: ProductListType.HTTP_USER_CONTRIBUTOR,
           parameters: userId,
           pageSize: pageSize,
           pageNumber: pageNumber,
           language: language,
+          productType: productType,
         );
 
   ProductList.informer(
@@ -97,12 +104,14 @@ class ProductList {
     required int pageSize,
     required int pageNumber,
     required OpenFoodFactsLanguage language,
+    required ProductType productType,
   }) : this._(
           listType: ProductListType.HTTP_USER_INFORMER,
           parameters: userId,
           pageSize: pageSize,
           pageNumber: pageNumber,
           language: language,
+          productType: productType,
         );
 
   ProductList.photographer(
@@ -110,12 +119,14 @@ class ProductList {
     required int pageSize,
     required int pageNumber,
     required OpenFoodFactsLanguage language,
+    required ProductType productType,
   }) : this._(
           listType: ProductListType.HTTP_USER_PHOTOGRAPHER,
           parameters: userId,
           pageSize: pageSize,
           pageNumber: pageNumber,
           language: language,
+          productType: productType,
         );
 
   ProductList.toBeCompleted(
@@ -123,12 +134,14 @@ class ProductList {
     required int pageSize,
     required int pageNumber,
     required OpenFoodFactsLanguage language,
+    required ProductType productType,
   }) : this._(
           listType: ProductListType.HTTP_USER_TO_BE_COMPLETED,
           parameters: userId,
           pageSize: pageSize,
           pageNumber: pageNumber,
           language: language,
+          productType: productType,
         );
 
   ProductList.allToBeCompleted({
@@ -136,12 +149,14 @@ class ProductList {
     required int pageNumber,
     required OpenFoodFactsLanguage language,
     required OpenFoodFactsCountry? country,
+    required ProductType productType,
   }) : this._(
           listType: ProductListType.HTTP_ALL_TO_BE_COMPLETED,
           pageSize: pageSize,
           pageNumber: pageNumber,
           language: language,
           country: country,
+          productType: productType,
         );
 
   ProductList.history() : this._(listType: ProductListType.HISTORY);
@@ -170,6 +185,9 @@ class ProductList {
 
   /// Country at query time.
   final OpenFoodFactsCountry? country;
+
+  /// ProductType at query time.
+  final ProductType? productType;
 
   /// "Total size" returned by the query.
   int totalSize = 0;
@@ -251,7 +269,8 @@ class ProductList {
             ',$pageSize'
             ',$pageNumber'
             ',${language?.code ?? ''}'
-            ',${country?.offTag ?? ''}';
+            ',${country?.offTag ?? ''}'
+            '${productType == null || productType == ProductType.food ? '' : ',${productType!.offTag}'}';
     }
   }
 

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_account.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_account.dart
@@ -171,6 +171,8 @@ class UserPreferencesAccount extends AbstractUserPreferences {
         productQuery: PagedUserProductQuery(
           userId: userId,
           type: UserSearchType.CONTRIBUTOR,
+          // TODO(monsieurtanuki): only food?
+          productType: ProductType.food,
         ),
         title: appLocalizations.user_search_contributor_title,
         iconData: Icons.add_circle_outline,
@@ -182,6 +184,7 @@ class UserPreferencesAccount extends AbstractUserPreferences {
         productQuery: PagedUserProductQuery(
           userId: userId,
           type: UserSearchType.INFORMER,
+          productType: ProductType.food,
         ),
         title: appLocalizations.user_search_informer_title,
         iconData: Icons.edit,
@@ -193,6 +196,7 @@ class UserPreferencesAccount extends AbstractUserPreferences {
         productQuery: PagedUserProductQuery(
           userId: userId,
           type: UserSearchType.PHOTOGRAPHER,
+          productType: ProductType.food,
         ),
         title: appLocalizations.user_search_photographer_title,
         iconData: Icons.add_a_photo,
@@ -204,6 +208,7 @@ class UserPreferencesAccount extends AbstractUserPreferences {
         productQuery: PagedUserProductQuery(
           userId: userId,
           type: UserSearchType.TO_BE_COMPLETED,
+          productType: ProductType.food,
         ),
         title: appLocalizations.user_search_to_be_completed_title,
         iconData: Icons.more_horiz,
@@ -296,7 +301,9 @@ class UserPreferencesAccount extends AbstractUserPreferences {
         'app/products',
       ),
       _buildProductQueryTile(
-        productQuery: PagedToBeCompletedProductQuery(),
+        productQuery: PagedToBeCompletedProductQuery(
+          productType: ProductType.food,
+        ),
         title: appLocalizations.all_search_to_be_completed_title,
         iconData: Icons.more_outlined,
         context: context,

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_contribute.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_contribute.dart
@@ -4,6 +4,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:http/http.dart' as http;
+import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:smooth_app/data_models/github_contributors_model.dart';
@@ -170,7 +171,10 @@ class UserPreferencesContribute extends AbstractUserPreferences {
                 ProductQueryPageHelper.openBestChoice(
                   name: appLocalizations.all_search_to_be_completed_title,
                   localDatabase: localDatabase,
-                  productQuery: PagedToBeCompletedProductQuery(),
+                  productQuery: PagedToBeCompletedProductQuery(
+                    // TODO(monsieurtanuki): only food?
+                    productType: ProductType.food,
+                  ),
                   // the other "context"s being popped
                   context: this.context,
                   editableAppBarTitle: false,

--- a/packages/smooth_app/lib/pages/product/common/search_helper.dart
+++ b/packages/smooth_app/lib/pages/product/common/search_helper.dart
@@ -26,6 +26,8 @@ abstract class SearchHelper extends ValueNotifier<SearchQuery?> {
   /// Hint text for the search field.
   String getHintText(final AppLocalizations appLocalizations);
 
+  Widget? getAdditionalFilter() => null;
+
   /// Returns all the previous queries, in reverse order.
   List<String> getAllQueries(final LocalDatabase localDatabase) =>
       DaoStringList(localDatabase).getAll(historyKey).reversed.toList();

--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -301,7 +301,10 @@ class _SummaryCardState extends State<SummaryCard> with UpToDateMixin {
             onPressed: () async => ProductQueryPageHelper.openBestChoice(
               name: categoryLabel!,
               localDatabase: context.read<LocalDatabase>(),
-              productQuery: CategoryProductQuery(categoryTag!),
+              productQuery: CategoryProductQuery(
+                categoryTag!,
+                productType: upToDateProduct.productType ?? ProductType.food,
+              ),
               context: context,
               searchResult: false,
             ),

--- a/packages/smooth_app/lib/pages/search/search_field.dart
+++ b/packages/smooth_app/lib/pages/search/search_field.dart
@@ -73,6 +73,7 @@ class _SearchFieldState extends State<SearchField> {
 
     final TextStyle textStyle = SearchFieldUIHelper.textStyle(context);
 
+    final Widget? additionalFilter = widget.searchHelper.getAdditionalFilter();
     return ChangeNotifierProvider<TextEditingController>.value(
       value: _controller!,
       child: SmoothHero(
@@ -90,19 +91,24 @@ class _SearchFieldState extends State<SearchField> {
             : null,
         child: Material(
           // ↑ Needed by the Hero Widget
-          child: TextField(
-            controller: _controller,
-            focusNode: _focusNode,
-            onSubmitted: (String query) => _performSearch(context, query),
-            textInputAction: TextInputAction.search,
-            enableSuggestions: widget.enableSuggestions,
-            autocorrect: widget.autocorrect,
-            style: textStyle,
-            decoration: _getInputDecoration(
-              context,
-              localizations,
-            ),
-            cursorColor: textStyle.color,
+          child: Column(
+            children: <Widget>[
+              TextField(
+                controller: _controller,
+                focusNode: _focusNode,
+                onSubmitted: (String query) => _performSearch(context, query),
+                textInputAction: TextInputAction.search,
+                enableSuggestions: widget.enableSuggestions,
+                autocorrect: widget.autocorrect,
+                style: textStyle,
+                decoration: _getInputDecoration(
+                  context,
+                  localizations,
+                ),
+                cursorColor: textStyle.color,
+              ),
+              if (additionalFilter != null) additionalFilter,
+            ],
           ),
         ),
       ),

--- a/packages/smooth_app/lib/query/category_product_query.dart
+++ b/packages/smooth_app/lib/query/category_product_query.dart
@@ -5,7 +5,11 @@ import 'package:smooth_app/query/paged_search_product_query.dart';
 
 /// Back-end query about a category.
 class CategoryProductQuery extends PagedSearchProductQuery {
-  CategoryProductQuery(this.categoryTag, {super.world});
+  CategoryProductQuery(
+    this.categoryTag, {
+    required super.productType,
+    super.world,
+  });
 
   // e.g. 'en:unsweetened-natural-soy-milks'
   final String categoryTag;
@@ -24,6 +28,7 @@ class CategoryProductQuery extends PagedSearchProductQuery {
         pageNumber: pageNumber,
         language: language,
         country: country,
+        productType: productType,
       );
 
   @override
@@ -33,11 +38,17 @@ class CategoryProductQuery extends PagedSearchProductQuery {
       ', $pageNumber'
       ', $language'
       ', $country'
+      ', $productType'
       ')';
 
   @override
-  PagedProductQuery? getWorldQuery() =>
-      world ? null : CategoryProductQuery(categoryTag, world: true);
+  PagedProductQuery? getWorldQuery() => world
+      ? null
+      : CategoryProductQuery(
+          categoryTag,
+          world: true,
+          productType: productType,
+        );
 
   @override
   bool hasDifferentCountryWorldData() => true;

--- a/packages/smooth_app/lib/query/keywords_product_query.dart
+++ b/packages/smooth_app/lib/query/keywords_product_query.dart
@@ -5,7 +5,11 @@ import 'package:smooth_app/query/paged_search_product_query.dart';
 
 /// Back-end query around user-entered keywords.
 class KeywordsProductQuery extends PagedSearchProductQuery {
-  KeywordsProductQuery(this.keywords, {super.world});
+  KeywordsProductQuery(
+    this.keywords, {
+    required super.productType,
+    super.world,
+  });
 
   final String keywords;
 
@@ -19,6 +23,7 @@ class KeywordsProductQuery extends PagedSearchProductQuery {
         pageNumber: pageNumber,
         language: language,
         country: country,
+        productType: productType,
       );
 
   @override
@@ -28,11 +33,17 @@ class KeywordsProductQuery extends PagedSearchProductQuery {
       ', $pageNumber'
       ', $language'
       ', $country'
+      ', $productType'
       ')';
 
   @override
-  PagedProductQuery? getWorldQuery() =>
-      world ? null : KeywordsProductQuery(keywords, world: true);
+  PagedProductQuery? getWorldQuery() => world
+      ? null
+      : KeywordsProductQuery(
+          keywords,
+          productType: productType,
+          world: true,
+        );
 
   @override
   bool hasDifferentCountryWorldData() => true;

--- a/packages/smooth_app/lib/query/paged_product_query.dart
+++ b/packages/smooth_app/lib/query/paged_product_query.dart
@@ -4,8 +4,12 @@ import 'package:smooth_app/query/product_query.dart';
 
 /// Paged product query (with [pageSize] and [pageNumber]).
 abstract class PagedProductQuery {
-  PagedProductQuery({this.world = false});
+  PagedProductQuery({
+    required this.productType,
+    this.world = false,
+  });
 
+  final ProductType productType;
   final int pageSize = _typicalPageSize;
 
   /// Likely to change: to next page, and back to top.
@@ -38,7 +42,7 @@ abstract class PagedProductQuery {
       OpenFoodAPIClient.searchProducts(
         ProductQuery.getReadUser(),
         getQueryConfiguration(),
-        uriHelper: ProductQuery.getUriProductHelper(),
+        uriHelper: ProductQuery.getUriProductHelper(productType: productType),
       );
 
   AbstractQueryConfiguration getQueryConfiguration();

--- a/packages/smooth_app/lib/query/paged_search_product_query.dart
+++ b/packages/smooth_app/lib/query/paged_search_product_query.dart
@@ -4,7 +4,10 @@ import 'package:smooth_app/query/product_query.dart';
 
 /// Back-end paged queries around search.
 abstract class PagedSearchProductQuery extends PagedProductQuery {
-  PagedSearchProductQuery({super.world});
+  PagedSearchProductQuery({
+    required super.productType,
+    super.world,
+  });
 
   Parameter getParameter();
 

--- a/packages/smooth_app/lib/query/paged_to_be_completed_product_query.dart
+++ b/packages/smooth_app/lib/query/paged_to_be_completed_product_query.dart
@@ -5,7 +5,10 @@ import 'package:smooth_app/query/product_query.dart';
 
 /// Back-end paged query for all "to-be-completed" products.
 class PagedToBeCompletedProductQuery extends PagedProductQuery {
-  PagedToBeCompletedProductQuery({super.world});
+  PagedToBeCompletedProductQuery({
+    required super.productType,
+    super.world,
+  });
 
   @override
   AbstractQueryConfiguration getQueryConfiguration() =>
@@ -32,6 +35,7 @@ class PagedToBeCompletedProductQuery extends PagedProductQuery {
         pageNumber: pageNumber,
         language: language,
         country: country,
+        productType: productType,
       );
 
   @override
@@ -40,11 +44,16 @@ class PagedToBeCompletedProductQuery extends PagedProductQuery {
       ', $pageNumber'
       ', $language'
       ', $country'
+      ', $productType'
       ')';
 
   @override
-  PagedProductQuery? getWorldQuery() =>
-      world ? null : PagedToBeCompletedProductQuery(world: true);
+  PagedProductQuery? getWorldQuery() => world
+      ? null
+      : PagedToBeCompletedProductQuery(
+          productType: productType,
+          world: true,
+        );
 
   @override
   bool hasDifferentCountryWorldData() => true;

--- a/packages/smooth_app/lib/query/paged_user_product_query.dart
+++ b/packages/smooth_app/lib/query/paged_user_product_query.dart
@@ -55,6 +55,7 @@ class PagedUserProductQuery extends PagedProductQuery {
   PagedUserProductQuery({
     required this.userId,
     required this.type,
+    required super.productType,
   });
 
   final String userId;
@@ -78,6 +79,7 @@ class PagedUserProductQuery extends PagedProductQuery {
           pageSize: pageSize,
           pageNumber: pageNumber,
           language: language,
+          productType: productType,
         );
       case UserSearchType.INFORMER:
         return ProductList.informer(
@@ -85,6 +87,7 @@ class PagedUserProductQuery extends PagedProductQuery {
           pageSize: pageSize,
           pageNumber: pageNumber,
           language: language,
+          productType: productType,
         );
       case UserSearchType.PHOTOGRAPHER:
         return ProductList.photographer(
@@ -92,6 +95,7 @@ class PagedUserProductQuery extends PagedProductQuery {
           pageSize: pageSize,
           pageNumber: pageNumber,
           language: language,
+          productType: productType,
         );
       case UserSearchType.TO_BE_COMPLETED:
         return ProductList.toBeCompleted(
@@ -99,6 +103,7 @@ class PagedUserProductQuery extends PagedProductQuery {
           pageSize: pageSize,
           pageNumber: pageNumber,
           language: language,
+          productType: productType,
         );
     }
   }
@@ -110,5 +115,6 @@ class PagedUserProductQuery extends PagedProductQuery {
       ', $pageSize'
       ', $pageNumber'
       ', $language'
+      ', $productType'
       ')';
 }

--- a/packages/smooth_app/lib/query/product_query.dart
+++ b/packages/smooth_app/lib/query/product_query.dart
@@ -1,6 +1,7 @@
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:smooth_app/data_models/preferences/user_preferences.dart';
@@ -299,4 +300,7 @@ extension ProductTypeExtension on ProductType {
         ProductType.petFood => 'openpetfoodfacts',
         ProductType.product => 'openproductsfacts',
       };
+
+  // TODO(monsieurtanuki): localize with very short names, or use icons instead
+  String getLabel(final AppLocalizations appLocalizations) => name;
 }


### PR DESCRIPTION
### What
- Now for term searches, there is an OxF "radio button": the search will be run on the specific server.
- Pending questions
  - for the user page ("products you edited") and contribute button ("contribute by completing products"), for the moment we consider only the food products, does that make sense? (impact on `user_preferences_account.dart`, `user_preferences_contribute.dart`)
  - Maybe reinit default product type (food) with latest value for the filter (impact on `search_product_helper.dart`)
  - Matomo: shouldn't we send the product type to Matomo? (impact at least on `product_query.dart`)
  - I believe it's very optimistic to display 4 labels in the filter - what about icons and hints? (impact on `product_query.dart`)

### Screenshots
| food | beauty |
| -- | -- |
| ![Screenshot_1727459262](https://github.com/user-attachments/assets/e41d2a72-3be9-4dfc-a3c4-8d990ea874be) | ![Screenshot_1727459267](https://github.com/user-attachments/assets/f23be2cc-25e7-46ba-8394-401c9db978b7) |

| pet food | products |
| -- | -- |
| ![Screenshot_1727459271](https://github.com/user-attachments/assets/21f5a90e-4b09-4fdf-80a9-c85d49aa0519) | ![Screenshot_1727459274](https://github.com/user-attachments/assets/aa29ba1e-0d0a-4cae-9d9c-e638cf88893f) |

### Part of 
- #5586

### Impacted files
* `category_product_query.dart`: refactored with new `productType` parameter
* `keywords_product_query.dart`: refactored with new `productType` parameter
* `paged_product_query.dart`: refactored with new `productType` parameter
* `paged_search_product_query.dart`: refactored with new `productType` parameter
* `paged_to_be_completed_product_query.dart`: refactored with new `productType` parameter
* `paged_user_product_query.dart`: refactored with new `productType` parameter
* `product_list.dart`: refactored with new `productType` parameter
* `product_query.dart`: added a "get label" method for `ProductType`
* `search_field.dart`: displayed the new optional "additional filter" (e.g. OxF)
* `search_helper.dart`: added a new optional "additional filter"
* `search_product_helper.dart`: new "product type filter" widget
* `summary_card.dart`: minor "productType" fix
* `user_preferences_account.dart`: added "productType.food" to user page counts
* `user_preferences_contribute.dart`: added "productType.food" to "to be completed" products