### PR TITLE
fix: Hide more interesting photo if nothing is available - M3

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -2460,10 +2460,6 @@
     "@edit_photo_select_existing_download_label": {
         "description": "Dialog label"
     },
-    "edit_photo_select_existing_downloaded_none": "There are no images previously uploaded related to this product.",
-    "@edit_photo_select_existing_downloaded_none": {
-        "description": "Error message"
-    },
     "edit_photo_language_not_this_one": "No image in that language yet",
     "@edit_photo_language_not_this_one": {
         "description": "Warning message: for this product and this field, there are 'translated' images, but not in that language"

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -2460,6 +2460,10 @@
     "@edit_photo_select_existing_download_label": {
         "description": "Dialog label"
     },
+    "edit_photo_select_existing_downloaded_none": "There are no images previously uploaded related to this product.",
+    "@edit_photo_select_existing_downloaded_none": {
+        "description": "Error message"
+    },
     "edit_photo_language_not_this_one": "No image in that language yet",
     "@edit_photo_language_not_this_one": {
         "description": "Warning message: for this product and this field, there are 'translated' images, but not in that language"

--- a/packages/smooth_app/lib/pages/image/product_image_gallery_other_view.dart
+++ b/packages/smooth_app/lib/pages/image/product_image_gallery_other_view.dart
@@ -23,8 +23,11 @@ double _getSquareSize(final BuildContext context) {
 /// Display of the other pictures of a product.
 class ProductImageGalleryOtherView extends StatefulWidget {
   const ProductImageGalleryOtherView({
+    required this.onPhotosAvailable,
     super.key,
   });
+
+  final Function(bool hasPhotos) onPhotosAvailable;
 
   @override
   State<ProductImageGalleryOtherView> createState() =>
@@ -49,7 +52,9 @@ class _ProductImageGalleryOtherViewState
       product,
       ImageSize.DISPLAY,
     );
+
     if (rawImages.isNotEmpty) {
+      widget.onPhotosAvailable(true);
       return _RawGridGallery(product, rawImages);
     }
     final double squareSize = _getSquareSize(context);
@@ -61,10 +66,12 @@ class _ProductImageGalleryOtherViewState
       ) {
         if (snapshot.connectionState != ConnectionState.done) {
           return SliverToBoxAdapter(
-            child: SizedBox(
-              width: squareSize,
-              height: squareSize,
-              child: const CircularProgressIndicator.adaptive(),
+            child: Center(
+              child: SizedBox(
+                width: squareSize,
+                height: squareSize,
+                child: const CircularProgressIndicator.adaptive(),
+              ),
             ),
           );
         }
@@ -84,16 +91,15 @@ class _ProductImageGalleryOtherViewState
           );
         }
         if (rawImages.isNotEmpty) {
+          widget.onPhotosAvailable(true);
           return _RawGridGallery(
             fetchedProduct.product ?? product,
             rawImages,
           );
         }
-        return SliverToBoxAdapter(
-          child: Text(
-            appLocalizations.edit_photo_select_existing_downloaded_none,
-          ),
-        );
+
+        widget.onPhotosAvailable(false);
+        return const SliverToBoxAdapter(child: EMPTY_WIDGET);
       },
     );
   }

--- a/packages/smooth_app/lib/pages/product/gallery_view/product_image_gallery_view.dart
+++ b/packages/smooth_app/lib/pages/product/gallery_view/product_image_gallery_view.dart
@@ -77,6 +77,7 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView>
   late OpenFoodFactsLanguage _language;
   late final List<ImageField> _mainImageFields;
   bool _clickedOtherPictureButton = false;
+  bool _hideOtherPhotos = false;
 
   @override
   void initState() {
@@ -177,21 +178,30 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView>
                                 ),
                               ),
                             ),
-                            SliverPadding(
-                              padding: const EdgeInsetsDirectional.symmetric(
-                                vertical: MEDIUM_SPACE,
-                                horizontal: SMALL_SPACE,
-                              ),
-                              sliver: SliverToBoxAdapter(
-                                child: Text(
-                                  appLocalizations.more_photos,
-                                  style:
-                                      Theme.of(context).textTheme.displayMedium,
+                            if (!_hideOtherPhotos)
+                              SliverPadding(
+                                padding: const EdgeInsetsDirectional.symmetric(
+                                  vertical: MEDIUM_SPACE,
+                                  horizontal: SMALL_SPACE,
+                                ),
+                                sliver: SliverToBoxAdapter(
+                                  child: _moreInterestingPhotoWidget(
+                                    appLocalizations,
+                                    context,
+                                  ),
                                 ),
                               ),
-                            ),
                             if (_shouldDisplayRawGallery())
-                              const ProductImageGalleryOtherView()
+                              ProductImageGalleryOtherView(
+                                  onPhotosAvailable: (bool hasPhotos) {
+                                if (_hideOtherPhotos != hasPhotos) {
+                                  onNextFrame(
+                                    () => setState(
+                                      () => _hideOtherPhotos = !hasPhotos,
+                                    ),
+                                  );
+                                }
+                              })
                             else
                               SliverToBoxAdapter(
                                 child: Padding(
@@ -235,6 +245,15 @@ class _ProductImageGalleryViewState extends State<ProductImageGalleryView>
       ),
     );
   }
+
+  Text _moreInterestingPhotoWidget(
+    AppLocalizations appLocalizations,
+    BuildContext context,
+  ) =>
+      Text(
+        appLocalizations.more_photos,
+        style: Theme.of(context).textTheme.displayMedium,
+      );
 
   bool _shouldDisplayRawGallery() =>
       _clickedOtherPictureButton ||


### PR DESCRIPTION
Hi everyone!

I've changed the "More interesting photos" behavior.

By default, the title and the grid are visible.
However, if there are no photos available, everything will be hidden.
But if you take a picture, this section will reappear.