### PR TITLE
fix: 5681 - startActivityAndCollapse + android 14

### DIFF
--- a/packages/smooth_app/android/app/src/main/kotlin/org/openfoodfacts/app/AppMainTile.kt
+++ b/packages/smooth_app/android/app/src/main/kotlin/org/openfoodfacts/app/AppMainTile.kt
@@ -1,5 +1,6 @@
 package org.openfoodfacts.app
 
+import android.app.PendingIntent
 import android.content.Intent
 import android.os.Build
 import android.service.quicksettings.Tile
@@ -27,7 +28,7 @@ class AppMainTile : TileService() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
             startActivityAndCollapse(
                 PendingIntent.getActivity(
-                    appContext,
+                    applicationContext,
                     0,
                     intent,
                     PendingIntent.FLAG_IMMUTABLE

--- a/packages/smooth_app/android/app/src/main/kotlin/org/openfoodfacts/app/AppMainTile.kt
+++ b/packages/smooth_app/android/app/src/main/kotlin/org/openfoodfacts/app/AppMainTile.kt
@@ -24,7 +24,18 @@ class AppMainTile : TileService() {
             flags += Intent.FLAG_ACTIVITY_NEW_TASK
         }
 
-        startActivityAndCollapse(intent)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            startActivityAndCollapse(
+                PendingIntent.getActivity(
+                    appContext,
+                    0,
+                    intent,
+                    PendingIntent.FLAG_IMMUTABLE
+                )
+            )
+        } else {
+            startActivityAndCollapse(intent)
+        }
     }
 
 }


### PR DESCRIPTION
### What
- Looks like we use a kotlin method deprecated in android 14.
- That said, I don't even know what a tile is.
- cf. https://stackoverflow.com/questions/77547985/launch-an-activity-from-tileservice-for-android-14-is-not-allowed

### Fixes bug(s)
- Fixes: #5681