### PR TITLE
Fix: Center loading indicator in Price screen issue #6423

### DIFF
--- a/packages/smooth_app/lib/pages/prices/prices_locations_page.dart
+++ b/packages/smooth_app/lib/pages/prices/prices_locations_page.dart
@@ -60,7 +60,7 @@ class _PricesLocationsPageState extends State<PricesLocationsPage>
           final AsyncSnapshot<MaybeError<GetLocationsResult>> snapshot,
         ) {
           if (snapshot.connectionState != ConnectionState.done) {
-            return const CircularProgressIndicator();
+            return const Center(child: CircularProgressIndicator());
           }
           if (snapshot.hasError) {
             return Text(snapshot.error!.toString());

--- a/packages/smooth_app/lib/pages/prices/prices_products_page.dart
+++ b/packages/smooth_app/lib/pages/prices/prices_products_page.dart
@@ -58,7 +58,7 @@ class _PricesProductsPageState extends State<PricesProductsPage>
           final AsyncSnapshot<MaybeError<GetPriceProductsResult>> snapshot,
         ) {
           if (snapshot.connectionState != ConnectionState.done) {
-            return const CircularProgressIndicator();
+            return const Center(child: CircularProgressIndicator());
           }
           if (snapshot.hasError) {
             return Text(snapshot.error!.toString());

--- a/packages/smooth_app/lib/pages/prices/prices_users_page.dart
+++ b/packages/smooth_app/lib/pages/prices/prices_users_page.dart
@@ -58,7 +58,7 @@ class _PricesUsersPageState extends State<PricesUsersPage>
           final AsyncSnapshot<MaybeError<GetUsersResult>> snapshot,
         ) {
           if (snapshot.connectionState != ConnectionState.done) {
-            return const CircularProgressIndicator();
+            return const Center(child: CircularProgressIndicator());
           }
           if (snapshot.hasError) {
             return Text(snapshot.error!.toString());

--- a/packages/smooth_app/lib/pages/prices/product_prices_list.dart
+++ b/packages/smooth_app/lib/pages/prices/product_prices_list.dart
@@ -59,7 +59,7 @@ class _ProductPricesListState extends State<ProductPricesList>
     switch (_productPriceRefresher.loadingStatus) {
       case null:
       case LoadingStatus.LOADING:
-        return const CircularProgressIndicator();
+        return const Center(child: CircularProgressIndicator());
       case LoadingStatus.ERROR:
         return Text(_productPriceRefresher.loadingError.toString());
       case LoadingStatus.LOADED:


### PR DESCRIPTION
### What

- Centered the loading indicator in the Price screen by wrapping `CircularProgressIndicator()` with `Center`.
### Screenshot

### Before
| <img width="321" alt="product_prices_list_old" src="https://github.com/user-attachments/assets/82fde9b3-06ba-4b89-82f4-21b0106170e2" /> | <img width="321" alt="prices_users_page_old" src="https://github.com/user-attachments/assets/457f392c-f644-4af6-b3a8-a1643d714a6d" /> | <img width="321" alt="prices_products_page_old" src="https://github.com/user-attachments/assets/40774f2f-2316-43aa-be0c-ad1666da9c6b" /> | <img width="321" alt="prices_locations_page_old" src="https://github.com/user-attachments/assets/8ec035ba-b48d-49d5-a7b2-a99e476f795f" /> |
|----|----|----|----|

### After
| <img width="321" alt="product_prices_list_new" src="https://github.com/user-attachments/assets/75e8d559-de2f-40ff-8dd8-5ecd8c9c6980" /> | <img width="321" alt="prices_users_page_new" src="https://github.com/user-attachments/assets/83466361-8563-4b8b-9920-571db789bffe" /> | <img width="321" alt="prices_products_page_new" src="https://github.com/user-attachments/assets/3efa4f77-46ba-41fa-92ce-097026edd81c" /> | <img width="321" alt="prices_locations_page_new" src="https://github.com/user-attachments/assets/0d8b9b6b-fddc-4c3b-9218-99c9c76efb00" /> |
|----|----|----|----|

### Changes made:
- Wrapped content with a Center widget in:
    - lib/pages/prices/product_prices_list.dart
	- lib/pages/prices/prices_users_page.dart
	- lib/pages/prices/prices_products_page.dart
	- lib/pages/prices/prices_locations_page.dart


### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes:  #6423  


### Part of 
- #6423 
