### PR TITLE
feat: Ignore invalid barcodes

### DIFF
--- a/packages/smooth_app/lib/data_models/continuous_scan_model.dart
+++ b/packages/smooth_app/lib/data_models/continuous_scan_model.dart
@@ -117,6 +117,9 @@ class ContinuousScanModel with ChangeNotifier {
     }
 
     code = _fixBarcodeIfNecessary(code);
+    if (code.length < 4) {
+      return false;
+    }
 
     if (_latestScannedBarcode == code || _barcodes.contains(code)) {
       lastConsultedBarcode = code;
@@ -295,7 +298,7 @@ class ContinuousScanModel with ChangeNotifier {
   /// Sometimes the scanner may fail, this is a simple fix for now
   /// But could be improved in the future
   String _fixBarcodeIfNecessary(String code) {
-    code = code.replaceAll('-', '');
+    code = code.replaceAll('-', '').trim();
 
     if (code.length == 12) {
       return '0$code';


### PR DESCRIPTION
Hi everyone!

We have a lot of invalid barcodes that are added to the carousel (thanks to https://github.com/openfoodfacts/smooth-app/issues/6051).
This PR will eliminate some of them just by checking the length.