### PR TITLE
fix: Display readable scanner type in debug info instead of object instance

### DIFF
--- a/packages/smooth_app/lib/pages/preferences/user_preferences_dev_debug_info.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_dev_debug_info.dart
@@ -57,7 +57,7 @@ class _UserPreferencesDebugInfoState extends State<UserPreferencesDebugInfo> {
 
     infos.putIfAbsent('Version', () => packageInfo.version);
     infos.putIfAbsent('BuildNumber', () => packageInfo.buildNumber);
-    infos.putIfAbsent('Scanner', () => GlobalVars.barcodeScanner);
+    infos.putIfAbsent('Scanner', () => GlobalVars.barcodeScanner.getType());
     infos.putIfAbsent('Store', () => GlobalVars.storeLabel);
     infos.putIfAbsent('PackageName', () => packageInfo.packageName);
   }


### PR DESCRIPTION
### What
In the app's DEV Mode, when opening "Debugging information" screen, the "Scanner" field displays Instance of `'scannerMLKit'` instead of a readable value.

 Screenshot
|Current behavior|Expected behavior|
|---|---|
| ![Image](https://github.com/user-attachments/assets/4b043047-1727-47ec-a5a8-5f950cce4f54) |  ![Image](https://github.com/user-attachments/assets/26c16509-1122-4e2f-8b05-66c85b232c78) |

### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes: - #6436 

### Part of 
- #6436 
