### PR TITLE
feat: add shortcut to GDPR requests Wikipage in Prices screen

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -407,6 +407,10 @@
   "@contribute_share_content": {
     "description": "Content that will be shared, don't forget to include the URL"
   },
+  "contribute_prices_gdpr": "Contribute prices by requesting a GDPR export of your loyalty cards data",
+  "@contribute_prices_gdpr": {
+    "description": "Label for option to contribute prices using GDPR export from loyalty cards"
+  },
   "tap_to_answer": "Tap here to answer questions",
   "@tap_to_answer": {
     "description": "Button label shown on a product, clicking the button opens a card with unanswered product questions, users can answer these to contribute to Open Food Facts and gain rewards."

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_prices.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_prices.dart
@@ -171,6 +171,12 @@ class UserPreferencesPrices extends AbstractUserPreferences {
         ),
         Icons.open_in_new,
       ),
+      _getListTile(
+        appLocalizations.contribute_prices_gdpr,
+        () async => LaunchUrlHelper.launchURL(
+            'https://wiki.openfoodfacts.org/GDPR_request'),
+        Icons.open_in_new,
+      ),
     ];
   }
 


### PR DESCRIPTION
### What

- Added a `_getListTile` in the Prices screen to include a Wiki link for GDPR requests.
- `feat`: Add GDPR link to the Prices screen.

---

### Screenshot  
<!-- Insert a screenshot to provide visual record of your changes, if visible -->  
<img src="https://github.com/user-attachments/assets/cedd27e1-cc49-449e-90c2-49c2fbba8b14" width="350"/>


---

### Fixes bug(s)

- Fixes: #6546

```dart
  _getListTile(
        appLocalizations.contribute_prices_gdpr,
        () async => LaunchUrlHelper.launchURL(
            'https://wiki.openfoodfacts.org/GDPR_request'),
        Icons.open_in_new,
      ),
```
`app_en.arb` file
```dart
  "contribute_prices_gdpr": "Contribute prices by requesting a GDPR export of your loyalty cards data",
  "@contribute_prices_gdpr": {
    "description": "Label for option to contribute prices using GDPR export from loyalty cards"
  },
```

---

### Part of

- #525 <!-- Add the most granular issue possible -->

---

