### PR TITLE
ci: Add GitHub action to run translation scripts on push to l10n_develop branch

### DIFF
--- a/packages/smooth_app/.github/workflows/run_translation_scripts.yml
+++ b/packages/smooth_app/.github/workflows/run_translation_scripts.yml
@@ -1,0 +1,24 @@
+name: Run Translation Scripts
+
+on:
+  push:
+    branches:
+      - l10n_develop
+
+jobs:
+  run-scripts:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run iOS translation script
+        run: |
+          chmod +x packages/smooth_app/ios/Runner/remove.sh
+          packages/smooth_app/ios/Runner/remove.sh
+
+      - name: Run l10n translation script
+        run: |
+          chmod +x packages/smooth_app/lib/l10n/remove_3_letter_locales.sh
+          packages/smooth_app/lib/l10n/remove_3_letter_locales.sh


### PR DESCRIPTION
Add a new GitHub action to run translation scripts on push to `l10n_develop` branch.

* **Trigger**: Set the action to run on push to the `l10n_develop` branch.
* **Checkout**: Add a step to check out the repository.
* **Run Scripts**: Add steps to run the iOS translation script and the l10n translation script, including setting execute permissions for the scripts.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/openfoodfacts/smooth-app/pull/5919?shareId=b42204f3-d5ec-4c2e-9483-3be92487b41f).