### PR TITLE
fix: Bring back the AppBar from user stats

### DIFF
--- a/packages/smooth_app/lib/pages/preferences/user_preferences_account.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_account.dart
@@ -298,7 +298,7 @@ class UserPreferencesAccount extends AbstractUserPreferences {
           localDatabase: localDatabase,
           productQuery: productQuery,
           context: context,
-          editableAppBarTitle: false,
+          editableAppBarTitle: true,
         ),
         iconData,
         lazyCounter: lazyCounter,


### PR DESCRIPTION
Hi everyone!

From the user prefs, we can click to have the list of products added/edited…
However, the screen containing the result lacks an `AppBar`.

This is just a one-line fix.

<img width="449" alt="Screenshot 2024-11-06 at 22 07 23" src="https://github.com/user-attachments/assets/0b81d623-fdbe-4c5b-9e8d-663ff1a0bd03">
