### PR TITLE
fix: 5682 - "Connection timed out" as possible gentle error for svg files

### DIFF
--- a/packages/smooth_app/lib/cards/category_cards/svg_safe_network.dart
+++ b/packages/smooth_app/lib/cards/category_cards/svg_safe_network.dart
@@ -125,11 +125,21 @@ class _SvgSafeNetworkState extends State<SvgSafeNetwork> {
             }
           }
           if (snapshot.error != null) {
-            final bool serverOrConnectionIssue =
-                snapshot.error.toString().contains("Failed host lookup: '");
-            if (!serverOrConnectionIssue) {
+            if (snapshot.error.toString().contains("Failed host lookup: '")) {
+              Logs.w(
+                'Failed host lookup for "$_url"',
+                ex: snapshot.error,
+              );
+            } else if (snapshot.error
+                .toString()
+                .contains('Connection timed out')) {
+              Logs.w(
+                'Connection timed out for "$_url"',
+                ex: snapshot.error,
+              );
+            } else {
               Logs.e(
-                'Could not download "$_url"',
+                'Could really not download "$_url"',
                 ex: snapshot.error,
               );
             }


### PR DESCRIPTION
### What
- Now we consider "Connection timed out" errors as mere warnings when we download svg files.
- Same as "Failed host lookup" (cf. #5104).

### Fixes bug(s)
- Fixes: #5682