### PR TITLE
docs: Add FVM instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,18 @@ Full list of features on the wiki: https://wiki.openfoodfacts.org/Mobile_App/Fea
 
 - Make sure you have installed flutter and all the requirements
   - [Official flutter installation guide](https://docs.flutter.dev/get-started/install)
+  - **For Freshers: Setting Up Your Environment with FVM**
+  - To manage Flutter versions easily, download and install **FVM (Flutter Version Management)**:
+    - Install FVM by following the [official FVM installation guide](https://fvm.app/documentation/getting-started/installation).
+    - Once FVM is installed, run the following commands to set Flutter to version 3.27.2:
+      ```bash
+      fvm install 3.27.2
+      fvm use 3.27.2
+      ```
+    - Verify the Flutter version with:
+      ```bash
+      fvm flutter --version
+      ```
 - Currently, the app uses the following version of Flutter: **3.27**.
 
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Full list of features on the wiki: https://wiki.openfoodfacts.org/Mobile_App/Fea
 
 - Make sure you have installed flutter and all the requirements
   - [Official flutter installation guide](https://docs.flutter.dev/get-started/install)
-  - **For Freshers: Setting Up Your Environment with FVM**
+  - **Setting Up Your Environment with FVM**
   - To manage Flutter versions easily, download and install **FVM (Flutter Version Management)**:
     - Install FVM by following the [official FVM installation guide](https://fvm.app/documentation/getting-started/installation).
     - Once FVM is installed, run the following commands to set Flutter to version 3.27.2:


### PR DESCRIPTION
### What
- Added FVM setup instructions for freshers under "How to run the project" in the README to simplify setting up Flutter 3.27.2, improving onboarding for new contributors.

### Screenshot
N/A (this is a text-only change to the README)

### Fixes bug(s)
- Fixes: N/A (no specific bug addressed; this is an enhancement)

### Part of 
- #525 (improving contributor experience)
- Part of my GSoC 2025 contribution to enhance developer experience (DevX) by addressing setup challenges for new contributors, as suggested by Malte.