### PR TITLE
chore: 5944 - systematically using "upToDateProduct"

### DIFF
--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_page.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_page.dart
@@ -74,7 +74,7 @@ class _KnowledgePanelPageState extends State<KnowledgePanelPage>
           ),
         ),
         subTitle: Text(
-          getProductNameAndBrands(widget.product, appLocalizations),
+          getProductNameAndBrands(upToDateProduct, appLocalizations),
           maxLines: 1,
           overflow: TextOverflow.ellipsis,
         ),

--- a/packages/smooth_app/lib/pages/product/edit_ocr/edit_ocr_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_ocr/edit_ocr_page.dart
@@ -63,11 +63,11 @@ class _EditOcrPageState extends State<EditOcrPage> with UpToDateMixin {
     initUpToDate(widget.product, context.read<LocalDatabase>());
     _multilingualHelper = MultilingualHelper(controller: _controller);
     _multilingualHelper.init(
-      multilingualTexts: _helper.getMultilingualTexts(widget.product),
-      monolingualText: _helper.getMonolingualText(widget.product),
-      selectedImages: widget.product.selectedImages,
+      multilingualTexts: _helper.getMultilingualTexts(upToDateProduct),
+      monolingualText: _helper.getMonolingualText(upToDateProduct),
+      selectedImages: upToDateProduct.selectedImages,
       imageField: _helper.getImageField(),
-      productLanguage: widget.product.lang,
+      productLanguage: upToDateProduct.lang,
     );
   }
 
@@ -79,7 +79,7 @@ class _EditOcrPageState extends State<EditOcrPage> with UpToDateMixin {
 
     try {
       final String? extractedText = await _helper.getExtractedText(
-        widget.product,
+        upToDateProduct,
         _multilingualHelper.getCurrentLanguage(),
       );
       if (!mounted) {
@@ -384,7 +384,7 @@ class _EditOcrPageState extends State<EditOcrPage> with UpToDateMixin {
                             onPressed: () async => confirmAndUploadNewPicture(
                               context,
                               imageField: ImageField.OTHER,
-                              barcode: widget.product.barcode!,
+                              barcode: barcode,
                               productType: upToDateProduct.productType,
                               language: language,
                               isLoggedInMandatory: widget.isLoggedInMandatory,
@@ -423,7 +423,7 @@ class _EditOcrPageState extends State<EditOcrPage> with UpToDateMixin {
   Product? _getMinimalistProduct() {
     Product? result;
 
-    Product getBasicProduct() => Product(barcode: widget.product.barcode);
+    Product getBasicProduct() => Product(barcode: barcode);
 
     if (_multilingualHelper.isMonolingual()) {
       final String? changed = _multilingualHelper.getChangedMonolingualText();

--- a/packages/smooth_app/lib/pages/product/gallery_view/product_image_gallery_view.dart
+++ b/packages/smooth_app/lib/pages/product/gallery_view/product_image_gallery_view.dart
@@ -84,7 +84,7 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView>
     initUpToDate(widget.product, context.read<LocalDatabase>());
     _language = ProductQuery.getLanguage();
     _mainImageFields = ImageFieldSmoothieExtension.getOrderedMainImageFields(
-      widget.product.productType,
+      upToDateProduct.productType,
     );
   }
 

--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -103,10 +103,7 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded>
   @override
   void initState() {
     super.initState();
-    initUpToDate(
-      widget.product,
-      context.read<LocalDatabase>(),
-    );
+    initUpToDate(widget.product, context.read<LocalDatabase>());
     _nutritionContainer = NutritionContainer(
       orderedNutrients: widget.orderedNutrients,
       product: upToDateProduct,
@@ -327,7 +324,7 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded>
   }
 
   Widget? _getServingFieldLeading(final AppLocalizations appLocalizations) {
-    if (widget.product.getOwnerFieldTimestamp(OwnerField.productField(
+    if (upToDateProduct.getOwnerFieldTimestamp(OwnerField.productField(
           ProductField.SERVING_SIZE,
           ProductQuery.getLanguage(),
         )) !=
@@ -342,10 +339,10 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded>
 
     if (_servingController?.initialValue?.isEmpty == true &&
         _servingController?.text.isEmpty == true &&
-        widget.product.quantity != null) {
+        upToDateProduct.quantity != null) {
       return IconButton(
         onPressed: () {
-          _servingController!.text = widget.product.quantity!;
+          _servingController!.text = upToDateProduct.quantity!;
         },
         icon: const icons.Milk.download(),
         visualDensity: VisualDensity.compact,
@@ -556,7 +553,7 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded>
       changedProduct,
       context: context,
       stamp: BackgroundTaskDetailsStamp.nutrition,
-      productType: widget.product.productType,
+      productType: upToDateProduct.productType,
     );
     return true;
   }

--- a/packages/smooth_app/lib/pages/product/product_image_swipeable_view.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_swipeable_view.dart
@@ -66,7 +66,7 @@ class _ProductImageSwipeableViewState extends State<ProductImageSwipeableView>
       _imageFields = <ImageField>[widget.imageField!];
     } else {
       _imageFields = ImageFieldSmoothieExtension.getOrderedMainImageFields(
-        widget.product.productType,
+        upToDateProduct.productType,
       );
     }
   }
@@ -102,7 +102,7 @@ class _ProductImageSwipeableViewState extends State<ProductImageSwipeableView>
         controller: _controller,
         itemCount: _imageFields.length,
         itemBuilder: (BuildContext context, int index) => ProductImageViewer(
-          product: widget.product,
+          product: upToDateProduct,
           imageField: _imageFields[index],
           isInitialImageViewed: widget.initialImageIndex == index,
           language: _currentLanguage,


### PR DESCRIPTION
### What
- When products are being updated by the user, we keep a stack of all pending changes, in order to maintain an up-to-date product while the changes are uploaded to the server.
- In some pages, in some rare widgets, we still used the latest downloaded product without applying the pending changes on top.
- That's solved in this PR. Not really fixing a specific created issue, more like "hey I changed the product name and it's not immediately reflected on the edit packaging page, how come?"

### Fixes bug(s)
- Closes: #5944

### Impacted files
* `edit_ocr_page.dart`: replaced "widget.product" with "upToDateProduct"; used "barcode" getter
* `knowledge_panel_page.dart`: replaced "widget.product" with "upToDateProduct"
* `nutrition_page_loaded.dart`: replaced "widget.product" with "upToDateProduct"
* `product_image_gallery_view.dart`: replaced "widget.product" with "upToDateProduct"
* `product_image_swipeable_view.dart`: replaced "widget.product" with "upToDateProduct"