### PR TITLE
chore: Unblock iOS build by using macos-15

### DIFF
--- a/.github/workflows/ios-release-to-org-openfoodfacts-scanner.yml
+++ b/.github/workflows/ios-release-to-org-openfoodfacts-scanner.yml
@@ -40,7 +40,7 @@ env:
 jobs:
   testflight-release:
     name: Build and deploy to TestFlight testers (org.openfoodfacts.scanner)
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:


### PR DESCRIPTION
GitHub doesn't provide images with iOS 18.2 on macos-latest.
Let's try with macos-15

https://github.com/actions/runner-images/issues/11335#issuecomment-2585534317