### PR TITLE
feat: Don't force a product type with custom URLs (login/signup)

### DIFF
--- a/packages/smooth_app/lib/data_models/login_result.dart
+++ b/packages/smooth_app/lib/data_models/login_result.dart
@@ -1,5 +1,7 @@
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/data_models/preferences/user_preferences.dart';
+import 'package:smooth_app/pages/preferences/user_preferences_dev_mode.dart';
 import 'package:smooth_app/query/product_query.dart';
 
 /// How did the login attempt work?
@@ -34,12 +36,19 @@ class LoginResult {
       text.startsWith('Failed host lookup: ');
 
   /// Checks credentials. Returns null if OK, or an error message.
-  static Future<LoginResult> getLoginResult(final User user) async {
+  static Future<LoginResult> getLoginResult(
+    final User user,
+    final UserPreferences userPreferences,
+  ) async {
     try {
+      final bool prodUrl = userPreferences
+              .getFlag(UserPreferencesDevMode.userPreferencesFlagProd) ??
+          true;
+
       final LoginStatus? loginStatus = await OpenFoodAPIClient.login2(
         user,
         uriHelper: ProductQuery.getUriProductHelper(
-          productType: ProductType.food,
+          productType: prodUrl ? ProductType.food : null,
         ),
       );
       if (loginStatus == null) {

--- a/packages/smooth_app/lib/data_models/user_management_provider.dart
+++ b/packages/smooth_app/lib/data_models/user_management_provider.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/data_models/login_result.dart';
+import 'package:smooth_app/data_models/preferences/user_preferences.dart';
 import 'package:smooth_app/database/dao_secured_string.dart';
 import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/services/smooth_services.dart';
@@ -14,8 +15,14 @@ class UserManagementProvider with ChangeNotifier {
   static const String _COOKIE = 'user_cookie';
 
   /// Checks credentials and conditionally saves them.
-  Future<LoginResult> login(final User user) async {
-    final LoginResult loginResult = await LoginResult.getLoginResult(user);
+  Future<LoginResult> login(
+    final User user,
+    final UserPreferences preferences,
+  ) async {
+    final LoginResult loginResult = await LoginResult.getLoginResult(
+      user,
+      preferences,
+    );
     if (loginResult.type != LoginResultType.successful) {
       return loginResult;
     }
@@ -101,7 +108,7 @@ class UserManagementProvider with ChangeNotifier {
 
   /// Check if the user is still logged in and the credentials are still valid
   /// If not, the user is logged out
-  Future<void> checkUserLoginValidity() async {
+  Future<void> checkUserLoginValidity(UserPreferences preferences) async {
     if (!ProductQuery.isLoggedIn()) {
       return;
     }
@@ -111,6 +118,7 @@ class UserManagementProvider with ChangeNotifier {
         userId: user.userId,
         password: user.password,
       ),
+      preferences,
     );
 
     if (loginResult.type == LoginResultType.unsuccessful) {

--- a/packages/smooth_app/lib/main.dart
+++ b/packages/smooth_app/lib/main.dart
@@ -144,7 +144,7 @@ Future<bool> _init1() async {
     daoString: DaoString(_localDatabase),
   );
   ProductQuery.setQueryType(_userPreferences);
-  UserManagementProvider().checkUserLoginValidity();
+  UserManagementProvider().checkUserLoginValidity(_userPreferences);
 
   await AnalyticsHelper.linkPreferences(_userPreferences);
 

--- a/packages/smooth_app/lib/pages/user_management/login_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/login_page.dart
@@ -55,6 +55,7 @@ class _LoginPageState extends State<LoginPage> with TraceableClientMixin {
         userId: userIdController.text,
         password: passwordController.text,
       ),
+      context.read<UserPreferences>(),
     );
     if (!context.mounted) {
       return;

--- a/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
@@ -12,6 +12,7 @@ import 'package:smooth_app/generic_lib/loading_dialog.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_text_form_field.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/user_management_helper.dart';
+import 'package:smooth_app/pages/preferences/user_preferences_dev_mode.dart';
 import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
@@ -331,6 +332,11 @@ class _SignUpPageState extends State<SignUpPage> with TraceableClientMixin {
       userId: _userController.trimmedText,
       password: _password1Controller.text,
     );
+    final bool prodUrl = context
+            .read<UserPreferences>()
+            .getFlag(UserPreferencesDevMode.userPreferencesFlagProd) ??
+        true;
+
     final SignUpStatus? status = await LoadingDialog.run<SignUpStatus>(
       context: context,
       future: OpenFoodAPIClient.register(
@@ -342,7 +348,7 @@ class _SignUpPageState extends State<SignUpPage> with TraceableClientMixin {
         country: ProductQuery.getCountry(),
         language: ProductQuery.getLanguage(),
         uriHelper: ProductQuery.getUriProductHelper(
-          productType: ProductType.food,
+          productType: prodUrl ? ProductType.food : null,
         ),
       ),
       title: appLocalisations.sign_up_page_action_doing_it,

--- a/packages/smooth_app/lib/query/product_query.dart
+++ b/packages/smooth_app/lib/query/product_query.dart
@@ -249,6 +249,10 @@ abstract class ProductQuery {
     );
   }
 
+  static String getProductTypeFromDomain(UriProductHelper uriProductHelper) {
+    return uriProductHelper.domain;
+  }
+
   static List<ProductField> get fields => const <ProductField>[
         ProductField.NAME,
         ProductField.NAME_ALL_LANGUAGES,


### PR DESCRIPTION
Hi everyone!

An environment with the new login mechanism is available on OPFF.
However, in the app, we force the food product type for login/signup.

This PR changes this behavior a little bit to only force the product type on prod.