### PR TITLE
feat: Edit mode: swipe-back gesture + may exit for OCR pages

### DIFF
--- a/packages/smooth_app/lib/pages/product/multilingual_helper.dart
+++ b/packages/smooth_app/lib/pages/product/multilingual_helper.dart
@@ -10,7 +10,7 @@ import 'package:smooth_app/query/product_query.dart';
 /// Typically, the old version will be used with "old" data, that have not
 /// downloaded yet the more "recent" multilingual fields
 /// (e.g. [ProductField.NAME_ALL_LANGUAGES]).
-class MultilingualHelper {
+class MultilingualHelper extends ChangeNotifier {
   MultilingualHelper({required this.controller});
 
   final TextEditingController controller;
@@ -165,8 +165,10 @@ class MultilingualHelper {
   }
 
   /// Saves the current input for the current language.
-  void _saveCurrentName() =>
-      _currentMultilingualTexts[_currentLanguage] = controller.text;
+  void _saveCurrentName() {
+    _currentMultilingualTexts[_currentLanguage] = controller.text;
+    notifyListeners();
+  }
 
   OpenFoodFactsLanguage getCurrentLanguage() =>
       isMonolingual() ? ProductQuery.getLanguage() : _currentLanguage;
@@ -177,4 +179,25 @@ class MultilingualHelper {
   }
 
   static String getCleanText(final String? name) => (name ?? '').trim();
+
+  bool hasChanged() {
+    if (isMonolingual()) {
+      return getChangedMonolingualText() != null;
+    } else if (_initialMultilingualTexts.length !=
+        _currentMultilingualTexts.length) {
+      return true;
+    } else if (_initialMultilingualTexts[_currentLanguage] != controller.text) {
+      return true;
+    }
+
+    for (final OpenFoodFactsLanguage language
+        in _initialMultilingualTexts.keys) {
+      if (getCleanText(_initialMultilingualTexts[language]) !=
+          getCleanText(_currentMultilingualTexts[language])) {
+        return true;
+      }
+    }
+
+    return false;
+  }
 }

--- a/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
@@ -25,7 +25,10 @@ abstract class AbstractSimpleInputPageHelper extends ChangeNotifier {
   /// Product we are about to edit.
   late Product product;
 
-  /// Terms as they were initially then edited by the user.
+  /// Terms as they were initially
+  late List<String> _initTerms;
+
+  /// Current terms edited by the user.
   late List<String> _terms;
 
   /// "Have the terms been changed?"
@@ -35,6 +38,7 @@ abstract class AbstractSimpleInputPageHelper extends ChangeNotifier {
   void reInit(final Product product) {
     this.product = product;
     _terms = List<String>.from(initTerms(this.product));
+    _initTerms = List<String>.from(_terms);
     _changed = false;
     notifyListeners();
   }
@@ -70,7 +74,7 @@ abstract class AbstractSimpleInputPageHelper extends ChangeNotifier {
       return false;
     }
     _terms.add(term);
-    _changed = true;
+    _changed = !const DeepCollectionEquality().equals(_terms, _initTerms);
     notifyListeners();
     return true;
   }
@@ -81,7 +85,7 @@ abstract class AbstractSimpleInputPageHelper extends ChangeNotifier {
   /// as we remove existing items.
   bool removeTerm(final String term) {
     if (_terms.remove(term)) {
-      _changed = true;
+      _changed = !const DeepCollectionEquality().equals(_terms, _initTerms);
       notifyListeners();
       return true;
     }
@@ -192,6 +196,8 @@ abstract class AbstractSimpleInputPageHelper extends ChangeNotifier {
     return true;
   }
 
+  bool hasChanged() => _changed;
+
   @protected
   List<String> splitString(String? input) {
     if (input == null) {
@@ -244,19 +250,25 @@ abstract class AbstractSimpleInputPageHelper extends ChangeNotifier {
       return;
     }
     _terms = List<String>.from(_itemsBeforeLastAddition!);
-    _changed = true;
     _itemsBeforeLastAddition = null;
     notifyListeners();
   }
 
   /// Mainly used when reordering the list.
   void replaceItems(final List<String> items) {
+    if (const DeepCollectionEquality().equals(_terms, items)) {
+      return;
+    }
+
     _terms = List<String>.of(items);
     _changed = true;
     notifyListeners();
   }
 
   void replaceItem(int position, String term) {
+    if (_terms[position] == term) {
+      return;
+    }
     _terms[position] = term;
     _changed = true;
     notifyListeners();

--- a/packages/smooth_app/lib/widgets/will_pop_scope.dart
+++ b/packages/smooth_app/lib/widgets/will_pop_scope.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
 
 /// Brings the same behavior as WillPopScope, which is now deprecated
 /// [onWillPop] is a bit different and still asks as the first value if we should block the pop
@@ -9,36 +10,61 @@ class WillPopScope2 extends StatelessWidget {
   const WillPopScope2({
     required this.child,
     required this.onWillPop,
+    this.controller,
     super.key,
   });
 
   final Widget child;
   final Future<(bool shouldClose, dynamic res)> Function() onWillPop;
+  final WillPopScope2Controller? controller;
 
   @override
   Widget build(BuildContext context) {
-    return PopScope(
-      canPop: false,
-      onPopInvokedWithResult: (bool didPop, dynamic result) async {
-        if (didPop) {
-          return;
-        }
-
-        final (bool shouldClose, dynamic res) = await onWillPop.call();
-        if (shouldClose == true) {
-          WidgetsBinding.instance.addPostFrameCallback((_) {
-            try {
-              GoRouter.of(context).pop(res);
-            } on GoError catch (error) {
-              if (error.message == 'There is nothing to pop') {
-                // Force to kill the app
-                SystemNavigator.pop();
+    return ChangeNotifierProvider<WillPopScope2Controller?>.value(
+      value: controller,
+      child: Consumer<WillPopScope2Controller?>(
+        builder: (_, WillPopScope2Controller? controller, __) {
+          return PopScope(
+            canPop: controller?.value ?? false,
+            onPopInvokedWithResult: (bool didPop, dynamic result) async {
+              if (didPop) {
+                return;
               }
-            }
-          });
-        }
-      },
-      child: child,
+
+              final (bool shouldClose, dynamic res) = await onWillPop.call();
+              if (shouldClose == true) {
+                WidgetsBinding.instance.addPostFrameCallback((_) {
+                  try {
+                    GoRouter.of(context).pop(res);
+                  } on GoError catch (error) {
+                    if (error.message == 'There is nothing to pop') {
+                      // Force to kill the app
+                      SystemNavigator.pop();
+                    }
+                  }
+                });
+              }
+            },
+            child: child,
+          );
+        },
+      ),
     );
+  }
+}
+
+/// Indicates if a [WillPopScope2] should allows to pop (= swipe back
+/// gesture on iOS) or not
+class WillPopScope2Controller extends ValueNotifier<bool> {
+  WillPopScope2Controller({required bool canPop}) : super(canPop);
+
+  void canPop(bool canPop) {
+    super.value = canPop;
+  }
+
+  @protected
+  @override
+  set value(bool value) {
+    throw Exception('Please use canPop() instead');
   }
 }


### PR DESCRIPTION
Hi everyone!

This feature brings the swipe-back gesture on iOS if nothing is changed on a page.
Also, the OCR page (ingredients / packaging) now have the "May exit" system.

🎥 Video: https://github.com/user-attachments/assets/9d721ce2-e9b2-4eb7-9e72-35567c997aa7

## Swipe back
![IMG_2166](https://github.com/user-attachments/assets/b07e2648-c5a2-4f61-905d-807e181c2e80)

## May exit popup for OCR page
![IMG_2167](https://github.com/user-attachments/assets/d95f9881-aefd-479c-bc78-33ca8ce93463)
