### PR TITLE
feat: 6104 - "eraser" feature for new images of "product" products

### DIFF
--- a/packages/smooth_app/lib/background/background_task_add_price.dart
+++ b/packages/smooth_app/lib/background/background_task_add_price.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:crop_image/crop_image.dart';
 import 'package:flutter/material.dart';
 import 'package:http_parser/http_parser.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
@@ -13,8 +12,6 @@ import 'package:smooth_app/background/background_task_upload.dart';
 import 'package:smooth_app/background/operation_type.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/pages/crop_parameters.dart';
-import 'package:smooth_app/pages/prices/eraser_model.dart';
-import 'package:smooth_app/pages/prices/eraser_painter.dart';
 import 'package:smooth_app/query/product_query.dart';
 
 // TODO(monsieurtanuki): use transient file, in order to have instant access to proof image?
@@ -192,19 +189,8 @@ class BackgroundTaskAddPrice extends BackgroundTaskPrice {
 
   @override
   Future<void> execute(final LocalDatabase localDatabase) async {
-    final List<Offset> offsets = <Offset>[];
-    if (eraserCoordinates != null) {
-      for (int i = 0; i < eraserCoordinates!.length; i += 2) {
-        final Offset offset = Offset(
-          eraserCoordinates![i],
-          eraserCoordinates![i + 1],
-        );
-        offsets.add(offset);
-      }
-    }
     final String? path = await BackgroundTaskImage.cropIfNeeded(
       fullPath: fullPath,
-      croppedPath: BackgroundTaskImage.getCroppedPath(fullPath),
       rotationDegrees: rotationDegrees,
       cropX1: cropX1,
       cropY1: cropY1,
@@ -212,20 +198,7 @@ class BackgroundTaskAddPrice extends BackgroundTaskPrice {
       cropY2: cropY2,
       compressQuality: 80,
       forceCompression: true,
-      overlayPainter: offsets.isEmpty
-          ? null
-          : EraserPainter(
-              eraserModel: EraserModel(
-                rotation: CropRotationExtension.fromDegrees(rotationDegrees)!,
-                offsets: offsets,
-              ),
-              cropRect: BackgroundTaskImage.getDownsizedRect(
-                cropX1,
-                cropY1,
-                cropX2,
-                cropY2,
-              ),
-            ),
+      eraserCoordinates: eraserCoordinates,
     );
     if (path == null) {
       // TODO(monsieurtanuki): maybe something more refined when we dismiss the picture, like alerting the user, though it's not supposed to happen anymore from upstream.

--- a/packages/smooth_app/lib/pages/crop_helper.dart
+++ b/packages/smooth_app/lib/pages/crop_helper.dart
@@ -31,7 +31,7 @@ abstract class CropHelper {
     required final File smallCroppedFile,
     required final Directory directory,
     required final int sequenceNumber,
-    final List<Offset>? offsets,
+    required final List<Offset> offsets,
   });
 
   /// Should we display the eraser with the crop grid?
@@ -47,16 +47,10 @@ abstract class CropHelper {
     required final CropController controller,
     required final File? fullFile,
     required final File smallCroppedFile,
-    final List<Offset>? offsets,
+    required final List<Offset> offsets,
   }) {
     final Rect cropRect = getLocalCropRect(controller);
-    final List<double> eraserCoordinates = <double>[];
-    if (offsets != null) {
-      for (final Offset offset in offsets) {
-        eraserCoordinates.add(offset.dx);
-        eraserCoordinates.add(offset.dy);
-      }
-    }
+    final List<double> eraserCoordinates = getEraserCoordinates(offsets);
     return CropParameters(
       fullFile: fullFile,
       smallCroppedFile: smallCroppedFile,
@@ -67,6 +61,33 @@ abstract class CropHelper {
       y2: cropRect.bottom.floor(),
       eraserCoordinates: eraserCoordinates,
     );
+  }
+
+  static List<double> getEraserCoordinates(
+    final List<Offset> offsets,
+  ) {
+    final List<double> eraserCoordinates = <double>[];
+    for (final Offset offset in offsets) {
+      eraserCoordinates.add(offset.dx);
+      eraserCoordinates.add(offset.dy);
+    }
+    return eraserCoordinates;
+  }
+
+  static List<Offset> getOffsets(
+    final List<double>? eraserCoordinates,
+  ) {
+    final List<Offset> offsets = <Offset>[];
+    if (eraserCoordinates != null) {
+      for (int i = 0; i < eraserCoordinates.length; i += 2) {
+        final Offset offset = Offset(
+          eraserCoordinates[i],
+          eraserCoordinates[i + 1],
+        );
+        offsets.add(offset);
+      }
+    }
+    return offsets;
   }
 
   /// Returns a copy of a file with the full image (no cropping here).

--- a/packages/smooth_app/lib/pages/product_crop_helper.dart
+++ b/packages/smooth_app/lib/pages/product_crop_helper.dart
@@ -65,6 +65,9 @@ class ProductCropNewHelper extends ProductCropHelper {
   bool isNewImage() => true;
 
   @override
+  bool get enableEraser => productType == ProductType.product;
+
+  @override
   Future<CropParameters?> process({
     required final BuildContext context,
     required final CropController controller,
@@ -73,7 +76,7 @@ class ProductCropNewHelper extends ProductCropHelper {
     required final File smallCroppedFile,
     required final Directory directory,
     required final int sequenceNumber,
-    final List<Offset>? offsets,
+    required final List<Offset> offsets,
   }) async {
     // in this case, it's a brand new picture, with crop parameters.
     // for performance reasons, we do not crop the image full-size here,
@@ -101,6 +104,7 @@ class ProductCropNewHelper extends ProductCropHelper {
       y1: cropRect.top.ceil(),
       x2: cropRect.right.floor(),
       y2: cropRect.bottom.floor(),
+      eraserCoordinates: CropHelper.getEraserCoordinates(offsets),
       context: context,
     );
 
@@ -111,6 +115,7 @@ class ProductCropNewHelper extends ProductCropHelper {
       controller: controller,
       fullFile: fullFile,
       smallCroppedFile: smallCroppedFile,
+      offsets: offsets,
     );
   }
 }
@@ -139,7 +144,7 @@ class ProductCropAgainHelper extends ProductCropHelper {
     required final File smallCroppedFile,
     required final Directory directory,
     required final int sequenceNumber,
-    final List<Offset>? offsets,
+    required final List<Offset> offsets,
   }) async {
     // in this case, it's an existing picture, with crop parameters.
     // we let the server do everything: better performance, and no privacy
@@ -167,6 +172,7 @@ class ProductCropAgainHelper extends ProductCropHelper {
       controller: controller,
       fullFile: null,
       smallCroppedFile: smallCroppedFile,
+      offsets: offsets,
     );
   }
 

--- a/packages/smooth_app/lib/pages/proof_crop_helper.dart
+++ b/packages/smooth_app/lib/pages/proof_crop_helper.dart
@@ -48,7 +48,7 @@ class ProofCropHelper extends CropHelper {
     required final File smallCroppedFile,
     required final Directory directory,
     required final int sequenceNumber,
-    final List<Offset>? offsets,
+    required final List<Offset> offsets,
   }) async {
     // It's a brand new picture, with crop parameters.
     // For performance reasons, we do not crop the image full-size here,


### PR DESCRIPTION
### What
- A new feature was needed for "product" products: being able to hide some parts of the uploaded images that may contain private data (e.g. IMEI).
- That feature was already present in price proof images.
- The feature is now available for product images:
  - only for new/uploaded images (not for crop operations from an already uploaded image)
  - only for products with "product" as product type
- Of course the feature is still available for proof images

### Screenshot
![Screenshot_1739889344](https://github.com/user-attachments/assets/ffd09026-409b-4740-b5e6-6587f6a164a1)


### Fixes bug(s)
- Closes: #6104

### Impacted files
* `background_task_add_price.dart`: minor refactoring
* `background_task_image.dart`: added `eraserCoordinates` field; moved here code about "eraser overlayPainter"
* `crop_helper.dart`: new methods `getEraserCoordinates` and `getOffsets`; minor refactoring
* `product_crop_helper.dart`: added "eraser" for "ProductType.product" only; minor refactoring
* `proof_crop_helper.dart`: minor refactoring