### PR TITLE
fix: Robotoff banner: bring back the pre-Material 3 visual

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -408,9 +408,9 @@
     "@saving_answer": {
         "description": "Dialog shown to users after they have answered a question, while the answer is being saved in the BE."
     },
-    "contribute_to_get_rewards": "Help improve food transparency and get rewards",
+    "contribute_to_get_rewards": "Become an actor of food transparency",
     "@contribute_to_get_rewards": {
-        "description": "Button description shown on a product, clicking the button opens a card with unanswered product questions, users can answer these to contribute to Open Food Facts and gain rewards."
+        "description": "Button description shown on a product, clicking the button opens a card with unanswered product questions, users can answer these to contribute to Open Food Facts."
     },
     "question_sign_in_text": "Sign in to your Open Food Facts account to get credit for your contributions",
     "question_yes_button_accessibility_value": "Answer with yes",

--- a/packages/smooth_app/lib/pages/product/product_questions_widget.dart
+++ b/packages/smooth_app/lib/pages/product/product_questions_widget.dart
@@ -314,11 +314,13 @@ class _ProductQuestionBanner extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    final Color contentColor = context.darkTheme() ? Colors.black : WHITE_COLOR;
+    final bool darkTheme = context.darkTheme();
+    final Color contentColor = darkTheme ? Colors.black : WHITE_COLOR;
 
     // We need to differentiate with / without a Shimmer, because
     // [Shimmer] doesn't support [Ink]
-    final Color backgroundColor = Theme.of(context).colorScheme.primary;
+    final ThemeData theme = Theme.of(context);
+    final Color backgroundColor = theme.colorScheme.primary;
 
     final Widget child;
     if (state is! _ProductQuestionsWithQuestions) {
@@ -327,60 +329,66 @@ class _ProductQuestionBanner extends StatelessWidget {
         child: EMPTY_WIDGET,
       );
     } else {
-      child = Semantics(
-        value: appLocalizations.tap_to_answer_hint,
-        button: true,
-        excludeSemantics: true,
-        child: Material(
-          type: MaterialType.transparency,
-          child: InkWell(
-            onTap: openQuestionsCallback,
-            child: Ink(
-              width: double.infinity,
-              color: backgroundColor,
-              padding: const EdgeInsetsDirectional.symmetric(
-                vertical: SMALL_SPACE,
-                horizontal: MEDIUM_SPACE,
-              ).add(
-                EdgeInsetsDirectional.only(
-                  bottom: MediaQuery.viewPaddingOf(context).bottom,
+      child = DecoratedBox(
+        decoration: BoxDecoration(
+          boxShadow: <BoxShadow>[
+            BoxShadow(
+              color: theme.shadowColor.withOpacity(darkTheme ? 0.5 : 0.2),
+              blurRadius: 2.5,
+              offset: const Offset(0.0, -4.0),
+            ),
+          ],
+        ),
+        child: Semantics(
+          value: appLocalizations.tap_to_answer_hint,
+          button: true,
+          excludeSemantics: true,
+          child: Material(
+            type: MaterialType.transparency,
+            child: InkWell(
+              onTap: openQuestionsCallback,
+              child: Ink(
+                width: double.infinity,
+                color: backgroundColor,
+                padding: const EdgeInsetsDirectional.symmetric(
+                  vertical: SMALL_SPACE,
+                  horizontal: MEDIUM_SPACE,
+                ).add(
+                  EdgeInsetsDirectional.only(
+                    bottom: MediaQuery.viewPaddingOf(context).bottom,
+                  ),
                 ),
-              ),
-              child: Row(
-                children: <Widget>[
-                  const _ProductQuestionIcon(),
-                  Expanded(
-                    child: RichText(
-                      text: TextSpan(
-                        text: '${appLocalizations.tap_to_answer}\n',
-                        style: Theme.of(context)
-                            .primaryTextTheme
-                            .bodyLarge!
-                            .copyWith(
-                              color: contentColor,
-                              height: 1.5,
-                              fontWeight: FontWeight.bold,
-                            ),
-                        children: <TextSpan>[
-                          TextSpan(
-                            text: appLocalizations.contribute_to_get_rewards,
-                            style: Theme.of(context)
-                                .primaryTextTheme
-                                .bodyMedium!
-                                .copyWith(
-                                  color: contentColor,
-                                ),
+                child: Row(
+                  children: <Widget>[
+                    const _ProductQuestionIcon(),
+                    Expanded(
+                      child: RichText(
+                        text: TextSpan(
+                          text: '${appLocalizations.tap_to_answer}\n',
+                          style: theme.primaryTextTheme.bodyLarge!.copyWith(
+                            color: contentColor,
+                            height: 1.5,
+                            fontWeight: FontWeight.bold,
                           ),
-                        ],
+                          children: <TextSpan>[
+                            TextSpan(
+                              text: appLocalizations.contribute_to_get_rewards,
+                              style:
+                                  theme.primaryTextTheme.bodyMedium!.copyWith(
+                                color: contentColor,
+                              ),
+                            ),
+                          ],
+                        ),
                       ),
                     ),
-                  ),
-                  Icon(
-                    Icons.arrow_circle_right_outlined,
-                    color: contentColor,
-                    size: 20.0,
-                  )
-                ],
+                    Icon(
+                      Icons.arrow_circle_right_outlined,
+                      color: contentColor,
+                      size: 20.0,
+                    )
+                  ],
+                ),
               ),
             ),
           ),

--- a/packages/smooth_app/lib/pages/product/product_questions_widget.dart
+++ b/packages/smooth_app/lib/pages/product/product_questions_widget.dart
@@ -12,6 +12,7 @@ import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/robotoff_insight_helper.dart';
 import 'package:smooth_app/pages/hunger_games/question_page.dart';
 import 'package:smooth_app/query/product_questions_query.dart';
+import 'package:smooth_app/themes/theme_provider.dart';
 
 class ProductQuestionsWidget extends StatefulWidget {
   const ProductQuestionsWidget(
@@ -313,8 +314,7 @@ class _ProductQuestionBanner extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    final bool isDarkMode = Theme.of(context).brightness == Brightness.dark;
-    final Color contentColor = isDarkMode ? Colors.black : WHITE_COLOR;
+    final Color contentColor = context.darkTheme() ? Colors.black : WHITE_COLOR;
 
     // We need to differentiate with / without a Shimmer, because
     // [Shimmer] doesn't support [Ink]
@@ -340,7 +340,7 @@ class _ProductQuestionBanner extends StatelessWidget {
               color: backgroundColor,
               padding: const EdgeInsetsDirectional.symmetric(
                 vertical: SMALL_SPACE,
-                horizontal: VERY_LARGE_SPACE,
+                horizontal: MEDIUM_SPACE,
               ).add(
                 EdgeInsetsDirectional.only(
                   bottom: MediaQuery.viewPaddingOf(context).bottom,
@@ -359,6 +359,7 @@ class _ProductQuestionBanner extends StatelessWidget {
                             .copyWith(
                               color: contentColor,
                               height: 1.5,
+                              fontWeight: FontWeight.bold,
                             ),
                         children: <TextSpan>[
                           TextSpan(


### PR DESCRIPTION
Hi everyone!

The upgrade to Material 3 has broken some titles.
Here's a fix for the Robotoff banner (+ some light shadow around it)

![IMG_1269](https://github.com/user-attachments/assets/75020240-a18d-4b11-917c-35ee2dffe811)


+ @teolemon Shouldn't we remove the claim about badges?