### PR TITLE
fix: 5970 - SQLITE error "typo"

### DIFF
--- a/packages/smooth_app/lib/database/dao_product.dart
+++ b/packages/smooth_app/lib/database/dao_product.dart
@@ -367,7 +367,7 @@ class DaoProduct extends AbstractSqlDao implements BulkDeletable {
       );
     } catch (e) {
       if (!e.toString().startsWith(
-            'DatabaseException(near "nulls": syntax error (code 1 SQLITE_ERROR[1])',
+            'DatabaseException(near "nulls": syntax error (code 1 SQLITE_ERROR',
           )) {
         rethrow;
       }


### PR DESCRIPTION
### What
- Like in #5960, the SQLITE error message needed to be edited, in order to support different variant.

### Fixes bug(s)
- Fixes: #5970