### PR TITLE
feat: Less annoying floating spam

### DIFF
--- a/packages/smooth_app/lib/background/background_task.dart
+++ b/packages/smooth_app/lib/background/background_task.dart
@@ -146,7 +146,7 @@ abstract class BackgroundTask {
           final String message,
           final AlignmentGeometry alignment,
         )) {
-      SmoothFloatingMessage(message: message).show(
+      SmoothFloatingMessage.loading(message: message).show(
         context,
         duration: SnackBarDuration.medium,
         alignment: alignment,

--- a/packages/smooth_app/lib/background/background_task_details.dart
+++ b/packages/smooth_app/lib/background/background_task_details.dart
@@ -100,10 +100,7 @@ class BackgroundTaskDetails extends BackgroundTaskBarcode
   @override
   (String, AlignmentGeometry)? getFloatingMessage(
           final AppLocalizations appLocalizations) =>
-      (
-        appLocalizations.product_task_background_schedule,
-        AlignmentDirectional.center,
-      );
+      null;
 
   /// Returns a new background task about changing a product.
   static BackgroundTaskDetails _getNewTask(

--- a/packages/smooth_app/lib/background/background_task_image.dart
+++ b/packages/smooth_app/lib/background/background_task_image.dart
@@ -104,10 +104,7 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
   @override
   (String, AlignmentGeometry)? getFloatingMessage(
           final AppLocalizations appLocalizations) =>
-      (
-        appLocalizations.image_upload_queued,
-        AlignmentDirectional.center,
-      );
+      null;
 
   /// Returns a new background task about changing a product.
   static BackgroundTaskImage _getNewTask(

--- a/packages/smooth_app/lib/background/background_task_price.dart
+++ b/packages/smooth_app/lib/background/background_task_price.dart
@@ -138,7 +138,7 @@ abstract class BackgroundTaskPrice extends BackgroundTask {
           final AppLocalizations appLocalizations) =>
       (
         appLocalizations.add_price_queued,
-        AlignmentDirectional.center,
+        AlignmentDirectional.bottomCenter,
       );
 
   @protected

--- a/packages/smooth_app/lib/background/background_task_unselect.dart
+++ b/packages/smooth_app/lib/background/background_task_unselect.dart
@@ -77,7 +77,7 @@ class BackgroundTaskUnselect extends BackgroundTaskBarcode
           final AppLocalizations appLocalizations) =>
       (
         appLocalizations.product_task_background_schedule,
-        AlignmentDirectional.topCenter,
+        AlignmentDirectional.bottomCenter,
       );
 
   /// Returns a new background task about unselecting a product image.

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1398,6 +1398,14 @@
     "@edit_product_label": {
         "description": "Edit product button label"
     },
+    "edit_product_pending_operations_banner_title": "Uploading your edits…",
+    "@edit_product_pending_operations_banner_title": {
+        "description": "When a product has pending edits (being sent to the server), there is a message on the edit page (here is the title of the message)."
+    },
+    "edit_product_pending_operations_banner_message": "Your edits are being **sent in the background** (or later in case of error).\nYou can continue editing other product fields.",
+    "@edit_product_pending_operations_banner_message": {
+        "description": "When a product has pending edits (being sent to the server), there is a message on the edit page. Please keep the ** syntax to make the text bold."
+    },
     "edit_product_label_short": "Edit",
     "@edit_product_label_short": {
         "description": "Edit product button short label (only the verb)"

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -3550,7 +3550,14 @@
     "knowledge_panel_nutriscore_banner_incorrect_score_title": "Why is this Nutri-Score different from the one on the package?",
     "knowledge_panel_nutriscore_banner_incorrect_score_message": "There are two possible explanations:\nThe list of ingredients and/or nutrition facts are not up-to-date.\n\nWe provide the \"New calculation\" of the Nutri-Score (or V2). Please check that you have the banner \"New calculation\" on the package.",
     "knowledge_panel_nutriscore_banner_incorrect_score_button1": "Check ingredients",
-    "knowledge_panel_nutriscore_banner_incorrect_score_button2": "Check nutrition facts"
-
-
+    "knowledge_panel_nutriscore_banner_incorrect_score_button2": "Check nutrition facts",
+    "url_not_supported": "Unfortunately, we can't open the URL:\n{url}",
+    "@url_not_supported": {
+        "description": "Error message when the app can't open a URL",
+        "placeholders": {
+            "url": {
+                "type": "String"
+            }
+        }
+    }
 }

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -1398,6 +1398,14 @@
     "@edit_product_label": {
         "description": "Edit product button label"
     },
+    "edit_product_pending_operations_banner_title": "Envoi de vos modifications…",
+    "@edit_product_pending_operations_banner_title": {
+        "description": "When a product has pending edits (being sent to the server), there is a message on the edit page (here is the title of the message)."
+    },
+    "edit_product_pending_operations_banner_message": "Vos modifications sont en cours d'envoi en **arrière-plan** (ou plus tard en cas d'erreur).\nVous pouvez continuer d'éditer d'autres champs du produit.",
+    "@edit_product_pending_operations_banner_message": {
+        "description": "When a product has pending edits (being sent to the server), there is a message on the edit page. Please keep the ** syntax to make the text bold."
+    },
     "edit_product_label_short": "Modifier",
     "@edit_product_label_short": {
         "description": "Edit product button short label (only the verb)"
@@ -3433,7 +3441,7 @@
     "@product_page_action_bar_item_disable": {
         "description": "Accessibility label to disable action (= make it invisible)"
     },
-    "product_page_pending_operations_banner_title": "Téléversement de vos modifications…",
+    "product_page_pending_operations_banner_title": "Envoi de vos modifications…",
     "@product_page_pending_operations_banner_title": {
         "description": "When a product has pending edits (being sent to the server), there is a message on the product page (here is the title of the message)."
     },

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -3556,5 +3556,14 @@
     "knowledge_panel_nutriscore_banner_incorrect_score_title": "Pourquoi ce Nutri-Score est-il différent de celui présent sur l'emballage ?",
     "knowledge_panel_nutriscore_banner_incorrect_score_message": "Il y a deux explications possibles :\nLa liste des ingrédients et/ou le tableau nutritionnel ne sont pas à jour.\n\nNous affichons le \"Nouveau calcul\" du Nutri-Score (ou V2). Vérifiez que le libellé \"Nouveau calcul\" est bien sur l'emballage.",
     "knowledge_panel_nutriscore_banner_incorrect_score_button1": "Vérifier les ingredients",
-    "knowledge_panel_nutriscore_banner_incorrect_score_button2": "Vérifier le tableau nutritionnel"
+    "knowledge_panel_nutriscore_banner_incorrect_score_button2": "Vérifier le tableau nutritionnel",
+    "url_not_supported": "Malheureusement, nous ne pouvez pas ouvrir l'adresse :\n{url}",
+    "@url_not_supported": {
+        "description": "Error message when the app can't open a URL",
+        "placeholders": {
+            "url": {
+                "type": "String"
+            }
+        }
+    }
 }

--- a/packages/smooth_app/lib/pages/navigator/app_navigator.dart
+++ b/packages/smooth_app/lib/pages/navigator/app_navigator.dart
@@ -495,7 +495,7 @@ class AppRoutes {
 
   static String get SIGNUP => '/${_InternalAppRoutes.SIGNUP_PAGE}';
 
-  // Open an external link (where path is relative to the OFF website)
+  // Open an external link
   static String EXTERNAL(String path) =>
       '/${_InternalAppRoutes.EXTERNAL_PAGE}?path=${Uri.encodeFull(path)}';
 }

--- a/packages/smooth_app/lib/pages/navigator/external_page.dart
+++ b/packages/smooth_app/lib/pages/navigator/external_page.dart
@@ -45,7 +45,6 @@ class _ExternalPageState extends State<ExternalPage> {
 
         if (widget.path.startsWith('http')) {
           url = widget.path;
-          throw Exception();
         } else {
           // First let's try with https://{country}.openfoodfacts.org
           final OpenFoodFactsCountry country = ProductQuery.getCountry();

--- a/packages/smooth_app/lib/pages/navigator/external_page.dart
+++ b/packages/smooth_app/lib/pages/navigator/external_page.dart
@@ -2,14 +2,17 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_custom_tabs/flutter_custom_tabs.dart' as tabs;
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
 import 'package:http/http.dart' as http;
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:path/path.dart' as path;
+import 'package:smooth_app/generic_lib/duration_constants.dart';
 import 'package:smooth_app/helpers/launch_url_helper.dart';
 import 'package:smooth_app/pages/navigator/app_navigator.dart';
 import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/services/smooth_services.dart';
+import 'package:smooth_app/widgets/smooth_floating_message.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 /// This screen is only used for deep links!
@@ -37,32 +40,38 @@ class _ExternalPageState extends State<ExternalPage> {
     super.initState();
 
     WidgetsBinding.instance.addPostFrameCallback((_) async {
-      // First let's try with https://{country}.openfoodfacts.org
-      final OpenFoodFactsCountry country = ProductQuery.getCountry();
-
-      String? url;
-      url = path.join(
-        'https://${country.offTag}.openfoodfacts.org',
-        widget.path,
-      );
-
-      if (await _testUrl(url)) {
-        url = null;
-      }
-
-      // If that's not OK, let's try with world.openfoodfacts.org?lc={language}
-      if (url == null) {
-        final OpenFoodFactsLanguage language = ProductQuery.getLanguage();
-
-        url = path.join(
-          'https://world.openfoodfacts.org',
-          widget.path,
-        );
-
-        url = '$url?lc=${language.offTag}';
-      }
-
       try {
+        String? url;
+
+        if (widget.path.startsWith('http')) {
+          url = widget.path;
+          throw Exception();
+        } else {
+          // First let's try with https://{country}.openfoodfacts.org
+          final OpenFoodFactsCountry country = ProductQuery.getCountry();
+
+          url = path.join(
+            'https://${country.offTag}.openfoodfacts.org',
+            widget.path,
+          );
+
+          if (await _testUrl(url)) {
+            url = null;
+          }
+
+          // If that's not OK, let's try with world.openfoodfacts.org?lc={language}
+          if (url == null) {
+            final OpenFoodFactsLanguage language = ProductQuery.getLanguage();
+
+            url = path.join(
+              'https://world.openfoodfacts.org',
+              widget.path,
+            );
+
+            url = '$url?lc=${language.offTag}';
+          }
+        }
+
         if (Platform.isAndroid) {
           /// Custom tabs
           WidgetsFlutterBinding.ensureInitialized();
@@ -81,6 +90,17 @@ class _ExternalPageState extends State<ExternalPage> {
         }
       } catch (e) {
         Logs.e('Unable to open an external link', ex: e);
+        if (mounted) {
+          SmoothFloatingMessage(
+            message:
+                AppLocalizations.of(context).url_not_supported(widget.path),
+            type: SmoothFloatingMessageType.error,
+          ).show(
+            context,
+            duration: SnackBarDuration.long,
+            alignment: Alignment.bottomCenter,
+          );
+        }
       } finally {
         if (mounted) {
           final bool success = AppNavigator.of(context).pop();
@@ -96,7 +116,11 @@ class _ExternalPageState extends State<ExternalPage> {
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold();
+    return const Scaffold(
+      body: Center(
+        child: CircularProgressIndicator.adaptive(),
+      ),
+    );
   }
 
   /// Check if an URL exist

--- a/packages/smooth_app/lib/widgets/smooth_banner.dart
+++ b/packages/smooth_app/lib/widgets/smooth_banner.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/themes/theme_provider.dart';
 import 'package:smooth_app/widgets/smooth_close_button.dart';
 import 'package:smooth_app/widgets/smooth_text.dart';
 
@@ -14,8 +15,10 @@ class SmoothBanner extends StatelessWidget {
     this.iconAlignment,
     this.iconColor,
     this.iconBackgroundColor,
+    this.titleBackgroundColor,
     this.contentBackgroundColor,
     this.onDismissClicked,
+    this.borderRadius,
     this.addSafeArea = false,
     this.topShadow = false,
     super.key,
@@ -31,10 +34,13 @@ class SmoothBanner extends StatelessWidget {
   final bool topShadow;
   final bool addSafeArea;
 
+  final BorderRadiusGeometry? borderRadius;
+
   final Color? iconColor;
   final Color? iconBackgroundColor;
   final Color? titleColor;
   final Color? contentColor;
+  final Color? titleBackgroundColor;
   final Color? contentBackgroundColor;
 
   static const Color _titleColor = Color(0xFF373737);
@@ -74,51 +80,65 @@ class SmoothBanner extends StatelessWidget {
               width: double.infinity,
               color: contentBackgroundColor ?? const Color(0xFFECECEC),
               padding: EdgeInsetsDirectional.only(
-                start: MEDIUM_SPACE,
-                end: MEDIUM_SPACE,
-                top: onDismissClicked != null
-                    ? VERY_SMALL_SPACE
-                    : BALANCED_SPACE,
                 bottom: onDismissClicked != null ? LARGE_SPACE : MEDIUM_SPACE,
               ),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: <Widget>[
-                  Row(
-                    children: <Widget>[
-                      Expanded(
-                        child: Text(
-                          title,
-                          style: TextStyle(
-                            fontSize: 16.0,
-                            fontWeight: FontWeight.bold,
-                            color: titleColor ?? _titleColor,
-                          ),
-                        ),
+                  ColoredBox(
+                    color: titleBackgroundColor ?? Colors.transparent,
+                    child: Padding(
+                      padding: EdgeInsetsDirectional.symmetric(
+                        horizontal: MEDIUM_SPACE,
+                        vertical: onDismissClicked != null
+                            ? VERY_SMALL_SPACE
+                            : BALANCED_SPACE,
                       ),
-                      if (onDismissClicked != null) ...<Widget>[
-                        const SizedBox(width: SMALL_SPACE),
-                        SmoothCloseButton(
-                          onClose: () => onDismissClicked!.call(
-                            SmoothBannerDismissEvent.fromButton,
+                      child: Row(
+                        children: <Widget>[
+                          Expanded(
+                            child: Text(
+                              title,
+                              style: TextStyle(
+                                fontSize: 16.0,
+                                fontWeight: FontWeight.bold,
+                                color: titleColor ?? _titleColor,
+                              ),
+                            ),
                           ),
-                          circleColor: titleColor ?? _titleColor,
-                          crossColor: Colors.white,
-                          circleSize: 26.0,
-                          crossSize: 12.0,
-                          tooltip: AppLocalizations.of(context)
-                              .owner_field_info_close_button,
-                        ),
-                      ],
-                    ],
+                          if (onDismissClicked != null) ...<Widget>[
+                            const SizedBox(width: SMALL_SPACE),
+                            SmoothCloseButton(
+                              onClose: () => onDismissClicked!.call(
+                                SmoothBannerDismissEvent.fromButton,
+                              ),
+                              circleColor: titleColor ?? _titleColor,
+                              crossColor: Colors.white,
+                              circleSize: 26.0,
+                              crossSize: 12.0,
+                              tooltip: AppLocalizations.of(context)
+                                  .owner_field_info_close_button,
+                            ),
+                          ],
+                        ],
+                      ),
+                    ),
                   ),
                   if (onDismissClicked == null)
-                    const SizedBox(height: VERY_SMALL_SPACE),
-                  TextWithBoldParts(
-                    text: content,
-                    textStyle: TextStyle(
-                      fontSize: 14.0,
-                      color: contentColor ?? const Color(0xFF373737),
+                    const SizedBox(
+                      height: VERY_SMALL_SPACE,
+                      width: MEDIUM_SPACE,
+                    ),
+                  Padding(
+                    padding: const EdgeInsetsDirectional.symmetric(
+                        horizontal: MEDIUM_SPACE),
+                    child: TextWithBoldParts(
+                      text: content,
+                      textStyle: TextStyle(
+                        fontSize: 14.0,
+                        height: 1.6,
+                        color: contentColor ?? const Color(0xFF373737),
+                      ),
                     ),
                   ),
                   if (bottomPadding > 0) SizedBox(height: bottomPadding),
@@ -130,14 +150,24 @@ class SmoothBanner extends StatelessWidget {
       ),
     );
 
+    if (borderRadius != null) {
+      child = ClipRRect(
+        borderRadius: borderRadius!,
+        child: child,
+      );
+    }
+
     if (topShadow) {
       child = DecoratedBox(
-        decoration: const BoxDecoration(
+        decoration: BoxDecoration(
+          borderRadius: borderRadius,
           boxShadow: <BoxShadow>[
             BoxShadow(
-              color: Colors.black12,
+              color: context.lightTheme()
+                  ? Colors.black12
+                  : const Color(0x10FFFFFF),
               blurRadius: 6.0,
-              offset: Offset(0.0, -4.0),
+              offset: const Offset(0.0, -4.0),
             ),
           ],
         ),


### PR DESCRIPTION
Hi everyone!

### Styles
The Floating message now have 3 styles: success / warning / error.
For the error one, the phone will also vibrate.

## Loading variant
A loading variant shows the cloud animation.

![IMG_1818](https://github.com/user-attachments/assets/c609dd71-a809-4ab7-9ad2-56b5291a313b)


## Dismissable popup
By clicking on the message, it will now disappear! 🎉

## Background tasks
Popups for background product edits (basic details, pictures, labels, origins…) are all removed, because we have this banner on the Edit page (slightly updated):
![Untitled](https://github.com/user-attachments/assets/4c10376b-814e-45d1-930e-f7c6e84d5f1c)


## External page (= opens links on the browser)
If the browser can't be opened, there's now an error.
This screen also supports full URL (with http://)

![IMG_1817](https://github.com/user-attachments/assets/7476b1a8-018a-4ac1-af42-b4d20448520f)
