### PR TITLE
fix: Improve the camera permission denied on tiny screens

### DIFF
--- a/packages/smooth_app/lib/pages/scan/scan_page.dart
+++ b/packages/smooth_app/lib/pages/scan/scan_page.dart
@@ -200,28 +200,30 @@ class _PermissionDeniedCard extends StatelessWidget {
                       ),
                       textAlign: TextAlign.center,
                     ),
-                    SingleChildScrollView(
-                      child: Padding(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: BALANCED_SPACE,
-                          vertical: BALANCED_SPACE,
-                        ),
-                        child: Text(
-                          localizations.permission_photo_denied_message(
-                            APP_NAME,
-                          ),
-                          textAlign: TextAlign.center,
-                          style: const TextStyle(
-                            height: 1.4,
-                            fontSize: 15.5,
-                          ),
-                        ),
-                      ),
-                    ),
                     SmoothActionButtonsBar.single(
                       action: SmoothActionButton(
                         text: localizations.permission_photo_denied_button,
                         onPressed: () => _askPermission(context),
+                      ),
+                    ),
+                    Expanded(
+                      child: SingleChildScrollView(
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: BALANCED_SPACE,
+                            vertical: BALANCED_SPACE,
+                          ),
+                          child: Text(
+                            localizations.permission_photo_denied_message(
+                              APP_NAME,
+                            ),
+                            textAlign: TextAlign.center,
+                            style: const TextStyle(
+                              height: 1.4,
+                              fontSize: 15.5,
+                            ),
+                          ),
+                        ),
                       ),
                     ),
                   ],


### PR DESCRIPTION
Hi everyone,

On small screens + with a font multiplier, the button allowing the camera permission requires scrolling.
It's now between the title and the message.

Clearly, that layout sucks.
![Screenshot_1735446495](https://github.com/user-attachments/assets/1e02959b-08ab-4a4a-8eb7-736a1b8deda9)
