### PR TITLE
fix: 5556 - try to display the questions when in button mode

### DIFF
--- a/packages/smooth_app/lib/pages/product/product_page/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/product_page/new_product_page.dart
@@ -222,6 +222,7 @@ class ProductPageState extends State<ProductPage>
                     upToDateProduct,
                     _productPreferences,
                     isFullVersion: true,
+                    showQuestionsBanner: true,
                   ),
                 ),
               ),


### PR DESCRIPTION
### What
- Half the population couldn't see the robotoff questions in the product page.
- Now they can.

### Screenshot
| as a "banner" | as a "button" |
| -- | -- |
| ![Image](https://github.com/user-attachments/assets/92b714dd-8e5d-4ff0-b120-4b1ce9fb2be0) | ![Image](https://github.com/user-attachments/assets/ab2c04d9-3a51-4a01-8e41-3699691bdb7c) |

### Fixes bug(s)
- Fixes: #5556