### PR TITLE
chore: 3 Providers lazy loaded

### DIFF
--- a/packages/smooth_app/lib/main.dart
+++ b/packages/smooth_app/lib/main.dart
@@ -118,8 +118,6 @@ late ProductPreferences _productPreferences;
 late LocalDatabase _localDatabase;
 late ThemeProvider _themeProvider;
 final ContinuousScanModel _continuousScanModel = ContinuousScanModel();
-final PermissionListener _permissionListener =
-    PermissionListener(permission: Permission.camera);
 bool _init1done = false;
 
 // Had to split init in 2 methods, for test/screenshots reasons.
@@ -221,8 +219,9 @@ class _SmoothAppState extends State<SmoothApp> {
             _provide<ProductPreferences>(_productPreferences),
             _provide<UserManagementProvider>(_userManagementProvider),
             _provide<LocalDatabase>(_localDatabase),
-            _provide<PermissionListener>(_permissionListener),
-
+            _lazyProvide<PermissionListener>(
+              (_) => PermissionListener(permission: Permission.camera),
+            ),
             _provide<ThemeProvider>(_themeProvider),
 
             /// The next two providers are only used with the AMOLED theme
@@ -232,11 +231,9 @@ class _SmoothAppState extends State<SmoothApp> {
             _lazyProvide<TextContrastProvider>(
               (_) => TextContrastProvider(_userPreferences),
             ),
+            _provide<ContinuousScanModel>(_continuousScanModel),
 
-            /// The next two providers are only used after the onboarding
-            _lazyProvide<ContinuousScanModel>(
-              (_) => _continuousScanModel,
-            ),
+            /// Only used after the onboarding
             _lazyProvide<AppNewsProvider>(
               (_) => AppNewsProvider(_userPreferences),
             ),

--- a/packages/smooth_app/lib/main.dart
+++ b/packages/smooth_app/lib/main.dart
@@ -117,8 +117,6 @@ late UserPreferences _userPreferences;
 late ProductPreferences _productPreferences;
 late LocalDatabase _localDatabase;
 late ThemeProvider _themeProvider;
-late ColorProvider _colorProvider;
-late TextContrastProvider _textContrastProvider;
 final ContinuousScanModel _continuousScanModel = ContinuousScanModel();
 final PermissionListener _permissionListener =
     PermissionListener(permission: Permission.camera);
@@ -154,8 +152,6 @@ Future<bool> _init1() async {
 
   await ProductQuery.initCountry(_userPreferences);
   _themeProvider = ThemeProvider(_userPreferences);
-  _colorProvider = ColorProvider(_userPreferences);
-  _textContrastProvider = TextContrastProvider(_userPreferences);
 
   await CameraHelper.init();
   await ProductQuery.setUuid(_localDatabase);
@@ -214,15 +210,6 @@ class _SmoothAppState extends State<SmoothApp> {
           return EMPTY_WIDGET;
         }
 
-        // The `create` constructor of [ChangeNotifierProvider] takes care of
-        // disposing the value.
-        ChangeNotifierProvider<T> provide<T extends ChangeNotifier>(T value,
-                {bool? lazy}) =>
-            ChangeNotifierProvider<T>(
-              create: (BuildContext context) => value,
-              lazy: lazy,
-            );
-
         if (!_screenshots) {
           // ending FlutterNativeSplash.preserve()
           FlutterNativeSplash.remove();
@@ -230,29 +217,37 @@ class _SmoothAppState extends State<SmoothApp> {
 
         return MultiProvider(
           providers: <SingleChildWidget>[
-            provide<UserPreferences>(_userPreferences),
-            provide<ProductPreferences>(_productPreferences),
-            provide<LocalDatabase>(_localDatabase),
-            provide<ThemeProvider>(_themeProvider),
-            provide<ColorProvider>(_colorProvider),
-            provide<TextContrastProvider>(_textContrastProvider),
-            provide<UserManagementProvider>(_userManagementProvider),
-            provide<ContinuousScanModel>(_continuousScanModel),
-            provide<PermissionListener>(_permissionListener),
-          ],
-          child: ChangeNotifierProvider<AppNewsProvider>(
-            create: (BuildContext context) => AppNewsProvider(
-              context.read<UserPreferences>(),
+            _provide<UserPreferences>(_userPreferences),
+            _provide<ProductPreferences>(_productPreferences),
+            _provide<UserManagementProvider>(_userManagementProvider),
+            _provide<LocalDatabase>(_localDatabase),
+            _provide<PermissionListener>(_permissionListener),
+
+            _provide<ThemeProvider>(_themeProvider),
+
+            /// The next two providers are only used with the AMOLED theme
+            _lazyProvide<ColorProvider>(
+              (_) => ColorProvider(_userPreferences),
             ),
-            lazy: true,
-            child: AnimationsLoader(
-              child: AppNavigator(
-                observers: <NavigatorObserver>[
-                  SentryNavigatorObserver(),
-                  matomoObserver,
-                ],
-                child: Builder(builder: _buildApp),
-              ),
+            _lazyProvide<TextContrastProvider>(
+              (_) => TextContrastProvider(_userPreferences),
+            ),
+
+            /// The next two providers are only used after the onboarding
+            _lazyProvide<ContinuousScanModel>(
+              (_) => _continuousScanModel,
+            ),
+            _lazyProvide<AppNewsProvider>(
+              (_) => AppNewsProvider(_userPreferences),
+            ),
+          ],
+          child: AnimationsLoader(
+            child: AppNavigator(
+              observers: <NavigatorObserver>[
+                SentryNavigatorObserver(),
+                matomoObserver,
+              ],
+              child: Builder(builder: _buildApp),
             ),
           ),
         );
@@ -260,11 +255,21 @@ class _SmoothAppState extends State<SmoothApp> {
     );
   }
 
+  ChangeNotifierProvider<T> _provide<T extends ChangeNotifier>(T value) =>
+      ChangeNotifierProvider<T>(
+        create: (BuildContext context) => value,
+      );
+
+  ChangeNotifierProvider<T> _lazyProvide<T extends ChangeNotifier>(
+    T Function(BuildContext) valueBuilder,
+  ) =>
+      ChangeNotifierProvider<T>(
+        create: valueBuilder,
+        lazy: true,
+      );
+
   Widget _buildApp(BuildContext context) {
     final ThemeProvider themeProvider = context.watch<ThemeProvider>();
-    final ColorProvider colorProvider = context.watch<ColorProvider>();
-    final TextContrastProvider textContrastProvider =
-        context.watch<TextContrastProvider>();
     final OnboardingPage lastVisitedOnboardingPage =
         _userPreferences.lastVisitedOnboardingPage;
     OnboardingFlowNavigator(_userPreferences);
@@ -287,14 +292,14 @@ class _SmoothAppState extends State<SmoothApp> {
         theme: SmoothTheme.getThemeData(
           Brightness.light,
           themeProvider,
-          colorProvider,
-          textContrastProvider,
+          () => context.watch<ColorProvider>(),
+          () => context.watch<TextContrastProvider>(),
         ),
         darkTheme: SmoothTheme.getThemeData(
           Brightness.dark,
           themeProvider,
-          colorProvider,
-          textContrastProvider,
+          () => context.watch<ColorProvider>(),
+          () => context.watch<TextContrastProvider>(),
         ),
         themeMode: themeProvider.currentThemeMode,
         routerConfig: AppNavigator.of(context).router,

--- a/packages/smooth_app/lib/themes/smooth_theme.dart
+++ b/packages/smooth_app/lib/themes/smooth_theme.dart
@@ -16,8 +16,8 @@ class SmoothTheme {
   static ThemeData getThemeData(
     final Brightness brightness,
     final ThemeProvider themeProvider,
-    final ColorProvider colorProvider,
-    final TextContrastProvider textContrastProvider,
+    final ColorProvider Function() colorProvider,
+    final TextContrastProvider Function() textContrastProvider,
   ) {
     ColorScheme myColorScheme;
 
@@ -25,10 +25,12 @@ class SmoothTheme {
       myColorScheme = lightColorScheme;
     } else {
       if (themeProvider.currentTheme == THEME_AMOLED) {
+        final ColorProvider colorNotifier = colorProvider();
+
         myColorScheme = trueDarkColorScheme.copyWith(
-          primary: getColorValue(colorProvider.currentColor),
+          primary: getColorValue(colorNotifier.currentColor),
           secondary: getShade(
-            getColorValue(colorProvider.currentColor),
+            getColorValue(colorNotifier.currentColor),
             darker: true,
             value: SECONDARY_COLOR_SHADE_VALUE,
           ),
@@ -167,9 +169,11 @@ class SmoothTheme {
   }
 
   static TextTheme getTextTheme(
-      ThemeProvider themeProvider, TextContrastProvider textContrastProvider) {
+    ThemeProvider themeProvider,
+    TextContrastProvider Function() textContrastProvider,
+  ) {
     final Color contrastLevel = themeProvider.currentTheme == THEME_AMOLED
-        ? getTextContrastLevel(textContrastProvider.currentContrastLevel)
+        ? getTextContrastLevel(textContrastProvider().currentContrastLevel)
         : Colors.white;
 
     return _TEXT_THEME.copyWith(

--- a/packages/smooth_app/test/tests_utils/mocks.dart
+++ b/packages/smooth_app/test/tests_utils/mocks.dart
@@ -62,14 +62,14 @@ class MockSmoothApp extends StatelessWidget {
           theme: SmoothTheme.getThemeData(
             Brightness.light,
             themeProvider,
-            () => context.watch<ColorProvider>(),
-            () => context.watch<TextContrastProvider>(),
+            () => colorProvider,
+            () => textContrastProvider,
           ),
           darkTheme: SmoothTheme.getThemeData(
             Brightness.dark,
             themeProvider,
-            () => context.watch<ColorProvider>(),
-            () => context.watch<TextContrastProvider>(),
+            () => colorProvider,
+            () => textContrastProvider,
           ),
           themeMode: themeProvider.currentThemeMode,
           home: child,

--- a/packages/smooth_app/test/tests_utils/mocks.dart
+++ b/packages/smooth_app/test/tests_utils/mocks.dart
@@ -62,14 +62,14 @@ class MockSmoothApp extends StatelessWidget {
           theme: SmoothTheme.getThemeData(
             Brightness.light,
             themeProvider,
-            colorProvider,
-            textContrastProvider,
+            () => context.watch<ColorProvider>(),
+            () => context.watch<TextContrastProvider>(),
           ),
           darkTheme: SmoothTheme.getThemeData(
             Brightness.dark,
             themeProvider,
-            colorProvider,
-            textContrastProvider,
+            () => context.watch<ColorProvider>(),
+            () => context.watch<TextContrastProvider>(),
           ),
           themeMode: themeProvider.currentThemeMode,
           home: child,


### PR DESCRIPTION
Hi everyone!

On start, we load several Providers for nothing.
-> `ColorProvider` and `ThemeConstrastProvider` are only used with the AMOLED theme
-> `AppNewsProvider` is only required after the onboarding
-> `PermissionListener` is required during the onboarding or after

By using a lazy loading mechanism, it will only init them if required.
It could improve a bit the time to launch the onboarding.

There's no issue in the code, the Providers will only be loaded when needed.