### PR TITLE
feat: Min/max version for the tagline

### DIFF
--- a/packages/smooth_app/lib/data_models/news_feed/newsfeed_json.dart
+++ b/packages/smooth_app/lib/data_models/news_feed/newsfeed_json.dart
@@ -15,7 +15,25 @@ class _TagLineJSON {
   final _TagLineJSONNewsList news;
   final _TaglineJSONFeed taglineFeed;
 
-  AppNews toTagLine(String locale) {
+  Future<AppNews> toTagLine(String locale, String appVersion) async {
+    final Map<String, AppNewsItem> tagLineNews = _getAppNewsItem(
+      locale,
+      appVersion,
+    );
+
+    final _TagLineJSONFeedLocale localizedFeed = taglineFeed.loadNews(locale);
+    final Iterable<AppNewsFeedItem> feed =
+        _getAppNewsFeedItems(localizedFeed, locale);
+
+    return AppNews(
+      news: AppNewsList(tagLineNews),
+      feed: AppNewsFeed(
+        feed.toList(growable: false),
+      ),
+    );
+  }
+
+  Map<String, AppNewsItem> _getAppNewsItem(String locale, String appVersion) {
     final Map<String, AppNewsItem> tagLineNews = news.map(
       (String key, _TagLineItemNewsItem value) => MapEntry<String, AppNewsItem>(
         key,
@@ -23,7 +41,33 @@ class _TagLineJSON {
       ),
     );
 
-    final _TagLineJSONFeedLocale localizedFeed = taglineFeed.loadNews(locale);
+    final int? appVersionNumber = _extractVersionNumber(appVersion);
+
+    for (final AppNewsItem item in tagLineNews.values) {
+      if (item.minAppVersion != null) {
+        final int? minVersionNumber = _extractVersionNumber(item.minAppVersion);
+
+        if (minVersionNumber != null && appVersionNumber != null) {
+          if (appVersionNumber < minVersionNumber) {
+            tagLineNews.remove(item.id);
+          }
+        }
+      }
+      if (item.maxAppVersion != null) {
+        final int? maxVersionNumber = _extractVersionNumber(item.maxAppVersion);
+
+        if (maxVersionNumber != null && appVersionNumber != null) {
+          if (appVersionNumber > maxVersionNumber) {
+            tagLineNews.remove(item.id);
+          }
+        }
+      }
+    }
+    return tagLineNews;
+  }
+
+  Iterable<AppNewsFeedItem> _getAppNewsFeedItems(
+      _TagLineJSONFeedLocale localizedFeed, String locale) {
     final Iterable<AppNewsFeedItem> feed = localizedFeed.news
         .map((_TagLineJSONFeedLocaleItem item) {
           if (news[item.id] == null) {
@@ -38,13 +82,14 @@ class _TagLineJSON {
                 item.startDate!.isBefore(DateTime.now())) &&
             (item.endDate == null || item.endDate!.isAfter(DateTime.now())))
         .whereNotNull();
+    return feed;
+  }
 
-    return AppNews(
-      news: AppNewsList(tagLineNews),
-      feed: AppNewsFeed(
-        feed.toList(growable: false),
-      ),
-    );
+  int? _extractVersionNumber(String? version) {
+    if (version == null) {
+      return null;
+    }
+    return int.tryParse(version.replaceAll(r'.', '').trim());
   }
 }
 
@@ -57,6 +102,8 @@ class _TagLineItemNewsItem {
     required _TagLineItemNewsTranslations translations,
     this.startDate,
     this.endDate,
+    this.minVersion,
+    this.maxVersion,
     this.style,
   }) : _translations = translations;
 
@@ -79,6 +126,8 @@ class _TagLineItemNewsItem {
         }),
         startDate = DateTime.tryParse(json['start_date']),
         endDate = DateTime.tryParse(json['end_date']),
+        minVersion = json['min_version'],
+        maxVersion = json['max_version'],
         style = json['style'] == null
             ? null
             : _TagLineNewsStyle.fromJson(json['style']);
@@ -88,6 +137,8 @@ class _TagLineItemNewsItem {
   final _TagLineItemNewsTranslations _translations;
   final DateTime? startDate;
   final DateTime? endDate;
+  final String? minVersion;
+  final String? maxVersion;
   final _TagLineNewsStyle? style;
 
   _TagLineItemNewsTranslation loadTranslation(String locale) {
@@ -120,6 +171,8 @@ class _TagLineItemNewsItem {
       buttonLabel: translation.buttonLabel,
       startDate: startDate,
       endDate: endDate,
+      minAppVersion: minVersion,
+      maxAppVersion: maxVersion,
       style: style?.toTagLineStyle(),
       image: translation.image?.overridesContent == true
           ? translation.image?.toTagLineImage()
@@ -312,7 +365,7 @@ class _TagLineNewsStyle {
     );
   }
 
-  AppNewsStyle toTagLineStyle() => AppNewsStyle.fromHexa(
+  AppNewsStyle toTagLineStyle() => AppNewsStyle.fromHex(
         titleBackground: titleBackground,
         titleTextColor: titleTextColor,
         titleIndicatorColor: titleIndicatorColor,

--- a/packages/smooth_app/lib/data_models/news_feed/newsfeed_json.dart
+++ b/packages/smooth_app/lib/data_models/news_feed/newsfeed_json.dart
@@ -185,6 +185,8 @@ class _TagLineItemNewsItem {
     _TagLineItemNewsTranslations? translations,
     DateTime? startDate,
     DateTime? endDate,
+    String? minVersion,
+    String? maxVersion,
     _TagLineNewsStyle? style,
   }) {
     return _TagLineItemNewsItem._(
@@ -194,6 +196,8 @@ class _TagLineItemNewsItem {
       translations: translations ?? _translations,
       startDate: startDate ?? this.startDate,
       endDate: endDate ?? this.endDate,
+      minVersion: minVersion ?? this.minVersion,
+      maxVersion: maxVersion ?? this.maxVersion,
       style: style ?? this.style,
     );
   }

--- a/packages/smooth_app/lib/data_models/news_feed/newsfeed_model.dart
+++ b/packages/smooth_app/lib/data_models/news_feed/newsfeed_model.dart
@@ -39,6 +39,8 @@ class AppNewsItem {
     this.buttonLabel,
     this.startDate,
     this.endDate,
+    this.minAppVersion,
+    this.maxAppVersion,
     this.image,
     this.style,
   });
@@ -50,12 +52,14 @@ class AppNewsItem {
   final String? buttonLabel;
   final DateTime? startDate;
   final DateTime? endDate;
+  final String? minAppVersion;
+  final String? maxAppVersion;
   final AppNewsImage? image;
   final AppNewsStyle? style;
 
   @override
   String toString() {
-    return 'AppNewsItem{id: $id, title: $title, message: $message, url: $url, buttonLabel: $buttonLabel, startDate: $startDate, endDate: $endDate, image: $image, style: $style}';
+    return 'AppNewsItem{id: $id, title: $title, message: $message, url: $url, buttonLabel: $buttonLabel, startDate: $startDate, endDate: $endDate, minAppVersion: $minAppVersion, maxAppVersion: $maxAppVersion, image: $image, style: $style}';
   }
 }
 
@@ -71,7 +75,7 @@ class AppNewsStyle {
     this.contentBackgroundColor,
   });
 
-  AppNewsStyle.fromHexa({
+  AppNewsStyle.fromHex({
     String? titleBackground,
     String? titleTextColor,
     String? titleIndicatorColor,
@@ -98,11 +102,11 @@ class AppNewsStyle {
   final Color? buttonTextColor;
   final Color? contentBackgroundColor;
 
-  static Color? _parseColor(String? hexa) {
-    if (hexa == null || hexa.length != 7) {
+  static Color? _parseColor(String? hex) {
+    if (hex == null || hex.length != 7) {
       return null;
     }
-    return Color(int.parse(hexa.substring(1), radix: 16));
+    return Color(int.parse(hex.substring(1), radix: 16));
   }
 
   @override

--- a/packages/smooth_app/lib/data_models/news_feed/newsfeed_provider.dart
+++ b/packages/smooth_app/lib/data_models/news_feed/newsfeed_provider.dart
@@ -5,6 +5,7 @@ import 'dart:isolate';
 import 'package:collection/collection.dart';
 import 'package:flutter/widgets.dart';
 import 'package:http/http.dart' as http;
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:path/path.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:smooth_app/data_models/news_feed/newsfeed_model.dart';
@@ -66,8 +67,15 @@ class AppNewsProvider extends ChangeNotifier {
       return;
     }
 
+    final PackageInfo app = await PackageInfo.fromPlatform();
+
     final AppNews? appNews = await Isolate.run(
-        () => _parseJSONAndGetLocalizedContent(jsonString!, locale));
+      () => _parseJSONAndGetLocalizedContent(
+        jsonString!,
+        locale,
+        app.version,
+      ),
+    );
     if (appNews == null) {
       _emit(const AppNewsStateError('Unable to parse the JSON news file'));
       Logs.e('Unable to parse the JSON news file');
@@ -89,11 +97,13 @@ class AppNewsProvider extends ChangeNotifier {
   static Future<AppNews?> _parseJSONAndGetLocalizedContent(
     String json,
     String locale,
+    String appVersion,
   ) async {
     try {
-      final _TagLineJSON tagLineJSON =
-          _TagLineJSON.fromJson(jsonDecode(json) as Map<dynamic, dynamic>);
-      return tagLineJSON.toTagLine(locale);
+      final _TagLineJSON tagLineJSON = _TagLineJSON.fromJson(
+        jsonDecode(json) as Map<dynamic, dynamic>,
+      );
+      return tagLineJSON.toTagLine(locale, appVersion);
     } catch (_) {
       return null;
     }

--- a/packages/smooth_app/lib/data_models/news_feed/newsfeed_provider.dart
+++ b/packages/smooth_app/lib/data_models/news_feed/newsfeed_provider.dart
@@ -79,9 +79,9 @@ class AppNewsProvider extends ChangeNotifier {
 
   void _emit(AppNewsState state) {
     _state = state;
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      notifyListeners();
-    });
+    WidgetsBinding.instance
+      ..addPostFrameCallback((_) => notifyListeners())
+      ..ensureVisualUpdate();
   }
 
   AppNewsState get state => _state;

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_dev_mode.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_dev_mode.dart
@@ -316,7 +316,7 @@ class UserPreferencesDevMode extends AbstractUserPreferences {
             return Consumer<AppNewsProvider>(
                 builder: (_, AppNewsProvider provider, __) {
               return Text(switch (provider.state) {
-                AppNewsStateLoading() => 'Loading...',
+                AppNewsStateLoading() => 'Loading…',
                 AppNewsStateLoaded(lastUpdate: final DateTime date) =>
                   appLocalizations
                       .dev_preferences_news_provider_status_subtitle(


### PR DESCRIPTION
Hi everyone!

The JSON can now provide a `min_version` and/or a `max_version` for each news item.
Some examples:
- Only `max_version`: a message to notify there's an update available
- `min_version` only or `min_version=max_version`: changelog of new features

By version, it's not the version code, but the version name (e.g.: `1.2.3`)

In this PR, there's also a fix, where sometimes the Tagline is not visible (mainly at launch) and the DEV Mode status is not refreshing.