### PR TITLE
fix: 5665 - display "add nutrition facts" button only for relevant types

### DIFF
--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_action_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_action_card.dart
@@ -65,7 +65,9 @@ class KnowledgePanelActionCard extends StatelessWidget {
       );
     }
     if (kpAction == KnowledgePanelAction.addNutritionFacts) {
-      return AddNutritionButton(product);
+      if (AddNutritionButton.acceptsNutritionFacts(product)) {
+        return AddNutritionButton(product);
+      }
     }
     Logs.e('unhandled knowledge panel action: $action');
     return null;

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels_builder.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels_builder.dart
@@ -65,7 +65,9 @@ class KnowledgePanelsBuilder {
                 ProductState.NUTRITION_FACTS_COMPLETED.toBeCompletedTag) ??
             false;
         if (nutritionAddOrUpdate) {
-          children.add(AddNutritionButton(product));
+          if (AddNutritionButton.acceptsNutritionFacts(product)) {
+            children.add(AddNutritionButton(product));
+          }
         }
 
         final bool needEditIngredients = context

--- a/packages/smooth_app/lib/pages/product/add_nutrition_button.dart
+++ b/packages/smooth_app/lib/pages/product/add_nutrition_button.dart
@@ -10,6 +10,10 @@ class AddNutritionButton extends StatelessWidget {
 
   final Product product;
 
+  static bool acceptsNutritionFacts(final Product product) =>
+      product.productType != ProductType.product &&
+      product.productType != ProductType.beauty;
+
   @override
   Widget build(BuildContext context) => addPanelButton(
         AppLocalizations.of(context).score_add_missing_nutrition_facts,

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -1829,4 +1829,4 @@ packages:
     version: "3.1.2"
 sdks:
   dart: ">=3.5.3 <4.0.0"
-  flutter: ">=3.22.0"
+  flutter: ">=3.24.0"


### PR DESCRIPTION
### What
- Now we don't display "add nutrition facts" button for irrelevant product types.

### Fixes bug(s)
- Fixes: #5665

### Impacted files
* `add_nutrition_button.dart`: new method to check if nutrition facts are relevant for this product type
* `knowledge_panel_action_card.dart`: checks if the product type matches before displaying the nutrition facts button
* `knowledge_panels_builder.dart`: checks if the product type matches before displaying the nutrition facts button
* `pubspec.lock`: upgrade to flutter `3.24`