### PR TITLE
fix: Location map AppBar fixes

### DIFF
--- a/packages/smooth_app/lib/pages/locations/location_map_page.dart
+++ b/packages/smooth_app/lib/pages/locations/location_map_page.dart
@@ -26,21 +26,14 @@ class LocationMapPage extends StatelessWidget {
     return SmoothScaffold(
       appBar: SmoothAppBar(
         title: title == null ? null : Text(title),
-        subTitle: subtitle == null ? null : Text(subtitle),
+        subTitle: subtitle == null
+            ? null
+            : Text(
+                subtitle,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
         actions: <Widget>[
-          IconButton(
-            icon: const Icon(Icons.check),
-            onPressed: () {
-              // pops that map page
-              Navigator.of(context).pop();
-              if (popFirst) {
-                // pops the result page
-                Navigator.of(context).pop();
-              }
-              // returns the result
-              Navigator.of(context).pop(osmLocation);
-            },
-          ),
           IconButton(
             icon: const Icon(Icons.info),
             onPressed: () => showCupertinoModalPopup<void>(
@@ -65,6 +58,19 @@ class LocationMapPage extends StatelessWidget {
                 ],
               ),
             ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.check),
+            onPressed: () {
+              // pops that map page
+              Navigator.of(context).pop();
+              if (popFirst) {
+                // pops the result page
+                Navigator.of(context).pop();
+              }
+              // returns the result
+              Navigator.of(context).pop(osmLocation);
+            },
           ),
         ],
       ),


### PR DESCRIPTION
Hi everyone!

Here are two changes for the location map page:
- We force the subtitle on 1 line (seems to be a Material 3 regression)
- The positive action should always be on the right

Before:
![IMG_1273](https://github.com/user-attachments/assets/7fe0bb14-3e60-4fec-91ab-1b3d7bd81fb6)

After:
![IMG_1274](https://github.com/user-attachments/assets/88105fe2-e5c9-4d12-8e2d-72efe63a7cf2)
