### PR TITLE
fix: 6425 - clean usage of nutriscore new icon in guide

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -3714,10 +3714,6 @@
   "@guide_nutriscore_v2_title": {
     "description": "The title of the guide (please don't forget the use of non-breaking spaces)"
   },
-  "guide_nutriscore_v2_file_language": "en",
-  "@guide_nutriscore_v2_file_language": {
-    "description": "The logo is only available in de/en/fr/ln/nl. Please use en if not available (in lowercase, please)."
-  },
   "guide_nutriscore_v2_what_is_nutriscore_title": "What is the Nutri-Score?",
   "guide_nutriscore_v2_what_is_nutriscore_paragraph1": "The Nutri-Score is a logo which aims to inform you about the **nutritional quality of foods**.",
   "@guide_nutriscore_v2_what_is_nutriscore_paragraph1": {

--- a/packages/smooth_app/lib/pages/guides/guide/guide_nutriscore_v2.dart
+++ b/packages/smooth_app/lib/pages/guides/guide/guide_nutriscore_v2.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:smooth_app/cards/category_cards/svg_cache.dart';
 import 'package:smooth_app/pages/guides/helpers/guides_content.dart';
 import 'package:smooth_app/pages/guides/helpers/guides_footer.dart';
 import 'package:smooth_app/pages/guides/helpers/guides_header.dart';
@@ -56,7 +57,9 @@ class _NutriScoreHeaderIllustration extends StatelessWidget {
       children: <Widget>[
         Expanded(
           flex: 32,
-          child: SvgPicture.asset('assets/cache/nutriscore-a.svg'),
+          child: SvgPicture.asset(
+            SvgCache.getAssetsCacheForNutriscore(NutriScoreValue.a, false),
+          ),
         ),
         const Expanded(
           flex: 28,
@@ -67,7 +70,8 @@ class _NutriScoreHeaderIllustration extends StatelessWidget {
         Expanded(
           flex: 40,
           child: SvgPicture.asset(
-              'assets/cache/nutriscore-a-new-${AppLocalizations.of(context).guide_nutriscore_v2_file_language}.svg'),
+            SvgCache.getAssetsCacheForNutriscore(NutriScoreValue.a, true),
+          ),
         ),
       ],
     );
@@ -93,7 +97,10 @@ class _NutriScoreSection1 extends StatelessWidget {
               .guide_nutriscore_v2_what_is_nutriscore_paragraph2,
         ),
         GuidesImage(
-          imagePath: 'assets/cache/nutriscore-a.svg',
+          imagePath: SvgCache.getAssetsCacheForNutriscore(
+            NutriScoreValue.a,
+            false,
+          ),
           caption: appLocalizations.guide_nutriscore_v2_nutriscore_a_caption,
           desiredWidthPercent: 0.30,
         ),
@@ -159,8 +166,10 @@ class _NutriScoreSection3 extends StatelessWidget {
           text: appLocalizations.guide_nutriscore_v2_new_logo_text,
         ),
         GuidesImage(
-          imagePath:
-              'assets/cache/nutriscore-a-new-${AppLocalizations.of(context).guide_nutriscore_v2_file_language}.svg',
+          imagePath: SvgCache.getAssetsCacheForNutriscore(
+            NutriScoreValue.a,
+            true,
+          ),
           caption: appLocalizations.guide_nutriscore_v2_new_logo_image_caption,
           desiredWidthPercent: 0.30,
         ),


### PR DESCRIPTION
### What
- Specifically in the nutriscore old/new transition guide, the new nutriscore svg file path was incorrectly set, using a translated label in order to retrieve the translated icon: the translated asset svg file might not exist (e.g. in Russian or in Italian).
- The nutriscore is currently supported by a limited set of countries/languages.
- The solution is to use an existing method that computes correctly the new nutriscore svg file according to the language.

### Fixes bug(s)
- Fixes: #6425

### Impacted files
* `app_en.arb`: removed useless and ambiguous label "guide_nutriscore_v2_file_language"
* `guide_nutriscore_v2.dart`: now using bullet-proof method `SvgCache.getAssetsCacheForNutriscore` for nutriscore new (and old) svg