### PR TITLE
chore: Change the onboarding for the AppStore + fix

### DIFF
--- a/packages/smooth_app/lib/pages/onboarding/consent_analytics_page.dart
+++ b/packages/smooth_app/lib/pages/onboarding/consent_analytics_page.dart
@@ -74,14 +74,14 @@ class ConsentAnalyticsPage extends StatelessWidget {
               ),
             ),
             OnboardingBottomBar(
-              rightButton: _buildButton(
+              leftButton: _buildButton(
                 context,
                 appLocalizations.refuse_button_label,
                 false,
                 const Color(0xFFA08D84),
                 Colors.white,
               ),
-              leftButton: _buildButton(
+              rightButton: _buildButton(
                 context,
                 appLocalizations.authorize_button_label,
                 true,

--- a/packages/smooth_app/lib/pages/onboarding/next_button.dart
+++ b/packages/smooth_app/lib/pages/onboarding/next_button.dart
@@ -36,7 +36,7 @@ class NextButton extends StatelessWidget {
         OnboardingFlowNavigator(userPreferences);
     final OnboardingPage previousPage = currentPage.getPrevPage();
     return OnboardingBottomBar(
-      rightButton: previousPage.isOnboardingNotStarted()
+      leftButton: previousPage.isOnboardingNotStarted()
           ? null
           : OnboardingBottomIcon(
               onPressed: () async => navigator.navigateToPage(
@@ -50,7 +50,7 @@ class NextButton extends StatelessWidget {
                   ? const EdgeInsetsDirectional.only(end: 2.0)
                   : EdgeInsets.zero,
             ),
-      leftButton: OnboardingBottomButton(
+      rightButton: OnboardingBottomButton(
         onPressed: () async {
           await OnboardingLoader(localDatabase)
               .runAtNextTime(currentPage, context);

--- a/packages/smooth_app/lib/pages/onboarding/onboarding_bottom_bar.dart
+++ b/packages/smooth_app/lib/pages/onboarding/onboarding_bottom_bar.dart
@@ -5,14 +5,14 @@ import 'package:smooth_app/generic_lib/design_constants.dart';
 /// Bottom Bar during onboarding. Typical use case: previous/next buttons.
 class OnboardingBottomBar extends StatelessWidget {
   const OnboardingBottomBar({
-    required this.leftButton,
+    required this.rightButton,
     required this.backgroundColor,
-    this.rightButton,
+    required this.leftButton,
     this.semanticsHorizontalOrder = true,
   });
 
-  final Widget leftButton;
-  final Widget? rightButton;
+  final Widget? leftButton;
+  final Widget rightButton;
 
   /// If [true], the [leftButton] will be said first by the screen reader.
   final bool semanticsHorizontalOrder;
@@ -27,7 +27,7 @@ class OnboardingBottomBar extends StatelessWidget {
     final Size screenSize = MediaQuery.sizeOf(context);
     // Side padding is 8% of total width.
     final double sidePadding = screenSize.width * .08;
-    final bool hasPrevious = rightButton != null;
+    final bool hasPrevious = leftButton != null;
     return Column(
       children: <Widget>[
         Container(
@@ -48,14 +48,14 @@ class OnboardingBottomBar extends StatelessWidget {
                 : MainAxisAlignment.end,
             crossAxisAlignment: CrossAxisAlignment.center,
             children: <Widget>[
-              if (rightButton != null)
+              if (leftButton != null)
                 Semantics(
-                  sortKey: OrdinalSortKey(semanticsHorizontalOrder ? 1.0 : 2.0),
-                  child: rightButton,
+                  sortKey: OrdinalSortKey(semanticsHorizontalOrder ? 2.0 : 1.0),
+                  child: leftButton,
                 ),
               Semantics(
-                sortKey: OrdinalSortKey(semanticsHorizontalOrder ? 2.0 : 1.0),
-                child: leftButton,
+                sortKey: OrdinalSortKey(semanticsHorizontalOrder ? 1.0 : 2.0),
+                child: rightButton,
               ),
             ],
           ),

--- a/packages/smooth_app/lib/pages/onboarding/permissions_page.dart
+++ b/packages/smooth_app/lib/pages/onboarding/permissions_page.dart
@@ -96,10 +96,12 @@ class _PermissionsPageState extends State<PermissionsPage> {
                 ),
               )),
               OnboardingBottomBar(
-                rightButton: _IgnoreButton(
-                  onPermissionIgnored: () => _moveToNextScreen(context),
-                ),
-                leftButton: _AskPermissionButton(
+                leftButton: !Platform.isIOS
+                    ? _IgnoreButton(
+                        onPermissionIgnored: () => _moveToNextScreen(context),
+                      )
+                    : null,
+                rightButton: _AskPermissionButton(
                   onPermissionIgnored: () => _moveToNextScreen(context),
                 ),
                 backgroundColor: widget.backgroundColor,
@@ -153,7 +155,9 @@ class _AskPermissionButton extends StatelessWidget {
       },
       backgroundColor: Colors.white,
       foregroundColor: Colors.black,
-      label: appLocalizations.authorize_button_label,
+      label: Platform.isIOS
+          ? appLocalizations.onboarding_continue_button
+          : appLocalizations.authorize_button_label,
     );
   }
 }


### PR DESCRIPTION
Hi everyone!

Apple asks us only to have one button for the permission page.
This also includes a fix, where right and left buttons were inverted.