### PR TITLE
feat: 5405 - 3 queues for background tasks (fast, slow, long haul)

### DIFF
--- a/packages/smooth_app/lib/background/background_task.dart
+++ b/packages/smooth_app/lib/background/background_task.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/background/background_task_manager.dart';
+import 'package:smooth_app/background/background_task_queue.dart';
 import 'package:smooth_app/background/background_task_refresh_later.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/duration_constants.dart';
@@ -122,10 +123,14 @@ abstract class BackgroundTask {
   @protected
   Future<void> addToManager(
     final LocalDatabase localDatabase, {
+    required final BackgroundTaskQueue queue,
     final BuildContext? context,
     final bool showSnackBar = true,
   }) async {
-    await BackgroundTaskManager.getInstance(localDatabase).add(this);
+    await BackgroundTaskManager.getInstance(
+      localDatabase,
+      queue: queue,
+    ).add(this);
     if (context == null || !context.mounted) {
       return;
     }

--- a/packages/smooth_app/lib/background/background_task_add_other_price.dart
+++ b/packages/smooth_app/lib/background/background_task_add_other_price.dart
@@ -5,6 +5,7 @@ import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/background/background_task.dart';
 import 'package:smooth_app/background/background_task_price.dart';
+import 'package:smooth_app/background/background_task_queue.dart';
 import 'package:smooth_app/background/operation_type.dart';
 import 'package:smooth_app/database/local_database.dart';
 
@@ -74,7 +75,11 @@ class BackgroundTaskAddOtherPrice extends BackgroundTaskPrice {
     if (!context.mounted) {
       return;
     }
-    await task.addToManager(localDatabase, context: context);
+    await task.addToManager(
+      localDatabase,
+      context: context,
+      queue: BackgroundTaskQueue.fast,
+    );
   }
 
   /// Returns a new background task about changing a product.

--- a/packages/smooth_app/lib/background/background_task_add_price.dart
+++ b/packages/smooth_app/lib/background/background_task_add_price.dart
@@ -8,6 +8,7 @@ import 'package:provider/provider.dart';
 import 'package:smooth_app/background/background_task.dart';
 import 'package:smooth_app/background/background_task_image.dart';
 import 'package:smooth_app/background/background_task_price.dart';
+import 'package:smooth_app/background/background_task_queue.dart';
 import 'package:smooth_app/background/background_task_upload.dart';
 import 'package:smooth_app/background/operation_type.dart';
 import 'package:smooth_app/database/local_database.dart';
@@ -122,7 +123,11 @@ class BackgroundTaskAddPrice extends BackgroundTaskPrice {
     if (!context.mounted) {
       return;
     }
-    await task.addToManager(localDatabase, context: context);
+    await task.addToManager(
+      localDatabase,
+      context: context,
+      queue: BackgroundTaskQueue.slow,
+    );
   }
 
   /// Returns a new background task about changing a product.

--- a/packages/smooth_app/lib/background/background_task_badge.dart
+++ b/packages/smooth_app/lib/background/background_task_badge.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:smooth_app/background/background_task_queue.dart';
 import 'package:smooth_app/database/local_database.dart';
 
 /// Badge about pending background tasks.
@@ -11,14 +12,17 @@ class BackgroundTaskBadge extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final LocalDatabase localDatabase = context.watch<LocalDatabase>();
-    final List<String> tasks = localDatabase.getAllTaskIds();
-    if (tasks.isEmpty) {
+    int count = 0;
+    for (final BackgroundTaskQueue queue in BackgroundTaskQueue.values) {
+      count += localDatabase.getAllTaskIds(queue.tagTaskQueue).length;
+    }
+    if (count == 0) {
       return child;
     }
     return Badge(
       backgroundColor: Colors.blue.shade900,
       label: Text(
-        '${tasks.length}',
+        '$count',
         style: const TextStyle(color: Colors.white),
       ),
       child: child,

--- a/packages/smooth_app/lib/background/background_task_crop.dart
+++ b/packages/smooth_app/lib/background/background_task_crop.dart
@@ -5,6 +5,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/background/background_task_barcode.dart';
+import 'package:smooth_app/background/background_task_queue.dart';
 import 'package:smooth_app/background/background_task_refresh_later.dart';
 import 'package:smooth_app/background/background_task_upload.dart';
 import 'package:smooth_app/background/operation_type.dart';
@@ -83,7 +84,11 @@ class BackgroundTaskCrop extends BackgroundTaskUpload {
     if (!context.mounted) {
       return;
     }
-    await task.addToManager(localDatabase, context: context);
+    await task.addToManager(
+      localDatabase,
+      context: context,
+      queue: BackgroundTaskQueue.fast,
+    );
   }
 
   @override

--- a/packages/smooth_app/lib/background/background_task_details.dart
+++ b/packages/smooth_app/lib/background/background_task_details.dart
@@ -6,6 +6,7 @@ import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/background/background_task_barcode.dart';
 import 'package:smooth_app/background/background_task_product_change.dart';
+import 'package:smooth_app/background/background_task_queue.dart';
 import 'package:smooth_app/background/operation_type.dart';
 import 'package:smooth_app/database/local_database.dart';
 
@@ -92,6 +93,7 @@ class BackgroundTaskDetails extends BackgroundTaskBarcode
       localDatabase,
       context: context,
       showSnackBar: showSnackBar,
+      queue: BackgroundTaskQueue.fast,
     );
   }
 

--- a/packages/smooth_app/lib/background/background_task_download_products.dart
+++ b/packages/smooth_app/lib/background/background_task_download_products.dart
@@ -3,6 +3,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/background/background_task.dart';
 import 'package:smooth_app/background/background_task_progressing.dart';
+import 'package:smooth_app/background/background_task_queue.dart';
 import 'package:smooth_app/background/operation_type.dart';
 import 'package:smooth_app/database/dao_product.dart';
 import 'package:smooth_app/database/dao_work_barcode.dart';
@@ -67,7 +68,10 @@ class BackgroundTaskDownloadProducts extends BackgroundTaskProgressing {
       downloadFlag,
       productType,
     );
-    await task.addToManager(localDatabase);
+    await task.addToManager(
+      localDatabase,
+      queue: BackgroundTaskQueue.longHaul,
+    );
   }
 
   @override

--- a/packages/smooth_app/lib/background/background_task_full_refresh.dart
+++ b/packages/smooth_app/lib/background/background_task_full_refresh.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import 'package:smooth_app/background/background_task.dart';
 import 'package:smooth_app/background/background_task_download_products.dart';
 import 'package:smooth_app/background/background_task_paged.dart';
+import 'package:smooth_app/background/background_task_queue.dart';
 import 'package:smooth_app/background/operation_type.dart';
 import 'package:smooth_app/background/work_type.dart';
 import 'package:smooth_app/database/dao_product.dart';
@@ -39,7 +40,11 @@ class BackgroundTaskFullRefresh extends BackgroundTaskPaged {
     if (!context.mounted) {
       return;
     }
-    await task.addToManager(localDatabase, context: context);
+    await task.addToManager(
+      localDatabase,
+      context: context,
+      queue: BackgroundTaskQueue.longHaul,
+    );
   }
 
   @override

--- a/packages/smooth_app/lib/background/background_task_hunger_games.dart
+++ b/packages/smooth_app/lib/background/background_task_hunger_games.dart
@@ -3,6 +3,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/background/background_task_barcode.dart';
+import 'package:smooth_app/background/background_task_queue.dart';
 import 'package:smooth_app/background/operation_type.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/helpers/robotoff_insight_helper.dart';
@@ -61,7 +62,11 @@ class BackgroundTaskHungerGames extends BackgroundTaskBarcode {
     if (!context.mounted) {
       return;
     }
-    await task.addToManager(localDatabase, context: context);
+    await task.addToManager(
+      localDatabase,
+      context: context,
+      queue: BackgroundTaskQueue.fast,
+    );
   }
 
   @override

--- a/packages/smooth_app/lib/background/background_task_image.dart
+++ b/packages/smooth_app/lib/background/background_task_image.dart
@@ -9,6 +9,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/background/background_task_barcode.dart';
+import 'package:smooth_app/background/background_task_queue.dart';
 import 'package:smooth_app/background/background_task_refresh_later.dart';
 import 'package:smooth_app/background/background_task_upload.dart';
 import 'package:smooth_app/background/operation_type.dart';
@@ -93,7 +94,11 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
     if (!context.mounted) {
       return;
     }
-    await task.addToManager(localDatabase, context: context);
+    await task.addToManager(
+      localDatabase,
+      context: context,
+      queue: BackgroundTaskQueue.slow,
+    );
   }
 
   @override

--- a/packages/smooth_app/lib/background/background_task_language_refresh.dart
+++ b/packages/smooth_app/lib/background/background_task_language_refresh.dart
@@ -2,6 +2,7 @@ import 'package:flutter/painting.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/background/background_task.dart';
+import 'package:smooth_app/background/background_task_queue.dart';
 import 'package:smooth_app/background/operation_type.dart';
 import 'package:smooth_app/database/dao_product.dart';
 import 'package:smooth_app/database/local_database.dart';
@@ -80,7 +81,10 @@ class BackgroundTaskLanguageRefresh extends BackgroundTask {
       excludeBarcodes,
       productType,
     );
-    await task.addToManager(localDatabase);
+    await task.addToManager(
+      localDatabase,
+      queue: BackgroundTaskQueue.longHaul,
+    );
   }
 
   @override

--- a/packages/smooth_app/lib/background/background_task_offline.dart
+++ b/packages/smooth_app/lib/background/background_task_offline.dart
@@ -4,6 +4,7 @@ import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/background/background_task.dart';
 import 'package:smooth_app/background/background_task_progressing.dart';
+import 'package:smooth_app/background/background_task_queue.dart';
 import 'package:smooth_app/background/background_task_top_barcodes.dart';
 import 'package:smooth_app/background/operation_type.dart';
 import 'package:smooth_app/background/work_type.dart';
@@ -48,7 +49,11 @@ class BackgroundTaskOffline extends BackgroundTaskProgressing {
     if (!context.mounted) {
       return;
     }
-    await task.addToManager(localDatabase, context: context);
+    await task.addToManager(
+      localDatabase,
+      context: context,
+      queue: BackgroundTaskQueue.longHaul,
+    );
   }
 
   @override

--- a/packages/smooth_app/lib/background/background_task_queue.dart
+++ b/packages/smooth_app/lib/background/background_task_queue.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:smooth_app/database/dao_string_list.dart';
+
+/// Queues for Background Tasks.
+enum BackgroundTaskQueue {
+  fast(
+    tagLastStartTimestamp: 'taskLastStartTimestamp',
+    tagLastStopTimestamp: 'taskLastStopTimestamp',
+    tagTaskQueue: DaoStringList.keyTasksFast,
+    iconData: Icons.bolt,
+    aLongEnoughTimeInMilliseconds: 20 * 60 * 1000,
+    minimumDurationBetweenRuns: 5 * 1000,
+  ),
+  slow(
+    tagLastStartTimestamp: 'taskLastStartTimestampSlow',
+    tagLastStopTimestamp: 'taskLastStopTimestampSlow',
+    tagTaskQueue: DaoStringList.keyTasksSlow,
+    iconData: Icons.upload,
+    aLongEnoughTimeInMilliseconds: 60 * 60 * 1000,
+    minimumDurationBetweenRuns: 5 * 1000,
+  ),
+  longHaul(
+    tagLastStartTimestamp: 'taskLastStartTimestampLongHaul',
+    tagLastStopTimestamp: 'taskLastStopTimestampLongHaul',
+    tagTaskQueue: DaoStringList.keyTasksLongHaul,
+    iconData: Icons.download,
+    aLongEnoughTimeInMilliseconds: 60 * 60 * 1000,
+    minimumDurationBetweenRuns: 60 * 1000,
+  );
+
+  const BackgroundTaskQueue({
+    required this.tagLastStartTimestamp,
+    required this.tagLastStopTimestamp,
+    required this.tagTaskQueue,
+    required this.iconData,
+    required this.aLongEnoughTimeInMilliseconds,
+    required this.minimumDurationBetweenRuns,
+  });
+
+  /// [DaoInt] key we use to store the latest start timestamp.
+  final String tagLastStartTimestamp;
+
+  /// [DaoInt] key we use to store the latest stop timestamp.
+  final String tagLastStopTimestamp;
+
+  /// [DaoStringList] key we use to store the task queue.
+  final String tagTaskQueue;
+
+  /// Duration in millis after which we can imagine the previous run failed.
+  final int aLongEnoughTimeInMilliseconds;
+
+  /// Minimum duration in millis between each run.
+  final int minimumDurationBetweenRuns;
+
+  final IconData iconData;
+}

--- a/packages/smooth_app/lib/background/background_task_refresh_later.dart
+++ b/packages/smooth_app/lib/background/background_task_refresh_later.dart
@@ -2,6 +2,7 @@ import 'package:flutter/painting.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/background/background_task_barcode.dart';
+import 'package:smooth_app/background/background_task_queue.dart';
 import 'package:smooth_app/background/operation_type.dart';
 import 'package:smooth_app/database/local_database.dart';
 
@@ -62,7 +63,10 @@ class BackgroundTaskRefreshLater extends BackgroundTaskBarcode {
       uniqueId,
       productType,
     );
-    await task.addToManager(localDatabase);
+    await task.addToManager(
+      localDatabase,
+      queue: BackgroundTaskQueue.fast,
+    );
   }
 
   @override

--- a/packages/smooth_app/lib/background/background_task_top_barcodes.dart
+++ b/packages/smooth_app/lib/background/background_task_top_barcodes.dart
@@ -4,6 +4,7 @@ import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/background/background_task.dart';
 import 'package:smooth_app/background/background_task_download_products.dart';
 import 'package:smooth_app/background/background_task_progressing.dart';
+import 'package:smooth_app/background/background_task_queue.dart';
 import 'package:smooth_app/background/operation_type.dart';
 import 'package:smooth_app/database/dao_work_barcode.dart';
 import 'package:smooth_app/database/local_database.dart';
@@ -62,7 +63,10 @@ class BackgroundTaskTopBarcodes extends BackgroundTaskProgressing {
       pageNumber,
       productType,
     );
-    await task.addToManager(localDatabase);
+    await task.addToManager(
+      localDatabase,
+      queue: BackgroundTaskQueue.longHaul,
+    );
   }
 
   @override

--- a/packages/smooth_app/lib/background/background_task_unselect.dart
+++ b/packages/smooth_app/lib/background/background_task_unselect.dart
@@ -4,6 +4,7 @@ import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/background/background_task_barcode.dart';
 import 'package:smooth_app/background/background_task_product_change.dart';
+import 'package:smooth_app/background/background_task_queue.dart';
 import 'package:smooth_app/background/background_task_refresh_later.dart';
 import 'package:smooth_app/background/background_task_upload.dart';
 import 'package:smooth_app/background/operation_type.dart';
@@ -64,7 +65,11 @@ class BackgroundTaskUnselect extends BackgroundTaskBarcode
     if (!context.mounted) {
       return;
     }
-    await task.addToManager(localDatabase, context: context);
+    await task.addToManager(
+      localDatabase,
+      context: context,
+      queue: BackgroundTaskQueue.fast,
+    );
   }
 
   @override

--- a/packages/smooth_app/lib/data_models/up_to_date_mixin.dart
+++ b/packages/smooth_app/lib/data_models/up_to_date_mixin.dart
@@ -49,7 +49,7 @@ mixin UpToDateMixin<T extends StatefulWidget> on State<T> {
   /// To be used in the `build` method, after a call to
   /// `context.watch<LocalDatabase>()`.
   void refreshUpToDate() {
-    BackgroundTaskManager.getInstance(_localDatabase).run();
+    BackgroundTaskManager.runAgain(_localDatabase);
     _refreshUpToDate();
   }
 

--- a/packages/smooth_app/lib/database/dao_string_list.dart
+++ b/packages/smooth_app/lib/database/dao_string_list.dart
@@ -13,8 +13,14 @@ class DaoStringList extends AbstractDao {
   /// Key for the list of location search history
   static const String keySearchLocationHistory = 'searchLocationHistory';
 
-  /// Key for the list of task ids.
-  static const String keyTasks = 'tasks';
+  /// Key for the list of task ids (fast tasks like product detail change).
+  static const String keyTasksFast = 'tasks';
+
+  /// Key for the list of task ids (slow tasks like image uploads).
+  static const String keyTasksSlow = 'tasksSlow';
+
+  /// Key for the list of task ids (long haul tasks like full refresh).
+  static const String keyTasksLongHaul = 'tasksLongHaul';
 
   /// Key for the list of latest languages used in the app.
   static const String keyLanguages = 'languages';
@@ -26,7 +32,9 @@ class DaoStringList extends AbstractDao {
   static const Map<String, int?> _maxLengths = <String, int?>{
     keySearchProductHistory: 10,
     keySearchLocationHistory: 10,
-    keyTasks: null,
+    keyTasksFast: null,
+    keyTasksSlow: null,
+    keyTasksLongHaul: null,
     // TODO(monsieurtanuki): more "latest" languages are possible if we create a page to remove some of them
     keyLanguages: 1,
   };

--- a/packages/smooth_app/lib/database/local_database.dart
+++ b/packages/smooth_app/lib/database/local_database.dart
@@ -41,15 +41,15 @@ class LocalDatabase extends ChangeNotifier {
 
   @override
   void notifyListeners() {
-    BackgroundTaskManager.getInstance(this).run();
+    BackgroundTaskManager.runAgain(this);
     super.notifyListeners();
   }
 
   /// Returns all the pending background task ids.
   ///
   /// Ugly solution to be able to mock hive data.
-  List<String> getAllTaskIds() =>
-      DaoStringList(this).getAll(DaoStringList.keyTasks);
+  List<String> getAllTaskIds(final String key) =>
+      DaoStringList(this).getAll(key);
 
   /// Ugly solution to be able to mock hive data.
   int? daoIntGet(final String key) => DaoInt(this).get(key);

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_page.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_page.dart
@@ -51,7 +51,7 @@ enum PreferencePageType {
     required final BuildContext context,
   }) {
     final LocalDatabase localDatabase = context.read<LocalDatabase>();
-    BackgroundTaskManager.getInstance(localDatabase).run();
+    BackgroundTaskManager.runAgain(localDatabase);
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final ThemeProvider themeProvider = context.read<ThemeProvider>();
     final ThemeData themeData = Theme.of(context);

--- a/packages/smooth_app/test/tests_utils/local_database_mock.dart
+++ b/packages/smooth_app/test/tests_utils/local_database_mock.dart
@@ -5,7 +5,7 @@ class MockLocalDatabase extends Mock implements LocalDatabase {
   final Map<String, int?> _daoInt = <String, int?>{};
 
   @override
-  List<String> getAllTaskIds() => <String>[];
+  List<String> getAllTaskIds(final String key) => <String>[];
 
   @override
   int? daoIntGet(final String key) => _daoInt[key];


### PR DESCRIPTION
### What
- Now we use 3 queues for the background tasks, for different purposes:
  - fast actions, like changing a product label
  - slow actions, like uploading a new photo
  - long haul actions, like refreshing the whole local database from the server
- The 3 queues are run in parallel.
- The main added value is that fast actions will be run earlier (and faster), as they won't have to wait for any slow or long haul action to finish. Particularly relevant with low connectivity.

### Screenshots
Example of background tasks on an _offline_ device (therefore everything fails):
* a fast product edit
* a price with proof upload
* a product photo upload
* a refresh of the whole local database

| task page (top) | task page (bottom) |
| -- | -- |
| ![Screenshot_20241026_152850](https://github.com/user-attachments/assets/ade7f069-bbc5-4b00-8d65-1e58f12dfc7f) | ![Screenshot_20241026_152856](https://github.com/user-attachments/assets/c969ee0c-d249-489a-a364-a2ad15027212) |

### Fixes bug(s)
- Closes: #5405

### Files
New file:
* `background_task_queue.dart`: Queues for Background Tasks.

Impacted files:
* `background_task.dart`: now we add tasks to a specific queue
* `background_task_add_other_price.dart`: assigned to `BackgroundTaskQueue.fast`
* `background_task_add_price.dart`: assigned to `BackgroundTaskQueue.slow`
* `background_task_badge.dart`: minor refactoring
* `background_task_crop.dart`: assigned to `BackgroundTaskQueue.fast`
* `background_task_details.dart`: assigned to `BackgroundTaskQueue.fast`
* `background_task_download_products.dart`: assigned to `BackgroundTaskQueue.longHaul`
* `background_task_full_refresh.dart`: assigned to `BackgroundTaskQueue.longHaul`
* `background_task_hunger_games.dart`: assigned to `BackgroundTaskQueue.fast`
* `background_task_image.dart`: assigned to `BackgroundTaskQueue.slow`
* `background_task_language_refresh.dart`: assigned to `BackgroundTaskQueue.longHaul`
* `background_task_manager.dart`: now using new class `BackgroundTaskQueue` in order to use multiple queues
* `background_task_offline.dart`: assigned to `BackgroundTaskQueue.longHaul`
* `background_task_refresh_later.dart`: assigned to `BackgroundTaskQueue.fast`
* `background_task_top_barcodes.dart`: assigned to `BackgroundTaskQueue.longHaul`
* `background_task_unselect.dart`: assigned to `BackgroundTaskQueue.fast`
* `dao_string_list.dart`: added 2 queues
* `local_database.dart`: now running all queues
* `local_database_mock.dart`: minor refactoring
* `offline_tasks_page.dart`: now taking queues into account
* `up_to_date_mixin.dart`: now running all queues
* `user_preferences_page.dart`: now running all queues