### PR TITLE
fix: Only set the product language on addition

### DIFF
--- a/packages/smooth_app/lib/background/background_task_details.dart
+++ b/packages/smooth_app/lib/background/background_task_details.dart
@@ -125,8 +125,6 @@ class BackgroundTaskDetails extends BackgroundTaskBarcode
   Product getProductChange() {
     final Product result =
         Product.fromJson(json.decode(inputMap) as Map<String, dynamic>);
-    // for good multilingual management
-    result.lang = getLanguage();
     return result;
   }
 

--- a/packages/smooth_app/lib/pages/product/add_new_product/add_new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_new_product/add_new_product_page.dart
@@ -434,8 +434,12 @@ class _AddNewProductPageState extends State<AddNewProductPage>
                 ),
               );
             }
+
+            /// TODO(g123k): Add a selector for the language in the UI
             await BackgroundTaskDetails.addTask(
-              Product(barcode: barcode)..productType = _inputProductType,
+              Product(barcode: barcode)
+                ..lang = ProductQuery.getLanguage()
+                ..productType = _inputProductType,
               context: context,
               stamp: BackgroundTaskDetailsStamp.productType,
               productType: _inputProductType,

--- a/packages/smooth_app/lib/pages/product/add_new_product/add_new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_new_product/add_new_product_page.dart
@@ -435,7 +435,7 @@ class _AddNewProductPageState extends State<AddNewProductPage>
               );
             }
 
-            /// TODO(g123k): Add a selector for the language in the UI
+            // TODO(g123k): Add a selector for the language in the UI
             await BackgroundTaskDetails.addTask(
               Product(barcode: barcode)
                 ..lang = ProductQuery.getLanguage()


### PR DESCRIPTION
Hi everyone!

In the app, if we do any kind of edit, the language of the product will be set to the user's.
But the product may be in another language and we may have broken many products.

This PR ensures that the language is only set during product addition.