### PR TITLE
fix: Warning on iOS about a negative padding

### DIFF
--- a/packages/smooth_app/lib/widgets/smooth_navigation_bar.dart
+++ b/packages/smooth_app/lib/widgets/smooth_navigation_bar.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:math' as math;
 
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
@@ -41,8 +42,11 @@ class _SmoothNavigationBarState extends State<SmoothNavigationBar> {
               : Theme.of(context).scaffoldBackgroundColor,
           child: Padding(
             padding: EdgeInsetsDirectional.only(
-              bottom: MediaQuery.of(context).padding.bottom -
-                  (Platform.isIOS ? 5.0 : 0.0),
+              bottom: math.max(
+                0,
+                MediaQuery.viewPaddingOf(context).bottom -
+                    (Platform.isIOS ? 5.0 : 0.0),
+              ),
             ),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceAround,


### PR DESCRIPTION
Hi everyone!

There is a small issue in the computation of bottom padding for the new nav bar.
I think the error is only on iOS:

```
======== Exception caught by widgets library =======================================================
The following assertion was thrown building SmoothNavigationBar(dependencies: [MediaQuery, _InheritedProviderScope<ThemeProvider?>], state: _SmoothNavigationBarState#785cd):
'package:flutter/src/rendering/shifted_box.dart': Failed assertion: line 112 pos 15: 'padding.isNonNegative': is not true.


Either the assertion indicates an error in the framework itself, or we should provide substantially more information in this error message to help you determine and fix the underlying cause.
In either case, please report this assertion by filing a bug on GitHub:
  https://github.com/flutter/flutter/issues/new?template=2_bug.yml

The relevant error-causing widget was: 
  SmoothNavigationBar SmoothNavigationBar:file:///Users/g123k/IdeaProjects/smooth-app/packages/smooth_app/lib/pages/page_manager.dart:97:16
```