### PR TITLE
feat: 5335 - owner field icon/info for "categories"

### DIFF
--- a/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
@@ -358,10 +358,7 @@ class _AddBasicDetailsPageState extends State<AddBasicDetailsPage> {
     final OpenFoodFactsLanguage? language,
   }) =>
       _isOwnerField(productField, language: language)
-          ? Semantics(
-              label: AppLocalizations.of(context).owner_field_info_title,
-              child: const Icon(OwnerFieldInfo.ownerFieldIconData),
-            )
+          ? const OwnerFieldIcon()
           : null;
 
   bool _hasOwnerField() {

--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -284,10 +284,7 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded>
                       ) ==
                       null
                   ? null
-                  : Semantics(
-                      label: appLocalizations.owner_field_info_title,
-                      child: const Icon(OwnerFieldInfo.ownerFieldIconData),
-                    ),
+                  : const OwnerFieldIcon(),
             ),
             textInputAction: TextInputAction.next,
             onFieldSubmitted: (_) {
@@ -569,10 +566,7 @@ class _NutrientValueCell extends StatelessWidget {
                 product.getOwnerFieldTimestamp(OwnerField.nutrient(nutrient)) ==
                     null
             ? null
-            : Semantics(
-                label: appLocalizations.owner_field_info_title,
-                child: const Icon(OwnerFieldInfo.ownerFieldIconData),
-              ),
+            : const OwnerFieldIcon(),
       ),
       keyboardType: const TextInputType.numberWithOptions(
         signed: false,

--- a/packages/smooth_app/lib/pages/product/owner_field_info.dart
+++ b/packages/smooth_app/lib/pages/product/owner_field_info.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
+/// Icon to display when the product field value is "producer provided".
+const IconData _ownerFieldIconData = Icons.factory;
+
 /// Standard info tile about "owner fields".
 class OwnerFieldInfo extends StatelessWidget {
   const OwnerFieldInfo({super.key});
-
-  /// Icon to display when the product field value is "producer provided".
-  static const IconData ownerFieldIconData = Icons.factory;
 
   @override
   Widget build(BuildContext context) {
@@ -16,9 +16,20 @@ class OwnerFieldInfo extends StatelessWidget {
     final Color? lightGrey = Colors.grey[300];
     return ListTile(
       tileColor: dark ? darkGrey : lightGrey,
-      leading: const Icon(ownerFieldIconData),
+      leading: const Icon(_ownerFieldIconData),
       title: Text(appLocalizations.owner_field_info_title),
       subtitle: Text(appLocalizations.owner_field_info_message),
     );
   }
+}
+
+/// Standard icon about "owner fields".
+class OwnerFieldIcon extends StatelessWidget {
+  const OwnerFieldIcon();
+
+  @override
+  Widget build(BuildContext context) => Semantics(
+        label: AppLocalizations.of(context).owner_field_info_title,
+        child: const Icon(_ownerFieldIconData),
+      );
 }

--- a/packages/smooth_app/lib/pages/product/simple_input_page.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page.dart
@@ -11,6 +11,7 @@ import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/pages/input/unfocus_field_when_tap_outside.dart';
 import 'package:smooth_app/pages/product/common/product_buttons.dart';
 import 'package:smooth_app/pages/product/may_exit_page_helper.dart';
+import 'package:smooth_app/pages/product/owner_field_info.dart';
 import 'package:smooth_app/pages/product/simple_input_page_helpers.dart';
 import 'package:smooth_app/pages/product/simple_input_widget.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
@@ -56,6 +57,17 @@ class _SimpleInputPageState extends State<SimpleInputPage> {
     final List<Widget> simpleInputs = <Widget>[];
     final List<String> titles = <String>[];
 
+    bool hasOwnerField = false;
+    for (final AbstractSimpleInputPageHelper helper in widget.helpers) {
+      if (helper.isOwnerField(widget.product)) {
+        hasOwnerField = true;
+        break;
+      }
+    }
+
+    if (hasOwnerField) {
+      simpleInputs.add(const OwnerFieldInfo());
+    }
     for (int i = 0; i < widget.helpers.length; i++) {
       titles.add(widget.helpers[i].getTitle(appLocalizations));
       simpleInputs.add(

--- a/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
@@ -184,6 +184,9 @@ abstract class AbstractSimpleInputPageHelper extends ChangeNotifier {
 
   /// Returns the enum to be used for matomo analytics.
   AnalyticsEditEvents getAnalyticsEditEvent();
+
+  /// Returns true if the field is an owner field.
+  bool isOwnerField(final Product product) => false;
 }
 
 /// Implementation for "Stores" of an [AbstractSimpleInputPageHelper].
@@ -396,6 +399,16 @@ class SimpleInputPageLabelHelper extends AbstractSimpleInputPageHelper {
 
 /// Implementation for "Categories" of an [AbstractSimpleInputPageHelper].
 class SimpleInputPageCategoryHelper extends AbstractSimpleInputPageHelper {
+  @override
+  bool isOwnerField(final Product product) =>
+      product.getOwnerFieldTimestamp(
+        OwnerField.productField(
+          ProductField.CATEGORIES,
+          ProductQuery.getLanguage(),
+        ),
+      ) !=
+      null;
+
   @override
   List<String> initTerms(final Product product) =>
       product.categoriesTagsInLanguages?[getLanguage()] ?? <String>[];

--- a/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
@@ -19,6 +19,7 @@ class SimpleInputTextField extends StatefulWidget {
     this.shapeProvider,
     this.padding,
     required this.productType,
+    this.suffixIcon,
   });
 
   final FocusNode focusNode;
@@ -33,6 +34,7 @@ class SimpleInputTextField extends StatefulWidget {
   final String? Function()? shapeProvider;
   final EdgeInsetsGeometry? padding;
   final ProductType? productType;
+  final Widget? suffixIcon;
 
   @override
   State<SimpleInputTextField> createState() => _SimpleInputTextFieldState();
@@ -81,6 +83,7 @@ class _SimpleInputTextFieldState extends State<SimpleInputTextField> {
               hintText: widget.hintText,
               constraints: widget.constraints,
               manager: _manager,
+              suffixIcon: widget.suffixIcon,
             ),
           ),
           if (widget.withClearButton)

--- a/packages/smooth_app/lib/pages/product/simple_input_widget.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_widget.dart
@@ -5,6 +5,7 @@ import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/helpers/collections_helper.dart';
 import 'package:smooth_app/helpers/haptic_feedback_helper.dart';
 import 'package:smooth_app/pages/product/explanation_widget.dart';
+import 'package:smooth_app/pages/product/owner_field_info.dart';
 import 'package:smooth_app/pages/product/simple_input_page_helpers.dart';
 import 'package:smooth_app/pages/product/simple_input_text_field.dart';
 
@@ -61,6 +62,7 @@ class _SimpleInputWidgetState extends State<SimpleInputWidget> {
       context,
       widget.product,
     );
+    final bool isOwnerField = widget.helper.isOwnerField(widget.product);
 
     return Column(
       mainAxisAlignment: MainAxisAlignment.start,
@@ -96,6 +98,7 @@ class _SimpleInputWidgetState extends State<SimpleInputWidget> {
                       start: 9.0,
                     ),
                     productType: widget.product.productType,
+                    suffixIcon: !isOwnerField ? null : const OwnerFieldIcon(),
                   ),
                 ),
                 Tooltip(


### PR DESCRIPTION
### What
- Now we display the "owner field" icon and info for "categories", when relevant.

### Screenshots
| "categories" page | "multi" page (top) | "multi" page (lower) |
| -- | -- | -- |
| ![Screenshot_1731431653](https://github.com/user-attachments/assets/057f4c2a-89c2-491c-bd5a-14bac4806634) | ![Screenshot_1731431662](https://github.com/user-attachments/assets/f967ebb7-aa86-42ad-aa5e-678a098cbadc) | ![Screenshot_1731431678](https://github.com/user-attachments/assets/87436cff-89b1-49f6-93b6-f9ae6f258ebb) |

### Fixes bug(s)
- Closes: #5335

### Impacted files
* `add_basic_details_page.dart`: minor refactoring
* `nutrition_page_loaded.dart`: minor refactoring
* `owner_field_info.dart`: new class `OwnerFieldIcon`
* `simple_input_page.dart`: now displays an `OwnerFieldInfo` if there's at least one owner field
* `simple_input_page_helpers.dart`: new method `bool isOwnerField`
* `simple_input_text_field.dart`: minor refactoring
* `simple_input_widget.dart`: now displays an `OwnerFieldIcon` if it's an owner field