### PR TITLE
feat: 5963 - store nutrient order and names in database

### DIFF
--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -741,10 +741,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_svg
-      sha256: "54900a1a1243f3c4a5506d853a2b5c2dbc38d5f27e52a52618a8054401431123"
+      sha256: c200fd79c918a40c5cd50ea0877fa13f81bdaf6f0a5d3dbcc2a13e3285d6aa1b
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.16"
+    version: "2.0.17"
   flutter_test:
     dependency: "direct dev"
     description: flutter


### PR DESCRIPTION
### What
- When we wanted to edit nutrition facts, we needed an access to the server to download the nutrient order and names.
- This download wasn't needed again in the same app session (cache in local static field).
- This download was indeed needed again after an app restart.
- Now we cache the result also in the local database, so that we'll have to download the data once and only once.
- That said
  - it means we cannot have it downloaded again (unless we code something specific in dev mode for instance), but in a first approach this data is very unlikely to change
  - the data will need to be downloaded if the user changes languages (unless the user already used that language, as the data would be already downloaded and stored in the local database)

### Fixes bug(s)
- Closes: #5963
- Closes: #6347