### PR TITLE
fix: osm_key duplicate column name

### DIFF
--- a/packages/smooth_app/lib/database/dao_osm_location.dart
+++ b/packages/smooth_app/lib/database/dao_osm_location.dart
@@ -69,7 +69,7 @@ class DaoOsmLocation extends AbstractSqlDao {
       final String column,
     ) =>
         e.toString().startsWith(
-            'DatabaseException(duplicate column name: $column (code 1 SQLITE_ERROR)');
+            'DatabaseException(duplicate column name: $column (code 1 SQLITE_ERROR[1])');
 
     if (oldVersion < 7) {
       try {

--- a/packages/smooth_app/lib/database/dao_osm_location.dart
+++ b/packages/smooth_app/lib/database/dao_osm_location.dart
@@ -69,7 +69,7 @@ class DaoOsmLocation extends AbstractSqlDao {
       final String column,
     ) =>
         e.toString().startsWith(
-            'DatabaseException(duplicate column name: $column (code 1 SQLITE_ERROR[1])');
+            'DatabaseException(duplicate column name: $column (code 1 SQLITE_ERROR');
 
     if (oldVersion < 7) {
       try {


### PR DESCRIPTION
### What
Part of #5789

Actually found small typo, looks right now. 
Otherwise we could use the string contains method. 
