### PR TITLE
fix: Hotfixes on 4.20.0

### DIFF
--- a/packages/smooth_app/lib/generic_lib/widgets/languages_selector.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/languages_selector.dart
@@ -8,6 +8,7 @@ import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/bottom_sheets/smooth_bottom_sheet.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_text_form_field.dart';
+import 'package:smooth_app/helpers/collections_helper.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_languages_list.dart';
 import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
@@ -157,6 +158,7 @@ class LanguagesSelector extends StatelessWidget {
         }
       } else if (popularList.containsKey(language.code)) {
         popularLanguagesList.add(language);
+        otherLanguagesList.add(language);
       } else {
         otherLanguagesList.add(language);
       }
@@ -171,7 +173,10 @@ class LanguagesSelector extends StatelessWidget {
     final Languages languagesHelper = Languages();
     _sortLanguages(selectedLanguagesList, languagesHelper);
     _sortLanguages(popularLanguagesList, languagesHelper);
-    _sortLanguages(otherLanguagesList, languagesHelper);
+    _sortLanguages(
+      otherLanguagesList.diff(popularLanguagesList).toList(growable: false),
+      languagesHelper,
+    );
 
     final OpenFoodFactsLanguage? language =
         await showSmoothModalSheetForTextField<OpenFoodFactsLanguage>(
@@ -263,8 +268,7 @@ class _LanguagesListState extends State<_LanguagesList> {
   void initState() {
     super.initState();
     _otherLanguages = List<OpenFoodFactsLanguage>.of(widget.otherLanguages);
-    _popularLanguages =
-        List<OpenFoodFactsLanguage>.of(widget.popularLanguages.take(3));
+    _popularLanguages = List<OpenFoodFactsLanguage>.of(widget.popularLanguages);
     _selectedLanguages =
         List<OpenFoodFactsLanguage>.of(widget.selectedLanguages);
   }
@@ -440,17 +444,21 @@ class _LanguagesListState extends State<_LanguagesList> {
   }
 
   List<OpenFoodFactsLanguage> _filterList(
-      List<OpenFoodFactsLanguage> list, String query) {
+    List<OpenFoodFactsLanguage> list,
+    String query,
+  ) {
+    final String queryForComparison = query.toLowerCase();
+
     return list
         .where((OpenFoodFactsLanguage item) =>
             Languages()
                 .getNameInEnglish(item)
                 .getComparisonSafeString()
-                .contains(query.toLowerCase()) ||
+                .contains(queryForComparison) ||
             Languages()
                 .getNameInLanguage(item)
                 .getComparisonSafeString()
-                .contains(query.toLowerCase()) ||
+                .contains(queryForComparison) ||
             item.code.contains(query))
         .toList(growable: false);
   }

--- a/packages/smooth_app/lib/pages/guides/helpers/guides_content.dart
+++ b/packages/smooth_app/lib/pages/guides/helpers/guides_content.dart
@@ -8,6 +8,7 @@ import 'package:smooth_app/helpers/physics.dart';
 import 'package:smooth_app/pages/guides/helpers/guides_header.dart';
 import 'package:smooth_app/resources/app_icons.dart';
 import 'package:smooth_app/themes/smooth_theme_colors.dart';
+import 'package:smooth_app/widgets/smooth_scaffold.dart';
 import 'package:smooth_app/widgets/smooth_text.dart';
 
 class GuidesPage extends StatelessWidget {
@@ -28,7 +29,8 @@ class GuidesPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
+    return SmoothScaffold(
+      brightness: Brightness.light,
       body: _GuidesPageBody(
         pageName: pageName,
         slivers: <Widget>[

--- a/packages/smooth_app/lib/pages/prices/infinite_scroll_manager.dart
+++ b/packages/smooth_app/lib/pages/prices/infinite_scroll_manager.dart
@@ -97,7 +97,7 @@ abstract class InfiniteScrollManager<T> {
 
   /// Load more items (next page)
   Future<void> loadMore(BuildContext context) async {
-    if (_totalPages != null && _currentPage >= _totalPages!) {
+    if (_totalPages == null || _currentPage >= _totalPages!) {
       return;
     }
     await _load(context: context, pageNumber: _currentPage + 1);

--- a/packages/smooth_app/lib/pages/product/attribute_icons.dart
+++ b/packages/smooth_app/lib/pages/product/attribute_icons.dart
@@ -292,7 +292,7 @@ class _AttributeAdditivesIcon extends AttributeIcon {
     super.semanticsLabel,
   }) : super._(
           icon: const FoodIcons.additives(),
-          iconSizeFactor: 0.6,
+          iconSizeFactor: 0.58,
           paddingFactor: const EdgeInsetsDirectional.only(bottom: 0.05),
         );
 }
@@ -322,7 +322,7 @@ class _AttributeCrustaceansIcon extends AttributeIcon {
           icon: const FoodIcons.crustaceans(),
           iconSizeFactor: 0.95,
           clip: true,
-          paddingFactor: const EdgeInsetsDirectional.only(top: 0.15),
+          paddingFactor: const EdgeInsetsDirectional.only(top: 0.18),
         );
 }
 
@@ -347,7 +347,7 @@ class _AttributeFishIcon extends AttributeIcon {
     super.semanticsLabel,
   }) : super._(
           icon: const FoodIcons.fish(),
-          iconSizeFactor: 0.8,
+          iconSizeFactor: 0.75,
           paddingFactor: const EdgeInsetsDirectional.only(
             top: 0.06,
             start: 0.02,
@@ -379,10 +379,10 @@ class _AttributeFairTradeIcon extends AttributeIcon {
     super.semanticsLabel,
   }) : super._(
           icon: const FoodIcons.fairTrade(),
-          iconSizeFactor: 0.8,
+          iconSizeFactor: 0.75,
           paddingFactor: const EdgeInsetsDirectional.only(
             top: 0.1,
-            start: 0.01,
+            start: 0.015,
           ),
         );
 }
@@ -396,6 +396,9 @@ class _AttributeFatIcon extends AttributeIcon {
   }) : super._(
           icon: const FoodIcons.fat(),
           iconSizeFactor: 0.7,
+          paddingFactor: const EdgeInsetsDirectional.only(
+            end: 0.02,
+          ),
         );
 }
 
@@ -407,7 +410,7 @@ class _AttributeForestFootprintIcon extends AttributeIcon {
     super.semanticsLabel,
   }) : super._(
           icon: const FoodIcons.forestFootprint(),
-          iconSizeFactor: 0.68,
+          iconSizeFactor: 0.65,
         );
 }
 
@@ -435,7 +438,7 @@ class _AttributeMilkIcon extends AttributeIcon {
     super.semanticsLabel,
   }) : super._(
           icon: const FoodIcons.milk(),
-          iconSizeFactor: 1.02,
+          iconSizeFactor: 1.0,
           clip: true,
           paddingFactor: const EdgeInsetsDirectional.only(
             top: 0.25,
@@ -451,7 +454,7 @@ class _AttributeMolluscsIcon extends AttributeIcon {
     super.semanticsLabel,
   }) : super._(
           icon: const FoodIcons.molluscs(),
-          iconSizeFactor: 0.7,
+          iconSizeFactor: 0.65,
         );
 }
 
@@ -547,10 +550,10 @@ class _AttributeNOVAIcon extends AttributeIcon {
     super.semanticsLabel,
   }) : super._(
           icon: const FoodIcons.nova4(),
-          iconSizeFactor: 0.65,
+          iconSizeFactor: 0.64,
           paddingFactor: const EdgeInsetsDirectional.only(
-            top: 0.09,
-            start: 0.025,
+            top: 0.07,
+            start: 0.02,
           ),
         );
 }
@@ -577,7 +580,7 @@ class _AttributePalmOilIcon extends AttributeIcon {
     super.semanticsLabel,
   }) : super._(
           icon: const FoodIcons.palmOil(),
-          iconSizeFactor: 0.75,
+          iconSizeFactor: 0.7,
           paddingFactor: const EdgeInsetsDirectional.only(top: 0.04),
         );
 }
@@ -617,7 +620,7 @@ class _AttributeSaturatedFatIcon extends AttributeIcon {
     super.semanticsLabel,
   }) : super._(
           icon: const FoodIcons.saturatedFat(),
-          iconSizeFactor: 0.75,
+          iconSizeFactor: 0.70,
         );
 }
 
@@ -629,7 +632,7 @@ class _AttributeSesameSeedsIcon extends AttributeIcon {
     super.semanticsLabel,
   }) : super._(
           icon: const FoodIcons.sesameSeeds(),
-          iconSizeFactor: 0.81,
+          iconSizeFactor: 0.80,
           paddingFactor: const EdgeInsetsDirectional.only(bottom: 0.02),
         );
 }
@@ -658,8 +661,8 @@ class _AttributeSugarIcon extends AttributeIcon {
     super.semanticsLabel,
   }) : super._(
           icon: const FoodIcons.sugar(),
-          iconSizeFactor: 0.65,
-          paddingFactor: const EdgeInsetsDirectional.only(bottom: 0.1),
+          iconSizeFactor: 0.60,
+          paddingFactor: const EdgeInsetsDirectional.only(bottom: 0.05),
         );
 }
 
@@ -671,8 +674,9 @@ class _AttributeSulphitesIcon extends AttributeIcon {
     super.semanticsLabel,
   }) : super._(
           icon: const FoodIcons.sulphites(),
-          iconSizeFactor: 0.9,
+          iconSizeFactor: 0.76,
           clip: true,
+          paddingFactor: const EdgeInsetsDirectional.only(bottom: 0.02),
         );
 }
 
@@ -684,7 +688,7 @@ class _AttributeVeganIcon extends AttributeIcon {
     super.semanticsLabel,
   }) : super._(
           icon: const FoodIcons.vegan(),
-          iconSizeFactor: 0.7,
+          iconSizeFactor: 0.62,
           paddingFactor: const EdgeInsetsDirectional.only(top: 0.07),
         );
 }
@@ -697,9 +701,8 @@ class _AttributeVegetarianIcon extends AttributeIcon {
     super.semanticsLabel,
   }) : super._(
           icon: const FoodIcons.vegetarian(),
-          iconSizeFactor: 0.65,
+          iconSizeFactor: 0.62,
           paddingFactor: const EdgeInsetsDirectional.only(
-            bottom: 0.04,
             end: 0.06,
           ),
         );

--- a/packages/smooth_app/lib/pages/product/attribute_icons.dart
+++ b/packages/smooth_app/lib/pages/product/attribute_icons.dart
@@ -522,9 +522,9 @@ class _AttributeNOVAIcon extends AttributeIcon {
     super.semanticsLabel,
   }) : super._(
           icon: const FoodIcons.nova2(),
-          iconSizeFactor: 0.67,
+          iconSizeFactor: 0.64,
           paddingFactor: const EdgeInsetsDirectional.only(
-            top: 0.08,
+            top: 0.05,
             start: 0.025,
           ),
         );
@@ -536,9 +536,9 @@ class _AttributeNOVAIcon extends AttributeIcon {
     super.semanticsLabel,
   }) : super._(
           icon: const FoodIcons.nova3(),
-          iconSizeFactor: 0.68,
+          iconSizeFactor: 0.64,
           paddingFactor: const EdgeInsetsDirectional.only(
-            top: 0.12,
+            top: 0.07,
             start: 0.025,
           ),
         );

--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -289,11 +289,13 @@ class _SummaryCardState extends State<SummaryCard> with UpToDateMixin {
         );
       }
     }
-    final Widget attributesContainer = Container(
-      alignment: AlignmentDirectional.topStart,
-      margin: const EdgeInsetsDirectional.only(bottom: LARGE_SPACE),
-      child: Column(children: displayedGroups),
-    );
+    final Widget attributesContainer = displayedGroups.isNotEmpty
+        ? Container(
+            alignment: AlignmentDirectional.topStart,
+            margin: const EdgeInsetsDirectional.only(bottom: LARGE_SPACE),
+            child: Column(children: displayedGroups),
+          )
+        : const SizedBox(height: SMALL_SPACE);
     // cf. https://github.com/openfoodfacts/smooth-app/issues/2147
 
     final List<Widget> summaryCardButtons = <Widget>[];


### PR DESCRIPTION
Hi everyone!

Here are some hotfixes for the 4.20.0 release:

- MAJOR: An "infinite" list shouldn't load the next page `if totalPages == null`
- MAJOR: If a popular language was not in the TOP 3, it was unavailable in the picker
- UI: Food icons paddings
- MINOR: Product page: when there's no attribute, we shouldn't add an unnecessary `Padding`
- MINOR UI: The Nutri-score V2 guide can have a black status bar

![Untitled](https://github.com/user-attachments/assets/febd132e-c74a-46c8-80d4-ddb2c9528a02)
![IMG_2662](https://github.com/user-attachments/assets/f638432c-1282-44b3-a036-2ec0aeabf12b)

