### PR TITLE
feat: 5411 - now uses nominatim location search if it looks like OSM type/id

### DIFF
--- a/packages/smooth_app/lib/data_models/location_list_nominatim_supplier.dart
+++ b/packages/smooth_app/lib/data_models/location_list_nominatim_supplier.dart
@@ -1,0 +1,84 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/data_models/location_list_supplier.dart';
+import 'package:smooth_app/pages/locations/osm_location.dart';
+import 'package:smooth_app/query/product_query.dart';
+
+/// Asynchronously loads locations from Nominatim and OSM ids.
+class LocationListNominatimSupplier extends LocationListSupplier {
+  LocationListNominatimSupplier(this.queries);
+
+  final List<String> queries;
+
+  @override
+  LocationListSupplier? get alternateSupplier => null;
+
+  @override
+  Future<String?> asyncLoad() async {
+    try {
+      locations.clear();
+      final http.Response response = await http.get(
+        Uri(
+          scheme: 'https',
+          host: 'nominatim.openstreetmap.org',
+          path: 'lookup',
+          query: 'osm_ids=${queries.join(',')}'
+              '&format=json'
+              '&accept-language=${ProductQuery.getLanguage().offTag}',
+        ),
+      );
+      if (response.statusCode != 200) {
+        return 'Could not retrieve locations';
+      }
+      final List<dynamic> list = json.decode(response.body);
+      for (final Map<String, dynamic> item in list) {
+        final LocationOSMType? osmType = LocationOSMType.fromOffTag(
+            (item['osm_type'] as String).toUpperCase());
+        if (osmType == null) {
+          continue;
+        }
+        final double longitude = double.parse(item['lon']);
+        final double latitude = double.parse(item['lat']);
+        final int osmId = item['osm_id'] as int;
+        final Map<String, dynamic>? address =
+            item['address'] as Map<String, dynamic>?;
+        final String? name = item['name'] as String?;
+        final String? osmKey = item['class'] as String?;
+        final String? osmValue = item['type'] as String?;
+        String? street;
+        String? city;
+        String? countryCode;
+        String? country;
+        String? postCode;
+        if (address != null) {
+          street = address['road'];
+          city = address['city'];
+          countryCode = address['country_code'];
+          country = address['country'];
+          postCode = address['postcode'];
+        }
+        final OsmLocation osmLocation = OsmLocation(
+          osmId: osmId,
+          osmType: osmType,
+          longitude: longitude,
+          latitude: latitude,
+          name: name,
+          city: city,
+          postcode: postCode,
+          street: street,
+          country: country,
+          countryCode: countryCode,
+          osmKey: osmKey,
+          osmValue: osmValue,
+        );
+        locations.add(osmLocation);
+      }
+    } catch (e) {
+      locations.clear();
+      return e.toString();
+    }
+    return null;
+  }
+}

--- a/packages/smooth_app/lib/data_models/location_list_photon_supplier.dart
+++ b/packages/smooth_app/lib/data_models/location_list_photon_supplier.dart
@@ -1,0 +1,123 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/data_models/location_list_supplier.dart';
+import 'package:smooth_app/data_models/location_osm_type_extension.dart';
+import 'package:smooth_app/pages/locations/osm_location.dart';
+import 'package:smooth_app/query/product_query.dart';
+
+/// Asynchronously loads locations from Photon and query searches.
+///
+/// We use 2 location suppliers:
+/// * the first one optimized on shops, as it's what we want.
+/// * an optional one with no restrictions, in case OSM data is a bit clumsy.
+class LocationListPhotonSupplier extends LocationListSupplier {
+  LocationListPhotonSupplier(
+    this.query,
+    this.optimizedSearch,
+  );
+
+  /// Query text.
+  final String query;
+
+  /// True if we want to focus on shops.
+  final bool optimizedSearch;
+
+  /// Returns additional query parameters.
+  String _getAdditionalParameters() =>
+      optimizedSearch ? '&osm_tag=shop&osm_tag=amenity' : '';
+
+  @override
+  LocationListSupplier? get alternateSupplier =>
+      !optimizedSearch ? null : LocationListPhotonSupplier(query, false);
+
+  @override
+  Future<String?> asyncLoad() async {
+    // don't ask me why, but it looks like we need to explicitly set a language,
+    // or else we get different (and not relevant) results
+    // and only en,fr,de can be used.
+    OpenFoodFactsLanguage getQueryLanguage() =>
+        switch (ProductQuery.getLanguage()) {
+          OpenFoodFactsLanguage.FRENCH => OpenFoodFactsLanguage.FRENCH,
+          OpenFoodFactsLanguage.GERMAN => OpenFoodFactsLanguage.GERMAN,
+          OpenFoodFactsLanguage.ENGLISH => OpenFoodFactsLanguage.ENGLISH,
+          _ => OpenFoodFactsLanguage.ENGLISH,
+        };
+
+    try {
+      locations.clear();
+      final http.Response response = await http.get(
+        Uri(
+          scheme: 'https',
+          host: 'photon.komoot.io',
+          path: 'api',
+          query: 'q=${Uri.encodeComponent(query)}'
+              '&lang=${getQueryLanguage().offTag}'
+              '${_getAdditionalParameters()}',
+        ),
+      );
+      if (response.statusCode != 200) {
+        return 'Could not retrieve locations';
+      }
+      final Map<String, dynamic> map = json.decode(response.body);
+      if (map['type'] != 'FeatureCollection') {
+        return 'Unexpected result type: ${map['type']}';
+      }
+      final List<dynamic> features = map['features'];
+      for (final Map<String, dynamic> item in features) {
+        final Map<String, dynamic> properties = item['properties'];
+        final String? short = properties['osm_type'];
+        if (short == null) {
+          continue;
+        }
+        LocationOSMType? osmType;
+        for (final LocationOSMType item in LocationOSMType.values) {
+          if (short == item.short) {
+            osmType = item;
+            break;
+          }
+        }
+        if (osmType == null) {
+          continue;
+        }
+        final Map<String, dynamic> geometry = item['geometry'];
+        final String type = geometry['type'];
+        if (type != 'Point') {
+          continue;
+        }
+        final List<dynamic> coordinates = geometry['coordinates'];
+        final double longitude = coordinates[0] as double;
+        final double latitude = coordinates[1] as double;
+        final int osmId = properties['osm_id'];
+        final String? name = properties['name'];
+        final String? street = properties['street'];
+        final String? city = properties['city'];
+        final String? countryCode = properties['countrycode'];
+        final String? country = properties['country'];
+        final String? postCode = properties['postcode'];
+        final String? osmKey = properties['osm_key'];
+        final String? osmValue = properties['osm_value'];
+        final OsmLocation osmLocation = OsmLocation(
+          osmId: osmId,
+          osmType: osmType,
+          longitude: longitude,
+          latitude: latitude,
+          name: name,
+          city: city,
+          postcode: postCode,
+          street: street,
+          country: country,
+          countryCode: countryCode,
+          osmKey: osmKey,
+          osmValue: osmValue,
+        );
+        locations.add(osmLocation);
+      }
+    } catch (e) {
+      locations.clear();
+      return e.toString();
+    }
+    return null;
+  }
+}

--- a/packages/smooth_app/lib/data_models/location_list_supplier.dart
+++ b/packages/smooth_app/lib/data_models/location_list_supplier.dart
@@ -6,8 +6,6 @@ import 'package:smooth_app/pages/locations/osm_location.dart';
 
 /// Asynchronously loads locations.
 abstract class LocationListSupplier {
-  LocationListSupplier();
-
   static LocationListSupplier getBestInitialSupplier(final String query) {
     int? osmId = int.tryParse(query);
     if (osmId != null) {

--- a/packages/smooth_app/lib/data_models/location_list_supplier.dart
+++ b/packages/smooth_app/lib/data_models/location_list_supplier.dart
@@ -1,113 +1,42 @@
-import 'dart:convert';
-
-import 'package:http/http.dart' as http;
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/data_models/location_list_nominatim_supplier.dart';
+import 'package:smooth_app/data_models/location_list_photon_supplier.dart';
+import 'package:smooth_app/data_models/location_osm_type_extension.dart';
 import 'package:smooth_app/pages/locations/osm_location.dart';
-import 'package:smooth_app/query/product_query.dart';
 
 /// Asynchronously loads locations.
-class LocationListSupplier {
-  LocationListSupplier(
-    this.query,
-    this.optimizedSearch,
-  );
+abstract class LocationListSupplier {
+  LocationListSupplier();
 
-  /// Query text.
-  final String query;
-
-  /// True if we want to focus on shops.
-  final bool optimizedSearch;
+  static LocationListSupplier getBestInitialSupplier(final String query) {
+    int? osmId = int.tryParse(query);
+    if (osmId != null) {
+      final List<String> queries = <String>[];
+      for (final LocationOSMType type in LocationOSMType.values) {
+        queries.add('${type.short}$osmId');
+      }
+      return LocationListNominatimSupplier(queries);
+    }
+    if (query.length > 1) {
+      final String firstChar = query.substring(0, 1).toUpperCase();
+      for (final LocationOSMType type in LocationOSMType.values) {
+        if (firstChar == type.short) {
+          osmId = int.tryParse(query.substring(1));
+          if (osmId != null) {
+            return LocationListNominatimSupplier(<String>[query]);
+          }
+        }
+      }
+    }
+    return LocationListPhotonSupplier(query, true);
+  }
 
   /// Locations as result.
   final List<OsmLocation> locations = <OsmLocation>[];
 
-  /// Returns additional query parameters.
-  String _getAdditionalParameters() =>
-      optimizedSearch ? '&osm_tag=shop&osm_tag=amenity' : '';
-
   /// Returns null if OK, or the message error
-  Future<String?> asyncLoad() async {
-    // don't ask me why, but it looks like we need to explicitly set a language,
-    // or else we get different (and not relevant) results
-    // and only en,fr,de can be used.
-    OpenFoodFactsLanguage getQueryLanguage() =>
-        switch (ProductQuery.getLanguage()) {
-          OpenFoodFactsLanguage.FRENCH => OpenFoodFactsLanguage.FRENCH,
-          OpenFoodFactsLanguage.GERMAN => OpenFoodFactsLanguage.GERMAN,
-          OpenFoodFactsLanguage.ENGLISH => OpenFoodFactsLanguage.ENGLISH,
-          _ => OpenFoodFactsLanguage.ENGLISH,
-        };
+  Future<String?> asyncLoad();
 
-    try {
-      locations.clear();
-      final http.Response response = await http.get(
-        Uri(
-          scheme: 'https',
-          host: 'photon.komoot.io',
-          path: 'api',
-          query: 'q=${Uri.encodeComponent(query)}'
-              '&lang=${getQueryLanguage().offTag}'
-              '${_getAdditionalParameters()}',
-        ),
-      );
-      if (response.statusCode != 200) {
-        return 'Could not retrieve locations';
-      }
-      final Map<String, dynamic> map = json.decode(response.body);
-      if (map['type'] != 'FeatureCollection') {
-        return 'Unexpected result type: ${map['type']}';
-      }
-      final List<dynamic> features = map['features'];
-      for (final Map<String, dynamic> item in features) {
-        final Map<String, dynamic> properties = item['properties'];
-        final LocationOSMType? osmType = _convertType(properties['osm_type']);
-        if (osmType == null) {
-          continue;
-        }
-        final Map<String, dynamic> geometry = item['geometry'];
-        final String type = geometry['type'];
-        if (type != 'Point') {
-          continue;
-        }
-        final List<dynamic> coordinates = geometry['coordinates'];
-        final double longitude = coordinates[0] as double;
-        final double latitude = coordinates[1] as double;
-        final int osmId = properties['osm_id'];
-        final String? name = properties['name'];
-        final String? street = properties['street'];
-        final String? city = properties['city'];
-        final String? countryCode = properties['countrycode'];
-        final String? country = properties['country'];
-        final String? postCode = properties['postcode'];
-        final String? osmKey = properties['osm_key'];
-        final String? osmValue = properties['osm_value'];
-        final OsmLocation osmLocation = OsmLocation(
-          osmId: osmId,
-          osmType: osmType,
-          longitude: longitude,
-          latitude: latitude,
-          name: name,
-          city: city,
-          postcode: postCode,
-          street: street,
-          country: country,
-          countryCode: countryCode,
-          osmKey: osmKey,
-          osmValue: osmValue,
-        );
-        locations.add(osmLocation);
-      }
-    } catch (e) {
-      locations.clear();
-      return e.toString();
-    }
-    return null;
-  }
-
-  static LocationOSMType? _convertType(final String type) => switch (type) {
-        'W' => LocationOSMType.way,
-        'N' => LocationOSMType.node,
-        'R' => LocationOSMType.relation,
-        _ => null,
-      };
+  /// Returns a possible alternate supplier, probably less restrictive.
+  LocationListSupplier? get alternateSupplier;
 }

--- a/packages/smooth_app/lib/data_models/location_osm_type_extension.dart
+++ b/packages/smooth_app/lib/data_models/location_osm_type_extension.dart
@@ -1,0 +1,6 @@
+import 'package:openfoodfacts/openfoodfacts.dart';
+
+// TODO(monsieurtanuki): move to off-dart?
+extension LocationOSMTypeExtension on LocationOSMType {
+  String get short => offTag.substring(0, 1);
+}

--- a/packages/smooth_app/lib/pages/locations/location_map_page.dart
+++ b/packages/smooth_app/lib/pages/locations/location_map_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
+import 'package:smooth_app/data_models/location_osm_type_extension.dart';
 import 'package:smooth_app/helpers/launch_url_helper.dart';
 import 'package:smooth_app/pages/locations/osm_location.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
@@ -54,6 +55,11 @@ class LocationMapPage extends StatelessWidget {
                     context,
                     '${osmLocation.latitude}, ${osmLocation.longitude}',
                     'Coordinates',
+                  ),
+                  _getItem(
+                    context,
+                    '${osmLocation.osmType.short}${osmLocation.osmId}',
+                    'OSM',
                   ),
                 ],
               ),

--- a/packages/smooth_app/lib/pages/locations/location_query_page.dart
+++ b/packages/smooth_app/lib/pages/locations/location_query_page.dart
@@ -1,7 +1,10 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:provider/provider.dart';
+import 'package:smooth_app/data_models/location_list_supplier.dart';
 import 'package:smooth_app/data_models/location_query_model.dart';
 import 'package:smooth_app/generic_lib/buttons/smooth_large_button_with_icon.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
@@ -69,7 +72,7 @@ class _LocationQueryPageState extends State<LocationQueryPage>
             }
             break;
           case LoadingStatus.LOADED:
-            if (_model.isEmpty() && !_model.isOptimized) {
+            if (_model.isEmpty() && _model.alternateSupplier == null) {
               return SearchEmptyScreen(
                 name: widget.query,
                 emptiness: _getEmptyText(
@@ -118,12 +121,13 @@ class _LocationQueryPageState extends State<LocationQueryPage>
           child: ListView.builder(
             itemBuilder: (BuildContext context, int index) {
               if (index >= _model.displayedResults.length) {
-                if (_model.isOptimized) {
+                final LocationListSupplier? supplier = _model.alternateSupplier;
+                if (supplier != null) {
                   return SmoothCard(
                     child: SmoothLargeButtonWithIcon(
                       text: appLocalizations.prices_location_search_broader,
                       leadingIcon: const Icon(Icons.search),
-                      onPressed: () => _model.loadMore(),
+                      onPressed: () => unawaited(_model.loadMore(supplier)),
                     ),
                   );
                 }
@@ -143,7 +147,7 @@ class _LocationQueryPageState extends State<LocationQueryPage>
               );
             },
             itemCount: _model.displayedResults.length +
-                (_model.isOptimized
+                (_model.alternateSupplier != null
                     ? 1
                     : _model.loadingStatus == LoadingStatus.LOADING
                         ? 1


### PR DESCRIPTION
### What
- Now we may use the nominatim lookup for location search.
- It'll automatically be used if the search string is just an integer, or N|R|W|n|r|w + an integer

### Screenshots
| search with type | search without type | map with osm type + id |
| -- | -- | -- |
| ![Screenshot_1740490564](https://github.com/user-attachments/assets/71974b9d-1e77-4603-a125-6253d32662f4) | ![Screenshot_1740490905](https://github.com/user-attachments/assets/5d4331ec-5718-450e-892b-b826559de216) | ![Screenshot_1740489722](https://github.com/user-attachments/assets/75f6b8b2-c015-47fa-9675-b2d1870b50b1) |

### Fixes bug(s)
- Closes: #5411

### Files
New files:
* `location_list_nominatim_supplier.dart`: Asynchronously loads locations from Nominatim and OSM ids.
* `location_list_photon_supplier.dart`: Asynchronously loads locations from Photon and query searches.
* `location_osm_type_extension.dart`: Extension on LocationOSMType.

Impacted files:
* `location_list_supplier.dart`: turned class into abstract extended by both photon and nominatim.
* `location_map_page.dart`: now displays the OSM type + id.
* `location_query_model.dart`: now we may use Nominatim search instead of photon search.
* `location_query_page.dart`: minor refactoring