### PR TITLE
fix: center loading indicator alignment

### DIFF
--- a/packages/smooth_app/lib/pages/prices/prices_locations_page.dart
+++ b/packages/smooth_app/lib/pages/prices/prices_locations_page.dart
@@ -60,7 +60,7 @@ class _PricesLocationsPageState extends State<PricesLocationsPage>
           final AsyncSnapshot<MaybeError<GetLocationsResult>> snapshot,
         ) {
           if (snapshot.connectionState != ConnectionState.done) {
-            return const CircularProgressIndicator();
+            return const Center(child: CircularProgressIndicator());
           }
           if (snapshot.hasError) {
             return Text(snapshot.error!.toString());

--- a/packages/smooth_app/lib/pages/prices/prices_products_page.dart
+++ b/packages/smooth_app/lib/pages/prices/prices_products_page.dart
@@ -58,7 +58,7 @@ class _PricesProductsPageState extends State<PricesProductsPage>
           final AsyncSnapshot<MaybeError<GetPriceProductsResult>> snapshot,
         ) {
           if (snapshot.connectionState != ConnectionState.done) {
-            return const CircularProgressIndicator();
+            return const Center(child: CircularProgressIndicator());
           }
           if (snapshot.hasError) {
             return Text(snapshot.error!.toString());

--- a/packages/smooth_app/lib/pages/prices/prices_users_page.dart
+++ b/packages/smooth_app/lib/pages/prices/prices_users_page.dart
@@ -58,7 +58,7 @@ class _PricesUsersPageState extends State<PricesUsersPage>
           final AsyncSnapshot<MaybeError<GetUsersResult>> snapshot,
         ) {
           if (snapshot.connectionState != ConnectionState.done) {
-            return const CircularProgressIndicator();
+            return const Center(child: CircularProgressIndicator());
           }
           if (snapshot.hasError) {
             return Text(snapshot.error!.toString());

--- a/packages/smooth_app/lib/pages/prices/product_prices_list.dart
+++ b/packages/smooth_app/lib/pages/prices/product_prices_list.dart
@@ -59,7 +59,7 @@ class _ProductPricesListState extends State<ProductPricesList>
     switch (_productPriceRefresher.loadingStatus) {
       case null:
       case LoadingStatus.LOADING:
-      return const Center(child: CircularProgressIndicator());
+        return const Center(child: CircularProgressIndicator());
       case LoadingStatus.ERROR:
         return Text(_productPriceRefresher.loadingError.toString());
       case LoadingStatus.LOADED:

--- a/packages/smooth_app/lib/pages/prices/product_prices_list.dart
+++ b/packages/smooth_app/lib/pages/prices/product_prices_list.dart
@@ -59,7 +59,7 @@ class _ProductPricesListState extends State<ProductPricesList>
     switch (_productPriceRefresher.loadingStatus) {
       case null:
       case LoadingStatus.LOADING:
-        return const CircularProgressIndicator();
+      return const Center(child: CircularProgressIndicator());
       case LoadingStatus.ERROR:
         return Text(_productPriceRefresher.loadingError.toString());
       case LoadingStatus.LOADED:


### PR DESCRIPTION
### What
- **fix:** Corrected the alignment of the loading indicator so it appears in the middle during loading states, enhancing the user experience.

### Screenshots
####  Before  
<div style="display: flex; gap: 10px; flex-wrap: wrap;">
  <img src="https://github.com/user-attachments/assets/f900165c-c802-4810-aeae-5f64aef30e76" width="300" alt="Before_1">
  <img src="https://github.com/user-attachments/assets/280e3363-787c-4733-ba9b-70831c30f423" width="300" alt="Before_2">
  <img src="https://github.com/user-attachments/assets/92be78f1-a8cd-4ea3-b6cf-ec72b4e2fee2" width="300" alt="Before_3">
  <img src="https://github.com/user-attachments/assets/38de330e-c295-4219-bbb7-62a0e28d9efa" width="300" alt="Before_4">
</div>  


#### After

<div style="display: flex; gap: 10px; flex-wrap: wrap;">
  <img src="https://github.com/user-attachments/assets/2d9683f0-821b-4d38-8673-a6ba4e1c7651" width="300" alt="After_1">
  <img src="https://github.com/user-attachments/assets/071c0f9c-5bb3-40f0-8ec1-df79f118e0a0" width="300" alt="After_2">
  <img src="https://github.com/user-attachments/assets/b468c0df-049b-45f5-bb1a-bf6cf562d54f" width="300" alt="After_3">
  <img src="https://github.com/user-attachments/assets/d0cde38d-423e-49e6-8851-fd98cbc85f4a" width="300" alt="After_4">
</div>  

### Fixes bug(s)
- Fixes: https://github.com/openfoodfacts/smooth-app/issues/6423

### Part of 
- https://github.com/openfoodfacts/smooth-app/issues/6423
