### PR TITLE
fix: dark mode issue in feedback page

### DIFF
--- a/packages/smooth_app/lib/pages/scan/carousel/main_card/bottom_cards/scan_app_review_card.dart
+++ b/packages/smooth_app/lib/pages/scan/carousel/main_card/bottom_cards/scan_app_review_card.dart
@@ -111,7 +111,7 @@ class ScanAppReview extends StatelessWidget {
                     backgroundColor:
                         lightTheme ? colors.primaryBlack : colors.primaryLight,
                     foregroundColor:
-                        lightTheme ? Colors.white : colors.primaryBlack,
+                        lightTheme ? Colors.white : colors.primaryDark,
                     icon: DecoratedBox(
                       decoration: ShapeDecoration(
                         shape: const CircleBorder(),

--- a/packages/smooth_app/lib/pages/scan/carousel/main_card/bottom_cards/scan_app_review_card.dart
+++ b/packages/smooth_app/lib/pages/scan/carousel/main_card/bottom_cards/scan_app_review_card.dart
@@ -67,7 +67,7 @@ class ScanAppReview extends StatelessWidget {
               ),
               onTap: () async {
                 final AppReviewProvider appReview =
-                context.read<AppReviewProvider>();
+                    context.read<AppReviewProvider>();
                 await ApplicationStore.openAppReview();
                 appReview.markAsReviewed(AppReviewResult.satisfied);
               },
@@ -79,11 +79,11 @@ class ScanAppReview extends StatelessWidget {
   }
 
   Future<void> _showUserFeedBackModalSheet(
-      BuildContext context,
-      AppReviewResult result,
-      ) async {
+    BuildContext context,
+    AppReviewResult result,
+  ) async {
     final SmoothColorsThemeExtension colors =
-    context.extension<SmoothColorsThemeExtension>();
+        context.extension<SmoothColorsThemeExtension>();
     final bool lightTheme = context.lightTheme(listen: false);
 
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
@@ -133,10 +133,11 @@ class ScanAppReview extends StatelessWidget {
                   child: _AppReviewButton(
                     onPressed: () => Navigator.of(context).pop(false),
                     text: appLocalizations.app_review_feedback_modal_later,
-                    backgroundColor:
-                    lightTheme ? colors.primaryMedium : colors.primarySemiDark,
+                    backgroundColor: lightTheme
+                        ? colors.primaryMedium
+                        : colors.primarySemiDark,
                     foregroundColor:
-                    lightTheme ? colors.primaryBlack : Colors.white,
+                        lightTheme ? colors.primaryBlack : Colors.white,
                   ),
                 ),
               ],

--- a/packages/smooth_app/lib/pages/scan/carousel/main_card/bottom_cards/scan_app_review_card.dart
+++ b/packages/smooth_app/lib/pages/scan/carousel/main_card/bottom_cards/scan_app_review_card.dart
@@ -67,7 +67,7 @@ class ScanAppReview extends StatelessWidget {
               ),
               onTap: () async {
                 final AppReviewProvider appReview =
-                context.read<AppReviewProvider>();
+                    context.read<AppReviewProvider>();
                 await ApplicationStore.openAppReview();
                 appReview.markAsReviewed(AppReviewResult.satisfied);
               },
@@ -79,11 +79,11 @@ class ScanAppReview extends StatelessWidget {
   }
 
   Future<void> _showUserFeedBackModalSheet(
-      BuildContext context,
-      AppReviewResult result,
-      ) async {
+    BuildContext context,
+    AppReviewResult result,
+  ) async {
     final SmoothColorsThemeExtension colors =
-    context.extension<SmoothColorsThemeExtension>();
+        context.extension<SmoothColorsThemeExtension>();
     final bool lightTheme = context.lightTheme(listen: false);
 
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
@@ -109,9 +109,9 @@ class ScanAppReview extends StatelessWidget {
                     onPressed: () => Navigator.of(context).pop(true),
                     text: appLocalizations.app_review_feedback_modal_open_form,
                     backgroundColor:
-                    lightTheme ? colors.primaryBlack : colors.primaryLight,
+                        lightTheme ? colors.primaryBlack : colors.primaryLight,
                     foregroundColor:
-                    lightTheme ? Colors.white : colors.primaryBlack,
+                        lightTheme ? Colors.white : colors.primaryBlack,
                     icon: DecoratedBox(
                       decoration: ShapeDecoration(
                         shape: const CircleBorder(),
@@ -138,9 +138,9 @@ class ScanAppReview extends StatelessWidget {
                     onPressed: () => Navigator.of(context).pop(false),
                     text: appLocalizations.app_review_feedback_modal_later,
                     backgroundColor:
-                    lightTheme ? colors.primaryLight : colors.primaryDark,
+                        lightTheme ? colors.primaryLight : colors.primaryDark,
                     foregroundColor:
-                    lightTheme ? colors.primaryDark : colors.primaryLight,
+                        lightTheme ? colors.primaryDark : colors.primaryLight,
                   ),
                 ),
               ],

--- a/packages/smooth_app/lib/pages/scan/carousel/main_card/bottom_cards/scan_app_review_card.dart
+++ b/packages/smooth_app/lib/pages/scan/carousel/main_card/bottom_cards/scan_app_review_card.dart
@@ -67,7 +67,7 @@ class ScanAppReview extends StatelessWidget {
               ),
               onTap: () async {
                 final AppReviewProvider appReview =
-                    context.read<AppReviewProvider>();
+                context.read<AppReviewProvider>();
                 await ApplicationStore.openAppReview();
                 appReview.markAsReviewed(AppReviewResult.satisfied);
               },
@@ -79,11 +79,11 @@ class ScanAppReview extends StatelessWidget {
   }
 
   Future<void> _showUserFeedBackModalSheet(
-    BuildContext context,
-    AppReviewResult result,
-  ) async {
+      BuildContext context,
+      AppReviewResult result,
+      ) async {
     final SmoothColorsThemeExtension colors =
-        context.extension<SmoothColorsThemeExtension>();
+    context.extension<SmoothColorsThemeExtension>();
     final bool lightTheme = context.lightTheme(listen: false);
 
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
@@ -108,10 +108,8 @@ class ScanAppReview extends StatelessWidget {
                   child: _AppReviewButton(
                     onPressed: () => Navigator.of(context).pop(true),
                     text: appLocalizations.app_review_feedback_modal_open_form,
-                    backgroundColor:
-                        lightTheme ? colors.primaryBlack : colors.primaryLight,
-                    foregroundColor:
-                        lightTheme ? Colors.white : colors.primaryDark,
+                    backgroundColor: colors.primaryBlack,
+                    foregroundColor: Colors.white,
                     icon: DecoratedBox(
                       decoration: const ShapeDecoration(
                         shape: CircleBorder(),
@@ -123,9 +121,7 @@ class ScanAppReview extends StatelessWidget {
                         ),
                         child: icons.Arrow.right(
                           size: 12.0,
-                          color: lightTheme
-                              ? colors.primaryBlack
-                              : colors.primaryLight,
+                          color: colors.primaryBlack,
                         ),
                       ),
                     ),
@@ -138,9 +134,9 @@ class ScanAppReview extends StatelessWidget {
                     onPressed: () => Navigator.of(context).pop(false),
                     text: appLocalizations.app_review_feedback_modal_later,
                     backgroundColor:
-                        lightTheme ? colors.primaryLight : colors.primaryDark,
+                    lightTheme ? colors.primaryMedium : colors.primarySemiDark,
                     foregroundColor:
-                        lightTheme ? colors.primaryDark : colors.primaryLight,
+                    lightTheme ? colors.primaryBlack : Colors.white,
                   ),
                 ),
               ],

--- a/packages/smooth_app/lib/pages/scan/carousel/main_card/bottom_cards/scan_app_review_card.dart
+++ b/packages/smooth_app/lib/pages/scan/carousel/main_card/bottom_cards/scan_app_review_card.dart
@@ -67,7 +67,7 @@ class ScanAppReview extends StatelessWidget {
               ),
               onTap: () async {
                 final AppReviewProvider appReview =
-                    context.read<AppReviewProvider>();
+                context.read<AppReviewProvider>();
                 await ApplicationStore.openAppReview();
                 appReview.markAsReviewed(AppReviewResult.satisfied);
               },
@@ -79,11 +79,11 @@ class ScanAppReview extends StatelessWidget {
   }
 
   Future<void> _showUserFeedBackModalSheet(
-    BuildContext context,
-    AppReviewResult result,
-  ) async {
+      BuildContext context,
+      AppReviewResult result,
+      ) async {
     final SmoothColorsThemeExtension colors =
-        context.extension<SmoothColorsThemeExtension>();
+    context.extension<SmoothColorsThemeExtension>();
     final bool lightTheme = context.lightTheme(listen: false);
 
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
@@ -108,12 +108,14 @@ class ScanAppReview extends StatelessWidget {
                   child: _AppReviewButton(
                     onPressed: () => Navigator.of(context).pop(true),
                     text: appLocalizations.app_review_feedback_modal_open_form,
-                    backgroundColor: colors.primaryBlack,
-                    foregroundColor: Colors.white,
+                    backgroundColor:
+                    lightTheme ? colors.primaryBlack : colors.primaryLight,
+                    foregroundColor:
+                    lightTheme ? Colors.white : colors.primaryBlack,
                     icon: DecoratedBox(
-                      decoration: const ShapeDecoration(
-                        shape: CircleBorder(),
-                        color: Colors.white,
+                      decoration: ShapeDecoration(
+                        shape: const CircleBorder(),
+                        color: lightTheme ? Colors.white : colors.primaryDark,
                       ),
                       child: Padding(
                         padding: const EdgeInsetsDirectional.all(
@@ -121,7 +123,9 @@ class ScanAppReview extends StatelessWidget {
                         ),
                         child: icons.Arrow.right(
                           size: 12.0,
-                          color: colors.primaryBlack,
+                          color: lightTheme
+                              ? colors.primaryBlack
+                              : colors.primaryLight,
                         ),
                       ),
                     ),
@@ -133,11 +137,10 @@ class ScanAppReview extends StatelessWidget {
                   child: _AppReviewButton(
                     onPressed: () => Navigator.of(context).pop(false),
                     text: appLocalizations.app_review_feedback_modal_later,
-                    backgroundColor: lightTheme
-                        ? colors.primaryMedium
-                        : colors.primarySemiDark,
+                    backgroundColor:
+                    lightTheme ? colors.primaryLight : colors.primaryDark,
                     foregroundColor:
-                        lightTheme ? colors.primaryBlack : Colors.white,
+                    lightTheme ? colors.primaryDark : colors.primaryLight,
                   ),
                 ),
               ],


### PR DESCRIPTION
Closes: #6571

The bug with dark mode in the feedback page is resolved by changing the background color, as the icon was not visible correctly in dark mode.

<img width="363" alt="Screenshot 2025-05-02 at 1 41 42 PM" src="https://github.com/user-attachments/assets/361241e8-eca1-4f6c-9534-d40d753a7758" />
