### PR TITLE
fix: scan card button not working

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_not_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_not_found.dart
@@ -87,7 +87,7 @@ class ScanProductCardNotFound extends StatelessWidget {
               spacer,
               ScanProductBaseCardButton(
                 text: appLocalizations.carousel_unknown_product_button,
-                onTap: dense ? () => _onTap(context) : null,
+                onTap: !dense ? () => _onTap(context) : null,
               ),
             ],
           );


### PR DESCRIPTION
Hi everyone!

For big screens, the "Add a product" button was not working on the carousel.