### PR TITLE
fix: Fixed issue 'DraggableScrollableSheet assertion error' #6441

### DIFF
--- a/packages/smooth_app/lib/pages/product/common/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_page.dart
@@ -17,7 +17,6 @@ import 'package:smooth_app/generic_lib/bottom_sheets/smooth_bottom_sheet.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/duration_constants.dart';
 import 'package:smooth_app/generic_lib/loading_dialog.dart';
-import 'package:smooth_app/generic_lib/widgets/smooth_responsive.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_snackbar.dart';
 import 'package:smooth_app/helpers/app_helper.dart';
 import 'package:smooth_app/helpers/robotoff_insight_helper.dart';
@@ -306,16 +305,6 @@ class _ProductListPageState extends State<ProductListPage>
     );
   }
 
-  double _computeModalInitHeight(BuildContext context) {
-    if (context.isSmallDevice()) {
-      return 0.7;
-    } else if (context.isSmartphoneDevice()) {
-      return 0.55;
-    } else {
-      return 0.45;
-    }
-  }
-
   Widget _buildItem(
     final bool dismissible,
     final List<String> barcodes,
@@ -541,7 +530,6 @@ class _ProductListPageState extends State<ProductListPage>
       bodyBuilder: (BuildContext context) => AllProductListModal(
         currentList: productList,
       ),
-      initHeight: _computeModalInitHeight(context),
     );
 
     if (selected == null) {


### PR DESCRIPTION
### What
This PR fixes an issue where the product list selection modal crashes on small devices due to a constraint violation in the DraggableScrollableSheet.


### Screenshot

| Before | After |
|--|--|
| ![Before](https://github.com/user-attachments/assets/cb3006d0-73e9-42f1-b1f7-4e56982ffb33) | ![After](https://github.com/user-attachments/assets/e56b1718-6adb-4f30-bb03-8223557b4aa9) |

### Changes:

- Removed the `initialHeight` parameter when calling showSmoothDraggableModalSheet
- Removed the `_computeModalInitHeight` function which was calculating heights that could exceed the maximum allowed size on small devices

### Why this approach:
We could have adjusted the values in `_computeModalInitHeight` to ensure they don't exceed the maximum, that approach would still have issues:
- Hardcoding specific height values is fragile and might fail on devices with different screen ratios or sizes we haven't tested
- The default behavior already handles different screen sizes appropriately without manual intervention
- Removing custom height calculation entirely makes the code more robust by relying on Flutter's built-in adaptive layout behavior

### Fixes bug(s)
- Fixes:  #6441 

### Part of 
- #6441 