### PR TITLE
feat: Edit page: new UI + clickable barcode + open on website

### DIFF
--- a/packages/smooth_app/lib/generic_lib/widgets/smooth_list_tile_card.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/smooth_list_tile_card.dart
@@ -2,6 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/themes/constant_icons.dart';
+import 'package:smooth_app/themes/smooth_theme.dart';
+import 'package:smooth_app/themes/smooth_theme_colors.dart';
+import 'package:smooth_app/themes/theme_provider.dart';
 
 /// Displays a [ListTile] in a [SmoothCard] wrapped with an [InkWell].
 class SmoothListTileCard extends StatelessWidget {
@@ -10,6 +13,7 @@ class SmoothListTileCard extends StatelessWidget {
     this.subtitle,
     this.onTap,
     this.leading,
+    this.margin,
     super.key,
   });
 
@@ -20,6 +24,7 @@ class SmoothListTileCard extends StatelessWidget {
     Widget? title,
     Widget? subtitle,
     GestureTapCallback? onTap,
+    EdgeInsetsGeometry? margin,
     Key? key,
   }) : this(
           title: title,
@@ -31,28 +36,53 @@ class SmoothListTileCard extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[icon ?? const Icon(Icons.edit)],
           ),
+          margin: margin,
         );
 
   final Widget? title;
   final Widget? subtitle;
   final Widget? leading;
   final GestureTapCallback? onTap;
+  final EdgeInsetsGeometry? margin;
 
   @override
-  Widget build(BuildContext context) => SmoothCard(
-        padding: EdgeInsets.zero,
-        child: InkWell(
-          borderRadius: ROUNDED_BORDER_RADIUS,
-          onTap: onTap,
-          child: Padding(
-            padding: const EdgeInsets.all(VERY_SMALL_SPACE),
-            child: ListTile(
-              title: title,
-              subtitle: subtitle,
-              leading: leading,
-              trailing: Icon(ConstantIcons.instance.getForwardIcon()),
-            ),
-          ),
+  Widget build(BuildContext context) {
+    final SmoothColorsThemeExtension extension =
+        context.extension<SmoothColorsThemeExtension>();
+    final bool lightTheme = context.lightTheme();
+
+    return SmoothCard(
+      padding: EdgeInsets.zero,
+      margin: margin ?? const EdgeInsets.all(VERY_SMALL_SPACE),
+      child: InkWell(
+        borderRadius: ROUNDED_BORDER_RADIUS,
+        onTap: onTap,
+        child: ListTile(
+          title: title,
+          subtitle: subtitle,
+          leading: leading != null
+              ? DecoratedBox(
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: lightTheme
+                        ? extension.primaryBlack
+                        : extension.primarySemiDark,
+                  ),
+                  child: Padding(
+                    padding: const EdgeInsetsDirectional.all(BALANCED_SPACE),
+                    child: IconTheme(
+                      data: IconThemeData(
+                        color: lightTheme ? Colors.white : Colors.white,
+                        size: 20.0,
+                      ),
+                      child: leading!,
+                    ),
+                  ),
+                )
+              : null,
+          trailing: Icon(ConstantIcons.instance.getForwardIcon()),
         ),
-      );
+      ),
+    );
+  }
 }

--- a/packages/smooth_app/lib/generic_lib/widgets/smooth_snackbar.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/smooth_snackbar.dart
@@ -65,6 +65,7 @@ class SmoothFloatingSnackbar extends SnackBar {
           content: Row(
             children: <Widget>[
               Expanded(child: Text(text)),
+              const SizedBox(width: SMALL_SPACE),
               const Icon(
                 Icons.check_circle,
                 color: Colors.white,

--- a/packages/smooth_app/lib/helpers/border_radius_helper.dart
+++ b/packages/smooth_app/lib/helpers/border_radius_helper.dart
@@ -29,4 +29,21 @@ class BorderRadiusHelper {
           : bottomStart ?? Radius.zero,
     );
   }
+
+  static BorderRadius horizontalDirectional({
+    required BuildContext context,
+    Radius? start,
+    Radius? end,
+  }) {
+    final TextDirection textDirection = Directionality.of(context);
+
+    return BorderRadius.horizontal(
+      left: textDirection == TextDirection.ltr
+          ? start ?? Radius.zero
+          : end ?? Radius.zero,
+      right: textDirection == TextDirection.ltr
+          ? end ?? Radius.zero
+          : start ?? Radius.zero,
+    );
+  }
 }

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -2604,15 +2604,10 @@
     },
     "clipboard_barcode_copy": "Copy barcode to clipboard",
     "@clipboard_barcode_copied": {
-        "description": "Snackbar label after clipboard copy",
-        "placeholders": {
-            "barcode": {
-                "type": "String",
-                "description": "barcode"
-            }
-        }
+        "description": "Snackbar label after clipboard copy"
     },
     "clipboard_barcode_copied": "Barcode {barcode} copied to the clipboard!",
+    "open_product_website": "Open this product on the website",
     "language_picker_label": "Your language",
     "@language_picker_label": {
         "description": "Choose Application Language"

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -2613,6 +2613,7 @@
         }
     },
     "clipboard_barcode_copied": "Le code-barres {barcode} a été copié dans le presse-papiers !",
+    "open_product_website": "Ouvrir le produit sur sur le site web",
     "language_picker_label": "Votre langue",
     "@language_picker_label": {
         "description": "Choose Application Language"

--- a/packages/smooth_app/lib/pages/product/edit_product_barcode.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_barcode.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
+import 'package:smooth_app/generic_lib/widgets/smooth_snackbar.dart';
+import 'package:smooth_app/resources/app_icons.dart';
+import 'package:smooth_app/themes/theme_provider.dart';
+import 'package:smooth_app/widgets/smooth_barcode_widget.dart';
+
+class EditProductBarcode extends StatefulWidget {
+  EditProductBarcode({
+    required this.barcode,
+  })  : assert(barcode.isNotEmpty == true),
+        assert(isAValidBarcode(barcode));
+
+  static const double barcodeHeight = 110.0;
+
+  final String barcode;
+
+  @override
+  State<EditProductBarcode> createState() => _EditProductBarcodeState();
+
+  static bool isAValidBarcode(String? barcode) =>
+      barcode != null && <int>[7, 8, 12, 13].contains(barcode.length);
+
+  static Color borderColor = const Color(0xFFC3C3C3);
+}
+
+class _EditProductBarcodeState extends State<EditProductBarcode> {
+  bool _isAnInvalidBarcode = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+
+    return SmoothCardWithRoundedHeader(
+      title: appLocalizations.barcode,
+      leading: const Barcode.rounded(),
+      trailing: _EditProductBarcodeCopyButton(barcode: widget.barcode),
+      titlePadding: const EdgeInsetsDirectional.only(
+        top: 2.0,
+        start: LARGE_SPACE,
+        end: SMALL_SPACE,
+        bottom: 2.0,
+      ),
+      contentPadding: const EdgeInsetsDirectional.only(
+        top: SMALL_SPACE,
+        bottom: VERY_SMALL_SPACE,
+      ),
+      child: MergeSemantics(
+        child: Padding(
+          padding: const EdgeInsetsDirectional.only(
+            top: VERY_SMALL_SPACE,
+            bottom: SMALL_SPACE,
+            start: SMALL_SPACE,
+          ),
+          child: Center(
+            child: FractionallySizedBox(
+              widthFactor: 0.65,
+              child: SmoothBarcodeWidget(
+                padding: EdgeInsets.zero,
+                color: context.lightTheme() ? Colors.black : Colors.white,
+                barcode: widget.barcode,
+                onInvalidBarcode: () {
+                  if (!_isAnInvalidBarcode) {
+                    WidgetsBinding.instance.addPostFrameCallback((_) {
+                      setState(() => _isAnInvalidBarcode = true);
+                    });
+                  }
+                },
+                height: _isAnInvalidBarcode
+                    ? null
+                    : EditProductBarcode.barcodeHeight,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _EditProductBarcodeCopyButton extends StatelessWidget {
+  const _EditProductBarcodeCopyButton({
+    required this.barcode,
+  });
+
+  final String barcode;
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+
+    return SmoothCardHeaderButton(
+      tooltip: appLocalizations.clipboard_barcode_copy,
+      child: const Icon(Icons.copy),
+      onTap: () {
+        Clipboard.setData(
+          ClipboardData(text: barcode),
+        );
+
+        ScaffoldMessenger.of(context).showSnackBar(
+          SmoothFloatingSnackbar.positive(
+            context: context,
+            text: appLocalizations.clipboard_barcode_copied(barcode),
+          ),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
Hi everyone!

Here are a few changes for the edit page:
- Updated UI
- The "copy barcode on the clipboard" icon is now next to the barcode
- The `AppBar` action is replaced by the ability to open the product on the website

![Untitled](https://github.com/user-attachments/assets/91b47841-a341-4795-94e2-143591582e8b)
