### PR TITLE
feat: 5643 - edit of products of any product type

### DIFF
--- a/packages/smooth_app/lib/background/background_task_barcode.dart
+++ b/packages/smooth_app/lib/background/background_task_barcode.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/foundation.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/background/background_task.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/pages/product/common/product_refresher.dart';
+import 'package:smooth_app/query/product_query.dart';
 
 /// Abstract background task that involves a single barcode.
 abstract class BackgroundTaskBarcode extends BackgroundTask {
@@ -11,20 +13,28 @@ abstract class BackgroundTaskBarcode extends BackgroundTask {
     super.language,
     required super.stamp,
     required this.barcode,
+    required this.productType,
   });
 
   BackgroundTaskBarcode.fromJson(super.json)
       : barcode = json[_jsonTagBarcode] as String,
+        productType =
+            ProductType.fromOffTag(json[_jsonTagProductType] as String?) ??
+                // for legacy reason (not refreshed products = no product type)
+                ProductType.food,
         super.fromJson();
 
   final String barcode;
+  final ProductType productType;
 
   static const String _jsonTagBarcode = 'barcode';
+  static const String _jsonTagProductType = 'productType';
 
   @override
   Map<String, dynamic> toJson() {
     final Map<String, dynamic> result = super.toJson();
     result[_jsonTagBarcode] = barcode;
+    result[_jsonTagProductType] = productType.offTag;
     return result;
   }
 
@@ -44,5 +54,10 @@ abstract class BackgroundTaskBarcode extends BackgroundTask {
       ProductRefresher().silentFetchAndRefresh(
         barcode: barcode,
         localDatabase: localDatabase,
+      );
+
+  @override
+  UriProductHelper get uriProductHelper => ProductQuery.getUriProductHelper(
+        productType: productType,
       );
 }

--- a/packages/smooth_app/lib/background/background_task_crop.dart
+++ b/packages/smooth_app/lib/background/background_task_crop.dart
@@ -16,6 +16,7 @@ class BackgroundTaskCrop extends BackgroundTaskUpload {
     required super.processName,
     required super.uniqueId,
     required super.barcode,
+    required super.productType,
     required super.language,
     required super.stamp,
     required super.imageField,
@@ -48,6 +49,7 @@ class BackgroundTaskCrop extends BackgroundTaskUpload {
   /// Adds the background task about uploading a product image.
   static Future<void> addTask(
     final String barcode, {
+    required final ProductType? productType,
     required final OpenFoodFactsLanguage language,
     required final int imageId,
     required final ImageField imageField,
@@ -67,6 +69,7 @@ class BackgroundTaskCrop extends BackgroundTaskUpload {
     final BackgroundTaskBarcode task = _getNewTask(
       language,
       barcode,
+      productType ?? ProductType.food,
       imageId,
       imageField,
       croppedFile,
@@ -95,6 +98,7 @@ class BackgroundTaskCrop extends BackgroundTaskUpload {
   static BackgroundTaskCrop _getNewTask(
     final OpenFoodFactsLanguage language,
     final String barcode,
+    final ProductType productType,
     final int imageId,
     final ImageField imageField,
     final File croppedFile,
@@ -108,6 +112,7 @@ class BackgroundTaskCrop extends BackgroundTaskUpload {
       BackgroundTaskCrop._(
         uniqueId: uniqueId,
         barcode: barcode,
+        productType: productType,
         processName: _operationType.processName,
         imageId: imageId,
         imageField: imageField.offTag,
@@ -158,6 +163,7 @@ class BackgroundTaskCrop extends BackgroundTaskUpload {
       await BackgroundTaskRefreshLater.addTask(
         barcode,
         localDatabase: localDatabase,
+        productType: productType,
       );
     }
   }

--- a/packages/smooth_app/lib/background/background_task_details.dart
+++ b/packages/smooth_app/lib/background/background_task_details.dart
@@ -13,6 +13,7 @@ import 'package:smooth_app/database/local_database.dart';
 ///
 /// With that stamp, we can de-duplicate similar tasks.
 enum BackgroundTaskDetailsStamp {
+  productType('product_type'),
   basicDetails('basic_details'),
   otherDetails('other_details'),
   ocrIngredients('ocr_ingredients'),
@@ -38,6 +39,7 @@ class BackgroundTaskDetails extends BackgroundTaskBarcode
     required super.processName,
     required super.uniqueId,
     required super.barcode,
+    required super.productType,
     required super.stamp,
     required this.inputMap,
   });
@@ -70,6 +72,7 @@ class BackgroundTaskDetails extends BackgroundTaskBarcode
     required final BuildContext context,
     required final BackgroundTaskDetailsStamp stamp,
     final bool showSnackBar = true,
+    required final ProductType? productType,
   }) async {
     final LocalDatabase localDatabase = context.read<LocalDatabase>();
     final String uniqueId = await _operationType.getNewKey(
@@ -80,6 +83,7 @@ class BackgroundTaskDetails extends BackgroundTaskBarcode
       minimalistProduct,
       uniqueId,
       stamp,
+      productType ?? ProductType.food,
     );
     if (!context.mounted) {
       return;
@@ -104,11 +108,13 @@ class BackgroundTaskDetails extends BackgroundTaskBarcode
     final Product minimalistProduct,
     final String uniqueId,
     final BackgroundTaskDetailsStamp stamp,
+    final ProductType productType,
   ) =>
       BackgroundTaskDetails._(
         uniqueId: uniqueId,
         processName: _operationType.processName,
         barcode: minimalistProduct.barcode!,
+        productType: productType,
         inputMap: jsonEncode(minimalistProduct.toJson()),
         stamp: getStamp(minimalistProduct.barcode!, stamp.tag),
       );

--- a/packages/smooth_app/lib/background/background_task_hunger_games.dart
+++ b/packages/smooth_app/lib/background/background_task_hunger_games.dart
@@ -13,6 +13,7 @@ class BackgroundTaskHungerGames extends BackgroundTaskBarcode {
     required super.processName,
     required super.uniqueId,
     required super.barcode,
+    required super.productType,
     required super.stamp,
     required this.insightId,
     required this.insightAnnotation,
@@ -80,6 +81,8 @@ class BackgroundTaskHungerGames extends BackgroundTaskBarcode {
         processName: _operationType.processName,
         uniqueId: uniqueId,
         barcode: barcode,
+        // not really relevant for Robotoff
+        productType: ProductType.food,
         stamp: _getStamp(barcode, insightId),
         insightId: insightId,
         insightAnnotation: insightAnnotation,

--- a/packages/smooth_app/lib/background/background_task_image.dart
+++ b/packages/smooth_app/lib/background/background_task_image.dart
@@ -22,6 +22,7 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
     required super.processName,
     required super.uniqueId,
     required super.barcode,
+    required super.productType,
     required super.language,
     required super.stamp,
     required super.imageField,
@@ -58,6 +59,7 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
   /// Adds the background task about uploading a product image.
   static Future<void> addTask(
     final String barcode, {
+    required final ProductType? productType,
     required final OpenFoodFactsLanguage language,
     required final ImageField imageField,
     required final File fullFile,
@@ -77,6 +79,7 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
     final BackgroundTaskBarcode task = _getNewTask(
       language,
       barcode,
+      productType ?? ProductType.food,
       imageField,
       fullFile,
       croppedFile,
@@ -105,6 +108,7 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
   static BackgroundTaskImage _getNewTask(
     final OpenFoodFactsLanguage language,
     final String barcode,
+    final ProductType productType,
     final ImageField imageField,
     final File fullFile,
     final File croppedFile,
@@ -118,6 +122,7 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
       BackgroundTaskImage._(
         uniqueId: uniqueId,
         barcode: barcode,
+        productType: productType,
         processName: _operationType.processName,
         imageField: imageField.offTag,
         fullPath: fullFile.path,
@@ -176,6 +181,7 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
       await BackgroundTaskRefreshLater.addTask(
         barcode,
         localDatabase: localDatabase,
+        productType: productType,
       );
     }
   }

--- a/packages/smooth_app/lib/background/background_task_refresh_later.dart
+++ b/packages/smooth_app/lib/background/background_task_refresh_later.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/painting.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/background/background_task_barcode.dart';
 import 'package:smooth_app/background/operation_type.dart';
 import 'package:smooth_app/database/local_database.dart';
@@ -14,6 +15,7 @@ class BackgroundTaskRefreshLater extends BackgroundTaskBarcode {
     required super.processName,
     required super.uniqueId,
     required super.barcode,
+    required super.productType,
     required super.stamp,
     required this.timestamp,
   });
@@ -49,12 +51,17 @@ class BackgroundTaskRefreshLater extends BackgroundTaskBarcode {
   static Future<void> addTask(
     final String barcode, {
     required final LocalDatabase localDatabase,
+    required final ProductType productType,
   }) async {
     final String uniqueId = await _operationType.getNewKey(
       localDatabase,
       barcode: barcode,
     );
-    final BackgroundTaskBarcode task = _getNewTask(barcode, uniqueId);
+    final BackgroundTaskBarcode task = _getNewTask(
+      barcode,
+      uniqueId,
+      productType,
+    );
     await task.addToManager(localDatabase);
   }
 
@@ -67,11 +74,13 @@ class BackgroundTaskRefreshLater extends BackgroundTaskBarcode {
   static BackgroundTaskRefreshLater _getNewTask(
     final String barcode,
     final String uniqueId,
+    final ProductType productType,
   ) =>
       BackgroundTaskRefreshLater._(
         uniqueId: uniqueId,
         processName: _operationType.processName,
         barcode: barcode,
+        productType: productType,
         timestamp: LocalDatabase.nowInMillis(),
         stamp: _getStamp(barcode),
       );

--- a/packages/smooth_app/lib/background/background_task_unselect.dart
+++ b/packages/smooth_app/lib/background/background_task_unselect.dart
@@ -19,6 +19,7 @@ class BackgroundTaskUnselect extends BackgroundTaskBarcode
     required super.uniqueId,
     required OpenFoodFactsLanguage super.language,
     required super.barcode,
+    required super.productType,
     required super.stamp,
     required this.imageField,
   });
@@ -43,6 +44,7 @@ class BackgroundTaskUnselect extends BackgroundTaskBarcode
   /// Adds the background task about unselecting a product image.
   static Future<void> addTask(
     final String barcode, {
+    required final ProductType? productType,
     required final ImageField imageField,
     required final BuildContext context,
     required final OpenFoodFactsLanguage language,
@@ -54,6 +56,7 @@ class BackgroundTaskUnselect extends BackgroundTaskBarcode
     );
     final BackgroundTaskBarcode task = _getNewTask(
       barcode,
+      productType ?? ProductType.food,
       imageField,
       uniqueId,
       language,
@@ -75,6 +78,7 @@ class BackgroundTaskUnselect extends BackgroundTaskBarcode
   /// Returns a new background task about unselecting a product image.
   static BackgroundTaskUnselect _getNewTask(
     final String barcode,
+    final ProductType productType,
     final ImageField imageField,
     final String uniqueId,
     final OpenFoodFactsLanguage language,
@@ -82,6 +86,7 @@ class BackgroundTaskUnselect extends BackgroundTaskBarcode
       BackgroundTaskUnselect._(
         uniqueId: uniqueId,
         barcode: barcode,
+        productType: productType,
         language: language,
         processName: _operationType.processName,
         imageField: imageField.offTag,
@@ -116,6 +121,7 @@ class BackgroundTaskUnselect extends BackgroundTaskBarcode
       await BackgroundTaskRefreshLater.addTask(
         barcode,
         localDatabase: localDatabase,
+        productType: productType,
       );
     }
   }

--- a/packages/smooth_app/lib/background/background_task_upload.dart
+++ b/packages/smooth_app/lib/background/background_task_upload.dart
@@ -16,6 +16,7 @@ abstract class BackgroundTaskUpload extends BackgroundTaskBarcode
     required super.processName,
     required super.uniqueId,
     required super.barcode,
+    required super.productType,
     required super.language,
     required super.stamp,
     required this.imageField,

--- a/packages/smooth_app/lib/cards/data_cards/product_image_carousel_item.dart
+++ b/packages/smooth_app/lib/cards/data_cards/product_image_carousel_item.dart
@@ -45,6 +45,7 @@ class _ProductImageCarouselItemState extends State<ProductImageCarouselItem> {
         onPressed: () async => confirmAndUploadNewPicture(
           context,
           barcode: widget.product.barcode!,
+          productType: widget.product.productType,
           imageField: widget.productImageData.imageField,
           language: ProductQuery.getLanguage(),
           isLoggedInMandatory: true,

--- a/packages/smooth_app/lib/data_models/up_to_date_changes.dart
+++ b/packages/smooth_app/lib/data_models/up_to_date_changes.dart
@@ -51,6 +51,9 @@ class UpToDateChanges {
   /// * [BackgroundTaskDetails]
   /// * [BackgroundTaskImage]
   Product _overwrite(final Product initial, final Product change) {
+    if (change.productType != null) {
+      initial.productType = change.productType;
+    }
     if (change.productName != null) {
       initial.productName = change.productName;
     }

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1769,6 +1769,25 @@
             }
         }
     },
+    "product_type_label_food": "Food",
+    "product_type_label_beauty": "Personal care",
+    "product_type_label_pet_food": "Pet food",
+    "product_type_label_product": "Other",
+    "product_type_selection_title": "Product type",
+    "product_type_selection_subtitle": "Select the type of this product",
+    "product_type_selection_empty": "You need to select a product type first!",
+    "@product_type_selection_empty": {
+        "description": "Error message about product type that needs to be set"
+    },
+    "product_type_selection_already": "You cannot change the product type ({productType})!",
+    "@product_type_selection_already": {
+        "description": "Error message about product type that cannot be set again",
+        "placeholders": {
+            "productType": {
+                "type": "String"
+            }
+        }
+    },
     "prices_app_dev_mode_flag": "Shortcut to Prices app on product page",
     "prices_app_button": "Go to Prices app",
     "prices_generic_title": "Prices",

--- a/packages/smooth_app/lib/pages/image/uploaded_image_gallery.dart
+++ b/packages/smooth_app/lib/pages/image/uploaded_image_gallery.dart
@@ -90,6 +90,7 @@ class UploadedImageGallery extends StatelessWidget {
                     isLoggedInMandatory: isLoggedInMandatory,
                     cropHelper: ProductCropAgainHelper(
                       barcode: barcode,
+                      productType: productType,
                       imageField: imageField,
                       imageId: int.parse(rawImage.imgid!),
                       language: language,

--- a/packages/smooth_app/lib/pages/image_crop_page.dart
+++ b/packages/smooth_app/lib/pages/image_crop_page.dart
@@ -257,6 +257,7 @@ Future<CropParameters?> confirmAndUploadNewPicture(
   final BuildContext context, {
   required final ImageField imageField,
   required final String barcode,
+  required final ProductType? productType,
   required final OpenFoodFactsLanguage language,
   required final bool isLoggedInMandatory,
 }) async =>
@@ -266,6 +267,7 @@ Future<CropParameters?> confirmAndUploadNewPicture(
         imageField: imageField,
         language: language,
         barcode: barcode,
+        productType: productType,
       ),
       isLoggedInMandatory: isLoggedInMandatory,
     );

--- a/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
@@ -296,6 +296,7 @@ class _AddBasicDetailsPageState extends State<AddBasicDetailsPage> {
       minimalistProduct,
       context: context,
       stamp: BackgroundTaskDetailsStamp.basicDetails,
+      productType: _product.productType,
     );
 
     return true;

--- a/packages/smooth_app/lib/pages/product/add_other_details_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_other_details_page.dart
@@ -141,6 +141,7 @@ class _AddOtherDetailsPageState extends State<AddOtherDetailsPage> {
       _getMinimalistProduct(),
       context: context,
       stamp: BackgroundTaskDetailsStamp.otherDetails,
+      productType: _product.productType,
     );
 
     return true;

--- a/packages/smooth_app/lib/pages/product/common/product_dialog_helper.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_dialog_helper.dart
@@ -1,10 +1,7 @@
-import 'dart:math' as math;
-
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
-import 'package:smooth_app/cards/category_cards/svg_cache.dart';
 import 'package:smooth_app/data_models/fetched_product.dart';
 import 'package:smooth_app/database/dao_product.dart';
 import 'package:smooth_app/database/local_database.dart';
@@ -60,16 +57,6 @@ class ProductDialogHelper {
   void _openProductNotFoundDialog() => showDialog<Widget>(
       context: context,
       builder: (BuildContext context) {
-        final double availableWidth = MediaQuery.sizeOf(context).width -
-            SmoothAlertDialog.defaultMargin.horizontal -
-            SmoothAlertDialog.defaultContentPadding(context).horizontal;
-
-        /// The nutriscore logo is 240*130
-        final double svgHeight = math.min(
-          (availableWidth * 0.4) / 240.0 * 130.0,
-          175.0,
-        );
-
         final double heightMultiplier = switch (context.deviceType) {
           DeviceType.small => 1,
           DeviceType.smartphone => 2,
@@ -100,33 +87,6 @@ class ProductDialogHelper {
               Text(
                 appLocalizations.barcode_barcode(barcode),
                 textAlign: TextAlign.center,
-              ),
-              SizedBox(height: MEDIUM_SPACE * heightMultiplier),
-              Semantics(
-                label: appLocalizations
-                    .new_product_dialog_illustration_description,
-                excludeSemantics: true,
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: <Widget>[
-                    Expanded(
-                      flex: 4,
-                      child: SvgCache(
-                        unknownSvgNutriscore,
-                        height: svgHeight,
-                      ),
-                    ),
-                    const Spacer(),
-                    Expanded(
-                      flex: 4,
-                      child: SvgCache(
-                        unknownSvgEcoscore,
-                        height: svgHeight,
-                      ),
-                    ),
-                  ],
-                ),
               ),
               SizedBox(height: SMALL_SPACE * heightMultiplier),
               Text(

--- a/packages/smooth_app/lib/pages/product/edit_new_packagings.dart
+++ b/packages/smooth_app/lib/pages/product/edit_new_packagings.dart
@@ -176,6 +176,7 @@ class _EditNewPackagingsState extends State<EditNewPackagings>
             context,
             imageField: ImageField.OTHER,
             barcode: barcode,
+            productType: upToDateProduct.productType,
             language: ProductQuery.getLanguage(),
             isLoggedInMandatory: widget.isLoggedInMandatory,
           ),
@@ -302,6 +303,7 @@ class _EditNewPackagingsState extends State<EditNewPackagings>
       changedProduct,
       context: context,
       stamp: BackgroundTaskDetailsStamp.structuredPackaging,
+      productType: upToDateProduct.productType,
     );
     return true;
   }

--- a/packages/smooth_app/lib/pages/product/edit_ocr/edit_ocr_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_ocr/edit_ocr_page.dart
@@ -126,6 +126,7 @@ class _EditOcrPageState extends State<EditOcrPage> with UpToDateMixin {
       changedProduct,
       context: context,
       stamp: _helper.getStamp(),
+      productType: upToDateProduct.productType,
     );
     return;
   }
@@ -383,6 +384,7 @@ class _EditOcrPageState extends State<EditOcrPage> with UpToDateMixin {
                               context,
                               imageField: ImageField.OTHER,
                               barcode: widget.product.barcode!,
+                              productType: upToDateProduct.productType,
                               language: language,
                               isLoggedInMandatory: widget.isLoggedInMandatory,
                             ),

--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -430,6 +430,7 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded>
       changedProduct,
       context: context,
       stamp: BackgroundTaskDetailsStamp.nutrition,
+      productType: widget.product.productType,
     );
     return true;
   }

--- a/packages/smooth_app/lib/pages/product/product_image_button.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_button.dart
@@ -85,6 +85,7 @@ enum ProductImageButtonType {
           ),
         ProductImageButtonType.unselect => ProductImageUnselectButton(
             product: product,
+            productType: product.productType,
             imageField: imageField,
             language: language,
             isLoggedInMandatory: isLoggedInMandatory,

--- a/packages/smooth_app/lib/pages/product/product_image_crop_button.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_crop_button.dart
@@ -122,6 +122,7 @@ class ProductImageCropButton extends ProductImageButton {
           cropHelper: ProductCropAgainHelper(
             language: language,
             barcode: barcode,
+            productType: productType,
             imageField: _imageData.imageField,
             imageId: imageId,
           ),
@@ -144,6 +145,7 @@ class ProductImageCropButton extends ProductImageButton {
             cropHelper: ProductCropNewHelper(
               language: language,
               barcode: barcode,
+              productType: product.productType,
               imageField: _imageData.imageField,
             ),
           ),

--- a/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
@@ -73,6 +73,7 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView>
               barcode: barcode,
               language: ProductQuery.getLanguage(),
               isLoggedInMandatory: true,
+              productType: upToDateProduct.productType,
             );
           },
           label: Text(appLocalizations.add_photo_button_label),

--- a/packages/smooth_app/lib/pages/product/product_image_local_button.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_local_button.dart
@@ -40,6 +40,7 @@ class ProductImageLocalButton extends ProductImageButton {
       context,
       imageField: imageField,
       barcode: barcode,
+      productType: product.productType,
       language: language,
       isLoggedInMandatory: isLoggedInMandatory,
     );

--- a/packages/smooth_app/lib/pages/product/product_image_unselect_button.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_unselect_button.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/background/background_task_unselect.dart';
 import 'package:smooth_app/database/local_database.dart';
@@ -14,8 +15,11 @@ class ProductImageUnselectButton extends ProductImageButton {
     required super.imageField,
     required super.language,
     required super.isLoggedInMandatory,
+    required this.productType,
     super.borderWidth,
   });
+
+  final ProductType? productType;
 
   @override
   IconData getIconData() => Icons.do_disturb_on;
@@ -70,6 +74,7 @@ class ProductImageUnselectButton extends ProductImageButton {
       imageField: imageField,
       context: context,
       language: language,
+      productType: productType,
     );
     localDatabase.notifyListeners();
     if (!context.mounted) {

--- a/packages/smooth_app/lib/pages/product/product_image_viewer.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_viewer.dart
@@ -119,6 +119,7 @@ class _ProductImageViewerState extends State<ProductImageViewer>
                                     context,
                                     imageField: widget.imageField,
                                     barcode: barcode,
+                                    productType: upToDateProduct.productType,
                                     language: widget.language,
                                     isLoggedInMandatory: true,
                                   );

--- a/packages/smooth_app/lib/pages/product/simple_input_page.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page.dart
@@ -190,6 +190,7 @@ class _SimpleInputPageState extends State<SimpleInputPage> {
         context: context,
         stamp: entry.key,
         showSnackBar: first,
+        productType: widget.product.productType,
       );
       first = false;
     }

--- a/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
@@ -130,6 +130,7 @@ abstract class AbstractSimpleInputPageHelper extends ChangeNotifier {
             context,
             imageField: ImageField.OTHER,
             barcode: product.barcode!,
+            productType: product.productType,
             language: ProductQuery.getLanguage(),
             // we're already logged in if needed
             isLoggedInMandatory: false,

--- a/packages/smooth_app/lib/pages/product_crop_helper.dart
+++ b/packages/smooth_app/lib/pages/product_crop_helper.dart
@@ -21,11 +21,13 @@ abstract class ProductCropHelper extends CropHelper {
     required this.imageField,
     required this.language,
     required this.barcode,
+    required this.productType,
   });
 
   final ImageField imageField;
   final OpenFoodFactsLanguage language;
   final String barcode;
+  final ProductType? productType;
 
   @override
   String getPageTitle(final AppLocalizations appLocalizations) =>
@@ -56,6 +58,7 @@ class ProductCropNewHelper extends ProductCropHelper {
     required super.imageField,
     required super.language,
     required super.barcode,
+    required super.productType,
   });
 
   @override
@@ -88,6 +91,7 @@ class ProductCropNewHelper extends ProductCropHelper {
     }
     await BackgroundTaskImage.addTask(
       barcode,
+      productType: productType,
       language: language,
       imageField: imageField,
       fullFile: fullFile,
@@ -117,6 +121,7 @@ class ProductCropAgainHelper extends ProductCropHelper {
     required super.imageField,
     required super.language,
     required super.barcode,
+    required super.productType,
     required this.imageId,
   });
 
@@ -143,6 +148,7 @@ class ProductCropAgainHelper extends ProductCropHelper {
     final Rect cropRect = _getServerCropRect(controller, image);
     await BackgroundTaskCrop.addTask(
       barcode,
+      productType: productType,
       language: language,
       imageField: imageField,
       imageId: imageId,

--- a/packages/smooth_app/lib/query/product_query.dart
+++ b/packages/smooth_app/lib/query/product_query.dart
@@ -301,6 +301,10 @@ extension ProductTypeExtension on ProductType {
         ProductType.product => 'openproductsfacts',
       };
 
-  // TODO(monsieurtanuki): localize with very short names, or use icons instead
-  String getLabel(final AppLocalizations appLocalizations) => name;
+  String getLabel(final AppLocalizations appLocalizations) => switch (this) {
+        ProductType.food => appLocalizations.product_type_label_food,
+        ProductType.beauty => appLocalizations.product_type_label_beauty,
+        ProductType.petFood => appLocalizations.product_type_label_pet_food,
+        ProductType.product => appLocalizations.product_type_label_product,
+      };
 }


### PR DESCRIPTION
### What
- The aim of this PR is to take into account the product type _for edit operations_. It implies updating data _on the related server_.
- As the product type is mandatory, for new found products we now ask first which product type it is. And that's it.
- For "old" products, we of course consider they are food. When refreshed from a server, they will deduce the product type from the server that hosts them.
- Et voilà: https://fr.openbeautyfacts.org/produit/3350033596092/dentifrices-fracheur-la-menthe-poivree-monoprix
- What is missing is fine-tuning the edit features for each product type (e.g. no nutrition for "products"). The current PR being big enough, other features will be coded in next PRs.

### Screenshots
| hey, new product! | select product type |
| -- | -- |
| ![Screenshot_1727880481](https://github.com/user-attachments/assets/45064f99-a255-44d6-bd7b-50655e2bf11c) | ![Screenshot_1727880489](https://github.com/user-attachments/assets/1884b7a2-4c33-4f3c-8f79-140e1d069727) |

| mandatory product type | cannot change product type |
| -- | -- |
| ![Screenshot_1727880496](https://github.com/user-attachments/assets/545ea4c9-0137-4b6b-882b-133044fa786b) | ![Screenshot_1727880513](https://github.com/user-attachments/assets/0a98ea6d-4abb-4ad1-8c66-c739027733f6) |

| photos | categories |
| -- | -- |
| ![Screenshot_1727881183](https://github.com/user-attachments/assets/15e4a09b-84da-4ecb-90fd-3d8e510c8961) | ![Screenshot_1727881226](https://github.com/user-attachments/assets/415009ec-050a-4d15-9040-de8af4d05e18) |

| ingredients | basic details |
| -- | -- |
| ![Screenshot_1727881270](https://github.com/user-attachments/assets/2f6c05e3-ad8f-44c9-90b1-a8aa45badaf9) | ![Screenshot_1727881339](https://github.com/user-attachments/assets/66681e69-8c19-49bd-be8e-f7656b89aa93) |

### Part of 
- #5643

### Impacted files
* `add_basic_details_page.dart`: added product type
* `add_new_product_page.dart`: added a "set product type page" for new products; added product type; minor refactoring
* `add_other_details_page.dart`: added product type
* `app_en.arb`: added 1 label per product type, and 4 labels for product type input
* `background_task_barcode.dart`: added product type
* `background_task_crop.dart`: added product type
* `background_task_details.dart`: added product type
* `background_task_hunger_games.dart`: added product type
* `background_task_image.dart`: added product type
* `background_task_refresh_later.dart`: added product type
* `background_task_unselect.dart`: added product type
* `background_task_upload.dart`: added product type
* `edit_new_packagings.dart`: added product type
* `edit_ocr_page.dart`: added product type
* `image_crop_page.dart`: added product type
* `nutrition_page_loaded.dart`: added product type
* `product_crop_helper.dart`: added product type
* `product_dialog_helper.dart`: removed irrelevant nutriscore and ecoscore logos for new found products, as we cannot say already if it's food
* `product_image_button.dart`: added product type
* `product_image_carousel_item.dart`: added product type
* `product_image_crop_button.dart`: added product type
* `product_image_gallery_view.dart`: added product type
* `product_image_local_button.dart`: added product type
* `product_image_unselect_button.dart`: added product type
* `product_image_viewer.dart`: added product type
* `product_query.dart`: localized labels for product type
* `simple_input_page.dart`: added product type
* `simple_input_page_helpers.dart`: added product type
* `up_to_date_changes.dart`: added product type
* `uploaded_image_gallery.dart`: added product type