### PR TITLE
feat: Better management of selectable texts on the product page

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/product_title_card.dart
+++ b/packages/smooth_app/lib/cards/product_cards/product_title_card.dart
@@ -5,7 +5,6 @@ import 'package:provider/provider.dart';
 import 'package:smooth_app/cards/product_cards/smooth_product_base_card.dart';
 import 'package:smooth_app/cards/product_cards/smooth_product_image.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
-import 'package:smooth_app/helpers/extension_on_text_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/pages/product/gallery_view/product_image_gallery_view.dart';
 
@@ -32,12 +31,36 @@ class ProductTitleCard extends StatelessWidget {
       selectable: isSelectable,
     );
 
-    final List<Widget> children;
-
     final Size imageSize =
         Size.square(MediaQuery.sizeOf(context).width * (dense ? 0.22 : 0.25));
 
-    children = <Widget>[
+    Widget child = Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: <Widget>[
+        ConstrainedBox(
+          constraints: BoxConstraints(
+            minHeight: DefaultTextStyle.of(context).style.fontSize! * 2.0,
+          ),
+          child: _ProductTitleCardName(
+            selectable: isSelectable,
+            dense: dense,
+          ),
+        ),
+        const SizedBox(height: SMALL_SPACE),
+        _ProductTitleCardBrand(
+          selectable: isSelectable,
+        ),
+        const SizedBox(height: 2.0),
+        trailing,
+      ],
+    );
+
+    if (isSelectable) {
+      child = SelectionArea(child: child);
+    }
+
+    final List<Widget> children = <Widget>[
       Padding(
         padding: const EdgeInsetsDirectional.only(top: SMALL_SPACE),
         child: IntrinsicHeight(
@@ -80,28 +103,9 @@ class ProductTitleCard extends StatelessWidget {
                     top: VERY_SMALL_SPACE,
                     bottom: VERY_SMALL_SPACE,
                   ),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: <Widget>[
-                      ConstrainedBox(
-                        constraints: BoxConstraints(
-                          minHeight:
-                              DefaultTextStyle.of(context).style.fontSize! *
-                                  2.0,
-                        ),
-                        child: _ProductTitleCardName(
-                          selectable: isSelectable,
-                          dense: dense,
-                        ),
-                      ),
-                      const SizedBox(height: SMALL_SPACE),
-                      _ProductTitleCardBrand(
-                        selectable: isSelectable,
-                      ),
-                      const SizedBox(height: 2.0),
-                      trailing,
-                    ],
+                  child: SelectionArea(
+                    selectionControls: null,
+                    child: child,
                   ),
                 ),
               ),
@@ -146,7 +150,7 @@ class _ProductTitleCardName extends StatelessWidget {
       textAlign: TextAlign.start,
       maxLines: dense ? 2 : null,
       overflow: TextOverflow.ellipsis,
-    ).selectable(isSelectable: selectable);
+    );
   }
 }
 
@@ -168,7 +172,7 @@ class _ProductTitleCardBrand extends StatelessWidget {
       brands,
       style: Theme.of(context).textTheme.bodyMedium,
       textAlign: TextAlign.start,
-    ).selectable(isSelectable: selectable);
+    );
   }
 }
 
@@ -187,6 +191,6 @@ class _ProductTitleCardTrailing extends StatelessWidget {
       product.quantity ?? '',
       style: Theme.of(context).textTheme.bodyMedium,
       textAlign: TextAlign.end,
-    ).selectable(isSelectable: selectable);
+    );
   }
 }

--- a/packages/smooth_app/lib/generic_lib/smooth_html_widget.dart
+++ b/packages/smooth_app/lib/generic_lib/smooth_html_widget.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_widget_from_html_core/flutter_widget_from_html_core.dart';
-import 'package:fwfh_selectable_text/fwfh_selectable_text.dart';
 import 'package:html/dom.dart' as dom;
 import 'package:smooth_app/helpers/launch_url_helper.dart';
 
@@ -52,5 +51,17 @@ class SmoothHtmlWidget extends StatelessWidget {
   }
 }
 
-class SelectableHtmlWidgetFactory extends WidgetFactory
-    with SelectableTextFactory {}
+class SelectableHtmlWidgetFactory extends WidgetFactory {
+  @override
+  Widget buildText(
+    BuildTree tree,
+    InheritedProperties resolved,
+    InlineSpan text,
+  ) {
+    return SelectableText.rich(
+      TextSpan(
+        children: <InlineSpan>[text],
+      ),
+    );
+  }
+}

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_group_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_group_card.dart
@@ -27,33 +27,35 @@ class KnowledgePanelGroupCard extends StatelessWidget {
     return Provider<KnowledgePanelPanelGroupElement>(
       lazy: true,
       create: (_) => groupElement,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          if (groupElement.title != null && groupElement.title!.isNotEmpty)
-            Padding(
-              padding: const EdgeInsetsDirectional.only(top: LARGE_SPACE),
-              child: Semantics(
-                explicitChildNodes: true,
-                child: Text(
-                  groupElement.title!,
-                  style: themeData.textTheme.titleSmall!.copyWith(
-                    fontSize: 15.5,
-                    fontWeight: FontWeight.w700,
-                    color: context.lightTheme()
-                        ? themeExtension.primaryUltraBlack
-                        : themeExtension.primaryLight,
+      child: SelectionArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            if (groupElement.title != null && groupElement.title!.isNotEmpty)
+              Padding(
+                padding: const EdgeInsetsDirectional.only(top: LARGE_SPACE),
+                child: Semantics(
+                  explicitChildNodes: true,
+                  child: Text(
+                    groupElement.title!,
+                    style: themeData.textTheme.titleSmall!.copyWith(
+                      fontSize: 15.5,
+                      fontWeight: FontWeight.w700,
+                      color: context.lightTheme()
+                          ? themeExtension.primaryUltraBlack
+                          : themeExtension.primaryLight,
+                    ),
                   ),
                 ),
               ),
-            ),
-          for (final String panelId in groupElement.panelIds)
-            KnowledgePanelCard(
-              panelId: panelId,
-              product: product,
-              isClickable: isClickable,
-            )
-        ],
+            for (final String panelId in groupElement.panelIds)
+              KnowledgePanelCard(
+                panelId: panelId,
+                product: product,
+                isClickable: isClickable,
+              )
+          ],
+        ),
       ),
     );
   }

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -334,10 +334,10 @@ packages:
     dependency: transitive
     description:
       name: csslib
-      sha256: "831883fb353c8bdc1d71979e5b342c7d88acfbc643113c14ae51e2442ea0f20f"
+      sha256: "09bad715f418841f976c77db72d5398dc1253c21fb9c0c7f0b0b985860b2d58e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.17.3"
+    version: "1.0.2"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -719,31 +719,15 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_widget_from_html_core
-      sha256: "23c72f8ce7ba1fd6f8fbdc107f07e04fe152ffd587be1b012938904bfda31950"
+      sha256: b1048fd119a14762e2361bd057da608148a895477846d6149109b2151d2f7abf
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.3+1"
+    version: "0.15.2"
   fuchsia_remote_debug_protocol:
     dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
-  fwfh_selectable_text:
-    dependency: "direct main"
-    description:
-      name: fwfh_selectable_text
-      sha256: "55a17a85c0b5e26833127c57fc7864055799c1c2dfdb2ed665ac925222718901"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.8.3+1"
-  fwfh_text_style:
-    dependency: transitive
-    description:
-      name: fwfh_text_style
-      sha256: "5f8b587fd223a6bf14aad3d3da5e7ced0628becbd0768f8e7ae25ff6b9f3d2ec"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.23.8"
   glob:
     dependency: transitive
     description:
@@ -788,10 +772,10 @@ packages:
     dependency: "direct main"
     description:
       name: html
-      sha256: "3a7812d5bcd2894edf53dfaf8cd640876cf6cef50a8f238745c8b8120ea74d3a"
+      sha256: "1fc58edeaec4307368c60d59b7e15b9d658b57d7f3125098b6294153c75337ec"
       url: "https://pub.dev"
     source: hosted
-    version: "0.15.4"
+    version: "0.15.5"
   http:
     dependency: "direct main"
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -19,10 +19,8 @@ dependencies:
   cupertino_icons: 1.0.8
   flutter_svg: 2.0.16
   flutter_map: 7.0.2
-  ## html & flutter_widget_from_html_core blocked by fwfh_selectable_text
-  html: 0.15.4
-  flutter_widget_from_html_core: 0.8.3+1
-  fwfh_selectable_text: 0.8.3+1
+  html: 0.15.5
+  flutter_widget_from_html_core: 0.15.2
   flutter_secure_storage: 9.2.3
   hive: 2.2.3
   hive_flutter: 1.1.0
@@ -161,9 +159,9 @@ flutter:
     - assets/product/
     - assets/icons/
 
-# /!\
-# Don't use icons SVGs (in assets/fonts/icons), but add them to the font
-# cf (assets/fonts/icons/README.md)
+  # /!\
+  # Don't use icons SVGs (in assets/fonts/icons), but add them to the font
+  # cf (assets/fonts/icons/README.md)
 
   fonts:
     - family: OpenSans


### PR DESCRIPTION
Hi everyone!

On the product page, selecting text is based on an unmaintained dependency.
Furthermore, Flutter now provides all the tools for selecting not one, but several blocks simultaneously.

I have implemented the Flutter way, by allowing to select a group in a KP.
🎥 Video: https://github.com/user-attachments/assets/646bb907-d063-4c61-af72-eca5ff92d1d4

Since the text is also clickable, generally speaking, this behavior is a bad idea. As you can see in the video, sometimes, I can drag the text because the click event has priority.
