### PR TITLE
feat: Custom Switch Widget

### DIFF
--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -25,6 +25,7 @@ import 'package:smooth_app/pages/product/simple_input_number_field.dart';
 import 'package:smooth_app/pages/text_field_helper.dart';
 import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
+import 'package:smooth_app/widgets/smooth_switch.dart';
 import 'package:smooth_app/widgets/will_pop_scope.dart';
 
 /// Actual nutrition page, with data already loaded.
@@ -309,44 +310,77 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded>
     );
   }
 
-  Widget _getServingSwitch(final AppLocalizations appLocalizations) => Row(
-        mainAxisAlignment: MainAxisAlignment.center,
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: <Widget>[
-          Expanded(
-            child: Align(
-              alignment: AlignmentDirectional.centerEnd,
-              child: Text(
-                appLocalizations.nutrition_page_per_100g,
-                style: _nutritionContainer.perSize == PerSize.oneHundredGrams
-                    ? const TextStyle(
-                        fontWeight: FontWeight.bold,
-                        decoration: TextDecoration.underline)
-                    : null,
+  Widget _getServingSwitch(final AppLocalizations appLocalizations) =>
+      IntrinsicHeight(
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: <Widget>[
+            Expanded(
+              child: Semantics(
+                label: appLocalizations.nutrition_page_per_100g,
+                button: true,
+                child: InkWell(
+                  excludeFromSemantics: true,
+                  borderRadius: const BorderRadius.horizontal(
+                    left: CIRCULAR_RADIUS,
+                  ),
+                  onTap: () => setState(
+                    () => _nutritionContainer.perSize = PerSize.oneHundredGrams,
+                  ),
+                  child: Align(
+                    alignment: AlignmentDirectional.centerEnd,
+                    child: Text(
+                      appLocalizations.nutrition_page_per_100g,
+                      style:
+                          _nutritionContainer.perSize == PerSize.oneHundredGrams
+                              ? const TextStyle(
+                                  fontWeight: FontWeight.bold,
+                                  decoration: TextDecoration.underline)
+                              : null,
+                    ),
+                  ),
+                ),
               ),
             ),
-          ),
-          Switch(
-            value: _nutritionContainer.perSize == PerSize.serving,
-            onChanged: (final bool value) => setState(
-              () => _nutritionContainer.perSize =
-                  value ? PerSize.serving : PerSize.oneHundredGrams,
-            ),
-          ),
-          Expanded(
-            child: Align(
-              alignment: AlignmentDirectional.centerStart,
-              child: Text(
-                appLocalizations.nutrition_page_per_serving,
-                style: _nutritionContainer.perSize == PerSize.serving
-                    ? const TextStyle(
-                        fontWeight: FontWeight.bold,
-                        decoration: TextDecoration.underline)
-                    : null,
+            ExcludeSemantics(
+              child: SmoothSwitch(
+                size: const Size(60.0, 30.0),
+                value: _nutritionContainer.perSize == PerSize.serving,
+                onChanged: (final bool value) => setState(
+                  () => _nutritionContainer.perSize =
+                      value ? PerSize.serving : PerSize.oneHundredGrams,
+                ),
               ),
             ),
-          )
-        ],
+            Expanded(
+              child: Semantics(
+                label: appLocalizations.nutrition_page_per_serving,
+                button: true,
+                child: InkWell(
+                  excludeFromSemantics: true,
+                  borderRadius: const BorderRadius.horizontal(
+                    right: CIRCULAR_RADIUS,
+                  ),
+                  onTap: () => setState(
+                    () => _nutritionContainer.perSize = PerSize.serving,
+                  ),
+                  child: Align(
+                    alignment: AlignmentDirectional.centerStart,
+                    child: Text(
+                      appLocalizations.nutrition_page_per_serving,
+                      style: _nutritionContainer.perSize == PerSize.serving
+                          ? const TextStyle(
+                              fontWeight: FontWeight.bold,
+                              decoration: TextDecoration.underline)
+                          : null,
+                    ),
+                  ),
+                ),
+              ),
+            )
+          ],
+        ),
       );
 
   Widget _switchNoNutrition(final AppLocalizations localizations) => SmoothCard(

--- a/packages/smooth_app/lib/themes/smooth_theme.dart
+++ b/packages/smooth_app/lib/themes/smooth_theme.dart
@@ -151,23 +151,29 @@ class SmoothTheme {
       switchTheme: SwitchThemeData(
         thumbColor:
             WidgetStateProperty.resolveWith<Color?>((Set<WidgetState> states) {
-          if (states.contains(WidgetState.disabled)) {
+          if (states.contains(WidgetState.selected)) {
+            if (brightness == Brightness.light) {
+              return smoothExtension.primaryDark;
+            } else {
+              return smoothExtension.primarySemiDark;
+            }
+          } else if (states.contains(WidgetState.disabled)) {
+            if (brightness == Brightness.light) {
+              return const Color(0xFFC2B5B0);
+            } else {
+              return smoothExtension.primaryNormal;
+            }
+          } else {
             return null;
           }
-          if (states.contains(WidgetState.selected)) {
-            return myColorScheme.primary;
-          }
-          return null;
         }),
         trackColor:
             WidgetStateProperty.resolveWith<Color?>((Set<WidgetState> states) {
-          if (states.contains(WidgetState.disabled)) {
-            return null;
+          if (brightness == Brightness.light) {
+            return smoothExtension.primaryMedium;
+          } else {
+            return const Color(0xFFEDE0DB);
           }
-          if (states.contains(WidgetState.selected)) {
-            return myColorScheme.primary;
-          }
-          return null;
         }),
       ),
     );

--- a/packages/smooth_app/lib/widgets/smooth_switch.dart
+++ b/packages/smooth_app/lib/widgets/smooth_switch.dart
@@ -1,0 +1,182 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/generic_lib/duration_constants.dart';
+import 'package:smooth_app/themes/smooth_theme.dart';
+import 'package:smooth_app/themes/smooth_theme_colors.dart';
+
+class SmoothSwitch extends StatefulWidget {
+  SmoothSwitch({
+    required this.value,
+    required this.onChanged,
+    this.size,
+    this.padding,
+    this.thumbActiveColor,
+    this.thumbInactiveColor,
+    this.backgroundActiveColor,
+    this.backgroundInactiveColor,
+    super.key,
+  }) : assert(size == null || (size.width >= 52.0 && size.height >= 30.0));
+
+  final bool value;
+  final ValueChanged<bool> onChanged;
+  final Size? size;
+  final EdgeInsetsGeometry? padding;
+  final Color? thumbActiveColor;
+  final Color? thumbInactiveColor;
+  final Color? backgroundActiveColor;
+  final Color? backgroundInactiveColor;
+
+  @override
+  State<SmoothSwitch> createState() => _SmoothSwitchState();
+}
+
+class _SmoothSwitchState extends State<SmoothSwitch>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _animationController;
+  late Animation<double> _progressAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _animationController = AnimationController(
+      vsync: this,
+      duration: SmoothAnimationsDuration.short,
+    )..addListener(() => setState(() {}));
+
+    _progressAnimation = Tween<double>(begin: 0.0, end: 1.0).animate(
+      CurvedAnimation(
+        parent: _animationController,
+        curve: Curves.easeIn,
+        reverseCurve: Curves.easeOut,
+      ),
+    );
+
+    if (widget.value) {
+      _animationController.forward(from: 1.0);
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant SmoothSwitch oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (oldWidget.value != widget.value) {
+      if (widget.value) {
+        _animationController.forward();
+      } else {
+        _animationController.reverse();
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final SwitchThemeData switchTheme = Theme.of(context).switchTheme;
+    final SmoothColorsThemeExtension theme =
+        context.extension<SmoothColorsThemeExtension>();
+
+    return Semantics(
+      toggled: widget.value,
+      excludeSemantics: true,
+      child: GestureDetector(
+        onTap: () {
+          widget.onChanged(!widget.value);
+        },
+        child: Padding(
+          padding: widget.padding ??
+              const EdgeInsets.symmetric(
+                horizontal: SMALL_SPACE,
+                vertical: SMALL_SPACE,
+              ),
+          child: CustomPaint(
+            size: widget.size ?? const Size(52.0, 30.0),
+            painter: _SmoothSwitchPainter(
+              progress: _progressAnimation.value,
+              thumbActiveColor: widget.thumbActiveColor ??
+                  switchTheme.thumbColor
+                      ?.resolve(<WidgetState>{WidgetState.selected}) ??
+                  theme.primaryDark,
+              thumbInactiveColor: widget.thumbInactiveColor ??
+                  switchTheme.thumbColor
+                      ?.resolve(<WidgetState>{WidgetState.disabled}) ??
+                  const Color(0xFFC2B5B0),
+              backgroundActiveColor: widget.backgroundActiveColor ??
+                  switchTheme.trackColor
+                      ?.resolve(<WidgetState>{WidgetState.selected}) ??
+                  theme.primaryMedium,
+              backgroundInactiveColor: widget.backgroundInactiveColor ??
+                  switchTheme.trackColor
+                      ?.resolve(<WidgetState>{WidgetState.disabled}) ??
+                  theme.primaryMedium,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(FlagProperty('active', value: widget.value));
+  }
+}
+
+class _SmoothSwitchPainter extends CustomPainter {
+  _SmoothSwitchPainter({
+    required this.progress,
+    required this.thumbActiveColor,
+    required this.thumbInactiveColor,
+    required this.backgroundActiveColor,
+    required this.backgroundInactiveColor,
+  });
+
+  final double progress;
+  final Color thumbActiveColor;
+  final Color thumbInactiveColor;
+  final Color backgroundActiveColor;
+  final Color backgroundInactiveColor;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final Paint paint = Paint()
+      ..color = Color.lerp(
+        backgroundInactiveColor,
+        backgroundActiveColor,
+        progress,
+      )!
+      ..style = PaintingStyle.fill;
+
+    final double radius = size.height / 2.0;
+    final double thumbRadius = radius;
+
+    final double thumbPosition = progress * (size.width - 2 * radius) + radius;
+
+    final Rect rect = Rect.fromLTWH(0.0, 2.0, size.width, size.height - 4.0);
+    final RRect rrect = RRect.fromRectAndRadius(rect, Radius.circular(radius));
+
+    canvas.drawRRect(rrect, paint);
+
+    paint.color = Color.lerp(
+      thumbInactiveColor,
+      thumbActiveColor,
+      progress,
+    )!;
+
+    canvas.drawCircle(Offset(thumbPosition, radius), thumbRadius, paint);
+  }
+
+  @override
+  bool shouldRepaint(_SmoothSwitchPainter oldDelegate) =>
+      oldDelegate.progress != progress ||
+      oldDelegate.thumbActiveColor != thumbActiveColor ||
+      oldDelegate.thumbInactiveColor != thumbInactiveColor ||
+      oldDelegate.backgroundActiveColor != backgroundActiveColor ||
+      oldDelegate.backgroundInactiveColor != backgroundInactiveColor;
+
+  @override
+  bool shouldRebuildSemantics(_SmoothSwitchPainter oldDelegate) =>
+      oldDelegate.progress != progress;
+}


### PR DESCRIPTION
Hi everyone!

In the upcoming food preferences, we will use a different Switch component:
<img width="396" alt="Screenshot 2024-11-20 at 00 08 24" src="https://github.com/user-attachments/assets/9607f3b3-c778-46a9-a53f-599f5a1307e9">

In this PR, the Widget is now available and used in the Nutritional facts screen, where the current one is barely visible (cf #5867).
🎥 Here's what it looks like: https://github.com/user-attachments/assets/469dbc16-8dd1-48a8-bf5f-d05e5a4fb486

💡 Also there's an improvement for this screen: "Per 100g" or "Per portion" is now clickable