### PR TITLE
fix: language filter to include English names

### DIFF
--- a/packages/smooth_app/lib/pages/preferences/language_selector/language_selector.dart
+++ b/packages/smooth_app/lib/pages/preferences/language_selector/language_selector.dart
@@ -283,6 +283,9 @@ class _LanguageSelectorScreen extends StatelessWidget {
           language == selectedLanguage ||
           Languages().getNameInLanguage(language).toLowerCase().contains(
                 filter.toLowerCase(),
+              ) ||
+          Languages().getNameInEnglish(language).toLowerCase().contains(
+                filter.toLowerCase(),
               ),
     );
   }


### PR DESCRIPTION
### What
fix: language filter to include English names

### Fixes bug(s)
- Fixes: Changed the function to include the English languages as well

### Part of 
- #6491 Partial filter on language selector
