### PR TITLE
fix: resolve layout overflow in first-time price privacy dialog

### DIFF
--- a/packages/smooth_app/lib/generic_lib/bottom_sheets/smooth_bottom_sheet.dart
+++ b/packages/smooth_app/lib/generic_lib/bottom_sheets/smooth_bottom_sheet.dart
@@ -220,6 +220,7 @@ Future<T?> showSmoothListOfChoicesModalSheet<T>({
       headerBackgroundColor: headerBackgroundColor,
       bodyPadding: EdgeInsets.zero,
       body: Column(children: items),
+      expandBody: true,
     ),
   );
 }
@@ -348,7 +349,7 @@ class SmoothModalSheet extends StatelessWidget {
     );
 
     if (expandBody) {
-      bodyChild = Expanded(child: bodyChild);
+      bodyChild = Expanded(child: SingleChildScrollView(child: bodyChild));
     }
 
     return ClipRRect(

--- a/packages/smooth_app/lib/generic_lib/bottom_sheets/smooth_bottom_sheet.dart
+++ b/packages/smooth_app/lib/generic_lib/bottom_sheets/smooth_bottom_sheet.dart
@@ -39,7 +39,7 @@ Future<T?> showSmoothModalSheet<T>({
 
   return showModalBottomSheet<T>(
     constraints: constraints,
-    isScrollControlled: isScrollControlled ?? minHeight != null,
+    isScrollControlled: true,
     context: context,
     shape: const RoundedRectangleBorder(
       borderRadius: BorderRadius.vertical(top: ROUNDED_RADIUS),
@@ -219,7 +219,7 @@ Future<T?> showSmoothListOfChoicesModalSheet<T>({
       prefixIndicatorColor: prefixIndicatorColor,
       headerBackgroundColor: headerBackgroundColor,
       bodyPadding: EdgeInsets.zero,
-      body: Column(children: items),
+      body: IntrinsicHeight(child: Column(mainAxisSize: MainAxisSize.min,children: items)),
     ),
   );
 }
@@ -357,12 +357,15 @@ class SmoothModalSheet extends StatelessWidget {
         decoration: const BoxDecoration(
           borderRadius: BorderRadius.vertical(top: ROUNDED_RADIUS),
         ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: <Widget>[
-            header,
-            bodyChild,
-          ],
+        child:
+        SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              header,
+              bodyChild,
+            ],
+          ),
         ),
       ),
     );

--- a/packages/smooth_app/lib/generic_lib/bottom_sheets/smooth_bottom_sheet.dart
+++ b/packages/smooth_app/lib/generic_lib/bottom_sheets/smooth_bottom_sheet.dart
@@ -220,7 +220,6 @@ Future<T?> showSmoothListOfChoicesModalSheet<T>({
       headerBackgroundColor: headerBackgroundColor,
       bodyPadding: EdgeInsets.zero,
       body: Column(children: items),
-      expandBody: true,
     ),
   );
 }
@@ -349,7 +348,7 @@ class SmoothModalSheet extends StatelessWidget {
     );
 
     if (expandBody) {
-      bodyChild = Expanded(child: SingleChildScrollView(child: bodyChild));
+      bodyChild = Expanded(child: bodyChild);
     }
 
     return ClipRRect(

--- a/packages/smooth_app/lib/generic_lib/bottom_sheets/smooth_bottom_sheet.dart
+++ b/packages/smooth_app/lib/generic_lib/bottom_sheets/smooth_bottom_sheet.dart
@@ -219,7 +219,8 @@ Future<T?> showSmoothListOfChoicesModalSheet<T>({
       prefixIndicatorColor: prefixIndicatorColor,
       headerBackgroundColor: headerBackgroundColor,
       bodyPadding: EdgeInsets.zero,
-      body: IntrinsicHeight(child: Column(mainAxisSize: MainAxisSize.min,children: items)),
+      body: IntrinsicHeight(
+          child: Column(mainAxisSize: MainAxisSize.min, children: items)),
     ),
   );
 }
@@ -357,8 +358,7 @@ class SmoothModalSheet extends StatelessWidget {
         decoration: const BoxDecoration(
           borderRadius: BorderRadius.vertical(top: ROUNDED_RADIUS),
         ),
-        child:
-        SingleChildScrollView(
+        child: SingleChildScrollView(
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[


### PR DESCRIPTION
### What
<!-- description of the PR -->
- **Changed**: Made the bottom sheet scrollable to fix layout overflow issues in the first-time price privacy dialog.

- **Reason**: Instead of increasing the max height of the bottom sheet (which could lead to usability issues on smaller screens), implemented a scrollable solution to ensure the content fits within the available space.

### Screenshot

https://github.com/user-attachments/assets/c4d284bb-d7d2-40c3-b435-2230446785b2

### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes: #6363

### Part of 
- #6363
