### PR TITLE
fix: 6565 - put back the fix about long bottom sheets

### DIFF
--- a/packages/smooth_app/lib/generic_lib/bottom_sheets/smooth_bottom_sheet.dart
+++ b/packages/smooth_app/lib/generic_lib/bottom_sheets/smooth_bottom_sheet.dart
@@ -358,12 +358,14 @@ class SmoothModalSheet extends StatelessWidget {
         decoration: const BoxDecoration(
           borderRadius: BorderRadius.vertical(top: ROUNDED_RADIUS),
         ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: <Widget>[
-            header,
-            bodyChild,
-          ],
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              header,
+              bodyChild,
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
### What
- The fix already existed in #6402.
- It was removed accidentally in #6505.
- This PR puts back the fix.

### Screenshots
| before | after - top | after - bottom |
| -- | -- | -- |
| ![Screenshot_1748272243](https://github.com/user-attachments/assets/c7c2897a-260d-4a96-9ef0-b4be00f45f24) | ![Screenshot_1748272263](https://github.com/user-attachments/assets/94dc1243-6976-4df2-9fc5-77f7737548f2) | ![Screenshot_1748272267](https://github.com/user-attachments/assets/274c7b1e-5c07-4caf-96a4-a78f1f226e70) |

### Fixes bug(s)
- Fixes: #6565