### PR TITLE
feat: An indicator if the photo may be locked by the producer

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_image.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_image.dart
@@ -10,6 +10,7 @@ import 'package:provider/provider.dart';
 import 'package:smooth_app/database/transient_file.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/pages/image/product_image_helper.dart';
+import 'package:smooth_app/pages/product/owner_field_info.dart';
 import 'package:smooth_app/pages/product/product_page/new_product_page.dart';
 import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/resources/app_icons.dart' as icons;
@@ -27,6 +28,7 @@ class ProductPicture extends StatefulWidget {
     VoidCallback? onTap,
     String? heroTag,
     bool? showObsoleteIcon,
+    bool? showOwnerIcon,
     BorderRadius? borderRadius,
     double? imageFoundBorder,
     double? imageNotFoundBorder,
@@ -45,23 +47,27 @@ class ProductPicture extends StatefulWidget {
           imageNotFoundBorder: imageNotFoundBorder ?? 0.0,
           errorTextStyle: errorTextStyle,
           showObsoleteIcon: showObsoleteIcon ?? false,
+          showOwnerIcon: showOwnerIcon ?? false,
         );
 
   ProductPicture.fromTransientFile({
     required TransientFile transientFile,
     required Size size,
+    Product? product,
+    ImageField? imageField,
     String? fallbackUrl,
     VoidCallback? onTap,
     String? heroTag,
     bool? showObsoleteIcon,
+    bool? showOwnerIcon,
     BorderRadius? borderRadius,
     double? imageFoundBorder,
     double? imageNotFoundBorder,
     TextStyle? errorTextStyle,
   }) : this._(
           transientFile: transientFile,
-          product: null,
-          imageField: null,
+          product: product,
+          imageField: imageField,
           language: null,
           size: size,
           fallbackUrl: fallbackUrl,
@@ -72,6 +78,7 @@ class ProductPicture extends StatefulWidget {
           imageNotFoundBorder: imageNotFoundBorder ?? 0.0,
           errorTextStyle: errorTextStyle,
           showObsoleteIcon: showObsoleteIcon ?? false,
+          showOwnerIcon: showOwnerIcon ?? false,
         );
 
   ProductPicture._({
@@ -88,6 +95,7 @@ class ProductPicture extends StatefulWidget {
     this.imageNotFoundBorder = 0.0,
     this.errorTextStyle,
     this.showObsoleteIcon = false,
+    this.showOwnerIcon = false,
     super.key,
   })  : assert(imageFoundBorder >= 0.0),
         assert(imageNotFoundBorder >= 0.0),
@@ -107,6 +115,9 @@ class ProductPicture extends StatefulWidget {
 
   /// Show the obsolete icon on top of the image
   final bool showObsoleteIcon;
+
+  /// Show the owner icon on top of the image
+  final bool showOwnerIcon;
 
   /// Rounded borders around the image
   final BorderRadius? borderRadius;
@@ -161,9 +172,16 @@ class _ProductPictureState extends State<ProductPicture> {
       child = _ProductPictureWithImageProvider(
         imageProvider: imageProvider!.$1!,
         outdated: imageProvider.$2,
+        locked: widget.imageField != null &&
+            widget.product?.isImageLocked(
+                  widget.imageField!,
+                  widget.language ?? ProductQuery.getLanguage(),
+                ) ==
+                true,
         heroTag: widget.heroTag,
         size: widget.size,
         showOutdated: widget.showObsoleteIcon,
+        showOwner: widget.showOwnerIcon,
         borderRadius: widget.borderRadius,
         border: widget.imageFoundBorder,
         onError: () {
@@ -243,10 +261,12 @@ class _ProductPictureWithImageProvider extends StatelessWidget {
   const _ProductPictureWithImageProvider({
     required this.imageProvider,
     required this.outdated,
+    required this.locked,
     required this.size,
     required this.child,
     required this.onError,
     required this.showOutdated,
+    required this.showOwner,
     required this.border,
     this.borderRadius,
     this.heroTag,
@@ -254,10 +274,12 @@ class _ProductPictureWithImageProvider extends StatelessWidget {
 
   final ImageProvider imageProvider;
   final bool outdated;
+  final bool locked;
   final Size size;
   final Widget? child;
   final VoidCallback onError;
   final bool showOutdated;
+  final bool showOwner;
   final BorderRadius? borderRadius;
   final double border;
   final String? heroTag;
@@ -318,43 +340,51 @@ class _ProductPictureWithImageProvider extends StatelessWidget {
       ),
     );
 
+    Widget? icons;
+
     if (showOutdated && outdated) {
-      return Semantics(
-        label: appLocalizations
-            .product_page_image_front_outdated_message_accessibility_label,
-        image: true,
-        excludeSemantics: true,
-        child: Tooltip(
-          message: appLocalizations.product_page_image_front_outdated_message,
-          child: Stack(
-            children: <Widget>[
-              image,
-              Positioned.directional(
-                bottom: 2.0,
-                end: 2.0,
-                textDirection: Directionality.of(context),
-                child: DecoratedBox(
-                  decoration: BoxDecoration(
-                    color: Colors.white54,
-                    borderRadius: borderRadius,
-                  ),
-                  child: const Padding(
-                    padding: EdgeInsetsDirectional.only(
-                      top: 4.5,
-                      bottom: 5.5,
-                      start: 5.0,
-                      end: 5.0,
-                    ),
-                    child: icons.Outdated(
-                      size: 15.0,
-                      color: Color(0xFF616161),
-                    ),
-                  ),
-                ),
+      icons = _OutdatedProductPictureIcon(
+        appLocalizations: appLocalizations,
+        borderRadius: borderRadius,
+      );
+    }
+
+    if (showOwner && locked) {
+      final Widget icon = _LockedProductPictureIcon(
+        appLocalizations: appLocalizations,
+        borderRadius: borderRadius,
+      );
+
+      if (icons != null) {
+        icons = Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            icons,
+            const SizedBox(height: SMALL_SPACE),
+            icon,
+          ],
+        );
+      } else {
+        icons = icon;
+      }
+    }
+
+    if (icons != null) {
+      return Stack(
+        children: <Widget>[
+          image,
+          Positioned.directional(
+            bottom: 2.0,
+            end: 2.0,
+            textDirection: Directionality.of(context),
+            child: IconTheme(
+              data: const IconThemeData(
+                color: Color(0xFF616161),
               ),
-            ],
+              child: icons,
+            ),
           ),
-        ),
+        ],
       );
     }
 
@@ -390,6 +420,97 @@ class _ProductPictureWithImageProvider extends StatelessWidget {
     } else {
       return image;
     }
+  }
+}
+
+class _OutdatedProductPictureIcon extends StatelessWidget {
+  const _OutdatedProductPictureIcon({
+    required this.appLocalizations,
+    required this.borderRadius,
+  });
+
+  final AppLocalizations appLocalizations;
+  final BorderRadius? borderRadius;
+
+  @override
+  Widget build(BuildContext context) {
+    return _ProductPictureIcon(
+      semanticsLabel: appLocalizations
+          .product_page_image_front_outdated_message_accessibility_label,
+      icon: const icons.Outdated(size: 15.0),
+      padding: const EdgeInsetsDirectional.only(
+        top: 4.5,
+        bottom: 5.5,
+        start: 5.0,
+        end: 5.0,
+      ),
+      borderRadius: borderRadius,
+    );
+  }
+}
+
+class _LockedProductPictureIcon extends StatelessWidget {
+  const _LockedProductPictureIcon({
+    required this.appLocalizations,
+    required this.borderRadius,
+  });
+
+  final AppLocalizations appLocalizations;
+  final BorderRadius? borderRadius;
+
+  @override
+  Widget build(BuildContext context) {
+    return _ProductPictureIcon(
+      semanticsLabel: appLocalizations
+          .product_page_image_front_locked_message_accessibility_label,
+      icon: IconTheme.merge(
+        data: const IconThemeData(size: 16.0),
+        child: const OwnerFieldIcon(),
+      ),
+      padding: const EdgeInsetsDirectional.only(
+        top: 4.5,
+        bottom: 5.5,
+        start: 5.0,
+        end: 5.0,
+      ),
+      borderRadius: borderRadius,
+    );
+  }
+}
+
+class _ProductPictureIcon extends StatelessWidget {
+  const _ProductPictureIcon({
+    required this.semanticsLabel,
+    required this.icon,
+    required this.padding,
+    this.borderRadius,
+  });
+
+  final String semanticsLabel;
+  final Widget icon;
+  final EdgeInsetsGeometry padding;
+  final BorderRadius? borderRadius;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: semanticsLabel,
+      image: true,
+      excludeSemantics: true,
+      child: Tooltip(
+        message: semanticsLabel,
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: Colors.white54,
+            borderRadius: borderRadius,
+          ),
+          child: Padding(
+            padding: padding,
+            child: icon,
+          ),
+        ),
+      ),
+    );
   }
 }
 

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_image.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_image.dart
@@ -9,6 +9,7 @@ import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/database/transient_file.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/helpers/image_field_extension.dart';
 import 'package:smooth_app/pages/image/product_image_helper.dart';
 import 'package:smooth_app/pages/product/owner_field_info.dart';
 import 'package:smooth_app/pages/product/product_page/new_product_page.dart';
@@ -27,11 +28,11 @@ class ProductPicture extends StatefulWidget {
     String? fallbackUrl,
     VoidCallback? onTap,
     String? heroTag,
-    bool? showObsoleteIcon,
-    bool? showOwnerIcon,
+    bool showObsoleteIcon = false,
+    bool showOwnerIcon = false,
     BorderRadius? borderRadius,
-    double? imageFoundBorder,
-    double? imageNotFoundBorder,
+    double imageFoundBorder = 0.0,
+    double imageNotFoundBorder = 0.0,
     TextStyle? errorTextStyle,
   }) : this._(
           transientFile: null,
@@ -43,42 +44,43 @@ class ProductPicture extends StatefulWidget {
           heroTag: heroTag,
           onTap: onTap,
           borderRadius: borderRadius,
-          imageFoundBorder: imageFoundBorder ?? 0.0,
-          imageNotFoundBorder: imageNotFoundBorder ?? 0.0,
+          imageFoundBorder: imageFoundBorder,
+          imageNotFoundBorder: imageNotFoundBorder,
           errorTextStyle: errorTextStyle,
-          showObsoleteIcon: showObsoleteIcon ?? false,
-          showOwnerIcon: showOwnerIcon ?? false,
+          showObsoleteIcon: showObsoleteIcon,
+          showOwnerIcon: showOwnerIcon,
         );
 
   ProductPicture.fromTransientFile({
     required TransientFile transientFile,
     required Size size,
+    OpenFoodFactsLanguage? language,
     Product? product,
     ImageField? imageField,
     String? fallbackUrl,
     VoidCallback? onTap,
     String? heroTag,
-    bool? showObsoleteIcon,
-    bool? showOwnerIcon,
+    bool showObsoleteIcon = false,
+    bool showOwnerIcon = false,
     BorderRadius? borderRadius,
-    double? imageFoundBorder,
-    double? imageNotFoundBorder,
+    double imageFoundBorder = 0.0,
+    double imageNotFoundBorder = 0.0,
     TextStyle? errorTextStyle,
   }) : this._(
           transientFile: transientFile,
           product: product,
           imageField: imageField,
-          language: null,
+          language: language,
           size: size,
           fallbackUrl: fallbackUrl,
           heroTag: heroTag,
           onTap: onTap,
           borderRadius: borderRadius,
-          imageFoundBorder: imageFoundBorder ?? 0.0,
-          imageNotFoundBorder: imageNotFoundBorder ?? 0.0,
+          imageFoundBorder: imageFoundBorder,
+          imageNotFoundBorder: imageNotFoundBorder,
           errorTextStyle: errorTextStyle,
-          showObsoleteIcon: showObsoleteIcon ?? false,
-          showOwnerIcon: showOwnerIcon ?? false,
+          showObsoleteIcon: showObsoleteIcon,
+          showOwnerIcon: showOwnerIcon,
         );
 
   ProductPicture._({
@@ -158,8 +160,11 @@ class _ProductPictureState extends State<ProductPicture> {
       child = _ProductPictureAssetsSvg(
         asset: 'assets/product/product_error.svg',
         semanticsLabel:
-            appLocalizations.product_page_image_error_accessibility_label,
-        text: appLocalizations.product_page_image_error,
+            appLocalizations.product_image_error_accessibility_label(
+          widget.imageField?.getPictureAccessibilityLabel(appLocalizations) ??
+              appLocalizations.product_image_front_accessibility_label,
+        ),
+        text: appLocalizations.product_image_error,
         textStyle: TextStyle(
           color: context.extension<SmoothColorsThemeExtension>().red,
         ).merge(widget.errorTextStyle ?? const TextStyle()),
@@ -171,6 +176,7 @@ class _ProductPictureState extends State<ProductPicture> {
     } else if (imageProvider?.$1 != null) {
       child = _ProductPictureWithImageProvider(
         imageProvider: imageProvider!.$1!,
+        imageField: widget.imageField,
         outdated: imageProvider.$2,
         locked: widget.imageField != null &&
             widget.product?.isImageLocked(
@@ -268,11 +274,13 @@ class _ProductPictureWithImageProvider extends StatelessWidget {
     required this.showOutdated,
     required this.showOwner,
     required this.border,
+    this.imageField,
     this.borderRadius,
     this.heroTag,
   });
 
   final ImageProvider imageProvider;
+  final ImageField? imageField;
   final bool outdated;
   final bool locked;
   final Size size;
@@ -290,7 +298,8 @@ class _ProductPictureWithImageProvider extends StatelessWidget {
     final bool lightTheme = context.lightTheme();
 
     final Widget image = Semantics(
-      label: appLocalizations.product_page_image_front_accessibility_label,
+      label: imageField?.getPictureAccessibilityLabel(appLocalizations) ??
+          appLocalizations.product_image_front_accessibility_label,
       image: true,
       excludeSemantics: true,
       child: SizedBox.fromSize(
@@ -340,33 +349,36 @@ class _ProductPictureWithImageProvider extends StatelessWidget {
       ),
     );
 
+    final Widget? iconOutdated = showOutdated && outdated
+        ? _OutdatedProductPictureIcon(
+            appLocalizations: appLocalizations,
+            borderRadius: borderRadius,
+            imageField: imageField,
+          )
+        : null;
+
+    final Widget? iconLocked = showOwner && locked
+        ? _LockedProductPictureIcon(
+            appLocalizations: appLocalizations,
+            borderRadius: borderRadius,
+            imageField: imageField,
+          )
+        : null;
+
     Widget? icons;
-
-    if (showOutdated && outdated) {
-      icons = _OutdatedProductPictureIcon(
-        appLocalizations: appLocalizations,
-        borderRadius: borderRadius,
+    if (iconOutdated == null) {
+      icons = iconLocked;
+    } else if (iconLocked == null) {
+      icons = iconOutdated;
+    } else {
+      icons = Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          iconOutdated,
+          const SizedBox(height: SMALL_SPACE),
+          iconLocked,
+        ],
       );
-    }
-
-    if (showOwner && locked) {
-      final Widget icon = _LockedProductPictureIcon(
-        appLocalizations: appLocalizations,
-        borderRadius: borderRadius,
-      );
-
-      if (icons != null) {
-        icons = Column(
-          mainAxisSize: MainAxisSize.min,
-          children: <Widget>[
-            icons,
-            const SizedBox(height: SMALL_SPACE),
-            icon,
-          ],
-        );
-      } else {
-        icons = icon;
-      }
     }
 
     if (icons != null) {
@@ -427,16 +439,21 @@ class _OutdatedProductPictureIcon extends StatelessWidget {
   const _OutdatedProductPictureIcon({
     required this.appLocalizations,
     required this.borderRadius,
+    this.imageField,
   });
 
+  final ImageField? imageField;
   final AppLocalizations appLocalizations;
   final BorderRadius? borderRadius;
 
   @override
   Widget build(BuildContext context) {
     return _ProductPictureIcon(
-      semanticsLabel: appLocalizations
-          .product_page_image_front_outdated_message_accessibility_label,
+      semanticsLabel:
+          appLocalizations.product_image_outdated_message_accessibility_label(
+        imageField?.getPictureAccessibilityLabel(appLocalizations) ??
+            appLocalizations.product_image_front_accessibility_label,
+      ),
       icon: const icons.Outdated(size: 15.0),
       padding: const EdgeInsetsDirectional.only(
         top: 4.5,
@@ -453,16 +470,21 @@ class _LockedProductPictureIcon extends StatelessWidget {
   const _LockedProductPictureIcon({
     required this.appLocalizations,
     required this.borderRadius,
+    this.imageField,
   });
 
+  final ImageField? imageField;
   final AppLocalizations appLocalizations;
   final BorderRadius? borderRadius;
 
   @override
   Widget build(BuildContext context) {
     return _ProductPictureIcon(
-      semanticsLabel: appLocalizations
-          .product_page_image_front_locked_message_accessibility_label,
+      semanticsLabel:
+          appLocalizations.product_image_locked_message_accessibility_label(
+        imageField?.getPictureAccessibilityLabel(appLocalizations) ??
+            appLocalizations.product_image_front_accessibility_label,
+      ),
       icon: IconTheme.merge(
         data: const IconThemeData(size: 16.0),
         child: const OwnerFieldIcon(),

--- a/packages/smooth_app/lib/helpers/image_field_extension.dart
+++ b/packages/smooth_app/lib/helpers/image_field_extension.dart
@@ -85,6 +85,22 @@ extension ImageFieldSmoothieExtension on ImageField {
         ImageField.OTHER => appLocalizations.take_more_photo_button_label,
       };
 
+  String getPictureAccessibilityLabel(
+    final AppLocalizations appLocalizations,
+  ) =>
+      switch (this) {
+        ImageField.FRONT =>
+          appLocalizations.product_image_front_accessibility_label,
+        ImageField.INGREDIENTS =>
+          appLocalizations.product_image_ingredients_accessibility_label,
+        ImageField.NUTRITION =>
+          appLocalizations.product_image_nutrition_accessibility_label,
+        ImageField.PACKAGING =>
+          appLocalizations.product_image_packaging_accessibility_label,
+        ImageField.OTHER =>
+          appLocalizations.product_image_other_accessibility_label,
+      };
+
   Widget getPhotoButton(
     final BuildContext context,
     final Product product,

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -3229,29 +3229,60 @@
             }
         }
     },
-    "product_page_image_front_accessibility_label": "Front picture",
-    "@product_page_image_front_accessibility_label": {
+    "product_image_front_accessibility_label": "Front picture",
+    "@product_image_front_accessibility_label": {
         "description": "Accessibility label for the image on the product page"
     },
-    "product_page_image_front_outdated_message": "This picture may be outdated",
-    "@product_page_image_front_outdated_message": {
+    "product_image_ingredients_accessibility_label": "Ingredients picture",
+    "@product_image_ingredients_accessibility_label": {
+        "description": "Accessibility label for the image of ingredients"
+    },
+    "product_image_nutrition_accessibility_label": "Nutrition picture",
+    "@product_image_nutrition_accessibility_label": {
+        "description": "Accessibility label for the image of the nutrition"
+    },
+    "product_image_packaging_accessibility_label": "Packaging picture",
+    "@product_image_packaging_accessibility_label": {
+        "description": "Accessibility label for the image of the packaging"
+    },
+    "product_image_other_accessibility_label": "Other picture",
+    "@product_image_other_accessibility_label": {
+        "description": "Accessibility label for an image"
+    },
+    "product_image_outdated_message": "This picture may be outdated",
+    "@product_image_outdated_message": {
         "description": "Small message to indicate that the image may be outdated"
     },
-    "product_page_image_front_outdated_message_accessibility_label": "Front picture (this image may be outdated)",
-    "@product_page_image_front_outdated_message_accessibility_label": {
-        "description": "Accessibility label for the image on the product page when it may be outdated"
+    "product_image_outdated_message_accessibility_label": "{type} (this image may be outdated)",
+    "@product_image_outdated_message_accessibility_label": {
+        "description": "Accessibility label for the image on the product page when it may be outdated",
+        "placeholders": {
+            "type": {
+                "type": "String"
+            }
+        }
     },
-    "product_page_image_front_locked_message_accessibility_label": "Front picture (this image may be locked by the producer)",
-    "@product_page_image_front_locked_message_accessibility_label": {
-        "description": "Accessibility label for the image on the product page when it may be locked (producer provided)"
+    "product_image_locked_message_accessibility_label": "{type} (this image may be locked by the producer)",
+    "@product_image_locked_message_accessibility_label": {
+        "description": "Accessibility label for the image on the product page when it may be locked (producer provided)",
+        "placeholders": {
+            "type": {
+                "type": "String"
+            }
+        }
     },
-    "product_page_image_error": "Unable to load the image!",
-    "@product_page_image_error": {
+    "product_image_error": "Unable to load the image!",
+    "@product_image_error": {
         "description": "Small message that will be displayed above the picture (please keep it short)"
     },
-    "product_page_image_error_accessibility_label": "Unable to load the front picture (network error?)",
-    "@product_page_image_error_accessibility_label": {
-        "description": "Accessibility label for the image on the product page when it fails to load"
+    "product_image_error_accessibility_label": "Unable to load the {type} (network error?)",
+    "@product_image_error_accessibility_label": {
+        "description": "Accessibility label for the image on the product page when it fails to load",
+        "placeholders": {
+            "type": {
+                "type": "String"
+            }
+        }
     },
     "product_page_image_no_image_available": "No\nimage!",
     "@product_page_image_no_image_available": {

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -2681,6 +2681,10 @@
     "@owner_field_info_close_button": {
         "description": "The owner info may be shown in a closeable dialog. This is the label of the button (used on a long press event and for the accessibility label)."
     },
+    "owner_field_image": "This image is provided by the producer. It may not be editable.",
+    "@owner_field_image": {
+        "description": "An image is directly provided by the producer. It may be locked and not be editable."
+    },
     "edit_packagings_title": "Packaging components",
     "@edit_packagings_title": {
         "description": "Title of the structured packagings page"
@@ -3236,6 +3240,10 @@
     "product_page_image_front_outdated_message_accessibility_label": "Front picture (this image may be outdated)",
     "@product_page_image_front_outdated_message_accessibility_label": {
         "description": "Accessibility label for the image on the product page when it may be outdated"
+    },
+    "product_page_image_front_locked_message_accessibility_label": "Front picture (this image may be locked by the producer)",
+    "@product_page_image_front_locked_message_accessibility_label": {
+        "description": "Accessibility label for the image on the product page when it may be locked (producer provided)"
     },
     "product_page_image_error": "Unable to load the image!",
     "@product_page_image_error": {

--- a/packages/smooth_app/lib/pages/product/gallery_view/product_image_gallery_details_banner.dart
+++ b/packages/smooth_app/lib/pages/product/gallery_view/product_image_gallery_details_banner.dart
@@ -1,0 +1,282 @@
+part of 'package:smooth_app/pages/product/gallery_view/product_image_gallery_photo_row.dart';
+
+Future<_PhotoRowActions?> _showPhotoBanner({
+  required final BuildContext context,
+  required final Product product,
+  required final ImageField imageField,
+  required final OpenFoodFactsLanguage language,
+  required final TransientFile transientFile,
+}) async {
+  final SmoothColorsThemeExtension extension =
+      context.extension<SmoothColorsThemeExtension>();
+  final bool lightTheme = context.lightTheme(listen: false);
+  final bool imageAvailable = transientFile.isImageAvailable();
+
+  final AppLocalizations appLocalizations = AppLocalizations.of(context);
+
+  final _PhotoRowActions? action =
+      await showSmoothListOfChoicesModalSheet<_PhotoRowActions>(
+    context: context,
+    title: imageAvailable
+        ? appLocalizations.product_image_action_replace_photo(
+            imageField.getProductImageTitle(appLocalizations))
+        : appLocalizations.product_image_action_add_photo(
+            imageField.getProductImageTitle(appLocalizations)),
+    values: _PhotoRowActions.values,
+    labels: <String>[
+      if (imageAvailable)
+        appLocalizations.product_image_action_take_new_picture
+      else
+        appLocalizations.product_image_action_take_picture,
+      appLocalizations.product_image_action_from_gallery,
+      appLocalizations.product_image_action_choose_existing_photo,
+    ],
+    prefixIconTint:
+        lightTheme ? extension.primaryDark : extension.primaryMedium,
+    prefixIcons: <Widget>[
+      const Icon(Icons.camera),
+      const Icon(Icons.perm_media_rounded),
+      const Icon(Icons.image_search_rounded),
+    ],
+    addEndArrowToItems: true,
+    footer: _PhotoRowBanner(
+      children: <Widget>[
+        _PhotoRowDate(transientFile: transientFile),
+        _PhotoRowLockedStatus(
+          product: product,
+          imageField: imageField,
+          language: language,
+        ),
+      ],
+    ),
+  );
+
+  return action;
+}
+
+class _PhotoRowBanner extends StatelessWidget {
+  const _PhotoRowBanner({required this.children});
+
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsetsDirectional.only(
+        top: MEDIUM_SPACE,
+        bottom: !(Platform.isIOS || Platform.isMacOS) ? 0.0 : VERY_SMALL_SPACE,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: children,
+      ),
+    );
+  }
+}
+
+enum _PhotoRowActions {
+  takePicture,
+  selectFromGallery,
+  selectFromProductPhotos,
+}
+
+/// The date of the photo (used in the modal sheet)
+class _PhotoRowDate extends StatelessWidget {
+  const _PhotoRowDate({
+    required this.transientFile,
+  });
+
+  final TransientFile transientFile;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!transientFile.isImageAvailable()) {
+      return EMPTY_WIDGET;
+    }
+
+    final SmoothColorsThemeExtension extension =
+        context.extension<SmoothColorsThemeExtension>();
+    final bool outdated = transientFile.expired;
+
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+
+    return _PhotoRowInfo(
+      icon: outdated ? _outdatedIcon : _successIcon,
+      iconBackgroundColor: outdated ? extension.warning : extension.success,
+      text: Padding(
+        /// Padding required by the use of [RichText]
+        padding: const EdgeInsetsDirectional.only(bottom: 2.75),
+        child: RichText(
+          text: TextSpan(
+            children: <TextSpan>[
+              TextSpan(
+                text: '${appLocalizations.date}${appLocalizations.sep}: ',
+                style: const TextStyle(
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              TextSpan(
+                text: DateFormat.yMd(ProductQuery.getLocaleString())
+                    .format(transientFile.uploadedDate!),
+              ),
+            ],
+            style: DefaultTextStyle.of(context).style.merge(
+                  const TextStyle(
+                    fontSize: 15.0,
+                    fontWeight: FontWeight.w500,
+                    color: Colors.white,
+                  ),
+                ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget get _outdatedIcon => const Padding(
+        padding: EdgeInsetsDirectional.only(
+          bottom: 1.5,
+          start: 1.5,
+        ),
+        child: icons.Outdated(
+          color: Colors.white,
+          size: 19.0,
+        ),
+      );
+
+  Widget get _successIcon => const Padding(
+        padding: EdgeInsetsDirectional.only(
+          bottom: 0.5,
+          start: 0.5,
+        ),
+        child: icons.Clock(
+          color: Colors.white,
+          size: 19.0,
+        ),
+      );
+}
+
+/// If the photo is locked by the owner (used in the modal sheet)
+class _PhotoRowLockedStatus extends StatelessWidget {
+  const _PhotoRowLockedStatus({
+    required this.product,
+    required this.imageField,
+    required this.language,
+  });
+
+  final Product product;
+  final ImageField imageField;
+  final OpenFoodFactsLanguage language;
+
+  @override
+  Widget build(BuildContext context) {
+    if (product.isImageLocked(imageField, language) != true) {
+      return EMPTY_WIDGET;
+    }
+
+    final SmoothColorsThemeExtension extension =
+        context.extension<SmoothColorsThemeExtension>();
+
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+
+    return Padding(
+      padding: const EdgeInsetsDirectional.only(top: SMALL_SPACE),
+      child: _PhotoRowInfo(
+        icon: const IconTheme(
+          data: IconThemeData(
+            size: 19.0,
+            color: Colors.white,
+          ),
+          child: Padding(
+            padding: EdgeInsetsDirectional.only(bottom: 2.0),
+            child: OwnerFieldIcon(),
+          ),
+        ),
+        iconBackgroundColor: extension.warning,
+        text: Text(
+          appLocalizations.owner_field_image,
+          style: const TextStyle(
+            fontWeight: FontWeight.w600,
+            color: Colors.white,
+          ),
+        ),
+        wrapTextInExpanded: true,
+      ),
+    );
+  }
+}
+
+/// Show an info in the modal sheet
+class _PhotoRowInfo extends StatelessWidget {
+  const _PhotoRowInfo({
+    required this.icon,
+    required this.iconBackgroundColor,
+    required this.text,
+    this.wrapTextInExpanded = false,
+  });
+
+  final Widget icon;
+  final Color iconBackgroundColor;
+  final Widget text;
+  final bool wrapTextInExpanded;
+
+  @override
+  Widget build(BuildContext context) {
+    final SmoothColorsThemeExtension extension =
+        context.extension<SmoothColorsThemeExtension>();
+
+    return Padding(
+      padding: const EdgeInsetsDirectional.symmetric(horizontal: SMALL_SPACE),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: extension.primaryDark,
+          borderRadius: BorderRadius.all(
+            Radius.circular(MediaQuery.of(context).size.height),
+          ),
+        ),
+        child: ConstrainedBox(
+          constraints: BoxConstraints(
+            minHeight: 47.5,
+            maxWidth: MediaQuery.sizeOf(context).width * 0.95,
+          ),
+          child: IntrinsicHeight(
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                SizedBox.square(
+                  dimension: 47.5,
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      color: iconBackgroundColor,
+                      shape: BoxShape.circle,
+                    ),
+                    child: Center(child: icon),
+                  ),
+                ),
+                _textWidget,
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget get _textWidget {
+    final Widget textWidget = Padding(
+      padding: const EdgeInsetsDirectional.only(
+        start: MEDIUM_SPACE,
+        end: VERY_LARGE_SPACE,
+      ),
+      child: text,
+    );
+
+    if (wrapTextInExpanded) {
+      return Expanded(
+        child: textWidget,
+      );
+    }
+
+    return textWidget;
+  }
+}

--- a/packages/smooth_app/lib/pages/product/gallery_view/product_image_gallery_photo_row.dart
+++ b/packages/smooth_app/lib/pages/product/gallery_view/product_image_gallery_photo_row.dart
@@ -25,6 +25,8 @@ import 'package:smooth_app/themes/smooth_theme.dart';
 import 'package:smooth_app/themes/smooth_theme_colors.dart';
 import 'package:smooth_app/themes/theme_provider.dart';
 
+part 'product_image_gallery_details_banner.dart';
+
 class ImageGalleryPhotoRow extends StatefulWidget {
   const ImageGalleryPhotoRow({
     required this.position,
@@ -164,6 +166,7 @@ class _ImageGalleryPhotoRowState extends State<ImageGalleryPhotoRow> {
                               return ProductPicture.fromTransientFile(
                                 product: product,
                                 imageField: widget.imageField,
+                                language: widget.language,
                                 transientFile: transientFile,
                                 size: Size(box.maxWidth, box.maxHeight),
                                 onTap: null,
@@ -231,48 +234,12 @@ class _ImageGalleryPhotoRowState extends State<ImageGalleryPhotoRow> {
     required final OpenFoodFactsLanguage language,
     required final TransientFile transientFile,
   }) async {
-    final SmoothColorsThemeExtension extension =
-        context.extension<SmoothColorsThemeExtension>();
-    final bool lightTheme = context.lightTheme(listen: false);
-    final bool imageAvailable = transientFile.isImageAvailable();
-
-    final AppLocalizations appLocalizations = AppLocalizations.of(context);
-
-    final _PhotoRowActions? action =
-        await showSmoothListOfChoicesModalSheet<_PhotoRowActions>(
+    final _PhotoRowActions? action = await _showPhotoBanner(
       context: context,
-      title: imageAvailable
-          ? appLocalizations.product_image_action_replace_photo(
-              widget.imageField.getProductImageTitle(appLocalizations))
-          : appLocalizations.product_image_action_add_photo(
-              widget.imageField.getProductImageTitle(appLocalizations)),
-      values: _PhotoRowActions.values,
-      labels: <String>[
-        if (imageAvailable)
-          appLocalizations.product_image_action_take_new_picture
-        else
-          appLocalizations.product_image_action_take_picture,
-        appLocalizations.product_image_action_from_gallery,
-        appLocalizations.product_image_action_choose_existing_photo,
-      ],
-      prefixIconTint:
-          lightTheme ? extension.primaryDark : extension.primaryMedium,
-      prefixIcons: <Widget>[
-        const Icon(Icons.camera),
-        const Icon(Icons.perm_media_rounded),
-        const Icon(Icons.image_search_rounded),
-      ],
-      addEndArrowToItems: true,
-      footer: _PhotoRowBanner(
-        children: <Widget>[
-          _PhotoRowDate(transientFile: transientFile),
-          _PhotoRowLockedStatus(
-            product: product,
-            imageField: widget.imageField,
-            language: language,
-          ),
-        ],
-      ),
+      product: product,
+      imageField: widget.imageField,
+      language: language,
+      transientFile: transientFile,
     );
 
     if (!context.mounted || action == null) {
@@ -362,233 +329,6 @@ class _ImageGalleryPhotoRowState extends State<ImageGalleryPhotoRow> {
         imageField,
         widget.language,
       );
-}
-
-enum _PhotoRowActions {
-  takePicture,
-  selectFromGallery,
-  selectFromProductPhotos,
-}
-
-/// The date of the photo (used in the modal sheet)
-class _PhotoRowDate extends StatelessWidget {
-  const _PhotoRowDate({
-    required this.transientFile,
-  });
-
-  final TransientFile transientFile;
-
-  @override
-  Widget build(BuildContext context) {
-    if (!transientFile.isImageAvailable()) {
-      return EMPTY_WIDGET;
-    }
-
-    final SmoothColorsThemeExtension extension =
-        context.extension<SmoothColorsThemeExtension>();
-    final bool outdated = transientFile.expired;
-
-    final AppLocalizations appLocalizations = AppLocalizations.of(context);
-
-    return _PhotoRowInfo(
-      icon: outdated ? _outdatedIcon : _successIcon,
-      iconBackgroundColor: outdated ? extension.warning : extension.success,
-      text: Padding(
-        /// Padding required by the use of [RichText]
-        padding: const EdgeInsetsDirectional.only(bottom: 2.75),
-        child: RichText(
-          text: TextSpan(
-            children: <TextSpan>[
-              TextSpan(
-                text: '${appLocalizations.date}${appLocalizations.sep}: ',
-                style: const TextStyle(
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-              TextSpan(
-                text: DateFormat.yMd(ProductQuery.getLocaleString())
-                    .format(transientFile.uploadedDate!),
-              ),
-            ],
-            style: DefaultTextStyle.of(context).style.merge(
-                  const TextStyle(
-                    fontSize: 15.0,
-                    fontWeight: FontWeight.w500,
-                    color: Colors.white,
-                  ),
-                ),
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget get _outdatedIcon => const Padding(
-        padding: EdgeInsetsDirectional.only(
-          bottom: 1.5,
-          start: 1.5,
-        ),
-        child: icons.Outdated(
-          color: Colors.white,
-          size: 19.0,
-        ),
-      );
-
-  Widget get _successIcon => const Padding(
-        padding: EdgeInsetsDirectional.only(
-          bottom: 0.5,
-          start: 0.5,
-        ),
-        child: icons.Clock(
-          color: Colors.white,
-          size: 19.0,
-        ),
-      );
-}
-
-/// If the photo is locked by the owner (used in the modal sheet)
-class _PhotoRowLockedStatus extends StatelessWidget {
-  const _PhotoRowLockedStatus({
-    required this.product,
-    required this.imageField,
-    required this.language,
-  });
-
-  final Product product;
-  final ImageField imageField;
-  final OpenFoodFactsLanguage language;
-
-  @override
-  Widget build(BuildContext context) {
-    if (product.isImageLocked(imageField, language) != true) {
-      return EMPTY_WIDGET;
-    }
-
-    final SmoothColorsThemeExtension extension =
-        context.extension<SmoothColorsThemeExtension>();
-
-    final AppLocalizations appLocalizations = AppLocalizations.of(context);
-
-    return Padding(
-      padding: const EdgeInsetsDirectional.only(top: SMALL_SPACE),
-      child: _PhotoRowInfo(
-        icon: const IconTheme(
-          data: IconThemeData(
-            size: 19.0,
-            color: Colors.white,
-          ),
-          child: Padding(
-            padding: EdgeInsetsDirectional.only(bottom: 2.0),
-            child: OwnerFieldIcon(),
-          ),
-        ),
-        iconBackgroundColor: extension.warning,
-        text: Text(
-          appLocalizations.owner_field_image,
-          style: const TextStyle(
-            fontWeight: FontWeight.w600,
-            color: Colors.white,
-          ),
-        ),
-        wrapTextInExpanded: true,
-      ),
-    );
-  }
-}
-
-class _PhotoRowBanner extends StatelessWidget {
-  const _PhotoRowBanner({required this.children});
-
-  final List<Widget> children;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: EdgeInsetsDirectional.only(
-        top: MEDIUM_SPACE,
-        bottom: !(Platform.isIOS || Platform.isMacOS) ? 0.0 : VERY_SMALL_SPACE,
-      ),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: children,
-      ),
-    );
-  }
-}
-
-/// Show an info in the modal sheet
-class _PhotoRowInfo extends StatelessWidget {
-  const _PhotoRowInfo({
-    required this.icon,
-    required this.iconBackgroundColor,
-    required this.text,
-    this.wrapTextInExpanded = false,
-  });
-
-  final Widget icon;
-  final Color iconBackgroundColor;
-  final Widget text;
-  final bool wrapTextInExpanded;
-
-  @override
-  Widget build(BuildContext context) {
-    final SmoothColorsThemeExtension extension =
-        context.extension<SmoothColorsThemeExtension>();
-
-    return Padding(
-      padding: const EdgeInsetsDirectional.symmetric(horizontal: SMALL_SPACE),
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          color: extension.primaryDark,
-          borderRadius: BorderRadius.all(
-            Radius.circular(MediaQuery.of(context).size.height),
-          ),
-        ),
-        child: ConstrainedBox(
-          constraints: BoxConstraints(
-            minHeight: 47.5,
-            maxWidth: MediaQuery.sizeOf(context).width * 0.95,
-          ),
-          child: IntrinsicHeight(
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: <Widget>[
-                SizedBox.square(
-                  dimension: 47.5,
-                  child: DecoratedBox(
-                    decoration: BoxDecoration(
-                      color: iconBackgroundColor,
-                      shape: BoxShape.circle,
-                    ),
-                    child: Center(child: icon),
-                  ),
-                ),
-                _textWidget,
-              ],
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget get _textWidget {
-    final Widget textWidget = Padding(
-      padding: const EdgeInsetsDirectional.only(
-        start: MEDIUM_SPACE,
-        end: VERY_LARGE_SPACE,
-      ),
-      child: text,
-    );
-
-    if (wrapTextInExpanded) {
-      return Expanded(
-        child: textWidget,
-      );
-    }
-
-    return textWidget;
-  }
 }
 
 class _PhotoRowIndicator extends StatelessWidget {

--- a/packages/smooth_app/lib/pages/product/gallery_view/product_image_gallery_photo_row.dart
+++ b/packages/smooth_app/lib/pages/product/gallery_view/product_image_gallery_photo_row.dart
@@ -15,6 +15,7 @@ import 'package:smooth_app/helpers/image_field_extension.dart';
 import 'package:smooth_app/pages/crop_parameters.dart';
 import 'package:smooth_app/pages/image/product_image_helper.dart';
 import 'package:smooth_app/pages/product/gallery_view/product_image_gallery_view.dart';
+import 'package:smooth_app/pages/product/owner_field_info.dart';
 import 'package:smooth_app/pages/product/product_image_server_button.dart';
 import 'package:smooth_app/pages/product/product_image_swipeable_view.dart';
 import 'package:smooth_app/query/product_query.dart';
@@ -101,6 +102,7 @@ class _ImageGalleryPhotoRowState extends State<ImageGalleryPhotoRow> {
               context: context,
               product: product,
               transientFile: transientFile,
+              language: widget.language,
             ),
             child: ClipRRect(
               borderRadius: ANGULAR_BORDER_RADIUS,
@@ -160,6 +162,8 @@ class _ImageGalleryPhotoRowState extends State<ImageGalleryPhotoRow> {
                               }
 
                               return ProductPicture.fromTransientFile(
+                                product: product,
+                                imageField: widget.imageField,
                                 transientFile: transientFile,
                                 size: Size(box.maxWidth, box.maxHeight),
                                 onTap: null,
@@ -171,6 +175,8 @@ class _ImageGalleryPhotoRowState extends State<ImageGalleryPhotoRow> {
                                   product.barcode!,
                                   widget.imageField,
                                 ),
+                                showObsoleteIcon: false,
+                                showOwnerIcon: true,
                               );
                             },
                           ),
@@ -222,6 +228,7 @@ class _ImageGalleryPhotoRowState extends State<ImageGalleryPhotoRow> {
   Future<void> _onLongTap({
     required final BuildContext context,
     required final Product product,
+    required final OpenFoodFactsLanguage language,
     required final TransientFile transientFile,
   }) async {
     final SmoothColorsThemeExtension extension =
@@ -256,7 +263,16 @@ class _ImageGalleryPhotoRowState extends State<ImageGalleryPhotoRow> {
         const Icon(Icons.image_search_rounded),
       ],
       addEndArrowToItems: true,
-      footer: _PhotoRowDate(transientFile: transientFile),
+      footer: _PhotoRowBanner(
+        children: <Widget>[
+          _PhotoRowDate(transientFile: transientFile),
+          _PhotoRowLockedStatus(
+            product: product,
+            imageField: widget.imageField,
+            language: language,
+          ),
+        ],
+      ),
     );
 
     if (!context.mounted || action == null) {
@@ -374,64 +390,33 @@ class _PhotoRowDate extends StatelessWidget {
 
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
 
-    return Padding(
-      padding: EdgeInsetsDirectional.only(
-        top: MEDIUM_SPACE,
-        bottom: !(Platform.isIOS || Platform.isMacOS) ? 0.0 : VERY_SMALL_SPACE,
-      ),
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          color: extension.primaryDark,
-          borderRadius: BorderRadius.all(
-            Radius.circular(MediaQuery.of(context).size.height),
-          ),
-        ),
-        child: IntrinsicHeight(
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: <Widget>[
-              AspectRatio(
-                aspectRatio: 1.0,
-                child: DecoratedBox(
-                  decoration: BoxDecoration(
-                    color: outdated ? extension.warning : extension.success,
-                    shape: BoxShape.circle,
-                  ),
-                  child: outdated ? _outdatedIcon : _successIcon,
+    return _PhotoRowInfo(
+      icon: outdated ? _outdatedIcon : _successIcon,
+      iconBackgroundColor: outdated ? extension.warning : extension.success,
+      text: Padding(
+        /// Padding required by the use of [RichText]
+        padding: const EdgeInsetsDirectional.only(bottom: 2.75),
+        child: RichText(
+          text: TextSpan(
+            children: <TextSpan>[
+              TextSpan(
+                text: '${appLocalizations.date}${appLocalizations.sep}: ',
+                style: const TextStyle(
+                  fontWeight: FontWeight.bold,
                 ),
               ),
-              Padding(
-                padding: const EdgeInsetsDirectional.only(
-                  start: MEDIUM_SPACE,
-                  end: VERY_LARGE_SPACE,
-                  bottom: 2.75,
-                ),
-                child: RichText(
-                  text: TextSpan(
-                    children: <TextSpan>[
-                      TextSpan(
-                        text:
-                            '${appLocalizations.date}${appLocalizations.sep}: ',
-                        style: const TextStyle(
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                      TextSpan(
-                        text: DateFormat.yMd(ProductQuery.getLocaleString())
-                            .format(transientFile.uploadedDate!),
-                      ),
-                    ],
-                    style: DefaultTextStyle.of(context).style.merge(
-                          const TextStyle(
-                            fontSize: 15.0,
-                            fontWeight: FontWeight.w500,
-                            color: Colors.white,
-                          ),
-                        ),
-                  ),
-                ),
+              TextSpan(
+                text: DateFormat.yMd(ProductQuery.getLocaleString())
+                    .format(transientFile.uploadedDate!),
               ),
             ],
+            style: DefaultTextStyle.of(context).style.merge(
+                  const TextStyle(
+                    fontSize: 15.0,
+                    fontWeight: FontWeight.w500,
+                    color: Colors.white,
+                  ),
+                ),
           ),
         ),
       ),
@@ -440,10 +425,8 @@ class _PhotoRowDate extends StatelessWidget {
 
   Widget get _outdatedIcon => const Padding(
         padding: EdgeInsetsDirectional.only(
-          top: 12.0,
-          bottom: 16.5,
-          start: 12.5,
-          end: 12.0,
+          bottom: 1.5,
+          start: 1.5,
         ),
         child: icons.Outdated(
           color: Colors.white,
@@ -453,16 +436,159 @@ class _PhotoRowDate extends StatelessWidget {
 
   Widget get _successIcon => const Padding(
         padding: EdgeInsetsDirectional.only(
-          top: 12.0,
-          bottom: 16.5,
-          start: 12.0,
-          end: 12.0,
+          bottom: 0.5,
+          start: 0.5,
         ),
         child: icons.Clock(
           color: Colors.white,
           size: 19.0,
         ),
       );
+}
+
+/// If the photo is locked by the owner (used in the modal sheet)
+class _PhotoRowLockedStatus extends StatelessWidget {
+  const _PhotoRowLockedStatus({
+    required this.product,
+    required this.imageField,
+    required this.language,
+  });
+
+  final Product product;
+  final ImageField imageField;
+  final OpenFoodFactsLanguage language;
+
+  @override
+  Widget build(BuildContext context) {
+    if (product.isImageLocked(imageField, language) != true) {
+      return EMPTY_WIDGET;
+    }
+
+    final SmoothColorsThemeExtension extension =
+        context.extension<SmoothColorsThemeExtension>();
+
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+
+    return Padding(
+      padding: const EdgeInsetsDirectional.only(top: SMALL_SPACE),
+      child: _PhotoRowInfo(
+        icon: const IconTheme(
+          data: IconThemeData(
+            size: 19.0,
+            color: Colors.white,
+          ),
+          child: Padding(
+            padding: EdgeInsetsDirectional.only(bottom: 2.0),
+            child: OwnerFieldIcon(),
+          ),
+        ),
+        iconBackgroundColor: extension.warning,
+        text: Text(
+          appLocalizations.owner_field_image,
+          style: const TextStyle(
+            fontWeight: FontWeight.w600,
+            color: Colors.white,
+          ),
+        ),
+        wrapTextInExpanded: true,
+      ),
+    );
+  }
+}
+
+class _PhotoRowBanner extends StatelessWidget {
+  const _PhotoRowBanner({required this.children});
+
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsetsDirectional.only(
+        top: MEDIUM_SPACE,
+        bottom: !(Platform.isIOS || Platform.isMacOS) ? 0.0 : VERY_SMALL_SPACE,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: children,
+      ),
+    );
+  }
+}
+
+/// Show an info in the modal sheet
+class _PhotoRowInfo extends StatelessWidget {
+  const _PhotoRowInfo({
+    required this.icon,
+    required this.iconBackgroundColor,
+    required this.text,
+    this.wrapTextInExpanded = false,
+  });
+
+  final Widget icon;
+  final Color iconBackgroundColor;
+  final Widget text;
+  final bool wrapTextInExpanded;
+
+  @override
+  Widget build(BuildContext context) {
+    final SmoothColorsThemeExtension extension =
+        context.extension<SmoothColorsThemeExtension>();
+
+    return Padding(
+      padding: const EdgeInsetsDirectional.symmetric(horizontal: SMALL_SPACE),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: extension.primaryDark,
+          borderRadius: BorderRadius.all(
+            Radius.circular(MediaQuery.of(context).size.height),
+          ),
+        ),
+        child: ConstrainedBox(
+          constraints: BoxConstraints(
+            minHeight: 47.5,
+            maxWidth: MediaQuery.sizeOf(context).width * 0.95,
+          ),
+          child: IntrinsicHeight(
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                SizedBox.square(
+                  dimension: 47.5,
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      color: iconBackgroundColor,
+                      shape: BoxShape.circle,
+                    ),
+                    child: Center(child: icon),
+                  ),
+                ),
+                _textWidget,
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget get _textWidget {
+    final Widget textWidget = Padding(
+      padding: const EdgeInsetsDirectional.only(
+        start: MEDIUM_SPACE,
+        end: VERY_LARGE_SPACE,
+      ),
+      child: text,
+    );
+
+    if (wrapTextInExpanded) {
+      return Expanded(
+        child: textWidget,
+      );
+    }
+
+    return textWidget;
+  }
 }
 
 class _PhotoRowIndicator extends StatelessWidget {
@@ -486,7 +612,9 @@ class _PhotoRowIndicator extends StatelessWidget {
             context.extension<SmoothColorsThemeExtension>(),
           ),
         ),
-        child: Center(child: child()),
+        child: Center(
+          child: child(),
+        ),
       ),
     );
   }

--- a/packages/smooth_app/lib/pages/product/owner_field_info.dart
+++ b/packages/smooth_app/lib/pages/product/owner_field_info.dart
@@ -54,11 +54,14 @@ class OwnerFieldBanner extends StatelessWidget {
 
 /// Standard icon about "owner fields".
 class OwnerFieldIcon extends StatelessWidget {
-  const OwnerFieldIcon();
+  const OwnerFieldIcon({this.size, super.key});
+
+  final double? size;
 
   @override
   Widget build(BuildContext context) => Icon(
         _ownerFieldIconData,
+        size: size,
         semanticLabel: AppLocalizations.of(context).owner_field_info_title,
       );
 }

--- a/packages/smooth_app/lib/pages/product/product_image_swipeable_view.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_swipeable_view.dart
@@ -5,9 +5,11 @@ import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/up_to_date_mixin.dart';
 import 'package:smooth_app/database/local_database.dart';
+import 'package:smooth_app/generic_lib/bottom_sheets/smooth_bottom_sheet.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_back_button.dart';
 import 'package:smooth_app/helpers/image_field_extension.dart';
+import 'package:smooth_app/pages/product/owner_field_info.dart';
 import 'package:smooth_app/pages/product/product_image_viewer.dart';
 import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
@@ -96,6 +98,13 @@ class _ProductImageSwipeableViewState extends State<ProductImageSwipeableView>
           iconColor: Colors.white,
           onPressed: () => Navigator.maybePop(context),
         ),
+        actions: <Widget>[
+          ValueListenableBuilder<int>(
+              valueListenable: _currentImageDataIndex,
+              builder: (_, int index, __) {
+                return _lockedIcon(_imageFields[index]);
+              })
+        ],
       ),
       body: PageView.builder(
         onPageChanged: (int index) => _currentImageDataIndex.value = index,
@@ -116,5 +125,49 @@ class _ProductImageSwipeableViewState extends State<ProductImageSwipeableView>
         ),
       ),
     );
+  }
+
+  Widget _lockedIcon(ImageField imageField) {
+    if (widget.product.isImageLocked(imageField, _currentLanguage) != true) {
+      return EMPTY_WIDGET;
+    } else {
+      final AppLocalizations appLocalizations = AppLocalizations.of(context);
+      return IconButton(
+        onPressed: () {
+          showSmoothModalSheet(
+              context: context,
+              builder: (BuildContext context) {
+                return SmoothModalSheet(
+                  title: appLocalizations.owner_field_info_title,
+                  prefixIndicator: true,
+                  body: SafeArea(
+                    top: false,
+                    child: Column(
+                      children: <Widget>[
+                        Container(
+                          decoration: BoxDecoration(
+                            color: Theme.of(context).colorScheme.secondary,
+                            shape: BoxShape.circle,
+                          ),
+                          padding: const EdgeInsetsDirectional.all(LARGE_SPACE),
+                          child: const OwnerFieldIcon(
+                            size: 30.0,
+                          ),
+                        ),
+                        const SizedBox(height: MEDIUM_SPACE),
+                        Text(
+                          appLocalizations.owner_field_info_message,
+                          style: const TextStyle(fontSize: 15.0),
+                        ),
+                      ],
+                    ),
+                  ),
+                );
+              });
+        },
+        tooltip: appLocalizations.owner_field_info_title,
+        icon: const OwnerFieldIcon(),
+      );
+    }
   }
 }


### PR DESCRIPTION
Hi everyone!

In the photo gallery + details, there's an indicator to show if a producer provides an image.
🎥 Video: https://github.com/user-attachments/assets/935bff9d-fd7b-4ad7-8ab7-82bcb1a19298

## Photo grid
![IMG_1522](https://github.com/user-attachments/assets/5e17e17b-0de4-45fb-a66e-caeac9a9fe11)

## Photo modal sheet
![IMG_1521](https://github.com/user-attachments/assets/f2308fdc-bc3f-442f-9e0d-ea1613687021)

## Photo details
![IMG_1524](https://github.com/user-attachments/assets/3e831a85-a59e-438b-b456-4683b77d9259)

## Photo details explanation
![IMG_EDF5117B04BB-1](https://github.com/user-attachments/assets/16b7cf41-8cc7-4d2f-98bb-a8966d96c66f)
