### PR TITLE
fix: Per 100g -> Per 100g/100ml

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -785,6 +785,7 @@
         "description": "Label to let the user choose between per 100g or per serving"
     },
     "nutrition_page_per_100g": "per 100g",
+    "nutrition_page_per_100g_100ml": "per 100g/ml",
     "nutrition_page_per_serving": "per serving",
     "nutrition_page_add_nutrient": "Add a nutrient",
     "nutrition_page_serving_size": "Serving size",

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -785,6 +785,7 @@
         "description": "Label to let the user choose between per 100g or per serving"
     },
     "nutrition_page_per_100g": "pour 100g",
+    "nutrition_page_per_100g_100ml": "pour 100g/ml",
     "nutrition_page_per_serving": "par portion",
     "nutrition_page_add_nutrient": "Ajouter un nutriment",
     "nutrition_page_serving_size": "Taille d'une portion",

--- a/packages/smooth_app/lib/pages/product/nutrition_page/widgets/nutrition_serving_switch.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page/widgets/nutrition_serving_switch.dart
@@ -57,7 +57,7 @@ class NutritionServingSwitch extends StatelessWidget {
                     items: <SmoothDropdownItem<PerSize>>[
                       SmoothDropdownItem<PerSize>(
                         value: PerSize.oneHundredGrams,
-                        label: appLocalizations.nutrition_page_per_100g,
+                        label: appLocalizations.nutrition_page_per_100g_100ml,
                       ),
                       SmoothDropdownItem<PerSize>(
                         value: PerSize.serving,


### PR DESCRIPTION
Hi!

Nutrition facts are given per 100g or per 100ml.
However, we only have "per 100g" in the app.

![IMG_2034](https://github.com/user-attachments/assets/c49f05a9-07c5-48d1-a608-c0dda56f084e)
