### PR TITLE
feat: Tagline: support "min_launches" attribute

### DIFF
--- a/packages/smooth_app/lib/data_models/news_feed/newsfeed_model.dart
+++ b/packages/smooth_app/lib/data_models/news_feed/newsfeed_model.dart
@@ -37,6 +37,7 @@ class AppNewsItem {
     required this.message,
     required this.url,
     this.buttonLabel,
+    this.minLaunches,
     this.startDate,
     this.endDate,
     this.minAppVersion,
@@ -50,6 +51,7 @@ class AppNewsItem {
   final String message;
   final String url;
   final String? buttonLabel;
+  final int? minLaunches;
   final DateTime? startDate;
   final DateTime? endDate;
   final String? minAppVersion;
@@ -59,7 +61,7 @@ class AppNewsItem {
 
   @override
   String toString() {
-    return 'AppNewsItem{id: $id, title: $title, message: $message, url: $url, buttonLabel: $buttonLabel, startDate: $startDate, endDate: $endDate, minAppVersion: $minAppVersion, maxAppVersion: $maxAppVersion, image: $image, style: $style}';
+    return 'AppNewsItem{id: $id, title: $title, message: $message, url: $url, buttonLabel: $buttonLabel, minLaunches: $minLaunches, startDate: $startDate, endDate: $endDate, minAppVersion: $minAppVersion, maxAppVersion: $maxAppVersion, image: $image, style: $style}';
   }
 }
 

--- a/packages/smooth_app/lib/data_models/news_feed/newsfeed_provider.dart
+++ b/packages/smooth_app/lib/data_models/news_feed/newsfeed_provider.dart
@@ -67,12 +67,14 @@ class AppNewsProvider extends ChangeNotifier {
     }
 
     final PackageInfo app = await PackageInfo.fromPlatform();
+    final int appLaunches = _preferences.appLaunches;
 
     final AppNews? appNews = await Isolate.run(
       () => _parseJSONAndGetLocalizedContent(
         jsonString!,
         locale,
         app.version,
+        appLaunches,
       ),
     );
     if (appNews == null) {
@@ -97,12 +99,13 @@ class AppNewsProvider extends ChangeNotifier {
     String json,
     String locale,
     String appVersion,
+    int appLaunches,
   ) async {
     try {
       final _TagLineJSON tagLineJSON = _TagLineJSON.fromJson(
         jsonDecode(json) as Map<dynamic, dynamic>,
       );
-      return tagLineJSON.toTagLine(locale, appVersion);
+      return tagLineJSON.toTagLine(locale, appVersion, appLaunches);
     } catch (_) {
       return null;
     }

--- a/packages/smooth_app/lib/data_models/preferences/user_preferences.dart
+++ b/packages/smooth_app/lib/data_models/preferences/user_preferences.dart
@@ -40,6 +40,7 @@ class UserPreferences extends ChangeNotifier {
       : _sharedPreferences = sharedPreferences {
     onCrashReportingChanged = ValueNotifier<bool>(crashReports);
     onAnalyticsChanged = ValueNotifier<bool>(userTracking);
+    _incrementAppLaunches();
   }
 
   /// Singleton
@@ -68,6 +69,7 @@ class UserPreferences extends ChangeNotifier {
   /// The current version of preferences
   static const String _TAG_VERSION = 'prefs_version';
   static const int _PREFS_CURRENT_VERSION = 3;
+  static const String _TAG_APP_LAUNCHES = 'appLaunches';
   static const String _TAG_PREFIX_IMPORTANCE = 'IMPORTANCE_AS_STRING';
   static const String _TAG_CURRENT_THEME_MODE = 'currentThemeMode';
   static const String _TAG_CURRENT_COLOR_SCHEME = 'currentColorScheme';
@@ -148,6 +150,13 @@ class UserPreferences extends ChangeNotifier {
       _TAG_VERSION,
       UserPreferences._PREFS_CURRENT_VERSION,
     );
+  }
+
+  int get appLaunches => _sharedPreferences.getInt(_TAG_APP_LAUNCHES) ?? 0;
+
+  Future<void> _incrementAppLaunches() async {
+    await _sharedPreferences.setInt(_TAG_APP_LAUNCHES, appLaunches + 1);
+    // No need to call notifyListeners here
   }
 
   String _getImportanceTag(final String variable) =>


### PR DESCRIPTION
Hi everyone!

We have complaints about the donation campaign from new users (= asked too early).
News in the tagline can now provide a `min_launches` attribute = min launches of the app.

cf https://github.com/openfoodfacts/smooth-app_assets/pull/8/files