### PR TITLE
feat: 4679 - added a way to edit traces

### DIFF
--- a/packages/smooth_app/lib/background/background_task_details.dart
+++ b/packages/smooth_app/lib/background/background_task_details.dart
@@ -26,6 +26,7 @@ enum BackgroundTaskDetailsStamp {
   embCodes('emb_codes'),
   labels('labels'),
   categories('categories'),
+  traces('traces'),
   countries('countries');
 
   const BackgroundTaskDetailsStamp(this.tag);
@@ -68,8 +69,7 @@ class BackgroundTaskDetails extends BackgroundTaskBarcode
       localDatabase.upToDate.addChange(uniqueId, getProductChange());
 
   /// Adds the background task about changing a product.
-  static Future<void> addTask(
-    final Product minimalistProduct, {
+  static Future<void> addTask(final Product minimalistProduct, {
     required final BuildContext context,
     required final BackgroundTaskDetailsStamp stamp,
     final bool showSnackBar = true,
@@ -99,16 +99,14 @@ class BackgroundTaskDetails extends BackgroundTaskBarcode
 
   @override
   (String, AlignmentGeometry)? getFloatingMessage(
-          final AppLocalizations appLocalizations) =>
+      final AppLocalizations appLocalizations) =>
       null;
 
   /// Returns a new background task about changing a product.
-  static BackgroundTaskDetails _getNewTask(
-    final Product minimalistProduct,
-    final String uniqueId,
-    final BackgroundTaskDetailsStamp stamp,
-    final ProductType productType,
-  ) =>
+  static BackgroundTaskDetails _getNewTask(final Product minimalistProduct,
+      final String uniqueId,
+      final BackgroundTaskDetailsStamp stamp,
+      final ProductType productType,) =>
       BackgroundTaskDetails._(
         uniqueId: uniqueId,
         processName: _operationType.processName,
@@ -124,7 +122,7 @@ class BackgroundTaskDetails extends BackgroundTaskBarcode
   @override
   Product getProductChange() {
     final Product result =
-        Product.fromJson(json.decode(inputMap) as Map<String, dynamic>);
+    Product.fromJson(json.decode(inputMap) as Map<String, dynamic>);
     return result;
   }
 
@@ -138,7 +136,7 @@ class BackgroundTaskDetails extends BackgroundTaskBarcode
       // For the moment, some fields can only be saved in V3,
       // and V3 can only save those fields.
       final ProductResultV3 result =
-          await OpenFoodAPIClient.temporarySaveProductV3(
+      await OpenFoodAPIClient.temporarySaveProductV3(
         getUser(),
         product.barcode!,
         packagings: product.packagings,
@@ -159,8 +157,10 @@ class BackgroundTaskDetails extends BackgroundTaskBarcode
         }
         throw Exception(
           'Could not save product - API V3'
-          ' - '
-          'status=${result.status} - errors=${result.errors} ${isInvalidUser ? _getIncompleteUserData() : ''}',
+              ' - '
+              'status=${result.status} - errors=${result.errors} ${isInvalidUser
+              ? _getIncompleteUserData()
+              : ''}',
         );
       }
       return;
@@ -181,10 +181,10 @@ class BackgroundTaskDetails extends BackgroundTaskBarcode
       }
       throw Exception(
         'Could not save product - API V2'
-        ' - status=${status.status}'
-        ' - errors=${status.error}'
-        ' - status_verbose=${status.statusVerbose}'
-        ' ${isInvalidUser ? _getIncompleteUserData() : ''}',
+            ' - status=${status.status}'
+            ' - errors=${status.error}'
+            ' - status_verbose=${status.statusVerbose}'
+            ' ${isInvalidUser ? _getIncompleteUserData() : ''}',
       );
     }
   }

--- a/packages/smooth_app/lib/background/background_task_details.dart
+++ b/packages/smooth_app/lib/background/background_task_details.dart
@@ -69,7 +69,8 @@ class BackgroundTaskDetails extends BackgroundTaskBarcode
       localDatabase.upToDate.addChange(uniqueId, getProductChange());
 
   /// Adds the background task about changing a product.
-  static Future<void> addTask(final Product minimalistProduct, {
+  static Future<void> addTask(
+    final Product minimalistProduct, {
     required final BuildContext context,
     required final BackgroundTaskDetailsStamp stamp,
     final bool showSnackBar = true,
@@ -99,14 +100,16 @@ class BackgroundTaskDetails extends BackgroundTaskBarcode
 
   @override
   (String, AlignmentGeometry)? getFloatingMessage(
-      final AppLocalizations appLocalizations) =>
+          final AppLocalizations appLocalizations) =>
       null;
 
   /// Returns a new background task about changing a product.
-  static BackgroundTaskDetails _getNewTask(final Product minimalistProduct,
-      final String uniqueId,
-      final BackgroundTaskDetailsStamp stamp,
-      final ProductType productType,) =>
+  static BackgroundTaskDetails _getNewTask(
+    final Product minimalistProduct,
+    final String uniqueId,
+    final BackgroundTaskDetailsStamp stamp,
+    final ProductType productType,
+  ) =>
       BackgroundTaskDetails._(
         uniqueId: uniqueId,
         processName: _operationType.processName,
@@ -122,7 +125,7 @@ class BackgroundTaskDetails extends BackgroundTaskBarcode
   @override
   Product getProductChange() {
     final Product result =
-    Product.fromJson(json.decode(inputMap) as Map<String, dynamic>);
+        Product.fromJson(json.decode(inputMap) as Map<String, dynamic>);
     return result;
   }
 
@@ -136,7 +139,7 @@ class BackgroundTaskDetails extends BackgroundTaskBarcode
       // For the moment, some fields can only be saved in V3,
       // and V3 can only save those fields.
       final ProductResultV3 result =
-      await OpenFoodAPIClient.temporarySaveProductV3(
+          await OpenFoodAPIClient.temporarySaveProductV3(
         getUser(),
         product.barcode!,
         packagings: product.packagings,
@@ -157,10 +160,8 @@ class BackgroundTaskDetails extends BackgroundTaskBarcode
         }
         throw Exception(
           'Could not save product - API V3'
-              ' - '
-              'status=${result.status} - errors=${result.errors} ${isInvalidUser
-              ? _getIncompleteUserData()
-              : ''}',
+          ' - '
+          'status=${result.status} - errors=${result.errors} ${isInvalidUser ? _getIncompleteUserData() : ''}',
         );
       }
       return;
@@ -181,10 +182,10 @@ class BackgroundTaskDetails extends BackgroundTaskBarcode
       }
       throw Exception(
         'Could not save product - API V2'
-            ' - status=${status.status}'
-            ' - errors=${status.error}'
-            ' - status_verbose=${status.statusVerbose}'
-            ' ${isInvalidUser ? _getIncompleteUserData() : ''}',
+        ' - status=${status.status}'
+        ' - errors=${status.error}'
+        ' - status_verbose=${status.statusVerbose}'
+        ' ${isInvalidUser ? _getIncompleteUserData() : ''}',
       );
     }
   }

--- a/packages/smooth_app/lib/data_models/up_to_date_changes.dart
+++ b/packages/smooth_app/lib/data_models/up_to_date_changes.dart
@@ -113,6 +113,12 @@ class UpToDateChanges {
     if (change.categoriesTagsInLanguages != null) {
       initial.categoriesTagsInLanguages = change.categoriesTagsInLanguages;
     }
+    if (change.traces != null) {
+      initial.traces = change.traces;
+    }
+    if (change.tracesTagsInLanguages != null) {
+      initial.tracesTagsInLanguages = change.tracesTagsInLanguages;
+    }
     if (change.countries != null) {
       initial.countries = change.countries;
     }

--- a/packages/smooth_app/lib/helpers/analytics_helper.dart
+++ b/packages/smooth_app/lib/helpers/analytics_helper.dart
@@ -190,6 +190,7 @@ enum AnalyticsEditEvents {
   powerEditScreen(name: 'Power Edit Screen'),
   ingredients_and_Origins(name: 'Ingredient And Origins'),
   categories(name: 'Categories'),
+  traces(name: 'Traces'),
   nutrition_Facts(name: 'Nutrition Facts'),
   labelsAndCertifications(name: 'Labels And Certifications'),
   packagingComponents(name: 'Packaging Components'),

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -770,6 +770,7 @@
   "score_add_missing_ingredients": "Add missing ingredients",
   "score_add_missing_packaging_image": "Add missing packaging image",
   "score_add_missing_nutrition_facts": "Add missing nutrition facts",
+  "score_add_missing_product_traces": "Add missing product traces",
   "score_add_missing_product_category": "Select a category",
   "score_add_missing_product_countries": "Add missing product countries",
   "score_add_missing_product_emb": "Add missing product traceability codes",
@@ -1600,6 +1601,10 @@
   "@edit_product_form_item_add_action_category": {
     "description": "Tooltip to show when the user long presses the (+) button on a category"
   },
+  "edit_product_form_item_add_action_trace": "Add a new trace",
+  "@edit_product_form_item_add_action_trace": {
+    "description": "Tooltip to show when the user long presses the (+) button on a trace"
+  },
   "edit_product_form_item_add_suggestion": "Add suggestion",
   "@edit_product_form_item_add_suggestion": {
     "description": "Tooltip to show when the user long presses the (+) button on a suggestion"
@@ -1795,6 +1800,18 @@
   "edit_product_form_item_emb_help_info2_item2_explanation": "EMB 72264",
   "@edit_product_form_item_emb_help_info2_item2_explanation": {
     "description": "Example of an EMB code"
+  },
+  "edit_product_form_item_traces_title": "Traces",
+  "@edit_product_form_item_traces_title": {
+    "description": "Product edition - Traces - Title"
+  },
+  "edit_product_form_item_traces_hint": "trace",
+  "@edit_product_form_item_traces_hint": {
+    "description": "Product edition - Traces - input textfield hint"
+  },
+  "edit_product_form_item_traces_type": "Input a trace (eg: Soy beans)",
+  "@edit_product_form_item_traces_type": {
+    "description": "Product edition - Traces - input textfield type"
   },
   "edit_product_form_item_categories_title": "Categories",
   "@edit_product_form_item_categories_title": {
@@ -2615,7 +2632,7 @@
     "description": "Community challenges of open prices"
   },
   "prices_multiple_proof_addition_system": "Add Multiple Proofs",
-  "@prices_multiple_proof_addition_system":{
+  "@prices_multiple_proof_addition_system": {
     "description": "Upload multiple proofs"
   },
   "all_search_prices_top_location_single_title": "Prices in a store",

--- a/packages/smooth_app/lib/pages/product/edit_product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product/edit_product_page.dart
@@ -20,6 +20,7 @@ import 'package:smooth_app/pages/product/gallery_view/product_image_gallery_view
 import 'package:smooth_app/pages/product/nutrition_page/nutrition_page_loader.dart';
 import 'package:smooth_app/pages/product/product_field_editor.dart';
 import 'package:smooth_app/pages/product/product_page/footer/new_product_footer.dart';
+import 'package:smooth_app/pages/product/simple_input/simple_input_page_trace_helper.dart';
 import 'package:smooth_app/pages/product/simple_input_page.dart';
 import 'package:smooth_app/pages/product/simple_input_page_helpers.dart';
 import 'package:smooth_app/resources/app_icons.dart' as icons;
@@ -150,6 +151,8 @@ class _EditProductPageState extends State<EditProductPage> with UpToDateMixin {
                     product: upToDateProduct,
                   ),
                 ),
+              if (upToDateProduct.productType != ProductType.product)
+                _getSimpleListTileItem(SimpleInputPageTraceHelper()),
               if (upToDateProduct.productType == null ||
                   upToDateProduct.productType == ProductType.food)
                 _getSimpleListTileItem(SimpleInputPageCategoryHelper())

--- a/packages/smooth_app/lib/pages/product/simple_input/simple_input_page_trace_helper.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input/simple_input_page_trace_helper.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';

--- a/packages/smooth_app/lib/pages/product/simple_input/simple_input_page_trace_helper.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input/simple_input_page_trace_helper.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/background/background_task_details.dart';
+import 'package:smooth_app/helpers/analytics_helper.dart';
+import 'package:smooth_app/pages/product/simple_input_page_helpers.dart';
+import 'package:smooth_app/query/product_query.dart';
+
+/// Implementation for "Traces" of an [AbstractSimpleInputPageHelper].
+class SimpleInputPageTraceHelper extends AbstractSimpleInputPageHelper {
+  @override
+  bool isOwnerField(final Product product) =>
+      product.getOwnerFieldTimestamp(
+        OwnerField.productField(
+          ProductField.TRACES,
+          ProductQuery.getLanguage(),
+        ),
+      ) !=
+      null;
+
+  @override
+  List<String> initTerms(final Product product) =>
+      product.tracesTagsInLanguages?[getLanguage()] ?? <String>[];
+
+  @override
+  void changeProduct(final Product changedProduct) {
+    // for the local change
+    changedProduct.tracesTagsInLanguages =
+        <OpenFoodFactsLanguage, List<String>>{getLanguage(): terms};
+    // for the server - write-only
+    changedProduct.traces = terms.join(separator);
+  }
+
+  @override
+  String getTitle(final AppLocalizations appLocalizations) =>
+      appLocalizations.edit_product_form_item_traces_title;
+
+  @override
+  String getAddButtonLabel(final AppLocalizations appLocalizations) =>
+      appLocalizations.score_add_missing_product_traces;
+
+  @override
+  String? getAddExplanationsTitle(AppLocalizations appLocalizations) => null;
+
+  @override
+  WidgetBuilder? getAddExplanationsContent() => null;
+
+  @override
+  String getAddHint(final AppLocalizations appLocalizations) =>
+      appLocalizations.edit_product_form_item_traces_hint;
+
+  @override
+  String getAddTooltip(AppLocalizations appLocalizations) =>
+      appLocalizations.edit_product_form_item_add_action_trace;
+
+  @override
+  TextCapitalization? getTextCapitalization() => TextCapitalization.sentences;
+
+  @override
+  String getTypeLabel(AppLocalizations appLocalizations) =>
+      appLocalizations.edit_product_form_item_traces_type;
+
+  @override
+  TagType? getTagType() => TagType.TRACES;
+
+  @override
+  Widget getIcon() => const Icon(Icons.photo_size_select_small_sharp);
+
+  @override
+  BackgroundTaskDetailsStamp getStamp() => BackgroundTaskDetailsStamp.traces;
+
+  @override
+  AnalyticsEditEvents getAnalyticsEditEvent() => AnalyticsEditEvents.traces;
+}

--- a/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart
@@ -16,6 +16,7 @@ import 'package:smooth_app/resources/app_icons.dart' as icons;
 import 'package:smooth_app/themes/theme_provider.dart';
 import 'package:smooth_app/widgets/smooth_explanation_banner.dart';
 
+// TODO(monsieurtanuki): split in different files, that one is too big.
 /// Abstract helper for Simple Input Page.
 ///
 /// * we retrieve the initial list of terms.

--- a/packages/smooth_app/lib/query/product_query.dart
+++ b/packages/smooth_app/lib/query/product_query.dart
@@ -307,5 +307,8 @@ abstract class ProductQuery {
         ProductField.OBSOLETE,
         ProductField.OWNER_FIELDS,
         ProductField.OWNER,
+        ProductField.TRACES,
+        ProductField.TRACES_TAGS,
+        ProductField.TRACES_TAGS_IN_LANGUAGES,
       ];
 }

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -1121,10 +1121,10 @@ packages:
     dependency: "direct main"
     description:
       name: openfoodfacts
-      sha256: af1f9f9a3112aa88a63602bde72a0dde799bfd0cb58b1b60beef2cf75b4b159e
+      sha256: "9076b266ff5c2d60ea875ae5649a2df7e29e7f97e3e05f55bf654196530327c2"
       url: "https://pub.dev"
     source: hosted
-    version: "3.20.0"
+    version: "3.21.0"
   openfoodfacts_flutter_lints:
     dependency: "direct dev"
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -100,7 +100,7 @@ dependencies:
     path: ../scanner/zxing
 
 
-  openfoodfacts: 3.20.0
+  openfoodfacts: 3.21.0
   # openfoodfacts:
   #   path: ../../../openfoodfacts-dart
 


### PR DESCRIPTION
### What
- This PR adds the "edit traces" feature.
- The feature is introduced as a "simple page helper", like categories
  - compliant with "owner" field icon when relevant
  - label suggestions

### Screenshot
| edit product | "owner" icon when relevant |
| -- | -- |
| ![Screenshot_1743265551](https://github.com/user-attachments/assets/418ab820-e7b2-4ad4-bcde-7e692e2f0f7a) | ![Screenshot_1743265536](https://github.com/user-attachments/assets/03305337-7382-4d2e-bcff-f944e10e0893) |

| edit trace page| label suggestion |
| -- | -- |
| ![Screenshot_1743265588](https://github.com/user-attachments/assets/2ed6deed-1183-414f-a5dc-4565fd0e643d) | ![Screenshot_1743265598](https://github.com/user-attachments/assets/0fc9d405-2076-4f7f-82d6-a651a73e7020) |

(please ignore the "more" icon on the last screenshot as it's a side-effect of my stupid Android emulator).

### Part of 
- #4679

### Files
New file:
* `simple_input_page_trace_helper.dart`: Implementation for "Traces" of an AbstractSimpleInputPageHelper.

Impacted files:
* `analytics_helper.dart`: added an entry for "traces"
* `app_en.arb`: added labels for "traces"
* `background_task_details.dart`: added an entry for "traces"
* `edit_product_page.dart`: added a button for "traces"
* `product_query.dart`: added entries for "traces"
* `pubspec.lock`: wtf
* `pubspec.yaml`: upgraded to off-dart 3.21.0, where we can edit traces
* `simple_input_page_helpers.dart`: added a warning "TODO" about the file being too big
* `up_to_date_changes.dart`: added an entry for "traces"