### PR TITLE
feat: Migration to the latest camera/mobile_scanner

### DIFF
--- a/packages/scanner/ml_kit/lib/src/mobile_scanner_controller.dart
+++ b/packages/scanner/ml_kit/lib/src/mobile_scanner_controller.dart
@@ -1,0 +1,142 @@
+import 'package:flutter/material.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
+import 'package:torch_light/torch_light.dart';
+
+class CustomScannerController {
+  CustomScannerController({
+    required MobileScannerController controller,
+  })  : _controller = controller,
+        _torchState = TorchState(),
+        _availableCamerasState = AvailableCamerasState(),
+        _cameraFacingState = CameraFacingState() {
+    _detectTorch();
+  }
+
+  final MobileScannerController _controller;
+  final TorchState _torchState;
+  final AvailableCamerasState _availableCamerasState;
+  final CameraFacingState _cameraFacingState;
+
+  bool _isStarted = false;
+  bool _isStarting = false;
+  bool _isClosing = false;
+  bool _isClosed = false;
+
+  Future<void> start() async {
+    if (isStarted || _isStarting || isClosing) {
+      return;
+    }
+
+    _isStarting = true;
+    _isClosed = false;
+    try {
+      await _controller.start();
+      _controller.addListener(_onControllerChanged);
+      _isStarted = true;
+
+      if (isTorchOn) {
+        // Slight delay, because it doesn't always work if called immediately
+        Future<void>.delayed(const Duration(milliseconds: 250), () {
+          turnTorchOn();
+        });
+      }
+      _isStarting = false;
+    } catch (_) {}
+  }
+
+  void _onControllerChanged() {
+    _availableCamerasState.value = _controller.value.availableCameras ?? 0;
+    _cameraFacingState.value = _controller.facing;
+  }
+
+  MobileScannerController get controller => _controller;
+
+  bool get isStarted => _isStarted;
+
+  bool get isClosing => _isClosing;
+
+  bool get isClosed => _isClosed;
+
+  Future<void> stop() async {
+    if (isClosed || isClosing || _isStarting) {
+      return;
+    }
+
+    _isClosing = true;
+    _isStarting = false;
+    _isStarted = false;
+    try {
+      await _controller.stop();
+      _controller.removeListener(_onControllerChanged);
+      _isClosing = false;
+      _isClosed = true;
+    } catch (_) {}
+  }
+
+  bool get hasTorch => _torchState.value != null;
+
+  ValueNotifier<bool?> get hasTorchState => _torchState;
+
+  bool get isTorchOn => _torchState.value == true;
+
+  void turnTorchOff() {
+    if (isTorchOn) {
+      _controller.toggleTorch();
+      _torchState.value = false;
+    }
+  }
+
+  void turnTorchOn() {
+    if (!isTorchOn) {
+      _controller.toggleTorch();
+      _torchState.value = true;
+    }
+  }
+
+  void toggleTorch() {
+    if (isTorchOn) {
+      turnTorchOff();
+    } else {
+      turnTorchOn();
+    }
+  }
+
+  ValueNotifier<int> get availableCameras => _availableCamerasState;
+  ValueNotifier<CameraFacing> get cameraFacing => _cameraFacingState;
+
+  void toggleCamera() {
+    _controller.switchCamera();
+    if (_controller.facing == CameraFacing.front) {
+      _torchState.value = null;
+      _cameraFacingState.value = CameraFacing.front;
+    } else if (_controller.facing == CameraFacing.front) {
+      _torchState.value = false;
+      _cameraFacingState.value = CameraFacing.back;
+    }
+  }
+
+  Future<void> _detectTorch() async {
+    try {
+      final bool isTorchAvailable = await TorchLight.isTorchAvailable();
+      if (isTorchAvailable) {
+        _torchState.value = false;
+      } else {
+        _torchState.value = null;
+      }
+    } on Exception catch (_) {}
+  }
+
+  Future<void> dispose() => _controller.dispose();
+}
+
+class TorchState extends ValueNotifier<bool?> {
+  TorchState({bool? value}) : super(value);
+}
+
+class AvailableCamerasState extends ValueNotifier<int> {
+  AvailableCamerasState() : super(0);
+}
+
+class CameraFacingState extends ValueNotifier<CameraFacing> {
+  CameraFacingState() : super(CameraFacing.back);
+}

--- a/packages/scanner/ml_kit/lib/src/mobile_scanner_controller.dart
+++ b/packages/scanner/ml_kit/lib/src/mobile_scanner_controller.dart
@@ -30,8 +30,8 @@ class CustomScannerController {
     _isStarting = true;
     _isClosed = false;
     try {
-      await _controller.start();
       _controller.addListener(_onControllerChanged);
+      await _controller.start();
       _isStarted = true;
 
       if (isTorchOn) {

--- a/packages/scanner/ml_kit/lib/src/scanner_ml_kit.dart
+++ b/packages/scanner/ml_kit/lib/src/scanner_ml_kit.dart
@@ -1,8 +1,9 @@
 import 'dart:async';
 
-import 'package:async/async.dart';
 import 'package:flutter/material.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
+import 'package:provider/provider.dart';
+import 'package:scanner_ml_kit/src/mobile_scanner_controller.dart';
 import 'package:scanner_shared/scanner_shared.dart';
 import 'package:visibility_detector/visibility_detector.dart';
 
@@ -69,7 +70,7 @@ class _SmoothBarcodeScannerMLKit extends StatefulWidget {
 }
 
 class _SmoothBarcodeScannerMLKitState extends State<_SmoothBarcodeScannerMLKit>
-    with SingleTickerProviderStateMixin, WidgetsBindingObserver {
+    with SingleTickerProviderStateMixin {
   // just 1D formats and ios supported
   static const List<BarcodeFormat> _barcodeFormats = <BarcodeFormat>[
     BarcodeFormat.code39,
@@ -85,268 +86,223 @@ class _SmoothBarcodeScannerMLKitState extends State<_SmoothBarcodeScannerMLKit>
   static const ValueKey<String> _visibilityKey =
       ValueKey<String>('VisibilityDetector');
 
-  bool _isStarted = true;
-
-  bool get _showFlipCameraButton => widget.hasMoreThanOneCamera;
-
-  final MobileScannerController _controller = MobileScannerController(
-    torchEnabled: false,
-    formats: _barcodeFormats,
-    facing: CameraFacing.back,
-    detectionSpeed: DetectionSpeed.normal,
-    detectionTimeoutMs: 250,
-    // to be raised in order to avoid crashes
-    returnImage: false,
-    autoStart: true,
-  );
-
-  // Stores a background operation when the screen isn't visible
-  CancelableOperation<void>? _autoStopCameraOperation;
-  // Stores the latest visibility value of the screen
-  VisibilityInfo? _latestVisibilityInfoEvent;
+  late CustomScannerController _cameraController;
+  late final AppLifecycleListener _lifecycleListener;
+  bool _screenVisible = false;
 
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addObserver(this);
+
+    _cameraController = CustomScannerController(
+      controller: MobileScannerController(
+        autoStart: false,
+        torchEnabled: false,
+        formats: _barcodeFormats,
+        facing: CameraFacing.back,
+        detectionSpeed: DetectionSpeed.normal,
+        detectionTimeoutMs: 250,
+        // to be raised in order to avoid crashes
+        returnImage: false,
+      ),
+    );
+    _lifecycleListener = AppLifecycleListener(
+      onPause: _onPause,
+      onResume: _onResume,
+    );
   }
 
-  @override
-  void didChangeAppLifecycleState(AppLifecycleState state) {
-    super.didChangeAppLifecycleState(state);
-
-    if (state == AppLifecycleState.paused) {
-      _stop();
-    } else if (state == AppLifecycleState.resumed) {
-      _autoStopCameraOperation?.cancel();
-      _checkIfAppIsRestarting();
-    }
-  }
-
-  void _checkIfAppIsRestarting([int retry = 0]) {
-    /// When the app is resumed (from the launcher for example), the camera is
-    /// always started due to the [autostart] feature and we can't
-    /// prevent this behavior.
-    ///
-    /// To fix it, we check when the app is resumed if the camera is the
-    /// visible page and if that's not the case, we wait for the camera to be
-    /// initialized to stop it.
-    ///
-    /// Comment from @g123k: This is a very hacky way (temporary I hope) and
-    /// more explanation are available on the PR:
-    /// [https://github.com/openfoodfacts/smooth-app/pull/4292]
-    ///
-    // ignore: prefer_function_declarations_over_variables
-    final Function fn = () {
-      if (ScreenVisibilityDetector.invisible(context)) {
-        _pauseCameraWhenInitialized();
-      } else if (retry < 1) {
-        // In 99% of cases, this won't happen, but if for some reason, we are
-        // "considered" as visible, we will retry in a few milliseconds
-        // and if we are still invisible -> force stop the camera
-        _autoStopCameraOperation = CancelableOperation<void>.fromFuture(
-          Future<void>.delayed(
-            const Duration(milliseconds: 500),
-            () => _checkIfAppIsRestarting(retry + 1),
-          ),
-        );
-      } else if (_latestVisibilityInfoEvent?.visible == false) {
-        _pauseCameraWhenInitialized();
-      }
-    };
-
-    // Ensure to wait for the first frame
-    if (retry == 0) {
-      // ignore: avoid_dynamic_calls
-      WidgetsBinding.instance.addPostFrameCallback((_) => fn.call());
-    } else {
-      // ignore: avoid_dynamic_calls
-      scheduleMicrotask(() => fn.call());
+  Future<void> _onResume() async {
+    if (_screenVisible) {
+      return _cameraController.start();
     }
   }
 
-  Future<void> _pauseCameraWhenInitialized() async {
-    if (!mounted) {
-      return;
-    }
-
-    if (_controller.isStarting) {
-      _autoStopCameraOperation = CancelableOperation<void>.fromFuture(
-        Future<void>.delayed(
-          const Duration(milliseconds: 250),
-          () => _pauseCameraWhenInitialized(),
-        ),
-      );
-    }
-
-    _controller.stop();
-  }
-
-  Future<void> _start() async {
-    if (_isStarted) {
-      return;
-    }
-    if (_controller.isStarting) {
-      return;
-    }
-    try {
-      await _controller.start();
-      _isStarted = true;
-    } on Exception {
-      widget.trackCustomEvent(
-          Scanner.ANALYTICS_STRANGE_RESTART, Scanner.ANALYTICS_CATEGORY);
-    }
-  }
-
-  Future<void> _stop() async {
-    _autoStopCameraOperation?.cancel();
-    if (!_isStarted) {
-      return;
-    }
-    try {
-      await _controller.stop();
-      _isStarted = false;
-    } on Exception {
-      widget.trackCustomEvent(
-          Scanner.ANALYTICS_STRANGE_RESTOP, Scanner.ANALYTICS_CATEGORY);
-    }
-  }
+  Future<void> _onPause() => _cameraController.stop();
 
   @override
   Widget build(BuildContext context) {
-    return VisibilityDetector(
-      key: _visibilityKey,
-      onVisibilityChanged: (final VisibilityInfo info) async {
-        _latestVisibilityInfoEvent = info;
-        if (info.visibleBounds.height > 0.0) {
-          await _start();
-        } else {
-          await _stop();
-        }
-      },
-      child: Stack(
-        children: <Widget>[
-          MobileScanner(
-            controller: _controller,
-            fit: BoxFit.cover,
-            errorBuilder: (
-              BuildContext context,
-              MobileScannerException error,
-              Widget? child,
-            ) =>
-                EMPTY_WIDGET,
-            onDetect: (final BarcodeCapture capture) async {
-              for (final Barcode barcode in capture.barcodes) {
-                final String? string = barcode.displayValue;
-                if (string != null) {
-                  await widget.onScan(string);
+    return Provider<CustomScannerController>.value(
+      value: _cameraController,
+      child: VisibilityDetector(
+        key: _visibilityKey,
+        onVisibilityChanged: (final VisibilityInfo info) async {
+          _screenVisible = info.visibleFraction > 0;
+          _onScreenVisibilityChanged(_screenVisible);
+        },
+        child: Stack(
+          children: <Widget>[
+            MobileScanner(
+              controller: _cameraController.controller,
+              fit: BoxFit.cover,
+              errorBuilder: (
+                BuildContext context,
+                MobileScannerException error,
+                Widget? child,
+              ) =>
+                  EMPTY_WIDGET,
+              onDetect: (final BarcodeCapture capture) async {
+                for (final Barcode barcode in capture.barcodes) {
+                  final String? string = barcode.displayValue;
+                  if (string != null) {
+                    await widget.onScan(string);
+                  }
                 }
-              }
-            },
-          ),
-          Center(
-            child: SmoothBarcodeScannerVisor(
-              contentPadding: widget.contentPadding,
+              },
             ),
-          ),
-          Align(
-            alignment: Alignment.bottomCenter,
-            child: Padding(
-              padding: const EdgeInsets.all(
-                SmoothBarcodeScannerVisor.CORNER_PADDING,
+            Center(
+              child: SmoothBarcodeScannerVisor(
+                contentPadding: widget.contentPadding,
               ),
-              child: Row(
-                mainAxisAlignment: _showFlipCameraButton
-                    ? MainAxisAlignment.spaceBetween
-                    : MainAxisAlignment.end,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: <Widget>[
-                  if (_showFlipCameraButton)
-                    VisorButton(
-                      onTap: () async {
-                        widget.hapticFeedback.call();
-                        await _controller.switchCamera();
-                      },
-                      tooltip: widget.toggleCameraModeTooltip ??
-                          'Switch between back and front camera',
-                      child: ValueListenableBuilder<CameraFacing>(
-                        valueListenable: _controller.cameraFacingState,
-                        builder: (
-                          BuildContext context,
-                          CameraFacing state,
-                          Widget? child,
-                        ) {
-                          switch (state) {
-                            case CameraFacing.front:
-                              return const Icon(Icons.camera_front);
-                            case CameraFacing.back:
-                              return const Icon(Icons.camera_rear);
-                          }
-                        },
-                      ),
+            ),
+            Align(
+              alignment: Alignment.bottomCenter,
+              child: Padding(
+                padding: const EdgeInsets.all(
+                  SmoothBarcodeScannerVisor.CORNER_PADDING,
+                ),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: <Widget>[
+                    _ToggleCameraIcon(
+                      toggleCameraModeTooltip: widget.toggleCameraModeTooltip,
+                      hapticFeedback: widget.hapticFeedback,
                     ),
-                  ValueListenableBuilder<bool?>(
-                    valueListenable: _controller.hasTorchState,
-                    builder: (
-                      BuildContext context,
-                      bool? state,
-                      Widget? child,
-                    ) {
-                      if (state != true) {
-                        return const SizedBox.shrink();
-                      }
-                      return VisorButton(
-                        tooltip: widget.toggleFlashModeTooltip ??
-                            'Turn ON or OFF the flash of the camera',
-                        onTap: () async {
-                          widget.hapticFeedback.call();
-
-                          try {
-                            await _controller.toggleTorch();
-                          } catch (err) {
-                            if (context.mounted) {
-                              widget.onCameraFlashError?.call(context);
-                            }
-                          }
-                        },
-                        child: ValueListenableBuilder<TorchState>(
-                          valueListenable: _controller.torchState,
-                          builder: (
-                            BuildContext context,
-                            TorchState state,
-                            Widget? child,
-                          ) {
-                            switch (state) {
-                              case TorchState.off:
-                                return const Icon(
-                                  Icons.flash_off,
-                                  color: Colors.white,
-                                );
-                              case TorchState.on:
-                                return const Icon(
-                                  Icons.flash_on,
-                                  color: Colors.white,
-                                );
-                            }
-                          },
-                        ),
-                      );
-                    },
-                  ),
-                ],
+                    _TorchIcon(
+                      toggleFlashModeTooltip: widget.toggleFlashModeTooltip,
+                      hapticFeedback: widget.hapticFeedback,
+                      onCameraFlashError: widget.onCameraFlashError,
+                    ),
+                  ],
+                ),
               ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }
 
+  void _onScreenVisibilityChanged(bool visible) {
+    if (visible) {
+      _cameraController.start();
+    } else {
+      _cameraController.stop();
+    }
+  }
+
   @override
   void dispose() {
-    WidgetsBinding.instance.removeObserver(this);
-    _autoStopCameraOperation?.cancel();
-    _controller.dispose();
+    _lifecycleListener.dispose();
+    _cameraController.dispose();
     super.dispose();
+  }
+}
+
+class _TorchIcon extends StatefulWidget {
+  const _TorchIcon({
+    required this.hapticFeedback,
+    required this.onCameraFlashError,
+    this.toggleFlashModeTooltip,
+  });
+
+  final String? toggleFlashModeTooltip;
+  final Future<void> Function() hapticFeedback;
+  final Function(BuildContext)? onCameraFlashError;
+
+  @override
+  State<_TorchIcon> createState() => _TorchIconState();
+}
+
+class _TorchIconState extends State<_TorchIcon> {
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<bool?>(
+      valueListenable: context.watch<CustomScannerController>().hasTorchState,
+      builder: (BuildContext context, bool? hasTorch, _) {
+        if (hasTorch == null) {
+          return EMPTY_WIDGET;
+        }
+
+        final CustomScannerController controller =
+            context.watch<CustomScannerController>();
+        final bool isTorchOn = controller.isTorchOn;
+
+        return VisorButton(
+          tooltip: widget.toggleFlashModeTooltip ??
+              'Turn ON or OFF the flash of the camera',
+          onTap: () async {
+            widget.hapticFeedback.call();
+
+            try {
+              context.read<CustomScannerController>().toggleTorch();
+            } catch (err) {
+              if (context.mounted) {
+                widget.onCameraFlashError?.call(context);
+              }
+            }
+          },
+          child: switch (isTorchOn) {
+            true => const Icon(
+                Icons.flash_off,
+                color: Colors.white,
+              ),
+            false => const Icon(
+                Icons.flash_on,
+                color: Colors.white,
+              ),
+          },
+        );
+      },
+    );
+  }
+}
+
+class _ToggleCameraIcon extends StatelessWidget {
+  const _ToggleCameraIcon({
+    required this.hapticFeedback,
+    this.toggleCameraModeTooltip,
+  });
+
+  final Future<void> Function() hapticFeedback;
+  final String? toggleCameraModeTooltip;
+
+  @override
+  Widget build(BuildContext context) {
+    final CustomScannerController controller =
+        context.watch<CustomScannerController>();
+
+    return ValueListenableBuilder<int>(
+        valueListenable: controller.availableCameras,
+        builder: (BuildContext context, int cameras, _) {
+          if (cameras <= 1) {
+            return EMPTY_WIDGET;
+          }
+
+          return VisorButton(
+            onTap: () async {
+              hapticFeedback.call();
+              controller.toggleCamera();
+            },
+            tooltip: toggleCameraModeTooltip ??
+                'Switch between back and front camera',
+            child: ValueListenableBuilder<CameraFacing>(
+              valueListenable: controller.cameraFacing,
+              builder: (
+                BuildContext context,
+                CameraFacing state,
+                Widget? child,
+              ) {
+                switch (state) {
+                  case CameraFacing.front:
+                    return const Icon(Icons.camera_front);
+                  case CameraFacing.back:
+                    return const Icon(Icons.camera_rear);
+                }
+              },
+            ),
+          );
+        });
   }
 }

--- a/packages/scanner/ml_kit/pubspec.yaml
+++ b/packages/scanner/ml_kit/pubspec.yaml
@@ -12,8 +12,11 @@ dependencies:
 
   visibility_detector: 0.4.0+2
   async: 2.11.0
+  provider: 6.1.2
 
-  mobile_scanner: 4.0.1
+  mobile_scanner: 6.0.2
+  torch_light: 1.1.0
+
   scanner_shared:
     path: ../shared
 

--- a/packages/smooth_app/android/app/build.gradle
+++ b/packages/smooth_app/android/app/build.gradle
@@ -26,7 +26,7 @@ android {
 
     defaultConfig {
         applicationId "org.openfoodfacts.scanner"
-        minSdk = flutter.minSdkVersion
+        minSdk = 23
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName

--- a/packages/smooth_app/ios/Podfile
+++ b/packages/smooth_app/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-platform :ios, '12.0'
+platform :ios, '15.5'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/packages/smooth_app/ios/Podfile.lock
+++ b/packages/smooth_app/ios/Podfile.lock
@@ -26,40 +26,29 @@ PODS:
     - Flutter
   - flutter_secure_storage (6.0.0):
     - Flutter
-  - GoogleDataTransport (9.4.1):
-    - GoogleUtilities/Environment (~> 7.7)
-    - nanopb (< 2.30911.0, >= 2.30908.0)
-    - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleMLKit/BarcodeScanning (4.0.0):
+  - GoogleDataTransport (10.1.0):
+    - nanopb (~> 3.30910.0)
+    - PromisesObjC (~> 2.4)
+  - GoogleMLKit/BarcodeScanning (7.0.0):
     - GoogleMLKit/MLKitCore
-    - MLKitBarcodeScanning (~> 3.0.0)
-  - GoogleMLKit/MLKitCore (4.0.0):
-    - MLKitCommon (~> 9.0.0)
-  - GoogleToolboxForMac/DebugUtils (2.3.2):
-    - GoogleToolboxForMac/Defines (= 2.3.2)
-  - GoogleToolboxForMac/Defines (2.3.2)
-  - GoogleToolboxForMac/Logger (2.3.2):
-    - GoogleToolboxForMac/Defines (= 2.3.2)
-  - "GoogleToolboxForMac/NSData+zlib (2.3.2)":
-    - GoogleToolboxForMac/Defines (= 2.3.2)
-  - "GoogleToolboxForMac/NSDictionary+URLArguments (2.3.2)":
-    - GoogleToolboxForMac/DebugUtils (= 2.3.2)
-    - GoogleToolboxForMac/Defines (= 2.3.2)
-    - "GoogleToolboxForMac/NSString+URLArguments (= 2.3.2)"
-  - "GoogleToolboxForMac/NSString+URLArguments (2.3.2)"
-  - GoogleUtilities/Environment (7.13.3):
+    - MLKitBarcodeScanning (~> 6.0.0)
+  - GoogleMLKit/MLKitCore (7.0.0):
+    - MLKitCommon (~> 12.0.0)
+  - GoogleToolboxForMac/Defines (4.2.1)
+  - GoogleToolboxForMac/Logger (4.2.1):
+    - GoogleToolboxForMac/Defines (= 4.2.1)
+  - "GoogleToolboxForMac/NSData+zlib (4.2.1)":
+    - GoogleToolboxForMac/Defines (= 4.2.1)
+  - GoogleUtilities/Environment (8.0.2):
     - GoogleUtilities/Privacy
-    - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/Logger (7.13.3):
+  - GoogleUtilities/Logger (8.0.2):
     - GoogleUtilities/Environment
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Privacy (7.13.3)
-  - GoogleUtilities/UserDefaults (7.13.3):
+  - GoogleUtilities/Privacy (8.0.2)
+  - GoogleUtilities/UserDefaults (8.0.2):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
-  - GoogleUtilitiesComponents (1.1.0):
-    - GoogleUtilities/Logger
-  - GTMSessionFetcher/Core (2.3.0)
+  - GTMSessionFetcher/Core (3.5.0)
   - image_picker_ios (0.0.1):
     - Flutter
   - in_app_review (0.2.0):
@@ -83,33 +72,32 @@ PODS:
   - Mantle (2.2.0):
     - Mantle/extobjc (= 2.2.0)
   - Mantle/extobjc (2.2.0)
-  - MLImage (1.0.0-beta4)
-  - MLKitBarcodeScanning (3.0.0):
-    - MLKitCommon (~> 9.0)
-    - MLKitVision (~> 5.0)
-  - MLKitCommon (9.0.0):
-    - GoogleDataTransport (~> 9.0)
-    - GoogleToolboxForMac/Logger (~> 2.1)
-    - "GoogleToolboxForMac/NSData+zlib (~> 2.1)"
-    - "GoogleToolboxForMac/NSDictionary+URLArguments (~> 2.1)"
-    - GoogleUtilities/UserDefaults (~> 7.0)
-    - GoogleUtilitiesComponents (~> 1.0)
-    - GTMSessionFetcher/Core (< 3.0, >= 1.1)
-  - MLKitVision (5.0.0):
-    - GoogleToolboxForMac/Logger (~> 2.1)
-    - "GoogleToolboxForMac/NSData+zlib (~> 2.1)"
-    - GTMSessionFetcher/Core (< 3.0, >= 1.1)
-    - MLImage (= 1.0.0-beta4)
-    - MLKitCommon (~> 9.0)
-  - mobile_scanner (3.5.6):
+  - MLImage (1.0.0-beta6)
+  - MLKitBarcodeScanning (6.0.0):
+    - MLKitCommon (~> 12.0)
+    - MLKitVision (~> 8.0)
+  - MLKitCommon (12.0.0):
+    - GoogleDataTransport (~> 10.0)
+    - GoogleToolboxForMac/Logger (< 5.0, >= 4.2.1)
+    - "GoogleToolboxForMac/NSData+zlib (< 5.0, >= 4.2.1)"
+    - GoogleUtilities/Logger (~> 8.0)
+    - GoogleUtilities/UserDefaults (~> 8.0)
+    - GTMSessionFetcher/Core (< 4.0, >= 3.3.2)
+  - MLKitVision (8.0.0):
+    - GoogleToolboxForMac/Logger (< 5.0, >= 4.2.1)
+    - "GoogleToolboxForMac/NSData+zlib (< 5.0, >= 4.2.1)"
+    - GTMSessionFetcher/Core (< 4.0, >= 3.3.2)
+    - MLImage (= 1.0.0-beta6)
+    - MLKitCommon (~> 12.0)
+  - mobile_scanner (6.0.2):
     - Flutter
-    - GoogleMLKit/BarcodeScanning (~> 4.0.0)
+    - GoogleMLKit/BarcodeScanning (~> 7.0.0)
   - MTBBarcodeScanner (5.0.11)
-  - nanopb (2.30910.0):
-    - nanopb/decode (= 2.30910.0)
-    - nanopb/encode (= 2.30910.0)
-  - nanopb/decode (2.30910.0)
-  - nanopb/encode (2.30910.0)
+  - nanopb (3.30910.0):
+    - nanopb/decode (= 3.30910.0)
+    - nanopb/encode (= 3.30910.0)
+  - nanopb/decode (3.30910.0)
+  - nanopb/encode (3.30910.0)
   - package_info_plus (0.4.5):
     - Flutter
   - path_provider_foundation (0.0.1):
@@ -121,12 +109,12 @@ PODS:
   - qr_code_scanner (0.2.0):
     - Flutter
     - MTBBarcodeScanner
-  - ReachabilitySwift (5.2.3)
+  - ReachabilitySwift (5.2.4)
   - rive_common (0.0.1):
     - Flutter
-  - SDWebImage (5.19.7):
-    - SDWebImage/Core (= 5.19.7)
-  - SDWebImage/Core (5.19.7)
+  - SDWebImage (5.20.0):
+    - SDWebImage/Core (= 5.20.0)
+  - SDWebImage/Core (5.20.0)
   - SDWebImageWebPCoder (0.14.6):
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.17)
@@ -143,6 +131,8 @@ PODS:
   - sqflite_darwin (0.0.4):
     - Flutter
     - FlutterMacOS
+  - torch_light (0.0.1):
+    - Flutter
   - url_launcher_ios (0.0.1):
     - Flutter
   - webview_flutter_wkwebview (0.0.1):
@@ -176,6 +166,7 @@ DEPENDENCIES:
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - sqflite_darwin (from `.symlinks/plugins/sqflite_darwin/darwin`)
+  - torch_light (from `.symlinks/plugins/torch_light/ios`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
   - webview_flutter_wkwebview (from `.symlinks/plugins/webview_flutter_wkwebview/darwin`)
 
@@ -185,7 +176,6 @@ SPEC REPOS:
     - GoogleMLKit
     - GoogleToolboxForMac
     - GoogleUtilities
-    - GoogleUtilitiesComponents
     - GTMSessionFetcher
     - libwebp
     - Mantle
@@ -254,60 +244,62 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
   sqflite_darwin:
     :path: ".symlinks/plugins/sqflite_darwin/darwin"
+  torch_light:
+    :path: ".symlinks/plugins/torch_light/ios"
   url_launcher_ios:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
   webview_flutter_wkwebview:
     :path: ".symlinks/plugins/webview_flutter_wkwebview/darwin"
 
 SPEC CHECKSUMS:
-  app_settings: 017320c6a680cdc94c799949d95b84cb69389ebc
-  audioplayers_darwin: 877d9a4d06331c5c374595e46e16453ac7eafa40
-  camera_avfoundation: dd002b0330f4981e1bbcb46ae9b62829237459a4
-  connectivity_plus: bf0076dd84a130856aa636df1c71ccaff908fa1d
-  device_info_plus: 97af1d7e84681a90d0693e63169a5d50e0839a0d
+  app_settings: 3507c575c2b18a462c99948f61d5de21d4420999
+  audioplayers_darwin: ccf9c770ee768abb07e26d90af093f7bab1c12ab
+  camera_avfoundation: 04b44aeb14070126c6529e5ab82cc7c9fca107cf
+  connectivity_plus: 481668c94744c30c53b8895afb39159d1e619bdf
+  device_info_plus: 71ffc6ab7634ade6267c7a93088ed7e4f74e5896
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_custom_tabs_ios: a651b18786388923b62de8c0537607de87c2eccf
-  flutter_email_sender: 10a22605f92809a11ef52b2f412db806c6082d40
-  flutter_icmp_ping: 2b159955eee0c487c766ad83fec224ae35e7c935
-  flutter_image_compress_common: ec1d45c362c9d30a3f6a0426c297f47c52007e3e
-  flutter_native_splash: e8a1e01082d97a8099d973f919f57904c925008a
-  flutter_secure_storage: d33dac7ae2ea08509be337e775f6b59f1ff45f12
-  GoogleDataTransport: 6c09b596d841063d76d4288cc2d2f42cc36e1e2a
-  GoogleMLKit: 2bd0dc6253c4d4f227aad460f69215a504b2980e
-  GoogleToolboxForMac: 8bef7c7c5cf7291c687cf5354f39f9db6399ad34
-  GoogleUtilities: ea963c370a38a8069cc5f7ba4ca849a60b6d7d15
-  GoogleUtilitiesComponents: 679b2c881db3b615a2777504623df6122dd20afe
-  GTMSessionFetcher: 3a63d75eecd6aa32c2fc79f578064e1214dfdec2
-  image_picker_ios: c560581cceedb403a6ff17f2f816d7fea1421fc1
-  in_app_review: 318597b3a06c22bb46dc454d56828c85f444f99d
-  integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
-  iso_countries: eb09d40f388e4c65e291e0bb36a701dfe7de6c74
+  flutter_custom_tabs_ios: dd647919edd75e82ba6b00009eb3460a28c011b8
+  flutter_email_sender: 2397f5e84aaacfb61af569637a963e7c687858d8
+  flutter_icmp_ping: 47c1df3440c18ddd39fc457e607bb3b42d4a339f
+  flutter_image_compress_common: 1697a328fd72bfb335507c6bca1a65fa5ad87df1
+  flutter_native_splash: 576fbd69b830a63594ae678396fa17e43abbc5f8
+  flutter_secure_storage: 1ed9476fba7e7a782b22888f956cce43e2c62f13
+  GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
+  GoogleMLKit: eff9e23ec1d90ea4157a1ee2e32a4f610c5b3318
+  GoogleToolboxForMac: d1a2cbf009c453f4d6ded37c105e2f67a32206d8
+  GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
+  GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
+  image_picker_ios: 7fe1ff8e34c1790d6fff70a32484959f563a928a
+  in_app_review: 8efcf4a4d3ba72d5d776d29e5a268f1abf64d184
+  integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
+  iso_countries: 7ca741b02ae533b86f1f18a8bb52961d776ac77e
   libwebp: 1786c9f4ff8a279e4dac1e8f385004d5fc253009
   Mantle: c5aa8794a29a022dfbbfc9799af95f477a69b62d
-  MLImage: 7bb7c4264164ade9bf64f679b40fb29c8f33ee9b
-  MLKitBarcodeScanning: 04e264482c5f3810cb89ebc134ef6b61e67db505
-  MLKitCommon: c1b791c3e667091918d91bda4bba69a91011e390
-  MLKitVision: 8baa5f46ee3352614169b85250574fde38c36f49
-  mobile_scanner: 38dcd8a49d7d485f632b7de65e4900010187aef2
+  MLImage: 0ad1c5f50edd027672d8b26b0fee78a8b4a0fc56
+  MLKitBarcodeScanning: 0a3064da0a7f49ac24ceb3cb46a5bc67496facd2
+  MLKitCommon: 07c2c33ae5640e5380beaaa6e4b9c249a205542d
+  MLKitVision: 45e79d68845a2de77e2dd4d7f07947f0ed157b0e
+  mobile_scanner: af8f71879eaba2bbcb4d86c6a462c3c0e7f23036
   MTBBarcodeScanner: f453b33c4b7dfe545d8c6484ed744d55671788cb
-  nanopb: 438bc412db1928dac798aa6fd75726007be04262
-  package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
-  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
-  permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
+  nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
+  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
+  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
+  permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
-  qr_code_scanner: bb67d64904c3b9658ada8c402e8b4d406d5d796e
-  ReachabilitySwift: 7f151ff156cea1481a8411701195ac6a984f4979
-  rive_common: cbbac3192af00d7341f19dae2f26298e9e37d99e
-  SDWebImage: 8a6b7b160b4d710e2a22b6900e25301075c34cb3
+  qr_code_scanner: d77f94ecc9abf96d9b9b8fc04ef13f611e5a147a
+  ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
+  rive_common: dd421daaf9ae69f0125aa761dd96abd278399952
+  SDWebImage: 73c6079366fea25fa4bb9640d5fb58f0893facd8
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   Sentry: f8374b5415bc38dfb5645941b3ae31230fbeae57
-  sentry_flutter: 0eb93e5279eb41e2392212afe1ccd2fecb4f8cbe
-  share_plus: 8b6f8b3447e494cca5317c8c3073de39b3600d1f
-  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
-  sqflite_darwin: 5a7236e3b501866c1c9befc6771dfd73ffb8702d
-  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
-  webview_flutter_wkwebview: 0982481e3d9c78fd5c6f62a002fcd24fc791f1e4
+  sentry_flutter: 0a211008f52553ba5dd81ceb71f48d78f0f1f6ab
+  share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
+  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
+  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
+  torch_light: d093d579a221a59ef8a6b8c0eca20d52f7178087
+  url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
+  webview_flutter_wkwebview: 44d4dee7d7056d5ad185d25b38404436d56c547c
 
-PODFILE CHECKSUM: 798cbe17fd0f5e52d4df92f6b2f3257201f5868e
+PODFILE CHECKSUM: 6ac49c02151268e5844d0422787205b7cbdd62d2
 
 COCOAPODS: 1.16.2

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -201,18 +201,18 @@ packages:
     dependency: "direct main"
     description:
       name: camera
-      sha256: dfa8fc5a1adaeb95e7a54d86a5bd56f4bb0e035515354c8ac6d262e35cec2ec8
+      sha256: "26ff41045772153f222ffffecba711a206f670f5834d40ebf5eed3811692f167"
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.6"
-  camera_android:
+    version: "0.11.0+2"
+  camera_android_camerax:
     dependency: transitive
     description:
-      name: camera_android
-      sha256: eacc70b6c81fa5e17921302fc17a1ae5983d94ce1d76c71e4869abdc615d35d2
+      name: camera_android_camerax
+      sha256: abcfa1ac32bd03116b4cfda7e8223ab391f01966e65823c064afe388550d1b3d
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.9+8"
+    version: "0.6.10+3"
   camera_avfoundation:
     dependency: transitive
     description:
@@ -1044,10 +1044,10 @@ packages:
     dependency: transitive
     description:
       name: mobile_scanner
-      sha256: "827765afbd4792ff3fd105ad593821ac0f6d8a7d352689013b07ee85be336312"
+      sha256: "728828a798d1a2ee506beb652ca23d974c542c96ed03dcbd5eaf97bef96cdaad"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.1"
+    version: "6.0.2"
   mockito:
     dependency: "direct dev"
     description:
@@ -1603,6 +1603,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.2"
+  torch_light:
+    dependency: transitive
+    description:
+      name: torch_light
+      sha256: a1397443a375c6991151547cb77361085df6cf8aa59999292e683db7385a0d15
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   typed_data:
     dependency: transitive
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -87,7 +87,7 @@ dependencies:
   # We use two different scanning engines, 
   # mobile scanner powered by ML Kit for the Play Store and Apple App Store,
   # but qr_code_scanner which uses the open source ZXing for F-Droid
-  camera: 0.10.6
+  camera: 0.11.0+2
   
   scanner_shared:
     path: ../scanner/shared


### PR DESCRIPTION
Hi everyone!

I won't have enough time to embed the new homepage in the app.
Here is, at least, a bump to the latest versions of `camera/mobile_scanner`.

Now, the scanner will start/stop correctly.
I also have to bump the min version (iOS 15 and Android 6)