### PR TITLE
fix: Adopt iOS code for Android status bar (Material 3 issue)

### DIFF
--- a/packages/smooth_app/lib/pages/onboarding/reinvention_page.dart
+++ b/packages/smooth_app/lib/pages/onboarding/reinvention_page.dart
@@ -9,6 +9,7 @@ import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/pages/onboarding/onboarding_flow_navigator.dart';
 import 'package:smooth_app/pages/onboarding/v2/onboarding_bottom_hills.dart';
 import 'package:smooth_app/themes/smooth_theme_colors.dart';
+import 'package:smooth_app/widgets/smooth_scaffold.dart';
 import 'package:smooth_app/widgets/smooth_text.dart';
 
 /// Onboarding page: "reinvention"
@@ -17,7 +18,7 @@ class OnboardingHomePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
+    return SmoothScaffold(
       backgroundColor: const Color(0xFFE3F3FE),
       body: Provider<OnboardingConfig>.value(
         value: OnboardingConfig._(MediaQuery.sizeOf(context)),

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_page.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_page.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -267,10 +265,9 @@ class _UserPreferencesPageState extends State<UserPreferencesPage>
     );
     return SmoothScaffold(
       statusBarBackgroundColor: dark ? null : headerColor,
-      brightness:
-          Theme.of(context).brightness == Brightness.light && Platform.isIOS
-              ? Brightness.dark
-              : Brightness.light,
+      brightness: Theme.of(context).brightness == Brightness.light
+          ? Brightness.dark
+          : Brightness.light,
       contentBehindStatusBar: false,
       spaceBehindStatusBar: false,
       appBar: SmoothAppBar(

--- a/packages/smooth_app/lib/widgets/smooth_scaffold.dart
+++ b/packages/smooth_app/lib/widgets/smooth_scaffold.dart
@@ -146,8 +146,7 @@ class SmoothScaffoldState extends ScaffoldState {
   SystemUiOverlayStyle get _overlayStyle {
     final Brightness? brightness;
 
-    // Invert brightness on iOS devices
-    if (Platform.isIOS && _brightness == null) {
+    if (_brightness == null) {
       switch (Theme.of(context).brightness) {
         case Brightness.dark:
           brightness = Brightness.light;


### PR DESCRIPTION
Hi everyone!

To fix the issue with the status bar on Android, we just need to adopt the code that was previously done for iOS.
… and we can live again in 2024 😉