### PR TITLE
feat: github action pinning with Ratchet

### DIFF
--- a/.github/workflows/android-release-to-org-openfoodfacts-scanner.yml
+++ b/.github/workflows/android-release-to-org-openfoodfacts-scanner.yml
@@ -48,28 +48,28 @@ on:
         required: true
       SIGN_KEY_PASSWORD:
         required: true
-  
+
 env:
   JAVA_VERSION: 21
   RUBY_VERSION: 3.2.0
-    
+
 jobs:
   deploy_android:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
 
       - run: echo Release type ${{ inputs.RELEASE_TYPE }} + Build type ${{ inputs.BUILD_TYPE }} + Tag name null if not github release ${{ inputs.TAG_NAME }}
 
       - name: Setup Java JDK
-        uses: actions/setup-java@v4.7.1
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # ratchet:actions/setup-java@v4.7.1
         with:
           distribution: 'zulu'
           java-version: ${{ env.JAVA_VERSION }}
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@e5ac7b085f6e63d49c8973eb0c6e04d876b881f1 # ratchet:ruby/setup-ruby@v1
         with:
           bundler-cache: true
           ruby-version: ${{ env.RUBY_VERSION }}
@@ -90,14 +90,14 @@ jobs:
         id: flutter-version
 
       - name: Setup Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@e938fdf56512cc96ef2f93601a5a40bde3801046 # ratchet:subosito/flutter-action@v2
         with:
           #channel: stable
           cache: true
           flutter-version: ${{ steps.flutter-version.outputs.FLUTTER_VERSION }}
           cache-key: flutter-${{ hashFiles('flutter-version.txt')}}-${{ hashFiles('packages\smooth_app\pubspec.lock')}}
 
-      - name: Flutter version    
+      - name: Flutter version
         run: flutter --version
 
       - name: Enable correct scanner dependency
@@ -112,7 +112,7 @@ jobs:
       # We are using the android version code here to have the version codes from iOS and android in sync 
       # in order for Sentry and other tools to work properly
       - name: Bump version
-        uses: maierj/fastlane-action@v3.1.0
+        uses: maierj/fastlane-action@5a3b971aaa26776459bb26894d6c1a1a84a311a7 # ratchet:maierj/fastlane-action@v3.1.0
         with:
           lane: setVersion
           subdirectory: ./packages/smooth_app/android/
@@ -123,13 +123,13 @@ jobs:
       - name: Build app
         run: echo $SIGN_STORE_PATH && pwd && cd ./packages/smooth_app/ && pwd && flutter build ${{ inputs.BUILD_TYPE }} --release -t lib/entrypoints/android/${{ inputs.FLAVOR }}.dart --target-platform android-arm,android-arm64
         env:
-         SIGN_STORE_PATH: ./../fastlane/envfiles/keystore.jks
-         SIGN_STORE_PASSWORD: ${{ secrets.SIGN_STORE_PASSWORD }}
-         SIGN_KEY_ALIAS: ${{ secrets.SIGN_KEY_ALIAS }}
-         SIGN_KEY_PASSWORD: ${{ secrets.SIGN_KEY_PASSWORD }}
+          SIGN_STORE_PATH: ./../fastlane/envfiles/keystore.jks
+          SIGN_STORE_PASSWORD: ${{ secrets.SIGN_STORE_PASSWORD }}
+          SIGN_KEY_ALIAS: ${{ secrets.SIGN_KEY_ALIAS }}
+          SIGN_KEY_PASSWORD: ${{ secrets.SIGN_KEY_PASSWORD }}
 
       - name: Upload binaries to release
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@04733e069f2d7f7f0b4aebc4fbdbce8613b03ccd # ratchet:svenstaro/upload-release-action@v2
         if: inputs.RELEASE_TYPE == 'GITHUB' && inputs.BUILD_TYPE == 'apk' && inputs.TAG_NAME != ''
         continue-on-error: true
         with:
@@ -139,13 +139,13 @@ jobs:
           overwrite: true
 
       - name: Release AAB
-        uses: maierj/fastlane-action@v3.1.0
+        uses: maierj/fastlane-action@5a3b971aaa26776459bb26894d6c1a1a84a311a7 # ratchet:maierj/fastlane-action@v3.1.0
         if: inputs.RELEASE_TYPE == 'PLAY' && inputs.BUILD_TYPE == 'appbundle'
         with:
           lane: release
           subdirectory: ./packages/smooth_app/android/
         env:
-         SIGN_STORE_PATH: ./../fastlane/envfiles/keystore.jks
-         SIGN_STORE_PASSWORD: ${{ secrets.SIGN_STORE_PASSWORD }}
-         SIGN_KEY_ALIAS: ${{ secrets.SIGN_KEY_ALIAS }}
-         SIGN_KEY_PASSWORD: ${{ secrets.SIGN_KEY_PASSWORD }}
+          SIGN_STORE_PATH: ./../fastlane/envfiles/keystore.jks
+          SIGN_STORE_PASSWORD: ${{ secrets.SIGN_STORE_PASSWORD }}
+          SIGN_KEY_ALIAS: ${{ secrets.SIGN_KEY_ALIAS }}
+          SIGN_KEY_PASSWORD: ${{ secrets.SIGN_KEY_PASSWORD }}

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -4,7 +4,7 @@ name: 'Auto-Assign Author to Pull Requests'
 on:
   pull_request_target:
     types: [opened, reopened]
-    
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -16,5 +16,5 @@ jobs:
   assign-author:
     runs-on: ubuntu-latest
     steps:
-      - uses: toshimaru/auto-author-assign@v2.1.1
-  
+      - uses: toshimaru/auto-author-assign@16f0022cf3d7970c106d8d1105f75a1165edb516 # ratchet:toshimaru/auto-author-assign@v2.1.1
+

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -2,75 +2,75 @@ name: Crowdin Action
 
 on:
   push:
-    branches: [ crowdin-trigger ]
+    branches: [crowdin-trigger]
 jobs:
   synchronize-with-crowdin:
     runs-on: ubuntu-latest
 
     steps:
 
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
 
-    - name: crowdin action
-      uses: crowdin/github-action@v2.7.0
-      continue-on-error: true
-      with:
-        # Upload sources to Crowdin
-        upload_sources: true
-        # Upload translations to Crowdin
-        upload_translations: false #default false
-        # Use this option to upload translations for a single specified language
-        upload_language: en
-        # Automatically approves uploaded translations
-        auto_approve_imported: true
-        # Defines whether to add translation if it is equal to source string in Crowdin project
-        import_eq_suggestions: true
-        # download translation options
-        download_translations: true
-        # Use this option to download translations for a single specified language
-        # download_language: # optional
-        # Skip untranslated strings in exported files (does not work with .docx, .html, .md and other document files)
-        skip_untranslated_strings: false
-        # Omit downloading not fully downloaded files
-        skip_untranslated_files: false
-        # Include approved translations only in exported files. If not combined with --skip-untranslated-strings option, strings without approval are fulfilled with the source language
-        # export_only_approved: # default is false
-        # Download translations with pushing to branch
-        push_translations: true
-        # Commit message for download translations
-        commit_message: "chore: New Crowdin translations"
-        # To download translations to the specified version branch
-        localization_branch_name: l10n_develop
-        # Make pull request of Crowdin translations
-        # Create pull request after pushing to branch
-        create_pull_request: true
-        # The title of the new pull request
-        pull_request_title: "chore: New Crowdin translations to review and merge"
-        # The contents of the pull request
-        pull_request_body: '### What\n- Automated pull request pulling in new or updated translations from Crowdin (https://translate.openfoodfacts.org).\n## Checklist\n- [ ] Check that they are no bad translations. If there are, correct them directly in Crowdin so that they are not resynced again. Then you can correct them here as well, or wait 24 hours for the sync to happen automatically.\n- [ ] Put extra attention on Acholi, which is used mistakenly as a sandbox by people discovering the self-service translation button on Open Food Facts\n- [ ] Once you are happy, that automated checks pass, you can approve the PR and merge it.\n### Part of\n- Translations'
-        # To add labels for created pull request
-        pull_request_labels: "translations"
-        # Create pull request to specified branch instead of default one
-        pull_request_base_branch_name: develop
-        # global options
-        # Option to upload or download files to the specified version branch in your Crowdin project
-        # crowdin_branch_name: # optional
-        # Option to specify a path to user-specific credentials, without / at the beginning
-        # identity: # optional
-        # Option to specify a path to the configuration file, without / at the beginning
-        # config: # optional
-        # Option to preview the list of managed files
-        # dryrun_action: # default is false
-        # Numerical ID of the project
-        # project_id: # optional
-        # Personal access token required for authentication
-        # token: # optional
-        # Base URL of Crowdin server for API requests execution
-        #base_url: 'https://crowdin.com'
-        # Path to your project directory on a local machine
-        #base_path: '/openfoodfacts'
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
-        CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+      - name: crowdin action
+        uses: crowdin/github-action@b8012bd5491b8aa8578b73ab5b5f5e7c94aaa6e2 # ratchet:crowdin/github-action@v2.7.0
+        continue-on-error: true
+        with:
+          # Upload sources to Crowdin
+          upload_sources: true
+          # Upload translations to Crowdin
+          upload_translations: false #default false
+          # Use this option to upload translations for a single specified language
+          upload_language: en
+          # Automatically approves uploaded translations
+          auto_approve_imported: true
+          # Defines whether to add translation if it is equal to source string in Crowdin project
+          import_eq_suggestions: true
+          # download translation options
+          download_translations: true
+          # Use this option to download translations for a single specified language
+          # download_language: # optional
+          # Skip untranslated strings in exported files (does not work with .docx, .html, .md and other document files)
+          skip_untranslated_strings: false
+          # Omit downloading not fully downloaded files
+          skip_untranslated_files: false
+          # Include approved translations only in exported files. If not combined with --skip-untranslated-strings option, strings without approval are fulfilled with the source language
+          # export_only_approved: # default is false
+          # Download translations with pushing to branch
+          push_translations: true
+          # Commit message for download translations
+          commit_message: "chore: New Crowdin translations"
+          # To download translations to the specified version branch
+          localization_branch_name: l10n_develop
+          # Make pull request of Crowdin translations
+          # Create pull request after pushing to branch
+          create_pull_request: true
+          # The title of the new pull request
+          pull_request_title: "chore: New Crowdin translations to review and merge"
+          # The contents of the pull request
+          pull_request_body: '### What\n- Automated pull request pulling in new or updated translations from Crowdin (https://translate.openfoodfacts.org).\n## Checklist\n- [ ] Check that they are no bad translations. If there are, correct them directly in Crowdin so that they are not resynced again. Then you can correct them here as well, or wait 24 hours for the sync to happen automatically.\n- [ ] Put extra attention on Acholi, which is used mistakenly as a sandbox by people discovering the self-service translation button on Open Food Facts\n- [ ] Once you are happy, that automated checks pass, you can approve the PR and merge it.\n### Part of\n- Translations'
+          # To add labels for created pull request
+          pull_request_labels: "translations"
+          # Create pull request to specified branch instead of default one
+          pull_request_base_branch_name: develop
+          # global options
+          # Option to upload or download files to the specified version branch in your Crowdin project
+          # crowdin_branch_name: # optional
+          # Option to specify a path to user-specific credentials, without / at the beginning
+          # identity: # optional
+          # Option to specify a path to the configuration file, without / at the beginning
+          # config: # optional
+          # Option to preview the list of managed files
+          # dryrun_action: # default is false
+          # Numerical ID of the project
+          # project_id: # optional
+          # Personal access token required for authentication
+          # token: # optional
+          # Base URL of Crowdin server for API requests execution
+          #base_url: 'https://crowdin.com'
+          # Path to your project directory on a local machine
+          #base_path: '/openfoodfacts'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/.github/workflows/dartdoc.yml
+++ b/.github/workflows/dartdoc.yml
@@ -1,36 +1,36 @@
-    name: GitHub Pages Deploy Action	
-    on:	
-        push:	
-            branches:	
-               - "develop"	
-               #- "dartdoc-smoothie"	
-    jobs:	
-        deploy-pages:	
-            name: Deploy to GitHub Pages	
-            runs-on: ubuntu-latest	
-            defaults:	
-              run:	
-                working-directory: ./packages/smooth_app	
-            steps:	
+name: GitHub Pages Deploy Action
+on:
+  push:
+    branches:
+      - "develop"
+      #- "dartdoc-smoothie"	
+jobs:
+  deploy-pages:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./packages/smooth_app
+    steps:
 
-            - name: Chekout code	
-              uses: actions/checkout@v4	
+      - name: Chekout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
 
-            - name: Setup Flutter	
-              uses: actions/cache@v4	
-              with:	
-                path: ${{ runner.tool_cache }}/flutter	
-                key: flutter-2.5.0-stable	
-            - uses: subosito/flutter-action@v2	
-              with:	
-                channel: stable	
-                flutter-version: 2.5.0	
+      - name: Setup Flutter
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # ratchet:actions/cache@v4
+        with:
+          path: ${{ runner.tool_cache }}/flutter
+          key: flutter-2.5.0-stable
+      - uses: subosito/flutter-action@e938fdf56512cc96ef2f93601a5a40bde3801046 # ratchet:subosito/flutter-action@v2
+        with:
+          channel: stable
+          flutter-version: 2.5.0
 
-            - name: Run Dartdoc	
-              run: pub global activate dartdoc && dartdoc	
+      - name: Run Dartdoc
+        run: pub global activate dartdoc && dartdoc
 
-            - name: Deploy API documentation to Github Pages	
-              uses: JamesIves/github-pages-deploy-action@v4.7.3	
-              with:	
-                BRANCH: gh-pages	
-                FOLDER: packages/smooth_app/doc/api/	
+      - name: Deploy API documentation to Github Pages
+        uses: JamesIves/github-pages-deploy-action@6c2d9db40f9296374acc17b90404b6e8864128c8 # ratchet:JamesIves/github-pages-deploy-action@v4.7.3
+        with:
+          BRANCH: gh-pages
+          FOLDER: packages/smooth_app/doc/api/

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,6 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@67d4f4bd7a9b17a0db54d2a7519187c65e339de8 # ratchet:actions/dependency-review-action@v4

--- a/.github/workflows/github-projects-pr.yml
+++ b/.github/workflows/github-projects-pr.yml
@@ -1,7 +1,7 @@
 name: Add PRs to the relevant GitHub Projects
 
 on:
-- pull_request_target
+  - pull_request_target
 
 jobs:
   add-to-project:
@@ -9,18 +9,18 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
     steps:
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@280af8ae1f83a494cfad2cb10f02f6d13529caa9 # ratchet:actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/7
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT || github.token }}
           label-operator: AND
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@280af8ae1f83a494cfad2cb10f02f6d13529caa9 # ratchet:actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/133 # Add issue to the Releases project
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: autorelease:\pending
-          label-operator: OR   
-      - uses: actions/add-to-project@main
+          label-operator: OR
+      - uses: actions/add-to-project@280af8ae1f83a494cfad2cb10f02f6d13529caa9 # ratchet:actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/136 # Add issue to the Translations project
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/github-projects-ventilation.yml
+++ b/.github/workflows/github-projects-ventilation.yml
@@ -24,43 +24,43 @@ jobs:
     name: Add issues to the relevant GitHub projects
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@280af8ae1f83a494cfad2cb10f02f6d13529caa9 # ratchet:actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/11
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: 🎨 Mockups available, 🎨 Mockup required
           label-operator: OR
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@280af8ae1f83a494cfad2cb10f02f6d13529caa9 # ratchet:actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/4 # Add issue to the packaging project
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: packaging input
           label-operator: OR
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@280af8ae1f83a494cfad2cb10f02f6d13529caa9 # ratchet:actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/35 # Add issue to the a11y project
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: accessibility
           label-operator: OR
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@280af8ae1f83a494cfad2cb10f02f6d13529caa9 # ratchet:actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/132 # Add issue to the Top upvoted issues board
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: ⭐ top issue, 👍 Top 10 Issue!
           label-operator: OR
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@280af8ae1f83a494cfad2cb10f02f6d13529caa9 # ratchet:actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/57 # Add issue to the Most impactful issues board
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: 🎯 P0, 🎯 P1
           label-operator: OR
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@280af8ae1f83a494cfad2cb10f02f6d13529caa9 # ratchet:actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/42 # Add issue to the Knowledge Panels issues board
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: 📖 Knowledge panels
           label-operator: OR
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@280af8ae1f83a494cfad2cb10f02f6d13529caa9 # ratchet:actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/84 # Add issue to the Metrics project
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/github-projects.yml
+++ b/.github/workflows/github-projects.yml
@@ -9,7 +9,7 @@ jobs:
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@280af8ae1f83a494cfad2cb10f02f6d13529caa9 # ratchet:actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/openfoodfacts/projects/7
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT || github.token }}

--- a/.github/workflows/internal-release.yml
+++ b/.github/workflows/internal-release.yml
@@ -3,11 +3,11 @@ on:
   workflow_dispatch:
 
 env:
- RUBY_VERSION: 3.2.0
+  RUBY_VERSION: 3.2.0
 
 jobs:
   tag-commit:
-    concurrency: 
+    concurrency:
       group: release
       cancel-in-progress: true
     if: github.triggering_actor == 'teolemon' || github.triggering_actor == 'stephanegigandet' || github.triggering_actor == 'g123k' || github.triggering_actor == 'monsieurtanuki' || github.triggering_actor == 'M123-dev'
@@ -18,9 +18,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@e5ac7b085f6e63d49c8973eb0c6e04d876b881f1 # ratchet:ruby/setup-ruby@v1
         with:
           bundler-cache: true
           ruby-version: ${{ env.RUBY_VERSION }}
@@ -44,7 +44,7 @@ jobs:
       # in order for Sentry and other tools to work properly
       # Outputs env: VERSION_CODE (integer)
       - name: Get latest VERSION_CODE
-        uses: maierj/fastlane-action@v3.1.0
+        uses: maierj/fastlane-action@5a3b971aaa26776459bb26894d6c1a1a84a311a7 # ratchet:maierj/fastlane-action@v3.1.0
         with:
           lane: getOldVersionCode
           subdirectory: packages/smooth_app/android
@@ -57,7 +57,7 @@ jobs:
         run: echo "NORMALIZED_TAG=$(echo "internal_${{ env.VERSION_NAME }}_${{ env.VERSION_CODE }}" | tr "." "_")" >> $GITHUB_ENV
 
       - name: Tag commit
-        uses: rickstaa/action-create-tag@v1
+        uses: rickstaa/action-create-tag@a1c7777fcb2fee4f19b0f283ba888afa11678b72 # ratchet:rickstaa/action-create-tag@v1
         continue-on-error: true
         with:
           tag: "${{ env.NORMALIZED_TAG }}"
@@ -68,10 +68,10 @@ jobs:
         id: set_output
         run: echo "VERSION_CODE=${{ env.VERSION_CODE }}" >> $GITHUB_OUTPUT && echo "VERSION_NAME=${{ env.VERSION_NAME }}" >> $GITHUB_OUTPUT
   android-release:
-    concurrency: 
+    concurrency:
       group: android-release
       cancel-in-progress: true
-    uses: openfoodfacts/smooth-app/.github/workflows/android-release-to-org-openfoodfacts-scanner.yml@develop
+    uses: openfoodfacts/smooth-app/.github/workflows/android-release-to-org-openfoodfacts-scanner.yml@5a88d11396cc10c393cbe72010f52a0ce10d338e # ratchet:openfoodfacts/smooth-app/.github/workflows/android-release-to-org-openfoodfacts-scanner.yml@develop
     needs: tag-commit
     with:
       VERSION_NAME: ${{ needs.tag-commit.outputs.VERSION_NAME}}
@@ -90,10 +90,10 @@ jobs:
       SIGN_KEY_PASSWORD: ${{secrets.KEY_FOR_SCANNER }}
 
   iOS-release:
-    concurrency: 
+    concurrency:
       group: iOS-release
       cancel-in-progress: true
-    uses: openfoodfacts/smooth-app/.github/workflows/ios-release-to-org-openfoodfacts-scanner.yml@develop
+    uses: openfoodfacts/smooth-app/.github/workflows/ios-release-to-org-openfoodfacts-scanner.yml@5a88d11396cc10c393cbe72010f52a0ce10d338e # ratchet:openfoodfacts/smooth-app/.github/workflows/ios-release-to-org-openfoodfacts-scanner.yml@develop
     needs: tag-commit
     with:
       VERSION_NAME: ${{ needs.tag-commit.outputs.VERSION_NAME}}

--- a/.github/workflows/ios-release-to-org-openfoodfacts-scanner.yml
+++ b/.github/workflows/ios-release-to-org-openfoodfacts-scanner.yml
@@ -16,11 +16,11 @@ on:
         required: true
       FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD:
         required: true
-      MATCH_GIT_BASIC_AUTHORIZATION: 
+      MATCH_GIT_BASIC_AUTHORIZATION:
         required: true
       MATCH_GIT_URL:
         required: true
-      MATCH_KEYCHAIN_PASSWORD: 
+      MATCH_KEYCHAIN_PASSWORD:
         required: true
       MATCH_PASSWORD:
         required: true
@@ -36,21 +36,21 @@ on:
 env:
   JAVA_VERSION: 21
   RUBY_VERSION: 3.2.0
- 
+
 jobs:
   testflight-release:
     name: Build and deploy to TestFlight testers (org.openfoodfacts.scanner)
     runs-on: macos-15
     steps:
-      - uses: maxim-lobanov/setup-xcode@v1
+      - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # ratchet:maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable
 
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@e5ac7b085f6e63d49c8973eb0c6e04d876b881f1 # ratchet:ruby/setup-ruby@v1
         with:
           bundler-cache: true
           ruby-version: ${{ env.RUBY_VERSION }}
@@ -61,7 +61,7 @@ jobs:
         run: bundle install
         working-directory: ./packages/smooth_app/android/
       - name: Setup Java JDK
-        uses: actions/setup-java@v4.7.1
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # ratchet:actions/setup-java@v4.7.1
         with:
           distribution: 'zulu'
           java-version: ${{ env.JAVA_VERSION }}
@@ -71,14 +71,14 @@ jobs:
         id: flutter-version
 
       - name: Setup Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@e938fdf56512cc96ef2f93601a5a40bde3801046 # ratchet:subosito/flutter-action@v2
         with:
           #channel: stable
           cache: true
           flutter-version: ${{ steps.flutter-version.outputs.FLUTTER_VERSION }}
           cache-key: flutter-${{ hashFiles('flutter-version.txt')}}-${{ hashFiles('packages\smooth_app\pubspec.lock')}}
 
-      - name: Flutter version    
+      - name: Flutter version
         run: flutter --version
 
       - name: Enable MLKit dependency
@@ -89,7 +89,7 @@ jobs:
 
       - name: Get dependencies
         run: ci/pub_upgrade.sh
-      
+
       - name: Bundle install
         run: cd ./packages/smooth_app/ios && gem install bundler:1.17.3 && bundle install
 
@@ -101,7 +101,7 @@ jobs:
       # We are using the android version code here to have the version codes from iOS and android in sync 
       # in order for Sentry and other tools to work properly
       - name: Bump version
-        uses: maierj/fastlane-action@v3.1.0
+        uses: maierj/fastlane-action@5a3b971aaa26776459bb26894d6c1a1a84a311a7 # ratchet:maierj/fastlane-action@v3.1.0
         with:
           lane: setVersion
           subdirectory: ./packages/smooth_app/android/
@@ -128,7 +128,7 @@ jobs:
 
       - name: cat Podfile
         run: cd ./packages/smooth_app/ios && cat Podfile
- 
+
       - name: Release ipa
         run: cd ./packages/smooth_app/ios && bundle exec fastlane beta
         env:

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -7,7 +7,7 @@
 
 name: Automatically add relevant labels to Pull Requests
 on:
-- pull_request_target
+  - pull_request_target
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -22,6 +22,6 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-    - uses: actions/labeler@v5
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # ratchet:actions/labeler@v5
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/merge-conflict-autolabel.yml
+++ b/.github/workflows/merge-conflict-autolabel.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check for merge conflicts
-        uses: eps1lon/actions-label-merge-conflict@releases/2.x
+        uses: eps1lon/actions-label-merge-conflict@fd1f295ee7443d13745804bc49fe158e240f6c6e # ratchet:eps1lon/actions-label-merge-conflict@releases/2.x
         with:
           dirtyLabel: "PR: needs rebase"
           removeOnDirtyLabel: "PR: ready to ship"

--- a/.github/workflows/on-demand.yml
+++ b/.github/workflows/on-demand.yml
@@ -15,58 +15,58 @@ jobs:
       contains(fromJSON('["COLLABORATOR", "CONTRIBUTOR", "MEMBER", "OWNER"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     steps:
-    - name: Get branch name
-      # see https://github.com/actions/checkout/issues/331
-      id: get-branch
-      run: echo ::set-output name=branch::$(gh pr view $PR_NO --repo $REPO --json headRefName --jq '.headRefName')
-      env:
-        REPO: ${{ github.repository }}
-        PR_NO: ${{ github.event.issue.number }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 1
-        # grab the PR branch
-        ref: ${{ steps.get-branch.outputs.branch }}
-        # We can't use GITHUB_TOKEN here because, github actions can't trigger actions
-        # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
-        # So this is a personal access token
-        token: ${{ secrets.GITHUB_TOKEN }}
-    # we need origin/main to have comparison linting work !
-    - name: Fetch origin/develop
-      run: |
-        git remote set-branches --add origin develop
-        git fetch origin
-    - name: Setup Flutter
-      uses: subosito/flutter-action@v2
-      with:
-        #channel: stable
-        cache: true
-        flutter-version: ${{ steps.flutter-version.outputs.FLUTTER_VERSION }}
-        cache-key: flutter-${{ hashFiles('flutter-version.txt')}}-${{ hashFiles('packages\smooth_app\pubspec.lock')}}
+      - name: Get branch name
+        # see https://github.com/actions/checkout/issues/331
+        id: get-branch
+        run: echo ::set-output name=branch::$(gh pr view $PR_NO --repo $REPO --json headRefName --jq '.headRefName')
+        env:
+          REPO: ${{ github.repository }}
+          PR_NO: ${{ github.event.issue.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
+        with:
+          fetch-depth: 1
+          # grab the PR branch
+          ref: ${{ steps.get-branch.outputs.branch }}
+          # We can't use GITHUB_TOKEN here because, github actions can't trigger actions
+          # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+          # So this is a personal access token
+          token: ${{ secrets.GITHUB_TOKEN }}
+      # we need origin/main to have comparison linting work !
+      - name: Fetch origin/develop
+        run: |
+          git remote set-branches --add origin develop
+          git fetch origin
+      - name: Setup Flutter
+        uses: subosito/flutter-action@e938fdf56512cc96ef2f93601a5a40bde3801046 # ratchet:subosito/flutter-action@v2
+        with:
+          #channel: stable
+          cache: true
+          flutter-version: ${{ steps.flutter-version.outputs.FLUTTER_VERSION }}
+          cache-key: flutter-${{ hashFiles('flutter-version.txt')}}-${{ hashFiles('packages\smooth_app\pubspec.lock')}}
 
-    - run: flutter --version
+      - run: flutter --version
 
-      # Get dependencies
-    - name: Get dependencies
-      run: ci/pub_upgrade.sh
+        # Get dependencies
+      - name: Get dependencies
+        run: ci/pub_upgrade.sh
 
-      # Check for formatting issues and fix them
-    - name: Check for formatting issues (run "dart format . ")
-      run: dart format .
-    - name: Push changes if needed
-      uses: stefanzweifel/git-auto-commit-action@v5
-      with:
-        commit_message: "chore: Linting changes"
-        branch: ${{ github.event.pull_request.head.ref }}
-        commit_user_name: Open Food Facts Bot
-        commit_user_email: contact@openfoodfacts.org
-        commit_author: Open Food Facts Bot <contact@openfoodfacts.org>
-        push_options: ""
-        status_options: '--untracked-files=no'
-        skip_dirty_check: false
-        create_branch: no
+        # Check for formatting issues and fix them
+      - name: Check for formatting issues (run "dart format . ")
+        run: dart format .
+      - name: Push changes if needed
+        uses: stefanzweifel/git-auto-commit-action@e348103e9026cc0eee72ae06630dbe30c8bf7a79 # ratchet:stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: Linting changes"
+          branch: ${{ github.event.pull_request.head.ref }}
+          commit_user_name: Open Food Facts Bot
+          commit_user_email: contact@openfoodfacts.org
+          commit_author: Open Food Facts Bot <contact@openfoodfacts.org>
+          push_options: ""
+          status_options: '--untracked-files=no'
+          skip_dirty_check: false
+          create_branch: no
 
   delete_3_letter_translation_files:
     name: "On demand deletion of 3-letter translation files"
@@ -76,42 +76,42 @@ jobs:
       contains(fromJSON('["COLLABORATOR", "CONTRIBUTOR", "MEMBER", "OWNER"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     steps:
-    - name: Get branch name
-      # see https://github.com/actions/checkout/issues/331
-      id: get-branch
-      run: echo ::set-output name=branch::$(gh pr view $PR_NO --repo $REPO --json headRefName --jq '.headRefName')
-      env:
-        REPO: ${{ github.repository }}
-        PR_NO: ${{ github.event.issue.number }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 1
-        # grab the PR branch
-        ref: ${{ steps.get-branch.outputs.branch }}
-        # We can't use GITHUB_TOKEN here because, github actions can't trigger actions
-        # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
-        # So this is a personal access token
-        token: ${{ secrets.GITHUB_TOKEN }}
-    # we need origin/main to have comparison linting work !
-    - name: Fetch origin/develop
-      run: |
-        git remote set-branches --add origin develop
-        git fetch origin
-    - name: Deletion of 3-letter translation files (1/2)
-      run: packages/smooth_app/ios/Runner/remove.sh
-    - name: Deletion of 3-letter translation files (2/2)
-      run: packages/smooth_app/lib/l10n/remove_3_letter_locales.sh
-    - name: Push changes if needed
-      uses: stefanzweifel/git-auto-commit-action@v5
-      with:
-        commit_message: "chore: Deletion of 3-letter translation files"
-        branch: ${{ github.event.pull_request.head.ref }}
-        commit_user_name: Open Food Facts Bot
-        commit_user_email: contact@openfoodfacts.org
-        commit_author: Open Food Facts Bot <contact@openfoodfacts.org>
-        push_options: ""
-        status_options: '--untracked-files=no'
-        skip_dirty_check: false
-        create_branch: no
+      - name: Get branch name
+        # see https://github.com/actions/checkout/issues/331
+        id: get-branch
+        run: echo ::set-output name=branch::$(gh pr view $PR_NO --repo $REPO --json headRefName --jq '.headRefName')
+        env:
+          REPO: ${{ github.repository }}
+          PR_NO: ${{ github.event.issue.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
+        with:
+          fetch-depth: 1
+          # grab the PR branch
+          ref: ${{ steps.get-branch.outputs.branch }}
+          # We can't use GITHUB_TOKEN here because, github actions can't trigger actions
+          # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+          # So this is a personal access token
+          token: ${{ secrets.GITHUB_TOKEN }}
+      # we need origin/main to have comparison linting work !
+      - name: Fetch origin/develop
+        run: |
+          git remote set-branches --add origin develop
+          git fetch origin
+      - name: Deletion of 3-letter translation files (1/2)
+        run: packages/smooth_app/ios/Runner/remove.sh
+      - name: Deletion of 3-letter translation files (2/2)
+        run: packages/smooth_app/lib/l10n/remove_3_letter_locales.sh
+      - name: Push changes if needed
+        uses: stefanzweifel/git-auto-commit-action@e348103e9026cc0eee72ae06630dbe30c8bf7a79 # ratchet:stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: Deletion of 3-letter translation files"
+          branch: ${{ github.event.pull_request.head.ref }}
+          commit_user_name: Open Food Facts Bot
+          commit_user_email: contact@openfoodfacts.org
+          commit_author: Open Food Facts Bot <contact@openfoodfacts.org>
+          push_options: ""
+          status_options: '--untracked-files=no'
+          skip_dirty_check: false
+          create_branch: no

--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -1,10 +1,10 @@
 name: SmoothApp Post-Submit Tests
 
-on: 
+on:
   push:
     branches:
       - "develop"
-    
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -13,10 +13,10 @@ jobs:
         shell: bash
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
 
       - name: Setup Java JDK
-        uses: actions/setup-java@v4.7.1
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # ratchet:actions/setup-java@v4.7.1
         with:
           distribution: 'zulu'
           java-version: 21
@@ -26,15 +26,15 @@ jobs:
         id: flutter-version
 
       - name: Setup Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@e938fdf56512cc96ef2f93601a5a40bde3801046 # ratchet:subosito/flutter-action@v2
         with:
           #channel: stable
           cache: true
           flutter-version: ${{ steps.flutter-version.outputs.FLUTTER_VERSION }}
           cache-key: flutter-${{ hashFiles('flutter-version.txt')}}-${{ hashFiles('packages\smooth_app\pubspec.lock')}}
-        
+
       - run: flutter --version
-      
+
       # Get dependencies.
       - name: Get dependencies
         run: ci/pub_upgrade.sh
@@ -42,28 +42,28 @@ jobs:
       # Check for formatting issues
       - name: Check for formatting issues (run "dart format . ")
         run: dart format --set-exit-if-changed .
-      
+
       # analyze Dart for errors
       - name: Analyze code
         run: flutter analyze --fatal-infos --fatal-warnings .
-      
+
       # Run tests
       - name: Run Tests with coverage
         run: ci/testing.sh
-            
+
       # Build apk.
       - name: Build APK
         run: flutter build apk --debug -t lib/entrypoints/android/main_google_play.dart
         working-directory: ./packages/smooth_app
 
       - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # ratchet:codecov/codecov-action@v5
         with:
           fail_ci_if_error: false
 
       # Upload generated apk to the artifacts.
       - name: Upload APK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4
         with:
           name: release-apk
           path: packages/smooth_app/build/app/outputs/flutter-apk/app-debug.apk

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -2,7 +2,7 @@ name: 🤳🥫 Open Food Facts mobile app Pre-Submit Tests
 
 on:
   pull_request:
-  
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -18,14 +18,14 @@ jobs:
 
     steps:
       - name: 📂 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
 
       # Get the Flutter version from ./flutter-version.txt
       - run: echo "FLUTTER_VERSION=$(cat flutter-version.txt)" >> $GITHUB_OUTPUT
         id: flutter-version
 
       - name: 🪺 Setup Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@e938fdf56512cc96ef2f93601a5a40bde3801046 # ratchet:subosito/flutter-action@v2
         with:
           #channel: stable
           cache: true
@@ -51,6 +51,6 @@ jobs:
         run: ci/testing.sh
 
       - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # ratchet:codecov/codecov-action@v5
         with:
           fail_ci_if_error: false

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,12 +1,12 @@
 name: Run release-please
 on:
-   push:
-     branches:
-       - develop
+  push:
+    branches:
+      - develop
 
 env:
   RUBY_VERSION: 3.2.0
-    
+
 
 jobs:
   release-please:
@@ -20,13 +20,13 @@ jobs:
       tag_name: ${{ steps.release_please.outputs.tag_name }}
     steps:
       - name: Release-please
-        uses: googleapis/release-please-action@v4.2.0
+        uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # ratchet:googleapis/release-please-action@v4.2.0
         id: release_please
         with:
-           token: ${{ secrets.GITHUB_TOKEN }}
-           release-type: simple
-           pull-request-title-pattern: "chore${scope}: 🚀 Open Food Facts Mobile app - Release${component} ${version}."
-           changelog-types: |
+          token: ${{ secrets.GITHUB_TOKEN }}
+          release-type: simple
+          pull-request-title-pattern: "chore${scope}: 🚀 Open Food Facts Mobile app - Release${component} ${version}."
+          changelog-types: |
             [
             {"type":"feat","section":"🚀 Features","hidden":false},
             {"type":"fix","section":"🐛 Bug Fixes","hidden":false},
@@ -38,7 +38,7 @@ jobs:
             ]
 
   create-release:
-    concurrency: 
+    concurrency:
       group: release
       cancel-in-progress: false
     runs-on: ubuntu-latest
@@ -49,7 +49,7 @@ jobs:
       VERSION_CODE: ${{ steps.set_output.outputs.VERSION_CODE }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
 
       - name: Set VERSION_NAME env
         run: echo "VERSION_NAME=${{ needs.release-please.outputs.major }}.${{ needs.release-please.outputs.minor }}.${{ needs.release-please.outputs.patch }}" >> $GITHUB_ENV
@@ -63,7 +63,7 @@ jobs:
           STORE_JKS_DECRYPTKEY: ${{ secrets.NEW_CYPHER }}
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@e5ac7b085f6e63d49c8973eb0c6e04d876b881f1 # ratchet:ruby/setup-ruby@v1
         with:
           bundler-cache: true
           ruby-version: ${{ env.RUBY_VERSION }}
@@ -75,17 +75,17 @@ jobs:
       # in order for Sentry and other tools to work properly
       # Outputs env: VERSION_CODE (integer)
       - name: Get latest VERSION_CODE
-        uses: maierj/fastlane-action@v3.1.0
+        uses: maierj/fastlane-action@5a3b971aaa26776459bb26894d6c1a1a84a311a7 # ratchet:maierj/fastlane-action@v3.1.0
         with:
           lane: getOldVersionCode
           subdirectory: packages/smooth_app/android
 
       - name: Version
         run: echo "${{ env.VERSION_NAME }}+${{ env.VERSION_CODE }}"
-        
+
       # We need to add the VERSION_CODE to the release in order for F-Droid to have the same VERSION_CODE as the other Stores
-      - name: Update release tag description 
-        uses: rickstaa/action-create-tag@v1
+      - name: Update release tag description
+        uses: rickstaa/action-create-tag@a1c7777fcb2fee4f19b0f283ba888afa11678b72 # ratchet:rickstaa/action-create-tag@v1
         continue-on-error: true
         with:
           tag: "v${{ env.VERSION_NAME }}"
@@ -97,7 +97,7 @@ jobs:
         run: echo ${{ env.VERSION_CODE }} > "./version-code.txt"
 
       - name: Upload version code to release
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@04733e069f2d7f7f0b4aebc4fbdbce8613b03ccd # ratchet:svenstaro/upload-release-action@v2
         with:
           file: ./version-code.txt
           tag: "v${{ env.VERSION_NAME }}"
@@ -108,10 +108,10 @@ jobs:
         run: echo "::set-output name=VERSION_NAME::${{ env.VERSION_NAME }}" && echo "::set-output name=VERSION_CODE::${{ env.VERSION_CODE }}"
 
   android-release:
-    concurrency: 
+    concurrency:
       group: android-release
       cancel-in-progress: false
-    uses: openfoodfacts/smooth-app/.github/workflows/android-release-to-org-openfoodfacts-scanner.yml@develop
+    uses: openfoodfacts/smooth-app/.github/workflows/android-release-to-org-openfoodfacts-scanner.yml@5a88d11396cc10c393cbe72010f52a0ce10d338e # ratchet:openfoodfacts/smooth-app/.github/workflows/android-release-to-org-openfoodfacts-scanner.yml@develop
     needs: [release-please, create-release]
     if: ${{ needs.release-please.outputs.release_created }}
     with:
@@ -131,10 +131,10 @@ jobs:
       SIGN_KEY_PASSWORD: ${{secrets.KEY_FOR_SCANNER }}
 
   iOS-release:
-    concurrency: 
+    concurrency:
       group: iOS-release
       cancel-in-progress: false
-    uses: openfoodfacts/smooth-app/.github/workflows/ios-release-to-org-openfoodfacts-scanner.yml@develop
+    uses: openfoodfacts/smooth-app/.github/workflows/ios-release-to-org-openfoodfacts-scanner.yml@5a88d11396cc10c393cbe72010f52a0ce10d338e # ratchet:openfoodfacts/smooth-app/.github/workflows/ios-release-to-org-openfoodfacts-scanner.yml@develop
     needs: [release-please, create-release]
     if: ${{ needs.release-please.outputs.release_created }}
     with:
@@ -154,10 +154,10 @@ jobs:
       AUTH_KEY_FILE_DECRYPTKEY: ${{ secrets.AUTH_KEY_FILE_DECRYPTKEY }}
 
   android-release-github:
-    concurrency: 
+    concurrency:
       group: android-release-github
       cancel-in-progress: false
-    uses: openfoodfacts/smooth-app/.github/workflows/android-release-to-org-openfoodfacts-scanner.yml@develop
+    uses: openfoodfacts/smooth-app/.github/workflows/android-release-to-org-openfoodfacts-scanner.yml@5a88d11396cc10c393cbe72010f52a0ce10d338e # ratchet:openfoodfacts/smooth-app/.github/workflows/android-release-to-org-openfoodfacts-scanner.yml@develop
     needs: [release-please, create-release]
     if: ${{ needs.release-please.outputs.release_created }}
     with:
@@ -178,10 +178,10 @@ jobs:
       SIGN_KEY_PASSWORD: ${{secrets.KEY_FOR_SCANNER }}
 
   android-release-github-fdroid:
-    concurrency: 
+    concurrency:
       group: android-release-github-fdroid
       cancel-in-progress: false
-    uses: openfoodfacts/smooth-app/.github/workflows/android-release-to-org-openfoodfacts-scanner.yml@develop
+    uses: openfoodfacts/smooth-app/.github/workflows/android-release-to-org-openfoodfacts-scanner.yml@5a88d11396cc10c393cbe72010f52a0ce10d338e # ratchet:openfoodfacts/smooth-app/.github/workflows/android-release-to-org-openfoodfacts-scanner.yml@develop
     needs: [release-please, create-release]
     if: ${{ needs.release-please.outputs.release_created }}
     with:

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -6,7 +6,7 @@ on:
       - opened
       - edited
       - synchronize
-      
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -16,7 +16,7 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # ratchet:amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/top-issues.yml
+++ b/.github/workflows/top-issues.yml
@@ -11,17 +11,17 @@ jobs:
     name: Display and label top issues.
     runs-on: ubuntu-latest
     steps:
-    - name: Run top issues action
-      uses: rickstaa/top-issues-action@v1
-      env:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        label: true
-        dashboard: true
-        dashboard_title: 👍 Top Issues Dashboard
-        dashboard_show_total_reactions: true
-        top_issues: true
-        top_bugs: true
-        top_features: true
-        top_pull_requests: true
-        top_list_size: 20
+      - name: Run top issues action
+        uses: rickstaa/top-issues-action@7e8dda5d5ae3087670f9094b9724a9a091fc3ba1 # ratchet:rickstaa/top-issues-action@v1
+        env:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          label: true
+          dashboard: true
+          dashboard_title: 👍 Top Issues Dashboard
+          dashboard_show_total_reactions: true
+          top_issues: true
+          top_bugs: true
+          top_features: true
+          top_pull_requests: true
+          top_list_size: 20

--- a/.github/workflows/update-assets.yml
+++ b/.github/workflows/update-assets.yml
@@ -4,7 +4,7 @@ on:
   # Allow to be run manually
   workflow_dispatch:
   schedule:
-  - cron: "0 19 * * *"
+    - cron: "0 19 * * *"
 
 jobs:
   update-assets:
@@ -13,28 +13,28 @@ jobs:
 
     steps:
 
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
 
-    - name: Upgrade assets
-      run: chmod +x ci/update_assets.sh && ci/update_assets.sh
+      - name: Upgrade assets
+        run: chmod +x ci/update_assets.sh && ci/update_assets.sh
 
-    - name: Check for uncommitted changes
-      id: check-changes
-      uses: mskri/check-uncommitted-changes-action@v1.0.1
-      
-    - name: Create Pull Request
-      if: steps.check-changes.outputs.outcome == failure()
-      id: cpr
-      uses: peter-evans/create-pull-request@v7
-      with:
-        base: develop
-        commit-message: Update assets
-        committer: GitHub <noreply@github.com>
-        author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-        signoff: false
-        branch: auto-update-assets
-        delete-branch: true
-        title: 'chore: Update assets'
-        body: |
-          Automated update of asset cache - Link to revert if needed: https://world.openfoodfacts.org/product/093270067481501/a-good-product-for-you-open-food-facts
+      - name: Check for uncommitted changes
+        id: check-changes
+        uses: mskri/check-uncommitted-changes-action@2b152539dd033c3a26e0dd1d8b9a0c8e4d3a8a19 # ratchet:mskri/check-uncommitted-changes-action@v1.0.1
+
+      - name: Create Pull Request
+        if: steps.check-changes.outputs.outcome == failure()
+        id: cpr
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # ratchet:peter-evans/create-pull-request@v7
+        with:
+          base: develop
+          commit-message: Update assets
+          committer: GitHub <noreply@github.com>
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          signoff: false
+          branch: auto-update-assets
+          delete-branch: true
+          title: 'chore: Update assets'
+          body: |
+            Automated update of asset cache - Link to revert if needed: https://world.openfoodfacts.org/product/093270067481501/a-good-product-for-you-open-food-facts

--- a/.github/workflows/update-xcode.txt
+++ b/.github/workflows/update-xcode.txt
@@ -13,12 +13,12 @@ jobs:
     name: Check for Xcode Updates
     runs-on: macOS-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # ratchet:actions/checkout@v2
         with:
           token: ${{ secrets.UPDATE_XCODE_VERSIONS_GITHUB_TOKEN }} # A token that can update workflows, required to push changes to workflow files
 
       - name: Update Xcode Versions
-        uses: josephduffy/update-xcode-version-action@master
+        uses: josephduffy/update-xcode-version-action@46b46c9d2640819b11a8ae9d0907057bf69b4757 # ratchet:josephduffy/update-xcode-version-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }} # Required to create pull requests, can be the default token provided by GitHub Actions
           xcode-versions-file: .github/xcode-versions.yml # Default, not required, but can be changed

--- a/.github/workflows/waldo_sessions.yml
+++ b/.github/workflows/waldo_sessions.yml
@@ -2,7 +2,7 @@ name: Upload builds to Waldo
 
 on:
   workflow_dispatch:
-    inputs: 
+    inputs:
       repo:
         description: 'Repo name (eg: openfoodfacts/smooth-app)'
         required: true
@@ -20,14 +20,14 @@ jobs:
         shell: bash
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
         with:
           repository: ${{ github.event.inputs.repo }}
           ref: ${{ github.event.inputs.branch }}
           fetch-depth: 0
 
       - name: Setup Java JDK
-        uses: actions/setup-java@v4.7.1
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # ratchet:actions/setup-java@v4.7.1
         with:
           distribution: 'zulu'
           java-version: 21
@@ -37,7 +37,7 @@ jobs:
         id: flutter-version
 
       - name: Setup Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@e938fdf56512cc96ef2f93601a5a40bde3801046 # ratchet:subosito/flutter-action@v2
         with:
           #channel: stable
           cache: true
@@ -48,14 +48,14 @@ jobs:
 
       - name: Get dependencies
         run: ci/pub_upgrade.sh
-        
+
       # Build apk.
       - name: Build APK
         run: flutter build apk --debug -t lib/entrypoints/android/main_google_play.dart
         working-directory: ./packages/smooth_app
 
       - name: Upload APK to Waldo
-        uses: waldoapp/gh-action-upload@v3
+        uses: waldoapp/gh-action-upload@65f402487e17e4f53c73a9e17afa543f51b215eb # ratchet:waldoapp/gh-action-upload@v3
         with:
           build_path: packages/smooth_app/build/app/outputs/flutter-apk/app-debug.apk
           upload_token: ${{ secrets.WALDO_SESSIONS_ANDROID }}


### PR DESCRIPTION
**Signed-off-by:** Jagjeevan Kashid <jagjeevandev97@gmail.com>
### What

Most CI/CD systems are one layer of indirection away from `curl | sudo bash`. Unless you are specifically pinning CI workflows, containers, and base images to checksummed versions, _everything_ is mutable: GitHub labels are mutable and Docker tags are mutable. This poses a substantial security and reliability risk.

**Few Week earlier the most popular action was compromised with `curl` command pointing to an python script :** [Link](https://alexwlchan.net/2025/github-actions-audit/)


Documentation related to ratchet is added on openfoodfacts-server repo