### PR TITLE
fix: 5151 - accept '-' as the hidden nutrient text

### DIFF
--- a/packages/smooth_app/lib/pages/product/nutrition_page/widgets/nutrition_facts_editor.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page/widgets/nutrition_facts_editor.dart
@@ -339,8 +339,8 @@ class _NutrientValueCell extends StatelessWidget {
                           if (value == null || value.trim().isEmpty) {
                             return null;
                           }
-                          // special case: "hidden" nutrient
-                          if (value == _hiddenNutrientValue) {
+                          // special case: "missing" nutrient
+                          if (value == _missingNutrientValue) {
                             return null;
                           }
                           try {
@@ -473,11 +473,11 @@ class _NutrientUnitVisibility extends StatelessWidget {
                 customBorder: const CircleBorder(),
                 onTap: () {
                   if (isValueSet) {
-                    controller.text = _hiddenNutrientValue;
+                    controller.text = _missingNutrientValue;
                   } else {
-                    if (controller.previousValue != _hiddenNutrientValue) {
+                    if (controller.previousValue != _missingNutrientValue) {
                       controller.text =
-                          controller.previousValue ?? _hiddenNutrientValue;
+                          controller.previousValue ?? _missingNutrientValue;
                     } else {
                       controller.text = '';
                     }
@@ -498,10 +498,10 @@ class _NutrientUnitVisibility extends StatelessWidget {
   }
 }
 
-const String _hiddenNutrientValue = '-';
+const String _missingNutrientValue = '-';
 
 extension NutritionTextEditionController on TextEditingController {
-  bool get isSet => text.trim() != _hiddenNutrientValue;
+  bool get isSet => text.trim() != _missingNutrientValue;
 }
 
 /// Use this Widget to be notified when the value is set or not

--- a/packages/smooth_app/lib/pages/product/nutrition_page/widgets/nutrition_facts_editor.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page/widgets/nutrition_facts_editor.dart
@@ -339,6 +339,10 @@ class _NutrientValueCell extends StatelessWidget {
                           if (value == null || value.trim().isEmpty) {
                             return null;
                           }
+                          // special case: "hidden" nutrient
+                          if (value == _hiddenNutrientValue) {
+                            return null;
+                          }
                           try {
                             decimalNumberFormat.parse(value);
                             return null;
@@ -469,10 +473,11 @@ class _NutrientUnitVisibility extends StatelessWidget {
                 customBorder: const CircleBorder(),
                 onTap: () {
                   if (isValueSet) {
-                    controller.text = '-';
+                    controller.text = _hiddenNutrientValue;
                   } else {
-                    if (controller.previousValue != '-') {
-                      controller.text = controller.previousValue ?? '-';
+                    if (controller.previousValue != _hiddenNutrientValue) {
+                      controller.text =
+                          controller.previousValue ?? _hiddenNutrientValue;
                     } else {
                       controller.text = '';
                     }
@@ -493,10 +498,10 @@ class _NutrientUnitVisibility extends StatelessWidget {
   }
 }
 
-extension NutritionTextEditionController on TextEditingController {
-  bool get isSet => text.trim() != '-';
+const String _hiddenNutrientValue = '-';
 
-  bool get isNotSet => text.trim() == '-';
+extension NutritionTextEditionController on TextEditingController {
+  bool get isSet => text.trim() != _hiddenNutrientValue;
 }
 
 /// Use this Widget to be notified when the value is set or not


### PR DESCRIPTION
### What
- Now it's possible to click on a "hide a nutrient" button and to save the nutrition page. There won't be any "invalid number" error.
- It still won't save your nutrient data as "hidden", and I'm afraid it never did, but that's another story.
- cc. @alexgarel @teolemon @g123k @aasami @jayaddison @FRAdrien @thomassth

### Fixes bug(s)
- Fixes: #5151
- Fixes: #6601
- Fixes: https://github.com/openfoodfacts/openfoodfacts-server/issues/11899