### PR TITLE
feat: Edit page: clickable barcode + open product on website

### DIFF
--- a/packages/smooth_app/lib/generic_lib/widgets/smooth_snackbar.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/smooth_snackbar.dart
@@ -65,6 +65,7 @@ class SmoothFloatingSnackbar extends SnackBar {
           content: Row(
             children: <Widget>[
               Expanded(child: Text(text)),
+              const SizedBox(width: SMALL_SPACE),
               const Icon(
                 Icons.check_circle,
                 color: Colors.white,

--- a/packages/smooth_app/lib/helpers/border_radius_helper.dart
+++ b/packages/smooth_app/lib/helpers/border_radius_helper.dart
@@ -29,4 +29,21 @@ class BorderRadiusHelper {
           : bottomStart ?? Radius.zero,
     );
   }
+
+  static BorderRadius horizontalDirectional({
+    required BuildContext context,
+    Radius? start,
+    Radius? end,
+  }) {
+    final TextDirection textDirection = Directionality.of(context);
+
+    return BorderRadius.horizontal(
+      left: textDirection == TextDirection.ltr
+          ? start ?? Radius.zero
+          : end ?? Radius.zero,
+      right: textDirection == TextDirection.ltr
+          ? end ?? Radius.zero
+          : start ?? Radius.zero,
+    );
+  }
 }

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -2604,15 +2604,10 @@
     },
     "clipboard_barcode_copy": "Copy barcode to clipboard",
     "@clipboard_barcode_copied": {
-        "description": "Snackbar label after clipboard copy",
-        "placeholders": {
-            "barcode": {
-                "type": "String",
-                "description": "barcode"
-            }
-        }
+        "description": "Snackbar label after clipboard copy"
     },
     "clipboard_barcode_copied": "Barcode {barcode} copied to the clipboard!",
+    "open_product_website": "Open this product on the website",
     "language_picker_label": "Your language",
     "@language_picker_label": {
         "description": "Choose Application Language"

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -2613,6 +2613,7 @@
         }
     },
     "clipboard_barcode_copied": "Le code-barres {barcode} a été copié dans le presse-papiers !",
+    "open_product_website": "Ouvrir le produit sur sur le site web",
     "language_picker_label": "Votre langue",
     "@language_picker_label": {
         "description": "Choose Application Language"

--- a/packages/smooth_app/lib/pages/product/edit_product_barcode.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_barcode.dart
@@ -1,0 +1,164 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/generic_lib/widgets/smooth_snackbar.dart';
+import 'package:smooth_app/helpers/border_radius_helper.dart';
+import 'package:smooth_app/themes/smooth_theme.dart';
+import 'package:smooth_app/themes/smooth_theme_colors.dart';
+import 'package:smooth_app/themes/theme_provider.dart';
+import 'package:smooth_app/widgets/smooth_barcode_widget.dart';
+
+class EditProductBarcode extends StatefulWidget {
+  EditProductBarcode({
+    required this.barcode,
+  })  : assert(barcode.isNotEmpty == true),
+        assert(isAValidBarcode(barcode));
+
+  static const double barcodeHeight = 120.0;
+
+  final String barcode;
+
+  @override
+  State<EditProductBarcode> createState() => _EditProductBarcodeState();
+
+  static bool isAValidBarcode(String? barcode) =>
+      barcode != null && <int>[7, 8, 12, 13].contains(barcode.length);
+
+  static Color borderColor = const Color(0xFFC3C3C3);
+}
+
+class _EditProductBarcodeState extends State<EditProductBarcode> {
+  bool _isAnInvalidBarcode = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final Size screenSize = MediaQuery.sizeOf(context);
+    final SmoothColorsThemeExtension extension =
+        context.extension<SmoothColorsThemeExtension>();
+
+    final Color color = context.lightTheme()
+        ? EditProductBarcode.borderColor
+        : extension.primaryLight;
+
+    return MergeSemantics(
+      child: Padding(
+        padding: const EdgeInsetsDirectional.only(
+          top: VERY_SMALL_SPACE,
+          bottom: SMALL_SPACE,
+        ),
+        child: Center(
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: <Widget>[
+              ExcludeSemantics(
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadiusHelper.fromDirectional(
+                      context: context,
+                      topStart: ROUNDED_RADIUS,
+                      bottomStart: ROUNDED_RADIUS,
+                      topEnd: ROUNDED_RADIUS,
+                    ),
+                    border: Border.all(
+                      color: color,
+                      width: 2.0,
+                    ),
+                    color: Colors.white70,
+                  ),
+                  child: ConstrainedBox(
+                    constraints: BoxConstraints(
+                      maxWidth: screenSize.width / 1.4,
+                      maxHeight: 120.0,
+                    ),
+                    child: SmoothBarcodeWidget(
+                      padding: const EdgeInsetsDirectional.only(
+                        top: MEDIUM_SPACE,
+                        start: 14.0,
+                        end: 19.0,
+                        bottom: MEDIUM_SPACE,
+                      ),
+                      color: context.lightTheme() ? Colors.black : Colors.white,
+                      barcode: widget.barcode,
+                      onInvalidBarcode: () {
+                        if (!_isAnInvalidBarcode) {
+                          WidgetsBinding.instance.addPostFrameCallback((_) {
+                            setState(() => _isAnInvalidBarcode = true);
+                          });
+                        }
+                      },
+                      height: _isAnInvalidBarcode
+                          ? null
+                          : EditProductBarcode.barcodeHeight,
+                    ),
+                  ),
+                ),
+              ),
+              _EditProductBarcodeCopyButton(
+                barcode: widget.barcode,
+                color: color,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _EditProductBarcodeCopyButton extends StatelessWidget {
+  const _EditProductBarcodeCopyButton({
+    required this.barcode,
+    required this.color,
+  });
+
+  final String barcode;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+
+    final BorderRadius borderRadius = BorderRadiusHelper.fromDirectional(
+      context: context,
+      bottomEnd: ROUNDED_RADIUS,
+      topEnd: ROUNDED_RADIUS,
+    );
+
+    return Ink(
+      decoration: BoxDecoration(
+        borderRadius: borderRadius,
+        color: color,
+      ),
+      child: Tooltip(
+        message: appLocalizations.clipboard_barcode_copy,
+        child: InkWell(
+          borderRadius: borderRadius,
+          splashColor: Colors.white54,
+          child: const Padding(
+            padding: EdgeInsetsDirectional.only(
+              start: 6.0,
+              end: 13.0,
+              top: SMALL_SPACE,
+              bottom: 9.0,
+            ),
+            child: Icon(Icons.copy),
+          ),
+          onTap: () {
+            Clipboard.setData(
+              ClipboardData(text: barcode),
+            );
+
+            ScaffoldMessenger.of(context).showSnackBar(
+              SmoothFloatingSnackbar.positive(
+                context: context,
+                text: appLocalizations.clipboard_barcode_copied(barcode),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/packages/smooth_app/lib/pages/product/edit_product_barcode.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_barcode.dart
@@ -56,12 +56,6 @@ class _EditProductBarcodeState extends State<EditProductBarcode> {
               ExcludeSemantics(
                 child: DecoratedBox(
                   decoration: BoxDecoration(
-                    borderRadius: BorderRadiusHelper.fromDirectional(
-                      context: context,
-                      topStart: ROUNDED_RADIUS,
-                      bottomStart: ROUNDED_RADIUS,
-                      topEnd: ROUNDED_RADIUS,
-                    ),
                     border: Border.all(
                       color: color,
                       width: 2.0,
@@ -77,7 +71,7 @@ class _EditProductBarcodeState extends State<EditProductBarcode> {
                       padding: const EdgeInsetsDirectional.only(
                         top: MEDIUM_SPACE,
                         start: 14.0,
-                        end: 19.0,
+                        end: 19.5,
                         bottom: MEDIUM_SPACE,
                       ),
                       color: context.lightTheme() ? Colors.black : Colors.white,

--- a/packages/smooth_app/lib/pages/product/edit_product_barcode.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_barcode.dart
@@ -46,6 +46,7 @@ class _EditProductBarcodeState extends State<EditProductBarcode> {
         padding: const EdgeInsetsDirectional.only(
           top: VERY_SMALL_SPACE,
           bottom: SMALL_SPACE,
+          start: SMALL_SPACE,
         ),
         child: Center(
           child: Row(

--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -1,6 +1,5 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
@@ -12,12 +11,14 @@ import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_back_button.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_list_tile_card.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
+import 'package:smooth_app/helpers/launch_url_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/pages/onboarding/currency_selector_helper.dart';
 import 'package:smooth_app/pages/prices/price_meta_product.dart';
 import 'package:smooth_app/pages/prices/product_price_add_page.dart';
 import 'package:smooth_app/pages/product/add_other_details_page.dart';
 import 'package:smooth_app/pages/product/common/product_refresher.dart';
+import 'package:smooth_app/pages/product/edit_product_barcode.dart';
 import 'package:smooth_app/pages/product/gallery_view/product_image_gallery_view.dart';
 import 'package:smooth_app/pages/product/nutrition_page_loaded.dart';
 import 'package:smooth_app/pages/product/product_field_editor.dart';
@@ -28,8 +29,6 @@ import 'package:smooth_app/resources/app_icons.dart' as icons;
 import 'package:smooth_app/themes/smooth_theme_colors.dart';
 import 'package:smooth_app/themes/theme_provider.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
-import 'package:smooth_app/widgets/smooth_barcode_widget.dart';
-import 'package:smooth_app/widgets/smooth_floating_message.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
 /// Page where we can indirectly edit all data about a product.
@@ -44,7 +43,7 @@ class EditProductPage extends StatefulWidget {
 
 class _EditProductPageState extends State<EditProductPage> with UpToDateMixin {
   final ScrollController _controller = ScrollController();
-  bool _barcodeVisibleInAppbar = false;
+  bool _actionsVisibleInAppbar = false;
 
   @override
   void initState() {
@@ -90,7 +89,7 @@ class _EditProductPageState extends State<EditProductPage> with UpToDateMixin {
                   maxFontSize:
                       theme.textTheme.titleLarge?.fontSize?.clamp(13.0, 20.0) ??
                           18.0,
-                  maxLines: !_barcodeVisibleInAppbar ? 2 : 1,
+                  maxLines: !_actionsVisibleInAppbar ? 2 : 1,
                   style: theme.textTheme.titleLarge?.copyWith(
                     fontWeight: FontWeight.w500,
                   ),
@@ -98,7 +97,7 @@ class _EditProductPageState extends State<EditProductPage> with UpToDateMixin {
                 if (barcode.isNotEmpty)
                   AnimatedContainer(
                     duration: const Duration(milliseconds: 250),
-                    height: _barcodeVisibleInAppbar ? 14.0 : 0.0,
+                    height: _actionsVisibleInAppbar ? 14.0 : 0.0,
                     child: Text(
                       barcode,
                       style: theme.textTheme.titleMedium?.copyWith(
@@ -114,20 +113,27 @@ class _EditProductPageState extends State<EditProductPage> with UpToDateMixin {
         actions: <Widget>[
           Semantics(
             button: true,
-            value: appLocalizations.clipboard_barcode_copy,
+            value: appLocalizations.open_product_website,
             excludeSemantics: true,
             child: Builder(builder: (BuildContext context) {
               return IconButton(
-                icon: const Icon(Icons.copy),
-                tooltip: appLocalizations.clipboard_barcode_copy,
+                icon: const icons.ExternalLink(
+                  size: 20.0,
+                ),
+                tooltip: appLocalizations.open_product_website,
                 onPressed: () {
-                  Clipboard.setData(
-                    ClipboardData(text: barcode),
+                  LaunchUrlHelper.launchURL(
+                    switch (upToDateProduct.productType) {
+                      ProductType.beauty =>
+                        'https://world.openbeautyfacts.org/product/${upToDateProduct.barcode}',
+                      ProductType.petFood =>
+                        'https://world.openpetfoodfacts.org/product/${upToDateProduct.barcode}',
+                      ProductType.product =>
+                        'https://world.openproductsfacts.org/product/${upToDateProduct.barcode}',
+                      _ =>
+                        'https://world.openfoodfacts.org/product/${upToDateProduct.barcode}',
+                    },
                   );
-
-                  SmoothFloatingMessage(
-                    message: appLocalizations.clipboard_barcode_copied(barcode),
-                  ).show(context, alignment: AlignmentDirectional.bottomCenter);
                 },
               );
             }),
@@ -150,8 +156,8 @@ class _EditProductPageState extends State<EditProductPage> with UpToDateMixin {
             ),
             controller: _controller,
             children: <Widget>[
-              if (_ProductBarcode.isAValidBarcode(barcode))
-                _ProductBarcode(product: upToDateProduct),
+              if (EditProductBarcode.isAValidBarcode(barcode))
+                EditProductBarcode(barcode: upToDateProduct.barcode ?? ''),
               _ListTitleItem(
                 leading: const icons.Edit(size: 18.0),
                 title: appLocalizations.edit_product_form_item_details_title,
@@ -370,11 +376,11 @@ class _EditProductPageState extends State<EditProductPage> with UpToDateMixin {
 
   void _onScrollChanged() {
     final bool visibleBarcode =
-        _controller.offset > _ProductBarcode._barcodeHeight;
+        _controller.offset > EditProductBarcode.barcodeHeight;
 
-    if (visibleBarcode != _barcodeVisibleInAppbar) {
+    if (visibleBarcode != _actionsVisibleInAppbar) {
       setState(() {
-        _barcodeVisibleInAppbar = visibleBarcode;
+        _actionsVisibleInAppbar = visibleBarcode;
       });
     }
   }
@@ -403,47 +409,4 @@ class _ListTitleItem extends SmoothListTileCard {
           icon: leading,
           subtitle: subtitle == null ? null : Text(subtitle),
         );
-}
-
-/// Barcodes only allowed have a length of 7, 8, 12 or 13 characters
-class _ProductBarcode extends StatefulWidget {
-  _ProductBarcode({required this.product})
-      : assert(product.barcode?.isNotEmpty == true),
-        assert(isAValidBarcode(product.barcode));
-
-  static const double _barcodeHeight = 120.0;
-
-  final Product product;
-
-  @override
-  State<_ProductBarcode> createState() => _ProductBarcodeState();
-
-  static bool isAValidBarcode(String? barcode) =>
-      barcode != null && <int>[7, 8, 12, 13].contains(barcode.length);
-}
-
-class _ProductBarcodeState extends State<_ProductBarcode> {
-  bool _isAnInvalidBarcode = false;
-
-  @override
-  Widget build(BuildContext context) {
-    final Size screenSize = MediaQuery.sizeOf(context);
-
-    return SmoothBarcodeWidget(
-      padding: EdgeInsets.symmetric(
-        horizontal: screenSize.width / 4,
-        vertical: SMALL_SPACE,
-      ),
-      color: context.lightTheme() ? Colors.black : Colors.white,
-      barcode: widget.product.barcode!,
-      onInvalidBarcode: () {
-        if (!_isAnInvalidBarcode) {
-          WidgetsBinding.instance.addPostFrameCallback((_) {
-            setState(() => _isAnInvalidBarcode = true);
-          });
-        }
-      },
-      height: _isAnInvalidBarcode ? null : _ProductBarcode._barcodeHeight,
-    );
-  }
 }


### PR DESCRIPTION
Hi everyone!

This PR introduces two changes:
- The copy barcode on the clipboard icon is now next to the barcode
- The `AppBar` action is replaced with the ability to open the product on the website

![IMG_DDD83186670A-1](https://github.com/user-attachments/assets/14b8da6f-15cb-4b09-9ce5-cccbe29dd9e2)