### PR TITLE
feat: Visual improvements for the scan page

### DIFF
--- a/packages/smooth_app/ios/Podfile.lock
+++ b/packages/smooth_app/ios/Podfile.lock
@@ -291,7 +291,7 @@ SPEC CHECKSUMS:
   mobile_scanner: 38dcd8a49d7d485f632b7de65e4900010187aef2
   MTBBarcodeScanner: f453b33c4b7dfe545d8c6484ed744d55671788cb
   nanopb: 438bc412db1928dac798aa6fd75726007be04262
-  package_info_plus: 58f0028419748fad15bf008b270aaa8e54380b1c
+  package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
   permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
@@ -302,7 +302,7 @@ SPEC CHECKSUMS:
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   Sentry: f8374b5415bc38dfb5645941b3ae31230fbeae57
   sentry_flutter: 0eb93e5279eb41e2392212afe1ccd2fecb4f8cbe
-  share_plus: 8875f4f2500512ea181eef553c3e27dba5135aad
+  share_plus: 8b6f8b3447e494cca5317c8c3073de39b3600d1f
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
   sqflite_darwin: a553b1fd6fe66f53bbb0fe5b4f5bab93f08d7a13
   url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe

--- a/packages/smooth_app/lib/cards/product_cards/product_title_card.dart
+++ b/packages/smooth_app/lib/cards/product_cards/product_title_card.dart
@@ -3,6 +3,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/cards/product_cards/smooth_product_base_card.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/helpers/extension_on_text_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 
@@ -52,15 +53,30 @@ class ProductTitleCard extends StatelessWidget {
       ];
     } else {
       children = <Widget>[
-        _ProductTitleCardName(
-          selectable: isSelectable,
-          dense: dense,
+        Padding(
+          padding: const EdgeInsetsDirectional.only(top: VERY_SMALL_SPACE),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    _ProductTitleCardName(
+                      selectable: isSelectable,
+                      dense: dense,
+                    ),
+                    _ProductTitleCardBrand(
+                      removable: isRemovable,
+                      selectable: isSelectable,
+                    ),
+                  ],
+                ),
+              ),
+              title,
+            ],
+          ),
         ),
-        _ProductTitleCardBrand(
-          removable: isRemovable,
-          selectable: isSelectable,
-        ),
-        title,
       ];
     }
 
@@ -154,6 +170,11 @@ class _ProductTitleCardTrailing extends StatelessWidget {
         alignment: AlignmentDirectional.centerEnd,
         child: ProductCardCloseButton(
           onRemove: onRemove,
+          padding: const EdgeInsetsDirectional.only(
+            start: SMALL_SPACE,
+            top: SMALL_SPACE,
+            bottom: SMALL_SPACE,
+          ),
         ),
       );
     } else {

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_base_card.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_base_card.dart
@@ -59,10 +59,12 @@ class ProductCardCloseButton extends StatelessWidget {
   const ProductCardCloseButton({
     this.onRemove,
     this.iconData = Icons.clear_rounded,
+    this.padding,
   });
 
   final OnRemoveCallback? onRemove;
   final IconData iconData;
+  final EdgeInsetsGeometry? padding;
 
   @override
   Widget build(BuildContext context) {
@@ -79,7 +81,7 @@ class ProductCardCloseButton extends StatelessWidget {
         child: Tooltip(
           message: appLocalizations.product_card_remove_product_tooltip,
           child: Padding(
-            padding: const EdgeInsets.all(SMALL_SPACE),
+            padding: padding ?? const EdgeInsets.all(SMALL_SPACE),
             child: Icon(
               iconData,
               size: DEFAULT_ICON_SIZE,

--- a/packages/smooth_app/lib/pages/product/product_compatibility_header.dart
+++ b/packages/smooth_app/lib/pages/product/product_compatibility_header.dart
@@ -52,6 +52,8 @@ class ProductCompatibilityHeader extends StatelessWidget {
                   helper.getHeaderText(appLocalizations),
                   style: themeData.textTheme.titleMedium?.copyWith(
                     color: helper.getHeaderForegroundColor(isDarkMode),
+                    fontSize: 15.0,
+                    fontWeight: FontWeight.w600,
                   ),
                 ),
               ),

--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -24,6 +24,8 @@ import 'package:smooth_app/pages/product/product_field_editor.dart';
 import 'package:smooth_app/pages/product/product_incomplete_card.dart';
 import 'package:smooth_app/pages/product/product_questions_widget.dart';
 import 'package:smooth_app/pages/product/summary_attribute_group.dart';
+import 'package:smooth_app/resources/app_icons.dart' as icons;
+import 'package:smooth_app/themes/smooth_theme_colors.dart';
 
 const List<String> _ATTRIBUTE_GROUP_ORDER = <String>[
   AttributeGroup.ATTRIBUTE_GROUP_ALLERGENS,
@@ -45,6 +47,7 @@ class SummaryCard extends StatefulWidget {
     this.isProductEditable = true,
     this.attributeGroupsClickable = true,
     this.padding,
+    this.shadow,
   });
 
   final Product _product;
@@ -72,6 +75,9 @@ class SummaryCard extends StatefulWidget {
   final bool attributeGroupsClickable;
 
   final EdgeInsetsGeometry? padding;
+
+  /// An optional shadow to apply to the card
+  final BoxShadow? shadow;
 
   @override
   State<SummaryCard> createState() => _SummaryCardState();
@@ -120,6 +126,9 @@ class _SummaryCardState extends State<SummaryCard> with UpToDateMixin {
   }
 
   Widget _buildLimitedSizeSummaryCard(double parentHeight) {
+    final SmoothColorsThemeExtension? themeExtension =
+        Theme.of(context).extension<SmoothColorsThemeExtension>();
+
     return Padding(
       padding: widget.padding ??
           const EdgeInsets.symmetric(
@@ -128,23 +137,30 @@ class _SummaryCardState extends State<SummaryCard> with UpToDateMixin {
           ),
       child: Stack(
         children: <Widget>[
-          ClipRRect(
-            borderRadius: ROUNDED_BORDER_RADIUS,
-            child: OverflowBox(
-              alignment: AlignmentDirectional.topStart,
-              minHeight: parentHeight,
-              maxHeight: double.infinity,
-              child: buildProductSmoothCard(
-                header: ProductCompatibilityHeader(
-                  product: upToDateProduct,
-                  productPreferences: widget._productPreferences,
-                  isSettingVisible: widget.isSettingVisible,
+          DecoratedBox(
+            decoration: BoxDecoration(
+              boxShadow:
+                  widget.shadow != null ? <BoxShadow>[widget.shadow!] : null,
+              borderRadius: ROUNDED_BORDER_RADIUS,
+            ),
+            child: ClipRRect(
+              borderRadius: ROUNDED_BORDER_RADIUS,
+              child: OverflowBox(
+                alignment: AlignmentDirectional.topStart,
+                minHeight: parentHeight,
+                maxHeight: double.infinity,
+                child: buildProductSmoothCard(
+                  header: ProductCompatibilityHeader(
+                    product: upToDateProduct,
+                    productPreferences: widget._productPreferences,
+                    isSettingVisible: widget.isSettingVisible,
+                  ),
+                  body: Padding(
+                    padding: SMOOTH_CARD_PADDING,
+                    child: _buildSummaryCardContent(context),
+                  ),
+                  margin: EdgeInsets.zero,
                 ),
-                body: Padding(
-                  padding: SMOOTH_CARD_PADDING,
-                  child: _buildSummaryCardContent(context),
-                ),
-                margin: EdgeInsets.zero,
               ),
             ),
           ),
@@ -157,18 +173,39 @@ class _SummaryCardState extends State<SummaryCard> with UpToDateMixin {
                   vertical: SMALL_SPACE,
                 ),
                 decoration: BoxDecoration(
-                  color: Theme.of(context).cardColor,
+                  color: themeExtension!.primaryNormal,
                   borderRadius:
                       const BorderRadius.vertical(bottom: ROUNDED_RADIUS),
                 ),
-                child: Center(
-                  child: Text(
-                    AppLocalizations.of(context).tap_for_more,
-                    style:
-                        Theme.of(context).primaryTextTheme.bodyLarge?.copyWith(
-                              color: PRIMARY_BLUE_COLOR,
-                            ),
-                  ),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: <Widget>[
+                    Padding(
+                      padding: const EdgeInsetsDirectional.only(bottom: 2.0),
+                      child: Text(
+                        AppLocalizations.of(context).tap_for_more,
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 15.0,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(
+                      width: BALANCED_SPACE,
+                    ),
+                    Container(
+                      decoration: const BoxDecoration(
+                        shape: BoxShape.circle,
+                        color: Colors.white,
+                      ),
+                      padding: const EdgeInsets.all(VERY_SMALL_SPACE),
+                      child: icons.Arrow.right(
+                        color: themeExtension.primaryNormal,
+                        size: 12.0,
+                      ),
+                    )
+                  ],
                 ),
               ),
             ],

--- a/packages/smooth_app/lib/pages/scan/scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/scan_page.dart
@@ -16,6 +16,8 @@ import 'package:smooth_app/helpers/haptic_feedback_helper.dart';
 import 'package:smooth_app/helpers/permission_helper.dart';
 import 'package:smooth_app/pages/scan/camera_scan_page.dart';
 import 'package:smooth_app/pages/scan/carousel/scan_carousel.dart';
+import 'package:smooth_app/themes/smooth_theme_colors.dart';
+import 'package:smooth_app/themes/theme_provider.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
 class ScanPage extends StatefulWidget {
@@ -52,6 +54,8 @@ class _ScanPageState extends State<ScanPage> {
     }
 
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final SmoothColorsThemeExtension themeExtension =
+        Theme.of(context).extension<SmoothColorsThemeExtension>()!;
     final TextDirection direction = Directionality.of(context);
     final bool hasACamera = CameraHelper.hasACamera;
 
@@ -60,86 +64,81 @@ class _ScanPageState extends State<ScanPage> {
           Theme.of(context).brightness == Brightness.light && Platform.isIOS
               ? Brightness.dark
               : null,
-      body: Container(
-        color: Colors.white,
-        child: SafeArea(
-          child: Container(
-            color: Theme.of(context).colorScheme.surface,
-            child: Column(
-              children: <Widget>[
-                if (hasACamera)
-                  Expanded(
-                    flex: 100 - _carouselHeightPct,
-                    child: Consumer<PermissionListener>(
-                      builder: (
-                        BuildContext context,
-                        PermissionListener listener,
-                        _,
-                      ) {
-                        switch (listener.value.status) {
-                          case DevicePermissionStatus.checking:
-                            return EMPTY_WIDGET;
-                          case DevicePermissionStatus.granted:
-                            // TODO(m123): change
-                            return const CameraScannerPage();
-                          default:
-                            return const _PermissionDeniedCard();
-                        }
-                      },
-                    ),
-                  ),
-                Expanded(
-                  flex: _carouselHeightPct,
-                  child: Padding(
-                    padding: const EdgeInsetsDirectional.only(
-                        bottom: BALANCED_SPACE),
-                    child: ScanPageCarousel(
-                      onPageChangedTo: (int page, String? barcode) async {
-                        if (barcode == null) {
-                          // We only notify for new products
-                          return;
-                        }
-
-                        // Both are Future methods, but it doesn't matter to wait here
-                        SmoothHapticFeedback.lightNotification();
-
-                        if (_userPreferences.playCameraSound) {
-                          await _initSoundManagerIfNecessary();
-                          await _musicPlayer!.stop();
-                          await _musicPlayer!.play(
-                            AssetSource('audio/beep.wav'),
-                            volume: 0.5,
-                            ctx: AudioContext(
-                              android: const AudioContextAndroid(
-                                isSpeakerphoneOn: false,
-                                stayAwake: false,
-                                contentType: AndroidContentType.sonification,
-                                usageType: AndroidUsageType.notification,
-                                audioFocus:
-                                    AndroidAudioFocus.gainTransientMayDuck,
-                              ),
-                              iOS: AudioContextIOS(
-                                category: AVAudioSessionCategory.soloAmbient,
-                                options: const <AVAudioSessionOptions>{
-                                  AVAudioSessionOptions.mixWithOthers,
-                                },
-                              ),
-                            ),
-                          );
-                        }
-
-                        SemanticsService.announce(
-                          appLocalizations.scan_announce_new_barcode(barcode),
-                          direction,
-                          assertiveness: Assertiveness.assertive,
-                        );
-                      },
-                    ),
-                  ),
+      backgroundColor:
+          context.lightTheme() ? themeExtension.primaryLight : null,
+      body: SafeArea(
+        child: Column(
+          children: <Widget>[
+            if (hasACamera)
+              Expanded(
+                flex: 100 - _carouselHeightPct,
+                child: Consumer<PermissionListener>(
+                  builder: (
+                    BuildContext context,
+                    PermissionListener listener,
+                    _,
+                  ) {
+                    switch (listener.value.status) {
+                      case DevicePermissionStatus.checking:
+                        return EMPTY_WIDGET;
+                      case DevicePermissionStatus.granted:
+                        // TODO(m123): change
+                        return const CameraScannerPage();
+                      default:
+                        return const _PermissionDeniedCard();
+                    }
+                  },
                 ),
-              ],
+              ),
+            Expanded(
+              flex: _carouselHeightPct,
+              child: Padding(
+                padding:
+                    const EdgeInsetsDirectional.only(bottom: BALANCED_SPACE),
+                child: ScanPageCarousel(
+                  onPageChangedTo: (int page, String? barcode) async {
+                    if (barcode == null) {
+                      // We only notify for new products
+                      return;
+                    }
+
+                    // Both are Future methods, but it doesn't matter to wait here
+                    SmoothHapticFeedback.lightNotification();
+
+                    if (_userPreferences.playCameraSound) {
+                      await _initSoundManagerIfNecessary();
+                      await _musicPlayer!.stop();
+                      await _musicPlayer!.play(
+                        AssetSource('audio/beep.wav'),
+                        volume: 0.5,
+                        ctx: AudioContext(
+                          android: const AudioContextAndroid(
+                            isSpeakerphoneOn: false,
+                            stayAwake: false,
+                            contentType: AndroidContentType.sonification,
+                            usageType: AndroidUsageType.notification,
+                            audioFocus: AndroidAudioFocus.gainTransientMayDuck,
+                          ),
+                          iOS: AudioContextIOS(
+                            category: AVAudioSessionCategory.soloAmbient,
+                            options: const <AVAudioSessionOptions>{
+                              AVAudioSessionOptions.mixWithOthers,
+                            },
+                          ),
+                        ),
+                      );
+                    }
+
+                    SemanticsService.announce(
+                      appLocalizations.scan_announce_new_barcode(barcode),
+                      direction,
+                      assertiveness: Assertiveness.assertive,
+                    );
+                  },
+                ),
+              ),
             ),
-          ),
+          ],
         ),
       ),
     );
@@ -191,9 +190,12 @@ class _PermissionDeniedCard extends StatelessWidget {
                 end: SMALL_SPACE,
                 bottom: 5.0,
               ),
+              borderRadius: BorderRadius.zero,
+              margin: EdgeInsets.zero,
               child: Align(
                 alignment: Alignment.topCenter,
                 child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
                   children: <Widget>[
                     Text(
                       localizations.permission_photo_denied_title,
@@ -203,22 +205,20 @@ class _PermissionDeniedCard extends StatelessWidget {
                       ),
                       textAlign: TextAlign.center,
                     ),
-                    Expanded(
-                      child: SingleChildScrollView(
-                        child: Padding(
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: BALANCED_SPACE,
-                            vertical: BALANCED_SPACE,
+                    SingleChildScrollView(
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: BALANCED_SPACE,
+                          vertical: BALANCED_SPACE,
+                        ),
+                        child: Text(
+                          localizations.permission_photo_denied_message(
+                            APP_NAME,
                           ),
-                          child: Text(
-                            localizations.permission_photo_denied_message(
-                              APP_NAME,
-                            ),
-                            textAlign: TextAlign.center,
-                            style: const TextStyle(
-                              height: 1.4,
-                              fontSize: 15.5,
-                            ),
+                          textAlign: TextAlign.center,
+                          style: const TextStyle(
+                            height: 1.4,
+                            fontSize: 15.5,
                           ),
                         ),
                       ),

--- a/packages/smooth_app/lib/pages/scan/scan_product_card.dart
+++ b/packages/smooth_app/lib/pages/scan/scan_product_card.dart
@@ -6,6 +6,7 @@ import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/pages/navigator/app_navigator.dart';
 import 'package:smooth_app/pages/product/hideable_container.dart';
 import 'package:smooth_app/pages/product/summary_card.dart';
+import 'package:smooth_app/themes/theme_provider.dart';
 
 class ScanProductCard extends StatelessWidget {
   ScanProductCard(this.product)
@@ -37,6 +38,14 @@ class ScanProductCard extends StatelessWidget {
             attributeGroupsClickable: false,
             padding: const EdgeInsets.symmetric(
               vertical: VERY_SMALL_SPACE,
+            ),
+            shadow: BoxShadow(
+              color: Theme.of(context)
+                  .shadowColor
+                  .withOpacity(context.lightTheme() ? 0.08 : 0.3),
+              offset: const Offset(0.0, 2.0),
+              blurRadius: 5.0,
+              spreadRadius: 1.0,
             ),
           ),
         ),


### PR DESCRIPTION
Hi everyone!

Here are a few visual changes for the scan page:

- We now have a light brown background in light mode (the same as the product page)
- The compatibility header has a "stronger" font-weight and is a bit taller (14 -> 14.5)
![IMG_1266](https://github.com/user-attachments/assets/d73032fd-e8c9-4d76-aa03-31e2ade0879e)

- Title and brands are aligned with the Close button (+ aligned with the Settings icon)
- Cards have a shadow
![IMG_1266](https://github.com/user-attachments/assets/2f26df97-64fa-46d2-9526-aa9ef43751a9)

- The "Tap for more info" button is better highlighted
![IMG_1264](https://github.com/user-attachments/assets/90600066-0aff-42c1-93a1-5bb748a74423)

- The error when the camera permission is not given is centered (previously at the top of the screen)
![IMG_1264](https://github.com/user-attachments/assets/2f6a8871-97a3-41b4-8af0-1a977dd74d95)


Here is the result in light and dark themes:

![IMG_E330376687E2-1](https://github.com/user-attachments/assets/6e7a8096-74c8-45a2-9e83-911c9e17839c)
![IMG_1265](https://github.com/user-attachments/assets/f62dfa8d-45ef-4cf2-8d75-907b95636cc4)
