### PR TITLE
fix: Center loading indicator in "My proofs" screen issue

### DIFF
--- a/packages/smooth_app/lib/pages/prices/prices_proofs_page.dart
+++ b/packages/smooth_app/lib/pages/prices/prices_proofs_page.dart
@@ -65,7 +65,7 @@ class _PricesProofsPageState extends State<PricesProofsPage>
           final AsyncSnapshot<MaybeError<GetProofsResult>> snapshot,
         ) {
           if (snapshot.connectionState != ConnectionState.done) {
-            return const CircularProgressIndicator();
+            return const Center(child: CircularProgressIndicator());
           }
           if (snapshot.hasError) {
             return Text(snapshot.error!.toString());


### PR DESCRIPTION
### What
- Fixed alignment of the loading indicator to ensure it appears centred in the “My Proofs” screen.
### Screenshot

| Before | After |
|--------|-------|
| ![Before Screenshot](https://github.com/user-attachments/assets/0401819a-57e8-4ee0-8b53-114f39cd79e7) | ![After Screenshot](https://github.com/user-attachments/assets/35192fce-a40c-4471-b7ab-5ebeb1bd180f) |


### Part of 
- #6423 <!-- Add the most granular issue possible -->
