### PR TITLE
fix: Language selector + ingredients (text field + outdated)

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/product_title_card.dart
+++ b/packages/smooth_app/lib/cards/product_cards/product_title_card.dart
@@ -51,6 +51,7 @@ class ProductTitleCard extends StatelessWidget {
         const SizedBox(height: SMALL_SPACE),
         _ProductTitleCardBrand(
           selectable: isSelectable,
+          dense: dense,
         ),
         const SizedBox(height: 2.0),
         trailing,
@@ -155,9 +156,11 @@ class _ProductTitleCardName extends StatelessWidget {
 class _ProductTitleCardBrand extends StatelessWidget {
   const _ProductTitleCardBrand({
     required this.selectable,
+    this.dense = false,
   });
 
   final bool selectable;
+  final bool dense;
 
   @override
   Widget build(BuildContext context) {
@@ -168,6 +171,8 @@ class _ProductTitleCardBrand extends StatelessWidget {
 
     return Text(
       brands,
+      maxLines: dense ? 1 : 2,
+      overflow: dense ? TextOverflow.ellipsis : null,
       style: Theme.of(context).textTheme.bodyMedium,
       textAlign: TextAlign.start,
     );

--- a/packages/smooth_app/lib/generic_lib/buttons/smooth_large_button_with_icon.dart
+++ b/packages/smooth_app/lib/generic_lib/buttons/smooth_large_button_with_icon.dart
@@ -13,6 +13,7 @@ class SmoothLargeButtonWithIcon extends StatelessWidget {
     this.foregroundColor,
     this.textAlign,
     this.textStyle,
+    this.elevation,
   });
 
   final String text;
@@ -24,6 +25,7 @@ class SmoothLargeButtonWithIcon extends StatelessWidget {
   final Color? foregroundColor;
   final TextAlign? textAlign;
   final TextStyle? textStyle;
+  final WidgetStateProperty<double?>? elevation;
 
   Color _getBackgroundColor(final ThemeData themeData) =>
       backgroundColor ?? themeData.colorScheme.secondary;
@@ -44,6 +46,7 @@ class SmoothLargeButtonWithIcon extends StatelessWidget {
       minWidth: double.infinity,
       padding: padding ?? const EdgeInsets.all(10),
       onPressed: onPressed,
+      elevation: elevation,
       buttonColor: _getBackgroundColor(themeData),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.start,

--- a/packages/smooth_app/lib/generic_lib/buttons/smooth_simple_button.dart
+++ b/packages/smooth_app/lib/generic_lib/buttons/smooth_simple_button.dart
@@ -12,6 +12,7 @@ class SmoothSimpleButton extends StatelessWidget {
     this.borderRadius = ROUNDED_BORDER_RADIUS,
     this.padding = const EdgeInsets.all(10),
     this.buttonColor,
+    this.elevation,
   });
 
   final Widget child;
@@ -21,6 +22,7 @@ class SmoothSimpleButton extends StatelessWidget {
   final BorderRadius borderRadius;
   final EdgeInsetsGeometry padding;
   final Color? buttonColor;
+  final WidgetStateProperty<double?>? elevation;
 
   @override
   Widget build(BuildContext context) {
@@ -31,6 +33,7 @@ class SmoothSimpleButton extends StatelessWidget {
       ),
       child: ElevatedButton(
         style: ButtonStyle(
+          elevation: elevation,
           backgroundColor: buttonColor == null
               ? null
               : WidgetStateProperty.all<Color>(buttonColor!),

--- a/packages/smooth_app/lib/generic_lib/widgets/language_selector.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/language_selector.dart
@@ -22,6 +22,7 @@ class LanguageSelector extends StatelessWidget {
     this.padding,
     this.borderRadius,
     this.product,
+    this.checkedIcon,
   });
 
   /// What to do when the language is selected.
@@ -37,6 +38,7 @@ class LanguageSelector extends StatelessWidget {
   final Widget? icon;
   final EdgeInsetsGeometry? padding;
   final BorderRadius? borderRadius;
+  final Widget? checkedIcon;
 
   /// Product from which we can extract the languages that matter.
   final Product? product;
@@ -67,6 +69,7 @@ class LanguageSelector extends StatelessWidget {
             context,
             selectedLanguages: selectedLanguages,
             languagePriority: languagePriority,
+            checkedIcon: checkedIcon,
           );
           if (language != null) {
             await daoStringList.add(
@@ -126,6 +129,7 @@ class LanguageSelector extends StatelessWidget {
     final BuildContext context, {
     final Iterable<OpenFoodFactsLanguage>? selectedLanguages,
     required final LanguagePriority languagePriority,
+    final Widget? checkedIcon,
   }) async {
     final ScrollController scrollController = ScrollController();
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
@@ -190,7 +194,8 @@ class LanguageSelector extends StatelessWidget {
                   selectedLanguages.contains(language);
               return ListTile(
                 dense: true,
-                trailing: selected ? const Icon(Icons.check) : null,
+                trailing:
+                    selected ? (checkedIcon ?? const Icon(Icons.check)) : null,
                 title: TextHighlighter(
                   text: _getCompleteName(language),
                   filter: languageSelectorController.text,

--- a/packages/smooth_app/lib/helpers/product_cards_helper.dart
+++ b/packages/smooth_app/lib/helpers/product_cards_helper.dart
@@ -312,12 +312,14 @@ Widget addPanelButton(
   final String? textAlign,
   final EdgeInsetsGeometry? padding,
   required final Function() onPressed,
+  WidgetStateProperty<double?>? elevation,
 }) =>
     Padding(
       padding: const EdgeInsets.symmetric(vertical: SMALL_SPACE),
       child: SmoothLargeButtonWithIcon(
         text: label,
         icon: iconData ?? Icons.add,
+        elevation: elevation,
         onPressed: onPressed,
         textAlign: iconData == null ? TextAlign.center : null,
         padding: padding,

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -793,6 +793,11 @@
         }
     },
     "product_image_outdated": "This image may be outdated",
+    "product_image_outdated_explanations_title": "This image may be outdated",
+    "product_image_outdated_explanations_content": "This image was taken more than a year ago.\n**Please check that's it's still up-to-date**.\n\nThis is **just a warning**. If the content is still the same, you can ignore this message.",
+    "@product_image_outdated_explanations_content": {
+        "description": "Please keep the ** syntax to make the text bold"
+    },
     "product_image_action_replace_photo": "Replace photo ({type})",
     "@product_image_action_replace_photo": {
         "description": "Action on the photo gallery to replace an existing picture",

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -793,6 +793,11 @@
         }
     },
     "product_image_outdated": "Cette image peut être obsolète",
+    "product_image_outdated_explanations_title": "Cette image peut-être obsolète",
+    "product_image_outdated_explanations_content": "Cette image a été prise il y a plus d'un an.\n**Merci de vérifier qu'elle est toujours d'actualité**.\n\nIl s'agit **uniquement d'une alerte**. Si le contenu n'a pas changé, vous pouvez ignorer ce message.",
+    "@product_image_outdated_explanations_content": {
+        "description": "Please keep the ** syntax to make the text bold"
+    },
     "product_image_action_replace_photo": "Remplacer la photo ({type})",
     "@product_image_action_replace_photo": {
         "description": "Action on the photo gallery to replace an existing picture",

--- a/packages/smooth_app/lib/pages/product/edit_language_tabbar.dart
+++ b/packages/smooth_app/lib/pages/product/edit_language_tabbar.dart
@@ -253,7 +253,7 @@ class _EditLanguageTabBarAddLanguageButton extends StatelessWidget {
                 width: lightTheme ? 1.5 : 2.0,
               ),
             ),
-            color: lightTheme ? theme.primaryDark : theme.primaryNormal,
+            color: lightTheme ? theme.primaryBlack : theme.primaryNormal,
           ),
           child: Material(
             type: MaterialType.transparency,

--- a/packages/smooth_app/lib/pages/product/edit_ocr/edit_ocr_image.dart
+++ b/packages/smooth_app/lib/pages/product/edit_ocr/edit_ocr_image.dart
@@ -19,6 +19,7 @@ import 'package:smooth_app/themes/smooth_theme.dart';
 import 'package:smooth_app/themes/smooth_theme_colors.dart';
 import 'package:smooth_app/themes/theme_provider.dart';
 import 'package:smooth_app/widgets/smooth_indicator_icon.dart';
+import 'package:smooth_app/widgets/smooth_text.dart';
 
 class EditOCRImageWidget extends StatelessWidget {
   const EditOCRImageWidget({
@@ -76,14 +77,21 @@ class EditOCRImageWidget extends StatelessWidget {
               color: extension.warning,
               borderRadius: ROUNDED_BORDER_RADIUS,
             ),
-            child: const Padding(
-              padding: EdgeInsetsDirectional.only(
-                top: 6.5,
-                bottom: 7.5,
-                start: 7.0,
-                end: 7.0,
+            child: Material(
+              type: MaterialType.transparency,
+              child: InkWell(
+                customBorder: const CircleBorder(),
+                onTap: () => _openOutdatedPictureExplanations(context),
+                child: const Padding(
+                  padding: EdgeInsetsDirectional.only(
+                    top: 6.5,
+                    bottom: 7.5,
+                    start: 7.0,
+                    end: 7.0,
+                  ),
+                  child: icons.Outdated(size: 15.0),
+                ),
               ),
-              child: icons.Outdated(size: 15.0),
             ),
           ),
         );
@@ -147,6 +155,26 @@ class EditOCRImageWidget extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+
+  Future<void> _openOutdatedPictureExplanations(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+
+    return showSmoothModalSheet<void>(
+      context: context,
+      builder: (BuildContext context) {
+        return SmoothModalSheet(
+          title: appLocalizations.product_image_outdated_explanations_title,
+          prefixIndicator: true,
+          body: SmoothModalSheetBodyContainer(
+            child: TextWithBoldParts(
+              text:
+                  appLocalizations.product_image_outdated_explanations_content,
+            ),
+          ),
+        );
+      },
     );
   }
 }

--- a/packages/smooth_app/lib/pages/product/edit_ocr/edit_ocr_textfield.dart
+++ b/packages/smooth_app/lib/pages/product/edit_ocr/edit_ocr_textfield.dart
@@ -132,6 +132,8 @@ class EditOCRTextField extends StatelessWidget {
                         ),
                       ),
                     ),
+                    onTapOutside: (_) =>
+                        FocusManager.instance.primaryFocus?.unfocus(),
                   ),
                 );
               },

--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -142,11 +142,11 @@ class _EditProductPageState extends State<EditProductPage> with UpToDateMixin {
         child: Scrollbar(
           controller: _controller,
           child: ListView(
-            padding: const EdgeInsetsDirectional.only(
+            padding: EdgeInsetsDirectional.only(
               top: SMALL_SPACE,
               start: VERY_SMALL_SPACE,
               end: VERY_SMALL_SPACE,
-              bottom: MEDIUM_SPACE,
+              bottom: MEDIUM_SPACE + MediaQuery.viewPaddingOf(context).bottom,
             ),
             controller: _controller,
             children: <Widget>[

--- a/packages/smooth_app/lib/pages/product/product_image_viewer.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_viewer.dart
@@ -238,6 +238,7 @@ class _ProductImageViewerState extends State<ProductImageViewer>
                       displayedLanguage: widget.language,
                       selectedLanguages: selectedLanguages,
                       foregroundColor: Colors.white,
+                      checkedIcon: const Icon(Icons.camera_alt_rounded),
                       padding: const EdgeInsetsDirectional.symmetric(
                         horizontal: 13.0,
                         vertical: SMALL_SPACE,

--- a/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
@@ -137,6 +137,7 @@ abstract class AbstractSimpleInputPageHelper extends ChangeNotifier {
             isLoggedInMandatory: false,
           ),
           iconData: Icons.add_a_photo,
+          elevation: const WidgetStatePropertyAll<double>(0.0),
           padding: const EdgeInsetsDirectional.only(
             top: SMALL_SPACE,
             bottom: SMALL_SPACE,

--- a/packages/smooth_app/lib/widgets/v2/smooth_buttons_bar.dart
+++ b/packages/smooth_app/lib/widgets/v2/smooth_buttons_bar.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/duration_constants.dart';
 import 'package:smooth_app/helpers/keyboard_helper.dart';
+import 'package:smooth_app/themes/smooth_theme.dart';
 import 'package:smooth_app/themes/smooth_theme_colors.dart';
 import 'package:smooth_app/themes/theme_provider.dart';
 
@@ -152,13 +153,13 @@ class _SmoothPositiveButton2 extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final SmoothColorsThemeExtension colors =
-        Theme.of(context).extension<SmoothColorsThemeExtension>()!;
+        context.extension<SmoothColorsThemeExtension>();
+    final bool lightTheme = context.lightTheme();
 
     return _SmoothBaseButton2(
       data: data,
-      backgroundColor:
-          context.lightTheme() ? colors.primaryBlack : colors.primaryDark,
-      foregroundColor: Colors.white,
+      backgroundColor: lightTheme ? colors.primaryBlack : colors.primaryLight,
+      foregroundColor: lightTheme ? Colors.white : colors.primaryDark,
     );
   }
 }
@@ -171,12 +172,15 @@ class _SmoothNegativeButton2 extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final SmoothColorsThemeExtension colors =
-        Theme.of(context).extension<SmoothColorsThemeExtension>()!;
+        context.extension<SmoothColorsThemeExtension>();
+
+    final bool lightTheme = context.lightTheme();
 
     return _SmoothBaseButton2(
       data: data,
-      backgroundColor: colors.primaryMedium,
-      foregroundColor: colors.primaryDark,
+      backgroundColor:
+          lightTheme ? colors.primaryMedium : colors.primaryDark,
+      foregroundColor: lightTheme ? colors.primaryDark : colors.primaryLight,
     );
   }
 }

--- a/packages/smooth_app/lib/widgets/v2/smooth_buttons_bar.dart
+++ b/packages/smooth_app/lib/widgets/v2/smooth_buttons_bar.dart
@@ -178,8 +178,7 @@ class _SmoothNegativeButton2 extends StatelessWidget {
 
     return _SmoothBaseButton2(
       data: data,
-      backgroundColor:
-          lightTheme ? colors.primaryMedium : colors.primaryDark,
+      backgroundColor: lightTheme ? colors.primaryMedium : colors.primaryDark,
       foregroundColor: lightTheme ? colors.primaryDark : colors.primaryLight,
     );
   }


### PR DESCRIPTION
Hi!

This PR brings 3 minor changes:

## Ingredients/packaging
- Tapping outside the ingredients/packaging textfield will close the keyboard
- The outdated icon on ingredients/packaging screen will show some explanations
![IMG_1772](https://github.com/user-attachments/assets/3f143d5d-3715-47c1-a011-fa6e3106a88e)


## Photo Gallery
- In the gallery, languages with photos will have a camera icon, instead of a ☑

![IMG_1763](https://github.com/user-attachments/assets/bd352d42-6833-4dd6-8db1-5e28007e2dfe)
