### PR TITLE
feat: 6352 - matomo events for food preferences

### DIFF
--- a/packages/smooth_app/lib/data_models/product_preferences.dart
+++ b/packages/smooth_app/lib/data_models/product_preferences.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/data_models/downloadable_string.dart';
 import 'package:smooth_app/database/dao_string.dart';
+import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/app_helper.dart';
 import 'package:smooth_app/query/product_query.dart';
 
@@ -199,6 +200,9 @@ class ProductPreferences extends ProductPreferencesManager with ChangeNotifier {
   }
 
   Future<void> resetImportances() async {
+    AnalyticsHelper.trackChangedPreferences(
+      AnalyticsChangedPreferences.preferencesClear,
+    );
     await clearImportances(notifyListeners: false);
     if (attributeGroups != null) {
       for (final AttributeGroup attributeGroup in attributeGroups!) {
@@ -217,6 +221,26 @@ class ProductPreferences extends ProductPreferencesManager with ChangeNotifier {
       }
     }
     notify();
+  }
+
+  @override
+  Future<void> setImportance(
+    final String attributeId,
+    final String importanceId, {
+    final bool notifyListeners = true,
+  }) async {
+    await super.setImportance(
+      attributeId,
+      importanceId,
+      notifyListeners: notifyListeners,
+    );
+    if (notifyListeners) {
+      AnalyticsHelper.trackChangedPreferences(
+        AnalyticsChangedPreferences.preferencesSet,
+        attributeId: attributeId,
+        importanceId: importanceId,
+      );
+    }
   }
 
   AttributeGroup getAttributeGroup(final String attributeId) {

--- a/packages/smooth_app/lib/helpers/analytics_helper.dart
+++ b/packages/smooth_app/lib/helpers/analytics_helper.dart
@@ -23,6 +23,7 @@ enum AnalyticsCategory {
   list(tag: 'list'),
   deepLink(tag: 'deep link'),
   hungerGame(tag: 'hunger game'),
+  changedPreferences(tag: 'changed preferences'),
   appRating(tag: 'app rating');
 
   const AnalyticsCategory({required this.tag});
@@ -180,6 +181,19 @@ enum AnalyticsRobotoffEvents {
   );
 
   const AnalyticsRobotoffEvents({required this.name});
+
+  final String name;
+}
+
+enum AnalyticsChangedPreferences {
+  preferencesSet(
+    name: 'set',
+  ),
+  preferencesClear(
+    name: 'clear',
+  );
+
+  const AnalyticsChangedPreferences({required this.name});
 
   final String name;
 }
@@ -405,6 +419,19 @@ class AnalyticsHelper {
         action: nutrient.name,
         barcode: product.barcode,
         productType: product.productType ?? ProductType.food,
+      );
+
+  static void trackChangedPreferences(
+    AnalyticsChangedPreferences event, {
+    final String? attributeId,
+    final String? importanceId,
+  }) =>
+      trackCustomEvent(
+        event.name,
+        AnalyticsCategory.changedPreferences.tag,
+        action: attributeId == null || importanceId == null
+            ? null
+            : '$attributeId=$importanceId',
       );
 
   static void trackProductEdit(


### PR DESCRIPTION
### What
* New matomo events for food preferences.

### Fixes bug(s)
- Closes: #6352

### Impacted files
* `analytics_helper.dart`: new matomo events for food preferences
* `product_preferences.dart`: sending matomo events where the food preferences are changed