### PR TITLE
feat: Portion calculator detached from nutrition facts

### DIFF
--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_page.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_page.dart
@@ -12,6 +12,7 @@ import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_expanded_card.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels_builder.dart';
 import 'package:smooth_app/pages/product/common/product_refresher.dart';
+import 'package:smooth_app/pages/product/portion_calculator.dart';
 import 'package:smooth_app/pages/product/product_field_editor.dart';
 import 'package:smooth_app/pages/scan/carousel/scan_carousel_manager.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
@@ -108,6 +109,13 @@ class _KnowledgePanelPageState extends State<KnowledgePanelPage>
                   ),
                 ),
               ),
+              if (PortionCalculator.isVisible(widget.panelId))
+                SmoothCard(
+                  padding: const EdgeInsetsDirectional.only(
+                    bottom: LARGE_SPACE,
+                  ),
+                  child: PortionCalculator(upToDateProduct),
+                ),
             ],
           ),
         ),

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_table_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_table_card.dart
@@ -8,8 +8,6 @@ import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/html/smooth_html_widget.dart';
 import 'package:smooth_app/helpers/html_extension.dart';
 import 'package:smooth_app/helpers/ui_helpers.dart';
-import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_card.dart';
-import 'package:smooth_app/pages/product/portion_calculator.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
 import 'package:smooth_app/themes/smooth_theme_colors.dart';
 import 'package:smooth_app/themes/theme_provider.dart';
@@ -95,37 +93,26 @@ class _KnowledgePanelTableCardState extends State<KnowledgePanelTableCard> {
 
   @override
   Widget build(BuildContext context) {
-    final bool withPortionCalculator =
-        widget.tableElement.id == KnowledgePanelCard.PANEL_NUTRITION_TABLE_ID;
+    return LayoutBuilder(
+      builder: (
+        BuildContext context,
+        BoxConstraints constraints,
+      ) {
+        final List<List<Widget>> rowsWidgets =
+            _buildRowWidgets(_buildRowCells(), constraints);
 
-    return LayoutBuilder(builder: (
-      BuildContext context,
-      BoxConstraints constraints,
-    ) {
-      final List<List<Widget>> rowsWidgets =
-          _buildRowWidgets(_buildRowCells(), constraints);
-
-      return Column(
-        children: <Widget>[
-          for (final List<Widget> row in rowsWidgets)
-            Semantics(
-              excludeSemantics: true,
-              value: _buildSemanticsValue(row),
-              child: IntrinsicHeight(child: Row(children: row)),
-            ),
-          if (withPortionCalculator) ...<Widget>[
-            const Padding(
-              padding: EdgeInsetsDirectional.only(
-                top: MEDIUM_SPACE,
-                bottom: LARGE_SPACE,
+        return Column(
+          children: <Widget>[
+            for (final List<Widget> row in rowsWidgets)
+              Semantics(
+                excludeSemantics: true,
+                value: _buildSemanticsValue(row),
+                child: IntrinsicHeight(child: Row(children: row)),
               ),
-              child: Divider(),
-            ),
-            PortionCalculator(widget.product),
-          ]
-        ],
-      );
-    });
+          ],
+        );
+      },
+    );
   }
 
   List<List<TableCell>> _buildRowCells() {

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -2769,6 +2769,10 @@
             }
         }
     },
+    "portion_calculator_computation_error": "Missing data. Calculation could not be performed.",
+    "@portion_calculator_computation_error": {
+        "description": "Error message to explain that the computation of the portion calculator failed."
+    },
     "portion_calculator_result_title": "Nutrition facts for {grams} g (or ml)",
     "@portion_calculator_result_title": {
         "description": "Title of the results of the portion calculator.",

--- a/packages/smooth_app/lib/pages/product/portion_calculator.dart
+++ b/packages/smooth_app/lib/pages/product/portion_calculator.dart
@@ -5,14 +5,23 @@ import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/generic_lib/bottom_sheets/smooth_bottom_sheet.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/duration_constants.dart';
+import 'package:smooth_app/generic_lib/widgets/smooth_snackbar.dart';
+import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_card.dart';
 import 'package:smooth_app/pages/product/ordered_nutrients_cache.dart';
 import 'package:smooth_app/pages/product/portion_helper.dart';
+import 'package:smooth_app/themes/smooth_theme.dart';
+import 'package:smooth_app/themes/smooth_theme_colors.dart';
+import 'package:smooth_app/widgets/smooth_circle.dart';
 
 /// Displays a portion size selector and a "compute!" button; results as dialog.
 class PortionCalculator extends StatefulWidget {
   const PortionCalculator(this.product);
 
   final Product product;
+
+  static bool isVisible(String panelId) {
+    return panelId == KnowledgePanelCard.PANEL_NUTRITION_TABLE_ID;
+  }
 
   @override
   State<PortionCalculator> createState() => _PortionCalculatorState();
@@ -38,6 +47,8 @@ class _PortionCalculatorState extends State<PortionCalculator> {
   @override
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final SmoothColorsThemeExtension extension =
+        context.extension<SmoothColorsThemeExtension>();
     final bool isQuantityValid = _isInputValid();
 
     return Column(
@@ -48,9 +59,38 @@ class _PortionCalculatorState extends State<PortionCalculator> {
         Semantics(
           value: appLocalizations.portion_calculator_description,
           excludeSemantics: true,
-          child: Text(
-            appLocalizations.portion_calculator_description,
-            style: Theme.of(context).textTheme.headlineMedium,
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: extension.primaryMedium,
+              borderRadius: const BorderRadius.vertical(
+                top: ROUNDED_RADIUS,
+              ),
+            ),
+            child: Padding(
+              padding: const EdgeInsetsDirectional.symmetric(
+                horizontal: LARGE_SPACE,
+                vertical: BALANCED_SPACE,
+              ),
+              child: Row(
+                children: <Widget>[
+                  const SmoothCircle(
+                    color: Colors.white,
+                    padding: EdgeInsets.all(SMALL_SPACE),
+                    child: Icon(
+                      Icons.calculate_rounded,
+                      size: 18.0,
+                    ),
+                  ),
+                  const SizedBox(width: MEDIUM_SPACE),
+                  Expanded(
+                    child: Text(
+                      appLocalizations.portion_calculator_description,
+                      style: Theme.of(context).textTheme.headlineMedium,
+                    ),
+                  ),
+                ],
+              ),
+            ),
           ),
         ),
         const SizedBox(height: MEDIUM_SPACE),
@@ -148,11 +188,13 @@ class _PortionCalculatorState extends State<PortionCalculator> {
   Future<void> _computeAndShow() async {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     if (widget.product.nutriments == null) {
+      _onComputationError();
       return;
     }
     final OrderedNutrientsCache? cache =
         await OrderedNutrientsCache.getCache(context);
     if (cache == null) {
+      _onComputationError();
       return;
     }
     if (!mounted) {
@@ -166,6 +208,7 @@ class _PortionCalculatorState extends State<PortionCalculator> {
       quantity,
     );
     if (helper.isEmpty) {
+      _onComputationError();
       return;
     }
     await showSmoothDraggableModalSheet<void>(
@@ -173,7 +216,7 @@ class _PortionCalculatorState extends State<PortionCalculator> {
       header: SmoothModalSheetHeader(
         title: appLocalizations.portion_calculator_result_title(quantity),
       ),
-      initHeight: 0.7,
+      initHeight: 0.6,
       bodyBuilder: (BuildContext context) {
         return SliverList(
           delegate: SliverChildBuilderDelegate(
@@ -191,7 +234,12 @@ class _PortionCalculatorState extends State<PortionCalculator> {
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         crossAxisAlignment: CrossAxisAlignment.center,
                         children: <Widget>[
-                          Text(helper.getName(position)),
+                          Text(
+                            helper.getName(position),
+                            style: const TextStyle(
+                              fontWeight: FontWeight.w500,
+                            ),
+                          ),
                           Text(helper.getValue(position)),
                         ],
                       ),
@@ -204,6 +252,15 @@ class _PortionCalculatorState extends State<PortionCalculator> {
           ),
         );
       },
+    );
+  }
+
+  void _onComputationError() {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SmoothFloatingSnackbar.error(
+        context: context,
+        text: AppLocalizations.of(context).portion_calculator_computation_error,
+      ),
     );
   }
 

--- a/packages/smooth_app/lib/widgets/smooth_circle.dart
+++ b/packages/smooth_app/lib/widgets/smooth_circle.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/cupertino.dart';
+
+/// A rounded background (useful for icons, etc.)
+class SmoothCircle extends StatelessWidget {
+  const SmoothCircle({
+    required this.padding,
+    required this.color,
+    required this.child,
+    super.key,
+  });
+
+  final EdgeInsetsGeometry padding;
+  final Color color;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: color,
+        shape: BoxShape.circle,
+      ),
+      child: Padding(
+        padding: padding,
+        child: child,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Hi everyone!

To better highlight the portion calculator, I've moved it to a separate card.
This is minor, but I think it's clearer.

![Untitled](https://github.com/user-attachments/assets/d6432378-5853-4d11-8c2b-f76c967e3e1f)
Note: the bold title is fixed with #6235 