### PR TITLE
chore: Minor onboarding improvements

### DIFF
--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_expanded_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_expanded_card.dart
@@ -37,6 +37,7 @@ class KnowledgePanelExpandedCard extends StatelessWidget {
           product: product,
           isInitiallyExpanded: isInitiallyExpanded,
           isClickable: isClickable,
+          isTextSelectable: true,
         );
         if (elementWidget != null) {
           elementWidgets.add(

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_group_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_group_card.dart
@@ -12,11 +12,13 @@ class KnowledgePanelGroupCard extends StatelessWidget {
     required this.groupElement,
     required this.product,
     required this.isClickable,
+    required this.isTextSelectable,
   });
 
   final KnowledgePanelPanelGroupElement groupElement;
   final Product product;
   final bool isClickable;
+  final bool isTextSelectable;
 
   @override
   Widget build(BuildContext context) {
@@ -24,40 +26,46 @@ class KnowledgePanelGroupCard extends StatelessWidget {
     final SmoothColorsThemeExtension themeExtension =
         themeData.extension<SmoothColorsThemeExtension>()!;
 
-    return Provider<KnowledgePanelPanelGroupElement>(
+    final Widget child = Provider<KnowledgePanelPanelGroupElement>(
       lazy: true,
       create: (_) => groupElement,
-      child: SelectionArea(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            if (groupElement.title != null && groupElement.title!.isNotEmpty)
-              Padding(
-                padding: const EdgeInsetsDirectional.only(top: LARGE_SPACE),
-                child: Semantics(
-                  explicitChildNodes: true,
-                  child: Text(
-                    groupElement.title!,
-                    style: themeData.textTheme.titleSmall!.copyWith(
-                      fontSize: 15.5,
-                      fontWeight: FontWeight.w700,
-                      color: context.lightTheme()
-                          ? themeExtension.primaryUltraBlack
-                          : themeExtension.primaryLight,
-                    ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          if (groupElement.title != null && groupElement.title!.isNotEmpty)
+            Padding(
+              padding: const EdgeInsetsDirectional.only(top: LARGE_SPACE),
+              child: Semantics(
+                explicitChildNodes: true,
+                child: Text(
+                  groupElement.title!,
+                  style: themeData.textTheme.titleSmall!.copyWith(
+                    fontSize: 15.5,
+                    fontWeight: FontWeight.w700,
+                    color: context.lightTheme()
+                        ? themeExtension.primaryUltraBlack
+                        : themeExtension.primaryLight,
                   ),
                 ),
               ),
-            for (final String panelId in groupElement.panelIds)
-              KnowledgePanelCard(
-                panelId: panelId,
-                product: product,
-                isClickable: isClickable,
-              )
-          ],
-        ),
+            ),
+          for (final String panelId in groupElement.panelIds)
+            KnowledgePanelCard(
+              panelId: panelId,
+              product: product,
+              isClickable: isClickable,
+            )
+        ],
       ),
     );
+
+    if (isTextSelectable) {
+      return SelectionArea(
+        child: child,
+      );
+    } else {
+      return child;
+    }
   }
 
   @override

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels_builder.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels_builder.dart
@@ -41,6 +41,7 @@ class KnowledgePanelsBuilder {
             product: product,
             isInitiallyExpanded: false,
             isClickable: true,
+            isTextSelectable: !onboardingMode,
           );
           if (widget != null) {
             children.add(widget);
@@ -164,12 +165,14 @@ class KnowledgePanelsBuilder {
     required final Product product,
     required final bool isInitiallyExpanded,
     required final bool isClickable,
+    required final bool isTextSelectable,
   }) {
     final Widget? result = _getElementWidget(
       element: knowledgePanelElement,
       product: product,
       isInitiallyExpanded: isInitiallyExpanded,
       isClickable: isClickable,
+      isTextSelectable: isTextSelectable,
     );
     if (result == null) {
       return null;
@@ -194,6 +197,7 @@ class KnowledgePanelsBuilder {
     required final Product product,
     required final bool isInitiallyExpanded,
     required final bool isClickable,
+    required final bool isTextSelectable,
   }) {
     switch (element.elementType) {
       case KnowledgePanelElementType.TEXT:
@@ -233,6 +237,7 @@ class KnowledgePanelsBuilder {
           groupElement: element.panelGroupElement!,
           product: product,
           isClickable: isClickable,
+          isTextSelectable: isTextSelectable,
         );
 
       case KnowledgePanelElementType.TABLE:

--- a/packages/smooth_app/lib/pages/onboarding/knowledge_panel_page_template.dart
+++ b/packages/smooth_app/lib/pages/onboarding/knowledge_panel_page_template.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -25,6 +23,7 @@ class KnowledgePanelPageTemplate extends StatefulWidget {
     required this.backgroundColor,
     required this.svgAsset,
     required this.nextKey,
+    this.selectableText = false,
   });
 
   final String headerTitle;
@@ -37,6 +36,8 @@ class KnowledgePanelPageTemplate extends StatefulWidget {
   final Color backgroundColor;
   final String svgAsset;
   final Key nextKey;
+
+  final bool selectableText;
 
   @override
   State<KnowledgePanelPageTemplate> createState() =>
@@ -88,7 +89,7 @@ class _KnowledgePanelPageTemplateState
           return ColoredBox(
             color: widget.backgroundColor,
             child: SafeArea(
-              bottom: Platform.isAndroid,
+              bottom: false,
               child: Stack(
                 fit: StackFit.expand,
                 children: <Widget>[

--- a/packages/smooth_app/lib/pages/onboarding/next_button.dart
+++ b/packages/smooth_app/lib/pages/onboarding/next_button.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
@@ -8,7 +6,7 @@ import 'package:smooth_app/data_models/preferences/user_preferences.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/pages/onboarding/onboarding_bottom_bar.dart';
 import 'package:smooth_app/pages/onboarding/onboarding_flow_navigator.dart';
-import 'package:smooth_app/themes/constant_icons.dart';
+import 'package:smooth_app/resources/app_icons.dart' as icons;
 
 /// Next button showed at the bottom of the onboarding flow.
 class NextButton extends StatelessWidget {
@@ -45,10 +43,10 @@ class NextButton extends StatelessWidget {
               ),
               backgroundColor: Colors.white,
               foregroundColor: Colors.black,
-              icon: ConstantIcons.instance.getBackIcon(),
-              iconPadding: Platform.isIOS || Platform.isMacOS
-                  ? const EdgeInsetsDirectional.only(end: 2.0)
-                  : EdgeInsets.zero,
+              icon: Directionality.of(context) == TextDirection.ltr
+                  ? const icons.Arrow.left()
+                  : const icons.Arrow.right(),
+              iconPadding: EdgeInsets.zero,
             ),
       rightButton: OnboardingBottomButton(
         onPressed: () async {

--- a/packages/smooth_app/lib/pages/onboarding/onboarding_bottom_bar.dart
+++ b/packages/smooth_app/lib/pages/onboarding/onboarding_bottom_bar.dart
@@ -122,7 +122,7 @@ class OnboardingBottomIcon extends StatelessWidget {
   final VoidCallback onPressed;
   final Color backgroundColor;
   final Color foregroundColor;
-  final IconData icon;
+  final Widget icon;
   final EdgeInsetsGeometry? iconPadding;
 
   @override
@@ -132,11 +132,12 @@ class OnboardingBottomIcon extends StatelessWidget {
           padding: const EdgeInsets.all(MEDIUM_SPACE),
           backgroundColor: backgroundColor,
           foregroundColor: foregroundColor,
+          iconColor: foregroundColor,
         ),
         onPressed: onPressed,
         child: Padding(
           padding: iconPadding ?? EdgeInsets.zero,
-          child: Icon(icon),
+          child: icon,
         ),
       );
 }


### PR DESCRIPTION
Hi everyone!

Here are a few minor improvements for the onboarding:
- The back icon was white on white (Flutter 3.27 regression)
- The back arrow now uses the same icon as in the "new design"
- Text selection is disabled on KPs
- On Android, for health/env cards, there's now a bottom padding

Everything is more or less summed up with this screenshot:
![IMG_1661](https://github.com/user-attachments/assets/48044d80-b5f6-4ab1-a3ac-289fd0966cd6)
