### PR TITLE
feat: 5621 - "road to scores" label now depends on OxF

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -682,6 +682,9 @@
         "description": "Button at the end of new product page, that takes you to completed product"
     },
     "hey_incomplete_product_message": "Tap to answer 3 questions NOW to compute Nutri-Score, Eco-Score & Ultra-processing (NOVA)!",
+    "hey_incomplete_product_message_beauty": "Tap now to answer 2 questions to help analyze this cosmetic!",
+    "hey_incomplete_product_message_pet_food": "Tap now to answer 3 questions to help analyze this pet food product!",
+    "hey_incomplete_product_message_product": "Tap now to help complete this product!",
     "nutritional_facts_photo_uploaded": "Nutrition facts photo uploaded",
     "@nutritional_facts_photo_uploaded": {},
     "recycling_photo_button_label": "Recycling photo",

--- a/packages/smooth_app/lib/pages/product/product_incomplete_card.dart
+++ b/packages/smooth_app/lib/pages/product/product_incomplete_card.dart
@@ -6,6 +6,7 @@ import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/pages/product/add_new_product_page.dart';
 import 'package:smooth_app/pages/product/product_field_editor.dart';
 import 'package:smooth_app/pages/product/simple_input_page_helpers.dart';
+import 'package:smooth_app/query/product_query.dart';
 
 /// "Incomplete product!" card to be displayed in product summary, if relevant.
 ///
@@ -99,7 +100,11 @@ class ProductIncompleteCard extends StatelessWidget {
       child: ElevatedButton.icon(
         label: Padding(
           padding: const EdgeInsets.symmetric(vertical: SMALL_SPACE),
-          child: Text(appLocalizations.hey_incomplete_product_message),
+          child: Text(
+            (product.productType ?? ProductType.food).getRoadToScoreLabel(
+              appLocalizations,
+            ),
+          ),
         ),
         icon: const Icon(
           Icons.bolt,

--- a/packages/smooth_app/lib/query/product_query.dart
+++ b/packages/smooth_app/lib/query/product_query.dart
@@ -307,4 +307,15 @@ extension ProductTypeExtension on ProductType {
         ProductType.petFood => appLocalizations.product_type_label_pet_food,
         ProductType.product => appLocalizations.product_type_label_product,
       };
+
+  String getRoadToScoreLabel(final AppLocalizations appLocalizations) =>
+      switch (this) {
+        ProductType.food => appLocalizations.hey_incomplete_product_message,
+        ProductType.beauty =>
+          appLocalizations.hey_incomplete_product_message_beauty,
+        ProductType.petFood =>
+          appLocalizations.hey_incomplete_product_message_pet_food,
+        ProductType.product =>
+          appLocalizations.hey_incomplete_product_message_product,
+      };
 }


### PR DESCRIPTION
### What
- "road to scores" label now depends on OxF

### Fixes bug(s)
- Closes: #5621

### Impacted files
* `app_en.arb`: added labels for OxF versions
* `product_incomplete_card.dart`: button label depends on OxF
* `product_query.dart`: new `getRoadToScoreLabel` method