### PR TITLE
fix: 5693 - able to run tasks without minimum duration wait

### DIFF
--- a/packages/smooth_app/lib/background/background_task_manager.dart
+++ b/packages/smooth_app/lib/background/background_task_manager.dart
@@ -161,15 +161,8 @@ class BackgroundTaskManager {
   /// `forceNowIfPossible = true`
   /// 2. we're just checking casually if there are pending tasks
   /// `forceNowIfPossible = false`
-  void run({final bool forceNowIfPossible = false}) {
-    final int? now = _canStartNow(forceNowIfPossible);
-    if (now == null) {
-      return;
-    }
-    // we need to put _running = true there in order to avoid async side-effects
-    _running = true;
-    unawaited(_runAsync(now));
-  }
+  void run({final bool forceNowIfPossible = false}) =>
+      unawaited(_runAsync(forceNowIfPossible));
 
   /// Runs all the pending tasks, and then smoothly ends.
   ///
@@ -178,7 +171,13 @@ class BackgroundTaskManager {
   /// If a task fails and another task with the same stamp comes after,
   /// we can remove the failed task from the list: it would have been
   /// overwritten anyway.
-  Future<void> _runAsync(final int now) async {
+  Future<void> _runAsync(final bool forceNowIfPossible) async {
+    final int? now = _canStartNow(forceNowIfPossible);
+    if (now == null) {
+      return;
+    }
+    _running = true;
+
     /// Will also set the "latest start timestamp".
     /// With this, we can detect a run that went wrong.
     /// Like, still running 1 hour later.

--- a/packages/smooth_app/lib/background/background_task_manager.dart
+++ b/packages/smooth_app/lib/background/background_task_manager.dart
@@ -107,10 +107,9 @@ class BackgroundTaskManager {
   /// With [forceNowIfPossible] we can be more aggressive and force the decision
   /// of running now or at least just after the current running block.
   int? _canStartNow(final bool forceNowIfPossible) {
-    final DaoInt daoInt = DaoInt(localDatabase);
     final int now = LocalDatabase.nowInMillis();
-    final int? latestRunStart = daoInt.get(_lastStartTimestampKey);
-    final int? latestRunStop = daoInt.get(_lastStopTimestampKey);
+    final int? latestRunStart = localDatabase.daoIntGet(_lastStartTimestampKey);
+    final int? latestRunStop = localDatabase.daoIntGet(_lastStopTimestampKey);
     if (_running) {
       // if pretending to be running but started a very very long time ago
       if (latestRunStart != null &&
@@ -142,8 +141,8 @@ class BackgroundTaskManager {
 
   /// Signals we've just finished working and that we're ready for a new run.
   Future<void> _justFinished() async {
-    await DaoInt(localDatabase).put(_lastStartTimestampKey, null);
-    await DaoInt(localDatabase).put(
+    await localDatabase.daoIntPut(_lastStartTimestampKey, null);
+    await localDatabase.daoIntPut(
       _lastStopTimestampKey,
       LocalDatabase.nowInMillis(),
     );
@@ -181,8 +180,7 @@ class BackgroundTaskManager {
     /// Will also set the "latest start timestamp".
     /// With this, we can detect a run that went wrong.
     /// Like, still running 1 hour later.
-    final DaoInt daoInt = DaoInt(localDatabase);
-    await daoInt.put(_lastStartTimestampKey, now);
+    await localDatabase.daoIntPut(_lastStartTimestampKey, now);
     bool runAgain = true;
     while (runAgain) {
       runAgain = false;

--- a/packages/smooth_app/lib/background/background_task_manager.dart
+++ b/packages/smooth_app/lib/background/background_task_manager.dart
@@ -40,7 +40,7 @@ class BackgroundTaskManager {
     );
     await DaoStringList(localDatabase).add(DaoStringList.keyTasks, taskId);
     await task.preExecute(localDatabase);
-    run();
+    run(forceNowIfPossible: true);
   }
 
   /// Finishes a task cleanly.
@@ -103,7 +103,10 @@ class BackgroundTaskManager {
   static const int _minimumDurationBetweenRuns = 5 * 1000;
 
   /// Returns the "now" timestamp if we can run now, or `null`.
-  int? _canStartNow() {
+  ///
+  /// With [forceNowIfPossible] we can be more aggressive and force the decision
+  /// of running now or at least just after the current running block.
+  int? _canStartNow(final bool forceNowIfPossible) {
     final DaoInt daoInt = DaoInt(localDatabase);
     final int now = LocalDatabase.nowInMillis();
     final int? latestRunStart = daoInt.get(_lastStartTimestampKey);
@@ -115,6 +118,10 @@ class BackgroundTaskManager {
         // we assume we can run now.
         return now;
       }
+      // let's try again at the end of the current run.
+      if (forceNowIfPossible) {
+        _forceRunAgain = true;
+      }
       return null;
     }
     // if the last run stopped correctly or was started a long time ago.
@@ -123,7 +130,10 @@ class BackgroundTaskManager {
       // if the last run stopped not enough time ago.
       if (latestRunStop != null &&
           latestRunStop + _minimumDurationBetweenRuns >= now) {
-        return null;
+        // let's apply that minimum duration if there's no rush
+        if (!forceNowIfPossible) {
+          return null;
+        }
       }
       return now;
     }
@@ -141,10 +151,24 @@ class BackgroundTaskManager {
 
   bool _running = false;
 
+  /// Flag to say: I know you're running, please try again, it's worth it.
+  bool _forceRunAgain = false;
+
   /// Runs all the pending tasks, and then smoothly ends, without awaiting.
-  void run() {
-    // no await
-    _runAsync();
+  ///
+  /// Can be called in 2 cases:
+  /// 1. we've just created a task and we really want it to be executed ASAP
+  /// `forceNowIfPossible = true`
+  /// 2. we're just checking casually if there are pending tasks
+  /// `forceNowIfPossible = false`
+  void run({final bool forceNowIfPossible = false}) {
+    final int? now = _canStartNow(forceNowIfPossible);
+    if (now == null) {
+      return;
+    }
+    // we need to put _running = true there in order to avoid async side-effects
+    _running = true;
+    unawaited(_runAsync(now));
   }
 
   /// Runs all the pending tasks, and then smoothly ends.
@@ -154,14 +178,7 @@ class BackgroundTaskManager {
   /// If a task fails and another task with the same stamp comes after,
   /// we can remove the failed task from the list: it would have been
   /// overwritten anyway.
-  Future<void> _runAsync() async {
-    final int? now = _canStartNow();
-    if (now == null) {
-      return;
-    }
-    _running = true;
-
-    ///
+  Future<void> _runAsync(final int now) async {
     /// Will also set the "latest start timestamp".
     /// With this, we can detect a run that went wrong.
     /// Like, still running 1 hour later.
@@ -196,6 +213,12 @@ class BackgroundTaskManager {
         }
       }
       await _justFinished();
+      if (!runAgain) {
+        if (_forceRunAgain) {
+          runAgain = true;
+          _forceRunAgain = false;
+        }
+      }
     }
     _running = false;
   }

--- a/packages/smooth_app/lib/database/local_database.dart
+++ b/packages/smooth_app/lib/database/local_database.dart
@@ -51,6 +51,13 @@ class LocalDatabase extends ChangeNotifier {
   List<String> getAllTaskIds() =>
       DaoStringList(this).getAll(DaoStringList.keyTasks);
 
+  /// Ugly solution to be able to mock hive data.
+  int? daoIntGet(final String key) => DaoInt(this).get(key);
+
+  /// Ugly solution to be able to mock hive data.
+  Future<void> daoIntPut(final String key, final int? value) =>
+      DaoInt(this).put(key, value);
+
   static Future<LocalDatabase> getLocalDatabase() async {
     // sql from there
     String? databasesRootPath;

--- a/packages/smooth_app/lib/pages/offline_tasks_page.dart
+++ b/packages/smooth_app/lib/pages/offline_tasks_page.dart
@@ -32,7 +32,9 @@ class _OfflineTaskState extends State<OfflineTaskPage> {
         actions: <Widget>[
           IconButton(
             onPressed: () =>
-                BackgroundTaskManager.getInstance(localDatabase).run(),
+                BackgroundTaskManager.getInstance(localDatabase).run(
+              forceNowIfPossible: true,
+            ),
             icon: const Icon(Icons.refresh),
           ),
         ],

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_page.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_page.dart
@@ -5,9 +5,11 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:provider/provider.dart';
+import 'package:smooth_app/background/background_task_manager.dart';
 import 'package:smooth_app/data_models/preferences/user_preferences.dart';
 import 'package:smooth_app/data_models/product_preferences.dart';
 import 'package:smooth_app/data_models/user_management_provider.dart';
+import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_back_button.dart';
 import 'package:smooth_app/helpers/app_helper.dart';
@@ -44,6 +46,8 @@ enum PreferencePageType {
     required final UserPreferences userPreferences,
     required final BuildContext context,
   }) {
+    final LocalDatabase localDatabase = context.read<LocalDatabase>();
+    BackgroundTaskManager.getInstance(localDatabase).run();
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final ThemeProvider themeProvider = context.read<ThemeProvider>();
     final ThemeData themeData = Theme.of(context);

--- a/packages/smooth_app/test/dialogs/generic_lib/dialogs_test.dart
+++ b/packages/smooth_app/test/dialogs/generic_lib/dialogs_test.dart
@@ -14,6 +14,7 @@ import 'package:smooth_app/themes/contrast_provider.dart';
 import 'package:smooth_app/themes/theme_provider.dart';
 
 import '../../tests_utils/goldens.dart';
+import '../../tests_utils/local_database_mock.dart';
 import '../../tests_utils/mocks.dart';
 
 void main() {
@@ -72,6 +73,7 @@ void main() {
                   const UserPreferencesPage(
                     type: PreferencePageType.CONTRIBUTE,
                   ),
+                  localDatabase: MockLocalDatabase(),
                 ),
               );
               await tester.pumpAndSettle();

--- a/packages/smooth_app/test/tests_utils/local_database_mock.dart
+++ b/packages/smooth_app/test/tests_utils/local_database_mock.dart
@@ -2,6 +2,15 @@ import 'package:mockito/mockito.dart';
 import 'package:smooth_app/database/local_database.dart';
 
 class MockLocalDatabase extends Mock implements LocalDatabase {
+  final Map<String, int?> _daoInt = <String, int?>{};
+
   @override
   List<String> getAllTaskIds() => <String>[];
+
+  @override
+  int? daoIntGet(final String key) => _daoInt[key];
+
+  @override
+  Future<void> daoIntPut(final String key, final int? value) async =>
+      _daoInt[key] = value;
 }

--- a/packages/smooth_app/test/users/forgot_password_page_layout_test.dart
+++ b/packages/smooth_app/test/users/forgot_password_page_layout_test.dart
@@ -11,6 +11,7 @@ import 'package:smooth_app/themes/contrast_provider.dart';
 import 'package:smooth_app/themes/theme_provider.dart';
 
 import '../tests_utils/goldens.dart';
+import '../tests_utils/local_database_mock.dart';
 import '../tests_utils/mocks.dart';
 
 void main() {
@@ -51,6 +52,7 @@ void main() {
             textContrastProvider,
             colorProvider,
             const ForgotPasswordPage(),
+            localDatabase: MockLocalDatabase(),
           ),
         );
         await tester.pump();

--- a/packages/smooth_app/test/users/login_page_layout_test.dart
+++ b/packages/smooth_app/test/users/login_page_layout_test.dart
@@ -11,6 +11,7 @@ import 'package:smooth_app/themes/contrast_provider.dart';
 import 'package:smooth_app/themes/theme_provider.dart';
 
 import '../tests_utils/goldens.dart';
+import '../tests_utils/local_database_mock.dart';
 import '../tests_utils/mocks.dart';
 
 void main() {
@@ -51,6 +52,7 @@ void main() {
             textContrastProvider,
             colorProvider,
             const LoginPage(),
+            localDatabase: MockLocalDatabase(),
           ),
         );
         await tester.pump();

--- a/packages/smooth_app/test/users/signup_page_layout_test.dart
+++ b/packages/smooth_app/test/users/signup_page_layout_test.dart
@@ -11,6 +11,7 @@ import 'package:smooth_app/themes/contrast_provider.dart';
 import 'package:smooth_app/themes/theme_provider.dart';
 
 import '../tests_utils/goldens.dart';
+import '../tests_utils/local_database_mock.dart';
 import '../tests_utils/mocks.dart';
 
 void main() {
@@ -51,6 +52,7 @@ void main() {
             textContrastProvider,
             colorProvider,
             const SignUpPage(),
+            localDatabase: MockLocalDatabase(),
           ),
         );
         await tester.pump();


### PR DESCRIPTION
### What
- There was an obvious specific case about background tasks that wasn't dealt with properly.
- The goal of the background task manager is to
  - add tasks to a queue
  - execute them one by one
  - restart them later if they failed (e.g. no internet or server down)
- Very often in the code, we ask the manager to run again, and most of the time nothing is done as there are no tasks in the queue.
- In order to prevent all the process of managing the queue and all the tasks reordering from happening too often, we say something like "hey, we've just tried less than 5 seconds ago, we'll try later".
- The thing is there are
  - cases when we don't really care ("oh I've opened a product page, let's see if there are pending tasks, just in case")
  - and cases when we do care ('hey I've just added prices/created the related task, let's run that ASAP")
- The point of this PR is to be able to say "hey, this time I do care", thanks to a new parameter when running the manager.
- More specifically about the issue, in the process of adding a task we stored the task and then ran the manager. The problem is that when we store the task we automatically do run the manager _before it's ready_, and then run it milliseconds later when it says "oh, I'm already running, I'm going to ignore your call". Therefore, now you can say "it's an important call", and have the task run ASAP.

### Fixes bug(s)
- Fixes: #5693

### Impacted files
* `background_task_manager.dart`: made it possible to force an immediate run if possible
* `offline_tasks_page.dart`: force an immediate run if possible when clicking on the refresh button