### PR TITLE
fix: 6616 - format robotoff extraction as acceptable numeric value

### DIFF
--- a/packages/smooth_app/lib/pages/product/nutrition_page/widgets/nutrition_facts_editor.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page/widgets/nutrition_facts_editor.dart
@@ -103,7 +103,15 @@ class _NutrientRowState extends State<NutrientRow>
     if (extractionValue != null) {
       final num? extractionValueNum = NumberFormat().tryParse(extractionValue);
       if (extractionValueNum == null) {
-        extractionValue = extractionValueNum.toString();
+        extractionValue = null;
+      } else {
+        try {
+          // get a decent displayable numeric value if possible
+          extractionValue =
+              widget.decimalNumberFormat.format(extractionValueNum);
+        } catch (e) {
+          // at least we tried
+        }
       }
     }
 


### PR DESCRIPTION
### What
- Robotoff nutrition extraction numbers weren't formatted in the local app country/language format.
- That caused "inconsistent format" errors.
- Now we apply the local format to the robotoff values.

### Screenshots
| formatted with comma | no change detected |
| -- | -- |
| ![Screenshot_1748501980](https://github.com/user-attachments/assets/27077c96-eb0a-4357-b647-ce3be8ab0f63) | ![Screenshot_1748502030](https://github.com/user-attachments/assets/30858978-ddba-47b5-a84a-63a78689d004) |

### Fixes bug(s)
- Fixes: #6616