### PR TITLE
feat: Keep alive for simple input widgets

### DIFF
--- a/packages/smooth_app/lib/pages/product/simple_input_page.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page.dart
@@ -7,6 +7,7 @@ import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/collections_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
+import 'package:smooth_app/helpers/ui_helpers.dart';
 import 'package:smooth_app/pages/input/unfocus_field_when_tap_outside.dart';
 import 'package:smooth_app/pages/product/common/product_buttons.dart';
 import 'package:smooth_app/pages/product/may_exit_page_helper.dart';
@@ -152,7 +153,12 @@ class _SimpleInputPageState extends State<SimpleInputPage> {
       }
     }
 
-    _willPopScope2Controller.canPop(true);
+    onNextFrame(() {
+      if (!mounted) {
+        return;
+      }
+      _willPopScope2Controller.canPop(true);
+    });
   }
 
   /// Returns `true` if we should really exit the page.

--- a/packages/smooth_app/lib/pages/product/simple_input_widget.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_widget.dart
@@ -40,7 +40,8 @@ class SimpleInputWidget extends StatefulWidget {
   State<SimpleInputWidget> createState() => _SimpleInputWidgetState();
 }
 
-class _SimpleInputWidgetState extends State<SimpleInputWidget> {
+class _SimpleInputWidgetState extends State<SimpleInputWidget>
+    with AutomaticKeepAliveClientMixin {
   late final FocusNode _focusNode;
 
   /// In order to add new items to the top of the list, we have our custom copy
@@ -61,6 +62,7 @@ class _SimpleInputWidgetState extends State<SimpleInputWidget> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
 
     final Widget? extraWidget = widget.helper.getExtraWidget(
@@ -362,6 +364,9 @@ class _SimpleInputWidgetState extends State<SimpleInputWidget> {
       SmoothHapticFeedback.lightNotification();
     }
   }
+
+  @override
+  bool get wantKeepAlive => true;
 
   @override
   void dispose() {


### PR DESCRIPTION
Hi everyone!

There is an annoying bug with the screen containing multiple fields. If you scroll to the bottom, the changes on the first fields are lost. Video:

https://github.com/user-attachments/assets/42d92aa8-47fc-4d07-854a-b509a712479f

This PR resolves this by adding some `KeepAlive`