### PR TITLE
fix: Update plural formatting in localization files for Greek and Dutch

### DIFF
--- a/packages/smooth_app/lib/l10n/app_el.arb
+++ b/packages/smooth_app/lib/l10n/app_el.arb
@@ -1157,14 +1157,14 @@
       "percent": {}
     }
   },
-  "plural_ago_days": "{count,plural, one {} =1{μια μέρα πριν} other{{count} μέρες πριν}}",
+  "plural_ago_days": "{count,plural,  =1{μια μέρα πριν} other{{count} μέρες πριν}}",
   "@plural_ago_days": {
     "description": "Cached results from: x days ago",
     "placeholders": {
       "count": {}
     }
   },
-  "plural_ago_hours": "{count,plural, one {} =1{μία ώρα πριν} other{{count} ώρες πριν}}",
+  "plural_ago_hours": "{count,plural,  =1{μία ώρα πριν} other{{count} ώρες πριν}}",
   "@plural_ago_hours": {
     "description": "Cached results from: x hours ago",
     "placeholders": {
@@ -2264,8 +2264,8 @@
   "prices_bulk_proof_upload_title": "Bulk Proof Upload",
   "prices_bulk_proof_upload_action": "Send the proof",
   "prices_generic_title": "Prices",
-  "prices_add_n_prices": "{count,plural, one {}=1{Προσθήκη τιμής} other{Προσθήκη {count} τιμών}}",
-  "prices_send_n_prices": "{count,plural, one {}=1{Στείλτε την τιμή} other{Στείλτε {count} τιμές}}",
+  "prices_add_n_prices": "{count,plural, =1{Προσθήκη τιμής} other{Προσθήκη {count} τιμών}}",
+  "prices_send_n_prices": "{count,plural, =1{Στείλτε την τιμή} other{Στείλτε {count} τιμές}}",
   "prices_add_an_item": "Προσθήκη αντικειμένου",
   "prices_add_a_price": "Add a price",
   "prices_add_a_receipt": "Προσθήκη απόδειξης",
@@ -2305,7 +2305,7 @@
       }
     }
   },
-  "prices_list_length_one_page": "{count,plural, one {}=0{Καμία τιμή ακόμα} =1{Μόνο μία τιμή} other{Και οι {count} τιμές}}",
+  "prices_list_length_one_page": "{count,plural, =0{Καμία τιμή ακόμα} =1{Μόνο μία τιμή} other{Και οι {count} τιμές}}",
   "@prices_list_length_one_page": {
     "description": "Number of prices for one-page result",
     "placeholders": {
@@ -2357,7 +2357,7 @@
   "@prices_open_proof": {
     "description": "Button to open a proof"
   },
-  "prices_proofs_list_length_one_page": "{count,plural, one {}=0{Καμία απόδειξη ακόμα} =1{Μόνο μία απόδειξη} other{Και οι {count} αποδείξεις}}",
+  "prices_proofs_list_length_one_page": "{count,plural, =0{Καμία απόδειξη ακόμα} =1{Μόνο μία απόδειξη} other{Και οι {count} αποδείξεις}}",
   "@prices_proofs_list_length_one_page": {
     "description": "Number of proofs for one-page result",
     "placeholders": {
@@ -2402,7 +2402,7 @@
       }
     }
   },
-  "prices_button_count_proof": "{count,plural, one {}=0{Καμία απόδειξη} =1{Μία απόδειξη} other{{count} αποδείξεις}}",
+  "prices_button_count_proof": "{count,plural, =0{Καμία απόδειξη} =1{Μία απόδειξη} other{{count} αποδείξεις}}",
   "@prices_button_count_proof": {
     "description": "Number of proofs, for a button",
     "placeholders": {
@@ -2411,7 +2411,7 @@
       }
     }
   },
-  "prices_button_count_product": "{count,plural, one {}=0{Κανένα προϊόν} =1{Ένα προϊόν} other{{count} προϊόντα}}",
+  "prices_button_count_product": "{count,plural, =0{Κανένα προϊόν} =1{Ένα προϊόν} other{{count} προϊόντα}}",
   "@prices_button_count_product": {
     "description": "Number of products, for a button",
     "placeholders": {
@@ -2420,7 +2420,7 @@
       }
     }
   },
-  "prices_button_count_user": "{count,plural, one {}=0{Κανένας χρήστης} =1{Ένας χρήστης} other{{count} χρήστες}}",
+  "prices_button_count_user": "{count,plural, =0{Κανένας χρήστης} =1{Ένας χρήστης} other{{count} χρήστες}}",
   "@prices_button_count_user": {
     "description": "Number of users, for a button",
     "placeholders": {
@@ -2429,7 +2429,7 @@
       }
     }
   },
-  "prices_button_count_price": "{count,plural, one {}=0{Καμία τιμή} =1{Μία τιμή} other{{count} τιμές}}",
+  "prices_button_count_price": "{count,plural, =0{Καμία τιμή} =1{Μία τιμή} other{{count} τιμές}}",
   "@prices_button_count_price": {
     "description": "Number of prices, for a button",
     "placeholders": {
@@ -3280,7 +3280,7 @@
   "@robotoff_continue": {
     "description": "Shown when robotoff question are all answered and user wants to continue answering"
   },
-  "robotoff_next_n_questions": "{count,plural,  one {}=1{Επόμενη ερώτηση} other{Επόμενες {count} ερωτήσεις}}",
+  "robotoff_next_n_questions": "{count,plural,  =1{Επόμενη ερώτηση} other{Επόμενες {count} ερωτήσεις}}",
   "@robotoff_next_n_questions": {
     "description": "Shown when robotoff question are all answered and user wants to continue answering",
     "placeholders": {

--- a/packages/smooth_app/lib/l10n/app_nl.arb
+++ b/packages/smooth_app/lib/l10n/app_nl.arb
@@ -1199,7 +1199,7 @@
       "count": {}
     }
   },
-  "multiselect_title": "{count,plural, one {}=0{Geen geselecteerd product} =1{Eén geselecteerd product} other{{count} geselecteerde producten}}",
+  "multiselect_title": "{count,plural, =0{Geen geselecteerd product} =1{Eén geselecteerd product} other{{count} geselecteerde producten}}",
   "@multiselect_title": {
     "description": "Page title with the number of selected items",
     "placeholders": {
@@ -2264,8 +2264,8 @@
   "prices_bulk_proof_upload_title": "Bulkbewijs uploaden",
   "prices_bulk_proof_upload_action": "Stuur het bewijs in",
   "prices_generic_title": "Prijzen",
-  "prices_add_n_prices": "{count,plural, one {}=1{Voeg een prijs toe} other{Voeg {count} prijzen toe}}",
-  "prices_send_n_prices": "{count,plural, one {}=1{Verstuur 1 prijs} other{Verstuur {count} prijzen}}",
+  "prices_add_n_prices": "{count,plural, =1{Voeg een prijs toe} other{Voeg {count} prijzen toe}}",
+  "prices_send_n_prices": "{count,plural, =1{Verstuur 1 prijs} other{Verstuur {count} prijzen}}",
   "prices_add_an_item": "Item toevoegen",
   "prices_add_a_price": "Voeg een prijs toe",
   "prices_add_a_receipt": "Een ontvangstbewijs toevoegen",
@@ -2293,7 +2293,7 @@
   "prices_barcode_enter": "Voer de streepjescode in",
   "prices_barcode_reader_action": "Streepjescodelezer",
   "prices_view_prices": "Bekijk de prijzen",
-  "prices_product_accessibility_summary": "{count,plural, one {}=1{1 prijs} other{{count} prijzen}} voor {product}",
+  "prices_product_accessibility_summary": "{count,plural, =1{1 prijs} other{{count} prijzen}} voor {product}",
   "@prices_product_accessibility_summary": {
     "description": "A card summarizing the number of prices for a product",
     "placeholders": {
@@ -2305,7 +2305,7 @@
       }
     }
   },
-  "prices_list_length_one_page": "{count,plural, one {}=0{Nog geen prijs} =1{Slechts één prijs} other{Alle {count} prijzen}}",
+  "prices_list_length_one_page": "{count,plural, =0{Nog geen prijs} =1{Slechts één prijs} other{Alle {count} prijzen}}",
   "@prices_list_length_one_page": {
     "description": "Number of prices for one-page result",
     "placeholders": {
@@ -2357,7 +2357,7 @@
   "@prices_open_proof": {
     "description": "Button to open a proof"
   },
-  "prices_proofs_list_length_one_page": "{count,plural, one {}=0{Nog geen bewijs} =1{Slechts één bewijs} other{Alle {count} bewijzen}}",
+  "prices_proofs_list_length_one_page": "{count,plural, =0{Nog geen bewijs} =1{Slechts één bewijs} other{Alle {count} bewijzen}}",
   "@prices_proofs_list_length_one_page": {
     "description": "Number of proofs for one-page result",
     "placeholders": {
@@ -2402,7 +2402,7 @@
       }
     }
   },
-  "prices_button_count_proof": "{count,plural, one {}=0{Geen bewijs} =1{Eén bewijs} other{{count} bewijzen}}",
+  "prices_button_count_proof": "{count,plural, =0{Geen bewijs} =1{Eén bewijs} other{{count} bewijzen}}",
   "@prices_button_count_proof": {
     "description": "Number of proofs, for a button",
     "placeholders": {
@@ -2411,7 +2411,7 @@
       }
     }
   },
-  "prices_button_count_product": "{count,plural, one {}=0{Geen product} =1{Eén product} other{{count} producten}}",
+  "prices_button_count_product": "{count,plural, =0{Geen product} =1{Eén product} other{{count} producten}}",
   "@prices_button_count_product": {
     "description": "Number of products, for a button",
     "placeholders": {
@@ -2420,7 +2420,7 @@
       }
     }
   },
-  "prices_button_count_user": "{count,plural, one {}=0{Geen gebruiker} =1{Eén gebruiker} other{{count} gebruikers}}",
+  "prices_button_count_user": "{count,plural, =0{Geen gebruiker} =1{Eén gebruiker} other{{count} gebruikers}}",
   "@prices_button_count_user": {
     "description": "Number of users, for a button",
     "placeholders": {
@@ -2429,7 +2429,7 @@
       }
     }
   },
-  "prices_button_count_price": "{count,plural, one {}=0{Geen prijs} =1{Eén prijs} other{{count} prijzen}}",
+  "prices_button_count_price": "{count,plural, =0{Geen prijs} =1{Eén prijs} other{{count} prijzen}}",
   "@prices_button_count_price": {
     "description": "Number of prices, for a button",
     "placeholders": {
@@ -3533,7 +3533,7 @@
   "@download_top_products": {
     "description": "Download the top 1000 products in your country for instant scanning"
   },
-  "download_top_n_products": "Top {count,plural,  one {}other{{count} producten}} downloaden in uw land voor direct scannen",
+  "download_top_n_products": "Top {count,plural,  other{{count} producten}} downloaden in uw land voor direct scannen",
   "@download_top_n_products": {
     "placeholders": {
       "count": {


### PR DESCRIPTION
### What
This pull request fixes pluralization logic in the Greek (`app_el.arb`) and Dutch (`app_nl.arb`) localization files by removing unnecessary `one` cases where they were preventing the app to build