### PR TITLE
fix: Move Hunger Games to a real view instead of overlay (#4681)

### DIFF
--- a/packages/smooth_app/lib/pages/hunger_games/question_card.dart
+++ b/packages/smooth_app/lib/pages/hunger_games/question_card.dart
@@ -60,7 +60,6 @@ class QuestionCard extends StatelessWidget {
                 mainAxisSize: MainAxisSize.max,
                 children: <Widget>[
                   Expanded(
-                    flex: 1,
                     child: question.imageUrl == null
                         ? EMPTY_WIDGET
                         : QuestionImageThumbnail(question),

--- a/packages/smooth_app/lib/pages/hunger_games/question_card.dart
+++ b/packages/smooth_app/lib/pages/hunger_games/question_card.dart
@@ -30,8 +30,6 @@ class QuestionCard extends StatelessWidget {
       context.read<LocalDatabase>(),
     );
 
-    final Size screenSize = MediaQuery.sizeOf(context);
-
     return FutureBuilder<FetchedProduct>(
       future: productFuture,
       builder: (
@@ -59,10 +57,10 @@ class QuestionCard extends StatelessWidget {
                 borderRadius: ROUNDED_BORDER_RADIUS,
               ),
               child: Column(
-                mainAxisSize: MainAxisSize.min,
+                mainAxisSize: MainAxisSize.max,
                 children: <Widget>[
-                  SizedBox(
-                    height: screenSize.height / 4,
+                  Expanded(
+                    flex: 1,
                     child: question.imageUrl == null
                         ? EMPTY_WIDGET
                         : QuestionImageThumbnail(question),

--- a/packages/smooth_app/lib/pages/hunger_games/question_card.dart
+++ b/packages/smooth_app/lib/pages/hunger_games/question_card.dart
@@ -62,7 +62,7 @@ class QuestionCard extends StatelessWidget {
                 mainAxisSize: MainAxisSize.min,
                 children: <Widget>[
                   SizedBox(
-                    height: screenSize.height / 6,
+                    height: screenSize.height / 4,
                     child: question.imageUrl == null
                         ? EMPTY_WIDGET
                         : QuestionImageThumbnail(question),

--- a/packages/smooth_app/lib/pages/hunger_games/question_image_thumbnail.dart
+++ b/packages/smooth_app/lib/pages/hunger_games/question_image_thumbnail.dart
@@ -14,34 +14,29 @@ class QuestionImageThumbnail extends StatelessWidget {
         margin: const EdgeInsets.fromLTRB(0, 0, 5, 0),
         decoration: const BoxDecoration(color: Colors.black12),
         child: GestureDetector(
-          onTap: () async => Navigator.of(context).push<void>(
-            MaterialPageRoute<void>(
-              builder: (BuildContext context) =>
-                  QuestionImageFullPage(question),
-              fullscreenDialog: true,
-            ),
-          ),
-          child: LayoutBuilder(
-            builder: (BuildContext context, BoxConstraints constraints) {
-              return SizedBox(
-                width: double.infinity,
-                height: double.infinity,
-                child: Image(
-                  image: NetworkImage(question.imageUrl!),
-                  fit: BoxFit.contain,
-                  errorBuilder: (_, __, ___) => EMPTY_WIDGET,
-                  loadingBuilder: (
-                    _,
-                    Widget child,
-                    ImageChunkEvent? progress,
-                  ) =>
-                      progress == null
-                          ? child
-                          : const CircularProgressIndicator.adaptive(),
+            onTap: () async => Navigator.of(context).push<void>(
+                  MaterialPageRoute<void>(
+                    builder: (BuildContext context) =>
+                        QuestionImageFullPage(question),
+                    fullscreenDialog: true,
+                  ),
                 ),
-              );
-            },
-          ),
-        ),
+            child: SizedBox(
+              width: double.infinity,
+              height: double.infinity,
+              child: Image(
+                image: NetworkImage(question.imageUrl!),
+                fit: BoxFit.contain,
+                errorBuilder: (_, __, ___) => EMPTY_WIDGET,
+                loadingBuilder: (
+                  _,
+                  Widget child,
+                  ImageChunkEvent? progress,
+                ) =>
+                    progress == null
+                        ? child
+                        : const CircularProgressIndicator.adaptive(),
+              ),
+            )),
       );
 }

--- a/packages/smooth_app/lib/pages/hunger_games/question_image_thumbnail.dart
+++ b/packages/smooth_app/lib/pages/hunger_games/question_image_thumbnail.dart
@@ -10,31 +10,43 @@ class QuestionImageThumbnail extends StatelessWidget {
   final RobotoffQuestion question;
 
   @override
-  Widget build(BuildContext context) => Container(
-        margin: const EdgeInsets.fromLTRB(0, 0, 5, 0),
-        decoration: const BoxDecoration(color: Colors.black12),
-        child: GestureDetector(
-          onTap: () async => Navigator.of(context).push<void>(
-            MaterialPageRoute<void>(
-              builder: (BuildContext context) =>
-                  QuestionImageFullPage(question),
-              fullscreenDialog: true,
-            ),
-          ),
-          child: Image(
-            image: NetworkImage(question.imageUrl!),
-            fit: BoxFit.cover,
-            height: double.infinity,
-            errorBuilder: (_, __, ___) => EMPTY_WIDGET,
-            loadingBuilder: (
-              _,
-              Widget child,
-              ImageChunkEvent? progress,
-            ) =>
-                progress == null
-                    ? child
-                    : const CircularProgressIndicator.adaptive(),
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.fromLTRB(0, 0, 5, 0),
+      decoration: const BoxDecoration(color: Colors.black12),
+      child: GestureDetector(
+        onTap: () async => Navigator.of(context).push<void>(
+          MaterialPageRoute<void>(
+            builder: (BuildContext context) => QuestionImageFullPage(question),
+            fullscreenDialog: true,
           ),
         ),
-      );
+        child: LayoutBuilder(
+          builder: (BuildContext context, BoxConstraints constraints) {
+            return SizedBox(
+              width: constraints.maxWidth,
+              height: constraints.maxHeight,
+              child: Image.network(
+                question.imageUrl!,
+                fit: BoxFit.cover,
+                errorBuilder: (_, __, ___) => EMPTY_WIDGET,
+                loadingBuilder: (
+                  BuildContext context,
+                  Widget child,
+                  ImageChunkEvent? loadingProgress,
+                ) {
+                  if (loadingProgress == null) {
+                    // TODO(monsieurtanuki): remove this when the image is not null anymore
+                    return child;
+                  }
+                  return const Center(
+                      child: CircularProgressIndicator.adaptive());
+                },
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
 }

--- a/packages/smooth_app/lib/pages/hunger_games/question_image_thumbnail.dart
+++ b/packages/smooth_app/lib/pages/hunger_games/question_image_thumbnail.dart
@@ -10,43 +10,38 @@ class QuestionImageThumbnail extends StatelessWidget {
   final RobotoffQuestion question;
 
   @override
-  Widget build(BuildContext context) {
-    return Container(
-      margin: const EdgeInsets.fromLTRB(0, 0, 5, 0),
-      decoration: const BoxDecoration(color: Colors.black12),
-      child: GestureDetector(
-        onTap: () async => Navigator.of(context).push<void>(
-          MaterialPageRoute<void>(
-            builder: (BuildContext context) => QuestionImageFullPage(question),
-            fullscreenDialog: true,
+  Widget build(BuildContext context) => Container(
+        margin: const EdgeInsets.fromLTRB(0, 0, 5, 0),
+        decoration: const BoxDecoration(color: Colors.black12),
+        child: GestureDetector(
+          onTap: () async => Navigator.of(context).push<void>(
+            MaterialPageRoute<void>(
+              builder: (BuildContext context) =>
+                  QuestionImageFullPage(question),
+              fullscreenDialog: true,
+            ),
+          ),
+          child: LayoutBuilder(
+            builder: (BuildContext context, BoxConstraints constraints) {
+              return SizedBox(
+                width: double.infinity,
+                height: double.infinity,
+                child: Image(
+                  image: NetworkImage(question.imageUrl!),
+                  fit: BoxFit.contain,
+                  errorBuilder: (_, __, ___) => EMPTY_WIDGET,
+                  loadingBuilder: (
+                    _,
+                    Widget child,
+                    ImageChunkEvent? progress,
+                  ) =>
+                      progress == null
+                          ? child
+                          : const CircularProgressIndicator.adaptive(),
+                ),
+              );
+            },
           ),
         ),
-        child: LayoutBuilder(
-          builder: (BuildContext context, BoxConstraints constraints) {
-            return SizedBox(
-              width: constraints.maxWidth,
-              height: constraints.maxHeight,
-              child: Image.network(
-                question.imageUrl!,
-                fit: BoxFit.cover,
-                errorBuilder: (_, __, ___) => EMPTY_WIDGET,
-                loadingBuilder: (
-                  BuildContext context,
-                  Widget child,
-                  ImageChunkEvent? loadingProgress,
-                ) {
-                  if (loadingProgress == null) {
-                    // TODO(monsieurtanuki): remove this when the image is not null anymore
-                    return child;
-                  }
-                  return const Center(
-                      child: CircularProgressIndicator.adaptive());
-                },
-              ),
-            );
-          },
-        ),
-      ),
-    );
-  }
+      );
 }

--- a/packages/smooth_app/lib/pages/hunger_games/question_page.dart
+++ b/packages/smooth_app/lib/pages/hunger_games/question_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:async/async.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -18,7 +20,6 @@ import 'package:smooth_app/query/random_questions_query.dart';
 
 class QuestionsPage extends StatefulWidget {
   const QuestionsPage({
-    super.key,
     this.product,
     this.questions,
   });
@@ -95,15 +96,17 @@ class _QuestionsPageState extends State<QuestionsPage>
 
   void _loadNextQuestions() {
     try {
-      setState(() {
-        _state = const _RobotoffQuestionLoadingState();
-      });
-      _loadQuestions(
+      if (mounted) {
+        setState(() {
+          _state = const _RobotoffQuestionLoadingState();
+        });
+      }
+      unawaited(_loadQuestions(
         request: _questionsQuery.getQuestions(
           _localDatabase,
           _numberQuestionsNext,
         ),
-      );
+      ));
       _currentQuestionIndex = 0;
     } catch (e) {
       _updateState(_RobotoffQuestionErrorState(Exception(e.toString())));
@@ -274,7 +277,7 @@ class _LoadingQuestionsView extends StatelessWidget {
           child: Center(
             child: DefaultTextStyle(
               textAlign: TextAlign.center,
-              style: TextStyle(color: colorScheme.onSurface),
+              style: const TextStyle(),
               child: FractionallySizedBox(
                 widthFactor: 0.8,
                 child: MergeSemantics(
@@ -284,10 +287,7 @@ class _LoadingQuestionsView extends StatelessWidget {
                       Text(
                         appLocalizations.hunger_games_loading_line1,
                         style: theme.textTheme.titleMedium?.copyWith(
-                          fontWeight: FontWeight.bold,
-                          fontSize: 19.0,
-                          color: colorScheme.primary,
-                        ),
+                            fontWeight: FontWeight.bold, fontSize: 19.0),
                       ),
                       SizedBox(height: screenHeight * 0.05),
                       LinearProgressIndicator(
@@ -297,10 +297,8 @@ class _LoadingQuestionsView extends StatelessWidget {
                       Text(
                         appLocalizations.hunger_games_loading_line2,
                         textAlign: TextAlign.center,
-                        style: theme.textTheme.bodyLarge?.copyWith(
-                          fontSize: 17.0,
-                          color: colorScheme.primary,
-                        ),
+                        style:
+                            theme.textTheme.bodyLarge?.copyWith(fontSize: 17.0),
                       ),
                     ],
                   ),
@@ -329,7 +327,7 @@ class _QuestionView extends StatelessWidget {
   Widget build(BuildContext context) {
     return Expanded(
       child: Column(
-        mainAxisSize: MainAxisSize.max, // <--- CAMBIATO
+        mainAxisSize: MainAxisSize.max,
         children: <Widget>[
           Expanded(
             child: QuestionCard(

--- a/packages/smooth_app/lib/pages/hunger_games/question_page.dart
+++ b/packages/smooth_app/lib/pages/hunger_games/question_page.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:async/async.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -108,69 +106,65 @@ class _QuestionsPageState extends State<QuestionsPage>
       );
       _currentQuestionIndex = 0;
     } catch (e) {
-      debugPrint('Error loading next questions: $e');
       _updateState(_RobotoffQuestionErrorState(Exception(e.toString())));
     }
   }
 
-  void _incrementQuestionsAnswered() {
-    setState(() {
-      _questionsAnswered++;
-    });
-  }
-
   @override
   Widget build(BuildContext context) {
-    return ChangeNotifierProvider(
-      create: (context) => _QuestionsAnsweredNotifier(),
-      child: Scaffold(
-        appBar: AppBar(
-          title: Text("Hunger Games"), //AppLocalizations.of(context).hunger_games_error_label),
-          leading: IconButton(
-            icon: const Icon(Icons.close),
-            onPressed: () => Navigator.of(context).pop(_questionsAnswered),
+    return ChangeNotifierProvider<_QuestionsAnsweredNotifier>(
+        create: (BuildContext context) => _QuestionsAnsweredNotifier(),
+        child: Scaffold(
+          appBar: AppBar(
+            title: const Text('Hunger Games'),
+            leading: IconButton(
+              icon: const Icon(Icons.close),
+              onPressed: () => Navigator.of(context).pop(_questionsAnswered),
+            ),
           ),
-        ),
-        body: SafeArea(
-          child: Center(
-            child: AnimatedSwitcher(
-              duration: SmoothAnimationsDuration.medium,
-              transitionBuilder: (Widget child, Animation<double> animation) {
-                final Offset animationStartOffset = _getAnimationStartOffset();
-                final Animation<Offset> inAnimation = Tween<Offset>(
-                  begin: animationStartOffset,
-                  end: Offset.zero,
-                ).animate(animation);
-                final Animation<Offset> outAnimation = Tween<Offset>(
-                  begin: animationStartOffset.scale(-1, -1),
-                  end: Offset.zero,
-                ).animate(animation);
+          body: SafeArea(
+            child: Center(
+              child: AnimatedSwitcher(
+                duration: SmoothAnimationsDuration.medium,
+                transitionBuilder: (Widget child, Animation<double> animation) {
+                  final Offset animationStartOffset =
+                      _getAnimationStartOffset();
+                  final Animation<Offset> inAnimation = Tween<Offset>(
+                    begin: animationStartOffset,
+                    end: Offset.zero,
+                  ).animate(animation);
+                  final Animation<Offset> outAnimation = Tween<Offset>(
+                    begin: animationStartOffset.scale(-1, -1),
+                    end: Offset.zero,
+                  ).animate(animation);
 
-                return ClipRect(
-                  child: SlideTransition(
-                    position: child.key == ValueKey<int>(_currentQuestionIndex)
-                        ? inAnimation
-                        : outAnimation,
-                    child: Padding(
-                      padding: const EdgeInsets.all(SMALL_SPACE),
-                      child: child,
+                  return ClipRect(
+                    child: SlideTransition(
+                      position:
+                          child.key == ValueKey<int>(_currentQuestionIndex)
+                              ? inAnimation
+                              : outAnimation,
+                      child: Padding(
+                        padding: const EdgeInsets.all(SMALL_SPACE),
+                        child: child,
+                      ),
                     ),
-                  ),
-                );
-              },
-              child: KeyedSubtree(
-                key: ValueKey<int>(_currentQuestionIndex),
-                child: switch (_state) {
-                  _RobotoffQuestionLoadingState _ => const _LoadingQuestionsView(),
-                  _RobotoffQuestionSuccessState _ => _buildQuestionsWidget(),
-                  _RobotoffQuestionErrorState _ => _ErrorLoadingView(onRetry: _loadQuestions),
+                  );
                 },
+                child: KeyedSubtree(
+                  key: ValueKey<int>(_currentQuestionIndex),
+                  child: switch (_state) {
+                    _RobotoffQuestionLoadingState _ =>
+                      const _LoadingQuestionsView(),
+                    _RobotoffQuestionSuccessState _ => _buildQuestionsWidget(),
+                    _RobotoffQuestionErrorState _ =>
+                      _ErrorLoadingView(onRetry: _loadQuestions),
+                  },
+                ),
               ),
             ),
           ),
-        ),
-      )
-    );
+        ));
   }
 
   Widget _buildQuestionsWidget() {
@@ -192,8 +186,8 @@ class _QuestionsPageState extends State<QuestionsPage>
           setState(() {
             _lastAnswer = answer;
             _currentQuestionIndex++;
+            _questionsAnswered++;
           });
-          _incrementQuestionsAnswered();
         },
       );
     }
@@ -241,7 +235,6 @@ class _QuestionsPageState extends State<QuestionsPage>
   String get actionName => 'Opened robotoff_question_page';
 }
 
-
 sealed class _RobotoffQuestionState {
   const _RobotoffQuestionState();
 }
@@ -281,7 +274,7 @@ class _LoadingQuestionsView extends StatelessWidget {
           child: Center(
             child: DefaultTextStyle(
               textAlign: TextAlign.center,
-              style: TextStyle(color: colorScheme.onBackground), 
+              style: TextStyle(color: colorScheme.onSurface),
               child: FractionallySizedBox(
                 widthFactor: 0.8,
                 child: MergeSemantics(
@@ -293,12 +286,12 @@ class _LoadingQuestionsView extends StatelessWidget {
                         style: theme.textTheme.titleMedium?.copyWith(
                           fontWeight: FontWeight.bold,
                           fontSize: 19.0,
-                          color: colorScheme.primary, 
+                          color: colorScheme.primary,
                         ),
                       ),
                       SizedBox(height: screenHeight * 0.05),
                       LinearProgressIndicator(
-                        color: colorScheme.primary, 
+                        color: colorScheme.primary,
                       ),
                       SizedBox(height: screenHeight * 0.10),
                       Text(
@@ -306,7 +299,7 @@ class _LoadingQuestionsView extends StatelessWidget {
                         textAlign: TextAlign.center,
                         style: theme.textTheme.bodyLarge?.copyWith(
                           fontSize: 17.0,
-                          color: colorScheme.primary, 
+                          color: colorScheme.primary,
                         ),
                       ),
                     ],
@@ -334,18 +327,22 @@ class _QuestionView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: <Widget>[
-        QuestionCard(
-          question,
-          initialProduct: initialProduct,
-        ),
-        QuestionAnswersOptions(
-          question,
-          onAnswer: onAnswer,
-        ),
-      ],
+    return Expanded(
+      child: Column(
+        mainAxisSize: MainAxisSize.max, // <--- CAMBIATO
+        children: <Widget>[
+          Expanded(
+            child: QuestionCard(
+              question,
+              initialProduct: initialProduct,
+            ),
+          ),
+          QuestionAnswersOptions(
+            question,
+            onAnswer: onAnswer,
+          ),
+        ],
+      ),
     );
   }
 }
@@ -363,13 +360,11 @@ class _QuestionsSuccessView extends StatelessWidget {
   Widget build(BuildContext context) {
     return CongratsWidget(
       continueButtonLabel: onContinue != null
-          ? AppLocalizations.of(context).robotoff_next_n_questions(10
-              
-              // QuestionPageState._numberQuestionsNext,
-            )
+          ? AppLocalizations.of(context).robotoff_next_n_questions(
+              _QuestionsPageState._numberQuestionsNext)
           : null,
       anonymousAnnotationList: anonymousAnnotationList,
-      onContinue: onContinue, 
+      onContinue: onContinue,
       result: _QuestionsAnsweredNotifier.of(context).value,
     );
   }
@@ -393,10 +388,11 @@ class _ErrorLoadingView extends StatelessWidget {
       child: DefaultTextStyle(
         textAlign: TextAlign.center,
         style: textTheme.bodyLarge?.copyWith(
-          fontWeight: FontWeight.bold,
-          fontSize: 20.0,
-          color: colorScheme.onBackground,
-        ) ?? const TextStyle(),
+              fontWeight: FontWeight.bold,
+              fontSize: 20.0,
+              color: colorScheme.onSurface,
+            ) ??
+            const TextStyle(),
         child: FractionallySizedBox(
           widthFactor: 0.8,
           child: Column(
@@ -406,7 +402,7 @@ class _ErrorLoadingView extends StatelessWidget {
                 appLocalizations.hunger_games_error_label,
                 style: textTheme.titleMedium?.copyWith(
                   fontSize: 20.0,
-                  color: colorScheme.error, 
+                  color: colorScheme.error,
                 ),
               ),
               const SizedBox(height: VERY_LARGE_SPACE),
@@ -414,14 +410,14 @@ class _ErrorLoadingView extends StatelessWidget {
                 text: appLocalizations.hunger_games_error_retry_button,
                 leadingIcon: Icon(
                   Icons.refresh,
-                  color: colorScheme.onPrimary, 
+                  color: colorScheme.onPrimary,
                 ),
                 onPressed: onRetry,
                 textStyle: textTheme.labelLarge?.copyWith(
                   fontSize: 18.0,
                   color: colorScheme.onPrimary,
                 ),
-                backgroundColor: colorScheme.primary, 
+                backgroundColor: colorScheme.primary,
               ),
             ],
           ),

--- a/packages/smooth_app/lib/pages/hunger_games/question_page.dart
+++ b/packages/smooth_app/lib/pages/hunger_games/question_page.dart
@@ -325,22 +325,20 @@ class _QuestionView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Expanded(
-      child: Column(
-        mainAxisSize: MainAxisSize.max,
-        children: <Widget>[
-          Expanded(
-            child: QuestionCard(
-              question,
-              initialProduct: initialProduct,
-            ),
-          ),
-          QuestionAnswersOptions(
+    return Column(
+      mainAxisSize: MainAxisSize.max,
+      children: <Widget>[
+        Expanded(
+          child: QuestionCard(
             question,
-            onAnswer: onAnswer,
+            initialProduct: initialProduct,
           ),
-        ],
-      ),
+        ),
+        QuestionAnswersOptions(
+          question,
+          onAnswer: onAnswer,
+        ),
+      ],
     );
   }
 }

--- a/packages/smooth_app/lib/pages/hunger_games/question_page.dart
+++ b/packages/smooth_app/lib/pages/hunger_games/question_page.dart
@@ -18,119 +18,9 @@ import 'package:smooth_app/query/product_questions_query.dart';
 import 'package:smooth_app/query/questions_query.dart';
 import 'package:smooth_app/query/random_questions_query.dart';
 
-Future<int?> openQuestionPage(
-  BuildContext context, {
-  Product? product,
-  List<RobotoffQuestion>? questions,
-}) =>
-    showGeneralDialog<int?>(
-      context: context,
-      barrierColor: Colors.black.withValues(alpha: 0.7),
-      pageBuilder: (_, __, ___) => EMPTY_WIDGET,
-      transitionBuilder: (
-        BuildContext context,
-        Animation<double> a1,
-        Animation<double> a2,
-        Widget child,
-      ) {
-        return ChangeNotifierProvider<_QuestionsAnsweredNotifier>(
-          create: (_) => _QuestionsAnsweredNotifier(),
-          child: SafeArea(
-            child: Stack(
-              children: <Widget>[
-                Positioned.fill(
-                  child: Builder(
-                    builder: (BuildContext context) {
-                      return GestureDetector(
-                        excludeFromSemantics: true,
-                        onTap: () => Navigator.of(context).pop(
-                          _QuestionsAnsweredNotifier.of(
-                            context,
-                            listen: false,
-                          ).value,
-                        ),
-                      );
-                    },
-                  ),
-                ),
-                Align(
-                  alignment: Alignment.center,
-                  child: Transform.scale(
-                    scale: a1.value,
-                    child: Opacity(
-                      opacity: a1.value,
-                      child: SafeArea(
-                        child: BackdropFilter(
-                          filter: ImageFilter.blur(sigmaX: 1.0, sigmaY: 1.0),
-                          child: _QuestionPage(
-                            product: product,
-                            questions: questions,
-                          ),
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
-                Positioned.directional(
-                  textDirection: Directionality.of(context),
-                  top: 0.0,
-                  start: SMALL_SPACE,
-                  child: Opacity(
-                    opacity: a1.value,
-                    child: const _CloseButton(),
-                  ),
-                ),
-              ],
-            ),
-          ),
-        );
-      },
-      transitionDuration: SmoothAnimationsDuration.medium,
-    );
-
-class _CloseButton extends StatelessWidget {
-  const _CloseButton();
-
-  @override
-  Widget build(BuildContext context) {
-    final String tooltip = MaterialLocalizations.of(context).closeButtonTooltip;
-
-    return Semantics(
-      value: tooltip,
-      button: true,
-      excludeSemantics: true,
-      child: Material(
-        type: MaterialType.button,
-        shape: const CircleBorder(),
-        color: Theme.of(context).primaryColor,
-        child: InkWell(
-          customBorder: const CircleBorder(),
-          onTap: () => Navigator.of(context).pop(
-            _QuestionsAnsweredNotifier.of(
-              context,
-              listen: false,
-            ).value,
-          ),
-          child: Tooltip(
-            message: tooltip,
-            child: Container(
-              width: kToolbarHeight,
-              height: kToolbarHeight,
-              alignment: Alignment.center,
-              child: const Icon(
-                Icons.close,
-                color: Colors.white,
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _QuestionPage extends StatefulWidget {
-  const _QuestionPage({
+class QuestionsPage extends StatefulWidget {
+  const QuestionsPage({
+    super.key,
     this.product,
     this.questions,
   });
@@ -139,10 +29,10 @@ class _QuestionPage extends StatefulWidget {
   final List<RobotoffQuestion>? questions;
 
   @override
-  State<_QuestionPage> createState() => _QuestionPageState();
+  State<QuestionsPage> createState() => _QuestionsPageState();
 }
 
-class _QuestionPageState extends State<_QuestionPage>
+class _QuestionsPageState extends State<QuestionsPage>
     with SingleTickerProviderStateMixin, TraceableClientMixin {
   final AnonymousAnnotationList _anonymousAnnotationList =
       <String, InsightAnnotation>{};
@@ -157,6 +47,7 @@ class _QuestionPageState extends State<_QuestionPage>
   CancelableOperation<List<RobotoffQuestion>>? _request;
   _RobotoffQuestionState _state = const _RobotoffQuestionLoadingState();
   int _currentQuestionIndex = 0;
+  int _questionsAnswered = 0;
 
   @override
   void initState() {
@@ -205,55 +96,80 @@ class _QuestionPageState extends State<_QuestionPage>
   }
 
   void _loadNextQuestions() {
-    _loadQuestions(
-      request: _questionsQuery.getQuestions(
-        _localDatabase,
-        _numberQuestionsNext,
-      ),
-    );
-    _currentQuestionIndex = 0;
+    try {
+      setState(() {
+        _state = const _RobotoffQuestionLoadingState();
+      });
+      _loadQuestions(
+        request: _questionsQuery.getQuestions(
+          _localDatabase,
+          _numberQuestionsNext,
+        ),
+      );
+      _currentQuestionIndex = 0;
+    } catch (e) {
+      debugPrint('Error loading next questions: $e');
+      _updateState(_RobotoffQuestionErrorState(Exception(e.toString())));
+    }
+  }
+
+  void _incrementQuestionsAnswered() {
+    setState(() {
+      _questionsAnswered++;
+    });
   }
 
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: AnimatedSwitcher(
-        duration: SmoothAnimationsDuration.medium,
-        transitionBuilder: (Widget child, Animation<double> animation) {
-          final Offset animationStartOffset = _getAnimationStartOffset();
-          final Animation<Offset> inAnimation = Tween<Offset>(
-            begin: animationStartOffset,
-            end: Offset.zero,
-          ).animate(animation);
-          final Animation<Offset> outAnimation = Tween<Offset>(
-            begin: animationStartOffset.scale(-1, -1),
-            end: Offset.zero,
-          ).animate(animation);
+    return ChangeNotifierProvider(
+      create: (context) => _QuestionsAnsweredNotifier(),
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text("Hunger Games"), //AppLocalizations.of(context).hunger_games_error_label),
+          leading: IconButton(
+            icon: const Icon(Icons.close),
+            onPressed: () => Navigator.of(context).pop(_questionsAnswered),
+          ),
+        ),
+        body: SafeArea(
+          child: Center(
+            child: AnimatedSwitcher(
+              duration: SmoothAnimationsDuration.medium,
+              transitionBuilder: (Widget child, Animation<double> animation) {
+                final Offset animationStartOffset = _getAnimationStartOffset();
+                final Animation<Offset> inAnimation = Tween<Offset>(
+                  begin: animationStartOffset,
+                  end: Offset.zero,
+                ).animate(animation);
+                final Animation<Offset> outAnimation = Tween<Offset>(
+                  begin: animationStartOffset.scale(-1, -1),
+                  end: Offset.zero,
+                ).animate(animation);
 
-          return ClipRect(
-            child: SlideTransition(
-              position: child.key == ValueKey<int>(_currentQuestionIndex)
-                  ? // Animate in the new question card.
-                  inAnimation
-                  // Animate out the old question card.
-                  : outAnimation,
-              child: Padding(
-                padding: const EdgeInsets.all(SMALL_SPACE),
-                child: child,
+                return ClipRect(
+                  child: SlideTransition(
+                    position: child.key == ValueKey<int>(_currentQuestionIndex)
+                        ? inAnimation
+                        : outAnimation,
+                    child: Padding(
+                      padding: const EdgeInsets.all(SMALL_SPACE),
+                      child: child,
+                    ),
+                  ),
+                );
+              },
+              child: KeyedSubtree(
+                key: ValueKey<int>(_currentQuestionIndex),
+                child: switch (_state) {
+                  _RobotoffQuestionLoadingState _ => const _LoadingQuestionsView(),
+                  _RobotoffQuestionSuccessState _ => _buildQuestionsWidget(),
+                  _RobotoffQuestionErrorState _ => _ErrorLoadingView(onRetry: _loadQuestions),
+                },
               ),
             ),
-          );
-        },
-        child: KeyedSubtree(
-          key: ValueKey<int>(_currentQuestionIndex),
-          child: switch (_state) {
-            _RobotoffQuestionLoadingState _ => const _LoadingQuestionsView(),
-            _RobotoffQuestionSuccessState _ => _buildQuestionsWidget(),
-            _RobotoffQuestionErrorState _ =>
-              _ErrorLoadingView(onRetry: _loadQuestions),
-          },
+          ),
         ),
-      ),
+      )
     );
   }
 
@@ -261,14 +177,13 @@ class _QuestionPageState extends State<_QuestionPage>
     final List<RobotoffQuestion> questions =
         (_state as _RobotoffQuestionSuccessState).questions;
 
-    if (questions.length == _currentQuestionIndex) {
+    if (_currentQuestionIndex >= questions.length) {
       return _QuestionsSuccessView(
         onContinue: widget.product == null ? _loadNextQuestions : null,
         anonymousAnnotationList: _anonymousAnnotationList,
       );
     } else {
       final RobotoffQuestion question = questions[_currentQuestionIndex];
-
       return _QuestionView(
         question: question,
         initialProduct: widget.product,
@@ -278,6 +193,7 @@ class _QuestionPageState extends State<_QuestionPage>
             _lastAnswer = answer;
             _currentQuestionIndex++;
           });
+          _incrementQuestionsAnswered();
         },
       );
     }
@@ -286,14 +202,11 @@ class _QuestionPageState extends State<_QuestionPage>
   Offset _getAnimationStartOffset() {
     switch (_lastAnswer) {
       case InsightAnnotation.YES:
-        // For [InsightAnnotation.YES]: Animation starts from left side and goes right.
         return const Offset(-1.0, 0);
       case InsightAnnotation.NO:
-        // For [InsightAnnotation.NO]: Animation starts from right side and goes left.
         return const Offset(1.0, 0);
       case InsightAnnotation.MAYBE:
       case null:
-        // For [InsightAnnotation.MAYBE]: Animation starts from bottom and goes up.
         return const Offset(0, 1);
     }
   }
@@ -302,8 +215,6 @@ class _QuestionPageState extends State<_QuestionPage>
     final RobotoffQuestion question,
     final InsightAnnotation insightAnnotation,
   ) async {
-    _QuestionsAnsweredNotifier.of(context, listen: false).increment();
-
     final String? barcode = question.barcode;
     final String? insightId = question.insightId;
     if (barcode == null || insightId == null) {
@@ -329,6 +240,7 @@ class _QuestionPageState extends State<_QuestionPage>
   @override
   String get actionName => 'Opened robotoff_question_page';
 }
+
 
 sealed class _RobotoffQuestionState {
   const _RobotoffQuestionState();
@@ -357,6 +269,8 @@ class _LoadingQuestionsView extends StatelessWidget {
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final double screenHeight = MediaQuery.sizeOf(context).height;
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme colorScheme = theme.colorScheme;
 
     return FutureBuilder<void>(
       future: Future<void>.delayed(const Duration(milliseconds: 500)),
@@ -367,7 +281,7 @@ class _LoadingQuestionsView extends StatelessWidget {
           child: Center(
             child: DefaultTextStyle(
               textAlign: TextAlign.center,
-              style: const TextStyle(),
+              style: TextStyle(color: colorScheme.onBackground), 
               child: FractionallySizedBox(
                 widthFactor: 0.8,
                 child: MergeSemantics(
@@ -376,19 +290,23 @@ class _LoadingQuestionsView extends StatelessWidget {
                     children: <Widget>[
                       Text(
                         appLocalizations.hunger_games_loading_line1,
-                        style: const TextStyle(
+                        style: theme.textTheme.titleMedium?.copyWith(
                           fontWeight: FontWeight.bold,
                           fontSize: 19.0,
+                          color: colorScheme.primary, 
                         ),
                       ),
                       SizedBox(height: screenHeight * 0.05),
-                      const LinearProgressIndicator(),
+                      LinearProgressIndicator(
+                        color: colorScheme.primary, 
+                      ),
                       SizedBox(height: screenHeight * 0.10),
                       Text(
                         appLocalizations.hunger_games_loading_line2,
                         textAlign: TextAlign.center,
-                        style: const TextStyle(
+                        style: theme.textTheme.bodyLarge?.copyWith(
                           fontSize: 17.0,
+                          color: colorScheme.primary, 
                         ),
                       ),
                     ],
@@ -445,12 +363,13 @@ class _QuestionsSuccessView extends StatelessWidget {
   Widget build(BuildContext context) {
     return CongratsWidget(
       continueButtonLabel: onContinue != null
-          ? AppLocalizations.of(context).robotoff_next_n_questions(
-              _QuestionPageState._numberQuestionsNext,
+          ? AppLocalizations.of(context).robotoff_next_n_questions(10
+              
+              // QuestionPageState._numberQuestionsNext,
             )
           : null,
       anonymousAnnotationList: anonymousAnnotationList,
-      onContinue: onContinue,
+      onContinue: onContinue, 
       result: _QuestionsAnsweredNotifier.of(context).value,
     );
   }
@@ -466,14 +385,18 @@ class _ErrorLoadingView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme colorScheme = theme.colorScheme;
+    final TextTheme textTheme = theme.textTheme;
 
     return Center(
       child: DefaultTextStyle(
         textAlign: TextAlign.center,
-        style: const TextStyle(
+        style: textTheme.bodyLarge?.copyWith(
           fontWeight: FontWeight.bold,
           fontSize: 20.0,
-        ),
+          color: colorScheme.onBackground,
+        ) ?? const TextStyle(),
         child: FractionallySizedBox(
           widthFactor: 0.8,
           child: Column(
@@ -481,15 +404,24 @@ class _ErrorLoadingView extends StatelessWidget {
             children: <Widget>[
               Text(
                 appLocalizations.hunger_games_error_label,
+                style: textTheme.titleMedium?.copyWith(
+                  fontSize: 20.0,
+                  color: colorScheme.error, 
+                ),
               ),
               const SizedBox(height: VERY_LARGE_SPACE),
               SmoothLargeButtonWithIcon(
                 text: appLocalizations.hunger_games_error_retry_button,
-                leadingIcon: const Icon(Icons.refresh),
-                onPressed: onRetry,
-                textStyle: const TextStyle(
-                  fontSize: 18.0,
+                leadingIcon: Icon(
+                  Icons.refresh,
+                  color: colorScheme.onPrimary, 
                 ),
+                onPressed: onRetry,
+                textStyle: textTheme.labelLarge?.copyWith(
+                  fontSize: 18.0,
+                  color: colorScheme.onPrimary,
+                ),
+                backgroundColor: colorScheme.primary, 
               ),
             ],
           ),

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_contribute.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_contribute.dart
@@ -309,16 +309,12 @@ class UserPreferencesContribute extends AbstractUserPreferences {
       AnalyticsEvent.hungerGameOpened,
     );
 
-
     Navigator.push(
       context,
       MaterialPageRoute<int>(
-        builder: (context) => QuestionsPage( ),
-        ),
-      ).then((questionsAnswered) {
-      // Gestisci il risultato se necessario
-    });
-
+        builder: (BuildContext context) => const QuestionsPage(),
+      ),
+    ).then((int? questionsAnswered) {});
   }
 
   UserPreferencesItem _getListTile(

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_contribute.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_contribute.dart
@@ -308,7 +308,17 @@ class UserPreferencesContribute extends AbstractUserPreferences {
     AnalyticsHelper.trackEvent(
       AnalyticsEvent.hungerGameOpened,
     );
-    await openQuestionPage(context);
+
+
+    Navigator.push(
+      context,
+      MaterialPageRoute<int>(
+        builder: (context) => QuestionsPage( ),
+        ),
+      ).then((questionsAnswered) {
+      // Gestisci il risultato se necessario
+    });
+
   }
 
   UserPreferencesItem _getListTile(

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_contribute.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_contribute.dart
@@ -309,12 +309,12 @@ class UserPreferencesContribute extends AbstractUserPreferences {
       AnalyticsEvent.hungerGameOpened,
     );
 
-    Navigator.push(
+    await Navigator.push<int>(
       context,
       MaterialPageRoute<int>(
         builder: (BuildContext context) => const QuestionsPage(),
       ),
-    ).then((int? questionsAnswered) {});
+    );
   }
 
   UserPreferencesItem _getListTile(

--- a/packages/smooth_app/lib/pages/product/product_questions_widget.dart
+++ b/packages/smooth_app/lib/pages/product/product_questions_widget.dart
@@ -77,24 +77,24 @@ class _ProductQuestionsWidgetState extends State<ProductQuestionsWidget>
   Future<void> _openQuestions() async {
     _trackEvent(AnalyticsEvent.questionClicked);
 
-    Navigator.push(
+    final int? questionsAnswered = await Navigator.push<int>(
       context,
       MaterialPageRoute<int>(
-      builder: (context) => QuestionsPage(
-        product: widget.product,
-        questions: (_state as _ProductQuestionsWithQuestions)
-            .questions
-            .toList(growable: false),
-            ),
-          ),
-        ).then((questionsAnswered) {
-          if (context.mounted && questionsAnswered != null && questionsAnswered > 0) {
-            return _reloadQuestions(
-              updateInsightAnnotations: true,
-              ignoreExistingQuestions: true,
-            );
-          }
-        });
+        builder: (BuildContext context) => QuestionsPage(
+          product: widget.product,
+          questions: (_state as _ProductQuestionsWithQuestions)
+              .questions
+              .toList(growable: false),
+        ),
+      ),
+    );
+
+    if (context.mounted && questionsAnswered != null && questionsAnswered > 0) {
+      await _reloadQuestions(
+        updateInsightAnnotations: true,
+        ignoreExistingQuestions: true,
+      );
+    }
   }
 
   Future<void> _reloadQuestions({

--- a/packages/smooth_app/lib/pages/product/product_questions_widget.dart
+++ b/packages/smooth_app/lib/pages/product/product_questions_widget.dart
@@ -77,20 +77,24 @@ class _ProductQuestionsWidgetState extends State<ProductQuestionsWidget>
   Future<void> _openQuestions() async {
     _trackEvent(AnalyticsEvent.questionClicked);
 
-    final int? answeredQuestions = await openQuestionPage(
+    Navigator.push(
       context,
-      product: widget.product,
-      questions: (_state as _ProductQuestionsWithQuestions)
-          .questions
-          .toList(growable: false),
-    );
-
-    if (context.mounted && answeredQuestions != null && answeredQuestions > 0) {
-      return _reloadQuestions(
-        updateInsightAnnotations: true,
-        ignoreExistingQuestions: true,
-      );
-    }
+      MaterialPageRoute<int>(
+      builder: (context) => QuestionsPage(
+        product: widget.product,
+        questions: (_state as _ProductQuestionsWithQuestions)
+            .questions
+            .toList(growable: false),
+            ),
+          ),
+        ).then((questionsAnswered) {
+          if (context.mounted && questionsAnswered != null && questionsAnswered > 0) {
+            return _reloadQuestions(
+              updateInsightAnnotations: true,
+              ignoreExistingQuestions: true,
+            );
+          }
+        });
   }
 
   Future<void> _reloadQuestions({

--- a/packages/smooth_app/lib/pages/product/product_questions_widget.dart
+++ b/packages/smooth_app/lib/pages/product/product_questions_widget.dart
@@ -77,7 +77,7 @@ class _ProductQuestionsWidgetState extends State<ProductQuestionsWidget>
   Future<void> _openQuestions() async {
     _trackEvent(AnalyticsEvent.questionClicked);
 
-    final int? questionsAnswered = await Navigator.push<int>(
+    final int? answeredQuestions = await Navigator.push<int>(
       context,
       MaterialPageRoute<int>(
         builder: (BuildContext context) => QuestionsPage(
@@ -89,7 +89,7 @@ class _ProductQuestionsWidgetState extends State<ProductQuestionsWidget>
       ),
     );
 
-    if (context.mounted && questionsAnswered != null && questionsAnswered > 0) {
+    if (context.mounted && answeredQuestions != null && answeredQuestions > 0) {
       await _reloadQuestions(
         updateInsightAnnotations: true,
         ignoreExistingQuestions: true,


### PR DESCRIPTION
Committer: Lorenzo Mascia <lorenzo.mascia@ericsson.com>

Changes :
	modified:   packages/smooth_app/lib/pages/hunger_games/question_card.dart
	modified:   packages/smooth_app/lib/pages/hunger_games/question_page.dart
	modified:   packages/smooth_app/lib/pages/preferences/user_preferences_contribute.dart
	modified:   packages/smooth_app/lib/pages/product/product_questions_widget.dart

### What
- Moved the Hunger Games screen from an overlay to a real view using a standard `Scaffold`, as described in the issue.
- This improves navigation consistency and aligns the UI with the rest of the app.

**fix: Move Hunger Games to real view instead of overlay**

### Screenshot

![Screenshot 2025-04-15 211841](https://github.com/user-attachments/assets/49474f14-a649-4a50-acbe-81154698bd93)
![Screenshot 2025-04-15 212004](https://github.com/user-attachments/assets/d0eb2634-9948-4920-9a0e-13fadaeb880c)

### Fixes bug(s)
- Fixes: #4681
