### PR TITLE
chore: Bump flutter_svg for smooth_app

### DIFF
--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -696,10 +696,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_svg
-      sha256: "7b4ca6cf3304575fe9c8ec64813c8d02ee41d2afe60bcfe0678bcb5375d596a2"
+      sha256: "1b7723a814d84fb65869ea7115cdb3ee7c3be5a27a755c1ec60e049f6b9fcbb2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.10+1"
+    version: "2.0.11"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   barcode_widget: 2.0.4
   carousel_slider: 5.0.0
   cupertino_icons: 1.0.8
-  flutter_svg: 2.0.10+1
+  flutter_svg: 2.0.11
   flutter_map: 7.0.2
   html: 0.15.4
   flutter_widget_from_html_core: 0.8.3+1


### PR DESCRIPTION
The build is failing due to different versions of `flutter_svg`:

```
Resolving dependencies...
Because every version of scanner_shared from path depends on flutter_svg 2.0.11 and smooth_app depends on flutter_svg 2.0.10+1, scanner_shared from path is forbidden.
So, because smooth_app depends on scanner_shared from path, version solving failed.


You can try the following suggestion to make the pubspec resolve:
* Try upgrading your constraint on flutter_svg: flutter pub add flutter_svg:^2.0.11
```
https://github.com/openfoodfacts/smooth-app/actions/runs/11642118846/job/32421359571#step:13:335