### PR TITLE
fix: The last "Authorise" button on the onboarding now working

### DIFF
--- a/packages/smooth_app/lib/pages/navigator/app_navigator.dart
+++ b/packages/smooth_app/lib/pages/navigator/app_navigator.dart
@@ -72,6 +72,13 @@ class AppNavigator extends InheritedWidget {
     _router.router.pushReplacement(routeName, extra: extra);
   }
 
+  /// Remove all the screens from the stack
+  void clearStack() {
+    while (_router.router.canPop() == true) {
+      _router.router.pop();
+    }
+  }
+
   void pop([dynamic result]) {
     _router.router.pop(result);
   }
@@ -286,7 +293,7 @@ class _SmoothGoRouter {
               externalLink = true;
             }
           } else if (path == _ExternalRoutes.MOBILE_APP_DOWNLOAD) {
-            return AppRoutes.HOME;
+            return AppRoutes.HOME();
           } else if (path == _ExternalRoutes.GUIDE_NUTRISCORE_V2) {
             return AppRoutes.GUIDE_NUTRISCORE_V2;
           } else if (path == _ExternalRoutes.SIGNUP) {
@@ -421,7 +428,8 @@ class AppRoutes {
   AppRoutes._();
 
   // Home page (or walkthrough during the onboarding)
-  static String get HOME => _InternalAppRoutes.HOME_PAGE;
+  static String HOME({bool redraw = false}) =>
+      '${_InternalAppRoutes.HOME_PAGE}?redraw:$redraw';
 
   // Product details (a [Product] is mandatory in the extra)
   static String PRODUCT(

--- a/packages/smooth_app/lib/pages/onboarding/onboarding_flow_navigator.dart
+++ b/packages/smooth_app/lib/pages/onboarding/onboarding_flow_navigator.dart
@@ -139,16 +139,23 @@ class OnboardingFlowNavigator {
   static final List<OnboardingPage> _historyOnboardingNav = <OnboardingPage>[];
 
   Future<void> navigateToPage(BuildContext context, OnboardingPage page) async {
-    _userPreferences.setLastVisitedOnboardingPage(page);
+    await _userPreferences.setLastVisitedOnboardingPage(page);
     _historyOnboardingNav.add(page);
 
-    final MaterialPageRoute<void> route = MaterialPageRoute<void>(
-      builder: (BuildContext context) => page.getPageWidget(context),
-    );
+    if (!context.mounted) {
+      return;
+    }
 
     if (page.isOnboardingComplete()) {
-      AppNavigator.of(context).pushReplacement(AppRoutes.HOME);
+      AppNavigator.of(context)
+        ..clearStack()
+        ..pushReplacement(
+          AppRoutes.HOME(redraw: true),
+        );
     } else {
+      final MaterialPageRoute<void> route = MaterialPageRoute<void>(
+        builder: (BuildContext context) => page.getPageWidget(context),
+      );
       await Navigator.of(context).push<void>(route);
     }
   }


### PR DESCRIPTION
Hi everyone!

The "Authorise" button in the Consent screen (on the onboarding) was visually broken.
Actually, the `build` method of the "real" Homepage was called… but never displayed.

The main issue is that the onboarding is mixing Navigator v1 and v2 calls.
Thus, the onboarding is considered as the "/" route, which is the same as the "real" homepage.

The trick is to have a difference between the two screens + manually clear the stack.