### PR TITLE
fix: Correct Finnish language translation

### DIFF
--- a/packages/smooth_app/lib/pages/preferences/user_preferences_languages_list.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_languages_list.dart
@@ -59,7 +59,7 @@ class Languages {
     OpenFoodFactsLanguage.EWE: 'Eʋegbe',
     OpenFoodFactsLanguage.BASQUE: 'euskara',
     OpenFoodFactsLanguage.PERSIAN: 'فارسی',
-    OpenFoodFactsLanguage.FINNISH: 'Suomalainen',
+    OpenFoodFactsLanguage.FINNISH: 'Suomi',
     OpenFoodFactsLanguage.FAROESE: 'Faroese',
     OpenFoodFactsLanguage.FRENCH: 'Français',
     OpenFoodFactsLanguage.FIJIAN_LANGUAGE: 'Fijian',


### PR DESCRIPTION
### What
Suomalainen refers to the adjectiv finnish and not the language. The language itself is called Suomi. Fun fact the land is also called Suomi in Finnish. 

See https://en.wikipedia.org/wiki/Suomi

Not sure if it needs to be updated on the server too?
