### PR TITLE
fix: 5 bugfixes (icons color, better network mgmt / Japanese…)

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_image.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_image.dart
@@ -412,18 +412,29 @@ class _ProductPictureWithImageProvider extends StatelessWidget {
       height: size.height,
       fit: BoxFit.contain,
       image: imageProvider,
-      loadingBuilder: (_, Widget child, ImageChunkEvent? loadingProgress) {
+      loadingBuilder: (
+        BuildContext context,
+        Widget child,
+        ImageChunkEvent? loadingProgress,
+      ) {
         if (loadingProgress == null) {
           return child;
         }
 
-        return const Center(
-          child: CircularProgressIndicator(),
-        );
+        return _loadingPlaceholder(context);
       },
       errorBuilder: (_, __, ___) {
         onError.call();
         return EMPTY_WIDGET;
+      },
+      frameBuilder: (BuildContext context, Widget child, int? frame, _) {
+        /// Force a loader, as the [loadingBuilder] has a [loadingProgress] of null,
+        /// which is not expected.
+        if (frame == null) {
+          return _loadingPlaceholder(context);
+        }
+
+        return child;
       },
     );
 
@@ -436,6 +447,21 @@ class _ProductPictureWithImageProvider extends StatelessWidget {
       return image;
     }
   }
+
+  Widget _loadingPlaceholder(BuildContext context) => DecoratedBox(
+        decoration: BoxDecoration(
+          borderRadius: borderRadius,
+          border: border > 0.0
+              ? Border.all(
+                  color: Theme.of(context).dividerColor,
+                  width: 1.0,
+                )
+              : null,
+        ),
+        child: const Center(
+          child: CircularProgressIndicator(),
+        ),
+      );
 }
 
 class _OutdatedProductPictureIcon extends StatelessWidget {

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_image.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_image.dart
@@ -427,7 +427,12 @@ class _ProductPictureWithImageProvider extends StatelessWidget {
         onError.call();
         return EMPTY_WIDGET;
       },
-      frameBuilder: (BuildContext context, Widget child, int? frame, _) {
+      frameBuilder: (
+        BuildContext context,
+        Widget child,
+        int? frame,
+        _,
+      ) {
         /// Force a loader, as the [loadingBuilder] has a [loadingProgress] of null,
         /// which is not expected.
         if (frame == null) {

--- a/packages/smooth_app/lib/generic_lib/widgets/images/smooth_image.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/images/smooth_image.dart
@@ -47,6 +47,15 @@ class SmoothImage extends StatelessWidget {
           fit: fit,
           loadingBuilder: _loadingBuilder,
           errorBuilder: _errorBuilder,
+          frameBuilder: (_, Widget child, int? frame, ____) {
+            if (frame == null) {
+              return const Center(
+                child: CircularProgressIndicator(),
+              );
+            }
+
+            return child;
+          },
           cacheWidth: cacheWidth,
           cacheHeight: cacheHeight,
         ),
@@ -89,33 +98,38 @@ class SmoothImage extends StatelessWidget {
 
     return ExcludeSemantics(
       child: AnimatedCrossFade(
-          crossFadeState: progress == null
-              ? CrossFadeState.showFirst
-              : CrossFadeState.showSecond,
-          duration: SmoothAnimationsDuration.long,
-          firstChild: child,
-          secondChild: Container(
-            color: theme.primaryColor.withValues(alpha: 0.1),
-            alignment: AlignmentDirectional.center,
-            padding: const EdgeInsets.all(SMALL_SPACE),
-            child: const SmoothAnimatedLogo(),
-          ),
-          layoutBuilder: (Widget topChild, Key topChildKey, Widget bottomChild,
-              Key bottomChildKey) {
-            return Stack(
-              clipBehavior: Clip.none,
-              children: <Widget>[
-                Positioned.fill(
-                  key: bottomChildKey,
-                  child: bottomChild,
-                ),
-                Positioned.fill(
-                  key: topChildKey,
-                  child: topChild,
-                ),
-              ],
-            );
-          }),
+        crossFadeState: progress == null
+            ? CrossFadeState.showFirst
+            : CrossFadeState.showSecond,
+        duration: SmoothAnimationsDuration.long,
+        firstChild: child,
+        secondChild: Container(
+          color: theme.primaryColor.withValues(alpha: 0.1),
+          alignment: AlignmentDirectional.center,
+          padding: const EdgeInsets.all(SMALL_SPACE),
+          child: const SmoothAnimatedLogo(),
+        ),
+        layoutBuilder: (
+          Widget topChild,
+          Key topChildKey,
+          Widget bottomChild,
+          Key bottomChildKey,
+        ) {
+          return Stack(
+            clipBehavior: Clip.none,
+            children: <Widget>[
+              Positioned.fill(
+                key: bottomChildKey,
+                child: bottomChild,
+              ),
+              Positioned.fill(
+                key: topChildKey,
+                child: topChild,
+              ),
+            ],
+          );
+        },
+      ),
     );
   }
 

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_table_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_table_card.dart
@@ -343,8 +343,8 @@ class _KnowledgePanelTableCardState extends State<KnowledgePanelTableCard> {
 
     /// Ensure the columns are not too wide or too narrow.
     final int sum = _columnsMaxLength.sum;
-    final int maxWidth = (sum ~/ _columnsMaxLength.length) - 4;
-    final int minWidth = maxWidth ~/ 4;
+    final int maxWidth = math.max((sum ~/ _columnsMaxLength.length) - 4, 1);
+    final int minWidth = math.max(maxWidth ~/ 4, 1);
 
     for (int i = 0; i < _columnsMaxLength.length; i++) {
       if (_columnsType[i] == _TableCellType.PERCENT) {

--- a/packages/smooth_app/lib/pages/prices/price_button.dart
+++ b/packages/smooth_app/lib/pages/prices/price_button.dart
@@ -28,16 +28,23 @@ class PriceButton extends StatelessWidget {
   Widget build(BuildContext context) {
     final Widget widget;
 
+    ButtonStyle? buttonStyleOverride;
+    if (buttonStyle != null && buttonStyle!.foregroundColor != null) {
+      buttonStyleOverride = buttonStyle!.copyWith(
+        iconColor: buttonStyle!.foregroundColor,
+      );
+    }
+
     if (iconData == null) {
       widget = ElevatedButton(
         onPressed: onPressed,
-        style: buttonStyle,
+        style: buttonStyleOverride ?? buttonStyle,
         child: Text(title!),
       );
     } else if (title == null) {
       widget = ElevatedButton(
         onPressed: onPressed,
-        style: buttonStyle,
+        style: buttonStyleOverride ?? buttonStyle,
         child: Icon(iconData),
       );
     } else {
@@ -45,7 +52,7 @@ class PriceButton extends StatelessWidget {
         onPressed: onPressed,
         icon: Icon(iconData),
         label: Text(title!),
-        style: buttonStyle,
+        style: buttonStyleOverride ?? buttonStyle,
       );
     }
 

--- a/packages/smooth_app/lib/pages/scan/carousel/main_card/scan_tagline.dart
+++ b/packages/smooth_app/lib/pages/scan/carousel/main_card/scan_tagline.dart
@@ -312,6 +312,11 @@ class _TagLineContentBody extends StatefulWidget {
 class _TagLineContentBodyState extends State<_TagLineContentBody> {
   bool _imageError = false;
 
+  static const EdgeInsetsGeometry _contentPadding = EdgeInsetsDirectional.only(
+    top: SMALL_SPACE,
+    bottom: VERY_SMALL_SPACE,
+  );
+
   @override
   Widget build(BuildContext context) {
     final ThemeProvider themeProvider = context.watch<ThemeProvider>();
@@ -333,16 +338,16 @@ class _TagLineContentBodyState extends State<_TagLineContentBody> {
       ),
     );
 
-    if (widget.image == null) {
-      return text;
+    if (widget.image == null || _imageError) {
+      return Padding(
+        padding: _contentPadding,
+        child: text,
+      );
     }
 
     final int imageFlex = ((widget.image!.width ?? 0.2) * 10).toInt();
     return Padding(
-      padding: const EdgeInsetsDirectional.only(
-        top: SMALL_SPACE,
-        bottom: VERY_SMALL_SPACE,
-      ),
+      padding: _contentPadding,
       child: Row(
         children: <Widget>[
           if (!_imageError) ...<Widget>[
@@ -375,6 +380,7 @@ class _TagLineContentBodyState extends State<_TagLineContentBody> {
         widget.image!.src,
         semanticsLabel: widget.image!.alt,
         loadingBuilder: (_) => _onLoading(),
+        errorBuilder: (_, __) => _onError(),
       );
     } else {
       return Image.network(

--- a/packages/smooth_app/lib/themes/smooth_theme.dart
+++ b/packages/smooth_app/lib/themes/smooth_theme.dart
@@ -69,7 +69,7 @@ class SmoothTheme {
                 ? Colors.white
                 : myColorScheme.onPrimary,
           ),
-          iconColor: WidgetStateProperty.all<Color>(Colors.white),
+          iconColor: WidgetStateProperty.all<Color>(myColorScheme.onPrimary),
         ),
       ),
       floatingActionButtonTheme: FloatingActionButtonThemeData(


### PR DESCRIPTION
Hi everyone!

Here are 4 fixes:
- The icon color in dark mode is now OK (my fault) #6122
- When the image in the tagline fails to load, the image container is hidden in all cases (non-vectorial + svg)
![IMG_1662](https://github.com/user-attachments/assets/47b0a84e-fd2c-4099-b3c3-96b943e900bd)

- Product picture: force a loader when the image is loading
![IMG_1664](https://github.com/user-attachments/assets/276173d9-8185-4dee-be4f-2f7e546b3078)

- Product gallery: force a loader when the image is loading
![IMG_1666](https://github.com/user-attachments/assets/d93e5c58-879d-4304-88bd-6eb86007457d)

- A table width can't have a width of 0 #6125
![IMG_1667](https://github.com/user-attachments/assets/000298b6-5674-4d3e-a16a-6067b8310ae3)
