### PR TITLE
fix: Image gallery language not selectable (+ too long AppBar title

### DIFF
--- a/packages/smooth_app/lib/pages/product/gallery_view/product_image_gallery_tabs.dart
+++ b/packages/smooth_app/lib/pages/product/gallery_view/product_image_gallery_tabs.dart
@@ -10,6 +10,7 @@ import 'package:smooth_app/generic_lib/widgets/language_priority.dart';
 import 'package:smooth_app/generic_lib/widgets/language_selector.dart';
 import 'package:smooth_app/helpers/border_radius_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
+import 'package:smooth_app/helpers/product_extension.dart';
 import 'package:smooth_app/helpers/provider_helper.dart';
 import 'package:smooth_app/helpers/ui_helpers.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_languages_list.dart';
@@ -237,7 +238,7 @@ class _ImageGalleryLanguagesProvider
   Product? product;
 
   void attachProduct(final Product product) {
-    if (product != this.product) {
+    if (!equalsProduct(product)) {
       this.product = product;
       refreshLanguages(initial: true);
     }
@@ -310,6 +311,33 @@ class _ImageGalleryLanguagesProvider
       selectedLanguage: value.selectedLanguage,
       hasNewLanguage: false,
     );
+  }
+
+  bool equalsProduct(Product product) {
+    if (this.product == null) {
+      return false;
+    }
+
+    return product.barcode == this.product!.barcode &&
+        product.productType == this.product!.productType &&
+        product.imageFrontUrl == this.product!.imageFrontUrl &&
+        product.imageFrontSmallUrl == this.product!.imageFrontSmallUrl &&
+        product.imageIngredientsUrl == this.product!.imageIngredientsUrl &&
+        product.imageIngredientsSmallUrl ==
+            this.product!.imageIngredientsSmallUrl &&
+        product.imageNutritionUrl == this.product!.imageNutritionUrl &&
+        product.imageNutritionSmallUrl ==
+            this.product!.imageNutritionSmallUrl &&
+        product.imagePackagingUrl == this.product!.imagePackagingUrl &&
+        product.imagePackagingSmallUrl ==
+            this.product!.imagePackagingSmallUrl &&
+        const ListEquality<ProductImage>()
+            .equals(product.selectedImages, this.product!.selectedImages) &&
+        const ListEquality<ProductImage>()
+            .equals(product.images, this.product!.images) &&
+        product.lastImage == this.product!.lastImage &&
+        const ListEquality<String>()
+            .equals(product.lastImageDates, this.product!.lastImageDates);
   }
 }
 

--- a/packages/smooth_app/lib/pages/product/gallery_view/product_image_gallery_tabs.dart
+++ b/packages/smooth_app/lib/pages/product/gallery_view/product_image_gallery_tabs.dart
@@ -10,7 +10,6 @@ import 'package:smooth_app/generic_lib/widgets/language_priority.dart';
 import 'package:smooth_app/generic_lib/widgets/language_selector.dart';
 import 'package:smooth_app/helpers/border_radius_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
-import 'package:smooth_app/helpers/product_extension.dart';
 import 'package:smooth_app/helpers/provider_helper.dart';
 import 'package:smooth_app/helpers/ui_helpers.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_languages_list.dart';

--- a/packages/smooth_app/lib/widgets/smooth_app_bar.dart
+++ b/packages/smooth_app/lib/widgets/smooth_app_bar.dart
@@ -281,6 +281,8 @@ class _AppBarTitle extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
         DefaultTextStyle(
+          maxLines: subTitle != null ? 1 : 2,
+          overflow: TextOverflow.ellipsis,
           style: (titleTextStyle ??
                   AppBarTheme.of(context).titleTextStyle ??
                   theme.appBarTheme.titleTextStyle?.copyWith(


### PR DESCRIPTION
Hi everyone!

This PR fixes two issues:
- We can't select a new language in the gallery
- When there is a subtitle, the `AppBar` continues to take 2 lines

🎥 Video: https://github.com/user-attachments/assets/a5ef22ff-6061-4181-99fc-a6eba040c6e8

One important thing: to prevent complex code and potential bugs, if a language is added from the "Details" view, it will only appear once uploaded (adding a language from this screen is a minor case, so I prefer to keep a maintainable code).