### PR TITLE
feat: Use a WebView for OFF links

### DIFF
--- a/packages/smooth_app/lib/generic_lib/html/smooth_html_factory.dart
+++ b/packages/smooth_app/lib/generic_lib/html/smooth_html_factory.dart
@@ -5,7 +5,11 @@ import 'package:smooth_app/generic_lib/html/smooth_html_marker_chip.dart';
 import 'package:smooth_app/generic_lib/html/smooth_html_marker_decimal.dart';
 
 class SmoothHtmlWidgetFactory extends WidgetFactory {
-  SmoothHtmlWidgetFactory();
+  SmoothHtmlWidgetFactory({
+    required this.onLinkClicked,
+  });
+
+  final Function(String link) onLinkClicked;
 
   @override
   Widget buildText(
@@ -53,5 +57,11 @@ class SmoothHtmlWidgetFactory extends WidgetFactory {
     } else {
       return super.buildListMarker(tree, resolved, listStyleType, index)!;
     }
+  }
+
+  @override
+  Future<bool> onTapUrl(String url) async {
+    onLinkClicked(url);
+    return true;
   }
 }

--- a/packages/smooth_app/lib/generic_lib/html/smooth_html_widget.dart
+++ b/packages/smooth_app/lib/generic_lib/html/smooth_html_widget.dart
@@ -4,6 +4,7 @@ import 'package:flutter_widget_from_html_core/flutter_widget_from_html_core.dart
 import 'package:html/dom.dart' as dom;
 import 'package:smooth_app/generic_lib/html/smooth_html_factory.dart';
 import 'package:smooth_app/helpers/launch_url_helper.dart';
+import 'package:smooth_app/pages/navigator/app_navigator.dart';
 
 class SmoothHtmlWidget extends StatelessWidget {
   const SmoothHtmlWidget(
@@ -45,8 +46,13 @@ class SmoothHtmlWidget extends StatelessWidget {
 
         return true;
       },
-      factoryBuilder: () =>
-          isSelectable ? SmoothHtmlWidgetFactory() : WidgetFactory(),
+      factoryBuilder: () => isSelectable
+          ? SmoothHtmlWidgetFactory(onLinkClicked: (String url) {
+              AppNavigator.of(context).push(
+                AppRoutes.EXTERNAL_WEBVIEW(url),
+              );
+            })
+          : WidgetFactory(),
       enableCaching: false,
     );
   }

--- a/packages/smooth_app/lib/generic_lib/html/smooth_html_widget.dart
+++ b/packages/smooth_app/lib/generic_lib/html/smooth_html_widget.dart
@@ -4,7 +4,6 @@ import 'package:flutter_widget_from_html_core/flutter_widget_from_html_core.dart
 import 'package:html/dom.dart' as dom;
 import 'package:smooth_app/generic_lib/html/smooth_html_factory.dart';
 import 'package:smooth_app/helpers/launch_url_helper.dart';
-import 'package:smooth_app/pages/navigator/app_navigator.dart';
 
 class SmoothHtmlWidget extends StatelessWidget {
   const SmoothHtmlWidget(
@@ -47,11 +46,10 @@ class SmoothHtmlWidget extends StatelessWidget {
         return true;
       },
       factoryBuilder: () => isSelectable
-          ? SmoothHtmlWidgetFactory(onLinkClicked: (String url) {
-              AppNavigator.of(context).push(
-                AppRoutes.EXTERNAL_WEBVIEW(url),
-              );
-            })
+          ? SmoothHtmlWidgetFactory(
+              onLinkClicked: (String url) =>
+                  LaunchUrlHelper.launchURLInWebViewOrBrowser(context, url),
+            )
           : WidgetFactory(),
       enableCaching: false,
     );

--- a/packages/smooth_app/lib/helpers/launch_url_helper.dart
+++ b/packages/smooth_app/lib/helpers/launch_url_helper.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/widgets.dart';
 import 'package:go_router/go_router.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
+import 'package:smooth_app/pages/navigator/app_navigator.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class LaunchUrlHelper {
@@ -15,7 +16,7 @@ class LaunchUrlHelper {
     assert(url.isNotEmpty);
 
     if (url.startsWith(RegExp(
-      'http(s)?://[a-z]*.open(food|beauty|products|petfood)facts.(net|org)',
+      r'http(s)?://[a-z\-]*.open(food|beauty|products|petfood)facts.(net|org)',
     ))) {
       AnalyticsHelper.trackOutlink(url: url);
       GoRouter.of(context).push(url);
@@ -41,6 +42,21 @@ class LaunchUrlHelper {
       );
     } catch (e) {
       throw 'Could not launch $url,Error: $e';
+    }
+  }
+
+  /// Launches the URL in a WebView if it's an OFF link or an external browser.
+  static Future<void> launchURLInWebViewOrBrowser(
+    BuildContext context,
+    String url, {
+    LaunchMode? mode,
+  }) async {
+    if (url.startsWith(RegExp(
+      r'http(s)?://[a-z\-]*.open(food|beauty|products|petfood)facts.(net|org)',
+    ))) {
+      AppNavigator.of(context).push(AppRoutes.EXTERNAL_WEBVIEW(url));
+    } else {
+      return launchURL(url, mode: mode);
     }
   }
 }

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_text_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_text_card.dart
@@ -6,8 +6,8 @@ import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/html/smooth_html_widget.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/helpers/extension_on_text_helper.dart';
+import 'package:smooth_app/helpers/launch_url_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
-import 'package:smooth_app/pages/navigator/app_navigator.dart';
 import 'package:smooth_app/resources/app_icons.dart' as icons;
 import 'package:smooth_app/themes/constant_icons.dart';
 import 'package:smooth_app/widgets/smooth_text.dart';
@@ -73,11 +73,9 @@ class KnowledgePanelTextCard extends StatelessWidget {
             appLocalizations
                 .knowledge_panel_text_source(textElement.sourceText!),
             trailingIcon: Icon(ConstantIcons.forwardIcon),
-            onPressed: () async => AppNavigator.of(context).push(
-              AppRoutes.EXTERNAL_WEBVIEW(
-                textElement.sourceUrl!,
-                pageTitle: textElement.sourceText,
-              ),
+            onPressed: () async => LaunchUrlHelper.launchURLInWebViewOrBrowser(
+              context,
+              textElement.sourceUrl!,
             ),
             borderRadius: ANGULAR_BORDER_RADIUS,
             elevation: const WidgetStatePropertyAll<double>(0.5),

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_text_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_text_card.dart
@@ -6,8 +6,8 @@ import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/html/smooth_html_widget.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/helpers/extension_on_text_helper.dart';
-import 'package:smooth_app/helpers/launch_url_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
+import 'package:smooth_app/pages/navigator/app_navigator.dart';
 import 'package:smooth_app/resources/app_icons.dart' as icons;
 import 'package:smooth_app/themes/constant_icons.dart';
 import 'package:smooth_app/widgets/smooth_text.dart';
@@ -70,18 +70,22 @@ class KnowledgePanelTextCard extends StatelessWidget {
             size: 0.0,
           ),
           child: addPanelButton(
-              appLocalizations
-                  .knowledge_panel_text_source(textElement.sourceText!),
-              trailingIcon: Icon(ConstantIcons.forwardIcon),
-              onPressed: () async => LaunchUrlHelper.launchURL(
-                    textElement.sourceUrl!,
-                  ),
-              borderRadius: ANGULAR_BORDER_RADIUS,
-              elevation: const WidgetStatePropertyAll<double>(0.5),
-              padding: const EdgeInsetsDirectional.symmetric(
-                horizontal: 0,
-                vertical: BALANCED_SPACE,
-              )),
+            appLocalizations
+                .knowledge_panel_text_source(textElement.sourceText!),
+            trailingIcon: Icon(ConstantIcons.forwardIcon),
+            onPressed: () async => AppNavigator.of(context).push(
+              AppRoutes.EXTERNAL_WEBVIEW(
+                textElement.sourceUrl!,
+                pageTitle: textElement.sourceText,
+              ),
+            ),
+            borderRadius: ANGULAR_BORDER_RADIUS,
+            elevation: const WidgetStatePropertyAll<double>(0.5),
+            padding: const EdgeInsetsDirectional.symmetric(
+              horizontal: 0,
+              vertical: BALANCED_SPACE,
+            ),
+          ),
         ),
       ],
     );

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -522,6 +522,10 @@
     "@label_refresh": {
         "description": "Refresh the cached product"
     },
+    "label_reload": "Reload",
+    "@label_reload": {
+        "description": "Reload a page"
+    },
     "image": "Image",
     "front_photo": "Front photo",
     "@front_photo": {

--- a/packages/smooth_app/lib/pages/navigator/app_navigator.dart
+++ b/packages/smooth_app/lib/pages/navigator/app_navigator.dart
@@ -11,6 +11,7 @@ import 'package:smooth_app/helpers/extension_on_text_helper.dart';
 import 'package:smooth_app/pages/guides/guide/guide_nutriscore_v2.dart';
 import 'package:smooth_app/pages/navigator/error_page.dart';
 import 'package:smooth_app/pages/navigator/external_page.dart';
+import 'package:smooth_app/pages/navigator/external_page_webview.dart';
 import 'package:smooth_app/pages/navigator/slide_up_transition.dart';
 import 'package:smooth_app/pages/onboarding/onboarding_flow_navigator.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_page.dart';
@@ -272,6 +273,18 @@ class _SmoothGoRouter {
             );
           },
         ),
+        GoRoute(
+          path: '/${_InternalAppRoutes.EXTERNAL_WEBVIEW_PAGE}',
+          pageBuilder: (BuildContext context, GoRouterState state) {
+            return OpenUpwardsPage.getTransition<void>(
+              key: state.pageKey,
+              child: ExternalPageInAWebView(
+                path: Uri.decodeFull(state.uri.queryParameters['path']!),
+                pageName: state.uri.queryParameters['title'],
+              ),
+            );
+          },
+        ),
       ],
       redirect: (BuildContext context, GoRouterState state) {
         final String path = state.matchedLocation;
@@ -433,6 +446,7 @@ class _InternalAppRoutes {
   static const String PREFERENCES_PAGE = '_preferences';
   static const String SEARCH_PAGE = '_search';
   static const String EXTERNAL_PAGE = '_external';
+  static const String EXTERNAL_WEBVIEW_PAGE = '_external_webview';
   static const String SIGNUP_PAGE = '_signup';
 
   static const String _GUIDES = '_guides';
@@ -495,7 +509,11 @@ class AppRoutes {
 
   static String get SIGNUP => '/${_InternalAppRoutes.SIGNUP_PAGE}';
 
-  // Open an external link
+  // Open an external link in the browser or custom tabs
   static String EXTERNAL(String path) =>
       '/${_InternalAppRoutes.EXTERNAL_PAGE}?path=${Uri.encodeFull(path)}';
+
+  // Open an external link in a WebView
+  static String EXTERNAL_WEBVIEW(String path, {String? pageTitle}) =>
+      '/${_InternalAppRoutes.EXTERNAL_WEBVIEW_PAGE}?title=$pageTitle&path=${Uri.encodeFull(path)}';
 }

--- a/packages/smooth_app/lib/pages/navigator/external_page_webview.dart
+++ b/packages/smooth_app/lib/pages/navigator/external_page_webview.dart
@@ -86,8 +86,6 @@ class _ExternalPageInAWebViewState extends State<ExternalPageInAWebView> {
     userAgent.write(packageInfo.buildNumber);
     userAgent.write(')');
 
-    print(userAgent.toString());
-
     _controller.setUserAgent(userAgent.toString());
   }
 

--- a/packages/smooth_app/lib/pages/navigator/external_page_webview.dart
+++ b/packages/smooth_app/lib/pages/navigator/external_page_webview.dart
@@ -1,0 +1,209 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:share_plus/share_plus.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/generic_lib/duration_constants.dart';
+import 'package:smooth_app/generic_lib/widgets/smooth_snackbar.dart';
+import 'package:smooth_app/helpers/ui_helpers.dart';
+import 'package:smooth_app/pages/navigator/external_page.dart';
+import 'package:smooth_app/themes/theme_provider.dart';
+import 'package:smooth_app/widgets/smooth_app_bar.dart';
+import 'package:smooth_app/widgets/smooth_scaffold.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+/// Instead of Custom Tabs / Browser with [ExternalPage], we force some links
+/// in a WebView
+/// The path can be relative to the OFF website or not.
+class ExternalPageInAWebView extends StatefulWidget {
+  const ExternalPageInAWebView({
+    required this.path,
+    required this.pageName,
+    super.key,
+  }) : assert(path != '');
+
+  final String path;
+  final String? pageName;
+
+  @override
+  State<ExternalPageInAWebView> createState() => _ExternalPageInAWebViewState();
+}
+
+class _ExternalPageInAWebViewState extends State<ExternalPageInAWebView> {
+  final WebViewController _controller = WebViewController();
+  String? _initialUrl;
+  String? _pageTitle;
+  int _progress = 100;
+
+  @override
+  void initState() {
+    super.initState();
+
+    onNextFrame(() {
+      if (context.darkTheme(listen: false)) {
+        _controller.setBackgroundColor(Colors.black);
+      }
+    });
+
+    _controller.setNavigationDelegate(
+      NavigationDelegate(
+        onProgress: (int progress) async {
+          if (progress < 100) {
+            _pageTitle = AppLocalizations.of(context).loading;
+          } else {
+            _pageTitle = await _controller.getTitle();
+          }
+          _progress = progress;
+          setState(() {});
+        },
+        onPageFinished: (String url) async {
+          _pageTitle = await _controller.getTitle();
+          setState(() {});
+        },
+      ),
+    );
+
+    Future.wait(<Future<void>>[
+      _setUserAgent(),
+      _fixUrl(),
+    ]).then((_) => setState(() {}));
+  }
+
+  Future<void> _fixUrl() async {
+    _initialUrl = await ExternalPage.rewritePath(widget.path);
+    _controller.loadRequest(Uri.parse(_initialUrl!));
+    setState(() {});
+  }
+
+  Future<void> _setUserAgent() async {
+    final StringBuffer userAgent = StringBuffer();
+    userAgent.write(await _controller.getUserAgent() ?? 'Mozilla/5.0');
+    userAgent.write(' Smoothie OpenFoodFactsMobile/');
+
+    final PackageInfo packageInfo = await PackageInfo.fromPlatform();
+    userAgent.write(packageInfo.version);
+    userAgent.write('(');
+    userAgent.write(packageInfo.buildNumber);
+    userAgent.write(')');
+
+    print(userAgent.toString());
+
+    _controller.setUserAgent(userAgent.toString());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_initialUrl == null) {
+      return SmoothScaffold(
+        appBar: SmoothAppBar(
+          title: Text(widget.pageName ?? AppLocalizations.of(context).loading),
+          leading: const CloseButton(),
+        ),
+        body: const Center(
+          child: CircularProgressIndicator.adaptive(),
+        ),
+      );
+    } else {
+      return SmoothScaffold(
+        appBar: SmoothAppBar(
+          title: Text(
+            _pageTitle ??
+                widget.pageName ??
+                AppLocalizations.of(context).loading,
+          ),
+          leading: const CloseButton(),
+          bottom: _progress < 100
+              ? PreferredSize(
+                  preferredSize: const Size(double.infinity, 5.0),
+                  child: LinearProgressIndicator(
+                    value: _progress / 100,
+                  ),
+                )
+              : null,
+        ),
+        bottomNavigationBar: _WebViewBottomBar(controller: _controller),
+        body: RefreshIndicator(
+          onRefresh: () => _controller.reload(),
+          child: WebViewWidget(
+            controller: _controller,
+          ),
+        ),
+      );
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.setNavigationDelegate(NavigationDelegate());
+    super.dispose();
+  }
+}
+
+class _WebViewBottomBar extends StatelessWidget {
+  const _WebViewBottomBar({
+    required this.controller,
+  });
+
+  final WebViewController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+
+    return Container(
+      color: AppBarTheme.of(context).backgroundColor,
+      child: Padding(
+        padding: EdgeInsetsDirectional.only(
+          top: VERY_SMALL_SPACE,
+          start: SMALL_SPACE,
+          end: SMALL_SPACE,
+          bottom: VERY_SMALL_SPACE + MediaQuery.viewPaddingOf(context).bottom,
+        ),
+        child: Row(
+          children: <Widget>[
+            IconButton(
+              icon: const Icon(Icons.arrow_back),
+              tooltip: appLocalizations.previous_label,
+              enableFeedback: true,
+              onPressed: () => controller.goBack(),
+            ),
+            IconButton(
+              icon: const Icon(Icons.arrow_forward),
+              tooltip: appLocalizations.next_label,
+              enableFeedback: true,
+              onPressed: () => controller.goForward(),
+            ),
+            IconButton(
+              icon: const Icon(Icons.refresh),
+              tooltip: appLocalizations.label_reload,
+              enableFeedback: true,
+              onPressed: () => controller.reload(),
+            ),
+            const Spacer(),
+            IconButton(
+              icon: const Icon(Icons.share),
+              tooltip: appLocalizations.share,
+              enableFeedback: true,
+              onPressed: () async {
+                final String? url = await controller.currentUrl();
+                if (url == null) {
+                  if (context.mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SmoothFloatingSnackbar(
+                        content: Text(appLocalizations.error_occurred),
+                        duration: SnackBarDuration.medium,
+                      ),
+                    );
+                  }
+                  return;
+                }
+
+                Share.shareUri(Uri.parse(url));
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_faq.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_faq.dart
@@ -179,7 +179,11 @@ class UserPreferencesFaq extends AbstractUserPreferences {
         labels: <String>[title],
         builder: (_) => UserPreferencesListTile(
           title: Text(title),
-          onTap: onTap ?? () async => LaunchUrlHelper.launchURL(url!),
+          onTap: onTap ??
+              () async => LaunchUrlHelper.launchURLInWebViewOrBrowser(
+                    context,
+                    url!,
+                  ),
           trailing: icon ??
               UserPreferencesListTile.getTintedIcon(Icons.open_in_new, context),
           leading: SizedBox(
@@ -274,7 +278,9 @@ class UserPreferencesFaq extends AbstractUserPreferences {
                       ),
                       const SizedBox(height: VERY_SMALL_SPACE),
                       SmoothAlertContentButton(
-                        onPressed: () async => LaunchUrlHelper.launchURL(
+                        onPressed: () async =>
+                            LaunchUrlHelper.launchURLInWebViewOrBrowser(
+                          context,
                           ProductQuery.replaceSubdomain(
                             'https://world.openfoodfacts.org/who-we-are',
                           ),
@@ -284,7 +290,9 @@ class UserPreferencesFaq extends AbstractUserPreferences {
                       ),
                       const SizedBox(height: VERY_SMALL_SPACE),
                       SmoothAlertContentButton(
-                        onPressed: () async => LaunchUrlHelper.launchURL(
+                        onPressed: () async =>
+                            LaunchUrlHelper.launchURLInWebViewOrBrowser(
+                          context,
                           ProductQuery.replaceSubdomain(
                             'https://world.openfoodfacts.org/terms-of-use',
                           ),
@@ -294,7 +302,9 @@ class UserPreferencesFaq extends AbstractUserPreferences {
                       ),
                       const SizedBox(height: VERY_SMALL_SPACE),
                       SmoothAlertContentButton(
-                        onPressed: () async => LaunchUrlHelper.launchURL(
+                        onPressed: () async =>
+                            LaunchUrlHelper.launchURLInWebViewOrBrowser(
+                          context,
                           ProductQuery.replaceSubdomain(
                             'https://world.openfoodfacts.org/legal',
                           ),
@@ -304,7 +314,9 @@ class UserPreferencesFaq extends AbstractUserPreferences {
                       ),
                       const SizedBox(height: VERY_SMALL_SPACE),
                       SmoothAlertContentButton(
-                        onPressed: () => LaunchUrlHelper.launchURL(
+                        onPressed: () =>
+                            LaunchUrlHelper.launchURLInWebViewOrBrowser(
+                          context,
                           ProductQuery.replaceSubdomain(
                             'https://world.openfoodfacts.org/privacy',
                           ),


### PR DESCRIPTION
Hi everyone!

If we try to open the website, we have a giant banner for the donation campaign.
The website will now remove this banner only if the user agent contains "Smoothie".

Unfortunately, we can't change the user agent for external browsers/custom tabs.
That's why we now have a dedicated page with a WebView.

The user agent will look like this:
```Mozilla/5.0 (iPhone; CPU iPhone OS 18_2_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Smoothie OpenFoodFactsMobile/0.0.0(734)```

Demo: https://github.com/user-attachments/assets/960554d6-eaae-498b-90ed-f1b841adc103

All links are handled in KPs + FAQ.