### PR TITLE
feat: The JSON of the tagline is now hosted on Github

### DIFF
--- a/packages/smooth_app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/smooth_app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -19,8 +19,9 @@ import rive_common
 import sentry_flutter
 import share_plus
 import shared_preferences_foundation
-import sqflite
+import sqflite_darwin
 import url_launcher_macos
+import webview_flutter_wkwebview
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AudioplayersDarwinPlugin.register(with: registry.registrar(forPlugin: "AudioplayersDarwinPlugin"))
@@ -39,4 +40,5 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
+  FLTWebViewFlutterPlugin.register(with: registry.registrar(forPlugin: "FLTWebViewFlutterPlugin"))
 }


### PR DESCRIPTION
Hi everyone!

To ease the hosting of static files/assets for the app, there is now a separate repo: https://github.com/openfoodfacts/smooth-app_assets

We start here with the tagline.
It should reduce a bit the load on the server.
