### PR TITLE
fix: Search results: fallbackUrl (same as the product page)

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
@@ -210,6 +210,7 @@ class _SmoothProductItemPicture extends StatelessWidget {
           ProductPicture.fromProduct(
             product: product,
             imageField: ImageField.FRONT,
+            fallbackUrl: product.imageFrontUrl,
             size: Size(size, size - (scoreWidget != null ? 25.0 : 5.0)),
             borderRadius: BorderRadius.vertical(
               top: hasScore ? Radius.zero : const Radius.circular(08.0),


### PR DESCRIPTION
The search results don't have a fallback URL for the picture.
It may result in different images between the search/history list and the product page.
But it may be better than only placeholders.