### PR TITLE
fix: Prevent unknown product names

### DIFF
--- a/packages/smooth_app/lib/helpers/product_cards_helper.dart
+++ b/packages/smooth_app/lib/helpers/product_cards_helper.dart
@@ -64,6 +64,11 @@ String getProductName(
 ) =>
     _clearString(product.productNameInLanguages?[ProductQuery.getLanguage()]) ??
     _clearString(product.productName) ??
+
+    /// Fallback to the first language available
+    _clearString(
+        product.productNameInLanguages![OpenFoodFactsLanguage.ENGLISH]) ??
+    _clearString(product.productNameInLanguages?.values.firstOrNull) ??
     appLocalizations.unknownProductName;
 
 String getProductBrands(


### PR DESCRIPTION
To prevent "Unknown product names", the algorithm is now:
- User language
- Default language
- (NEW) English
- (NEW) Any other translation 