### PR TITLE
fix: 6587 - fine tuning about prices infinite scrolling

### DIFF
--- a/packages/smooth_app/lib/pages/prices/infinite_scroll_list.dart
+++ b/packages/smooth_app/lib/pages/prices/infinite_scroll_list.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
+import 'package:smooth_app/generic_lib/widgets/smooth_snackbar.dart';
 import 'package:smooth_app/pages/prices/infinite_scroll_manager.dart';
 
 /// A generic stateful widget for infinite scrolling lists that works with InfiniteScrollManager.
@@ -73,13 +74,20 @@ class _InfiniteScrollListState<T> extends State<InfiniteScrollList<T>> {
   }
 
   Future<void> _loadMoreItems() async {
-    if (mounted) {
-      setState(() {});
-      await widget.manager.loadMore(context);
-      if (mounted) {
-        setState(() {});
-      }
+    if (!mounted) {
+      return;
     }
+    setState(() {});
+    await widget.manager.loadMore(context);
+    if (!mounted) {
+      return;
+    }
+    setState(() {});
+    ScaffoldMessenger.of(context).showSnackBar(
+      SmoothFloatingSnackbar(
+        content: Text(_getItemCount(context)),
+      ),
+    );
   }
 
   Widget _buildLoadingState(BuildContext context) {
@@ -101,32 +109,20 @@ class _InfiniteScrollListState<T> extends State<InfiniteScrollList<T>> {
     );
   }
 
+  String _getItemCount(BuildContext context) =>
+      widget.manager.formattedItemCount(context);
+
   Widget _buildFooter(BuildContext context) {
     return const SizedBox(height: MINIMUM_TOUCH_SIZE * 2);
   }
 
-  Widget _buildHeader(BuildContext context) {
-    final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    String title;
-    final int totalPages = widget.manager.totalPages ?? 1;
-    final int currentPage = widget.manager.currentPage;
-    final int itemsCount = widget.manager.items.length;
-    final int totalItems = widget.manager.totalItems ?? itemsCount;
-
-    if (totalPages > 1) {
-      title = appLocalizations.prices_list_length_many_pages(
-        itemsCount,
-        totalItems,
+  Widget _buildHeader(BuildContext context) => SmoothCard(
+        child: ListTile(
+          title: Text(
+            _getItemCount(context),
+          ),
+        ),
       );
-      title = '$title ($currentPage / $totalPages)';
-    } else {
-      title = appLocalizations.prices_list_length_one_page(
-        itemsCount,
-      );
-    }
-
-    return SmoothCard(child: ListTile(title: Text(title)));
-  }
 
   @override
   Widget build(BuildContext context) {

--- a/packages/smooth_app/lib/pages/prices/infinite_scroll_manager.dart
+++ b/packages/smooth_app/lib/pages/prices/infinite_scroll_manager.dart
@@ -131,14 +131,6 @@ abstract class InfiniteScrollManager<T> {
     }
   }
 
-  /// Returns a formatted page indicator (e.g., "Page 1 / 5")
-  String formattedPageIndicator(BuildContext context) {
-    final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    return _totalPages != null
-        ? appLocalizations.page_indicator_with_total(_currentPage, _totalPages!)
-        : appLocalizations.page_indicator(_currentPage);
-  }
-
   /// Returns a formatted item count (e.g., "25 of 100 items")
   String formattedItemCount(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);

--- a/packages/smooth_app/lib/pages/prices/prices_locations_page.dart
+++ b/packages/smooth_app/lib/pages/prices/prices_locations_page.dart
@@ -66,8 +66,19 @@ class _InfiniteScrollLocationManager extends InfiniteScrollManager<Location> {
     final MaybeError<GetLocationsResult> result =
         await OpenPricesAPIClient.getLocations(
       GetLocationsParameters()
+        ..orderBy = const <OrderBy<GetLocationsOrderField>>[
+          OrderBy<GetLocationsOrderField>(
+            field: GetLocationsOrderField.priceCount,
+            ascending: false,
+          ),
+          OrderBy<GetLocationsOrderField>(
+            field: GetLocationsOrderField.created,
+            ascending: false,
+          ),
+        ]
         ..pageNumber = pageNumber
         ..pageSize = 10,
+      uriHelper: ProductQuery.uriPricesHelper,
     );
     if (result.isError) {
       throw result.detailError;

--- a/packages/smooth_app/lib/pages/prices/prices_users_page.dart
+++ b/packages/smooth_app/lib/pages/prices/prices_users_page.dart
@@ -59,7 +59,7 @@ class _PricesUsersPageState extends State<PricesUsersPage>
 
 /// A manager for handling user data with infinite scrolling
 class _InfiniteScrollUserManager extends InfiniteScrollManager<PriceUser> {
-  static const int _pageSize = 10;
+  static const int _pageSize = 20;
 
   @override
   Future<void> fetchData(final int pageNumber) async {


### PR DESCRIPTION
### What
* More neutral count labels for all pages (instead of always referencing "prices", sometimes inadequately)
* Added a snackbar about counts when scrolling down
* Fixed location order and server parameters
* Now displaying pages of 20 users (instead of 10)

### Screenshots
| prices (top) | prices (snackbar) |
| -- | -- |
| ![Screenshot_1748276367](https://github.com/user-attachments/assets/9210803d-41d0-49a2-9024-25189832e740) | ![Screenshot_1748276371](https://github.com/user-attachments/assets/3c815a35-edb8-4700-ba19-f8f1c485e0a6) |

| users | locations |
| -- | -- |
| ![Screenshot_1748276416](https://github.com/user-attachments/assets/e208533d-edff-453d-8547-a64bb06bd9c4) | ![Screenshot_1748277103](https://github.com/user-attachments/assets/5ed20ebd-a925-4aef-b592-c6a10bc9ea91) |


### Fixes bug(s)
- Fixes: #6587

### Impacted files
* `infinite_scroll_list.dart`: no more reference to "prices" or pages in the count label; added a snackbar about counts when scrolling down
* `infinite_scroll_manager.dart`: minor refactoring
* `prices_locations_page.dart`: now ordering by descending counts, and using the prices env of the app (instead of always PROD)
* `prices_users_page.dart`: now displaying pages of 20 users