### PR TITLE
fix: 5634 - refresh of price lazy counters when accessing lists

### DIFF
--- a/packages/smooth_app/lib/data_models/preferences/user_preferences.dart
+++ b/packages/smooth_app/lib/data_models/preferences/user_preferences.dart
@@ -176,8 +176,20 @@ class UserPreferences extends ChangeNotifier {
 
   String _getLazyCountTag(final String tag) => '$_TAG_LAZY_COUNT_PREFIX$tag';
 
-  Future<void> setLazyCount(final int value, final String suffixTag) async =>
-      _sharedPreferences.setInt(_getLazyCountTag(suffixTag), value);
+  Future<void> setLazyCount(
+    final int value,
+    final String suffixTag, {
+    required final bool notify,
+  }) async {
+    final int? oldValue = getLazyCount(suffixTag);
+    if (value == oldValue) {
+      return;
+    }
+    await _sharedPreferences.setInt(_getLazyCountTag(suffixTag), value);
+    if (notify) {
+      notifyListeners();
+    }
+  }
 
   int? getLazyCount(final String suffixTag) =>
       _sharedPreferences.getInt(_getLazyCountTag(suffixTag));

--- a/packages/smooth_app/lib/pages/preferences/lazy_counter.dart
+++ b/packages/smooth_app/lib/pages/preferences/lazy_counter.dart
@@ -16,9 +16,14 @@ abstract class LazyCounter {
   /// Sets the value cached locally;
   Future<void> setLocalCount(
     final int value,
-    final UserPreferences userPreferences,
-  ) =>
-      userPreferences.setLazyCount(value, getSuffixTag());
+    final UserPreferences userPreferences, {
+    required final bool notify,
+  }) =>
+      userPreferences.setLazyCount(
+        value,
+        getSuffixTag(),
+        notify: notify,
+      );
 
   /// Returns the suffix tag used to cache the value locally;
   @protected

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_account.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_account.dart
@@ -276,6 +276,7 @@ class UserPreferencesAccount extends AbstractUserPreferences {
                   uriHelper: ProductQuery.uriPricesHelper,
                 ),
                 title: appLocalizations.all_search_prices_latest_title,
+                lazyCounterPrices: const LazyCounterPrices(null),
               ),
             ),
           ),

--- a/packages/smooth_app/lib/pages/prices/get_prices_model.dart
+++ b/packages/smooth_app/lib/pages/prices/get_prices_model.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/pages/preferences/lazy_counter.dart';
 import 'package:smooth_app/pages/prices/price_meta_product.dart';
 import 'package:smooth_app/pages/prices/product_price_add_page.dart';
 import 'package:smooth_app/query/product_query.dart';
@@ -13,6 +14,7 @@ class GetPricesModel {
     required this.displayProduct,
     required this.uri,
     required this.title,
+    this.lazyCounterPrices,
     this.enableCountButton = true,
     this.subtitle,
     this.addButton,
@@ -83,6 +85,9 @@ class GetPricesModel {
 
   /// "Enable the count button?". Typically "false" for product price pages.
   final bool enableCountButton;
+
+  /// Lazy Counter to refresh.
+  final LazyCounterPrices? lazyCounterPrices;
 
   static const int pageSize = 10;
 }

--- a/packages/smooth_app/lib/pages/prices/price_user_button.dart
+++ b/packages/smooth_app/lib/pages/prices/price_user_button.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/pages/preferences/lazy_counter.dart';
 import 'package:smooth_app/pages/prices/get_prices_model.dart';
 import 'package:smooth_app/pages/prices/price_button.dart';
 import 'package:smooth_app/pages/prices/prices_page.dart';
@@ -46,6 +47,7 @@ class PriceUserButton extends StatelessWidget {
               ),
               title: showUserTitle(user: user, context: context),
               subtitle: user,
+              lazyCounterPrices: LazyCounterPrices(user),
             ),
           ),
         ),

--- a/packages/smooth_app/lib/pages/prices/product_prices_list.dart
+++ b/packages/smooth_app/lib/pages/prices/product_prices_list.dart
@@ -1,7 +1,11 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:provider/provider.dart';
+import 'package:smooth_app/data_models/preferences/user_preferences.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/pages/prices/get_prices_model.dart';
@@ -50,6 +54,15 @@ class _ProductPricesListState extends State<ProductPricesList>
             return Text(snapshot.data!.error!);
           }
           final GetPricesResult result = snapshot.data!.value;
+          if (widget.model.lazyCounterPrices != null && result.total != null) {
+            unawaited(
+              widget.model.lazyCounterPrices!.setLocalCount(
+                result.total!,
+                context.read<UserPreferences>(),
+                notify: true,
+              ),
+            );
+          }
           // highly improbable
           if (result.items == null) {
             return const Text('empty list');


### PR DESCRIPTION
### What
- About a month ago, we switched to "lazy" counts (e.g. my prices) for the user page: we count only the very first time, or on demand (refresh button).
- That brings incoherence when we go to the list page and then back to the "counts" page: the lazy count was not explicitly refreshed and kept its old value.
- The purpose of this PR is to refresh the price lazy counts each time we go to the corresponding list page (that of course computes the latest counts).

### Screenshots
For "Derniers prix ajoutés" = latest added prices
| lazy 34441 | displayed list | refreshed lazy 37199 |
| -- | -- | -- |
| ![Screenshot_20241009_094803](https://github.com/user-attachments/assets/76a0110a-4952-44ef-b132-b5267ad8deaa) | ![Screenshot_20241009_094823](https://github.com/user-attachments/assets/dbdee241-6df2-40f5-841d-839f94fc520e) | ![Screenshot_20241009_094837](https://github.com/user-attachments/assets/d36ee98a-9f4a-4f78-97fd-9c7d522c9238) |

### Fixes bug(s)
- Fixes: #5634

### Impacted files
* `get_prices_model.dart`: added a `LazyCounterPrices?` parameter
* `lazy_counter.dart`: added a `bool notify` parameter
* `lazy_counter_widget.dart`: now refreshed by "external" new count
* `price_user_button.dart`: added a `LazyCounterPrices` parameter to have the counter refreshed
* `product_prices_list.dart`: now setting the lazy counter when displaying the list
* `user_preferences.dart`: added a `bool notify` parameter for the lazy counter setter
* `user_preferences_account.dart`: added a `LazyCounterPrices` parameter to have the counter refreshed