### PR TITLE
feat: Brands edition in a list + reorderable items

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -744,6 +744,7 @@
     "score_add_missing_product_labels": "Add missing product labels",
     "score_add_missing_product_origins": "Add missing product origins",
     "score_add_missing_product_stores": "Add missing product stores",
+    "score_add_missing_product_brands": "Add missing product brands",
     "score_update_nutrition_facts": "Update nutrition facts",
     "nutrition_page_title": "Nutrition Facts",
     "nutrition_page_unspecified": "Nutrition facts are not specified on the product",
@@ -1412,6 +1413,10 @@
     "edit_product_form_item_error_empty": "Please enter a non-empty value!",
     "@edit_product_form_item_error_empty": {
         "description": "Error message when the user tries to submit an empty value"
+    },
+    "edit_product_form_item_error_existing": "This value is already added!",
+    "@edit_product_form_item_error_existing": {
+        "description": "Error message when the user tries to re-submit an existing value"
     },
     "@edit_product_label_short": {
         "description": "Edit product button short label (only the verb)"

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1414,7 +1414,7 @@
     "@edit_product_form_item_error_empty": {
         "description": "Error message when the user tries to submit an empty value"
     },
-    "edit_product_form_item_error_existing": "This value is already added!",
+    "edit_product_form_item_error_existing": "This value is already there!",
     "@edit_product_form_item_error_existing": {
         "description": "Error message when the user tries to re-submit an existing value"
     },

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -1425,6 +1425,10 @@
     "@edit_product_form_item_error_empty": {
         "description": "Error message when the user tries to submit an empty value"
     },
+    "edit_product_form_item_error_existing": "Cette valeur existe déjà !",
+    "@edit_product_form_item_error_existing": {
+        "description": "Error message when the user tries to re-submit an existing value"
+    },
     "edit_product_form_item_add_action": "Ajouter un nouveau {itemType}",
     "description": "Infobulle à afficher lorsque l'utilisateur appuie longuement sur le bouton (+)",
     "@edit_product_form_item_add_action": {

--- a/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
@@ -6,6 +6,7 @@ import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/pages/image_crop_page.dart';
+import 'package:smooth_app/pages/product/multilingual_helper.dart';
 import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/resources/app_icons.dart' as icons;
 
@@ -32,7 +33,11 @@ abstract class AbstractSimpleInputPageHelper extends ChangeNotifier {
     notifyListeners();
   }
 
-  final String _separator = ',';
+  /// Doesn't need to be overridden (only for brands).
+  String get separator => ',';
+
+  /// Is the list of terms reorderable?
+  bool get reorderable => false;
 
   /// Returns the terms as they were initially in the product.
   ///
@@ -103,6 +108,9 @@ abstract class AbstractSimpleInputPageHelper extends ChangeNotifier {
   /// Returns the tag type for autocomplete suggestions.
   TagType? getTagType();
 
+  /// Instead of the tag type, returns the autocomplete manager.
+  AutocompleteManager? getAutocompleteManager() => null;
+
   /// Returns the icon data for the list tile.
   Widget getIcon();
 
@@ -163,7 +171,7 @@ abstract class AbstractSimpleInputPageHelper extends ChangeNotifier {
     if (input.isEmpty) {
       return <String>[];
     }
-    return input.split(_separator);
+    return input.split(separator);
   }
 
   /// Returns the current language.
@@ -187,11 +195,91 @@ abstract class AbstractSimpleInputPageHelper extends ChangeNotifier {
     return result;
   }
 
+  /// Mainly used when reordering the list.
+  void replaceItems(final List<String> items) {
+    _terms = items;
+    _changed = true;
+    notifyListeners();
+  }
+
   /// Returns the enum to be used for matomo analytics.
   AnalyticsEditEvents getAnalyticsEditEvent();
 
   /// Returns true if the field is an owner field.
   bool isOwnerField(final Product product) => false;
+}
+
+/// Implementation for "Brands" of an [AbstractSimpleInputPageHelper].
+class SimpleInputPageBrandsHelper extends AbstractSimpleInputPageHelper {
+  @override
+  String get separator => ', ';
+
+  @override
+  bool get reorderable => true;
+
+  @override
+  List<String> initTerms(final Product product) => splitString(product.brands);
+
+  @override
+  void changeProduct(final Product changedProduct) =>
+      changedProduct.brands = MultilingualHelper.getCleanText(
+        formatProductBrands(terms.join(separator)),
+      );
+
+  @override
+  String getTitle(final AppLocalizations appLocalizations) =>
+      appLocalizations.brand_names;
+
+  @override
+  String getAddButtonLabel(final AppLocalizations appLocalizations) =>
+      appLocalizations.score_add_missing_product_brands;
+
+  @override
+  String getAddHint(final AppLocalizations appLocalizations) =>
+      appLocalizations.add_basic_details_brand_names_hint;
+
+  @override
+  String getTypeLabel(AppLocalizations appLocalizations) =>
+      appLocalizations.brand_names;
+
+  @override
+  TagType? getTagType() => null;
+
+  @override
+  AutocompleteManager? getAutocompleteManager() => AutocompleteManager(
+        TaxonomyNameAutocompleter(
+          taxonomyNames: <TaxonomyName>[TaxonomyName.brand],
+          // for brands, language must be English
+          language: OpenFoodFactsLanguage.ENGLISH,
+          user: ProductQuery.getReadUser(),
+          limit: 25,
+          fuzziness: Fuzziness.none,
+          uriHelper: ProductQuery.getUriProductHelper(
+            productType: product.productType,
+          ),
+        ),
+      );
+
+  @override
+  Widget getIcon() => const icons.Fruit();
+
+  @override
+  bool isOwnerField(Product product) =>
+      product.getOwnerFieldTimestamp(
+        OwnerField.productField(
+          ProductField.BRANDS,
+          ProductQuery.getLanguage(),
+        ),
+      ) !=
+      null;
+
+  @override
+  BackgroundTaskDetailsStamp getStamp() =>
+      BackgroundTaskDetailsStamp.basicDetails;
+
+  @override
+  AnalyticsEditEvents getAnalyticsEditEvent() =>
+      AnalyticsEditEvents.basicDetails;
 }
 
 /// Implementation for "Stores" of an [AbstractSimpleInputPageHelper].
@@ -201,7 +289,7 @@ class SimpleInputPageStoreHelper extends AbstractSimpleInputPageHelper {
 
   @override
   void changeProduct(final Product changedProduct) =>
-      changedProduct.stores = terms.join(_separator);
+      changedProduct.stores = terms.join(separator);
 
   @override
   String getTitle(final AppLocalizations appLocalizations) =>
@@ -239,7 +327,7 @@ class SimpleInputPageOriginHelper extends AbstractSimpleInputPageHelper {
 
   @override
   void changeProduct(final Product changedProduct) =>
-      changedProduct.origins = terms.join(_separator);
+      changedProduct.origins = terms.join(separator);
 
   @override
   String getTitle(final AppLocalizations appLocalizations) =>
@@ -295,7 +383,7 @@ class SimpleInputPageEmbCodeHelper extends AbstractSimpleInputPageHelper {
 
   @override
   void changeProduct(final Product changedProduct) =>
-      changedProduct.embCodes = terms.join(_separator);
+      changedProduct.embCodes = terms.join(separator);
 
   @override
   String getTitle(final AppLocalizations appLocalizations) =>
@@ -354,7 +442,7 @@ class SimpleInputPageLabelHelper extends AbstractSimpleInputPageHelper {
     changedProduct.labelsTagsInLanguages =
         <OpenFoodFactsLanguage, List<String>>{getLanguage(): terms};
     // for the server - write-only
-    changedProduct.labels = terms.join(_separator);
+    changedProduct.labels = terms.join(separator);
   }
 
   @override
@@ -424,7 +512,7 @@ class SimpleInputPageCategoryHelper extends AbstractSimpleInputPageHelper {
     changedProduct.categoriesTagsInLanguages =
         <OpenFoodFactsLanguage, List<String>>{getLanguage(): terms};
     // for the server - write-only
-    changedProduct.categories = terms.join(_separator);
+    changedProduct.categories = terms.join(separator);
   }
 
   @override
@@ -483,7 +571,7 @@ class SimpleInputPageCountryHelper extends AbstractSimpleInputPageHelper {
     changedProduct.countriesTagsInLanguages =
         <OpenFoodFactsLanguage, List<String>>{getLanguage(): terms};
     // for the server - write-only
-    changedProduct.countries = terms.join(_separator);
+    changedProduct.countries = terms.join(separator);
   }
 
   @override

--- a/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
@@ -33,7 +33,6 @@ abstract class AbstractSimpleInputPageHelper extends ChangeNotifier {
     notifyListeners();
   }
 
-  /// Doesn't need to be overridden (only for brands).
   String get separator => ',';
 
   /// Is the list of terms reorderable?

--- a/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
@@ -13,6 +13,7 @@ class SimpleInputTextField extends StatefulWidget {
     required this.tagType,
     required this.hintText,
     required this.controller,
+    this.autocompleteManager,
     this.withClearButton = false,
     this.minLengthForSuggestions = 1,
     this.categories,
@@ -26,6 +27,7 @@ class SimpleInputTextField extends StatefulWidget {
 
   final FocusNode focusNode;
   final Key autocompleteKey;
+  final AutocompleteManager? autocompleteManager;
   final BoxConstraints constraints;
   final TagType? tagType;
   final String hintText;
@@ -50,23 +52,24 @@ class _SimpleInputTextFieldState extends State<SimpleInputTextField> {
   @override
   void initState() {
     super.initState();
-    _manager = widget.tagType == null
-        ? null
-        : AutocompleteManager(
-            TagTypeAutocompleter(
-              tagType: widget.tagType!,
-              language: ProductQuery.getLanguage(),
-              country: ProductQuery.getCountry(),
-              categories: widget.categories,
-              shape: widget.shapeProvider?.call(),
-              user: ProductQuery.getReadUser(),
-              // number of suggestions the user can scroll through: compromise between quantity and readability of the suggestions
-              limit: 15,
-              uriHelper: ProductQuery.getUriProductHelper(
-                productType: widget.productType,
-              ),
-            ),
-          );
+    _manager = widget.autocompleteManager ??
+        (widget.tagType == null
+            ? null
+            : AutocompleteManager(
+                TagTypeAutocompleter(
+                  tagType: widget.tagType!,
+                  language: ProductQuery.getLanguage(),
+                  country: ProductQuery.getCountry(),
+                  categories: widget.categories,
+                  shape: widget.shapeProvider?.call(),
+                  user: ProductQuery.getReadUser(),
+                  // number of suggestions the user can scroll through: compromise between quantity and readability of the suggestions
+                  limit: 15,
+                  uriHelper: ProductQuery.getUriProductHelper(
+                    productType: widget.productType,
+                  ),
+                ),
+              ));
   }
 
   @override

--- a/packages/smooth_app/lib/pages/product/simple_input_widget.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_widget.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
@@ -211,6 +213,16 @@ class _SimpleInputWidgetState extends State<SimpleInputWidget> {
         setState(() {});
       },
       onReorderStart: (_) => SmoothHapticFeedback.lightNotification(),
+      proxyDecorator: (Widget child, int index, Animation<double> animation) {
+        final double animValue = Curves.easeInOut.transform(animation.value);
+        final double elevation = lerpDouble(0, 1, animValue)!;
+
+        return Material(
+          elevation: elevation,
+          borderRadius: ANGULAR_BORDER_RADIUS,
+          child: child,
+        );
+      },
       shrinkWrap: true,
       physics: const NeverScrollableScrollPhysics(),
     );

--- a/packages/smooth_app/lib/pages/product/simple_input_widget.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_widget.dart
@@ -142,8 +142,10 @@ class _SimpleInputWidgetState extends State<SimpleInputWidget> {
         _getList(appLocalizations),
         if (extraWidget != null)
           extraWidget
+        else if (_localTerms.isEmpty)
+          const SizedBox(height: MEDIUM_SPACE)
         else
-          const SizedBox(height: MEDIUM_SPACE),
+          const SizedBox(height: VERY_SMALL_SPACE),
       ],
     );
 
@@ -260,6 +262,7 @@ class _SimpleInputWidgetState extends State<SimpleInputWidget> {
       contentPadding: const EdgeInsetsDirectional.only(
         start: LARGE_SPACE,
       ),
+      minTileHeight: 48.0,
       title: child,
     );
   }

--- a/packages/smooth_app/lib/pages/product/simple_input_widget.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_widget.dart
@@ -14,6 +14,7 @@ import 'package:smooth_app/pages/product/owner_field_info.dart';
 import 'package:smooth_app/pages/product/simple_input_page_helpers.dart';
 import 'package:smooth_app/pages/product/simple_input_text_field.dart';
 import 'package:smooth_app/resources/app_icons.dart' as icons;
+import 'package:smooth_app/themes/theme_provider.dart';
 
 /// Simple input widget: we have a list of terms, we add, we remove.
 class SimpleInputWidget extends StatefulWidget {
@@ -219,6 +220,7 @@ class _SimpleInputWidgetState extends State<SimpleInputWidget> {
 
         return Material(
           elevation: elevation,
+          shadowColor: context.darkTheme() ? Colors.white24 : null,
           borderRadius: ANGULAR_BORDER_RADIUS,
           child: child,
         );

--- a/packages/smooth_app/lib/pages/product/simple_input_widget.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_widget.dart
@@ -20,12 +20,14 @@ class SimpleInputWidget extends StatefulWidget {
     required this.product,
     required this.controller,
     required this.displayTitle,
+    this.newElementsToTop = true,
   });
 
   final AbstractSimpleInputPageHelper helper;
   final Product product;
   final TextEditingController controller;
   final bool displayTitle;
+  final bool newElementsToTop;
 
   @override
   State<SimpleInputWidget> createState() => _SimpleInputWidgetState();
@@ -51,12 +53,6 @@ class _SimpleInputWidgetState extends State<SimpleInputWidget> {
   }
 
   @override
-  void dispose() {
-    _focusNode.dispose();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final String? explanations =
@@ -72,8 +68,9 @@ class _SimpleInputWidgetState extends State<SimpleInputWidget> {
       children: <Widget>[
         if (explanations != null && !widget.displayTitle)
           Padding(
-            padding:
-                const EdgeInsetsDirectional.symmetric(horizontal: SMALL_SPACE),
+            padding: const EdgeInsetsDirectional.symmetric(
+              horizontal: SMALL_SPACE,
+            ),
             child: ExplanationWidget(explanations),
           ),
         LayoutBuilder(
@@ -94,6 +91,8 @@ class _SimpleInputWidgetState extends State<SimpleInputWidget> {
                       focusNode: _focusNode,
                       constraints: constraints,
                       tagType: widget.helper.getTagType(),
+                      autocompleteManager:
+                          widget.helper.getAutocompleteManager(),
                       hintText: widget.helper.getAddHint(appLocalizations),
                       controller: widget.controller,
                       padding: const EdgeInsets.symmetric(
@@ -137,47 +136,7 @@ class _SimpleInputWidgetState extends State<SimpleInputWidget> {
             );
           },
         ),
-        AnimatedList(
-          key: _listKey,
-          initialItemCount: _localTerms.length,
-          padding:
-              const EdgeInsetsDirectional.symmetric(horizontal: SMALL_SPACE),
-          itemBuilder: (
-            BuildContext context,
-            int position,
-            Animation<double> animation,
-          ) {
-            final String term = _localTerms[position];
-            final Widget child = Text(term);
-
-            return KeyedSubtree(
-              key: ValueKey<String>(term),
-              child: SizeTransition(
-                sizeFactor: animation,
-                child: ListTile(
-                  trailing: Tooltip(
-                    message: appLocalizations
-                        .edit_product_form_item_remove_item_tooltip,
-                    child: InkWell(
-                      customBorder: const CircleBorder(),
-                      onTap: () => _onRemoveItem(term, child),
-                      child: const Padding(
-                        padding: EdgeInsets.all(SMALL_SPACE),
-                        child: Icon(Icons.delete),
-                      ),
-                    ),
-                  ),
-                  contentPadding: const EdgeInsetsDirectional.only(
-                    start: LARGE_SPACE,
-                  ),
-                  title: child,
-                ),
-              ),
-            );
-          },
-          shrinkWrap: true,
-          physics: const NeverScrollableScrollPhysics(),
-        ),
+        _getList(appLocalizations),
         if (extraWidget != null)
           extraWidget
         else
@@ -206,14 +165,99 @@ class _SimpleInputWidgetState extends State<SimpleInputWidget> {
     );
   }
 
-  void _onAddItem() {
-    if (widget.controller.text.trim().isEmpty) {
-      final AppLocalizations appLocalizations = AppLocalizations.of(context);
+  Widget _getList(AppLocalizations appLocalizations) {
+    if (!widget.helper.reorderable) {
+      return AnimatedList(
+        key: _listKey,
+        initialItemCount: _localTerms.length,
+        padding: const EdgeInsetsDirectional.symmetric(horizontal: SMALL_SPACE),
+        itemBuilder: (
+          BuildContext context,
+          int position,
+          Animation<double> animation,
+        ) {
+          return KeyedSubtree(
+            key: ValueKey<String>(_localTerms[position]),
+            child: SizeTransition(
+              sizeFactor: animation,
+              child: _getItem(context, position),
+            ),
+          );
+        },
+        shrinkWrap: true,
+        physics: const NeverScrollableScrollPhysics(),
+      );
+    }
 
+    return ReorderableListView.builder(
+      padding: const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
+      buildDefaultDragHandles: false,
+      itemBuilder: (BuildContext context, int index) {
+        return KeyedSubtree(
+          key: ValueKey<String>(_localTerms[index]),
+          child: _getItem(context, index),
+        );
+      },
+      itemCount: _localTerms.length,
+      onReorder: (int oldIndex, int newIndex) {
+        if (oldIndex < newIndex) {
+          newIndex--;
+        }
+
+        final String oldValue = _localTerms[oldIndex];
+        _localTerms.removeAt(oldIndex);
+        _localTerms.insert(newIndex, oldValue);
+        widget.helper.replaceItems(_localTerms);
+        setState(() {});
+      },
+      onReorderStart: (_) => SmoothHapticFeedback.lightNotification(),
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+    );
+  }
+
+  Widget _getItem(
+    BuildContext context,
+    int position,
+  ) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+
+    final String term = _localTerms[position];
+    final Text child = Text(term);
+
+    return ListTile(
+      leading: widget.helper.reorderable
+          ? ReorderableDelayedDragStartListener(
+              index: position,
+              child: const icons.Menu.hamburger(),
+            )
+          : null,
+      trailing: Tooltip(
+        message: appLocalizations.edit_product_form_item_remove_item_tooltip,
+        child: InkWell(
+          customBorder: const CircleBorder(),
+          onTap: () => _onRemoveItem(term, child),
+          child: const Padding(
+            padding: EdgeInsets.all(SMALL_SPACE),
+            child: Icon(Icons.delete),
+          ),
+        ),
+      ),
+      contentPadding: const EdgeInsetsDirectional.only(
+        start: LARGE_SPACE,
+      ),
+      title: child,
+    );
+  }
+
+  void _onAddItem() {
+    _focusNode.unfocus();
+
+    if (widget.controller.text.trim().isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
         SmoothFloatingSnackbar.error(
           context: context,
-          text: appLocalizations.edit_product_form_item_error_empty,
+          text: AppLocalizations.of(context).edit_product_form_item_error_empty,
         ),
       );
 
@@ -224,20 +268,38 @@ class _SimpleInputWidgetState extends State<SimpleInputWidget> {
       // Add new items to the top of our list
       final Iterable<String> newTerms = widget.helper.terms.diff(_localTerms);
       final int newTermsCount = newTerms.length;
-      _localTerms.insertAll(0, newTerms);
-      _listKey.currentState?.insertAllItems(0, newTermsCount);
-    }
 
-    SmoothHapticFeedback.lightNotification();
+      if (widget.newElementsToTop) {
+        _localTerms.insertAll(0, newTerms);
+        _listKey.currentState?.insertAllItems(0, newTermsCount);
+      } else {
+        _localTerms.addAll(newTerms);
+        _listKey.currentState?.insertItem(_localTerms.length - newTermsCount);
+      }
+
+      SmoothHapticFeedback.lightNotification();
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SmoothFloatingSnackbar.error(
+          context: context,
+          text: AppLocalizations.of(context)
+              .edit_product_form_item_error_existing,
+        ),
+      );
+
+      SmoothHapticFeedback.error();
+    }
   }
 
   void _onRemoveItem(String term, Widget child) {
     if (widget.helper.removeTerm(term)) {
       final int position = _localTerms.indexOf(term);
       if (position >= 0) {
-        _localTerms.remove(term);
-        _listKey.currentState?.removeItem(position,
-            (_, Animation<double> animation) {
+        _localTerms.removeAt(position);
+        _listKey.currentState?.removeItem(position, (
+          _,
+          Animation<double> animation,
+        ) {
           return FadeTransition(
             opacity: animation,
             child: SizeTransition(
@@ -246,10 +308,18 @@ class _SimpleInputWidgetState extends State<SimpleInputWidget> {
             ),
           );
         });
+
+        setState(() {});
       }
 
       SmoothHapticFeedback.lightNotification();
     }
+  }
+
+  @override
+  void dispose() {
+    _focusNode.dispose();
+    super.dispose();
   }
 }
 


### PR DESCRIPTION
Hi everyone!

This PR will finally resolve the issue with autocompletion on multiple brands.
The brands are displayed in a list and are even reorderable.

Video: 

https://github.com/user-attachments/assets/f5891095-3163-4b1a-bbcb-204d1bcabe42

## New feature when editing
For all fields, adding an existing value will display an error VS nothing before
![IMG_1759](https://github.com/user-attachments/assets/3c9b414a-8014-4724-a17a-d538088f5373)
