### PR TITLE
feat: Credential/Password sharing for android and website

### DIFF
--- a/packages/smooth_app/android/app/src/main/AndroidManifest.xml
+++ b/packages/smooth_app/android/app/src/main/AndroidManifest.xml
@@ -41,9 +41,7 @@
                     android:name="io.flutter.embedding.android.NormalTheme"
                     android:resource="@style/NormalTheme"
             />
-            <meta-data 
-                android:name="asset_statements" 
-                android:resource="@string/asset_statements"/>
+            
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
@@ -563,6 +561,10 @@
                 <data android:scheme="https" />
             </intent-filter>
         </activity>
+
+        <meta-data 
+                android:name="asset_statements" 
+                android:resource="@string/asset_statements"/>
 
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/packages/smooth_app/android/app/src/main/AndroidManifest.xml
+++ b/packages/smooth_app/android/app/src/main/AndroidManifest.xml
@@ -41,6 +41,9 @@
                     android:name="io.flutter.embedding.android.NormalTheme"
                     android:resource="@style/NormalTheme"
             />
+            <meta-data 
+                android:name="asset_statements" 
+                android:resource="@string/asset_statements"/>
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/packages/smooth_app/android/app/src/main/res/values/strings.xml
+++ b/packages/smooth_app/android/app/src/main/res/values/strings.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">OpenFoodFacts</string>
-
+    <string name="asset_statements" translatable="false">
+    [{
+        \"include\": \"https://world.openfoodfacts.org/.well-known/assetlinks.json\"
+    }]
+    </string>
 </resources>

--- a/packages/smooth_app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/smooth_app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,7 @@
 import FlutterMacOS
 import Foundation
 
+import app_settings
 import audioplayers_darwin
 import connectivity_plus
 import device_info_plus
@@ -24,6 +25,7 @@ import url_launcher_macos
 import webview_flutter_wkwebview
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  AppSettingsPlugin.register(with: registry.registrar(forPlugin: "AppSettingsPlugin"))
   AudioplayersDarwinPlugin.register(with: registry.registrar(forPlugin: "AudioplayersDarwinPlugin"))
   ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))

--- a/packages/smooth_app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/smooth_app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,7 +5,6 @@
 import FlutterMacOS
 import Foundation
 
-import app_settings
 import audioplayers_darwin
 import connectivity_plus
 import device_info_plus
@@ -25,7 +24,6 @@ import url_launcher_macos
 import webview_flutter_wkwebview
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
-  AppSettingsPlugin.register(with: registry.registrar(forPlugin: "AppSettingsPlugin"))
   AudioplayersDarwinPlugin.register(with: registry.registrar(forPlugin: "AudioplayersDarwinPlugin"))
   ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))


### PR DESCRIPTION
### What
- Through this PR, the user is now able to share his credentials between the app and website.
-  Thing to note is that, the pop-up will appear only if the account in which the credential is stored, is present in both the phone and computer.

### Screenshot
<!-- Insert a screenshot to provide visual record of your changes, if visible -->
In Website
![Screenshot 2025-03-31 093037](https://github.com/user-attachments/assets/d89ee337-79a4-47a8-b9e5-cdc388ea739f)
![Screenshot 2025-03-31 093048](https://github.com/user-attachments/assets/c10ca95a-06a9-4718-9be1-d63de5832c56)

In App
<img src=https://github.com/user-attachments/assets/42ab3c2a-d949-4238-9168-72a0916f092d width="200"> <img src=https://github.com/user-attachments/assets/1ae1897a-7682-4198-9e57-bc1b89cbb938 width="200">


### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes: https://github.com/openfoodfacts/smooth-app/issues/6416

### Part of 
- #525 <!-- Add the most granular issue possible -->
