### PR TITLE
fix: 6063 - no "edit proof" on existing proof

### DIFF
--- a/packages/smooth_app/lib/pages/prices/price_proof_card.dart
+++ b/packages/smooth_app/lib/pages/prices/price_proof_card.dart
@@ -60,17 +60,19 @@ class PriceProofCard extends StatelessWidget {
                     ? appLocalizations.prices_proof_receipt
                     : appLocalizations.prices_proof_price_tag,
             icon: !model.hasImage ? _iconTodo : _iconDone,
-            onPressed: () async {
-              final _ProofSource? proofSource =
-                  await _ProofSource.select(context);
-              if (proofSource == null) {
-                return;
-              }
-              if (!context.mounted) {
-                return;
-              }
-              return proofSource.process(context, model);
-            },
+            onPressed: model.proof != null
+                ? null
+                : () async {
+                    final _ProofSource? proofSource =
+                        await _ProofSource.select(context);
+                    if (proofSource == null) {
+                      return;
+                    }
+                    if (!context.mounted) {
+                      return;
+                    }
+                    return proofSource.process(context, model);
+                  },
           ),
           LayoutBuilder(
             builder: (BuildContext context, BoxConstraints constraints) => Row(


### PR DESCRIPTION
### What
- When you click on Prices / My proofs, then click on a proof, you have the possibility to add prices to that proof.
- Then, in the related "add prices" page, you shouldn't think you can change the proof.
- The solution is to disable the "edit proof" button, as it was already done for the "receipt" / "price tag" selection

### Fixes bug(s)
- Fixes: #6063