### PR TITLE
fix: Added dynamic padding to reach Sign Up button and Create Account button with the keyboard open

### DIFF
--- a/packages/smooth_app/lib/pages/user_management/login_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/login_page.dart
@@ -104,9 +104,10 @@ class _LoginPageState extends State<LoginPage> with TraceableClientMixin {
               alignment: Alignment.topCenter,
               width: double.infinity,
               padding: EdgeInsetsDirectional.only(
-                  start: size.width * 0.15,
-                  end: size.width * 0.15,
-                  bottom: MediaQuery.viewInsetsOf(context).bottom * 0.25),
+                start: size.width * 0.15,
+                end: size.width * 0.15,
+                bottom: MediaQuery.viewInsetsOf(context).bottom * 0.25,
+              ),
               child: AutofillGroup(
                 child: Center(
                   child: Column(

--- a/packages/smooth_app/lib/pages/user_management/login_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/login_page.dart
@@ -106,7 +106,7 @@ class _LoginPageState extends State<LoginPage> with TraceableClientMixin {
               padding: EdgeInsetsDirectional.only(
                 start: size.width * 0.15,
                 end: size.width * 0.15,
-                bottom: size.width * 0.05,
+              bottom: MediaQuery.of(context).viewInsets.bottom*0.25,
               ),
               child: AutofillGroup(
                 child: Center(

--- a/packages/smooth_app/lib/pages/user_management/login_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/login_page.dart
@@ -104,10 +104,9 @@ class _LoginPageState extends State<LoginPage> with TraceableClientMixin {
               alignment: Alignment.topCenter,
               width: double.infinity,
               padding: EdgeInsetsDirectional.only(
-                start: size.width * 0.15,
-                end: size.width * 0.15,
-                bottom: MediaQuery.viewInsetsOf(context).bottom * 0.25
-              ),
+                  start: size.width * 0.15,
+                  end: size.width * 0.15,
+                  bottom: MediaQuery.viewInsetsOf(context).bottom * 0.25),
               child: AutofillGroup(
                 child: Center(
                   child: Column(

--- a/packages/smooth_app/lib/pages/user_management/login_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/login_page.dart
@@ -106,7 +106,7 @@ class _LoginPageState extends State<LoginPage> with TraceableClientMixin {
               padding: EdgeInsetsDirectional.only(
                 start: size.width * 0.15,
                 end: size.width * 0.15,
-              bottom: MediaQuery.of(context).viewInsets.bottom*0.25,
+                bottom: MediaQuery.viewInsetsOf(context).bottom * 0.25
               ),
               child: AutofillGroup(
                 child: Center(

--- a/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
@@ -89,9 +89,10 @@ class _SignUpPageState extends State<SignUpPage> with TraceableClientMixin {
           child: Scrollbar(
             child: ListView(
               padding: EdgeInsetsDirectional.only(
-                  start: size.width * 0.05,
-                  end: size.width * 0.05,
-                  bottom: MediaQuery.viewInsetsOf(context).bottom * 0.25),
+                start: size.width * 0.05,
+                end: size.width * 0.05,
+                bottom: MediaQuery.viewInsetsOf(context).bottom * 0.25,
+              ),
               children: <Widget>[
                 SmoothTextFormField(
                   textInputType: TextInputType.name,

--- a/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
@@ -88,7 +88,11 @@ class _SignUpPageState extends State<SignUpPage> with TraceableClientMixin {
           key: _formKey,
           child: Scrollbar(
             child: ListView(
-              padding: EdgeInsets.fromLTRB(size.width * 0.05, 0 , size.width * 0.05 ,MediaQuery.of(context).viewInsets.bottom*0.25),
+              padding: EdgeInsetsDirectional.only(
+                start: size.width * 0.05,
+                end: size.width * 0.05,
+                bottom: MediaQuery.viewInsetsOf(context).bottom * 0.25
+              ),
               children: <Widget>[
                 SmoothTextFormField(
                   textInputType: TextInputType.name,

--- a/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
@@ -89,10 +89,9 @@ class _SignUpPageState extends State<SignUpPage> with TraceableClientMixin {
           child: Scrollbar(
             child: ListView(
               padding: EdgeInsetsDirectional.only(
-                start: size.width * 0.05,
-                end: size.width * 0.05,
-                bottom: MediaQuery.viewInsetsOf(context).bottom * 0.25
-              ),
+                  start: size.width * 0.05,
+                  end: size.width * 0.05,
+                  bottom: MediaQuery.viewInsetsOf(context).bottom * 0.25),
               children: <Widget>[
                 SmoothTextFormField(
                   textInputType: TextInputType.name,

--- a/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
@@ -88,7 +88,7 @@ class _SignUpPageState extends State<SignUpPage> with TraceableClientMixin {
           key: _formKey,
           child: Scrollbar(
             child: ListView(
-              padding: EdgeInsets.symmetric(horizontal: size.width * 0.05),
+              padding: EdgeInsets.fromLTRB(size.width * 0.05, 0 , size.width * 0.05 ,MediaQuery.of(context).viewInsets.bottom*0.25),
               children: <Widget>[
                 SmoothTextFormField(
                   textInputType: TextInputType.name,


### PR DESCRIPTION
### What
<!-- description of the PR -->
- Added dynamic padding in relation to the keyboard height to ensure it only affects the UI when the keyboard is open and the buttons are reachable <!-- Changed x to achieve y -->
<!-- 
Please name your pull request following this scheme: `type: What you did` this allows us to automatically generate the changelog
Following `type`s are allowed:
  - `feat`, for Features
  - `fix`, for Bug Fixes
  - `docs`, for Documentation
  - `ci`, for Automation
  - `refactor`, for code Refactoring
  - `chore`, for Miscellaneous things
-->
### Screenshot
<!-- Insert a screenshot to provide visual record of your changes, if visible -->
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/59a05fb8-6d8c-4224-9092-ccdff1c1991b" width="400"></td>
    <td><img src="https://github.com/user-attachments/assets/5ad9a5cc-ebf6-4ea9-9819-c3d71b0d520f" width="400"></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/ed2d5b93-4767-46bb-bc57-77473464ed83" width="400"></td>
    <td><img src="https://github.com/user-attachments/assets/8441ebf3-10d9-43b4-bcca-fb80a5c5bc2d" width="400"></td>
  </tr>
</table>

### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes: #5877<!-- #1 Note: you can also use Closes: -->

### Part of 
- #5877 <!-- Add the most granular issue possible -->

