### PR TITLE
fix: 6021 - resilience for svg and 'Connection reset by peer'

### DIFF
--- a/packages/smooth_app/lib/cards/category_cards/svg_safe_network.dart
+++ b/packages/smooth_app/lib/cards/category_cards/svg_safe_network.dart
@@ -136,16 +136,25 @@ class _SvgSafeNetworkState extends State<SvgSafeNetwork> {
             }
           }
           if (snapshot.error != null) {
-            if (snapshot.error.toString().contains("Failed host lookup: '")) {
+            String? findWarningLabel() {
+              const List<String> warningLabels = <String>[
+                'Failed host lookup',
+                'Connection timed out',
+                'Connection reset by peer',
+              ];
+              final String error = snapshot.error.toString();
+              for (final String warningLabel in warningLabels) {
+                if (error.contains(warningLabel)) {
+                  return warningLabel;
+                }
+              }
+              return null;
+            }
+
+            final String? warningLabel = findWarningLabel();
+            if (warningLabel != null) {
               Logs.w(
-                'Failed host lookup for "$_url"',
-                ex: snapshot.error,
-              );
-            } else if (snapshot.error
-                .toString()
-                .contains('Connection timed out')) {
-              Logs.w(
-                'Connection timed out for "$_url"',
+                '$warningLabel for "$_url"',
                 ex: snapshot.error,
               );
             } else {


### PR DESCRIPTION
### What
Now we have the same resilience level for failed SVG downloads in 3 cases:
- 'Failed host lookup'
- 'Connection timed out'
- 'Connection reset by peer'

### Fixes bug(s)
- Fixes: #6021