### PR TITLE
feat: Snackbar action button with a different background color

### DIFF
--- a/packages/smooth_app/lib/generic_lib/widgets/smooth_snackbar.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/smooth_snackbar.dart
@@ -82,7 +82,7 @@ class SmoothFloatingSnackbar extends SnackBar {
     super.width,
     super.shape,
     super.hitTestBehavior,
-    super.action,
+    SnackBarAction? action,
     super.actionOverflowThreshold,
     super.showCloseIcon,
     super.closeIconColor,
@@ -101,6 +101,10 @@ class SmoothFloatingSnackbar extends SnackBar {
           behavior: SnackBarBehavior.floating,
           backgroundColor:
               context.extension<SmoothColorsThemeExtension>().error,
+          action: action?.copyWith(
+            backgroundColor: Colors.white38,
+            textColor: Colors.white,
+          ),
           content: Row(
             children: <Widget>[
               ExcludeSemantics(
@@ -138,4 +142,25 @@ class SmoothFloatingSnackbar extends SnackBar {
             ],
           ),
         );
+}
+
+extension SnackBarActionExtension on SnackBarAction {
+  SnackBarAction copyWith({
+    String? label,
+    VoidCallback? onPressed,
+    Color? textColor,
+    Color? disabledTextColor,
+    Color? backgroundColor,
+    Color? disabledBackgroundColor,
+  }) {
+    return SnackBarAction(
+      textColor: textColor ?? this.textColor,
+      disabledTextColor: disabledTextColor ?? this.disabledTextColor,
+      backgroundColor: backgroundColor ?? this.backgroundColor,
+      disabledBackgroundColor:
+          disabledBackgroundColor ?? this.disabledBackgroundColor,
+      label: label ?? this.label,
+      onPressed: onPressed ?? this.onPressed,
+    );
+  }
 }

--- a/packages/smooth_app/lib/pages/product/common/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_page.dart
@@ -417,11 +417,9 @@ class _ProductListPageState extends State<ProductListPage>
                     ? appLocalizations.product_removed_list
                     : appLocalizations.product_could_not_remove,
               ),
-              duration: SnackBarDuration.medium,
               action: !removed
                   ? null
                   : SnackBarAction(
-                      textColor: PRIMARY_BLUE_COLOR,
                       label: appLocalizations.undo,
                       onPressed: () async {
                         barcodes.insert(index, barcode);

--- a/packages/smooth_app/lib/themes/smooth_theme.dart
+++ b/packages/smooth_app/lib/themes/smooth_theme.dart
@@ -100,6 +100,7 @@ class SmoothTheme {
           fontWeight: FontWeight.w500,
         ),
         actionTextColor: Colors.white,
+        actionBackgroundColor: smoothExtension.primaryDark,
         backgroundColor: smoothExtension.primaryBlack,
       ),
       bannerTheme: MaterialBannerThemeData(


### PR DESCRIPTION
Hi everyone!

To improve the readability/accessibility of SnackBar buttons, they now have a background color.
Also, we've received one feedback on Slack: the duration of the SnackBar used on the lists is too short (fixed).

Before/After:
![Untitled](https://github.com/user-attachments/assets/bb250d63-424a-4251-9344-e2b545edc573)
