### PR TITLE
fix: 5830 - sorted "more photos" by timestamp

### DIFF
--- a/packages/smooth_app/lib/helpers/product_cards_helper.dart
+++ b/packages/smooth_app/lib/helpers/product_cards_helper.dart
@@ -410,10 +410,9 @@ List<ProductImage> getRawProductImages(
   final Product product,
   final ImageSize imageSize,
 ) {
-  final List<ProductImage> result = <ProductImage>[];
   final List<ProductImage>? rawImages = product.getRawImages();
   if (rawImages == null) {
-    return result;
+    return <ProductImage>[];
   }
   final Map<int, ProductImage> map = <int, ProductImage>{};
   for (final ProductImage productImage in rawImages) {
@@ -439,10 +438,22 @@ List<ProductImage> getRawProductImages(
     }
     map[imageId] = productImage;
   }
-  final List<int> sortedIds = List<int>.of(map.keys);
-  sortedIds.sort();
-  for (final int id in sortedIds) {
-    result.add(map[id]!);
-  }
+  final List<ProductImage> result = List<ProductImage>.of(map.values);
+  result.sort(
+    (
+      final ProductImage a,
+      final ProductImage b,
+    ) {
+      final int result = (a.uploaded?.millisecondsSinceEpoch ?? 0).compareTo(
+        b.uploaded?.millisecondsSinceEpoch ?? 0,
+      );
+      if (result != 0) {
+        return result;
+      }
+      return (int.tryParse(a.imgid ?? '0') ?? 0).compareTo(
+        int.tryParse(b.imgid ?? '0') ?? 0,
+      );
+    },
+  );
   return result;
 }


### PR DESCRIPTION
### What
- Now "more photos" are sorted by descending timestamps, instead of descending ids.

### Screenshots
| before | after |
| -- | -- |
| ![Screenshot_1731409722](https://github.com/user-attachments/assets/ce4f258a-c1b5-4c4e-b492-823b8ed90bff) | ![Screenshot_1731409831](https://github.com/user-attachments/assets/74d71073-6fee-4efd-905f-5f94e89c5e0c) |

### Fixes bug(s)
- Closes: #5830

### Impacted file
* `product_cards_helper.dart`: sorted "more photos" by timestamp