### PR TITLE
fix: 6020 - disable automatic report of failed http connections

### DIFF
--- a/packages/smooth_app/lib/helpers/analytics_helper.dart
+++ b/packages/smooth_app/lib/helpers/analytics_helper.dart
@@ -237,6 +237,7 @@ class AnalyticsHelper {
         options
           ..tracesSampleRate = 1.0
           ..beforeSend = _beforeSend
+          ..captureFailedRequests = false
           ..environment =
               '${GlobalVars.storeLabel.name}-${GlobalVars.scannerLabel.name}';
       },


### PR DESCRIPTION
### What
- We're flooded with "connection errors" related to svg icons: top 1, top 2 and top 3 sentry errors this week!
- Those errors are caused by transient network or server errors.
- That makes the weekly sentry report almost irrelevant, and it hides less frequent errors that would be worth investigating.
- We tried to "catch" those connection errors, but somehow the errors still appeared in sentry.
- The probable reason is that there's a (relatively) new parameter in sentry, true by default, that reports ALL connection errors, even before we "catch" them.
- Let's set this parameter to "false". Honestly it didn't change anything on my emulator, but I wasn't able to reproduce the same error in a first place, even after warping a little the svg URLs.

### Fixes bug(s)
- Fixes: #6020