### PR TITLE
fix: Knowledge Panel page: bg color in light mode + product name

### DIFF
--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_page.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_page.dart
@@ -8,10 +8,14 @@ import 'package:smooth_app/data_models/up_to_date_mixin.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
+import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_expanded_card.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels_builder.dart';
 import 'package:smooth_app/pages/product/common/product_refresher.dart';
 import 'package:smooth_app/pages/scan/carousel/scan_carousel_manager.dart';
+import 'package:smooth_app/themes/smooth_theme.dart';
+import 'package:smooth_app/themes/smooth_theme_colors.dart';
+import 'package:smooth_app/themes/theme_provider.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
@@ -57,13 +61,22 @@ class _KnowledgePanelPageState extends State<KnowledgePanelPage>
     context.watch<LocalDatabase>();
     refreshUpToDate();
     return SmoothScaffold(
+      backgroundColor: context.lightTheme()
+          ? context.extension<SmoothColorsThemeExtension>().primaryLight
+          : null,
       appBar: SmoothAppBar(
         title: Semantics(
           label: _getTitleForAccessibility(appLocalizations, title),
           child: Text(
             title,
-            maxLines: 2,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
           ),
+        ),
+        subTitle: Text(
+          getProductNameAndBrands(widget.product, appLocalizations),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
         ),
       ),
       body: RefreshIndicator(


### PR DESCRIPTION
Hi everyone!

Here are two enhancements for the KP details page:
- In light mode, the background color is the same as the product page
- In all configs, in the header, we now display the product name

![KP](https://github.com/user-attachments/assets/fc5f5376-b59d-487f-895e-7dbc10eb8689)
