### PR TITLE
fix: Save & restore when leaving an edit page

### DIFF
--- a/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_basic_details_page.dart
@@ -251,6 +251,7 @@ class _AddBasicDetailsPageState extends State<AddBasicDetailsPage> {
       final bool? pleaseSave =
           await MayExitPageHelper().openSaveBeforeLeavingDialog(context);
       if (pleaseSave == null) {
+        _brandsHelper.restoreItemsBeforeLastAddition();
         return false;
       }
       if (pleaseSave == false) {
@@ -300,6 +301,10 @@ class _AddBasicDetailsPageState extends State<AddBasicDetailsPage> {
       hasChanged = true;
     }
 
+    _brandsHelper.addItemsFromController(
+      _brandsController,
+      clearController: false,
+    );
     if (_brandsHelper.getChangedProduct(result)) {
       hasChanged = true;
     }

--- a/packages/smooth_app/lib/pages/product/simple_input_page.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page.dart
@@ -139,7 +139,10 @@ class _SimpleInputPageState extends State<SimpleInputPage> {
     bool added = false;
     for (int i = 0; i < widget.helpers.length; i++) {
       final AbstractSimpleInputPageHelper helper = widget.helpers[i];
-      if (helper.addItemsFromController(_controllers[i])) {
+      if (helper.addItemsFromController(
+        _controllers[i],
+        clearController: false,
+      )) {
         added = true;
       }
       final Product changedProduct = Product(barcode: widget.product.barcode);
@@ -158,6 +161,9 @@ class _SimpleInputPageState extends State<SimpleInputPage> {
       final bool? pleaseSave =
           await MayExitPageHelper().openSaveBeforeLeavingDialog(context);
       if (pleaseSave == null) {
+        for (int i = 0; i < widget.helpers.length; i++) {
+          widget.helpers[i].restoreItemsBeforeLastAddition();
+        }
         return false;
       }
       if (pleaseSave == false) {

--- a/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
@@ -194,10 +194,17 @@ abstract class AbstractSimpleInputPageHelper extends ChangeNotifier {
   @protected
   OpenFoodFactsLanguage getLanguage() => ProductQuery.getLanguage();
 
+  List<String>? _itemsBeforeLastAddition;
+
   /// Adds all the non-already existing items from the controller.
   ///
   /// The item separator is the comma.
-  bool addItemsFromController(final TextEditingController controller) {
+  bool addItemsFromController(
+    final TextEditingController controller, {
+    bool clearController = true,
+  }) {
+    _itemsBeforeLastAddition = List<String>.from(_terms);
+
     final List<String> input = controller.text.split(',');
     bool result = false;
     for (final String item in input) {
@@ -205,10 +212,20 @@ abstract class AbstractSimpleInputPageHelper extends ChangeNotifier {
         result = true;
       }
     }
-    if (result) {
+    if (result && clearController) {
       controller.text = '';
     }
     return result;
+  }
+
+  void restoreItemsBeforeLastAddition() {
+    if (_itemsBeforeLastAddition == null) {
+      return;
+    }
+    _terms = List<String>.from(_itemsBeforeLastAddition!);
+    _changed = true;
+    _itemsBeforeLastAddition = null;
+    notifyListeners();
   }
 
   /// Mainly used when reordering the list.


### PR DESCRIPTION
Hi everyone!

The initial goal of this PR was to fix #6242.

But one more issue appeared, and this time for all `SimpleInputWidget` (labels, stores, origins…)
If you dismissed the popup to save or cancel, your current input was lost, and the item was not added to the list of values.
Now, if you dismiss this popup, the internal save is canceled and everything is restored.

https://github.com/user-attachments/assets/75b81da5-856b-4967-af08-8a6e107f716c

