### PR TITLE
fix: Force the color of the Scan buttons

### DIFF
--- a/packages/smooth_app/lib/pages/scan/scan_header.dart
+++ b/packages/smooth_app/lib/pages/scan/scan_header.dart
@@ -30,6 +30,9 @@ class _ScanHeaderState extends State<ScanHeader> {
           borderRadius: BorderRadius.all(Radius.circular(18.0)),
         ),
       ),
+      iconColor: WidgetStateProperty.all<Color>(
+        Theme.of(context).colorScheme.onPrimary,
+      ),
       foregroundColor: WidgetStateProperty.all<Color>(
         Theme.of(context).colorScheme.onPrimary,
       ),


### PR DESCRIPTION
Regression after the migration to Flutter 3.27
![IMG_B54CBC448B4E-1](https://github.com/user-attachments/assets/2bb34a93-6b1d-4865-aa34-b34bdd0def22)
