### PR TITLE
fix: ImageViewer fails with a semi-empty product

### DIFF
--- a/packages/smooth_app/lib/helpers/image_field_extension.dart
+++ b/packages/smooth_app/lib/helpers/image_field_extension.dart
@@ -131,4 +131,12 @@ extension ImageFieldSmoothieExtension on ImageField {
           ),
         ),
       );
+
+  String? getImageUrl(Product product) => switch (this) {
+        ImageField.FRONT => product.imageFrontUrl,
+        ImageField.INGREDIENTS => product.imageIngredientsUrl,
+        ImageField.NUTRITION => product.imageNutritionUrl,
+        ImageField.PACKAGING => product.imagePackagingUrl,
+        ImageField.OTHER => null,
+      };
 }

--- a/packages/smooth_app/lib/pages/product/edit_product_image_viewer.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product_image_viewer.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import 'package:scanner_shared/scanner_shared.dart';
 import 'package:smooth_app/database/transient_file.dart';
 import 'package:smooth_app/generic_lib/duration_constants.dart';
+import 'package:smooth_app/helpers/image_field_extension.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/helpers/ui_helpers.dart';
 import 'package:smooth_app/pages/product/helpers/pinch_to_zoom_indicator.dart';
@@ -136,14 +137,14 @@ class _EditProductImageViewerState extends State<EditProductImageViewer>
 
     final Iterable<OpenFoodFactsLanguage> languages = getProductImageLanguages(
       product,
-      ImageField.NUTRITION,
+      widget.imageField,
     );
 
     for (final OpenFoodFactsLanguage language in <OpenFoodFactsLanguage?>[
       widget.language,
       ProductQuery.getLanguage(),
       OpenFoodFactsLanguage.ENGLISH,
-      languages.first,
+      if (languages.isNotEmpty) languages.first,
     ].nonNulls) {
       if (languages.contains(language)) {
         return TransientFile.fromProduct(
@@ -154,7 +155,7 @@ class _EditProductImageViewerState extends State<EditProductImageViewer>
       }
     }
 
-    return NetworkImage(product.imageNutritionUrl ?? '');
+    return NetworkImage(widget.imageField.getImageUrl(product) ?? '');
   }
 
   Widget _frameBuilder(


### PR DESCRIPTION
Hi everyone!

The ImageViewer for the product name may fail if the product is mostly empty.
![IMG_9C3E282266EA-1](https://github.com/user-attachments/assets/a6cc910e-4d8c-44a9-a5b3-f734e490d74e)

This PR also fixes an issue with the URL used as a fallback.