### PR TITLE
feat: Nutrition page (auto-focus on new fields + owner field)

### DIFF
--- a/packages/smooth_app/lib/pages/product/nutrition_add_nutrient_button.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_add_nutrient_button.dart
@@ -16,11 +16,11 @@ import 'package:smooth_app/widgets/smooth_text.dart';
 class NutritionAddNutrientButton extends StatelessWidget {
   const NutritionAddNutrientButton({
     required this.nutritionContainer,
-    required this.refreshParent,
+    required this.onNutrientSelected,
   });
 
   final NutritionContainer nutritionContainer;
-  final VoidCallback refreshParent;
+  final Function(OrderedNutrient nutrient) onNutrientSelected;
 
   @override
   Widget build(BuildContext context) {
@@ -95,7 +95,7 @@ class NutritionAddNutrientButton extends StatelessWidget {
         );
         if (selected != null) {
           nutritionContainer.add(selected);
-          refreshParent.call();
+          onNutrientSelected.call(selected);
         }
       },
       style: ButtonStyle(

--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -90,10 +90,6 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded>
     with UpToDateMixin {
   late final NumberFormat _decimalNumberFormat;
   late final NutritionContainer _nutritionContainer;
-  bool _ownerFieldBannerVisible = false;
-
-  /// When the banner is visible, we add a padding to the list
-  double _ownerFieldBannerHeight = 0.0;
 
   final Map<Nutrient, TextEditingControllerWithHistory> _controllers =
       <Nutrient, TextEditingControllerWithHistory>{};
@@ -152,46 +148,22 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded>
             title: appLocalizations.nutrition_page_title,
             product: upToDateProduct,
           ),
-          body: Stack(
-            children: <Widget>[
-              Positioned.fill(
-                child: Padding(
+          body: Padding(
+            padding: const EdgeInsetsDirectional.symmetric(
+              horizontal: LARGE_SPACE,
+            ),
+            child: Form(
+              key: _formKey,
+              child: Provider<List<FocusNode>>.value(
+                value: _focusNodes,
+                child: ListView(
                   padding: const EdgeInsetsDirectional.symmetric(
-                    horizontal: LARGE_SPACE,
+                    vertical: SMALL_SPACE,
                   ),
-                  child: Form(
-                    key: _formKey,
-                    child: Provider<List<FocusNode>>.value(
-                      value: _focusNodes,
-                      child: ListView(
-                        padding: const EdgeInsetsDirectional.symmetric(
-                          vertical: SMALL_SPACE,
-                        ),
-                        children: children,
-                      ),
-                    ),
-                  ),
+                  children: children,
                 ),
               ),
-              Positioned(
-                bottom: 0.0,
-                left: 0.0,
-                right: 0.0,
-                child: AnimatedOwnerFieldBanner(
-                  visible: _ownerFieldBannerVisible,
-                  shadow: true,
-                  onHeightChanged: (double height) {
-                    _ownerFieldBannerHeight = height;
-                    if (_ownerFieldBannerVisible) {
-                      setState(() {});
-                    }
-                  },
-                  onDismissClicked: () {
-                    setState(() => _ownerFieldBannerVisible = false);
-                  },
-                ),
-              ),
-            ],
+            ),
           ),
           bottomNavigationBar: ProductBottomButtonsBar(
             onSave: () async => _exitPage(
@@ -285,10 +257,6 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded>
           },
         ),
       );
-
-      if (_ownerFieldBannerVisible) {
-        children.add(SizedBox(height: _ownerFieldBannerHeight));
-      }
     } else {
       for (final Nutrient nutrient in _controllers.keys) {
         _controllers[nutrient]!.dispose();
@@ -346,9 +314,7 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded>
         )) !=
         null) {
       return IconButton(
-        onPressed: () {
-          context.read<_NutritionPageLoadedState>().toggleOwnerFieldBanner();
-        },
+        onPressed: () => showOwnerFieldInfoInModalSheet(context),
         icon: const OwnerFieldIcon(),
       );
     }
@@ -573,12 +539,6 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded>
     );
     return true;
   }
-
-  void toggleOwnerFieldBanner() {
-    setState(() {
-      _ownerFieldBannerVisible = !_ownerFieldBannerVisible;
-    });
-  }
 }
 
 class _NutrientRow extends StatelessWidget {
@@ -672,11 +632,7 @@ class _NutrientValueCell extends StatelessWidget {
                     null
             ? null
             : IconButton(
-                onPressed: () {
-                  context
-                      .read<_NutritionPageLoadedState>()
-                      .toggleOwnerFieldBanner();
-                },
+                onPressed: () => showOwnerFieldInfoInModalSheet(context),
                 icon: const OwnerFieldIcon(),
               ),
       ),

--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -116,6 +116,9 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded>
 
   @override
   void dispose() {
+    for (final FocusNode node in _focusNodes) {
+      node.dispose();
+    }
     _focusNodes.clear();
 
     for (final TextEditingControllerWithHistory controller
@@ -245,7 +248,10 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded>
         );
 
         if (_nutrientToHighlight == orderedNutrient) {
-          onNextFrame(() => _focusNodes[i].requestFocus());
+          final FocusNode focusNode = _focusNodes[i];
+          onNextFrame(() {
+            return focusNode.requestFocus();
+          });
           _nutrientToHighlight = null;
         }
       }
@@ -258,6 +264,7 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded>
         ),
       );
     } else {
+      // Ensure we won't have any memory leak
       for (final Nutrient nutrient in _controllers.keys) {
         _controllers[nutrient]!.dispose();
       }

--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -97,7 +97,7 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded>
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
   final List<FocusNode> _focusNodes = <FocusNode>[];
 
-  /// When a nutrient is added, ensure the focus will be on it
+  /// When a nutrient is added, ensure that the focus will be on it
   OrderedNutrient? _nutrientToHighlight;
 
   @override

--- a/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page_loaded.dart
@@ -15,6 +15,7 @@ import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/image_field_extension.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/helpers/text_input_formatters_helper.dart';
+import 'package:smooth_app/helpers/ui_helpers.dart';
 import 'package:smooth_app/pages/product/common/product_buttons.dart';
 import 'package:smooth_app/pages/product/common/product_refresher.dart';
 import 'package:smooth_app/pages/product/may_exit_page_helper.dart';
@@ -99,6 +100,9 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded>
   TextEditingControllerWithHistory? _servingController;
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
   final List<FocusNode> _focusNodes = <FocusNode>[];
+
+  /// When a nutrient is added, ensure the focus will be on it
+  OrderedNutrient? _nutrientToHighlight;
 
   @override
   void initState() {
@@ -231,7 +235,9 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded>
       children.add(_getServingSwitch(appLocalizations));
 
       if (_focusNodes.length != displayableNutrients.length) {
-        _focusNodes.clear();
+        for (final FocusNode node in _focusNodes) {
+          node.unfocus();
+        }
         _focusNodes.addAll(
           List<FocusNode>.generate(
             displayableNutrients.length,
@@ -265,11 +271,18 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded>
             ),
           ),
         );
+
+        if (_nutrientToHighlight == orderedNutrient) {
+          onNextFrame(() => _focusNodes[i].requestFocus());
+          _nutrientToHighlight = null;
+        }
       }
       children.add(
         NutritionAddNutrientButton(
           nutritionContainer: _nutritionContainer,
-          refreshParent: () => setState(() {}),
+          onNutrientSelected: (final OrderedNutrient nutrient) {
+            setState(() => _nutrientToHighlight = nutrient);
+          },
         ),
       );
 
@@ -277,6 +290,9 @@ class _NutritionPageLoadedState extends State<NutritionPageLoaded>
         children.add(SizedBox(height: _ownerFieldBannerHeight));
       }
     } else {
+      for (final Nutrient nutrient in _controllers.keys) {
+        _controllers[nutrient]!.dispose();
+      }
       _focusNodes.clear();
     }
     return children;


### PR DESCRIPTION
Hi everyone!

This PR changes 2 behaviors on the nutrition page:
- When a new field is added (eg: calcium), the focus will be moved to the text field
- For the owner field icon, it opens the modal sheet with explanations

Video: 

https://github.com/user-attachments/assets/3fc6f419-b4a2-4996-b45a-459edc0e5afa

