### PR TITLE
fix: 6061 - "my proofs" are "my" proofs

### DIFF
--- a/packages/smooth_app/lib/pages/prices/prices_proofs_page.dart
+++ b/packages/smooth_app/lib/pages/prices/prices_proofs_page.dart
@@ -176,6 +176,7 @@ class _PricesProofsPageState extends State<PricesProofsPage>
             ascending: false,
           ),
         ]
+        ..owner = user.userId
         ..pageSize = _pageSize
         ..pageNumber = 1,
       uriHelper: ProductQuery.uriPricesHelper,


### PR DESCRIPTION
### What
- A recent change in Prices made "my proofs" page display proofs from anybody.
- Now we're explicitly restricting to proofs of the current user.

### Fixes bug(s)
- Fixes: #6061