### PR TITLE
fix: Remove the color below the search page (dark mode)

### DIFF
--- a/packages/smooth_app/lib/pages/search/search_field.dart
+++ b/packages/smooth_app/lib/pages/search/search_field.dart
@@ -91,6 +91,7 @@ class _SearchFieldState extends State<SearchField> {
             : null,
         child: Material(
           // ↑ Needed by the Hero Widget
+          color: Colors.transparent,
           child: Column(
             children: <Widget>[
               TextField(


### PR DESCRIPTION
Hi everyone!

There is a tiny visual issue with the search bar on the search page:
![IMG_1502](https://github.com/user-attachments/assets/47d5937c-224d-4d07-baa6-2ec5b5d6d5ec)

It's only visible in dark mode.