### PR TITLE
feat: 5700 - no click for KP title without additional elements

### DIFF
--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_card.dart
@@ -43,11 +43,18 @@ class KnowledgePanelCard extends StatelessWidget {
       );
     }
 
+    // in some cases there's nothing to click about.
+    // cf. https://github.com/openfoodfacts/smooth-app/issues/5700
+    final bool improvedIsClickable = isClickable &&
+        KnowledgePanelsBuilder.hasSomethingToDisplay(
+          product,
+          panelId,
+        );
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: SMALL_SPACE),
       child: InkWell(
         borderRadius: ANGULAR_BORDER_RADIUS,
-        onTap: !isClickable
+        onTap: !improvedIsClickable
             ? null
             : () async => Navigator.push<Widget>(
                   context,
@@ -64,7 +71,7 @@ class KnowledgePanelCard extends StatelessWidget {
                 ),
         child: KnowledgePanelsBuilder.getPanelSummaryWidget(
               panel,
-              isClickable: isClickable,
+              isClickable: improvedIsClickable,
               margin: EdgeInsets.zero,
             ) ??
             const SizedBox(),

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels_builder.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels_builder.dart
@@ -149,6 +149,24 @@ class KnowledgePanelsBuilder {
     return elements.first;
   }
 
+  /// Returns true if there are elements to display for that panel.
+  static bool hasSomethingToDisplay(
+    final Product product,
+    final String panelId,
+  ) {
+    final KnowledgePanel panel =
+        KnowledgePanelsBuilder.getKnowledgePanel(product, panelId)!;
+    if (panel.elements == null) {
+      return false;
+    }
+    for (final KnowledgePanelElement element in panel.elements!) {
+      if (_hasSomethingToDisplay(element: element, product: product)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   /// Returns a padded widget that displays the KP element, or rarely null.
   static Widget? getElementWidget({
     required final KnowledgePanelElement knowledgePanelElement,
@@ -178,6 +196,8 @@ class KnowledgePanelsBuilder {
   }
 
   /// Returns the widget that displays the KP element, or rarely null.
+  ///
+  /// cf. [_hasSomethingToDisplay].
   static Widget? _getElementWidget({
     required final KnowledgePanelElement element,
     required final Product product,
@@ -242,10 +262,33 @@ class KnowledgePanelsBuilder {
           element.actionElement!,
           product,
         );
+    }
+  }
 
-      default:
-        Logs.e('unexpected element type: ${element.elementType}');
-        return null;
+  /// Returns true if the element has something to display.
+  ///
+  /// cf. [_getElementWidget].
+  static bool _hasSomethingToDisplay({
+    required final KnowledgePanelElement element,
+    required final Product product,
+  }) {
+    switch (element.elementType) {
+      case KnowledgePanelElementType.TEXT:
+      case KnowledgePanelElementType.IMAGE:
+      case KnowledgePanelElementType.PANEL_GROUP:
+      case KnowledgePanelElementType.TABLE:
+      case KnowledgePanelElementType.MAP:
+      case KnowledgePanelElementType.ACTION:
+        return true;
+      case KnowledgePanelElementType.UNKNOWN:
+        return false;
+      case KnowledgePanelElementType.PANEL:
+        final String panelId = element.panelElement!.panelId;
+        final KnowledgePanel? panel = getKnowledgePanel(product, panelId);
+        if (panel == null) {
+          return false;
+        }
+        return true;
     }
   }
 


### PR DESCRIPTION
### What
- Now we check if a KP title has additional elements to display.
- If not, we don't make it clickable - no tap action, no forward arrow.

### Fixes bug(s)
- Fixes: #5700

### Impacted files
* `knowledge_panel_card.dart`: overrides the "isClickable" parameter in case there are eventually no further elements to display
* `knowledge_panels_builder.dart`: new helper methods