### PR TITLE
fix: Harmonize owner field icon + bugfixes

### DIFF
--- a/packages/smooth_app/lib/generic_lib/widgets/smooth_text_form_field.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/smooth_text_form_field.dart
@@ -30,6 +30,7 @@ class SmoothTextFormField extends StatefulWidget {
     this.focusNode,
     this.spellCheckConfiguration,
     this.allowEmojis = true,
+    this.maxLines,
   });
 
   final TextFieldTypes type;
@@ -49,6 +50,7 @@ class SmoothTextFormField extends StatefulWidget {
   final FocusNode? focusNode;
   final SpellCheckConfiguration? spellCheckConfiguration;
   final bool allowEmojis;
+  final int? maxLines;
 
   @override
   State<SmoothTextFormField> createState() => _SmoothTextFormFieldState();
@@ -90,6 +92,7 @@ class _SmoothTextFormFieldState extends State<SmoothTextFormField> {
       focusNode: widget.focusNode,
       autofillHints: widget.autofillHints,
       autofocus: widget.autofocus ?? false,
+      maxLines: widget.maxLines,
       autovalidateMode: AutovalidateMode.onUserInteraction,
       onChanged: widget.onChanged ??
           (String data) {
@@ -118,7 +121,7 @@ class _SmoothTextFormFieldState extends State<SmoothTextFormField> {
           overflow: TextOverflow.ellipsis,
         ),
         hintText: widget.hintText,
-        hintMaxLines: 2,
+        hintMaxLines: widget.maxLines ?? 2,
         border: const OutlineInputBorder(
           borderRadius: CIRCULAR_BORDER_RADIUS,
         ),
@@ -142,7 +145,7 @@ class _SmoothTextFormFieldState extends State<SmoothTextFormField> {
                         : const Icon(Icons.visibility),
                   )
                 : null),
-        errorMaxLines: 2,
+        errorMaxLines: widget.maxLines ?? 2,
       ),
     );
   }

--- a/packages/smooth_app/lib/pages/input/smooth_autocomplete_text_field.dart
+++ b/packages/smooth_app/lib/pages/input/smooth_autocomplete_text_field.dart
@@ -24,6 +24,7 @@ class SmoothAutocompleteTextField extends StatefulWidget {
     this.borderRadius,
     this.padding,
     this.textStyle,
+    this.textCapitalization,
   });
 
   final FocusNode focusNode;
@@ -38,6 +39,7 @@ class SmoothAutocompleteTextField extends StatefulWidget {
   final BorderRadius? borderRadius;
   final EdgeInsetsGeometry? padding;
   final TextStyle? textStyle;
+  final TextCapitalization? textCapitalization;
 
   @override
   State<SmoothAutocompleteTextField> createState() =>
@@ -90,6 +92,8 @@ class _SmoothAutocompleteTextFieldState
           if (!widget.allowEmojis)
             FilteringTextInputFormatter.deny(TextHelper.emojiRegex),
         ],
+        textCapitalization:
+            widget.textCapitalization ?? TextCapitalization.none,
         style: widget.textStyle,
         decoration: InputDecoration(
           contentPadding: widget.padding ??

--- a/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
@@ -329,23 +329,6 @@ class _AddBasicDetailsPageState extends State<AddBasicDetailsPage> {
     }
   }
 
-  bool _hasOwnerField() {
-    if (_multilingualHelper.isMonolingual()) {
-      if (_isOwnerField(ProductField.NAME)) {
-        return true;
-      }
-    } else {
-      if (_isOwnerField(
-        ProductField.NAME_IN_LANGUAGES,
-        language: _multilingualHelper.getCurrentLanguage(),
-      )) {
-        return true;
-      }
-    }
-    return _isOwnerField(ProductField.BRANDS) ||
-        _isOwnerField(ProductField.QUANTITY);
-  }
-
   bool _isOwnerField(
     final ProductField productField, {
     final OpenFoodFactsLanguage? language,

--- a/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
@@ -88,24 +88,6 @@ class _AddBasicDetailsPageState extends State<AddBasicDetailsPage> {
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
 
-    Widget child = Provider<Product>.value(
-      value: _product,
-      child: _buildForm(
-        context: context,
-        appLocalizations: appLocalizations,
-        showPhotos: _showPhotosBanner,
-      ),
-    );
-
-    if (_hasOwnerField()) {
-      child = Column(
-        children: <Widget>[
-          Expanded(child: child),
-          const OwnerFieldBanner(),
-        ],
-      );
-    }
-
     return WillPopScope2(
       onWillPop: () async => (await _mayExitPage(saving: false), null),
       child: UnfocusFieldWhenTapOutside(
@@ -129,7 +111,14 @@ class _AddBasicDetailsPageState extends State<AddBasicDetailsPage> {
           backgroundColor: context.lightTheme()
               ? context.extension<SmoothColorsThemeExtension>().primaryLight
               : null,
-          body: child,
+          body: Provider<Product>.value(
+            value: _product,
+            child: _buildForm(
+              context: context,
+              appLocalizations: appLocalizations,
+              showPhotos: _showPhotosBanner,
+            ),
+          ),
           bottomNavigationBar: ProductBottomButtonsBar(
             onSave: () async => _exitPage(
               await _mayExitPage(saving: true),
@@ -398,6 +387,7 @@ class _ProductMonolingualNameInputWidget extends StatelessWidget {
                 (Platform.isAndroid || Platform.isIOS)
             ? const SpellCheckConfiguration()
             : const SpellCheckConfiguration.disabled(),
+        maxLines: 1,
       ),
     );
   }
@@ -524,6 +514,8 @@ class _ProductQuantityInputWidget extends StatelessWidget {
         type: TextFieldTypes.PLAIN_TEXT,
         hintText: appLocalizations.add_basic_details_quantity_hint,
         hintTextStyle: SmoothTextFormField.defaultHintTextStyle(context),
+        allowEmojis: false,
+        maxLines: 1,
       ),
     );
   }
@@ -549,10 +541,13 @@ class _BasicDetailInputWrapper extends StatelessWidget {
     return SmoothCardWithRoundedHeader(
       title: title,
       leading: icon,
-      trailing: ownerField
-          ? const Padding(
-              padding: EdgeInsetsDirectional.only(end: 7.0),
-              child: OwnerFieldIcon(),
+      trailing: ownerField ? const OwnerFieldSmoothCardIcon() : null,
+      titlePadding: ownerField
+          ? const EdgeInsetsDirectional.only(
+              top: 2.0,
+              start: LARGE_SPACE,
+              end: SMALL_SPACE,
+              bottom: 2.0,
             )
           : null,
       contentPadding: EdgeInsets.zero,

--- a/packages/smooth_app/lib/pages/product/edit_ocr/edit_ocr_image.dart
+++ b/packages/smooth_app/lib/pages/product/edit_ocr/edit_ocr_image.dart
@@ -13,6 +13,7 @@ import 'package:smooth_app/pages/image/product_image_helper.dart';
 import 'package:smooth_app/pages/product/edit_ocr/edit_ocr_page.dart';
 import 'package:smooth_app/pages/product/edit_ocr/edit_ocr_textfield.dart';
 import 'package:smooth_app/pages/product/edit_ocr/ocr_helper.dart';
+import 'package:smooth_app/pages/product/owner_field_info.dart';
 import 'package:smooth_app/resources/app_animations.dart';
 import 'package:smooth_app/resources/app_icons.dart' as icons;
 import 'package:smooth_app/themes/smooth_theme.dart';
@@ -101,12 +102,12 @@ class EditOCRImageWidget extends StatelessWidget {
         reduceHeader = true;
 
         if (headerIcons == null) {
-          headerIcons = const EditOCROwnerFieldIcon();
+          headerIcons = const OwnerFieldSmoothCardIcon();
         } else {
           headerIcons = Row(
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
-              const EditOCROwnerFieldIcon(),
+              const OwnerFieldSmoothCardIcon(),
               headerIcons,
             ],
           );

--- a/packages/smooth_app/lib/pages/product/edit_ocr/edit_ocr_image.dart
+++ b/packages/smooth_app/lib/pages/product/edit_ocr/edit_ocr_image.dart
@@ -11,7 +11,6 @@ import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/helpers/num_utils.dart';
 import 'package:smooth_app/pages/image/product_image_helper.dart';
 import 'package:smooth_app/pages/product/edit_ocr/edit_ocr_page.dart';
-import 'package:smooth_app/pages/product/edit_ocr/edit_ocr_textfield.dart';
 import 'package:smooth_app/pages/product/edit_ocr/ocr_helper.dart';
 import 'package:smooth_app/pages/product/owner_field_info.dart';
 import 'package:smooth_app/resources/app_animations.dart';

--- a/packages/smooth_app/lib/pages/product/edit_ocr/edit_ocr_textfield.dart
+++ b/packages/smooth_app/lib/pages/product/edit_ocr/edit_ocr_textfield.dart
@@ -59,7 +59,7 @@ class EditOCRTextField extends StatelessWidget {
         trailing: Row(
           mainAxisSize: MainAxisSize.min,
           children: <Widget>[
-            if (isOwnerField) const EditOCROwnerFieldIcon(),
+            if (isOwnerField) const OwnerFieldSmoothCardIcon(),
             ExplanationTitleIcon(
               type: helper.getType(appLocalizations),
               text: helper.getInstructions(appLocalizations),
@@ -179,24 +179,6 @@ class EditOCRExtraButton extends StatelessWidget {
           bottom: SMALL_SPACE,
           start: VERY_SMALL_SPACE,
         ),
-      ),
-    );
-  }
-}
-
-class EditOCROwnerFieldIcon extends StatelessWidget {
-  const EditOCROwnerFieldIcon();
-
-  @override
-  Widget build(BuildContext context) {
-    final AppLocalizations appLocalizations = AppLocalizations.of(context);
-
-    return SmoothCardHeaderButton(
-      tooltip: appLocalizations.owner_field_info_title,
-      child: const OwnerFieldIcon(),
-      onTap: () => showOwnerFieldInfoInModalSheet(
-        context,
-        headerColor: SmoothCardWithRoundedHeader.getHeaderColor(context),
       ),
     );
   }

--- a/packages/smooth_app/lib/pages/product/owner_field_info.dart
+++ b/packages/smooth_app/lib/pages/product/owner_field_info.dart
@@ -2,30 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:smooth_app/generic_lib/bottom_sheets/smooth_bottom_sheet.dart';
 import 'package:smooth_app/generic_lib/duration_constants.dart';
+import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/widgets/smooth_banner.dart';
 import 'package:smooth_app/widgets/widget_height.dart';
 
 /// Icon to display when the product field value is "producer provided".
 const IconData _ownerFieldIconData = Icons.factory;
-
-/// Standard info tile about "owner fields".
-class OwnerFieldInfo extends StatelessWidget {
-  const OwnerFieldInfo({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    final bool dark = Theme.of(context).brightness == Brightness.dark;
-    final Color? darkGrey = Colors.grey[700];
-    final Color? lightGrey = Colors.grey[300];
-    return ListTile(
-      tileColor: dark ? darkGrey : lightGrey,
-      leading: const Icon(_ownerFieldIconData),
-      title: Text(appLocalizations.owner_field_info_title),
-      subtitle: Text(appLocalizations.owner_field_info_message),
-    );
-  }
-}
 
 class OwnerFieldBanner extends StatelessWidget {
   const OwnerFieldBanner({
@@ -188,4 +170,22 @@ Future<void> showOwnerFieldInfoInModalSheet(
       );
     },
   );
+}
+
+class OwnerFieldSmoothCardIcon extends StatelessWidget {
+  const OwnerFieldSmoothCardIcon();
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+
+    return SmoothCardHeaderButton(
+      tooltip: appLocalizations.owner_field_info_title,
+      child: const OwnerFieldIcon(),
+      onTap: () => showOwnerFieldInfoInModalSheet(
+        context,
+        headerColor: SmoothCardWithRoundedHeader.getHeaderColor(context),
+      ),
+    );
+  }
 }

--- a/packages/smooth_app/lib/pages/product/simple_input_page.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page.dart
@@ -10,7 +10,6 @@ import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/pages/input/unfocus_field_when_tap_outside.dart';
 import 'package:smooth_app/pages/product/common/product_buttons.dart';
 import 'package:smooth_app/pages/product/may_exit_page_helper.dart';
-import 'package:smooth_app/pages/product/owner_field_info.dart';
 import 'package:smooth_app/pages/product/simple_input_page_helpers.dart';
 import 'package:smooth_app/pages/product/simple_input_widget.dart';
 import 'package:smooth_app/themes/smooth_theme_colors.dart';
@@ -58,17 +57,6 @@ class _SimpleInputPageState extends State<SimpleInputPage> {
     final List<Widget> simpleInputs = <Widget>[];
     final List<String> titles = <String>[];
 
-    bool hasOwnerField = false;
-    for (final AbstractSimpleInputPageHelper helper in widget.helpers) {
-      if (helper.isOwnerField(widget.product)) {
-        hasOwnerField = true;
-        break;
-      }
-    }
-
-    if (hasOwnerField) {
-      simpleInputs.add(const OwnerFieldInfo());
-    }
     for (int i = 0; i < widget.helpers.length; i++) {
       titles.add(widget.helpers[i].getTitle(appLocalizations));
       simpleInputs.add(
@@ -93,7 +81,7 @@ class _SimpleInputPageState extends State<SimpleInputPage> {
               helper: widget.helpers[i],
               product: widget.product,
               controller: _controllers[i],
-              displayTitle: widget.helpers.length > 1,
+              displayTitle: true,
             ),
           ),
         ),

--- a/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
@@ -120,6 +120,12 @@ abstract class AbstractSimpleInputPageHelper extends ChangeNotifier {
   ) =>
       null;
 
+  /// Text capitalization for the text field.
+  TextCapitalization? getTextCapitalization() => null;
+
+  /// Allow emojis in the text field.
+  bool getAllowEmojis() => false;
+
   /// Typical extra widget for the "add other pics" button.
   @protected
   Widget getExtraPhotoWidget(
@@ -432,6 +438,9 @@ class SimpleInputPageEmbCodeHelper extends AbstractSimpleInputPageHelper {
         product,
         AppLocalizations.of(context).add_emb_photo_button_label,
       );
+
+  @override
+  TextCapitalization getTextCapitalization() => TextCapitalization.characters;
 }
 
 /// Implementation for "Labels" of an [AbstractSimpleInputPageHelper].

--- a/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
@@ -128,9 +128,11 @@ abstract class AbstractSimpleInputPageHelper extends ChangeNotifier {
     final String title,
   ) =>
       Padding(
-        padding: const EdgeInsets.symmetric(
-          vertical: SMALL_SPACE,
-          horizontal: SMALL_SPACE,
+        padding: const EdgeInsetsDirectional.only(
+          top: 0,
+          start: SMALL_SPACE,
+          end: SMALL_SPACE,
+          bottom: SMALL_SPACE,
         ),
         child: addPanelButton(
           title,
@@ -171,7 +173,9 @@ abstract class AbstractSimpleInputPageHelper extends ChangeNotifier {
     if (input.isEmpty) {
       return <String>[];
     }
-    return input.split(separator);
+    return input.split(separator.trim()).map((String e) => e.trim()).toList(
+          growable: false,
+        );
   }
 
   /// Returns the current language.

--- a/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_text_field.dart
@@ -23,6 +23,8 @@ class SimpleInputTextField extends StatefulWidget {
     required this.productType,
     this.suffixIcon,
     this.borderRadius,
+    this.textCapitalization,
+    this.allowEmojis,
   });
 
   final FocusNode focusNode;
@@ -41,6 +43,8 @@ class SimpleInputTextField extends StatefulWidget {
   final ProductType? productType;
   final Widget? suffixIcon;
   final BorderRadius? borderRadius;
+  final TextCapitalization? textCapitalization;
+  final bool? allowEmojis;
 
   @override
   State<SimpleInputTextField> createState() => _SimpleInputTextFieldState();
@@ -87,6 +91,8 @@ class _SimpleInputTextFieldState extends State<SimpleInputTextField> {
               focusNode: widget.focusNode,
               controller: widget.controller,
               autocompleteKey: widget.autocompleteKey,
+              textCapitalization: widget.textCapitalization,
+              allowEmojis: widget.allowEmojis ?? true,
               hintText: widget.hintText,
               constraints: widget.constraints,
               manager: _manager,

--- a/packages/smooth_app/lib/pages/product/simple_input_widget.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_widget.dart
@@ -64,7 +64,6 @@ class _SimpleInputWidgetState extends State<SimpleInputWidget> {
       context,
       widget.product,
     );
-    final bool isOwnerField = widget.helper.isOwnerField(widget.product);
 
     final Widget child = Column(
       mainAxisSize: MainAxisSize.min,
@@ -106,7 +105,6 @@ class _SimpleInputWidgetState extends State<SimpleInputWidget> {
                         start: 3.0,
                       ),
                       productType: widget.product.productType,
-                      suffixIcon: !isOwnerField ? null : const OwnerFieldIcon(),
                       borderRadius: const BorderRadius.all(
                         Radius.circular(20.0),
                       ),
@@ -149,16 +147,16 @@ class _SimpleInputWidgetState extends State<SimpleInputWidget> {
       ],
     );
 
+    final Widget? trailingHeader = _getTrailingHeader(
+      explanations,
+      appLocalizations,
+    );
+
     return SmoothCardWithRoundedHeader(
       leading: widget.helper.getIcon(),
       title: widget.helper.getTitle(appLocalizations),
-      trailing: explanations != null && widget.displayTitle
-          ? ExplanationTitleIcon(
-              text: explanations,
-              type: widget.helper.getTitle(appLocalizations),
-            )
-          : null,
-      titlePadding: explanations != null && widget.displayTitle
+      trailing: trailingHeader,
+      titlePadding: trailingHeader != null
           ? const EdgeInsetsDirectional.only(
               top: 2.0,
               start: LARGE_SPACE,
@@ -168,6 +166,36 @@ class _SimpleInputWidgetState extends State<SimpleInputWidget> {
           : null,
       child: child,
     );
+  }
+
+  Widget? _getTrailingHeader(
+    String? explanations,
+    AppLocalizations appLocalizations,
+  ) {
+    if (!widget.displayTitle) {
+      return null;
+    }
+
+    final List<Widget> children = <Widget>[
+      if (widget.helper.isOwnerField(widget.product))
+        const OwnerFieldSmoothCardIcon(),
+      if (explanations != null)
+        ExplanationTitleIcon(
+          text: explanations,
+          type: widget.helper.getTitle(appLocalizations),
+        ),
+    ];
+
+    if (children.isEmpty) {
+      return null;
+    } else if (children.length == 1) {
+      return children.first;
+    } else {
+      return Row(
+        mainAxisSize: MainAxisSize.min,
+        children: children,
+      );
+    }
   }
 
   Widget _getList(AppLocalizations appLocalizations) {

--- a/packages/smooth_app/lib/pages/product/simple_input_widget.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_widget.dart
@@ -95,6 +95,8 @@ class _SimpleInputWidgetState extends State<SimpleInputWidget> {
                       tagType: widget.helper.getTagType(),
                       autocompleteManager:
                           widget.helper.getAutocompleteManager(),
+                      textCapitalization: widget.helper.getTextCapitalization(),
+                      allowEmojis: widget.helper.getAllowEmojis(),
                       hintText: widget.helper.getAddHint(appLocalizations),
                       controller: widget.controller,
                       padding: const EdgeInsets.symmetric(

--- a/packages/smooth_app/lib/pages/product/simple_input_widget.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_widget.dart
@@ -139,7 +139,12 @@ class _SimpleInputWidgetState extends State<SimpleInputWidget> {
         ),
         _getList(appLocalizations),
         if (extraWidget != null)
-          extraWidget
+          Padding(
+            padding: EdgeInsetsDirectional.only(
+              top: _localTerms.isEmpty ? SMALL_SPACE : 0.0,
+            ),
+            child: extraWidget,
+          )
         else if (_localTerms.isEmpty)
           const SizedBox(height: MEDIUM_SPACE)
         else

--- a/packages/smooth_app/lib/pages/user_management/login_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/login_page.dart
@@ -189,6 +189,7 @@ class _LoginPageState extends State<LoginPage> with TraceableClientMixin {
                         textInputType: TextInputType.text,
                         controller: passwordController,
                         hintText: appLocalizations.password,
+                        maxLines: 1,
                         prefixIcon: const Icon(Icons.vpn_key),
                         enabled: !_runningQuery,
                         textInputAction: TextInputAction.send,

--- a/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
@@ -165,6 +165,7 @@ class _SignUpPageState extends State<SignUpPage> with TraceableClientMixin {
                 focusNode: _password1FocusNode,
                 textInputAction: TextInputAction.next,
                 hintText: appLocalizations.sign_up_page_password_hint,
+                maxLines: 1,
                 onFieldSubmitted: (_) =>
                     FocusScope.of(context).requestFocus(_password2FocusNode),
                 prefixIcon: const Icon(Icons.vpn_key),
@@ -188,6 +189,7 @@ class _SignUpPageState extends State<SignUpPage> with TraceableClientMixin {
                 focusNode: _password2FocusNode,
                 textInputAction: TextInputAction.send,
                 hintText: appLocalizations.sign_up_page_confirm_password_hint,
+                maxLines: 1,
                 prefixIcon: const Icon(Icons.vpn_key),
                 autofillHints: const <String>[
                   AutofillHints.newPassword,


### PR DESCRIPTION
Hi everyone!

## Harmonization of the owner field icon
The owner field icon is always in the header of the title (Basic details / the list of multiple inputs / single)
![IMG_1775](https://github.com/user-attachments/assets/b2359f1d-11c6-4334-8242-40db3f181a0a)

## Improvements
- For all text fields, emojis are disabled
- For EMB Codes, the keyboard is forced in "uppercase mode"

## Bugfixes
There was an issue with the brands' input when the separator was incorrect.