### PR TITLE
feat: upgrade to off-dart 3.18.0

### DIFF
--- a/packages/smooth_app/lib/pages/locations/osm_location.dart
+++ b/packages/smooth_app/lib/pages/locations/osm_location.dart
@@ -19,8 +19,8 @@ class OsmLocation {
   });
 
   OsmLocation.fromPrice(final Location location)
-      : osmId = location.osmId,
-        osmType = location.type,
+      : osmId = location.osmId!,
+        osmType = location.type!,
         longitude = location.longitude ?? 0,
         latitude = location.latitude ?? 0,
         name = location.name,

--- a/packages/smooth_app/lib/pages/prices/price_model.dart
+++ b/packages/smooth_app/lib/pages/prices/price_model.dart
@@ -144,7 +144,7 @@ class PriceModel with ChangeNotifier {
     notifyListeners();
   }
 
-  OsmLocation? get location => proof != null
+  OsmLocation? get location => proof?.location?.osmId != null
       ? OsmLocation.fromPrice(proof!.location!)
       : _locations!.firstOrNull;
 

--- a/packages/smooth_app/lib/query/product_query.dart
+++ b/packages/smooth_app/lib/query/product_query.dart
@@ -293,5 +293,6 @@ abstract class ProductQuery {
         ProductField.WEBSITE,
         ProductField.OBSOLETE,
         ProductField.OWNER_FIELDS,
+        ProductField.OWNER,
       ];
 }

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -1076,10 +1076,10 @@ packages:
     dependency: "direct main"
     description:
       name: openfoodfacts
-      sha256: "0ad8ac186a09427d74567460bbcdb1a984afd2558a172afaab87825f0bfec026"
+      sha256: "2a2076e5190e4b573ce5326cd4981ebdefa33c57c0507ca0057c57c12b79c47a"
       url: "https://pub.dev"
     source: hosted
-    version: "3.17.1"
+    version: "3.18.0"
   openfoodfacts_flutter_lints:
     dependency: "direct dev"
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -99,7 +99,7 @@ dependencies:
     path: ../scanner/zxing
 
 
-  openfoodfacts: 3.17.1
+  openfoodfacts: 3.18.0
   # openfoodfacts:
   #   path: ../../../openfoodfacts-dart
 


### PR DESCRIPTION
### What
- Upgrade to off-dart 3.18.0

### Fixes bug(s)
- Fixes: #5943

### Impacted files
* `osm_location.dart`: minor refactoring due to 3.18.0 - now we may have proofs without osm location (e.g. internet)
* `price_model.dart`: minor refactoring due to 3.18.0 - now we may have proofs without osm location (e.g. internet)
* `product_query.dart`: added the `OWNER` product field to be retrieved
* `product_refresher.dart`: now we use only the `food` server for single barcode queries, but with `ProductTypeFilter.all`
* `pubspec.lock`: wtf
* `pubspec.yaml`: upgraded to off-dart 3.18.0