### PR TITLE
fix: UI Styling Issue in Compatibility Percentage Display #6431

### DIFF
--- a/packages/smooth_app/lib/pages/product/product_page/new_product_header.dart
+++ b/packages/smooth_app/lib/pages/product/product_page/new_product_header.dart
@@ -349,8 +349,7 @@ class _ProductCompatibilityScore extends StatelessWidget {
                       textAlign: TextAlign.center,
                       overflow: TextOverflow.fade,
                       textScaler: TextScaler.noScaling,
-                      style: TextStyle(
-                        fontSize: _getCompatibilityFontSize(compatibilityLabel),
+                      style: const TextStyle(
                         height: 0.9,
                         fontWeight: FontWeight.w500,
                       ),
@@ -363,22 +362,6 @@ class _ProductCompatibilityScore extends StatelessWidget {
         ],
       ),
     );
-  }
-
-  double _getCompatibilityFontSize(String compatibilityLabel) {
-    final int length = compatibilityLabel.length;
-
-    if (length <= 13) {
-      return 8.0;
-    } else if (length == 14) {
-      return 7.5;
-    } else if (length == 15) {
-      return 7.0;
-    } else if (length == 16) {
-      return 6.5;
-    } else {
-      return 6.0;
-    }
   }
 
   double computeWidth(BuildContext context) {

--- a/packages/smooth_app/lib/pages/product/product_page/new_product_header.dart
+++ b/packages/smooth_app/lib/pages/product/product_page/new_product_header.dart
@@ -364,10 +364,8 @@ class _ProductCompatibilityScore extends StatelessWidget {
   double _getCompatibilityFontSize(String compatibilityLabel) {
     final int length = compatibilityLabel.length;
 
-    if (length < 13) {
-      return 9.0;
-    } else if (length == 13) {
-      return 8.5;
+    if (length <= 13) {
+      return 8.0;
     } else if (length == 14) {
       return 7.5;
     } else if (length == 15) {

--- a/packages/smooth_app/lib/pages/product/product_page/new_product_header.dart
+++ b/packages/smooth_app/lib/pages/product/product_page/new_product_header.dart
@@ -340,16 +340,20 @@ class _ProductCompatibilityScore extends StatelessWidget {
                       fontWeight: FontWeight.bold,
                     ),
                   ),
-                  Text(
-                    compatibilityLabel,
-                    maxLines: 1,
-                    textAlign: TextAlign.center,
-                    overflow: TextOverflow.fade,
-                    textScaler: TextScaler.noScaling,
-                    style: TextStyle(
-                      fontSize: _getCompatibilityFontSize(compatibilityLabel),
-                      height: 0.9,
-                      fontWeight: FontWeight.w500,
+                  FittedBox(
+                    alignment: Alignment.center,
+                    fit: BoxFit.scaleDown,
+                    child: Text(
+                      compatibilityLabel,
+                      maxLines: 1,
+                      textAlign: TextAlign.center,
+                      overflow: TextOverflow.fade,
+                      textScaler: TextScaler.noScaling,
+                      style: TextStyle(
+                        fontSize: _getCompatibilityFontSize(compatibilityLabel),
+                        height: 0.9,
+                        fontWeight: FontWeight.w500,
+                      ),
                     ),
                   ),
                 ],


### PR DESCRIPTION
### What
Adjusted the font size logic for compatibility labels to ensure text visibility across all devices.


### Screenshot

| Before | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/f8514675-bcde-4c00-abc1-583dec7e6a32) | ![after](https://github.com/user-attachments/assets/76ede0f1-5bd7-42cd-b38f-fc9d9fbee710) |
| <img width="399" alt="Screenshot 2025-03-09 at 1 21 04 AM" src="https://github.com/user-attachments/assets/c7caf233-2a45-467a-b0f0-047b902730cd" /> | <img width="397" alt="Screenshot 2025-03-09 at 1 21 36 AM" src="https://github.com/user-attachments/assets/b5abeeb8-8b3d-4f1a-9049-354f8286d513" /> |

I tried modifying EdgeInsets (padding) first, but this resulted in inconsistencies across devices. The font size adjustment provides a reliable solution that maintains proper text visibility on both Android and iOS across various screen sizes and ratios.
A font size of 8.0 for a length of 13 seems to be the sweet spot for all devices.

### Fixes bug(s)
- Fixes: #6431 

### Part of 
- #6431 
