### PR TITLE
feat: Improvements for the product page (Part 2)

### DIFF
--- a/packages/smooth_app/lib/helpers/product_cards_helper.dart
+++ b/packages/smooth_app/lib/helpers/product_cards_helper.dart
@@ -10,6 +10,8 @@ import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/helpers/image_field_extension.dart';
 import 'package:smooth_app/helpers/ui_helpers.dart';
 import 'package:smooth_app/query/product_query.dart';
+import 'package:smooth_app/themes/smooth_theme_colors.dart';
+import 'package:smooth_app/themes/theme_provider.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
 
 SmoothAppBar buildEditProductAppBar({
@@ -88,26 +90,99 @@ const EdgeInsets SMOOTH_CARD_PADDING = EdgeInsets.symmetric(
 /// A SmoothCard on Product cards using default margin and padding.
 Widget buildProductSmoothCard({
   Widget? header,
+  Widget? title,
+  EdgeInsetsGeometry? titlePadding,
   required Widget body,
-  EdgeInsets? padding = EdgeInsets.zero,
-  EdgeInsets? margin = const EdgeInsets.symmetric(
+  EdgeInsetsGeometry? padding = EdgeInsets.zero,
+  EdgeInsetsGeometry? margin = const EdgeInsets.symmetric(
     horizontal: SMALL_SPACE,
   ),
-}) =>
-    SmoothCard(
-      margin: margin,
-      padding: padding,
-      child: switch (header) {
-        Object _ => Column(
-            mainAxisSize: MainAxisSize.min,
-            children: <Widget>[
-              if (header != null) header,
-              body,
-            ],
-          ),
-        _ => body
-      },
+}) {
+  assert(
+    (header != null && title == null) || header == null,
+    "You can't pass a header and a title at the same time",
+  );
+
+  Widget child;
+
+  if (title != null) {
+    child = Column(
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        _ProductSmoothCardTitle(
+          title: title,
+          padding: titlePadding,
+        ),
+        body,
+      ],
     );
+  } else if (header != null) {
+    child = Column(
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        header,
+        body,
+      ],
+    );
+  } else {
+    child = body;
+  }
+
+  return SmoothCard(
+    margin: margin,
+    padding: padding,
+    child: child,
+  );
+}
+
+class _ProductSmoothCardTitle extends StatelessWidget {
+  const _ProductSmoothCardTitle({
+    required this.title,
+    this.padding,
+  });
+
+  final Widget title;
+  final EdgeInsetsGeometry? padding;
+
+  @override
+  Widget build(BuildContext context) {
+    final SmoothColorsThemeExtension colors =
+        Theme.of(context).extension<SmoothColorsThemeExtension>()!;
+    final EdgeInsetsGeometry effectivePadding = padding ??
+        const EdgeInsetsDirectional.symmetric(
+          vertical: MEDIUM_SPACE,
+        );
+    final TextStyle titleStyle =
+        Theme.of(context).textTheme.displaySmall ?? const TextStyle();
+    final double fontSize = titleStyle.fontSize ?? 15.0;
+
+    return Container(
+      constraints: BoxConstraints(
+        minHeight:
+            MEDIUM_SPACE * 2 + MediaQuery.textScalerOf(context).scale(fontSize),
+      ),
+      decoration: BoxDecoration(
+        color: context.lightTheme()
+            ? colors.primaryMedium
+            : colors.primarySemiDark,
+        borderRadius: const BorderRadius.vertical(
+          top: ROUNDED_RADIUS,
+        ),
+      ),
+      padding: effectivePadding,
+      child: Center(
+        child: DefaultTextStyle(
+          style: titleStyle,
+          textAlign: TextAlign.center,
+          child: SizedBox(
+            width: double.infinity,
+            child: title,
+          ),
+        ),
+      ),
+    );
+  }
+}
 
 // used to be in now defunct `AttributeListExpandable`
 List<Attribute> getPopulatedAttributes(
@@ -170,7 +245,7 @@ List<Attribute> getSortedAttributes(
   }
   final Map<String, List<Attribute>> mandatoryAttributesByGroup =
       <String, List<Attribute>>{};
-  // collecting all the mandatory attributes, by group
+// collecting all the mandatory attributes, by group
   for (final AttributeGroup attributeGroup in product.attributeGroups!) {
     mandatoryAttributesByGroup[attributeGroup.id!] = getFilteredAttributes(
       attributeGroup,
@@ -181,7 +256,7 @@ List<Attribute> getSortedAttributes(
     );
   }
 
-  // now ordering by attribute group order
+// now ordering by attribute group order
   for (final String attributeGroupId in attributeGroupOrder) {
     final List<Attribute>? attributes =
         mandatoryAttributesByGroup[attributeGroupId];
@@ -266,7 +341,7 @@ ProductImageData getProductImageData(
     language,
   );
   if (productImage != null) {
-    // we found a localized version for this image
+// we found a localized version for this image
     return ProductImageData(
       imageId: productImage.imgid,
       imageField: imageField,
@@ -344,7 +419,7 @@ List<ProductImage> getRawProductImages(
   for (final ProductImage productImage in rawImages) {
     final int? imageId = int.tryParse(productImage.imgid!);
     if (imageId == null) {
-      // highly unlikely
+// highly unlikely
       continue;
     }
     final ProductImage? previous = map[imageId];
@@ -354,12 +429,12 @@ List<ProductImage> getRawProductImages(
     }
     final ImageSize? currentImageSize = productImage.size;
     if (currentImageSize == null) {
-      // highly unlikely
+// highly unlikely
       continue;
     }
     final ImageSize? previousImageSize = previous.size;
     if (previousImageSize == imageSize) {
-      // we already have the best
+// we already have the best
       continue;
     }
     map[imageId] = productImage;

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_group_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_group_card.dart
@@ -4,6 +4,8 @@ import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_card.dart';
+import 'package:smooth_app/themes/smooth_theme_colors.dart';
+import 'package:smooth_app/themes/theme_provider.dart';
 
 class KnowledgePanelGroupCard extends StatelessWidget {
   const KnowledgePanelGroupCard({
@@ -19,6 +21,9 @@ class KnowledgePanelGroupCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ThemeData themeData = Theme.of(context);
+    final SmoothColorsThemeExtension themeExtension =
+        themeData.extension<SmoothColorsThemeExtension>()!;
+
     return Provider<KnowledgePanelPanelGroupElement>(
       lazy: true,
       create: (_) => groupElement,
@@ -32,8 +37,13 @@ class KnowledgePanelGroupCard extends StatelessWidget {
                 explicitChildNodes: true,
                 child: Text(
                   groupElement.title!,
-                  style:
-                      themeData.textTheme.titleSmall!.apply(color: Colors.grey),
+                  style: themeData.textTheme.titleSmall!.copyWith(
+                    fontSize: 15.5,
+                    fontWeight: FontWeight.w700,
+                    color: context.lightTheme()
+                        ? themeExtension.primaryUltraBlack
+                        : themeExtension.primaryLight,
+                  ),
                 ),
               ),
             ),

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_product_cards.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_product_cards.dart
@@ -4,7 +4,6 @@ import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels_builder.dart';
 import 'package:smooth_app/themes/smooth_theme_colors.dart';
-import 'package:smooth_app/themes/theme_provider.dart';
 
 class KnowledgePanelProductCards extends StatelessWidget {
   const KnowledgePanelProductCards(this.knowledgePanelWidgets);
@@ -26,31 +25,12 @@ class KnowledgePanelProductCards extends StatelessWidget {
 
       if (hasTitle) {
         content = buildProductSmoothCard(
-          body: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              Container(
-                decoration: BoxDecoration(
-                  color: context.lightTheme()
-                      ? colors.primaryMedium
-                      : colors.primarySemiDark,
-                  borderRadius: const BorderRadius.vertical(
-                    top: ROUNDED_RADIUS,
-                  ),
-                ),
-                width: double.infinity,
-                padding: const EdgeInsetsDirectional.symmetric(
-                  vertical: SMALL_SPACE,
-                ),
-                child: Center(child: widget.children.first),
-              ),
-              Padding(
-                padding: SMOOTH_CARD_PADDING,
-                child: Column(
-                  children: widget.children.sublist(1),
-                ),
-              ),
-            ],
+          title: Text((widget.children.first as KnowledgePanelTitle).title),
+          body: Padding(
+            padding: SMOOTH_CARD_PADDING,
+            child: Column(
+              children: widget.children.sublist(1),
+            ),
           ),
           padding: EdgeInsets.zero,
           margin: EdgeInsets.zero,
@@ -71,10 +51,8 @@ class KnowledgePanelProductCards extends StatelessWidget {
 
     return Center(
       child: Padding(
-        padding: const EdgeInsetsDirectional.only(
-          bottom: SMALL_SPACE,
-          start: SMALL_SPACE,
-          end: SMALL_SPACE,
+        padding: const EdgeInsetsDirectional.symmetric(
+          horizontal: SMALL_SPACE,
         ),
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_product_cards.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_product_cards.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels_builder.dart';
-import 'package:smooth_app/themes/smooth_theme_colors.dart';
 
 class KnowledgePanelProductCards extends StatelessWidget {
   const KnowledgePanelProductCards(this.knowledgePanelWidgets);
@@ -12,9 +11,6 @@ class KnowledgePanelProductCards extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final SmoothColorsThemeExtension colors =
-        Theme.of(context).extension<SmoothColorsThemeExtension>()!;
-
     final List<Widget> widgetsWrappedInSmoothCards =
         knowledgePanelWidgets.map((Widget widget) {
       /// When we have a panel with a title (e.g. "Health"), we change

--- a/packages/smooth_app/lib/pages/prices/prices_card.dart
+++ b/packages/smooth_app/lib/pages/prices/prices_card.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -9,8 +11,9 @@ import 'package:smooth_app/pages/prices/get_prices_model.dart';
 import 'package:smooth_app/pages/prices/price_meta_product.dart';
 import 'package:smooth_app/pages/prices/prices_page.dart';
 import 'package:smooth_app/pages/prices/product_price_add_page.dart';
-import 'package:smooth_app/resources/app_icons.dart';
+import 'package:smooth_app/resources/app_icons.dart' as icons;
 import 'package:smooth_app/themes/smooth_theme_colors.dart';
+import 'package:smooth_app/themes/theme_provider.dart';
 
 /// Card that displays buttons related to prices.
 class PricesCard extends StatelessWidget {
@@ -21,87 +24,108 @@ class PricesCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    final SmoothColorsThemeExtension? themeExtension =
-        Theme.of(context).extension<SmoothColorsThemeExtension>();
+    final SmoothColorsThemeExtension themeExtension =
+        Theme.of(context).extension<SmoothColorsThemeExtension>()!;
 
     return buildProductSmoothCard(
+      title: Stack(
+        children: <Widget>[
+          Positioned.directional(
+            textDirection: Directionality.of(context),
+            start: LARGE_SPACE,
+            child: Container(
+              decoration: BoxDecoration(
+                color: themeExtension.orange,
+                shape: BoxShape.circle,
+              ),
+              padding: const EdgeInsetsDirectional.only(
+                top: 5.0,
+                start: 6.0,
+                end: 6.0,
+                bottom: 7.0,
+              ),
+              child: const icons.Lab(
+                size: 10.0,
+                color: Colors.white,
+              ),
+            ),
+          ),
+          const SizedBox(width: SMALL_SPACE),
+          Center(child: Text(appLocalizations.prices_generic_title)),
+        ],
+      ),
       body: Container(
         width: double.infinity,
         padding: const EdgeInsetsDirectional.all(LARGE_SPACE),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisAlignment: MainAxisAlignment.start,
+        child: Stack(
           children: <Widget>[
-            Row(
-              mainAxisSize: MainAxisSize.min,
-              children: <Widget>[
-                Text(
-                  AppLocalizations.of(context).prices_generic_title,
-                  style: Theme.of(context).textTheme.displaySmall,
-                ),
-                const SizedBox(width: SMALL_SPACE),
-                Container(
-                  decoration: BoxDecoration(
-                    color: themeExtension!.secondaryNormal,
-                    borderRadius: CIRCULAR_BORDER_RADIUS,
-                  ),
-                  margin: const EdgeInsets.only(top: 0.5),
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: MEDIUM_SPACE,
-                    vertical: VERY_SMALL_SPACE,
-                  ),
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: <Widget>[
-                      Text(
-                        appLocalizations.preview_badge,
-                        style: const TextStyle(
-                          color: Colors.white,
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                      const SizedBox(width: SMALL_SPACE),
-                      const Lab(
-                        color: Colors.white,
-                        size: 13.0,
-                      ),
-                    ],
-                  ),
-                ),
-              ],
+            Positioned.directional(
+              textDirection: Directionality.of(context),
+              bottom: 0.0,
+              end: 0.0,
+              child: const _PricesCardTitleIcon(),
             ),
-            const SizedBox(height: SMALL_SPACE),
-            Padding(
-              padding: const EdgeInsets.all(SMALL_SPACE),
-              child: SmoothLargeButtonWithIcon(
-                text: appLocalizations.prices_view_prices,
-                icon: CupertinoIcons.tag_fill,
-                onPressed: () async => Navigator.of(context).push(
-                  MaterialPageRoute<void>(
-                    builder: (BuildContext context) => PricesPage(
-                      GetPricesModel.product(
-                        product: PriceMetaProduct.product(product),
-                        context: context,
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisAlignment: MainAxisAlignment.start,
+              children: <Widget>[
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
+                  child: SmoothLargeButtonWithIcon(
+                    text: appLocalizations.prices_view_prices,
+                    icon: CupertinoIcons.tag_fill,
+                    onPressed: () async => Navigator.of(context).push(
+                      MaterialPageRoute<void>(
+                        builder: (BuildContext context) => PricesPage(
+                          GetPricesModel.product(
+                            product: PriceMetaProduct.product(product),
+                            context: context,
+                          ),
+                        ),
                       ),
                     ),
                   ),
                 ),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.all(SMALL_SPACE),
-              child: SmoothLargeButtonWithIcon(
-                text: appLocalizations.prices_add_a_price,
-                icon: Icons.add,
-                onPressed: () async => ProductPriceAddPage.showProductPage(
-                  context: context,
-                  product: PriceMetaProduct.product(product),
-                  proofType: ProofType.priceTag,
+                Padding(
+                  padding: const EdgeInsets.all(SMALL_SPACE),
+                  child: SmoothLargeButtonWithIcon(
+                    text: appLocalizations.prices_add_a_price,
+                    icon: Icons.add,
+                    onPressed: () async => ProductPriceAddPage.showProductPage(
+                      context: context,
+                      product: PriceMetaProduct.product(product),
+                      proofType: ProofType.priceTag,
+                    ),
+                  ),
                 ),
-              ),
+              ],
             ),
           ],
         ),
+      ),
+      margin: const EdgeInsetsDirectional.only(
+        start: SMALL_SPACE,
+        end: SMALL_SPACE,
+        top: VERY_LARGE_SPACE,
+      ),
+    );
+  }
+}
+
+class _PricesCardTitleIcon extends StatelessWidget {
+  const _PricesCardTitleIcon();
+
+  @override
+  Widget build(BuildContext context) {
+    final SmoothColorsThemeExtension? themeExtension =
+        Theme.of(context).extension<SmoothColorsThemeExtension>();
+
+    return Transform.rotate(
+      angle: -pi / 6,
+      child: icons.Lab(
+        size: 100.0,
+        color: themeExtension?.orange
+            .withOpacity(context.lightTheme() ? 0.15 : 0.4),
       ),
     );
   }

--- a/packages/smooth_app/lib/pages/product/product_page/new_product_footer.dart
+++ b/packages/smooth_app/lib/pages/product/product_page/new_product_footer.dart
@@ -25,33 +25,23 @@ import 'package:smooth_app/themes/theme_provider.dart';
 class ProductFooter extends StatelessWidget {
   const ProductFooter({super.key});
 
-  static const double kHeight = 46.0;
+  static const double kHeight = 48.0;
 
   @override
   Widget build(BuildContext context) {
-    double bottomPadding = MediaQuery.viewPaddingOf(context).bottom;
-    // Add an extra padding (for Android)
-    if (bottomPadding == 0.0) {
-      bottomPadding = 16.0;
-    }
-
     return DecoratedBox(
       decoration: BoxDecoration(
         color: Theme.of(context).scaffoldBackgroundColor,
         boxShadow: <BoxShadow>[
           BoxShadow(
-            color: Theme.of(context).shadowColor.withOpacity(0.1),
+            color: Theme.of(context)
+                .shadowColor
+                .withOpacity(context.lightTheme() ? 0.25 : 0.6),
             blurRadius: 10.0,
           ),
         ],
       ),
-      child: Padding(
-        padding: EdgeInsetsDirectional.only(
-          top: 16.0,
-          bottom: bottomPadding,
-        ),
-        child: const _ProductFooterButtonsBar(),
-      ),
+      child: const _ProductFooterButtonsBar(),
     );
   }
 }
@@ -64,8 +54,14 @@ class _ProductFooterButtonsBar extends StatelessWidget {
     final SmoothColorsThemeExtension themeExtension =
         Theme.of(context).extension<SmoothColorsThemeExtension>()!;
 
+    double bottomPadding = MediaQuery.viewPaddingOf(context).bottom;
+    // Add an extra padding (for Android)
+    if (bottomPadding == 0.0) {
+      bottomPadding = LARGE_SPACE;
+    }
+
     return SizedBox(
-      height: ProductFooter.kHeight,
+      height: ProductFooter.kHeight + LARGE_SPACE + bottomPadding,
       child: OutlinedButtonTheme(
         data: OutlinedButtonThemeData(
           style: OutlinedButton.styleFrom(
@@ -80,8 +76,12 @@ class _ProductFooterButtonsBar extends StatelessWidget {
           ),
         ),
         child: ListView(
-          padding:
-              const EdgeInsetsDirectional.symmetric(horizontal: SMALL_SPACE),
+          padding: EdgeInsetsDirectional.only(
+            start: SMALL_SPACE,
+            end: SMALL_SPACE,
+            top: LARGE_SPACE,
+            bottom: bottomPadding,
+          ),
           scrollDirection: Axis.horizontal,
           children: const <Widget>[
             SizedBox(width: 10.0),
@@ -383,6 +383,7 @@ class _ProductFooterFilledButton extends StatelessWidget {
           side: BorderSide.none,
         ),
         child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
           children: <Widget>[
             IconTheme(
               data: const IconThemeData(

--- a/packages/smooth_app/lib/pages/product/product_page/new_product_footer.dart
+++ b/packages/smooth_app/lib/pages/product/product_page/new_product_footer.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
@@ -56,8 +58,8 @@ class _ProductFooterButtonsBar extends StatelessWidget {
 
     double bottomPadding = MediaQuery.viewPaddingOf(context).bottom;
     // Add an extra padding (for Android)
-    if (bottomPadding == 0.0) {
-      bottomPadding = LARGE_SPACE;
+    if (Platform.isAndroid) {
+      bottomPadding += MEDIUM_SPACE;
     }
 
     return SizedBox(
@@ -71,7 +73,6 @@ class _ProductFooterButtonsBar extends StatelessWidget {
             side: BorderSide(color: themeExtension.greyLight),
             padding: const EdgeInsetsDirectional.symmetric(
               horizontal: 19.0,
-              vertical: 14.0,
             ),
           ),
         ),

--- a/packages/smooth_app/lib/pages/product/product_page/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/product_page/new_product_page.dart
@@ -258,8 +258,6 @@ class ProductPageState extends State<ProductPage>
           if (questionsLayout == ProductQuestionsLayout.banner)
             // assuming it's tall enough in order to go above the banner
             const SizedBox(height: 4 * VERY_LARGE_SPACE),
-          // Space for the navigation bar
-          SizedBox(height: MediaQuery.paddingOf(context).bottom),
         ],
       ),
     );

--- a/packages/smooth_app/lib/pages/product/website_card.dart
+++ b/packages/smooth_app/lib/pages/product/website_card.dart
@@ -3,6 +3,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/helpers/launch_url_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
+import 'package:smooth_app/resources/app_icons.dart' as icons;
 
 /// Card that displays a website link.
 class WebsiteCard extends StatelessWidget {
@@ -15,57 +16,58 @@ class WebsiteCard extends StatelessWidget {
     final AppLocalizations localizations = AppLocalizations.of(context);
     final String website = _getWebsite();
 
-    return buildProductSmoothCard(
-      body: Semantics(
-        label: localizations.product_field_website_title,
-        value: Uri.parse(website).host,
-        link: true,
-        excludeSemantics: true,
+    return Semantics(
+      label: localizations.product_field_website_title,
+      value: Uri.parse(website).host,
+      link: true,
+      excludeSemantics: true,
+      child: Padding(
+        padding: const EdgeInsetsDirectional.only(
+          top: VERY_LARGE_SPACE,
+          start: SMALL_SPACE,
+          end: SMALL_SPACE,
+        ),
         child: InkWell(
           onTap: () async => LaunchUrlHelper.launchURL(website),
           borderRadius: ROUNDED_BORDER_RADIUS,
-          child: Container(
-            width: double.infinity,
-            padding: const EdgeInsetsDirectional.only(
-              start: LARGE_SPACE,
-              top: LARGE_SPACE,
-              bottom: LARGE_SPACE,
-              // To be perfectly aligned with arrows
-              end: 21.0,
-            ),
-            child: Row(
-              children: <Widget>[
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisAlignment: MainAxisAlignment.start,
-                    children: <Widget>[
-                      Text(
-                        localizations.product_field_website_title,
-                        style: Theme.of(context).textTheme.displaySmall,
-                      ),
-                      const SizedBox(height: SMALL_SPACE),
-                      Text(
-                        website,
-                        overflow: TextOverflow.ellipsis,
-                        style: Theme.of(context)
-                            .textTheme
-                            .bodyMedium
-                            ?.copyWith(color: Colors.blue),
-                      ),
-                    ],
+          child: buildProductSmoothCard(
+            title: Text(localizations.product_field_website_title),
+            body: Container(
+              width: double.infinity,
+              padding: const EdgeInsetsDirectional.only(
+                start: LARGE_SPACE,
+                top: LARGE_SPACE,
+                bottom: LARGE_SPACE,
+                // To be perfectly aligned with arrows
+                end: 21.0,
+              ),
+              child: Row(
+                children: <Widget>[
+                  Expanded(
+                    child: Text(
+                      website,
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context)
+                          .textTheme
+                          .bodyMedium
+                          ?.copyWith(color: Colors.blue),
+                    ),
                   ),
-                ),
-                const Icon(Icons.open_in_new),
-              ],
+                  const Padding(
+                    padding: EdgeInsetsDirectional.only(
+                      start: 5.0,
+                      end: 3.0,
+                    ),
+                    child: icons.ExternalLink(
+                      size: 20.0,
+                    ),
+                  ),
+                ],
+              ),
             ),
+            margin: EdgeInsets.zero,
           ),
         ),
-      ),
-      margin: const EdgeInsets.only(
-        left: SMALL_SPACE,
-        right: SMALL_SPACE,
-        bottom: MEDIUM_SPACE,
       ),
     );
   }


### PR DESCRIPTION
Hi everyone!

After #5749, there were some minor details to fix.
Here's the list:

- Subtitles now are… subtitles (= with a bigger size and a darker font)
![IMG_1255 copy](https://github.com/user-attachments/assets/19d6a89c-6120-4f70-8ad2-e37f5e1242f3)

- The action bar has a darker shadow + more paddings on Android
![IMG_1255](https://github.com/user-attachments/assets/4eb8d790-1628-4735-b70c-e04e8ff2a9d5)

- All sections have equal spacings (+ no more blank spacing at the end)
![IMG_1256](https://github.com/user-attachments/assets/8c7d81f5-cd0a-49f4-8564-7b75d4436f4f)

- Websites and Prices blocks share the same title layout as Health/Environment
![IMG_1256](https://github.com/user-attachments/assets/54062429-9a28-49d6-bd35-a591fb21bc26)

And the same goes for dark mode:
![IMG_1252](https://github.com/user-attachments/assets/d67b4379-22e0-4909-8d6e-601a089b5324)
![IMG_1254](https://github.com/user-attachments/assets/efbe308e-2489-4a57-a51e-e8fb96157735)

+ Some refactored code