### PR TITLE
feat: Add a loading state to the tagline image

### DIFF
--- a/packages/smooth_app/lib/cards/category_cards/svg_async_asset.dart
+++ b/packages/smooth_app/lib/cards/category_cards/svg_async_asset.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:smooth_app/cards/category_cards/asset_cache_helper.dart';
+import 'package:smooth_app/cards/category_cards/svg_safe_network.dart';
 import 'package:smooth_app/helpers/app_helper.dart';
 
 /// Widget with async load of SVG asset file
@@ -18,9 +19,15 @@ import 'package:smooth_app/helpers/app_helper.dart';
 /// E.g. with https://jakearchibald.github.io/svgomg/
 /// C.f. https://github.com/openfoodfacts/smooth-app/issues/52
 class SvgAsyncAsset extends StatefulWidget {
-  const SvgAsyncAsset(this.assetCacheHelper);
+  const SvgAsyncAsset(
+    this.assetCacheHelper, {
+    this.loadingBuilder,
+    this.errorBuilder,
+  });
 
   final AssetCacheHelper assetCacheHelper;
+  final WidgetBuilder? loadingBuilder;
+  final WidgetErrorBuilder? errorBuilder;
 
   @override
   State<SvgAsyncAsset> createState() => _SvgAsyncAssetState();
@@ -65,7 +72,14 @@ class _SvgAsyncAssetState extends State<SvgAsyncAsset> {
               );
             } else {
               widget.assetCacheHelper.notFound();
+              if (widget.errorBuilder != null) {
+                return widget.errorBuilder!(context, Exception('Not found'));
+              }
             }
+          }
+
+          if (widget.loadingBuilder != null) {
+            return widget.loadingBuilder!(context);
           }
           return widget.assetCacheHelper.getEmptySpace();
         },

--- a/packages/smooth_app/lib/cards/category_cards/svg_cache.dart
+++ b/packages/smooth_app/lib/cards/category_cards/svg_cache.dart
@@ -12,11 +12,15 @@ class SvgCache extends AbstractCache {
     super.width,
     super.height,
     this.color,
+    this.loadingBuilder,
+    this.errorBuilder,
     this.semanticsLabel,
   });
 
   final Color? color;
   final String? semanticsLabel;
+  final WidgetBuilder? loadingBuilder;
+  final WidgetErrorBuilder? errorBuilder;
 
   @override
   List<String> getCachedFilenames() {
@@ -65,6 +69,8 @@ class SvgCache extends AbstractCache {
     return SvgSafeNetwork(
       helper,
       key: helper.getKey(),
+      loadingBuilder: loadingBuilder,
+      errorBuilder: errorBuilder,
     );
   }
 

--- a/packages/smooth_app/lib/cards/category_cards/svg_safe_network.dart
+++ b/packages/smooth_app/lib/cards/category_cards/svg_safe_network.dart
@@ -18,9 +18,16 @@ import 'package:smooth_app/services/smooth_services.dart';
 /// ecoscore svg widget when the URL changes.
 /// cf. https://api.flutter.dev/flutter/foundation/Key-class.html
 class SvgSafeNetwork extends StatefulWidget {
-  const SvgSafeNetwork(this.helper, {required super.key});
+  const SvgSafeNetwork(
+    this.helper, {
+    this.loadingBuilder,
+    this.errorBuilder,
+    required super.key,
+  });
 
   final AssetCacheHelper helper;
+  final WidgetBuilder? loadingBuilder;
+  final WidgetErrorBuilder? errorBuilder;
 
   @override
   State<SvgSafeNetwork> createState() => _SvgSafeNetworkState();
@@ -75,7 +82,8 @@ class _SvgSafeNetworkState extends State<SvgSafeNetwork> {
           return cached;
         }
         throw Exception(
-            'Failed to load SVG: $_url ${response1.statusCode} $alternateUrl ${response2.statusCode}');
+          'Failed to load SVG: $_url ${response1.statusCode} $alternateUrl ${response2.statusCode}',
+        );
       }
     }
 
@@ -119,8 +127,11 @@ class _SvgSafeNetworkState extends State<SvgSafeNetwork> {
                 fit: BoxFit.contain,
                 semanticsLabel: widget.helper.semanticsLabel ??
                     SvgCache.getSemanticsLabel(context, _url),
-                placeholderBuilder: (BuildContext context) =>
-                    SvgAsyncAsset(widget.helper),
+                placeholderBuilder: (BuildContext context) => SvgAsyncAsset(
+                  widget.helper,
+                  loadingBuilder: widget.loadingBuilder,
+                  errorBuilder: widget.errorBuilder,
+                ),
               );
             }
           }
@@ -151,3 +162,6 @@ class _SvgSafeNetworkState extends State<SvgSafeNetwork> {
 
 /// Network cache, with url as key and SVG data as value.
 Map<String, String> _networkCache = <String, String>{};
+
+typedef WidgetErrorBuilder = Widget Function(
+    BuildContext context, dynamic exception);

--- a/packages/smooth_app/lib/generic_lib/widgets/images/smooth_image.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/images/smooth_image.dart
@@ -1,11 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/scheduler.dart';
-import 'package:flutter_svg/flutter_svg.dart';
-import 'package:provider/provider.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/duration_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/picture_not_found.dart';
-import 'package:smooth_app/themes/theme_provider.dart';
+import 'package:smooth_app/generic_lib/widgets/smooth_app_logo.dart';
 
 /// Container to display a product image on a product card.
 ///
@@ -101,10 +98,7 @@ class SmoothImage extends StatelessWidget {
             color: theme.primaryColor.withOpacity(0.1),
             alignment: AlignmentDirectional.center,
             padding: const EdgeInsets.all(SMALL_SPACE),
-            child: const _SmoothAnimatedLogo(
-              opacityMax: 0.65,
-              opacityMin: 0.2,
-            ),
+            child: const SmoothAnimatedLogo(),
           ),
           layoutBuilder: (Widget topChild, Key topChildKey, Widget bottomChild,
               Key bottomChildKey) {
@@ -138,147 +132,8 @@ class SmoothImage extends StatelessWidget {
           Colors.grey.withOpacity(0.7),
           BlendMode.srcIn,
         ),
-        child: const _SmoothAppLogo(),
+        child: const SmoothAppLogo(),
       ),
     );
-  }
-}
-
-/// An animated logo which can depend on [SmoothSharedAnimationController]
-/// to ensure animations are synced
-class _SmoothAnimatedLogo extends StatefulWidget {
-  const _SmoothAnimatedLogo({
-    required this.opacityMax,
-    required this.opacityMin,
-  });
-
-  final double opacityMin;
-  final double opacityMax;
-
-  @override
-  State<_SmoothAnimatedLogo> createState() => _SmoothAnimatedLogoState();
-}
-
-class _SmoothAnimatedLogoState extends State<_SmoothAnimatedLogo>
-    with SingleTickerProviderStateMixin {
-  AnimationController? _controller;
-  Animation<double>? _animation;
-
-  @override
-  void initState() {
-    super.initState();
-
-    SchedulerBinding.instance.addPostFrameCallback((_) {
-      _attachAnimation();
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Opacity(
-      opacity: _animation?.value ?? widget.opacityMin,
-      child: const _SmoothAppLogo(),
-    );
-  }
-
-  void _attachAnimation() {
-    AnimationController? controller =
-        _SmoothSharedAnimationControllerState.of(context);
-
-    if (controller == null) {
-      _controller = AnimationController(
-        duration: const Duration(seconds: 1),
-        vsync: this,
-      );
-      controller = _controller;
-    }
-
-    _animation = Tween<double>(begin: widget.opacityMin, end: widget.opacityMax)
-        .animate(controller!)
-      ..addListener(_onAnimationChanged);
-
-    if (!controller.isAnimating) {
-      controller.repeat(reverse: true);
-    }
-  }
-
-  void _onAnimationChanged() {
-    setState(() {});
-  }
-
-  @override
-  void dispose() {
-    _animation?.removeListener(_onAnimationChanged);
-    _controller?.dispose();
-    super.dispose();
-  }
-}
-
-class _SmoothAppLogo extends StatelessWidget {
-  const _SmoothAppLogo();
-
-  @override
-  Widget build(BuildContext context) {
-    final ThemeProvider themeProvider = context.watch<ThemeProvider>();
-
-    return SvgPicture.asset(
-      !themeProvider.isDarkMode(context)
-          ? 'assets/app/release_icon_transparent.svg'
-          : 'assets/app/release_icon_dark_transparent_no_border.svg',
-    );
-  }
-}
-
-/// A shared [AnimationController] that can be used by multiple
-/// [_SmoothAnimatedLogo] and ensure they are all perfectly synced.
-class SmoothSharedAnimationController extends StatefulWidget {
-  const SmoothSharedAnimationController({
-    required this.child,
-  });
-
-  final Widget child;
-
-  @override
-  State<SmoothSharedAnimationController> createState() =>
-      _SmoothSharedAnimationControllerState();
-}
-
-class _SmoothSharedAnimationControllerState
-    extends State<SmoothSharedAnimationController>
-    with SingleTickerProviderStateMixin {
-  late AnimationController _controller;
-
-  @override
-  void initState() {
-    super.initState();
-    _controller = AnimationController(
-      duration: const Duration(seconds: 1),
-      vsync: this,
-    );
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Provider<_SmoothSharedAnimationControllerState>(
-      create: (_) => this,
-      child: widget.child,
-    );
-  }
-
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
-
-  static AnimationController? of(BuildContext context) {
-    try {
-      return Provider.of<_SmoothSharedAnimationControllerState>(
-        context,
-        listen: false,
-      )._controller;
-    } catch (_) {
-      return null;
-    }
   }
 }

--- a/packages/smooth_app/lib/generic_lib/widgets/smooth_app_logo.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/smooth_app_logo.dart
@@ -1,0 +1,144 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:provider/provider.dart';
+import 'package:smooth_app/themes/theme_provider.dart';
+
+/// An animated logo which can depend on [SmoothSharedAnimationController]
+/// to ensure animations are synced
+class SmoothAnimatedLogo extends StatefulWidget {
+  const SmoothAnimatedLogo({
+    this.opacityMax = 0.65,
+    this.opacityMin = 0.2,
+  });
+
+  final double opacityMin;
+  final double opacityMax;
+
+  @override
+  State<SmoothAnimatedLogo> createState() => _SmoothAnimatedLogoState();
+}
+
+class _SmoothAnimatedLogoState extends State<SmoothAnimatedLogo>
+    with SingleTickerProviderStateMixin {
+  AnimationController? _controller;
+  Animation<double>? _animation;
+
+  @override
+  void initState() {
+    super.initState();
+
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      _attachAnimation();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Opacity(
+      opacity: _animation?.value ?? widget.opacityMin,
+      child: const SmoothAppLogo(),
+    );
+  }
+
+  void _attachAnimation() {
+    AnimationController? controller =
+        _SmoothSharedAnimationControllerState.of(context);
+
+    if (controller == null) {
+      _controller = AnimationController(
+        duration: const Duration(seconds: 1),
+        vsync: this,
+      );
+      controller = _controller;
+    }
+
+    _animation = Tween<double>(begin: widget.opacityMin, end: widget.opacityMax)
+        .animate(controller!)
+      ..addListener(_onAnimationChanged);
+
+    if (!controller.isAnimating) {
+      controller.repeat(reverse: true);
+    }
+  }
+
+  void _onAnimationChanged() {
+    if (context.mounted) {
+      setState(() {});
+    }
+  }
+
+  @override
+  void dispose() {
+    _animation?.removeListener(_onAnimationChanged);
+    _controller?.dispose();
+    super.dispose();
+  }
+}
+
+class SmoothAppLogo extends StatelessWidget {
+  const SmoothAppLogo();
+
+  @override
+  Widget build(BuildContext context) {
+    return SvgPicture.asset(
+      context.lightTheme()
+          ? 'assets/app/release_icon_transparent.svg'
+          : 'assets/app/release_icon_dark_transparent_no_border.svg',
+    );
+  }
+}
+
+/// A shared [AnimationController] that can be used by multiple
+/// [SmoothAnimatedLogo] and ensure they are all perfectly synced.
+class SmoothSharedAnimationController extends StatefulWidget {
+  const SmoothSharedAnimationController({
+    required this.child,
+  });
+
+  final Widget child;
+
+  @override
+  State<SmoothSharedAnimationController> createState() =>
+      _SmoothSharedAnimationControllerState();
+}
+
+class _SmoothSharedAnimationControllerState
+    extends State<SmoothSharedAnimationController>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      duration: const Duration(seconds: 1),
+      vsync: this,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Provider<_SmoothSharedAnimationControllerState>(
+      create: (_) => this,
+      child: widget.child,
+    );
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  static AnimationController? of(BuildContext context) {
+    try {
+      return Provider.of<_SmoothSharedAnimationControllerState>(
+        context,
+        listen: false,
+      )._controller;
+    } catch (_) {
+      return null;
+    }
+  }
+}

--- a/packages/smooth_app/lib/pages/product/common/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_page.dart
@@ -17,7 +17,7 @@ import 'package:smooth_app/generic_lib/bottom_sheets/smooth_bottom_sheet.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/duration_constants.dart';
 import 'package:smooth_app/generic_lib/loading_dialog.dart';
-import 'package:smooth_app/generic_lib/widgets/images/smooth_image.dart';
+import 'package:smooth_app/generic_lib/widgets/smooth_app_logo.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_responsive.dart';
 import 'package:smooth_app/helpers/app_helper.dart';
 import 'package:smooth_app/helpers/robotoff_insight_helper.dart';

--- a/packages/smooth_app/lib/pages/product/common/product_query_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_query_page.dart
@@ -15,7 +15,7 @@ import 'package:smooth_app/generic_lib/buttons/smooth_large_button_with_icon.dar
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/duration_constants.dart';
 import 'package:smooth_app/generic_lib/loading_dialog.dart';
-import 'package:smooth_app/generic_lib/widgets/images/smooth_image.dart';
+import 'package:smooth_app/generic_lib/widgets/smooth_app_logo.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_back_button.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_error_card.dart';

--- a/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_gallery_view.dart
@@ -9,6 +9,7 @@ import 'package:smooth_app/generic_lib/buttons/smooth_large_button_with_icon.dar
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/images/smooth_image.dart';
 import 'package:smooth_app/generic_lib/widgets/language_selector.dart';
+import 'package:smooth_app/generic_lib/widgets/smooth_app_logo.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/image_field_extension.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';

--- a/packages/smooth_app/lib/pages/scan/carousel/main_card/scan_tagline.dart
+++ b/packages/smooth_app/lib/pages/scan/carousel/main_card/scan_tagline.dart
@@ -9,6 +9,7 @@ import 'package:smooth_app/data_models/news_feed/newsfeed_model.dart';
 import 'package:smooth_app/data_models/news_feed/newsfeed_provider.dart';
 import 'package:smooth_app/data_models/preferences/user_preferences.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/generic_lib/widgets/smooth_app_logo.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/helpers/launch_url_helper.dart';
 import 'package:smooth_app/helpers/provider_helper.dart';
@@ -121,9 +122,11 @@ class _ScanTagLineContentState extends State<_ScanTagLineContent> {
             ),
           ),
           child: Padding(
-            padding: const EdgeInsets.symmetric(
-              vertical: VERY_SMALL_SPACE,
-              horizontal: MEDIUM_SPACE,
+            padding: const EdgeInsetsDirectional.only(
+              start: LARGE_SPACE,
+              end: MEDIUM_SPACE,
+              top: VERY_SMALL_SPACE,
+              bottom: VERY_SMALL_SPACE,
             ),
             child: _TagLineContentTitle(
               title: currentNews.title,
@@ -146,7 +149,7 @@ class _ScanTagLineContentState extends State<_ScanTagLineContent> {
               ),
             ),
             child: Padding(
-              padding: const EdgeInsets.symmetric(
+              padding: const EdgeInsetsDirectional.symmetric(
                 vertical: SMALL_SPACE,
                 horizontal: MEDIUM_SPACE,
               ),
@@ -220,16 +223,19 @@ class _TagLineContentTitle extends StatelessWidget {
                 ),
               ),
             ),
-            const SizedBox(width: VERY_SMALL_SPACE),
+            const SizedBox(width: BALANCED_SPACE),
             Expanded(
-                child: Text(
-              title,
-              style: TextStyle(
-                fontWeight: FontWeight.bold,
-                fontSize: 16.0,
-                color: titleColor ?? Colors.white,
+              child: Text(
+                title,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  fontWeight: FontWeight.bold,
+                  fontSize: 16.0,
+                  color: titleColor ?? Colors.white,
+                ),
               ),
-            ))
+            ),
           ],
         ),
       ),
@@ -306,26 +312,40 @@ class _TagLineContentBodyState extends State<_TagLineContentBody> {
       return SvgCache(
         widget.image!.src,
         semanticsLabel: widget.image!.alt,
+        loadingBuilder: (_) => _onLoading(),
       );
     } else {
       return Image.network(
         semanticLabel: widget.image!.alt,
-        errorBuilder: (
-          BuildContext context,
-          Object error,
-          StackTrace? stackTrace,
+        loadingBuilder: (
+          _,
+          Widget child,
+          ImageChunkEvent? loadingProgress,
         ) {
-          WidgetsBinding.instance.addPostFrameCallback((_) {
-            if (_imageError != true) {
-              setState(() => _imageError = true);
-            }
-          });
+          if (loadingProgress == null) {
+            return _onLoading();
+          }
 
-          return EMPTY_WIDGET;
+          return child;
         },
+        errorBuilder: (_, __, ___) => _onError(),
         widget.image!.src ?? '-',
       );
     }
+  }
+
+  Widget _onLoading() {
+    return const SmoothAnimatedLogo();
+  }
+
+  Widget _onError() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_imageError != true) {
+        setState(() => _imageError = true);
+      }
+    });
+
+    return EMPTY_WIDGET;
   }
 }
 
@@ -352,19 +372,25 @@ class _TagLineContentButton extends StatelessWidget {
       style: FilledButton.styleFrom(
         backgroundColor: backgroundColor ?? theme.primaryBlack,
         foregroundColor: foregroundColor ?? Colors.white,
-        padding: const EdgeInsets.symmetric(
+        padding: const EdgeInsetsDirectional.symmetric(
           vertical: VERY_SMALL_SPACE,
-          horizontal: MEDIUM_SPACE,
+          horizontal: VERY_LARGE_SPACE,
         ),
         minimumSize: const Size(0, 20.0),
       ),
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: <Widget>[
-          Text(label ?? localizations.tagline_feed_news_button),
+          Padding(
+            padding: const EdgeInsetsDirectional.only(bottom: 0.5),
+            child: Text(
+              label ?? localizations.tagline_feed_news_button,
+              style: const TextStyle(fontWeight: FontWeight.bold),
+            ),
+          ),
           const SizedBox(width: MEDIUM_SPACE),
-          const Arrow.right(
-            size: 12.0,
+          const CircledArrow.right(
+            size: 20.0,
           ),
         ],
       ),

--- a/packages/smooth_app/lib/resources/app_icons.dart
+++ b/packages/smooth_app/lib/resources/app_icons.dart
@@ -299,56 +299,38 @@ class ClearText extends AppIcon {
   }
 }
 
-class Delete extends AppIcon {
-  const Delete.trash({
-    super.color,
-    super.size,
-    super.shadow,
-    super.key,
-  }) : super._(_IconsFont.delete_trash);
-}
-
-class Document extends AppIcon {
-  const Document({
-    super.color,
-    super.size,
-    super.shadow,
-    super.key,
-  }) : super._(_IconsFont.document);
-}
-
-class DoubleChevron extends AppIcon {
-  const DoubleChevron.left({
-    super.color,
-    super.size,
-    super.shadow,
-    super.key,
-  })  : turns = 3,
-        super._(_IconsFont.double_chevron);
-
-  const DoubleChevron.right({
-    super.color,
-    super.size,
-    super.shadow,
-    super.key,
-  })  : turns = 1,
-        super._(_IconsFont.double_chevron);
-
-  const DoubleChevron.up({
+class CircledArrow extends AppIcon {
+  const CircledArrow.right({
     super.color,
     super.size,
     super.shadow,
     super.key,
   })  : turns = 0,
-        super._(_IconsFont.double_chevron);
+        super._(_IconsFont.circled_arrow);
 
-  const DoubleChevron.down({
+  const CircledArrow.left({
     super.color,
     super.size,
     super.shadow,
     super.key,
   })  : turns = 2,
-        super._(_IconsFont.double_chevron);
+        super._(_IconsFont.circled_arrow);
+
+  const CircledArrow.down({
+    super.color,
+    super.size,
+    super.shadow,
+    super.key,
+  })  : turns = 1,
+        super._(_IconsFont.circled_arrow);
+
+  const CircledArrow.up({
+    super.color,
+    super.size,
+    super.shadow,
+    super.key,
+  })  : turns = 3,
+        super._(_IconsFont.circled_arrow);
 
   final int turns;
 
@@ -359,15 +341,6 @@ class DoubleChevron extends AppIcon {
       child: super.build(context),
     );
   }
-}
-
-class CircledArrow extends AppIcon {
-  const CircledArrow({
-    super.color,
-    super.size,
-    super.shadow,
-    super.key,
-  }) : super._(_IconsFont.circled_arrow);
 }
 
 class Close extends AppIcon {
@@ -449,6 +422,24 @@ class DangerousZone extends AppIcon {
   }) : super._(_IconsFont.dangerous_zone);
 }
 
+class Delete extends AppIcon {
+  const Delete.trash({
+    super.color,
+    super.size,
+    super.shadow,
+    super.key,
+  }) : super._(_IconsFont.delete_trash);
+}
+
+class Document extends AppIcon {
+  const Document({
+    super.color,
+    super.size,
+    super.shadow,
+    super.key,
+  }) : super._(_IconsFont.document);
+}
+
 class Donate extends AppIcon {
   const Donate({
     super.color,
@@ -456,6 +447,50 @@ class Donate extends AppIcon {
     super.shadow,
     super.key,
   }) : super._(_IconsFont.donate);
+}
+
+class DoubleChevron extends AppIcon {
+  const DoubleChevron.left({
+    super.color,
+    super.size,
+    super.shadow,
+    super.key,
+  })  : turns = 3,
+        super._(_IconsFont.double_chevron);
+
+  const DoubleChevron.right({
+    super.color,
+    super.size,
+    super.shadow,
+    super.key,
+  })  : turns = 1,
+        super._(_IconsFont.double_chevron);
+
+  const DoubleChevron.up({
+    super.color,
+    super.size,
+    super.shadow,
+    super.key,
+  })  : turns = 0,
+        super._(_IconsFont.double_chevron);
+
+  const DoubleChevron.down({
+    super.color,
+    super.size,
+    super.shadow,
+    super.key,
+  })  : turns = 2,
+        super._(_IconsFont.double_chevron);
+
+  final int turns;
+
+  @override
+  Widget build(BuildContext context) {
+    return RotatedBox(
+      quarterTurns: turns,
+      child: super.build(context),
+    );
+  }
 }
 
 class Edit extends AppIcon {


### PR DESCRIPTION
Hi everyone!

The tagline image may take some time to load.
This PR adds a loading state and some minor visual changes:
![IMG_1337](https://github.com/user-attachments/assets/af592e12-6b7e-4fe6-93f9-52fb8d18ee39) 

➡️ As the SVG part is "your creation" @monsieurtanuki, please tell me if it's OK to add `loadingBuilder` and `errorBuilder`.

In terms of changes:
- `svg_async_asset.dart`: Add `loadingBuilder` and `errorBuilder`
- `svg_cache.dart`: Add `loadingBuilder` and `errorBuilder`
- `svg_safe_network.dart`: Add `loadingBuilder` and `errorBuilder`
- `smooth_image.dart`: The logo is moved to a dedicated file
- `smooth_app_logo.dart`: Exposes the 2 variants (animated and static)
- `scan_tagline.dart`: loading state + some minor changes (paddings essentially)
- `app_icons.dart`: Multiple constructors for `CircledArrow` + reordering classes alphabetically
