### PR TITLE
fix: Search Results Not Updating After Changing Country Without App Restart

### DIFF
--- a/packages/smooth_app/lib/pages/preferences/country_selector/country_selector.dart
+++ b/packages/smooth_app/lib/pages/preferences/country_selector/country_selector.dart
@@ -11,6 +11,7 @@ import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/helpers/provider_helper.dart';
 import 'package:smooth_app/pages/prices/emoji_helper.dart';
+import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/services/smooth_services.dart';
 import 'package:smooth_app/widgets/selector_screen/smooth_screen_list_choice.dart';
 import 'package:smooth_app/widgets/selector_screen/smooth_screen_selector_provider.dart';

--- a/packages/smooth_app/lib/pages/preferences/country_selector/country_selector_provider.dart
+++ b/packages/smooth_app/lib/pages/preferences/country_selector/country_selector_provider.dart
@@ -165,8 +165,8 @@ class _CountrySelectorProvider extends PreferencesSelectorProvider<Country> {
   }
 
   @override
-  Future<void> onSaveItem(Country country) => ProductQuery.setCountry(preferences,
-   country.countryCode);
+  Future<void> onSaveItem(Country country) =>
+      ProductQuery.setCountry(preferences, country.countryCode);
 }
 
 class CountriesHelper {

--- a/packages/smooth_app/lib/pages/preferences/country_selector/country_selector_provider.dart
+++ b/packages/smooth_app/lib/pages/preferences/country_selector/country_selector_provider.dart
@@ -165,9 +165,8 @@ class _CountrySelectorProvider extends PreferencesSelectorProvider<Country> {
   }
 
   @override
-  Future<void> onSaveItem(Country country) => preferences.setUserCountryCode(
-        country.countryCode,
-      );
+  Future<void> onSaveItem(Country country) => ProductQuery.setCountry(preferences,
+   country.countryCode);
 }
 
 class CountriesHelper {


### PR DESCRIPTION
### What
<!-- description of the PR -->
closes #6575 
- Used `ProductQuery.setCountry` instead of `preferences.setUserCountryCode` to update new saved country
### Screenshot
<!-- Insert a screenshot to provide visual record of your changes, if visible -->

### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes: Search Results Not Updating After Changing Country Without App Restart

### Part of 
- #991 
