### PR TITLE
fix: Improvements for small screens

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_base_card.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_base_card.dart
@@ -1,3 +1,4 @@
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
@@ -179,7 +180,7 @@ class _SmoothProductCardHeader extends StatelessWidget {
               ),
               SizedBox(width: dense ? BALANCED_SPACE : MEDIUM_SPACE),
               Expanded(
-                child: Text(
+                child: AutoSizeText(
                   label,
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
@@ -326,7 +327,7 @@ class ScanProductBaseCardButton extends StatelessWidget {
   });
 
   final String text;
-  final VoidCallback onTap;
+  final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_not_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_not_found.dart
@@ -39,7 +39,6 @@ class ScanProductCardNotFound extends StatelessWidget {
       ),
       child: LayoutBuilder(
         builder: (BuildContext context, BoxConstraints constraints) {
-          final bool dense = constraints.maxHeight < 275.0;
           final Widget spacer;
 
           if (dense) {

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_not_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_not_found.dart
@@ -37,55 +37,81 @@ class ScanProductCardNotFound extends StatelessWidget {
         end: 5.0,
         child: OrangeErrorAnimation(),
       ),
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.start,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          ScanProductBaseCardTitle(
-            title: appLocalizations.carousel_unknown_product_title,
-            padding: EdgeInsetsDirectional.only(
-              top: dense ? 0.0 : 5.0,
-              end: 25.0,
-            ),
-          ),
-          SizedBox(height: dense ? BALANCED_SPACE : LARGE_SPACE),
-          ScanProductBaseCardText(
-            text: TextWithBubbleParts(
-              text: appLocalizations.carousel_unknown_product_text,
-              backgroundColor: theme.primarySemiDark,
-              textStyle: const TextStyle(
-                fontSize: 14.5,
+      child: LayoutBuilder(
+        builder: (BuildContext context, BoxConstraints constraints) {
+          final bool dense = constraints.maxHeight < 275.0;
+          final Widget spacer;
+
+          if (dense) {
+            spacer = const SizedBox(height: MEDIUM_SPACE);
+          } else {
+            spacer = const Spacer();
+          }
+
+          final Widget child = Column(
+            mainAxisAlignment: MainAxisAlignment.start,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              ScanProductBaseCardTitle(
+                title: appLocalizations.carousel_unknown_product_title,
+                padding: EdgeInsetsDirectional.only(
+                  top: dense ? 0.0 : 5.0,
+                  end: 25.0,
+                ),
               ),
-              bubbleTextStyle: const TextStyle(
-                color: Colors.white,
-                fontWeight: FontWeight.w600,
-                fontSize: 13.5,
+              SizedBox(height: dense ? BALANCED_SPACE : LARGE_SPACE),
+              ScanProductBaseCardText(
+                text: TextWithBubbleParts(
+                  text: appLocalizations.carousel_unknown_product_text,
+                  backgroundColor: theme.primarySemiDark,
+                  textStyle: const TextStyle(
+                    fontSize: 14.5,
+                  ),
+                  bubbleTextStyle: const TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.w600,
+                    fontSize: 13.5,
+                  ),
+                  bubblePadding: const EdgeInsetsDirectional.only(
+                    top: 2.5,
+                    bottom: 3.5,
+                    start: 10.0,
+                    end: 10.0,
+                  ),
+                ),
               ),
-              bubblePadding: const EdgeInsetsDirectional.only(
-                top: 2.5,
-                bottom: 3.5,
-                start: 10.0,
-                end: 10.0,
+              ScanProductBaseCardBarcode(
+                barcode: barcode,
+                height: 75.0,
+                padding: const EdgeInsetsDirectional.only(top: MEDIUM_SPACE),
               ),
-            ),
-          ),
-          ScanProductBaseCardBarcode(
-            barcode: barcode,
-            height: 75.0,
-            padding: const EdgeInsetsDirectional.only(top: MEDIUM_SPACE),
-          ),
-          const Spacer(),
-          ScanProductBaseCardButton(
-            text: appLocalizations.carousel_unknown_product_button,
-            onTap: () async {
-              await AppNavigator.of(context).push(
-                AppRoutes.PRODUCT_CREATOR(barcode),
-              );
-              await onAddProduct?.call();
-            },
-          ),
-        ],
+              spacer,
+              ScanProductBaseCardButton(
+                text: appLocalizations.carousel_unknown_product_button,
+                onTap: () => _onTap(context),
+              ),
+            ],
+          );
+
+          if (dense) {
+            return SingleChildScrollView(
+              child: InkWell(
+                onTap: () => _onTap(context),
+                child: child,
+              ),
+            );
+          } else {
+            return child;
+          }
+        },
       ),
     );
+  }
+
+  Future<void> _onTap(BuildContext context) async {
+    await AppNavigator.of(context).push(
+      AppRoutes.PRODUCT_CREATOR(barcode),
+    );
+    await onAddProduct?.call();
   }
 }

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_not_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_not_found.dart
@@ -88,7 +88,7 @@ class ScanProductCardNotFound extends StatelessWidget {
               spacer,
               ScanProductBaseCardButton(
                 text: appLocalizations.carousel_unknown_product_button,
-                onTap: () => _onTap(context),
+                onTap: dense ? () => _onTap(context) : null,
               ),
             ],
           );

--- a/packages/smooth_app/lib/pages/product/product_page/new_product_header.dart
+++ b/packages/smooth_app/lib/pages/product/product_page/new_product_header.dart
@@ -333,6 +333,7 @@ class _ProductCompatibilityScore extends StatelessWidget {
                     '${compatibility.score}%',
                     maxLines: 1,
                     textAlign: TextAlign.center,
+                    textScaler: TextScaler.noScaling,
                     style: const TextStyle(
                       fontSize: 12.0,
                       height: 0.9,

--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -152,6 +152,7 @@ class _SummaryCardState extends State<SummaryCard> with UpToDateMixin {
               ),
             ),
             Container(
+              width: double.infinity,
               padding: widget.buttonPadding ??
                   const EdgeInsets.symmetric(
                     vertical: SMALL_SPACE,
@@ -163,35 +164,42 @@ class _SummaryCardState extends State<SummaryCard> with UpToDateMixin {
                 borderRadius:
                     const BorderRadius.vertical(bottom: ROUNDED_RADIUS),
               ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: <Widget>[
-                  Padding(
-                    padding: const EdgeInsetsDirectional.only(bottom: 2.0),
-                    child: Text(
-                      AppLocalizations.of(context).tap_for_more,
-                      style: const TextStyle(
-                        color: Colors.white,
-                        fontSize: 15.0,
-                        fontWeight: FontWeight.w600,
+              child: Padding(
+                padding: const EdgeInsetsDirectional.only(
+                  start: SMALL_SPACE,
+                  end: SMALL_SPACE,
+                  bottom: 2.0,
+                ),
+                child: FittedBox(
+                  fit: BoxFit.scaleDown,
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: <Widget>[
+                      Text(
+                        AppLocalizations.of(context).tap_for_more,
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 15.0,
+                          fontWeight: FontWeight.w600,
+                        ),
                       ),
-                    ),
+                      const SizedBox(
+                        width: BALANCED_SPACE,
+                      ),
+                      Container(
+                        decoration: BoxDecoration(
+                          shape: BoxShape.circle,
+                          color: themeExtension.orange,
+                        ),
+                        padding: const EdgeInsets.all(VERY_SMALL_SPACE),
+                        child: const icons.Arrow.right(
+                          color: Colors.white,
+                          size: 12.0,
+                        ),
+                      ),
+                    ],
                   ),
-                  const SizedBox(
-                    width: BALANCED_SPACE,
-                  ),
-                  Container(
-                    decoration: BoxDecoration(
-                      shape: BoxShape.circle,
-                      color: themeExtension.orange,
-                    ),
-                    padding: const EdgeInsets.all(VERY_SMALL_SPACE),
-                    child: const icons.Arrow.right(
-                      color: Colors.white,
-                      size: 12.0,
-                    ),
-                  ),
-                ],
+                ),
               ),
             ),
           ],

--- a/packages/smooth_app/lib/pages/scan/carousel/main_card/scan_tagline.dart
+++ b/packages/smooth_app/lib/pages/scan/carousel/main_card/scan_tagline.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
@@ -139,6 +140,7 @@ class _ScanTagLineContentState extends State<_ScanTagLineContent> {
                 backgroundColor: currentNews.style?.titleBackground,
                 indicatorColor: currentNews.style?.titleIndicatorColor,
                 titleColor: currentNews.style?.titleTextColor,
+                dense: dense,
               ),
             ),
           ),
@@ -202,6 +204,7 @@ class _ScanTagLineContentState extends State<_ScanTagLineContent> {
 class _TagLineContentTitle extends StatelessWidget {
   const _TagLineContentTitle({
     required this.title,
+    required this.dense,
     this.backgroundColor,
     this.indicatorColor,
     this.titleColor,
@@ -211,6 +214,7 @@ class _TagLineContentTitle extends StatelessWidget {
   final Color? backgroundColor;
   final Color? indicatorColor;
   final Color? titleColor;
+  final bool dense;
 
   @override
   Widget build(BuildContext context) {
@@ -220,7 +224,7 @@ class _TagLineContentTitle extends StatelessWidget {
       label: localizations.scan_tagline_news_item_accessibility(title),
       excludeSemantics: true,
       child: ConstrainedBox(
-        constraints: const BoxConstraints(minHeight: 30.0),
+        constraints: BoxConstraints(minHeight: dense ? 28.0 : 30.0),
         child: Row(
           children: <Widget>[
             SizedBox.square(
@@ -234,9 +238,10 @@ class _TagLineContentTitle extends StatelessWidget {
             ),
             const SizedBox(width: BALANCED_SPACE),
             Expanded(
-              child: Text(
+              child: AutoSizeText(
                 title,
                 maxLines: 1,
+                minFontSize: 8.0,
                 overflow: TextOverflow.ellipsis,
                 style: TextStyle(
                   fontWeight: FontWeight.bold,
@@ -310,7 +315,7 @@ class _TagLineContentBodyState extends State<_TagLineContentBody> {
               ),
             ),
           ),
-          const SizedBox(width: MEDIUM_SPACE),
+          SizedBox(width: widget.dense ? SMALL_SPACE : MEDIUM_SPACE),
         ],
         Expanded(
           flex: 10 - imageFlex,

--- a/packages/smooth_app/lib/widgets/smooth_navigation_bar.dart
+++ b/packages/smooth_app/lib/widgets/smooth_navigation_bar.dart
@@ -177,9 +177,11 @@ class _SmoothNavigationBarItemState extends State<_SmoothNavigationBarItem>
     final bool lightTheme = context.lightTheme();
 
     return Padding(
-      padding: const EdgeInsets.symmetric(
-        vertical: MEDIUM_SPACE,
-        horizontal: SMALL_SPACE,
+      padding: const EdgeInsetsDirectional.only(
+        start: MEDIUM_SPACE,
+        end: MEDIUM_SPACE,
+        top: SMALL_SPACE,
+        bottom: 6.0,
       ),
       child: Column(
         mainAxisSize: MainAxisSize.min,


### PR DESCRIPTION
Hi!

Here are a few improvements for small screens:

- The `NavBar` gains 2 pixels
- The tagline tries to find a few pixels
- The title of the tagline uses an `AutoSizeText`
- The title of a scan card uses an `AutoSizeText`
- The "tap for more info" button scales down if there's not enough space
- The "not found" scan card is scrollable and fully clickable only on small screens (irrelevant for bigger ones)
- Product compatibility on the product page: the percentage doesn't scale

Until we destroy the carousel, we can't have a real fix for this screen.