### PR TITLE
feat: Product page - manage user lists in a bottom sheet 

### DIFF
--- a/packages/smooth_app/lib/generic_lib/bottom_sheets/smooth_bottom_sheet.dart
+++ b/packages/smooth_app/lib/generic_lib/bottom_sheets/smooth_bottom_sheet.dart
@@ -4,6 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
 import 'package:smooth_app/generic_lib/bottom_sheets/smooth_draggable_bottom_sheet_route.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/resources/app_icons.dart' as icons;
+import 'package:smooth_app/themes/smooth_theme_colors.dart';
 
 Future<T?> showSmoothModalSheet<T>({
   required BuildContext context,
@@ -90,47 +92,65 @@ class SmoothModalSheet extends StatelessWidget {
 class SmoothModalSheetHeader extends StatelessWidget implements SizeWidget {
   const SmoothModalSheetHeader({
     required this.title,
+    this.prefix,
     this.suffix,
+    this.foregroundColor,
+    this.backgroundColor,
   });
 
   static const double MIN_HEIGHT = 50.0;
 
   final String title;
+  final SizeWidget? prefix;
   final SizeWidget? suffix;
+  final Color? foregroundColor;
+  final Color? backgroundColor;
 
   @override
   Widget build(BuildContext context) {
     final Color primaryColor = Theme.of(context).primaryColor;
 
-    return Container(
-      height: suffix is SmoothModalSheetHeaderButton ? double.infinity : null,
-      color: primaryColor.withOpacity(0.2),
-      constraints: const BoxConstraints(minHeight: MIN_HEIGHT),
-      padding: EdgeInsetsDirectional.only(
-        start: VERY_LARGE_SPACE,
-        top: VERY_SMALL_SPACE,
-        bottom: VERY_SMALL_SPACE,
-        end: VERY_LARGE_SPACE -
-            (suffix?.requiresPadding == true ? 0 : LARGE_SPACE),
-      ),
-      child: IntrinsicHeight(
-        child: Row(
-          children: <Widget>[
-            Expanded(
-              child: Semantics(
-                sortKey: const OrdinalSortKey(1.0),
-                child: Text(
-                  title,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                        fontWeight: FontWeight.bold,
-                      ),
+    return IconTheme(
+      data: IconThemeData(color: foregroundColor),
+      child: Container(
+        height: suffix is SmoothModalSheetHeaderButton ? double.infinity : null,
+        color: backgroundColor ?? primaryColor.withOpacity(0.2),
+        constraints: const BoxConstraints(minHeight: MIN_HEIGHT),
+        padding: EdgeInsetsDirectional.only(
+          start: (prefix?.requiresPadding == true ? 0 : VERY_LARGE_SPACE),
+          top: VERY_SMALL_SPACE,
+          bottom: VERY_SMALL_SPACE,
+          end: VERY_LARGE_SPACE -
+              (suffix?.requiresPadding == true ? 0 : LARGE_SPACE),
+        ),
+        child: IntrinsicHeight(
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: <Widget>[
+              if (prefix != null)
+                Padding(
+                  padding:
+                      const EdgeInsetsDirectional.only(end: BALANCED_SPACE),
+                  child: prefix,
+                ),
+              Expanded(
+                child: Semantics(
+                  sortKey: const OrdinalSortKey(1.0),
+                  child: Text(
+                    title,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                          fontWeight: FontWeight.bold,
+                          fontSize: 18.0,
+                          color: foregroundColor,
+                        ),
+                  ),
                 ),
               ),
-            ),
-            if (suffix != null) suffix!
-          ],
+              if (suffix != null) suffix!
+            ],
+          ),
         ),
       ),
     );
@@ -245,9 +265,11 @@ class SmoothModalSheetHeaderCloseButton extends StatelessWidget
     implements SizeWidget {
   const SmoothModalSheetHeaderCloseButton({
     this.semanticsOrder,
+    this.addPadding,
   });
 
   final double? semanticsOrder;
+  final bool? addPadding;
 
   @override
   Widget build(BuildContext context) {
@@ -264,7 +286,9 @@ class SmoothModalSheetHeaderCloseButton extends StatelessWidget
           customBorder: const CircleBorder(),
           child: const Padding(
             padding: EdgeInsets.all(MEDIUM_SPACE),
-            child: Icon(Icons.clear),
+            child: icons.Close(
+              size: 15.0,
+            ),
           ),
         ),
       ),
@@ -276,7 +300,33 @@ class SmoothModalSheetHeaderCloseButton extends StatelessWidget
       (MEDIUM_SPACE * 2) + (Theme.of(context).iconTheme.size ?? 20.0);
 
   @override
+  bool get requiresPadding => addPadding ?? false;
+}
+
+class SmoothModalSheetHeaderPrefixIndicator extends StatelessWidget
+    implements SizeWidget {
+  const SmoothModalSheetHeaderPrefixIndicator({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final SmoothColorsThemeExtension extension =
+        Theme.of(context).extension<SmoothColorsThemeExtension>()!;
+
+    return Container(
+      width: 10.0,
+      height: 10.0,
+      decoration: BoxDecoration(
+        color: extension.secondaryNormal,
+        shape: BoxShape.circle,
+      ),
+    );
+  }
+
+  @override
   bool get requiresPadding => false;
+
+  @override
+  double widgetHeight(BuildContext context) => 10.0;
 }
 
 abstract class SizeWidget implements Widget {

--- a/packages/smooth_app/lib/generic_lib/bottom_sheets/smooth_draggable_bottom_sheet.dart
+++ b/packages/smooth_app/lib/generic_lib/bottom_sheets/smooth_draggable_bottom_sheet.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:provider/provider.dart';
 
 class SmoothDraggableBottomSheet extends StatefulWidget {
   const SmoothDraggableBottomSheet({
@@ -172,20 +173,23 @@ class _SmoothDraggableContentState extends State<_SmoothDraggableContent> {
   Widget build(BuildContext context) {
     return Scrollbar(
       controller: widget.scrollController,
-      child: CustomScrollView(
-        cacheExtent: widget.cacheExtent,
-        key: _contentKey,
-        controller: widget.scrollController,
-        slivers: <Widget>[
-          SliverPersistentHeader(
-            pinned: true,
-            delegate: _SliverHeader(
-              child: widget.headerBuilder(context),
-              height: widget.headerHeight,
+      child: ChangeNotifierProvider<ScrollController>.value(
+        value: widget.scrollController,
+        child: CustomScrollView(
+          cacheExtent: widget.cacheExtent,
+          key: _contentKey,
+          controller: widget.scrollController,
+          slivers: <Widget>[
+            SliverPersistentHeader(
+              pinned: true,
+              delegate: _SliverHeader(
+                child: widget.headerBuilder(context),
+                height: widget.headerHeight,
+              ),
             ),
-          ),
-          widget.bodyBuilder(context),
-        ],
+            widget.bodyBuilder(context),
+          ],
+        ),
       ),
     );
   }

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1569,6 +1569,10 @@
     "@user_list_subtitle_product": {
         "description": "Subtitle of a paragraph about user lists in a product context"
     },
+    "user_list_title": "Your lists",
+    "@user_list_title": {
+        "description": "Label for the user lists (when the user wants to add a product to a list)"
+    },
     "user_list_add_product": "Add the product to your lists",
     "@user_list_add_product": {
         "description": "Label for the dialog to add a product to a list"
@@ -1612,6 +1616,10 @@
     "user_list_name_error_same": "That is the same name",
     "@user_list_name_error_same": {
         "description": "Validation error about the renamed name that is the same as the initial list name"
+    },
+    "user_list_name_input_hint": "Name of the list",
+    "@user_list_name_input_hint": {
+        "description": "A hint to indicate that the user should input a name of a list"
     },
     "try_again": "Try Again",
     "@try_again": {

--- a/packages/smooth_app/lib/pages/product/product_list_helper.dart
+++ b/packages/smooth_app/lib/pages/product/product_list_helper.dart
@@ -1,0 +1,498 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:provider/provider.dart';
+import 'package:smooth_app/data_models/product_list.dart';
+import 'package:smooth_app/database/dao_product_list.dart';
+import 'package:smooth_app/database/local_database.dart';
+import 'package:smooth_app/generic_lib/buttons/smooth_simple_button.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/helpers/collections_helper.dart';
+import 'package:smooth_app/helpers/haptic_feedback_helper.dart';
+import 'package:smooth_app/helpers/provider_helper.dart';
+import 'package:smooth_app/pages/product_list_user_dialog_helper.dart';
+import 'package:smooth_app/resources/app_icons.dart';
+import 'package:smooth_app/themes/smooth_theme_colors.dart';
+import 'package:smooth_app/widgets/smooth_checkbox.dart';
+
+class AddProductToListContainer extends StatelessWidget {
+  const AddProductToListContainer({required this.barcode, super.key});
+
+  final String barcode;
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider<_ProductUserListsProvider>(
+      create: (BuildContext context) => _ProductUserListsProvider(
+        DaoProductList(context.read<LocalDatabase>()),
+        barcode,
+      ),
+      child: Consumer<_ProductUserListsProvider>(
+        builder: (
+          final BuildContext context,
+          final _ProductUserListsProvider productUserListsProvider,
+          final Widget? child,
+        ) {
+          return switch (productUserListsProvider.value) {
+            _ProductUserListsLoadingState _ => const _AddToProductListLoading(),
+            _ProductUserListsEmptyState _ =>
+              const _AddToProductListNoListAvailable(),
+            _ProductUserListsWithState _ => const _AddToProductListWithLists(),
+          };
+        },
+      ),
+    );
+  }
+}
+
+/// Widget when the [_ProductUserListsProvider] is loading lists
+class _AddToProductListLoading extends StatelessWidget {
+  const _AddToProductListLoading();
+
+  @override
+  Widget build(BuildContext context) {
+    return const SliverFillRemaining(
+      child: Center(
+        child: CircularProgressIndicator.adaptive(),
+      ),
+    );
+  }
+}
+
+/// Widget when there is no user list
+/// A button to create a new list (in a dialog)
+class _AddToProductListNoListAvailable extends StatelessWidget {
+  const _AddToProductListNoListAvailable();
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+
+    return SliverFillRemaining(
+      child: Center(
+        child: Padding(
+          padding: const EdgeInsetsDirectional.only(
+            start: LARGE_SPACE,
+            end: LARGE_SPACE,
+            bottom: VERY_LARGE_SPACE,
+          ),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: <Widget>[
+              ExcludeSemantics(
+                child: Container(
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: Theme.of(context)
+                        .extension<SmoothColorsThemeExtension>()!
+                        .secondaryLight,
+                  ),
+                  padding: const EdgeInsets.all(VERY_LARGE_SPACE),
+                  child: const Milk(
+                    size: 40.0,
+                    color: Colors.white,
+                  ),
+                ),
+              ),
+              const SizedBox(height: VERY_LARGE_SPACE),
+              Text(
+                appLocalizations.user_list_empty_label,
+                textAlign: TextAlign.center,
+                style: const TextStyle(fontWeight: FontWeight.w600),
+              ),
+              const SizedBox(height: VERY_LARGE_SPACE),
+              SmoothSimpleButton(
+                onPressed: () async {
+                  final ProductList? list = await ProductListUserDialogHelper(
+                          DaoProductList(context.read<LocalDatabase>()))
+                      .showCreateUserListDialog(
+                    context,
+                  );
+
+                  if (list != null && context.mounted) {
+                    final _ProductUserListsProvider provider =
+                        context.read<_ProductUserListsProvider>();
+                    await provider.addAProductToAList(list.parameters);
+                    await provider.reloadLists();
+                  }
+                },
+                child: Text(
+                  appLocalizations.user_list_button_new,
+                  style: const TextStyle(fontWeight: FontWeight.w600),
+                ),
+              )
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Widget when there are user lists
+/// A list of:
+/// -> Add new list button
+/// -> List of user lists
+class _AddToProductListWithLists extends StatelessWidget {
+  const _AddToProductListWithLists();
+
+  static const double MIN_ITEM_HEIGHT = 48.0;
+
+  @override
+  Widget build(BuildContext context) {
+    final _ProductUserListsWithState state = context
+        .watch<_ProductUserListsProvider>()
+        .value as _ProductUserListsWithState;
+
+    return SliverList(
+      delegate: SliverChildBuilderDelegate(
+        (BuildContext context, int index) {
+          if (index == 0) {
+            return _AddToProductListAddNewList(
+              userLists: state.userLists.map((MapEntry<String, bool> entry) {
+                return entry.key;
+              }),
+            );
+          } else if (index <= state.userLists.length) {
+            final MapEntry<String, bool> entry = state.userLists[index - 1];
+            return _AddToProductListItem(
+              listId: entry.key,
+              selected: entry.value,
+              includeDivider: index < state.userLists.length,
+            );
+          } else {
+            return SizedBox(height: MediaQuery.viewPaddingOf(context).bottom);
+          }
+        },
+        childCount: state.userLists.length + 2,
+      ),
+    );
+  }
+}
+
+/// An item showing a user list and handling the click
+class _AddToProductListItem extends StatelessWidget {
+  const _AddToProductListItem({
+    required this.listId,
+    required this.selected,
+    required this.includeDivider,
+  });
+
+  final String listId;
+  final bool selected;
+  final bool includeDivider;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: <Widget>[
+        InkWell(
+          onTap: () {
+            SmoothHapticFeedback.lightNotification();
+            Provider.of<_ProductUserListsProvider>(context, listen: false)
+                .toggleProductToList(listId);
+          },
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(
+              minHeight: _AddToProductListWithLists.MIN_ITEM_HEIGHT,
+            ),
+            child: Padding(
+              padding: EdgeInsetsDirectional.symmetric(
+                horizontal: LARGE_SPACE,
+                // The CupertinoCheckbox has huge paddings
+                // (that we can't override)
+                vertical:
+                    (Platform.isIOS || Platform.isMacOS) ? 2.0 : MEDIUM_SPACE,
+              ),
+              child: Row(
+                children: <Widget>[
+                  IgnorePointer(
+                    child: SmoothCheckbox(
+                      value: selected,
+                      onChanged: (_) {},
+                    ),
+                  ),
+                  const SizedBox(width: MEDIUM_SPACE),
+                  Expanded(
+                    child: Text(
+                      listId,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+        if (includeDivider) const _AddToProductListDivider()
+      ],
+    );
+  }
+}
+
+/// Widget that shows an inline way to create a list
+class _AddToProductListAddNewList extends StatefulWidget {
+  const _AddToProductListAddNewList({required this.userLists});
+
+  final Iterable<String> userLists;
+
+  @override
+  State<_AddToProductListAddNewList> createState() =>
+      _AddToProductListAddNewListState();
+}
+
+class _AddToProductListAddNewListState
+    extends State<_AddToProductListAddNewList> {
+  final TextEditingController _controller = TextEditingController();
+  bool _editMode = false;
+  bool _inputValid = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final Color? mainColor = Theme.of(context)
+        .checkboxTheme
+        .fillColor!
+        .resolve(<WidgetState>{WidgetState.selected});
+
+    return Column(
+      children: <Widget>[
+        IconTheme(
+          data: IconThemeData(color: mainColor),
+          child: InkWell(
+            onTap: () {
+              setState(() {
+                if (!_editMode) {
+                  _controller.clear();
+                  _editMode = true;
+                  _inputValid = false;
+                }
+              });
+            },
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(
+                minHeight: _AddToProductListWithLists.MIN_ITEM_HEIGHT,
+              ),
+              child: Padding(
+                padding: EdgeInsetsDirectional.symmetric(
+                  horizontal:
+                      (Platform.isIOS || Platform.isMacOS) ? 25.5 : 28.0,
+                ),
+                child: Row(
+                  children: <Widget>[
+                    const Icon(Icons.add_circle_rounded),
+                    const SizedBox(width: VERY_LARGE_SPACE),
+                    Expanded(
+                      child: _editMode
+                          ? Padding(
+                              padding:
+                                  const EdgeInsetsDirectional.only(bottom: 1.0),
+                              child: TextField(
+                                controller: _controller,
+                                autofocus: true,
+                                decoration: InputDecoration(
+                                  isDense: true,
+                                  hintText: appLocalizations
+                                      .user_list_name_input_hint,
+                                  hintStyle: TextStyle(
+                                    fontStyle: FontStyle.italic,
+                                    color: Theme.of(context).hintColor,
+                                  ),
+                                  contentPadding: EdgeInsets.zero,
+                                  border: InputBorder.none,
+                                ),
+                                textInputAction: TextInputAction.done,
+                                maxLines: 1,
+                                textAlignVertical: TextAlignVertical.top,
+                                style: DefaultTextStyle.of(context).style,
+                                onChanged: _checkInput,
+                                onSubmitted: (_) => _inputValid
+                                    ? () => _addList(context)
+                                    : null,
+                              ),
+                            )
+                          : Text(
+                              appLocalizations.user_list_button_new,
+                            ),
+                    ),
+                    if (_editMode)
+                      IconButton(
+                        icon: const Icon(Icons.cancel),
+                        onPressed: () => setState(() => _editMode = false),
+                      ),
+                    if (_editMode)
+                      IconButton(
+                        icon: const Icon(Icons.check_circle),
+                        onPressed: _inputValid ? () => _addList(context) : null,
+                      ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+        const _AddToProductListDivider(),
+      ],
+    );
+  }
+
+  void _checkInput(String value) {
+    final bool validInput =
+        value.trim().isNotEmpty && !widget.userLists.containsIgnoreCase(value);
+
+    if (validInput != _inputValid) {
+      setState(() {
+        _inputValid = validInput;
+      });
+    }
+  }
+
+  void _addList(BuildContext context) {
+    if (!_inputValid) {
+      return;
+    }
+
+    SmoothHapticFeedback.lightNotification();
+    Provider.of<_ProductUserListsProvider>(context, listen: false)
+        .createUserList(_controller.value.text);
+
+    setState(() => _editMode = false);
+  }
+}
+
+class _AddToProductListDivider extends StatelessWidget {
+  const _AddToProductListDivider();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsetsDirectional.symmetric(
+        horizontal: LARGE_SPACE,
+      ),
+      child: SizedBox(
+        height: 1.0,
+        width: double.infinity,
+        child: ColoredBox(
+          color: Theme.of(context)
+              .extension<SmoothColorsThemeExtension>()!
+              .primaryLight,
+        ),
+      ),
+    );
+  }
+}
+
+/// Logic for the user lists
+class _ProductUserListsProvider extends ValueNotifier<_ProductUserListsState> {
+  _ProductUserListsProvider(this.dao, this.barcode)
+      : super(const _ProductUserListsLoadingState()) {
+    reloadLists();
+  }
+
+  final DaoProductList dao;
+  final String barcode;
+
+  Future<void> reloadLists() async {
+    emit(const _ProductUserListsLoadingState());
+
+    final List<String> lists = dao.getUserLists();
+    if (lists.isEmpty) {
+      emit(const _ProductUserListsEmptyState());
+      return;
+    }
+
+    // Sort by ignoring case
+    lists.sort(
+      (String a, String b) => a.toLowerCase().compareTo(b.toLowerCase()),
+    );
+
+    // Create a list of user lists with a boolean if the product is in it
+    final List<String> listsWithProduct =
+        await dao.getUserListsWithBarcodes(<String>[barcode]);
+
+    final List<MapEntry<String, bool>> userLists = <MapEntry<String, bool>>[];
+    for (final String listId in lists) {
+      userLists.add(
+        MapEntry<String, bool>(listId, listsWithProduct.contains(listId)),
+      );
+    }
+
+    emit(_ProductUserListsWithState(userLists));
+  }
+
+  Future<bool> toggleProductToList(String listId) async {
+    if (value is! _ProductUserListsWithState) {
+      return false;
+    }
+
+    /// Fake the UI first (otherwise there is a slight delay)
+    final bool selected = !(value as _ProductUserListsWithState)
+        .userLists
+        .firstWhere((MapEntry<String, bool> item) => item.key == listId)
+        .value;
+
+    _fakeStateChange(
+      listId,
+      selected,
+    );
+
+    return dao.set(
+      ProductList.user(listId),
+      barcode,
+      selected,
+    );
+  }
+
+  /// Create a new user list and add the product to it
+  Future<bool> createUserList(String listId) async {
+    /// Fake the UI first (otherwise there is a slight delay)
+    _fakeStateChange(listId, true);
+
+    final ProductList userList = ProductList.user(listId);
+    await dao.put(userList);
+    return addAProductToAList(listId);
+  }
+
+  Future<bool> addAProductToAList(String listId) {
+    return dao.set(ProductList.user(listId), barcode, true);
+  }
+
+  /// Force reload the UI.
+  /// If [listId] doesn't exist, it will be added at the top.
+  bool _fakeStateChange(String listId, bool selected) {
+    final List<MapEntry<String, bool>> lists = List<MapEntry<String, bool>>.of(
+        (value as _ProductUserListsWithState).userLists);
+
+    final int position =
+        lists.indexWhere((MapEntry<String, bool> item) => item.key == listId);
+
+    if (position >= 0) {
+      lists[position] = MapEntry<String, bool>(listId, selected);
+    } else {
+      lists.insert(0, MapEntry<String, bool>(listId, selected));
+    }
+
+    emit(_ProductUserListsWithState(lists));
+    return true;
+  }
+}
+
+sealed class _ProductUserListsState {
+  const _ProductUserListsState();
+}
+
+class _ProductUserListsLoadingState extends _ProductUserListsState {
+  const _ProductUserListsLoadingState();
+}
+
+class _ProductUserListsEmptyState extends _ProductUserListsState {
+  const _ProductUserListsEmptyState();
+}
+
+class _ProductUserListsWithState extends _ProductUserListsState {
+  _ProductUserListsWithState(this.userLists);
+
+  final List<MapEntry<String, bool>> userLists;
+}

--- a/packages/smooth_app/lib/pages/product/product_page/new_product_footer.dart
+++ b/packages/smooth_app/lib/pages/product/product_page/new_product_footer.dart
@@ -6,8 +6,8 @@ import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:smooth_app/data_models/preferences/user_preferences.dart';
-import 'package:smooth_app/database/dao_product_list.dart';
 import 'package:smooth_app/database/local_database.dart';
+import 'package:smooth_app/generic_lib/bottom_sheets/smooth_bottom_sheet.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_snackbar.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
@@ -16,8 +16,8 @@ import 'package:smooth_app/pages/prices/price_meta_product.dart';
 import 'package:smooth_app/pages/prices/product_price_add_page.dart';
 import 'package:smooth_app/pages/product/common/product_query_page_helper.dart';
 import 'package:smooth_app/pages/product/edit_product_page.dart';
+import 'package:smooth_app/pages/product/product_list_helper.dart';
 import 'package:smooth_app/pages/product/product_page/new_product_page.dart';
-import 'package:smooth_app/pages/product_list_user_dialog_helper.dart';
 import 'package:smooth_app/query/category_product_query.dart';
 import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/resources/app_icons.dart' as icons;
@@ -117,13 +117,27 @@ class _ProductAddToListButton extends StatelessWidget {
   }
 
   Future<bool?> _editList(BuildContext context, Product product) async {
-    final LocalDatabase localDatabase = context.read<LocalDatabase>();
-    final DaoProductList daoProductList = DaoProductList(localDatabase);
-    return ProductListUserDialogHelper(daoProductList)
-        .showUserAddProductsDialog(
-      context,
-      <String>{product.barcode!},
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final SmoothColorsThemeExtension? extension =
+        Theme.of(context).extension<SmoothColorsThemeExtension>();
+
+    showSmoothDraggableModalSheet(
+      context: context,
+      header: SmoothModalSheetHeader(
+        backgroundColor: extension!.primaryDark,
+        foregroundColor: Colors.white,
+        prefix: const SmoothModalSheetHeaderPrefixIndicator(),
+        title: appLocalizations.user_list_title,
+        suffix: const SmoothModalSheetHeaderCloseButton(
+          addPadding: true,
+        ),
+      ),
+      bodyBuilder: (BuildContext context) => AddProductToListContainer(
+        barcode: product.barcode!,
+      ),
     );
+
+    return true;
   }
 }
 

--- a/packages/smooth_app/lib/themes/smooth_theme.dart
+++ b/packages/smooth_app/lib/themes/smooth_theme.dart
@@ -116,12 +116,16 @@ class SmoothTheme {
             return null;
           }
           if (states.contains(WidgetState.selected)) {
-            return smoothExtension.primarySemiDark;
+            return brightness == Brightness.light
+                ? smoothExtension.primarySemiDark
+                : smoothExtension.primaryNormal;
           }
           return null;
         }),
         side: BorderSide(
-          color: smoothExtension.primaryBlack,
+          color: brightness == Brightness.light
+              ? smoothExtension.primaryBlack
+              : smoothExtension.primarySemiDark,
           width: 2.0,
         ),
         shape: RoundedRectangleBorder(

--- a/packages/smooth_app/lib/themes/smooth_theme.dart
+++ b/packages/smooth_app/lib/themes/smooth_theme.dart
@@ -116,10 +116,18 @@ class SmoothTheme {
             return null;
           }
           if (states.contains(WidgetState.selected)) {
-            return myColorScheme.primary;
+            return smoothExtension.primarySemiDark;
           }
           return null;
         }),
+        side: BorderSide(
+          color: smoothExtension.primaryBlack,
+          width: 2.0,
+        ),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(3.0),
+        ),
+        checkColor: const WidgetStatePropertyAll<Color>(Colors.white),
       ),
       radioTheme: RadioThemeData(
         fillColor:

--- a/packages/smooth_app/lib/widgets/smooth_checkbox.dart
+++ b/packages/smooth_app/lib/widgets/smooth_checkbox.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+
+/// A [Checkbox.adaptive] that ensures that the Cupertino variant follows
+/// the same theme as the Material variant.
+/// (Active color = fill color)
+class SmoothCheckbox extends StatelessWidget {
+  const SmoothCheckbox({
+    super.key,
+    required this.value,
+    this.tristate = false,
+    required this.onChanged,
+    this.mouseCursor,
+    this.activeColor,
+    this.fillColor,
+    this.checkColor,
+    this.focusColor,
+    this.hoverColor,
+    this.overlayColor,
+    this.splashRadius,
+    this.materialTapTargetSize,
+    this.visualDensity,
+    this.focusNode,
+    this.autofocus = false,
+    this.shape,
+    this.side,
+    this.isError = false,
+    this.semanticLabel,
+  });
+
+  final bool? value;
+  final ValueChanged<bool?>? onChanged;
+  final MouseCursor? mouseCursor;
+  final Color? activeColor;
+  final WidgetStateProperty<Color?>? fillColor;
+  final Color? checkColor;
+  final bool tristate;
+  final MaterialTapTargetSize? materialTapTargetSize;
+  final VisualDensity? visualDensity;
+  final Color? focusColor;
+  final Color? hoverColor;
+  final WidgetStateProperty<Color?>? overlayColor;
+  final double? splashRadius;
+  final FocusNode? focusNode;
+  final bool autofocus;
+  final OutlinedBorder? shape;
+  final BorderSide? side;
+  final bool isError;
+  final String? semanticLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Checkbox.adaptive(
+      value: value,
+      onChanged: onChanged,
+      mouseCursor: mouseCursor,
+      activeColor: (fillColor ?? Theme.of(context).checkboxTheme.fillColor!)
+          .resolve(<WidgetState>{WidgetState.selected}),
+      fillColor: fillColor,
+      checkColor: checkColor,
+      tristate: tristate,
+      materialTapTargetSize: materialTapTargetSize,
+      visualDensity: visualDensity ?? VisualDensity.standard,
+      focusColor: focusColor,
+      hoverColor: hoverColor,
+      overlayColor: overlayColor,
+      splashRadius: splashRadius,
+      focusNode: focusNode,
+      autofocus: autofocus,
+      shape: shape,
+      side: side,
+      isError: isError,
+      semanticLabel: semanticLabel,
+    );
+  }
+}


### PR DESCRIPTION
Hi everyone!

Instead of using dialogs, handling users lists from the product page is now using a bottom sheet.
If there is no list -> the (old) dialog is shown
If there is at least one list -> a list is shown + an inline way to create dialogs

Here is a demo:
1. There is no user list (= dialog)
2. A list is "inline" created
3. A list can't be created if it has the same name as another
4. A third list is created

https://github.com/user-attachments/assets/773d9894-5288-4798-832a-2548364eed29

