### PR TITLE
fix: Disable text selection on the scan card

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/product_title_card.dart
+++ b/packages/smooth_app/lib/cards/product_cards/product_title_card.dart
@@ -103,10 +103,7 @@ class ProductTitleCard extends StatelessWidget {
                     top: VERY_SMALL_SPACE,
                     bottom: VERY_SMALL_SPACE,
                   ),
-                  child: SelectionArea(
-                    selectionControls: null,
-                    child: child,
-                  ),
+                  child: child,
                 ),
               ),
             ],
@@ -148,7 +145,7 @@ class _ProductTitleCardName extends StatelessWidget {
       getProductName(product, appLocalizations),
       style: dense ? textStyle : textStyle?.copyWith(fontSize: 18.0),
       textAlign: TextAlign.start,
-      maxLines: dense ? 2 : null,
+      maxLines: 2,
       overflow: TextOverflow.ellipsis,
     );
   }

--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -46,6 +46,7 @@ class SummaryCard extends StatefulWidget {
     this.isPictureVisible = true,
     this.attributeGroupsClickable = true,
     this.scrollableContent = false,
+    this.isTextSelectable,
     this.margin,
     this.contentPadding,
     this.buttonPadding,
@@ -75,6 +76,9 @@ class SummaryCard extends StatefulWidget {
 
   /// If true, all chips / groups are clickable
   final bool attributeGroupsClickable;
+
+  /// If true, the text will be selectable
+  final bool? isTextSelectable;
 
   /// Margin for the card
   final EdgeInsetsGeometry? margin;
@@ -309,7 +313,7 @@ class _SummaryCardState extends State<SummaryCard> with UpToDateMixin {
       children: <Widget>[
         ProductTitleCard(
           upToDateProduct,
-          widget.isFullVersion,
+          widget.isTextSelectable ?? widget.isFullVersion,
           heroTag: widget.heroTag,
           dense: !widget.isFullVersion,
           isPictureVisible: widget.isPictureVisible,

--- a/packages/smooth_app/lib/pages/scan/scan_product_card.dart
+++ b/packages/smooth_app/lib/pages/scan/scan_product_card.dart
@@ -64,6 +64,7 @@ class ScanProductCardFound extends StatelessWidget {
             vertical: VERY_SMALL_SPACE,
           ),
           scrollableContent: true,
+          isTextSelectable: false,
         ),
       ),
     );


### PR DESCRIPTION
Hi everyone!

After #6113, it was difficult to click on the scan card due to the selectable text:
![IMG_FE4AEA05DA70-1](https://github.com/user-attachments/assets/109224f6-d7d6-43a6-b9ee-041248f4d0b6)

This PR disables the selection feature.