### PR TITLE
feat: 5905 - toggle instead of check box for "discount" price

### DIFF
--- a/packages/smooth_app/lib/pages/prices/price_amount_card.dart
+++ b/packages/smooth_app/lib/pages/prices/price_amount_card.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
-import 'package:smooth_app/generic_lib/buttons/smooth_large_button_with_icon.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/pages/prices/price_amount_field.dart';
@@ -65,12 +64,13 @@ class _PriceAmountCardState extends State<PriceAmountCard> {
             onPressed:
                 total == 1 ? null : () => priceModel.removeAt(widget.index),
           ),
-          SmoothLargeButtonWithIcon(
-            icon: model.promo ? Icons.check_box : Icons.check_box_outline_blank,
-            text: appLocalizations.prices_amount_is_discounted,
-            onPressed: () => setState(
+          SwitchListTile(
+            value: model.promo,
+            onChanged: (final bool value) => setState(
               () => model.promo = !model.promo,
             ),
+            title: Text(appLocalizations.prices_amount_is_discounted),
+            controlAffinity: ListTileControlAffinity.leading,
           ),
           const SizedBox(height: SMALL_SPACE),
           Row(


### PR DESCRIPTION
### What
- Toggle instead of check box for "discount" price

### Screenshots
![image](https://github.com/user-attachments/assets/d47cce30-a825-4db1-a54e-0318c4a97545)
![image](https://github.com/user-attachments/assets/498921c7-f932-473f-9300-06af630a510e)

### Fixes bug(s)
- Closes: #5905