### PR TITLE
fix: Add price: swipe gesture available on iOS without changes

### DIFF
--- a/packages/smooth_app/lib/helpers/provider_helper.dart
+++ b/packages/smooth_app/lib/helpers/provider_helper.dart
@@ -39,6 +39,48 @@ class _ListenerState<T> extends SingleChildState<Listener<T>> {
   }
 }
 
+class ChangeNotifierListener<T extends ChangeNotifier> extends StatefulWidget {
+  const ChangeNotifierListener({
+    required this.child,
+    required this.listener,
+    super.key,
+  });
+
+  final Widget child;
+  final Function(BuildContext context, T notifier) listener;
+
+  @override
+  State<ChangeNotifierListener<T>> createState() =>
+      _ChangeNotifierListenerState<T>();
+}
+
+class _ChangeNotifierListenerState<T extends ChangeNotifier>
+    extends State<ChangeNotifierListener<T>> {
+  T? _notifier;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _notifier ??= context.read<T>()..replaceListener(_onNotifierChanged);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.child;
+  }
+
+  void _onNotifierChanged() {
+    widget.listener(context, _notifier!);
+  }
+
+  @override
+  void dispose() {
+    _notifier?.removeListener(_onNotifierChanged);
+    _notifier = null;
+    super.dispose();
+  }
+}
+
 /// Same as [Listener] but for [ValueNotifier] : notifies when the value changes
 class ValueNotifierListener<T extends ValueNotifier<S>, S>
     extends SingleChildStatefulWidget {
@@ -205,6 +247,13 @@ class _ConsumerValueNotifierFilterState<T extends ValueNotifier<S>, S>
       },
       child: widget.child,
     );
+  }
+}
+
+extension ChangeNotifierExtensions on ChangeNotifier {
+  void replaceListener(VoidCallback listener) {
+    removeListener(listener);
+    addListener(listener);
   }
 }
 


### PR DESCRIPTION
Hi everyone!

On iOS, the Add price page is annoying as the swipe gesture is always disabled.
On product edition, when there's no change, this gesture is available.

The PR adds it by default.
There's also a new `ChangeNotifierListener` widget.

📹 Demo: 

https://github.com/user-attachments/assets/cc9e7f10-202c-4242-bfd3-381f09b7946d

