### PR TITLE
feat: 5643 - removed irrelevant editors for non-FOOD products

### DIFF
--- a/packages/smooth_app/lib/helpers/image_field_extension.dart
+++ b/packages/smooth_app/lib/helpers/image_field_extension.dart
@@ -5,12 +5,26 @@ import 'package:smooth_app/generic_lib/buttons/smooth_large_button_with_icon.dar
 import 'package:smooth_app/pages/product/product_image_swipeable_view.dart';
 
 extension ImageFieldSmoothieExtension on ImageField {
-  static const List<ImageField> orderedMain = <ImageField>[
-    ImageField.FRONT,
-    ImageField.INGREDIENTS,
-    ImageField.NUTRITION,
-    ImageField.PACKAGING,
-  ];
+  static List<ImageField> getOrderedMainImageFields(
+    final ProductType? productType,
+  ) =>
+      switch (productType) {
+        ProductType.product => const <ImageField>[
+            ImageField.FRONT,
+            ImageField.PACKAGING,
+          ],
+        ProductType.beauty => const <ImageField>[
+            ImageField.FRONT,
+            ImageField.INGREDIENTS,
+            ImageField.PACKAGING,
+          ],
+        null || ProductType.food || ProductType.petFood => const <ImageField>[
+            ImageField.FRONT,
+            ImageField.INGREDIENTS,
+            ImageField.NUTRITION,
+            ImageField.PACKAGING,
+          ],
+      };
 
   void setUrl(final Product product, final String url) {
     switch (this) {
@@ -31,67 +45,45 @@ extension ImageFieldSmoothieExtension on ImageField {
     }
   }
 
-  String getProductImageButtonText(final AppLocalizations appLocalizations) {
-    switch (this) {
-      case ImageField.FRONT:
-        return appLocalizations.front_photo;
-      case ImageField.INGREDIENTS:
-        return appLocalizations.ingredients_photo;
-      case ImageField.NUTRITION:
-        return appLocalizations.nutrition_facts_photo;
-      case ImageField.PACKAGING:
-        return appLocalizations.packaging_information_photo;
-      case ImageField.OTHER:
-        return appLocalizations.more_photos;
-    }
-  }
+  String getProductImageButtonText(final AppLocalizations appLocalizations) =>
+      switch (this) {
+        ImageField.FRONT => appLocalizations.front_photo,
+        ImageField.INGREDIENTS => appLocalizations.ingredients_photo,
+        ImageField.NUTRITION => appLocalizations.nutrition_facts_photo,
+        ImageField.PACKAGING => appLocalizations.packaging_information_photo,
+        ImageField.OTHER => appLocalizations.more_photos,
+      };
 
   /// Returns a verbose description of the image field.
-  String getImagePageTitle(final AppLocalizations appLocalizations) {
-    switch (this) {
-      case ImageField.FRONT:
-        return appLocalizations.front_packaging_photo_title;
-      case ImageField.INGREDIENTS:
-        return appLocalizations.ingredients_photo_title;
-      case ImageField.NUTRITION:
-        return appLocalizations.nutritional_facts_photo_title;
-      case ImageField.PACKAGING:
-        return appLocalizations.recycling_photo_title;
-      case ImageField.OTHER:
-        return appLocalizations.take_more_photo_title;
-    }
-  }
+  String getImagePageTitle(final AppLocalizations appLocalizations) =>
+      switch (this) {
+        ImageField.FRONT => appLocalizations.front_packaging_photo_title,
+        ImageField.INGREDIENTS => appLocalizations.ingredients_photo_title,
+        ImageField.NUTRITION => appLocalizations.nutritional_facts_photo_title,
+        ImageField.PACKAGING => appLocalizations.recycling_photo_title,
+        ImageField.OTHER => appLocalizations.take_more_photo_title,
+      };
 
   /// Returns a compact description of the image field.
-  String getProductImageTitle(final AppLocalizations appLocalizations) {
-    switch (this) {
-      case ImageField.FRONT:
-        return appLocalizations.product;
-      case ImageField.INGREDIENTS:
-        return appLocalizations.ingredients;
-      case ImageField.NUTRITION:
-        return appLocalizations.nutrition;
-      case ImageField.PACKAGING:
-        return appLocalizations.packaging_information;
-      case ImageField.OTHER:
-        return appLocalizations.more_photos;
-    }
-  }
+  String getProductImageTitle(final AppLocalizations appLocalizations) =>
+      switch (this) {
+        ImageField.FRONT => appLocalizations.product,
+        ImageField.INGREDIENTS => appLocalizations.ingredients,
+        ImageField.NUTRITION => appLocalizations.nutrition,
+        ImageField.PACKAGING => appLocalizations.packaging_information,
+        ImageField.OTHER => appLocalizations.more_photos,
+      };
 
-  String getAddPhotoButtonText(final AppLocalizations appLocalizations) {
-    switch (this) {
-      case ImageField.FRONT:
-        return appLocalizations.front_packaging_photo_button_label;
-      case ImageField.INGREDIENTS:
-        return appLocalizations.ingredients_photo_button_label;
-      case ImageField.NUTRITION:
-        return appLocalizations.nutritional_facts_photo_button_label;
-      case ImageField.PACKAGING:
-        return appLocalizations.recycling_photo_button_label;
-      case ImageField.OTHER:
-        return appLocalizations.take_more_photo_button_label;
-    }
-  }
+  String getAddPhotoButtonText(final AppLocalizations appLocalizations) =>
+      switch (this) {
+        ImageField.FRONT => appLocalizations.front_packaging_photo_button_label,
+        ImageField.INGREDIENTS =>
+          appLocalizations.ingredients_photo_button_label,
+        ImageField.NUTRITION =>
+          appLocalizations.nutritional_facts_photo_button_label,
+        ImageField.PACKAGING => appLocalizations.recycling_photo_button_label,
+        ImageField.OTHER => appLocalizations.take_more_photo_button_label,
+      };
 
   Widget getPhotoButton(
     final BuildContext context,

--- a/packages/smooth_app/lib/helpers/product_cards_helper.dart
+++ b/packages/smooth_app/lib/helpers/product_cards_helper.dart
@@ -246,7 +246,9 @@ List<ProductImageData> getProductMainImagesData(
   final OpenFoodFactsLanguage language,
 ) {
   final List<ProductImageData> result = <ProductImageData>[];
-  for (final ImageField imageField in ImageFieldSmoothieExtension.orderedMain) {
+  for (final ImageField imageField
+      in ImageFieldSmoothieExtension.getOrderedMainImageFields(
+          product.productType)) {
     result.add(getProductImageData(product, imageField, language));
   }
   return result;

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels_builder.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels_builder.dart
@@ -201,9 +201,14 @@ class KnowledgePanelsBuilder {
         if (panel == null) {
           // happened in https://github.com/openfoodfacts/smooth-app/issues/2682
           // due to some inconsistencies in the data sent by the server
-          Logs.w(
-            'unknown panel "$panelId" for barcode "${product.barcode}"',
-          );
+          if (panelId == 'ecoscore' &&
+              (product.productType ?? ProductType.food) != ProductType.food) {
+            // just ignore
+          } else {
+            Logs.w(
+              'unknown panel "$panelId" for barcode "${product.barcode}"',
+            );
+          }
           return null;
         }
         return KnowledgePanelCard(

--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -172,15 +172,17 @@ class _EditProductPageState extends State<EditProductPage> with UpToDateMixin {
                   SimpleInputPageCategoryHelper(),
                 ],
               ),
-              _ListTitleItem(
-                leading: const SvgIcon('assets/cacheTintable/ingredients.svg'),
-                title:
-                    appLocalizations.edit_product_form_item_ingredients_title,
-                onTap: () async => ProductFieldOcrIngredientEditor().edit(
-                  context: context,
-                  product: upToDateProduct,
+              if (upToDateProduct.productType != ProductType.product)
+                _ListTitleItem(
+                  leading:
+                      const SvgIcon('assets/cacheTintable/ingredients.svg'),
+                  title:
+                      appLocalizations.edit_product_form_item_ingredients_title,
+                  onTap: () async => ProductFieldOcrIngredientEditor().edit(
+                    context: context,
+                    product: upToDateProduct,
+                  ),
                 ),
-              ),
               if (upToDateProduct.productType == null ||
                   upToDateProduct.productType == ProductType.food)
                 _getSimpleListTileItem(SimpleInputPageCategoryHelper())

--- a/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
@@ -39,6 +39,7 @@ class ProductImageGalleryView extends StatefulWidget {
 class _ProductImageGalleryViewState extends State<ProductImageGalleryView>
     with UpToDateMixin {
   late OpenFoodFactsLanguage _language;
+  late final List<ImageField> _mainImageFields;
   bool _clickedOtherPictureButton = false;
 
   @override
@@ -46,6 +47,9 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView>
     super.initState();
     initUpToDate(widget.product, context.read<LocalDatabase>());
     _language = ProductQuery.getLanguage();
+    _mainImageFields = ImageFieldSmoothieExtension.getOrderedMainImageFields(
+      widget.product.productType,
+    );
   }
 
   @override
@@ -113,11 +117,12 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView>
                         (BuildContext context, int index) {
                           return _PhotoRow(
                             position: index,
+                            imageField: _mainImageFields[index],
                             product: upToDateProduct,
                             language: _language,
                           );
                         },
-                        childCount: 4,
+                        childCount: _mainImageFields.length,
                       ),
                     ),
                     SliverPadding(
@@ -187,15 +192,16 @@ class _PhotoRow extends StatelessWidget {
     required this.position,
     required this.product,
     required this.language,
+    required this.imageField,
   });
 
   final int position;
   final Product product;
   final OpenFoodFactsLanguage language;
+  final ImageField imageField;
 
   @override
   Widget build(BuildContext context) {
-    final ImageField imageField = _getImageField(position);
     final TransientFile transientFile = _getTransientFile(imageField);
 
     final bool expired = transientFile.expired;
@@ -293,7 +299,4 @@ class _PhotoRow extends StatelessWidget {
         imageField,
         language,
       );
-
-  ImageField _getImageField(final int index) =>
-      ImageFieldSmoothieExtension.orderedMain[index];
 }

--- a/packages/smooth_app/lib/pages/product/product_image_swipeable_view.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_swipeable_view.dart
@@ -65,7 +65,9 @@ class _ProductImageSwipeableViewState extends State<ProductImageSwipeableView>
     if (widget.imageField != null) {
       _imageFields = <ImageField>[widget.imageField!];
     } else {
-      _imageFields = ImageFieldSmoothieExtension.orderedMain;
+      _imageFields = ImageFieldSmoothieExtension.getOrderedMainImageFields(
+        widget.product.productType,
+      );
     }
   }
 


### PR DESCRIPTION
### What
* now the main image fields depend on product type (e.g. no nutrition and ingredients for PRODUCTS)
* no ingredient editor for PRODUCTS in the edit product page
* one single editor page for new found products that are not FOOD

### Screenshots
| PRODUCTS (no ingredients, no nutrition) | BEAUTY (no nutrition) |
| -- | -- |
| ![Screenshot_1727971782](https://github.com/user-attachments/assets/a35a97ba-44f4-4f5b-9745-8d9671172d3a) | ![Screenshot_1727972267](https://github.com/user-attachments/assets/55a1ea37-e2c6-4f94-a636-0e3351c336c3) |
| ![Screenshot_1727971771](https://github.com/user-attachments/assets/9d57cc5c-b303-44de-971d-e31718f97bee) | ![Screenshot_1727972249](https://github.com/user-attachments/assets/e16f2357-024a-4f92-bd1d-43b1f06a81e6) |
| ![Screenshot_1727978217](https://github.com/user-attachments/assets/610abce9-1b01-4435-982c-b6775be3c634) | ![Screenshot_1727974797](https://github.com/user-attachments/assets/749000a0-14e5-4929-92e2-dc5ef6c01b26) |
| ![Screenshot_1727978222](https://github.com/user-attachments/assets/316551ae-fbe7-4f03-a4ab-51f40eb4e90b) | ![Screenshot_1727975824](https://github.com/user-attachments/assets/09211b13-6476-4850-b0d7-e24e21ccb5b1) |

### Part of 
- #5643

### Impacted files
* `add_new_product_page.dart`: editors different when not FOOD; minor refactoring
* `edit_product_page.dart`: no ingredient editor for PRODUCTS
* `image_field_extension.dart`: now the main image fields depend on product type; minor refactoring (more compact `switch` syntax)
* `knowledge_panels_builder.dart`: minor fix
* `product_cards_helper.dart`: now the main image fields depend on product type
* `product_image_gallery_view.dart`: now the main image fields depend on product type
* `product_image_swipeable_view.dart`: now the main image fields depend on product type