### PR TITLE
feat: KP visual enhancements (titles, chips, text buttons…) - M2

### DIFF
--- a/packages/smooth_app/lib/cards/data_cards/score_card.dart
+++ b/packages/smooth_app/lib/cards/data_cards/score_card.dart
@@ -120,7 +120,7 @@ class ScoreCard extends StatelessWidget {
                   ),
                 ),
               ),
-              if (isClickable) Icon(ConstantIcons.instance.getForwardIcon()),
+              if (isClickable) Icon(ConstantIcons.forwardIcon),
             ],
           ),
         ),

--- a/packages/smooth_app/lib/generic_lib/bottom_sheets/smooth_bottom_sheet.dart
+++ b/packages/smooth_app/lib/generic_lib/bottom_sheets/smooth_bottom_sheet.dart
@@ -499,18 +499,23 @@ class SmoothModalSheetHeaderCloseButton extends StatelessWidget
 
 class SmoothModalSheetHeaderPrefixIndicator extends StatelessWidget
     implements SizeWidget {
-  const SmoothModalSheetHeaderPrefixIndicator({super.key});
+  const SmoothModalSheetHeaderPrefixIndicator({
+    this.color,
+    super.key,
+  });
+
+  final Color? color;
 
   @override
   Widget build(BuildContext context) {
-    return const Padding(
-      padding: EdgeInsetsDirectional.only(end: VERY_SMALL_SPACE),
+    return Padding(
+      padding: const EdgeInsetsDirectional.only(end: VERY_SMALL_SPACE),
       child: SizedBox(
         width: 10.0,
         height: 10.0,
         child: DecoratedBox(
           decoration: BoxDecoration(
-            color: Colors.white,
+            color: color ?? Colors.white,
             shape: BoxShape.circle,
           ),
         ),

--- a/packages/smooth_app/lib/generic_lib/buttons/smooth_large_button_with_icon.dart
+++ b/packages/smooth_app/lib/generic_lib/buttons/smooth_large_button_with_icon.dart
@@ -1,30 +1,33 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:smooth_app/generic_lib/buttons/smooth_simple_button.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
 
 class SmoothLargeButtonWithIcon extends StatelessWidget {
   const SmoothLargeButtonWithIcon({
     required this.text,
-    required this.icon,
     required this.onPressed,
     this.padding,
-    this.trailing,
+    this.leadingIcon,
+    this.trailingIcon,
     this.backgroundColor,
     this.foregroundColor,
     this.textAlign,
     this.textStyle,
+    this.borderRadius,
     this.elevation,
   });
 
   final String text;
-  final IconData icon;
+  final Widget? leadingIcon;
+  final Widget? trailingIcon;
   final VoidCallback? onPressed;
   final EdgeInsetsGeometry? padding;
-  final IconData? trailing;
   final Color? backgroundColor;
   final Color? foregroundColor;
   final TextAlign? textAlign;
   final TextStyle? textStyle;
+  final BorderRadiusGeometry? borderRadius;
   final WidgetStateProperty<double?>? elevation;
 
   Color _getBackgroundColor(final ThemeData themeData) =>
@@ -44,36 +47,38 @@ class SmoothLargeButtonWithIcon extends StatelessWidget {
 
     return SmoothSimpleButton(
       minWidth: double.infinity,
-      padding: padding ?? const EdgeInsets.all(10),
+      padding: padding ?? const EdgeInsets.all(BALANCED_SPACE),
       onPressed: onPressed,
       elevation: elevation,
+      borderRadius: borderRadius ?? ROUNDED_BORDER_RADIUS,
       buttonColor: _getBackgroundColor(themeData),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.start,
-        children: <Widget>[
-          Icon(
-            icon,
-            color: _getForegroundColor(themeData),
-          ),
-          const Spacer(),
-          Expanded(
-            flex: 10,
-            child: AutoSizeText(
-              text,
-              maxLines: 3,
-              minFontSize: 10,
-              textAlign: textAlign,
-              style: style,
-              overflow: TextOverflow.ellipsis,
+      child: IconTheme(
+        data: IconThemeData(
+          color: _getForegroundColor(themeData),
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.start,
+          children: <Widget>[
+            if (leadingIcon != null) ...<Widget>[
+              leadingIcon!,
+              const SizedBox(width: BALANCED_SPACE),
+            ],
+            Expanded(
+              child: AutoSizeText(
+                text,
+                maxLines: 3,
+                minFontSize: 10,
+                textAlign: textAlign,
+                style: style,
+                overflow: TextOverflow.ellipsis,
+              ),
             ),
-          ),
-          const Spacer(),
-          if (trailing != null)
-            Icon(
-              trailing,
-              color: _getForegroundColor(themeData),
-            ),
-        ],
+            if (trailingIcon != null) ...<Widget>[
+              const SizedBox(width: BALANCED_SPACE),
+              trailingIcon!,
+            ],
+          ],
+        ),
       ),
     );
   }

--- a/packages/smooth_app/lib/generic_lib/buttons/smooth_simple_button.dart
+++ b/packages/smooth_app/lib/generic_lib/buttons/smooth_simple_button.dart
@@ -7,10 +7,10 @@ class SmoothSimpleButton extends StatelessWidget {
   const SmoothSimpleButton({
     required this.child,
     required this.onPressed,
-    this.minWidth = 15,
-    this.height = 20,
-    this.borderRadius = ROUNDED_BORDER_RADIUS,
-    this.padding = const EdgeInsets.all(10),
+    this.minWidth = 15.0,
+    this.height = 20.0,
+    this.borderRadius,
+    this.padding = const EdgeInsetsDirectional.all(BALANCED_SPACE),
     this.buttonColor,
     this.elevation,
   });
@@ -19,7 +19,7 @@ class SmoothSimpleButton extends StatelessWidget {
   final VoidCallback? onPressed;
   final double minWidth;
   final double height;
-  final BorderRadius borderRadius;
+  final BorderRadiusGeometry? borderRadius;
   final EdgeInsetsGeometry padding;
   final Color? buttonColor;
   final WidgetStateProperty<double?>? elevation;
@@ -38,7 +38,9 @@ class SmoothSimpleButton extends StatelessWidget {
               ? null
               : WidgetStateProperty.all<Color>(buttonColor!),
           shape: WidgetStateProperty.all<RoundedRectangleBorder>(
-            RoundedRectangleBorder(borderRadius: borderRadius),
+            RoundedRectangleBorder(
+              borderRadius: borderRadius ?? ROUNDED_BORDER_RADIUS,
+            ),
           ),
           overlayColor: context.read<ThemeProvider>().isAmoledTheme
               ? WidgetStateProperty.resolveWith((Set<WidgetState> states) {

--- a/packages/smooth_app/lib/generic_lib/html/smooth_html_factory.dart
+++ b/packages/smooth_app/lib/generic_lib/html/smooth_html_factory.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_widget_from_html_core/flutter_widget_from_html_core.dart';
+import 'package:smooth_app/generic_lib/html/smooth_html_fake_button.dart';
+import 'package:smooth_app/generic_lib/html/smooth_html_marker_chip.dart';
+import 'package:smooth_app/generic_lib/html/smooth_html_marker_decimal.dart';
+
+class SmoothHtmlWidgetFactory extends WidgetFactory {
+  SmoothHtmlWidgetFactory();
+
+  @override
+  Widget buildText(
+    BuildTree tree,
+    InheritedProperties resolved,
+    InlineSpan text,
+  ) {
+    if ((text as TextSpan).text == '→ ' && text.children?.isNotEmpty == true) {
+      /// Create a fake button if it's within the text
+      return SmoothHtmlFakeButton(children: text.children!);
+    } else if (<String>['li', 'ul'].contains(tree.element.localName)) {
+      /// Add some bottom padding to the list items
+      return Padding(
+        padding: const EdgeInsetsDirectional.only(bottom: 14.0),
+        child: SelectableText.rich(
+          TextSpan(
+            children: <InlineSpan>[text],
+            style: resolved.prepareTextStyle().copyWith(
+                  height: 1.6,
+                ),
+          ),
+        ),
+      );
+    } else {
+      return SelectableText.rich(
+        TextSpan(
+          children: <InlineSpan>[text],
+          style: resolved.prepareTextStyle(),
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget buildListMarker(
+    BuildTree tree,
+    InheritedProperties resolved,
+    String listStyleType,
+    int index,
+  ) {
+    if (listStyleType == 'disc') {
+      return const SmoothHtmlChip();
+    } else if (listStyleType == 'decimal') {
+      return SmoothHtmlDecimal(index: index);
+    } else {
+      return super.buildListMarker(tree, resolved, listStyleType, index)!;
+    }
+  }
+}

--- a/packages/smooth_app/lib/generic_lib/html/smooth_html_fake_button.dart
+++ b/packages/smooth_app/lib/generic_lib/html/smooth_html_fake_button.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/helpers/extension_on_text_helper.dart';
+import 'package:smooth_app/resources/app_icons.dart' as icons;
+import 'package:smooth_app/themes/smooth_theme.dart';
+import 'package:smooth_app/themes/smooth_theme_colors.dart';
+
+class SmoothHtmlFakeButton extends StatelessWidget {
+  const SmoothHtmlFakeButton({
+    required this.children,
+    super.key,
+  });
+
+  final List<InlineSpan> children;
+
+  @override
+  Widget build(BuildContext context) {
+    final SmoothColorsThemeExtension extension =
+        context.extension<SmoothColorsThemeExtension>();
+
+    return SizedBox(
+      width: double.infinity,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: extension.primaryMedium,
+          borderRadius: ANGULAR_BORDER_RADIUS,
+          boxShadow: const <BoxShadow>[
+            BoxShadow(
+              color: Colors.black12,
+              blurRadius: 2.0,
+              offset: Offset(0.0, 2.0),
+            ),
+          ],
+        ),
+        child: Padding(
+          padding: const EdgeInsetsDirectional.symmetric(
+            horizontal: VERY_LARGE_SPACE,
+            vertical: LARGE_SPACE,
+          ),
+          child: Row(
+            children: <Widget>[
+              Expanded(
+                child: SelectableText.rich(
+                  TextSpan(
+                    children: children.map((InlineSpan span) {
+                      if (span is TextSpan) {
+                        return span.copyWith(
+                          style: span.style?.copyWith(
+                            color: Colors.black,
+                            decoration: TextDecoration.none,
+                          ),
+                        );
+                      }
+
+                      return span;
+                    }).toList(),
+                  ),
+                ),
+              ),
+              const icons.ExternalLink(
+                color: Colors.black,
+                size: 16.0,
+              )
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/smooth_app/lib/generic_lib/html/smooth_html_marker_chip.dart
+++ b/packages/smooth_app/lib/generic_lib/html/smooth_html_marker_chip.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:smooth_app/resources/app_icons.dart' as icons;
+import 'package:smooth_app/themes/smooth_theme.dart';
+import 'package:smooth_app/themes/smooth_theme_colors.dart';
+import 'package:smooth_app/themes/theme_provider.dart';
+
+class SmoothHtmlChip extends StatelessWidget {
+  const SmoothHtmlChip({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final SmoothColorsThemeExtension extension =
+        context.extension<SmoothColorsThemeExtension>();
+
+    /// We can't use top Padding, so we draw on a canvas
+    return CustomPaint(
+      painter: _HtmlChipPainter(
+        color:
+            context.lightTheme() ? extension.greyLight : extension.greyNormal,
+        textDirection: Directionality.of(context),
+      ),
+      child: const SizedBox.square(dimension: 10.0),
+    );
+  }
+}
+
+class _HtmlChipPainter extends CustomPainter {
+  _HtmlChipPainter({
+    required this.color,
+    required this.textDirection,
+  });
+
+  final Color color;
+  final TextDirection textDirection;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final double dimension = size.width;
+    final double halfSize = size.width / 2;
+
+    canvas.translate(-10.0, 0.0);
+
+    canvas.drawCircle(
+      Offset(halfSize, halfSize + 0.5),
+      size.width,
+      Paint()..color = color,
+    );
+
+    final IconData icon = const icons.Arrow.right().icon;
+    final TextPainter textPainter = TextPainter(textDirection: textDirection);
+    textPainter.text = TextSpan(
+      text: String.fromCharCode(icon.codePoint),
+      style: TextStyle(fontSize: dimension, fontFamily: icon.fontFamily),
+    );
+    textPainter.layout();
+    textPainter.paint(
+      canvas,
+      Offset(
+        (size.width - dimension) / 2,
+        (size.height - dimension) / 2,
+      ),
+    );
+  }
+
+  @override
+  bool shouldRepaint(_HtmlChipPainter oldDelegate) => false;
+
+  @override
+  bool shouldRebuildSemantics(_HtmlChipPainter oldDelegate) => false;
+}

--- a/packages/smooth_app/lib/generic_lib/html/smooth_html_marker_decimal.dart
+++ b/packages/smooth_app/lib/generic_lib/html/smooth_html_marker_decimal.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:smooth_app/themes/smooth_theme.dart';
+import 'package:smooth_app/themes/smooth_theme_colors.dart';
+import 'package:smooth_app/themes/theme_provider.dart';
+
+class SmoothHtmlDecimal extends StatelessWidget {
+  const SmoothHtmlDecimal({
+    required this.index,
+    super.key,
+  });
+
+  final int index;
+
+  @override
+  Widget build(BuildContext context) {
+    final SmoothColorsThemeExtension extension =
+        context.extension<SmoothColorsThemeExtension>();
+
+    return CustomPaint(
+      painter: _HtmlDecimalPainter(
+        color:
+            context.lightTheme() ? extension.greyLight : extension.greyNormal,
+        index: index,
+        textDirection: Directionality.of(context),
+        textStyle: const TextStyle(
+          color: Colors.white,
+          fontSize: 10.0,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+      child: const SizedBox.square(dimension: 10.0),
+    );
+  }
+}
+
+class _HtmlDecimalPainter extends CustomPainter {
+  _HtmlDecimalPainter({
+    required this.index,
+    required this.color,
+    required this.textDirection,
+    required this.textStyle,
+  });
+
+  final int index;
+  final Color color;
+  final TextDirection textDirection;
+  final TextStyle textStyle;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final double halfSize = size.width / 2;
+
+    canvas.translate(-10.0, 0.0);
+
+    canvas.drawCircle(
+      Offset(halfSize, halfSize),
+      size.width,
+      Paint()..color = color,
+    );
+
+    final TextPainter textPainter = TextPainter(textDirection: textDirection);
+    textPainter.text = TextSpan(
+      text: index.toString(),
+      style: textStyle,
+    );
+    textPainter.layout();
+    textPainter.paint(
+      canvas,
+      Offset(
+        (size.width - textPainter.width) / 2,
+        (size.height - textPainter.height) / 2,
+      ),
+    );
+  }
+
+  @override
+  bool shouldRepaint(_HtmlDecimalPainter oldDelegate) => false;
+
+  @override
+  bool shouldRebuildSemantics(_HtmlDecimalPainter oldDelegate) => false;
+}

--- a/packages/smooth_app/lib/generic_lib/html/smooth_html_widget.dart
+++ b/packages/smooth_app/lib/generic_lib/html/smooth_html_widget.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_widget_from_html_core/flutter_widget_from_html_core.dart';
 import 'package:html/dom.dart' as dom;
+import 'package:smooth_app/generic_lib/html/smooth_html_factory.dart';
 import 'package:smooth_app/helpers/launch_url_helper.dart';
 
 class SmoothHtmlWidget extends StatelessWidget {
@@ -45,23 +46,8 @@ class SmoothHtmlWidget extends StatelessWidget {
         return true;
       },
       factoryBuilder: () =>
-          isSelectable ? SelectableHtmlWidgetFactory() : WidgetFactory(),
+          isSelectable ? SmoothHtmlWidgetFactory() : WidgetFactory(),
       enableCaching: false,
-    );
-  }
-}
-
-class SelectableHtmlWidgetFactory extends WidgetFactory {
-  @override
-  Widget buildText(
-    BuildTree tree,
-    InheritedProperties resolved,
-    InlineSpan text,
-  ) {
-    return SelectableText.rich(
-      TextSpan(
-        children: <InlineSpan>[text],
-      ),
     );
   }
 }

--- a/packages/smooth_app/lib/generic_lib/widgets/smooth_back_button.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/smooth_back_button.dart
@@ -34,7 +34,7 @@ class SmoothBackButton extends StatelessWidget {
             child: Padding(
               padding: _iconPadding,
               child: Icon(
-                ConstantIcons.instance.getBackIcon(),
+                ConstantIcons.backIcon,
                 color: iconColor ??
                     (Theme.of(context).colorScheme.brightness ==
                             Brightness.light

--- a/packages/smooth_app/lib/generic_lib/widgets/smooth_card.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/smooth_card.dart
@@ -113,7 +113,9 @@ class SmoothCardWithRoundedHeader extends StatelessWidget {
     this.titleTextStyle,
     this.titlePadding,
     this.contentPadding,
+    this.titleBackgroundColor,
     this.contentBackgroundColor,
+    this.borderRadius,
   });
 
   final String title;
@@ -124,7 +126,9 @@ class SmoothCardWithRoundedHeader extends StatelessWidget {
   final TextStyle? titleTextStyle;
   final EdgeInsetsGeometry? titlePadding;
   final EdgeInsetsGeometry? contentPadding;
+  final Color? titleBackgroundColor;
   final Color? contentBackgroundColor;
+  final BorderRadius? borderRadius;
 
   @override
   Widget build(BuildContext context) {
@@ -132,12 +136,12 @@ class SmoothCardWithRoundedHeader extends StatelessWidget {
     final SmoothColorsThemeExtension extension =
         context.extension<SmoothColorsThemeExtension>();
 
-    final Color color = getHeaderColor(context);
+    final Color color = titleBackgroundColor ?? getHeaderColor(context);
 
     return DecoratedBox(
-      decoration: const BoxDecoration(
-        borderRadius: ROUNDED_BORDER_RADIUS,
-        boxShadow: <BoxShadow>[
+      decoration: BoxDecoration(
+        borderRadius: borderRadius ?? ROUNDED_BORDER_RADIUS,
+        boxShadow: const <BoxShadow>[
           BoxShadow(
             color: Color(0x03000000),
             blurRadius: 2.0,
@@ -154,7 +158,7 @@ class SmoothCardWithRoundedHeader extends StatelessWidget {
             child: CustomPaint(
               painter: _SmoothCardWithRoundedHeaderBackgroundPainter(
                 color: color,
-                radius: ROUNDED_RADIUS,
+                radius: borderRadius?.topRight ?? ROUNDED_RADIUS,
               ),
               child: Padding(
                 padding: titlePadding ??
@@ -215,6 +219,7 @@ class SmoothCardWithRoundedHeader extends StatelessWidget {
                 const EdgeInsetsDirectional.only(
                   top: MEDIUM_SPACE,
                 ),
+            borderRadius: borderRadius ?? ROUNDED_BORDER_RADIUS,
             color: contentBackgroundColor ??
                 (context.darkTheme() ? extension.primaryUltraBlack : null),
             child: child,
@@ -251,7 +256,7 @@ class _SmoothCardWithRoundedHeaderBackgroundPainter extends CustomPainter {
           0.0,
           0.0,
           size.width,
-          size.height + ROUNDED_RADIUS.y,
+          size.height + radius.y,
         ),
         topLeft: radius,
         topRight: radius,

--- a/packages/smooth_app/lib/generic_lib/widgets/smooth_list_tile_card.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/smooth_list_tile_card.dart
@@ -80,7 +80,7 @@ class SmoothListTileCard extends StatelessWidget {
                   ),
                 )
               : null,
-          trailing: Icon(ConstantIcons.instance.getForwardIcon()),
+          trailing: Icon(ConstantIcons.forwardIcon),
         ),
       ),
     );

--- a/packages/smooth_app/lib/helpers/extension_on_text_helper.dart
+++ b/packages/smooth_app/lib/helpers/extension_on_text_helper.dart
@@ -1,4 +1,6 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 extension Selectable on Text {
   Widget selectable({bool isSelectable = true}) {
@@ -43,9 +45,40 @@ extension StringExtensions on String {
 
     return count;
   }
+
+  String firstLetterInUppercase() {
+    return isNotEmpty ? '${this[0].toUpperCase()}${substring(1)}' : '';
+  }
 }
 
 extension TextScalerExtension on BuildContext {
   /// Returns the text font multiplier
   double textScaler() => MediaQuery.textScalerOf(this).scale(1.0);
+}
+
+extension TextSpanExtension on TextSpan {
+  TextSpan copyWith({
+    TextStyle? style,
+    List<InlineSpan>? children,
+    String? text,
+    GestureRecognizer? recognizer,
+    MouseCursor? mouseCursor,
+    PointerEnterEventListener? onEnter,
+    PointerExitEventListener? onExit,
+    String? semanticsLabel,
+    Locale? locale,
+    bool? spellOut,
+  }) =>
+      TextSpan(
+        style: style ?? this.style,
+        children: children ?? this.children,
+        text: text ?? this.text,
+        recognizer: recognizer ?? this.recognizer,
+        mouseCursor: mouseCursor ?? this.mouseCursor,
+        onEnter: onEnter ?? this.onEnter,
+        onExit: onExit ?? this.onExit,
+        semanticsLabel: semanticsLabel ?? this.semanticsLabel,
+        locale: locale ?? this.locale,
+        spellOut: spellOut ?? this.spellOut,
+      );
 }

--- a/packages/smooth_app/lib/helpers/image_field_extension.dart
+++ b/packages/smooth_app/lib/helpers/image_field_extension.dart
@@ -117,7 +117,7 @@ extension ImageFieldSmoothieExtension on ImageField {
             ),
           ),
         ),
-        icon: Icons.camera_alt,
+        leadingIcon: const Icon(Icons.camera_alt),
         text: getProductImageButtonText(AppLocalizations.of(context)),
       );
 }

--- a/packages/smooth_app/lib/helpers/product_cards_helper.dart
+++ b/packages/smooth_app/lib/helpers/product_cards_helper.dart
@@ -86,7 +86,7 @@ String formatProductBrands(String brands) {
 }
 
 /// Padding to be used while building the SmoothCard on any Product card.
-const EdgeInsets SMOOTH_CARD_PADDING = EdgeInsets.symmetric(
+const EdgeInsetsGeometry SMOOTH_CARD_PADDING = EdgeInsetsDirectional.symmetric(
   horizontal: MEDIUM_SPACE,
   vertical: VERY_SMALL_SPACE,
 );
@@ -308,20 +308,26 @@ List<Attribute> getFilteredAttributes(
 
 Widget addPanelButton(
   final String label, {
-  final IconData? iconData,
+  final Widget? leadingIcon,
+  final Widget? trailingIcon,
   final String? textAlign,
   final EdgeInsetsGeometry? padding,
   required final Function() onPressed,
+  BorderRadiusGeometry? borderRadius,
   WidgetStateProperty<double?>? elevation,
 }) =>
     Padding(
       padding: const EdgeInsets.symmetric(vertical: SMALL_SPACE),
       child: SmoothLargeButtonWithIcon(
         text: label,
-        icon: iconData ?? Icons.add,
+        leadingIcon: leadingIcon,
+        trailingIcon: trailingIcon,
+        borderRadius: borderRadius,
         elevation: elevation,
         onPressed: onPressed,
-        textAlign: iconData == null ? TextAlign.center : null,
+        textAlign: leadingIcon == null && trailingIcon == null
+            ? TextAlign.center
+            : null,
         padding: padding,
       ),
     );

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_action_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_action_card.dart
@@ -2,7 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
-import 'package:smooth_app/generic_lib/smooth_html_widget.dart';
+import 'package:smooth_app/generic_lib/html/smooth_html_widget.dart';
 import 'package:smooth_app/pages/product/add_nutrition_button.dart';
 import 'package:smooth_app/pages/product/add_ocr_button.dart';
 import 'package:smooth_app/pages/product/add_packaging_button.dart';

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_card.dart
@@ -52,7 +52,9 @@ class KnowledgePanelCard extends StatelessWidget {
           panelId,
         );
     return Padding(
-      padding: const EdgeInsets.symmetric(vertical: SMALL_SPACE),
+      padding: const EdgeInsetsDirectional.symmetric(
+        vertical: SMALL_SPACE,
+      ),
       child: InkWell(
         borderRadius: ANGULAR_BORDER_RADIUS,
         onTap: !improvedIsClickable

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_expanded_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_expanded_card.dart
@@ -2,8 +2,12 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
+import 'package:smooth_app/cards/data_cards/score_card.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels_builder.dart';
+import 'package:smooth_app/themes/smooth_theme.dart';
+import 'package:smooth_app/themes/smooth_theme_colors.dart';
+import 'package:smooth_app/themes/theme_provider.dart';
 
 class KnowledgePanelExpandedCard extends StatelessWidget {
   const KnowledgePanelExpandedCard({
@@ -20,29 +24,37 @@ class KnowledgePanelExpandedCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final KnowledgePanel panel =
-        KnowledgePanelsBuilder.getKnowledgePanel(product, panelId)!;
+    final KnowledgePanel panel = KnowledgePanelsBuilder.getKnowledgePanel(
+      product,
+      panelId,
+    )!;
+
     final List<Widget> elementWidgets = <Widget>[];
-    final Widget? summary = KnowledgePanelsBuilder.getPanelSummaryWidget(
-      panel,
-      isClickable: false,
-    );
-    if (summary != null) {
-      elementWidgets.add(summary);
+
+    final List<Widget>? summaryWidgets = _getSummary(panel);
+    if (summaryWidgets != null) {
+      elementWidgets.addAll(summaryWidgets);
     }
+
     if (panel.elements != null) {
-      for (final KnowledgePanelElement element in panel.elements!) {
+      for (int i = 0; i < panel.elements!.length; i++) {
+        final KnowledgePanelElement element = panel.elements![i];
         final Widget? elementWidget = KnowledgePanelsBuilder.getElementWidget(
           knowledgePanelElement: element,
           product: product,
           isInitiallyExpanded: isInitiallyExpanded,
           isClickable: isClickable,
           isTextSelectable: true,
+          position: i,
         );
         if (elementWidget != null) {
           elementWidgets.add(
             Padding(
-              padding: const EdgeInsetsDirectional.only(top: VERY_SMALL_SPACE),
+              padding: EdgeInsetsDirectional.only(
+                top: VERY_SMALL_SPACE,
+                start: isInitiallyExpanded ? MEDIUM_SPACE : 0.0,
+                end: isInitiallyExpanded ? MEDIUM_SPACE : 0.0,
+              ),
               child: elementWidget,
             ),
           );
@@ -59,13 +71,87 @@ class KnowledgePanelExpandedCard extends StatelessWidget {
     );
   }
 
+  List<Widget>? _getSummary(KnowledgePanel panel) {
+    final Widget? summary = KnowledgePanelsBuilder.getPanelSummaryWidget(
+      panel,
+      isClickable: false,
+    );
+
+    if (summary != null) {
+      if (isInitiallyExpanded) {
+        if (summary is ScoreCard) {
+          return <Widget>[
+            Padding(
+              padding: const EdgeInsetsDirectional.symmetric(
+                horizontal: MEDIUM_SPACE,
+              ),
+              child: summary,
+            ),
+          ];
+        } else {
+          return <Widget>[
+            _KnowledgePanelSummaryCardTitle(
+              child: summary,
+            ),
+            const SizedBox(height: SMALL_SPACE)
+          ];
+        }
+      } else {
+        return <Widget>[summary];
+      }
+    }
+
+    return null;
+  }
+
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(StringProperty('panelId', panelId));
     properties.add(
-      DiagnosticsProperty<bool>('initiallyExpanded', isInitiallyExpanded),
+      DiagnosticsProperty<bool>(
+        'initiallyExpanded',
+        isInitiallyExpanded,
+      ),
     );
     properties.add(DiagnosticsProperty<bool>('clickable', isClickable));
+  }
+}
+
+/// Force a background around a summary Widget
+class _KnowledgePanelSummaryCardTitle extends StatelessWidget {
+  const _KnowledgePanelSummaryCardTitle({
+    required this.child,
+  });
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final SmoothColorsThemeExtension extension =
+        context.extension<SmoothColorsThemeExtension>();
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: context.lightTheme()
+            ? extension.primaryMedium
+            : extension.primaryUltraBlack,
+        borderRadius: const BorderRadius.vertical(
+          top: ROUNDED_RADIUS,
+        ),
+      ),
+      child: Padding(
+        padding: const EdgeInsetsDirectional.symmetric(
+          vertical: SMALL_SPACE,
+          horizontal: MEDIUM_SPACE,
+        ),
+        child: DefaultTextStyle.merge(
+          child: child,
+          style: const TextStyle(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_group_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_group_card.dart
@@ -2,8 +2,10 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
+import 'package:smooth_app/generic_lib/bottom_sheets/smooth_bottom_sheet.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_card.dart';
+import 'package:smooth_app/themes/smooth_theme.dart';
 import 'package:smooth_app/themes/smooth_theme_colors.dart';
 import 'package:smooth_app/themes/theme_provider.dart';
 
@@ -13,18 +15,21 @@ class KnowledgePanelGroupCard extends StatelessWidget {
     required this.product,
     required this.isClickable,
     required this.isTextSelectable,
+    required this.position,
   });
 
   final KnowledgePanelPanelGroupElement groupElement;
   final Product product;
   final bool isClickable;
   final bool isTextSelectable;
+  final int position;
 
   @override
   Widget build(BuildContext context) {
     final ThemeData themeData = Theme.of(context);
     final SmoothColorsThemeExtension themeExtension =
-        themeData.extension<SmoothColorsThemeExtension>()!;
+        context.extension<SmoothColorsThemeExtension>();
+    final bool lightTheme = context.lightTheme();
 
     final Widget child = Provider<KnowledgePanelPanelGroupElement>(
       lazy: true,
@@ -34,26 +39,61 @@ class KnowledgePanelGroupCard extends StatelessWidget {
         children: <Widget>[
           if (groupElement.title != null && groupElement.title!.isNotEmpty)
             Padding(
-              padding: const EdgeInsetsDirectional.only(top: LARGE_SPACE),
+              padding: EdgeInsetsDirectional.only(
+                top: position == 0 ? VERY_SMALL_SPACE : VERY_LARGE_SPACE,
+              ),
               child: Semantics(
                 explicitChildNodes: true,
-                child: Text(
-                  groupElement.title!,
-                  style: themeData.textTheme.titleSmall!.copyWith(
-                    fontSize: 15.5,
-                    fontWeight: FontWeight.w700,
-                    color: context.lightTheme()
-                        ? themeExtension.primaryUltraBlack
-                        : themeExtension.primaryLight,
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    color: lightTheme
+                        ? themeExtension.primaryLight
+                        : themeExtension.primarySemiDark,
+                    borderRadius: ANGULAR_BORDER_RADIUS,
+                  ),
+                  child: Padding(
+                    padding: const EdgeInsetsDirectional.symmetric(
+                      horizontal: MEDIUM_SPACE,
+                      vertical: SMALL_SPACE,
+                    ),
+                    child: SizedBox(
+                      width: double.infinity,
+                      child: Row(
+                        children: <Widget>[
+                          SmoothModalSheetHeaderPrefixIndicator(
+                            color: lightTheme
+                                ? themeExtension.primaryUltraBlack
+                                : themeExtension.primaryLight,
+                          ),
+                          const SizedBox(width: SMALL_SPACE),
+                          Text(
+                            groupElement.title!,
+                            textAlign: TextAlign.start,
+                            style: themeData.textTheme.titleSmall!.copyWith(
+                              fontSize: 16.0,
+                              fontWeight: FontWeight.w700,
+                              color: lightTheme
+                                  ? themeExtension.primaryUltraBlack
+                                  : themeExtension.primaryLight,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
                   ),
                 ),
               ),
             ),
           for (final String panelId in groupElement.panelIds)
-            KnowledgePanelCard(
-              panelId: panelId,
-              product: product,
-              isClickable: isClickable,
+            Padding(
+              padding: const EdgeInsetsDirectional.symmetric(
+                horizontal: VERY_SMALL_SPACE,
+              ),
+              child: KnowledgePanelCard(
+                panelId: panelId,
+                product: product,
+                isClickable: isClickable,
+              ),
             )
         ],
       ),

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_page.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_page.dart
@@ -84,39 +84,32 @@ class _KnowledgePanelPageState extends State<KnowledgePanelPage>
       ),
       body: RefreshIndicator(
         onRefresh: () => _refreshProduct(context),
-        child: CustomScrollView(
-          physics: const AlwaysScrollableScrollPhysics(),
-          slivers: <Widget>[
-            SliverToBoxAdapter(
-              child: Column(
-                children: <Widget>[
-                  Padding(
-                    padding: const EdgeInsetsDirectional.only(
-                      bottom: SMALL_SPACE,
-                      top: SMALL_SPACE,
-                    ),
-                    child: SmoothCard(
-                      padding: const EdgeInsetsDirectional.only(
-                        top: SMALL_SPACE,
-                        start: SMALL_SPACE,
-                        end: SMALL_SPACE,
-                        bottom: LARGE_SPACE,
-                      ),
-                      child: DefaultTextStyle.merge(
-                        style: const TextStyle(fontSize: 15.0, height: 1.5),
-                        child: KnowledgePanelExpandedCard(
-                          panelId: widget.panelId,
-                          product: upToDateProduct,
-                          isInitiallyExpanded: true,
-                          isClickable: true,
-                        ),
-                      ),
-                    ),
+        child: Scrollbar(
+          child: ListView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            padding: EdgeInsetsDirectional.only(
+              top: SMALL_SPACE,
+              start: VERY_SMALL_SPACE,
+              end: VERY_SMALL_SPACE,
+              bottom: SMALL_SPACE + MediaQuery.viewPaddingOf(context).bottom,
+            ),
+            children: <Widget>[
+              SmoothCard(
+                padding: const EdgeInsetsDirectional.only(
+                  bottom: LARGE_SPACE,
+                ),
+                child: DefaultTextStyle.merge(
+                  style: const TextStyle(fontSize: 15.0, height: 1.5),
+                  child: KnowledgePanelExpandedCard(
+                    panelId: widget.panelId,
+                    product: upToDateProduct,
+                    isInitiallyExpanded: true,
+                    isClickable: true,
                   ),
-                ],
+                ),
               ),
-            )
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_product_cards.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_product_cards.dart
@@ -23,7 +23,10 @@ class KnowledgePanelProductCards extends StatelessWidget {
         content = buildProductSmoothCard(
           title: Text((widget.children.first as KnowledgePanelTitle).title),
           body: Padding(
-            padding: SMOOTH_CARD_PADDING,
+            padding: const EdgeInsetsDirectional.symmetric(
+              horizontal: SMALL_SPACE,
+              vertical: SMALL_SPACE,
+            ),
             child: Column(
               children: widget.children.sublist(1),
             ),

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_table_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_table_card.dart
@@ -5,7 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
-import 'package:smooth_app/generic_lib/smooth_html_widget.dart';
+import 'package:smooth_app/generic_lib/html/smooth_html_widget.dart';
 import 'package:smooth_app/helpers/html_extension.dart';
 import 'package:smooth_app/helpers/ui_helpers.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_card.dart';
@@ -113,8 +113,16 @@ class _KnowledgePanelTableCardState extends State<KnowledgePanelTableCard> {
               value: _buildSemanticsValue(row),
               child: IntrinsicHeight(child: Row(children: row)),
             ),
-          if (withPortionCalculator) const Divider(),
-          if (withPortionCalculator) PortionCalculator(widget.product)
+          if (withPortionCalculator) ...<Widget>[
+            const Padding(
+              padding: EdgeInsetsDirectional.only(
+                top: MEDIUM_SPACE,
+                bottom: LARGE_SPACE,
+              ),
+              child: Divider(),
+            ),
+            PortionCalculator(widget.product),
+          ]
         ],
       );
     });

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_text_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_text_card.dart
@@ -3,9 +3,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
-import 'package:smooth_app/generic_lib/smooth_html_widget.dart';
+import 'package:smooth_app/generic_lib/html/smooth_html_widget.dart';
+import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
+import 'package:smooth_app/helpers/extension_on_text_helper.dart';
 import 'package:smooth_app/helpers/launch_url_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
+import 'package:smooth_app/resources/app_icons.dart' as icons;
+import 'package:smooth_app/themes/constant_icons.dart';
 import 'package:smooth_app/widgets/smooth_text.dart';
 
 /// Card that displays a Knowledge Panel _Text_ element.
@@ -18,14 +22,35 @@ class KnowledgePanelTextCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final Widget text = MergeSemantics(
-      child: SmoothHtmlWidget(
-        textElement.html,
-        textStyle: WellSpacedTextHelper.TEXT_STYLE_WITH_WELL_SPACED.copyWith(
-          fontSize: 15.0,
+    final String warningLabel =
+        AppLocalizations.of(context).knowledge_panel_warning_text;
+    final RegExp regExp = RegExp('$warningLabel\\s?:\\s?');
+
+    final Widget text;
+
+    if (textElement.html.startsWith(regExp)) {
+      text = _KnowledgePanelWarningTextCard(
+        title: warningLabel,
+        text: textElement.html.replaceFirst(regExp, '').trim(),
+      );
+    } else {
+      text = Padding(
+        padding: const EdgeInsetsDirectional.only(
+          top: SMALL_SPACE,
+          start: SMALL_SPACE,
+          end: SMALL_SPACE,
         ),
-      ),
-    );
+        child: MergeSemantics(
+          child: SmoothHtmlWidget(
+            textElement.html,
+            textStyle:
+                WellSpacedTextHelper.TEXT_STYLE_WITH_WELL_SPACED.copyWith(
+              fontSize: 15.5,
+            ),
+          ),
+        ),
+      );
+    }
 
     if (!_hasSource) {
       return text;
@@ -45,13 +70,18 @@ class KnowledgePanelTextCard extends StatelessWidget {
             size: 0.0,
           ),
           child: addPanelButton(
-            appLocalizations
-                .knowledge_panel_text_source(textElement.sourceText!),
-            iconData: null,
-            onPressed: () async => LaunchUrlHelper.launchURL(
-              textElement.sourceUrl!,
-            ),
-          ),
+              appLocalizations
+                  .knowledge_panel_text_source(textElement.sourceText!),
+              trailingIcon: Icon(ConstantIcons.forwardIcon),
+              onPressed: () async => LaunchUrlHelper.launchURL(
+                    textElement.sourceUrl!,
+                  ),
+              borderRadius: ANGULAR_BORDER_RADIUS,
+              elevation: const WidgetStatePropertyAll<double>(0.5),
+              padding: const EdgeInsetsDirectional.symmetric(
+                horizontal: 0,
+                vertical: BALANCED_SPACE,
+              )),
         ),
       ],
     );
@@ -66,5 +96,49 @@ class KnowledgePanelTextCard extends StatelessWidget {
     super.debugFillProperties(properties);
     properties.add(StringProperty('text', textElement.sourceText));
     properties.add(StringProperty('url', textElement.sourceUrl));
+  }
+}
+
+/// Custom layout for texts starting with "Warning: ".
+class _KnowledgePanelWarningTextCard extends StatelessWidget {
+  const _KnowledgePanelWarningTextCard({
+    required this.title,
+    required this.text,
+  });
+
+  final String title;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsetsDirectional.only(bottom: BALANCED_SPACE),
+      child: SelectionArea(
+        child: SmoothCardWithRoundedHeader(
+          title: title,
+          titleBackgroundColor: const Color(0xFF666666),
+          contentBackgroundColor: const Color(0xFFF3F3F3),
+          borderRadius: BorderRadius.circular(14.0),
+          leading: const Padding(
+            padding: EdgeInsetsDirectional.only(
+              bottom: 1.0,
+              end: 1.0,
+            ),
+            child: icons.Warning(size: 15.0),
+          ),
+          contentPadding: const EdgeInsetsDirectional.symmetric(
+            horizontal: LARGE_SPACE,
+            vertical: BALANCED_SPACE,
+          ),
+          child: Text(
+            text.firstLetterInUppercase(),
+            style: const TextStyle(
+              color: Colors.black,
+              height: 1.5,
+            ),
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_title_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_title_card.dart
@@ -45,6 +45,7 @@ class KnowledgePanelTitleCard extends StatelessWidget {
         }
       }
     }
+
     List<Widget> iconWidget;
     if (knowledgePanelTitleElement.iconUrl != null) {
       iconWidget = <Widget>[
@@ -129,7 +130,7 @@ class KnowledgePanelTitleCard extends StatelessWidget {
                 },
               ),
             ),
-            if (isClickable) Icon(ConstantIcons.instance.getForwardIcon()),
+            if (isClickable) Icon(ConstantIcons.forwardIcon),
           ],
         ),
       ),

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_world_map_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_world_map_card.dart
@@ -76,12 +76,15 @@ class KnowledgePanelWorldMapCard extends StatelessWidget {
               Positioned.fill(
                 child: IgnorePointer(
                   ignoring: true,
-                  child: FlutterMap(
-                    options: mapOptions,
-                    children: <Widget>[
-                      ...children,
-                      const _ExpandMapIcon(),
-                    ],
+                  child: ClipRRect(
+                    borderRadius: const BorderRadius.all(Radius.circular(6.0)),
+                    child: FlutterMap(
+                      options: mapOptions,
+                      children: <Widget>[
+                        ...children,
+                        const _ExpandMapIcon(),
+                      ],
+                    ),
                   ),
                 ),
               ),

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels_builder.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels_builder.dart
@@ -35,13 +35,15 @@ class KnowledgePanelsBuilder {
     if (rootPanel != null) {
       children.add(KnowledgePanelTitle(title: rootPanel.titleElement!.title));
       if (rootPanel.elements != null) {
-        for (final KnowledgePanelElement element in rootPanel.elements!) {
+        for (int i = 0; i < rootPanel.elements!.length; i++) {
+          final KnowledgePanelElement element = rootPanel.elements![i];
           final Widget? widget = getElementWidget(
             knowledgePanelElement: element,
             product: product,
             isInitiallyExpanded: false,
             isClickable: true,
             isTextSelectable: !onboardingMode,
+            position: i,
           );
           if (widget != null) {
             children.add(widget);
@@ -166,6 +168,7 @@ class KnowledgePanelsBuilder {
     required final bool isInitiallyExpanded,
     required final bool isClickable,
     required final bool isTextSelectable,
+    required final int position,
   }) {
     final Widget? result = _getElementWidget(
       element: knowledgePanelElement,
@@ -173,6 +176,7 @@ class KnowledgePanelsBuilder {
       isInitiallyExpanded: isInitiallyExpanded,
       isClickable: isClickable,
       isTextSelectable: isTextSelectable,
+      position: position,
     );
     if (result == null) {
       return null;
@@ -183,10 +187,15 @@ class KnowledgePanelsBuilder {
     ].contains(knowledgePanelElement.elementType)) {
       return result;
     }
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
-      child: result,
-    );
+
+    if (result is KnowledgePanelTextCard) {
+      return result;
+    } else {
+      return Padding(
+        padding: const EdgeInsetsDirectional.symmetric(horizontal: SMALL_SPACE),
+        child: result,
+      );
+    }
   }
 
   /// Returns the widget that displays the KP element, or rarely null.
@@ -198,6 +207,7 @@ class KnowledgePanelsBuilder {
     required final bool isInitiallyExpanded,
     required final bool isClickable,
     required final bool isTextSelectable,
+    required final int position,
   }) {
     switch (element.elementType) {
       case KnowledgePanelElementType.TEXT:
@@ -238,6 +248,7 @@ class KnowledgePanelsBuilder {
           product: product,
           isClickable: isClickable,
           isTextSelectable: isTextSelectable,
+          position: position,
         );
 
       case KnowledgePanelElementType.TABLE:
@@ -292,7 +303,8 @@ class KnowledgePanelsBuilder {
   static Widget? getPanelSummaryWidget(
     final KnowledgePanel knowledgePanel, {
     required final bool isClickable,
-    final EdgeInsets? margin,
+    final EdgeInsetsGeometry? margin,
+    final EdgeInsetsGeometry? padding,
   }) {
     if (knowledgePanel.titleElement == null) {
       return null;
@@ -309,7 +321,9 @@ class KnowledgePanelsBuilder {
       case null:
       case TitleElementType.UNKNOWN:
         return Padding(
-          padding: const EdgeInsets.symmetric(horizontal: SMALL_SPACE),
+          padding: const EdgeInsetsDirectional.symmetric(
+            horizontal: SMALL_SPACE,
+          ).add(padding ?? EdgeInsets.zero),
           child: KnowledgePanelTitleCard(
             knowledgePanelTitleElement: knowledgePanel.titleElement!,
             evaluation: knowledgePanel.evaluation,

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -3530,5 +3530,15 @@
     "not_applicable_short": "N/A",
     "@not_applicable_short": {
         "description": "Acronym for Not Applicable"
-    }
+    },
+    "knowledge_panel_warning_text": "Warning",
+    "@knowledge_panel_warning_text": {
+        "description": "Warning text at the beginning of a sentence in the knowledge panel (you can find this word on the NutriScore KP of 3033491279300)"
+    },
+    "knowledge_panel_nutriscore_banner_incorrect_score_title": "Why is this Nutri-Score different from the one on the package?",
+    "knowledge_panel_nutriscore_banner_incorrect_score_message": "There are two possible explanations:\nThe list of ingredients and/or nutrition facts are not up-to-date.\n\nWe provide the \"New calculation\" of the Nutri-Score (or V2). Please check that you have the banner \"New calculation\" on the package.",
+    "knowledge_panel_nutriscore_banner_incorrect_score_button1": "Check ingredients",
+    "knowledge_panel_nutriscore_banner_incorrect_score_button2": "Check nutrition facts"
+
+
 }

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -3536,5 +3536,13 @@
     "not_applicable_short": "N/A",
     "@not_applicable_short": {
         "description": "Acronym for Not Applicable"
-    }
+    },
+    "knowledge_panel_warning_text": "Avertissement",
+    "@knowledge_panel_warning_text": {
+        "description": "Warning text at the beginning of a sentence in the knowledge panel (you can find this word on the NutriScore KP of 3033491279300)"
+    },
+    "knowledge_panel_nutriscore_banner_incorrect_score_title": "Pourquoi ce Nutri-Score est-il différent de celui présent sur l'emballage ?",
+    "knowledge_panel_nutriscore_banner_incorrect_score_message": "Il y a deux explications possibles :\nLa liste des ingrédients et/ou le tableau nutritionnel ne sont pas à jour.\n\nNous affichons le \"Nouveau calcul\" du Nutri-Score (ou V2). Vérifiez que le libellé \"Nouveau calcul\" est bien sur l'emballage.",
+    "knowledge_panel_nutriscore_banner_incorrect_score_button1": "Vérifier les ingredients",
+    "knowledge_panel_nutriscore_banner_incorrect_score_button2": "Vérifier le tableau nutritionnel"
 }

--- a/packages/smooth_app/lib/pages/folksonomy/folksonomy_card.dart
+++ b/packages/smooth_app/lib/pages/folksonomy/folksonomy_card.dart
@@ -87,7 +87,7 @@ class _FolksonomyCardList extends StatelessWidget {
                 textAlign: TextAlign.center,
               ),
             ),
-            Icon(ConstantIcons.instance.getForwardIcon()),
+            Icon(ConstantIcons.forwardIcon),
           ],
         ),
       );
@@ -117,7 +117,7 @@ class _FolksonomyCardList extends StatelessWidget {
                 ),
               ),
             ),
-            Icon(ConstantIcons.instance.getForwardIcon()),
+            Icon(ConstantIcons.forwardIcon),
           ],
         ),
       );

--- a/packages/smooth_app/lib/pages/html_page.dart
+++ b/packages/smooth_app/lib/pages/html_page.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:smooth_app/generic_lib/smooth_html_widget.dart';
+import 'package:smooth_app/generic_lib/html/smooth_html_widget.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 

--- a/packages/smooth_app/lib/pages/hunger_games/question_page.dart
+++ b/packages/smooth_app/lib/pages/hunger_games/question_page.dart
@@ -485,7 +485,7 @@ class _ErrorLoadingView extends StatelessWidget {
               const SizedBox(height: VERY_LARGE_SPACE),
               SmoothLargeButtonWithIcon(
                 text: appLocalizations.hunger_games_error_retry_button,
-                icon: Icons.refresh,
+                leadingIcon: const Icon(Icons.refresh),
                 onPressed: onRetry,
                 textStyle: const TextStyle(
                   fontSize: 18.0,

--- a/packages/smooth_app/lib/pages/locations/location_query_page.dart
+++ b/packages/smooth_app/lib/pages/locations/location_query_page.dart
@@ -122,7 +122,7 @@ class _LocationQueryPageState extends State<LocationQueryPage>
                   return SmoothCard(
                     child: SmoothLargeButtonWithIcon(
                       text: appLocalizations.prices_location_search_broader,
-                      icon: Icons.search,
+                      leadingIcon: const Icon(Icons.search),
                       onPressed: () => _model.loadMore(),
                     ),
                   );

--- a/packages/smooth_app/lib/pages/navigator/error_page.dart
+++ b/packages/smooth_app/lib/pages/navigator/error_page.dart
@@ -40,7 +40,7 @@ class ErrorPage extends StatelessWidget {
               const SizedBox(height: VERY_LARGE_SPACE * 2),
               SmoothLargeButtonWithIcon(
                 text: localizations.page_not_found_button,
-                icon: Icons.home,
+                leadingIcon: const Icon(Icons.home),
                 padding: const EdgeInsets.symmetric(vertical: LARGE_SPACE),
                 onPressed: () {
                   AppNavigator.of(context).pop();

--- a/packages/smooth_app/lib/pages/personalized_ranking_page.dart
+++ b/packages/smooth_app/lib/pages/personalized_ranking_page.dart
@@ -132,7 +132,7 @@ class _PersonalizedRankingPageState extends State<PersonalizedRankingPage>
                 child: Padding(
                   padding: const EdgeInsets.all(SMALL_SPACE),
                   child: SmoothLargeButtonWithIcon(
-                    icon: Icons.refresh,
+                    leadingIcon: const Icon(Icons.refresh),
                     text: appLocalizations.refresh_with_new_preferences,
                     onPressed: () {
                       _compactPreferences = compactPreferences;

--- a/packages/smooth_app/lib/pages/preferences/abstract_user_preferences.dart
+++ b/packages/smooth_app/lib/pages/preferences/abstract_user_preferences.dart
@@ -59,7 +59,7 @@ abstract class AbstractUserPreferences {
 
   @protected
   Icon? getForwardIcon() => UserPreferencesListTile.getTintedIcon(
-        ConstantIcons.instance.getForwardIcon(),
+        ConstantIcons.forwardIcon,
         context,
       );
 

--- a/packages/smooth_app/lib/pages/prices/price_add_product_card.dart
+++ b/packages/smooth_app/lib/pages/prices/price_add_product_card.dart
@@ -52,7 +52,7 @@ class _PriceAddProductCardState extends State<PriceAddProductCard> {
         children: <Widget>[
           SmoothLargeButtonWithIcon(
             text: appLocalizations.prices_barcode_reader_action,
-            icon: Icons.barcode_reader,
+            leadingIcon: const Icon(Icons.barcode_reader),
             onPressed: () async {
               final UserPreferences userPreferences =
                   context.read<UserPreferences>();
@@ -81,7 +81,7 @@ class _PriceAddProductCardState extends State<PriceAddProductCard> {
           ),
           SmoothLargeButtonWithIcon(
             text: appLocalizations.prices_barcode_enter,
-            icon: Icons.text_fields,
+            leadingIcon: const Icon(Icons.text_fields),
             onPressed: () async {
               final String? barcode = await _textInput(context);
               if (barcode == null) {

--- a/packages/smooth_app/lib/pages/prices/price_currency_selector.dart
+++ b/packages/smooth_app/lib/pages/prices/price_currency_selector.dart
@@ -32,7 +32,7 @@ class PriceCurrencySelector extends StatelessWidget {
               model.currency = currency;
             },
       text: model.currency.getFullName(),
-      icon: _helper.currencyIconData,
+      leadingIcon: Icon(_helper.currencyIconData),
     );
   }
 }

--- a/packages/smooth_app/lib/pages/prices/price_date_card.dart
+++ b/packages/smooth_app/lib/pages/prices/price_date_card.dart
@@ -27,7 +27,7 @@ class PriceDateCard extends StatelessWidget {
       ),
       child: SmoothLargeButtonWithIcon(
         text: dateFormat.format(model.date),
-        icon: Icons.calendar_month,
+        leadingIcon: const Icon(Icons.calendar_month),
         onPressed: model.proof != null
             ? null
             : () async {

--- a/packages/smooth_app/lib/pages/prices/price_location_card.dart
+++ b/packages/smooth_app/lib/pages/prices/price_location_card.dart
@@ -35,9 +35,9 @@ class PriceLocationCard extends StatelessWidget {
             : location.getTitle() ??
                 location.getSubtitle() ??
                 location.getLatLng().toString(),
-        icon: location == null
-            ? Icons.shopping_cart
-            : PriceButton.locationIconData,
+        leadingIcon: location == null
+            ? const Icon(Icons.shopping_cart)
+            : const Icon(PriceButton.locationIconData),
         onPressed: model.proof != null
             ? null
             : () async {

--- a/packages/smooth_app/lib/pages/prices/price_proof_card.dart
+++ b/packages/smooth_app/lib/pages/prices/price_proof_card.dart
@@ -69,7 +69,9 @@ class PriceProofCard extends StatelessWidget {
                   : model.proofType == ProofType.receipt
                       ? appLocalizations.prices_proof_receipt
                       : appLocalizations.prices_proof_price_tag,
-              icon: !model.hasImage ? _iconTodo : _iconDone,
+              leadingIcon: !model.hasImage
+                  ? const Icon(_iconTodo)
+                  : const Icon(_iconDone),
               onPressed: model.proof != null
                   ? null
                   : () async {

--- a/packages/smooth_app/lib/pages/prices/prices_card.dart
+++ b/packages/smooth_app/lib/pages/prices/prices_card.dart
@@ -79,7 +79,7 @@ class PricesCard extends StatelessWidget {
                   padding: const EdgeInsets.all(SMALL_SPACE),
                   child: SmoothLargeButtonWithIcon(
                     text: appLocalizations.prices_add_a_price,
-                    icon: Icons.add,
+                    leadingIcon: const Icon(Icons.add),
                     onPressed: () async => ProductPriceAddPage.showProductPage(
                       context: context,
                       product: PriceMetaProduct.product(product),
@@ -169,7 +169,7 @@ class _PricesCardViewButtonState extends State<_PricesCardViewButton> {
             ),
             child: SmoothLargeButtonWithIcon(
               text: appLocalizations.prices_view_prices,
-              icon: CupertinoIcons.tag_fill,
+              leadingIcon: const Icon(CupertinoIcons.tag_fill),
               onPressed: () async => Navigator.of(context).push(
                 MaterialPageRoute<void>(
                   builder: (BuildContext context) => PricesPage(

--- a/packages/smooth_app/lib/pages/product/add_new_product_helper.dart
+++ b/packages/smooth_app/lib/pages/product/add_new_product_helper.dart
@@ -101,9 +101,9 @@ class AddNewProductButton extends StatelessWidget {
       padding: const EdgeInsets.symmetric(vertical: SMALL_SPACE),
       child: SmoothLargeButtonWithIcon(
         text: label,
-        icon: iconData,
+        leadingIcon: Icon(iconData),
         onPressed: onPressed,
-        trailing: showTrailing ? Icons.edit : null,
+        trailingIcon: showTrailing ? const Icon(Icons.edit) : null,
         backgroundColor: onPressed == null
             ? (dark ? darkGrey : lightGrey)
             : done

--- a/packages/smooth_app/lib/pages/product/common/product_query_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_query_page.dart
@@ -447,7 +447,7 @@ class _ProductQueryPageState extends State<ProductQueryPage>
   Widget _getLargeButtonWithIcon(final _Action action) =>
       SmoothLargeButtonWithIcon(
         text: action.text,
-        icon: action.iconData,
+        leadingIcon: Icon(action.iconData),
         onPressed: action.onPressed,
       );
 

--- a/packages/smooth_app/lib/pages/product/edit_new_packagings.dart
+++ b/packages/smooth_app/lib/pages/product/edit_new_packagings.dart
@@ -153,7 +153,7 @@ class _EditNewPackagingsState extends State<EditNewPackagings>
         ),
         child: addPanelButton(
           appLocalizations.edit_packagings_element_add.toUpperCase(),
-          iconData: Icons.add,
+          leadingIcon: const Icon(Icons.add),
           onPressed: () => setState(
             () => _addPackagingToControllers(
               ProductPackaging(),
@@ -180,7 +180,7 @@ class _EditNewPackagingsState extends State<EditNewPackagings>
             language: ProductQuery.getLanguage(),
             isLoggedInMandatory: widget.isLoggedInMandatory,
           ),
-          iconData: Icons.add_a_photo,
+          leadingIcon: const Icon(Icons.add_a_photo),
         ),
       ),
     );

--- a/packages/smooth_app/lib/pages/product/edit_ocr/edit_ocr_textfield.dart
+++ b/packages/smooth_app/lib/pages/product/edit_ocr/edit_ocr_textfield.dart
@@ -173,7 +173,7 @@ class EditOCRExtraButton extends StatelessWidget {
           language: multilingualHelper.getCurrentLanguage(),
           isLoggedInMandatory: isLoggedInMandatory,
         ),
-        iconData: Icons.add_a_photo_rounded,
+        leadingIcon: const Icon(Icons.add_a_photo_rounded),
         padding: const EdgeInsetsDirectional.only(
           top: SMALL_SPACE,
           bottom: SMALL_SPACE,

--- a/packages/smooth_app/lib/pages/product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_page.dart
@@ -122,7 +122,8 @@ class _EditProductPageState extends State<EditProductPage> with UpToDateMixin {
                 ),
                 tooltip: appLocalizations.open_product_website,
                 onPressed: () {
-                  LaunchUrlHelper.launchURL(
+                  LaunchUrlHelper.launchURLAndFollowDeepLinks(
+                    context,
                     switch (upToDateProduct.productType) {
                       ProductType.beauty =>
                         'https://world.openbeautyfacts.org/product/${upToDateProduct.barcode}',

--- a/packages/smooth_app/lib/pages/product/gallery_view/product_image_gallery_view.dart
+++ b/packages/smooth_app/lib/pages/product/gallery_view/product_image_gallery_view.dart
@@ -199,7 +199,9 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView>
                                   child: SmoothLargeButtonWithIcon(
                                     text:
                                         appLocalizations.view_more_photo_button,
-                                    icon: Icons.photo_camera_rounded,
+                                    leadingIcon: const Icon(
+                                      Icons.photo_camera_rounded,
+                                    ),
                                     onPressed: () => setState(
                                       () => _clickedOtherPictureButton = true,
                                     ),

--- a/packages/smooth_app/lib/pages/product/product_loader_page.dart
+++ b/packages/smooth_app/lib/pages/product/product_loader_page.dart
@@ -149,7 +149,7 @@ class _ProductLoaderNotFoundState extends StatelessWidget {
           const SizedBox(height: VERY_LARGE_SPACE * 2),
           SmoothLargeButtonWithIcon(
             text: localizations.add_product_information_button_label,
-            icon: Icons.add,
+            leadingIcon: const Icon(Icons.add),
             padding: const EdgeInsets.symmetric(vertical: LARGE_SPACE),
             onPressed: () {
               AppNavigator.of(context).pushReplacement(
@@ -194,7 +194,7 @@ class _ProductLoaderNetworkErrorState extends StatelessWidget {
           const SizedBox(height: VERY_LARGE_SPACE * 2),
           SmoothLargeButtonWithIcon(
             text: localizations.retry_button_label,
-            icon: Icons.sync,
+            leadingIcon: const Icon(Icons.sync),
             padding: const EdgeInsets.symmetric(vertical: LARGE_SPACE),
             onPressed: onRetry,
           )

--- a/packages/smooth_app/lib/pages/product/product_page/new_product_header.dart
+++ b/packages/smooth_app/lib/pages/product/product_page/new_product_header.dart
@@ -175,7 +175,7 @@ class _ProductHeaderBackButton extends StatelessWidget {
             child: SizedBox.expand(
               child: backButtonType == ProductPageBackButton.minimize
                   ? const icons.Chevron.down(size: 16.0)
-                  : Icon(ConstantIcons.instance.getBackIcon()),
+                  : Icon(ConstantIcons.backIcon),
             ),
           ),
         ),

--- a/packages/smooth_app/lib/pages/product/product_page/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/product_page/new_product_page.dart
@@ -228,7 +228,7 @@ class ProductPageState extends State<ProductPage>
                 padding: const EdgeInsets.all(SMALL_SPACE),
                 child: SmoothLargeButtonWithIcon(
                   text: appLocalizations.reorder_attribute_action,
-                  icon: Icons.sort,
+                  leadingIcon: const Icon(Icons.sort),
                   onPressed: () async => Navigator.push(
                     context,
                     MaterialPageRoute<void>(

--- a/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
@@ -151,7 +151,7 @@ abstract class AbstractSimpleInputPageHelper extends ChangeNotifier {
             // we're already logged in if needed
             isLoggedInMandatory: false,
           ),
-          iconData: Icons.add_a_photo,
+          leadingIcon: const Icon(Icons.add_a_photo),
           elevation: const WidgetStatePropertyAll<double>(0.0),
           padding: const EdgeInsetsDirectional.only(
             top: SMALL_SPACE,

--- a/packages/smooth_app/lib/pages/search/search_field.dart
+++ b/packages/smooth_app/lib/pages/search/search_field.dart
@@ -178,7 +178,7 @@ class _BackIcon extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return SearchBarIcon(
-      icon: Icon(ConstantIcons.instance.getBackIcon()),
+      icon: Icon(ConstantIcons.backIcon),
       label: MaterialLocalizations.of(context).closeButtonTooltip,
       onTap: () => Navigator.of(context).pop(),
     );

--- a/packages/smooth_app/lib/themes/constant_icons.dart
+++ b/packages/smooth_app/lib/themes/constant_icons.dart
@@ -3,28 +3,21 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 class ConstantIcons {
-  @visibleForTesting
-  const ConstantIcons();
-
-  static ConstantIcons get instance => _instance ??= const ConstantIcons();
-  static ConstantIcons? _instance;
-
-  /// Setter that allows tests to override the singleton instance.
-  @visibleForTesting
-  static set instance(ConstantIcons testInstance) => _instance = testInstance;
+  const ConstantIcons._();
 
   static bool _isApple() =>
       defaultTargetPlatform == TargetPlatform.iOS ||
       defaultTargetPlatform == TargetPlatform.macOS;
 
-  IconData getShareIcon() =>
+  static IconData get shareIcon =>
       _isApple() ? CupertinoIcons.square_arrow_up : Icons.share;
 
-  IconData getBackIcon() => _isApple() ? CupertinoIcons.back : Icons.arrow_back;
+  static IconData get backIcon =>
+      _isApple() ? CupertinoIcons.back : Icons.arrow_back;
 
-  IconData getForwardIcon() =>
+  static IconData get forwardIcon =>
       _isApple() ? CupertinoIcons.forward : Icons.arrow_forward;
 
-  IconData getCameraFlip() =>
+  static IconData get cameraFlip =>
       _isApple() ? Icons.flip_camera_ios : Icons.flip_camera_android;
 }


### PR DESCRIPTION
Hi everyone!

This PR improves a lot the UI of KPs.
Video: 

https://github.com/user-attachments/assets/12ec42cc-6c43-493e-bf39-c0242df3af75

## Product page: better titles
![KP1](https://github.com/user-attachments/assets/5230a058-5866-4da8-8de4-eeba8e1af661)

## HTML support
- ul/li items are fully supported
- For buttons within texts, I fake them (but it should be fixed on the server)
![KP3](https://github.com/user-attachments/assets/f9b0b10c-60c3-45ad-9fa0-3c8a4ad79c3b)

## Details screen
- If it's not a score, the title is now highlighted
![KP4](https://github.com/user-attachments/assets/9866b2c4-7c2b-419e-922d-c60adb274063)

## Warning containers
This one is pure custom: if a text starts with "Warning", this Container will be visible
![KP2](https://github.com/user-attachments/assets/f984772b-87a6-4eaf-beb2-a5894950634d)