### PR TITLE
fix: an issue where there was a contradictory instruction in the adding new product screen for English localization only

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -2718,7 +2718,7 @@
   "@add_basic_details_product_name_add_translation": {
     "description": "Button to add a new translation for the product name"
   },
-  "add_basic_details_product_name_warning_translations": "Before validating, please ensure you only add a translation **if the language is not present on the packaging**",
+  "add_basic_details_product_name_warning_translations": "Before validating, please ensure you only add a translation **if the language is present on the packaging**",
   "@add_basic_details_product_name_warning_translations": {
     "description": "Warning message displayed on top of new translations for the product name"
   },


### PR DESCRIPTION
### What
<!-- description of the PR -->
This PR resolves an issue where there was a contradictory instruction in the adding new product screen, namely with the contradictory information revolving around providing translated product names. 
- Changed the English localization string for `add_basic_details_product_name_warning_translations` to remove "not " so that the contradictory instruction is removed. <!-- Changed x to achieve y -->
<!-- 
Please name your pull request following this scheme: `type: What you did` this allows us to automatically generate the changelog
Following `type`s are allowed:
  - `feat`, for Features
  - `fix`, for Bug Fixes
  - `docs`, for Documentation
  - `ci`, for Automation
  - `refactor`, for code Refactoring
  - `chore`, for Miscellaneous things
-->
### Screenshot
<!-- Insert a screenshot to provide visual record of your changes, if visible -->
![Screenshot 1742238731](https://github.com/user-attachments/assets/5f21471d-8003-42f8-b6c2-6cbbadd2225b)
![Screenshot 1742238637](https://github.com/user-attachments/assets/cd16ac37-048a-45f5-b99e-6c058eb1d16a)

### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes: #6454 <!-- #1 Note: you can also use Closes: -->

### Part of 
- #6454 <!-- Add the most granular issue possible -->
