### PR TITLE
fix: Several fixes for product addition

### DIFF
--- a/packages/smooth_app/lib/pages/product/add_new_product/add_new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_new_product/add_new_product_page.dart
@@ -28,6 +28,9 @@ import 'package:smooth_app/pages/product/product_image_swipeable_view.dart';
 import 'package:smooth_app/pages/product/product_type_extensions.dart';
 import 'package:smooth_app/pages/product/simple_input_page_helpers.dart';
 import 'package:smooth_app/query/product_query.dart';
+import 'package:smooth_app/themes/smooth_theme.dart';
+import 'package:smooth_app/themes/smooth_theme_colors.dart';
+import 'package:smooth_app/themes/theme_provider.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 import 'package:smooth_app/widgets/v2/smooth_buttons_bar.dart';
 import 'package:smooth_app/widgets/will_pop_scope.dart';
@@ -98,6 +101,7 @@ class _AddNewProductPageState extends State<AddNewProductPage>
       (widget.displayPictures ? 1 : 0);
 
   double get _progress => (_pageNumber + 1) / _totalPages;
+
   bool get _isLastPage => (_pageNumber + 1) == _totalPages;
   ProductType? _inputProductType;
   late ColorScheme _colorScheme;
@@ -236,6 +240,7 @@ class _AddNewProductPageState extends State<AddNewProductPage>
       onWillPop: () async => (await _onWillPop(), null),
       child: SmoothScaffold(
         body: SafeArea(
+          bottom: false,
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
@@ -261,6 +266,10 @@ class _AddNewProductPageState extends State<AddNewProductPage>
               Expanded(
                 child: PageView(
                   controller: _pageController,
+                  physics:
+                      widget.displayProductType && _inputProductType == null
+                          ? const NeverScrollableScrollPhysics()
+                          : null,
                   children: <Widget>[
                     if (widget.displayProductType)
                       _buildCard(_getProductTypes(context)),
@@ -460,6 +469,9 @@ class _AddNewProductPageState extends State<AddNewProductPage>
 
   List<Widget> _getEcoscoreRows(final BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final SmoothColorsThemeExtension extension =
+        context.extension<SmoothColorsThemeExtension>();
+
     final Attribute? attribute = _getAttribute(Attribute.ATTRIBUTE_ECOSCORE);
     return <Widget>[
       AddNewProductTitle(appLocalizations.new_product_title_ecoscore),
@@ -474,18 +486,21 @@ class _AddNewProductPageState extends State<AddNewProductPage>
         ),
       ),
       const SizedBox(height: 15.0),
-      GestureDetector(
+      InkWell(
+        borderRadius: ROUNDED_BORDER_RADIUS,
         onTap: () {
           setState(() => _ecoscoreExpanded = !_ecoscoreExpanded);
         },
-        child: Container(
+        child: Ink(
           padding: const EdgeInsets.symmetric(
             vertical: BALANCED_SPACE,
             horizontal: 15.0,
           ),
           decoration: BoxDecoration(
             borderRadius: ROUNDED_BORDER_RADIUS,
-            color: _colorScheme.surface,
+            color: context.lightTheme()
+                ? extension.primaryNormal
+                : extension.primaryMedium,
           ),
           child: Row(
             children: <Widget>[

--- a/packages/smooth_app/lib/pages/product/product_incomplete_card.dart
+++ b/packages/smooth_app/lib/pages/product/product_incomplete_card.dart
@@ -110,8 +110,8 @@ class ProductIncompleteCard extends StatelessWidget {
           Icons.bolt,
           color: Colors.amber,
         ),
-        onPressed: () async => Navigator.push<void>(
-          context,
+        onPressed: () async =>
+            Navigator.of(context, rootNavigator: true).push<void>(
           MaterialPageRoute<void>(
             builder: (BuildContext context) => AddNewProductPage.fromProduct(
               product,


### PR DESCRIPTION
Hi everyone!

Here are a few fixes for the product addition screen.

## From the carousel
The screen was displayed with tabs + non-functioning exit buttons (#5975).

## Blocking product selection
The next button was blocked, but the scroll was still possible

## Buttons bar in dark mode
Old visual:
![IMG_1532](https://github.com/user-attachments/assets/9070bbfe-8eb0-4d94-9aac-9316414753a3)


## Button in dark mode (#5961)
New color:
![IMG_1534](https://github.com/user-attachments/assets/17a27169-87fd-4ebf-b645-c89779d63ce3)
