### PR TITLE
fix: Ensure all titles on KP pages are in bold

### DIFF
--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_title_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_title_card.dart
@@ -106,7 +106,9 @@ class KnowledgePanelTitleCard extends StatelessWidget {
                             color: colorFromEvaluation,
                             fontSize: hasSubtitle ? 15.5 : 15.0,
                             fontWeight: hasSubtitle
-                                ? FontWeight.w500
+                                ? isClickable
+                                    ? FontWeight.w600
+                                    : FontWeight.bold
                                 : FontWeight.normal,
                           ),
                         ),
@@ -121,7 +123,10 @@ class KnowledgePanelTitleCard extends StatelessWidget {
                             child: Text(
                               knowledgePanelTitleElement.subtitle!,
                               style: WellSpacedTextHelper
-                                  .TEXT_STYLE_WITH_WELL_SPACED,
+                                  .TEXT_STYLE_WITH_WELL_SPACED
+                                  .copyWith(
+                                fontWeight: FontWeight.w500,
+                              ),
                             ).selectable(isSelectable: !isClickable),
                           ),
                         ),


### PR DESCRIPTION
![Untitled](https://github.com/user-attachments/assets/a378a051-67df-4f8b-a40b-fda999c0c2cf)

+ no regression on the product page