### PR TITLE
fix: Ignore existing Robotoff questions when reloading

### DIFF
--- a/packages/smooth_app/lib/helpers/robotoff_question_helper.dart
+++ b/packages/smooth_app/lib/helpers/robotoff_question_helper.dart
@@ -1,0 +1,25 @@
+import 'package:collection/collection.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+
+extension RobotoffQuestionHelper on List<RobotoffQuestion> {
+  bool areSameAs(List<RobotoffQuestion> questions) {
+    return equals(questions, RobotoffQuestionsEquality());
+  }
+}
+
+class RobotoffQuestionsEquality implements Equality<RobotoffQuestion> {
+  @override
+  bool equals(RobotoffQuestion e1, RobotoffQuestion e2) =>
+      e1.insightId == e2.insightId;
+
+  @override
+  int hash(RobotoffQuestion e) => e.insightId.hashCode;
+
+  @override
+  bool isValidKey(Object? o) {
+    if (o is RobotoffQuestion) {
+      return true;
+    }
+    throw UnimplementedError();
+  }
+}

--- a/packages/smooth_app/lib/pages/product/product_page/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/product_page/new_product_page.dart
@@ -142,7 +142,10 @@ class ProductPageState extends State<ProductPage>
                 },
                 child: hasPendingOperations
                     ? const ProductPageLoadingIndicator()
-                    : ProductQuestionsWidget(upToDateProduct),
+                    : KeepQuestionWidgetAlive(
+                        keepWidgetAlive: _keepRobotoffQuestionsAlive,
+                        child: ProductQuestionsWidget(upToDateProduct),
+                      ),
               ),
             ),
           ],
@@ -194,14 +197,11 @@ class ProductPageState extends State<ProductPage>
               child: HeroMode(
                 enabled: widget.withHeroAnimation &&
                     widget.heroTag?.isNotEmpty == true,
-                child: KeepQuestionWidgetAlive(
-                  keepWidgetAlive: _keepRobotoffQuestionsAlive,
-                  child: SummaryCard(
-                    upToDateProduct,
-                    _productPreferences,
-                    heroTag: widget.heroTag,
-                    isFullVersion: true,
-                  ),
+                child: SummaryCard(
+                  upToDateProduct,
+                  _productPreferences,
+                  heroTag: widget.heroTag,
+                  isFullVersion: true,
                 ),
               ),
             ),


### PR DESCRIPTION
Hi everyone!

My previous PR (#6078) was not strict enough to remove the Robotoff banner.
Basically, if the API still returns the same questions, the banner will reappear.

We now ensure that after answering questions AND if questions are the same, the banner won't be displayed.