### PR TITLE
fix: adjust padding logic in product image gallery layout

### DIFF
--- a/packages/smooth_app/lib/pages/image/product_image_gallery_other_view.dart
+++ b/packages/smooth_app/lib/pages/image/product_image_gallery_other_view.dart
@@ -133,7 +133,7 @@ class _RawGridGallery extends StatelessWidget {
           return Padding(
             padding: EdgeInsetsDirectional.only(
               start: VERY_SMALL_SPACE,
-              end: index % _columns == 0 ? VERY_SMALL_SPACE : 0.0,
+              end: (index - 1) % _columns == 0 ? VERY_SMALL_SPACE : 0.0,
               bottom: VERY_SMALL_SPACE,
             ),
             child: Stack(


### PR DESCRIPTION
### What

- Fixed spacing inconsistencies by changing the padding logic in the product gallery page, other photos section

### Screenshot
<!-- Insert a screenshot to provide visual record of your changes, if visible -->
![Screenshot_2025-04-03-17-21-26-05_1d77bc0953a7db61673d4bea4cd4be8a](https://github.com/user-attachments/assets/25d5a979-3d1e-445f-a297-62d81e77a0a2)

### Fixes bug(s)
- Fixes:  #6489 

