### PR TITLE
feat: 6017 - from proof page, show previously added prices

### DIFF
--- a/packages/smooth_app/lib/pages/prices/price_add_product_card.dart
+++ b/packages/smooth_app/lib/pages/prices/price_add_product_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/preferences/user_preferences.dart';
 import 'package:smooth_app/database/local_database.dart';
@@ -115,6 +116,13 @@ class _PriceAddProductCardState extends State<PriceAddProductCard> {
         final PriceAmountModel model = priceModel.elementAt(i);
         if (model.product.barcode == barcode) {
           return true;
+        }
+      }
+      if (priceModel.existingPrices != null) {
+        for (final Price price in priceModel.existingPrices!) {
+          if (price.productCode == barcode) {
+            return true;
+          }
         }
       }
       return false;

--- a/packages/smooth_app/lib/pages/prices/price_existing_amount_card.dart
+++ b/packages/smooth_app/lib/pages/prices/price_existing_amount_card.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
@@ -6,9 +8,10 @@ import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/pages/prices/price_existing_amount_field.dart';
 import 'package:smooth_app/pages/prices/price_meta_product.dart';
 import 'package:smooth_app/pages/prices/price_product_list_tile.dart';
+import 'package:smooth_app/query/product_query.dart';
 
 /// Card that displays an existing amount.
-class PriceExistingAmountCard extends StatelessWidget {
+class PriceExistingAmountCard extends StatefulWidget {
   const PriceExistingAmountCard(
     this.price,
   );
@@ -16,11 +19,62 @@ class PriceExistingAmountCard extends StatelessWidget {
   final Price price;
 
   @override
+  State<PriceExistingAmountCard> createState() =>
+      _PriceExistingAmountCardState();
+}
+
+class _PriceExistingAmountCardState extends State<PriceExistingAmountCard> {
+  String? _categoryTag;
+  String? _categoryName;
+
+  @override
+  void initState() {
+    super.initState();
+    _categoryTag = widget.price.categoryTag;
+    unawaited(_loadCategoryName());
+  }
+
+  Future<void> _loadCategoryName() async {
+    if (_categoryTag == null) {
+      return;
+    }
+    final OpenFoodFactsLanguage language = ProductQuery.getLanguage();
+    final Map<String, TaxonomyCategory>? map =
+        await OpenFoodAPIClient.getTaxonomyCategories(
+      TaxonomyCategoryQueryConfiguration(
+        tags: <String>[_categoryTag!],
+        country: ProductQuery.getCountry(),
+        languages: <OpenFoodFactsLanguage>[language],
+        fields: <TaxonomyCategoryField>[TaxonomyCategoryField.NAME],
+        includeChildren: false,
+      ),
+    );
+    if (map == null) {
+      return;
+    }
+    final TaxonomyCategory? category = map[_categoryTag];
+    if (category == null) {
+      return;
+    }
+    final Map<OpenFoodFactsLanguage, String>? categoryNames = category.name;
+    if (categoryNames == null || categoryNames.isEmpty) {
+      return;
+    }
+    _categoryName = categoryNames[language];
+    if (_categoryName != null) {
+      if (mounted) {
+        setState(() {});
+      }
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    final bool isDiscounted = price.priceIsDiscounted ?? false;
+    final bool isDiscounted = widget.price.priceIsDiscounted ?? false;
     return SmoothCardWithRoundedHeader(
-      title: appLocalizations.prices_amount_subtitle,
+      // TODO(monsieurtanuki): localize
+      title: 'Price previously added',
       leading: const Icon(Icons.history),
       contentPadding: const EdgeInsetsDirectional.symmetric(
         vertical: MEDIUM_SPACE,
@@ -28,9 +82,13 @@ class PriceExistingAmountCard extends StatelessWidget {
       ),
       child: Column(
         children: <Widget>[
-          if (price.product != null)
+          if (widget.price.product != null)
             PriceProductListTile(
-              product: PriceMetaProduct.priceProduct(price.product!),
+              product: PriceMetaProduct.priceProduct(widget.price.product!),
+            ),
+          if (_categoryName != null || _categoryTag != null)
+            ListTile(
+              title: Text((_categoryName ?? _categoryTag)!),
             ),
           SwitchListTile(
             value: isDiscounted,
@@ -43,7 +101,8 @@ class PriceExistingAmountCard extends StatelessWidget {
             children: <Widget>[
               Expanded(
                 child: PriceExistingAmountField(
-                  value: price.price,
+                  value: widget.price.price,
+                  pricePer: widget.price.pricePer,
                 ),
               ),
               const SizedBox(width: LARGE_SPACE),
@@ -51,7 +110,8 @@ class PriceExistingAmountCard extends StatelessWidget {
                 child: !isDiscounted
                     ? Container()
                     : PriceExistingAmountField(
-                        value: price.priceWithoutDiscount,
+                        value: widget.price.priceWithoutDiscount,
+                        pricePer: widget.price.pricePer,
                       ),
               ),
             ],

--- a/packages/smooth_app/lib/pages/prices/price_existing_amount_card.dart
+++ b/packages/smooth_app/lib/pages/prices/price_existing_amount_card.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
+import 'package:smooth_app/pages/prices/price_existing_amount_field.dart';
+import 'package:smooth_app/pages/prices/price_meta_product.dart';
+import 'package:smooth_app/pages/prices/price_product_list_tile.dart';
+
+/// Card that displays an existing amount.
+class PriceExistingAmountCard extends StatelessWidget {
+  const PriceExistingAmountCard(
+    this.price,
+  );
+
+  final Price price;
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final bool isDiscounted = price.priceIsDiscounted ?? false;
+    return SmoothCardWithRoundedHeader(
+      title: appLocalizations.prices_amount_subtitle,
+      leading: const Icon(Icons.history),
+      contentPadding: const EdgeInsetsDirectional.symmetric(
+        vertical: MEDIUM_SPACE,
+        horizontal: SMALL_SPACE,
+      ),
+      child: Column(
+        children: <Widget>[
+          if (price.product != null)
+            PriceProductListTile(
+              product: PriceMetaProduct.priceProduct(price.product!),
+            ),
+          SwitchListTile(
+            value: isDiscounted,
+            onChanged: null,
+            title: Text(appLocalizations.prices_amount_is_discounted),
+            controlAffinity: ListTileControlAffinity.leading,
+          ),
+          const SizedBox(height: SMALL_SPACE),
+          Row(
+            children: <Widget>[
+              Expanded(
+                child: PriceExistingAmountField(
+                  value: price.price,
+                ),
+              ),
+              const SizedBox(width: LARGE_SPACE),
+              Expanded(
+                child: !isDiscounted
+                    ? Container()
+                    : PriceExistingAmountField(
+                        value: price.priceWithoutDiscount,
+                      ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/smooth_app/lib/pages/prices/price_existing_amount_field.dart
+++ b/packages/smooth_app/lib/pages/prices/price_existing_amount_field.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:smooth_app/generic_lib/widgets/smooth_text_form_field.dart';
+
+/// Text field that displays a read-only amount for an existing price.
+class PriceExistingAmountField extends StatelessWidget {
+  const PriceExistingAmountField({
+    required this.value,
+  });
+
+  final num? value;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextEditingController controller = TextEditingController();
+    controller.text = value == null ? '' : '$value';
+    return SmoothTextFormField(
+      type: TextFieldTypes.PLAIN_TEXT,
+      controller: controller,
+      enabled: false,
+      hintText: '',
+    );
+  }
+}

--- a/packages/smooth_app/lib/pages/prices/price_existing_amount_field.dart
+++ b/packages/smooth_app/lib/pages/prices/price_existing_amount_field.dart
@@ -1,18 +1,21 @@
 import 'package:flutter/material.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_text_form_field.dart';
 
 /// Text field that displays a read-only amount for an existing price.
 class PriceExistingAmountField extends StatelessWidget {
   const PriceExistingAmountField({
     required this.value,
+    required this.pricePer,
   });
 
   final num? value;
+  final PricePer? pricePer;
 
   @override
   Widget build(BuildContext context) {
     final TextEditingController controller = TextEditingController();
-    controller.text = value == null ? '' : '$value';
+    controller.text = value == null ? '' : '$value${_getPricePer()}';
     return SmoothTextFormField(
       type: TextFieldTypes.PLAIN_TEXT,
       controller: controller,
@@ -20,4 +23,11 @@ class PriceExistingAmountField extends StatelessWidget {
       hintText: '',
     );
   }
+
+  // TODO(monsieurtanuki): localize
+  String? _getPricePer() => switch (pricePer) {
+        null => '',
+        PricePer.kilogram => ' / kg',
+        PricePer.unit => ' / unit'
+      };
 }

--- a/packages/smooth_app/lib/pages/prices/price_model.dart
+++ b/packages/smooth_app/lib/pages/prices/price_model.dart
@@ -20,6 +20,7 @@ class PriceModel with ChangeNotifier {
     required final Currency currency,
     final PriceMetaProduct? initialProduct,
   })  : _proof = null,
+        existingPrices = null,
         _proofType = proofType,
         _date = DateTime.now(),
         _currency = currency,
@@ -30,6 +31,7 @@ class PriceModel with ChangeNotifier {
 
   PriceModel.proof({
     required Proof proof,
+    this.existingPrices,
   }) : _priceAmountModels = <PriceAmountModel>[] {
     setProof(proof, init: true);
   }
@@ -79,6 +81,8 @@ class PriceModel with ChangeNotifier {
   bool get hasImage => _proof != null || _cropParameters != null;
 
   final List<PriceAmountModel> _priceAmountModels;
+
+  final List<Price>? existingPrices;
 
   void add(final PriceAmountModel priceAmountModel) {
     _hasChanged = true;

--- a/packages/smooth_app/lib/pages/prices/product_price_add_page.dart
+++ b/packages/smooth_app/lib/pages/prices/product_price_add_page.dart
@@ -16,6 +16,7 @@ import 'package:smooth_app/pages/prices/price_add_product_card.dart';
 import 'package:smooth_app/pages/prices/price_amount_card.dart';
 import 'package:smooth_app/pages/prices/price_currency_card.dart';
 import 'package:smooth_app/pages/prices/price_date_card.dart';
+import 'package:smooth_app/pages/prices/price_existing_amount_card.dart';
 import 'package:smooth_app/pages/prices/price_location_card.dart';
 import 'package:smooth_app/pages/prices/price_meta_product.dart';
 import 'package:smooth_app/pages/prices/price_model.dart';
@@ -151,6 +152,9 @@ class _ProductPriceAddPageState extends State<ProductPriceAddPage>
                     const SizedBox(height: LARGE_SPACE),
                     const PriceCurrencyCard(),
                     const SizedBox(height: LARGE_SPACE),
+                    if (model.existingPrices != null)
+                      for (final Price price in model.existingPrices!)
+                        PriceExistingAmountCard(price),
                     for (int i = 0; i < model.length; i++)
                       PriceAmountCard(
                         key: Key(model.elementAt(i).product.barcode),


### PR DESCRIPTION
### What
- When we added prices to an existing proof, we couldn't see which prices were already added.
- In this PR, we load the related existing prices and we display them in the "add price" page.

### Screenshot
![Screenshot_1740314439](https://github.com/user-attachments/assets/343410fd-a3a1-4738-80b6-a5bd11b69802)

### Fixes bug(s)
- Closes: #6017

### Files
New files:
* `price_existing_amount_card.dart`: Card that displays an existing amount.
* `price_existing_amount_field.dart`: Text field that displays a read-only amount for an existing price.

Impacted files:
* `price_add_product_card.dart`: checking if the barcode to be added already existed in the already added prices too, not only among the current amounts.
* `price_model.dart`: now maintaining a list of already added prices
* `price_proof_page.dart`: now we load async'ly the proof-related prices in order to display them in the next "add prices" page
* `product_price_add_page.dart`: now displaying the previously added prices