### PR TITLE
feat: 5586 - explicit call to "food" server for user login actions

### DIFF
--- a/packages/smooth_app/lib/data_models/login_result.dart
+++ b/packages/smooth_app/lib/data_models/login_result.dart
@@ -38,7 +38,9 @@ class LoginResult {
     try {
       final LoginStatus? loginStatus = await OpenFoodAPIClient.login2(
         user,
-        uriHelper: ProductQuery.getUriProductHelper(),
+        uriHelper: ProductQuery.getUriProductHelper(
+          productType: ProductType.food,
+        ),
       );
       if (loginStatus == null) {
         return const LoginResult(LoginResultType.serverIssue);

--- a/packages/smooth_app/lib/pages/user_management/forgot_password_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/forgot_password_page.dart
@@ -37,7 +37,9 @@ class _ForgotPasswordPageState extends State<ForgotPasswordPage>
         _userIdController.text,
         country: ProductQuery.getCountry(),
         language: ProductQuery.getLanguage(),
-        uriHelper: ProductQuery.getUriProductHelper(),
+        uriHelper: ProductQuery.getUriProductHelper(
+          productType: ProductType.food,
+        ),
       );
       if (status.status == 200) {
         _send = true;

--- a/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
@@ -336,7 +336,9 @@ class _SignUpPageState extends State<SignUpPage> with TraceableClientMixin {
         orgName: _foodProducer ? _brandController.trimmedText : null,
         country: ProductQuery.getCountry(),
         language: ProductQuery.getLanguage(),
-        uriHelper: ProductQuery.getUriProductHelper(),
+        uriHelper: ProductQuery.getUriProductHelper(
+          productType: ProductType.food,
+        ),
       ),
       title: appLocalisations.sign_up_page_action_doing_it,
     );


### PR DESCRIPTION
### What
- For user login actions (sign up, register, forgot password), now we explicitly go to the "food" server.
- The point is to reduce the number of implicit calls to the food server.

### Part of 
- #5586
