### PR TITLE
fix: Improvements for devices with text scale multipliers

### DIFF
--- a/packages/smooth_app/lib/pages/image/product_image_widget.dart
+++ b/packages/smooth_app/lib/pages/image/product_image_widget.dart
@@ -89,20 +89,21 @@ class ProductImageWidget extends StatelessWidget {
                     horizontal: SMALL_SPACE,
                     vertical: VERY_SMALL_SPACE,
                   ),
-                  child: Stack(
+                  child: Row(
                     children: <Widget>[
-                      Center(
+                      Expanded(
                         child: AutoSizeText(
                           date,
                           maxLines: 1,
+                          textAlign: TextAlign.center,
                           style: const TextStyle(color: Colors.white),
                         ),
                       ),
                       if (expired)
-                        Positioned.directional(
-                          end: 0.0,
-                          height: 20.0,
-                          textDirection: Directionality.of(context),
+                        Padding(
+                          padding: const EdgeInsetsDirectional.only(
+                            start: VERY_SMALL_SPACE,
+                          ),
                           child: icons.Outdated(
                             size: 18.0,
                             color: colors.orange,

--- a/packages/smooth_app/lib/pages/product/product_page/new_product_header.dart
+++ b/packages/smooth_app/lib/pages/product/product_page/new_product_header.dart
@@ -344,6 +344,7 @@ class _ProductCompatibilityScore extends StatelessWidget {
                     maxLines: 1,
                     textAlign: TextAlign.center,
                     overflow: TextOverflow.fade,
+                    textScaler: TextScaler.noScaling,
                     style: TextStyle(
                       fontSize: _getCompatibilityFontSize(compatibilityLabel),
                       height: 0.9,

--- a/packages/smooth_app/lib/widgets/smooth_navigation_bar.dart
+++ b/packages/smooth_app/lib/widgets/smooth_navigation_bar.dart
@@ -226,7 +226,11 @@ class _SmoothNavigationBarItemState extends State<_SmoothNavigationBarItem>
               fontSize: 14.5,
               fontWeight: widget.selected ? FontWeight.w700 : FontWeight.w600,
             ),
-            child: Text(widget.destination.label),
+            child: Text(
+              widget.destination.label,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
           ),
         ],
       ),


### PR DESCRIPTION
Hi everyone!

Here are a few fixes for text multipliers.

The nav bar label is on a single line:
![IMG_1560](https://github.com/user-attachments/assets/6aa76b1c-a599-4780-a448-a47612100749)

The compatible indicator always fits the space:
![IMG_1558](https://github.com/user-attachments/assets/4cb3d64c-fbd4-4cec-b8c3-f7c09fd07567)

In other photos, the obsolete indicator is not below the text:
![IMG_1559](https://github.com/user-attachments/assets/6ed2ae30-7138-4f3d-9660-2e74371835fe)
