### PR TITLE
fix: 5864 - more verbose error message for details

### DIFF
--- a/packages/smooth_app/lib/background/background_task_details.dart
+++ b/packages/smooth_app/lib/background/background_task_details.dart
@@ -186,8 +186,10 @@ class BackgroundTaskDetails extends BackgroundTaskBarcode
       }
       throw Exception(
         'Could not save product - API V2'
-        ' - '
-        'status=${status.status} - errors=${status.error ?? status.statusVerbose} ${isInvalidUser ? _getIncompleteUserData() : ''}',
+        ' - status=${status.status}'
+        ' - errors=${status.error}'
+        ' - status_verbose=${status.statusVerbose}'
+        ' ${isInvalidUser ? _getIncompleteUserData() : ''}',
       );
     }
   }

--- a/packages/smooth_app/lib/background/background_task_details.dart
+++ b/packages/smooth_app/lib/background/background_task_details.dart
@@ -187,7 +187,7 @@ class BackgroundTaskDetails extends BackgroundTaskBarcode
       throw Exception(
         'Could not save product - API V2'
         ' - '
-        'status=${status.status} - errors=${status.error} ${isInvalidUser ? _getIncompleteUserData() : ''}',
+        'status=${status.status} - errors=${status.error ?? status.statusVerbose} ${isInvalidUser ? _getIncompleteUserData() : ''}',
       );
     }
   }

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -1076,10 +1076,10 @@ packages:
     dependency: "direct main"
     description:
       name: openfoodfacts
-      sha256: "56df1ab54751a1b4491d99580b90141ea3327cf546724fa6055943e85d64fd51"
+      sha256: "0ad8ac186a09427d74567460bbcdb1a984afd2558a172afaab87825f0bfec026"
       url: "https://pub.dev"
     source: hosted
-    version: "3.17.0"
+    version: "3.17.1"
   openfoodfacts_flutter_lints:
     dependency: "direct dev"
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -99,7 +99,7 @@ dependencies:
     path: ../scanner/zxing
 
 
-  openfoodfacts: 3.17.0
+  openfoodfacts: 3.17.1
   # openfoodfacts:
   #   path: ../../../openfoodfacts-dart
 


### PR DESCRIPTION
### What
- Now for errors happening in background tasks regarding "edit product details", we consider status fields 'error' _and_ 'status_verbose', in order to be more talkative.

### Screenshot
![Screenshot_1732205400](https://github.com/user-attachments/assets/785168a5-d693-4e90-8500-78e518263607)

### Part of 
- #5864
