### PR TITLE
fix: Fix regressions after Material 3 migration

### DIFF
--- a/packages/smooth_app/lib/pages/page_manager.dart
+++ b/packages/smooth_app/lib/pages/page_manager.dart
@@ -79,30 +79,42 @@ class PageManagerState extends State<PageManager> {
     final bool isProd = userPreferences
             .getFlag(UserPreferencesDevMode.userPreferencesFlagProd) ??
         true;
-    final BottomNavigationBar bar = BottomNavigationBar(
-      onTap: (int index) {
-        if (_currentPage == BottomNavigationTab.Scan &&
-            _pageKeys[index] == BottomNavigationTab.Scan) {
-          carouselManager.showSearchCard();
-        }
+    final Widget bar = DecoratedBox(
+      decoration: BoxDecoration(
+        boxShadow: <BoxShadow>[
+          BoxShadow(
+            color: Theme.of(context).shadowColor.withOpacity(0.3),
+            offset: Offset.zero,
+            blurRadius: 10.0,
+            spreadRadius: 1.0,
+          ),
+        ],
+      ),
+      child: BottomNavigationBar(
+        onTap: (int index) {
+          if (_currentPage == BottomNavigationTab.Scan &&
+              _pageKeys[index] == BottomNavigationTab.Scan) {
+            carouselManager.showSearchCard();
+          }
 
-        _selectTab(_pageKeys[index], index);
-      },
-      currentIndex: _currentPage.index,
-      items: <BottomNavigationBarItem>[
-        BottomNavigationBarItem(
-          icon: const Icon(Icons.account_circle),
-          label: appLocalizations.profile_navbar_label,
-        ),
-        BottomNavigationBarItem(
-          icon: const Icon(Icons.search),
-          label: appLocalizations.scan_navbar_label,
-        ),
-        BottomNavigationBarItem(
-          icon: const Icon(Icons.list),
-          label: appLocalizations.list_navbar_label,
-        ),
-      ],
+          _selectTab(_pageKeys[index], index);
+        },
+        currentIndex: _currentPage.index,
+        items: <BottomNavigationBarItem>[
+          BottomNavigationBarItem(
+            icon: const Icon(Icons.account_circle),
+            label: appLocalizations.profile_navbar_label,
+          ),
+          BottomNavigationBarItem(
+            icon: const Icon(Icons.search),
+            label: appLocalizations.scan_navbar_label,
+          ),
+          BottomNavigationBarItem(
+            icon: const Icon(Icons.list),
+            label: appLocalizations.list_navbar_label,
+          ),
+        ],
+      ),
     );
     return WillPopScope2(
       onWillPop: () async {

--- a/packages/smooth_app/lib/pages/scan/scan_header.dart
+++ b/packages/smooth_app/lib/pages/scan/scan_header.dart
@@ -29,6 +29,12 @@ class _ScanHeaderState extends State<ScanHeader> {
           borderRadius: BorderRadius.all(Radius.circular(18.0)),
         ),
       ),
+      foregroundColor: WidgetStateProperty.all<Color>(
+        Theme.of(context).colorScheme.onPrimary,
+      ),
+      textStyle: WidgetStateProperty.all<TextStyle>(
+        const TextStyle(fontWeight: FontWeight.w600),
+      ),
     );
 
     final bool compareFeatureAvailable = model.compareFeatureAvailable;

--- a/packages/smooth_app/lib/themes/smooth_theme.dart
+++ b/packages/smooth_app/lib/themes/smooth_theme.dart
@@ -61,6 +61,8 @@ class SmoothTheme {
         selectedLabelStyle: const TextStyle(fontWeight: FontWeight.bold),
         showUnselectedLabels: true,
         unselectedIconTheme: const IconThemeData(size: 20.0),
+        elevation: 0.0,
+        enableFeedback: true,
       ),
       elevatedButtonTheme: ElevatedButtonThemeData(
         style: ButtonStyle(


### PR DESCRIPTION
Hi everyone!

This PR fixes three things:

- The white-on-white button in dark mode (@see #5738)
- The same buttons now have a bolder font
- Add a shadow to the `BottomNavigationBar`

![IMG_42A7D541749C-1](https://github.com/user-attachments/assets/bdd9f50c-8833-415e-8c76-ebac60020fdf)
![IMG_42A7D541749C-2](https://github.com/user-attachments/assets/a97e13fb-46ba-4529-8ba2-1b8c69365f13)
