### PR TITLE
feat: 5639 - storing the latest selected product type

### DIFF
--- a/packages/smooth_app/lib/data_models/preferences/user_preferences.dart
+++ b/packages/smooth_app/lib/data_models/preferences/user_preferences.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
@@ -54,6 +55,9 @@ class UserPreferences extends ChangeNotifier {
     return _instance!;
   }
 
+  /// Once we initialized with main.dart, we don't need the "async".
+  static UserPreferences getUserPreferencesSync() => _instance!;
+
   late ValueNotifier<bool> onCrashReportingChanged;
   late ValueNotifier<bool> onAnalyticsChanged;
 
@@ -82,6 +86,7 @@ class UserPreferences extends ChangeNotifier {
   static const String _TAG_USER_GROUP = '_user_group';
   static const String _TAG_UNIQUE_RANDOM = '_unique_random';
   static const String _TAG_LAZY_COUNT_PREFIX = '_lazy_count_prefix';
+  static const String _TAG_LATEST_PRODUCT_TYPE = '_latest_product_type';
 
   /// Camera preferences
 
@@ -468,4 +473,16 @@ class UserPreferences extends ChangeNotifier {
       );
     }
   }
+
+  ProductType get latestProductType =>
+      ProductType.fromOffTag(
+          _sharedPreferences.getString(_TAG_LATEST_PRODUCT_TYPE)) ??
+      ProductType.food;
+
+  set latestProductType(final ProductType value) => unawaited(
+        _sharedPreferences.setString(
+          _TAG_LATEST_PRODUCT_TYPE,
+          value.offTag,
+        ),
+      );
 }

--- a/packages/smooth_app/lib/pages/search/search_product_helper.dart
+++ b/packages/smooth_app/lib/pages/search/search_product_helper.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';

--- a/packages/smooth_app/lib/pages/search/search_product_helper.dart
+++ b/packages/smooth_app/lib/pages/search/search_product_helper.dart
@@ -1,8 +1,11 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/fetched_product.dart';
+import 'package:smooth_app/data_models/preferences/user_preferences.dart';
 import 'package:smooth_app/database/dao_string_list.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
@@ -17,10 +20,11 @@ import 'package:smooth_app/query/product_query.dart';
 
 /// Search helper dedicated to product search.
 class SearchProductHelper extends SearchHelper {
-  SearchProductHelper();
+  SearchProductHelper() {
+    _productType = UserPreferences.getUserPreferencesSync().latestProductType;
+  }
 
-  // TODO(monsieurtanuki): maybe reinit it with latest value
-  ProductType _productType = ProductType.food;
+  late ProductType _productType;
 
   @override
   String get historyKey => DaoStringList.keySearchProductHistory;
@@ -154,7 +158,8 @@ class _ProductTypeFilterState extends State<_ProductTypeFilter> {
       segments: segments,
       selected: <ProductType>{widget.searchProductHelper._productType},
       onSelectionChanged: (Set<ProductType> newSelection) => setState(
-        () => widget.searchProductHelper._productType = newSelection.first,
+        () => UserPreferences.getUserPreferencesSync().latestProductType =
+            widget.searchProductHelper._productType = newSelection.first,
       ),
     );
   }


### PR DESCRIPTION
### What
- There is a "product type" filter in the search page.
- The value of this filter wasn't kept for the next search. Now it is.

### Fixes bug(s)
- Closes: #5639

### Impacted files
* `search_product_helper.dart`: initialized and set the latest selected product type
* `user_preferences.dart`: new preference field where we store the latest selected product type