### PR TITLE
fix: 5742 - centered tooltip after detail changes

### DIFF
--- a/packages/smooth_app/lib/background/background_task_details.dart
+++ b/packages/smooth_app/lib/background/background_task_details.dart
@@ -102,7 +102,7 @@ class BackgroundTaskDetails extends BackgroundTaskBarcode
           final AppLocalizations appLocalizations) =>
       (
         appLocalizations.product_task_background_schedule,
-        AlignmentDirectional.bottomCenter,
+        AlignmentDirectional.center,
       );
 
   /// Returns a new background task about changing a product.


### PR DESCRIPTION
### What
- For a new product, we ask the product type first.
- Then, we land on the photo page, but meanwhile we save the "this is a product of this type" info on the type-related server, which triggers a background task and a tooltip message.
- Now, we center the tooltip message (instead of bottomCenter), which doesn't block the view of the bottom buttons anymore.

### Screenshot
![Screenshot_1730037243](https://github.com/user-attachments/assets/7fc410ef-dd3b-44db-b965-0d41e6787812)


### Fixes bug(s)
- Fixes: #5742

### Impacted file
* `background_task_details.dart`: centered instead of bottomCentered