### PR TITLE
fix: Product attributes: visible dividers in dark mode + …

### DIFF
--- a/packages/smooth_app/lib/pages/product/summary_attribute_group.dart
+++ b/packages/smooth_app/lib/pages/product/summary_attribute_group.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/themes/theme_provider.dart';
 
 /// Shows the attribute groups in a product summary card.
 class SummaryAttributeGroup extends StatelessWidget {
@@ -67,15 +68,9 @@ class _SummaryAttributeGroupHeader extends StatelessWidget {
                 .apply(color: Colors.grey),
           ),
         )
-      : Padding(
-          padding: const EdgeInsetsDirectional.only(
-            top: VERY_SMALL_SPACE,
-            bottom: SMALL_SPACE,
-          ),
-          child: isFirstGroup
-              ? EMPTY_WIDGET
-              : const Divider(
-                  color: Colors.black12,
-                ),
-        );
+      : isFirstGroup
+          ? const SizedBox(height: SMALL_SPACE)
+          : Divider(
+              color: context.lightTheme() ? Colors.black12 : Colors.white24,
+            );
 }


### PR DESCRIPTION
Hi everyone!

Here are two changes to the attributes on the product page:
- Dividers are visible in dark mode
- Less vertical paddings

Old vs new:
![Untitled](https://github.com/user-attachments/assets/4a5d26c5-be1d-4784-b6bb-d0dc7085b27a)
