### PR TITLE
fix: Potential fix for code scanning alert no. 2: Untrusted Checkout TOCTOU

### DIFF
--- a/.github/workflows/on-demand.yml
+++ b/.github/workflows/on-demand.yml
@@ -76,20 +76,12 @@ jobs:
       contains(fromJSON('["COLLABORATOR", "CONTRIBUTOR", "MEMBER", "OWNER"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     steps:
-    - name: Get branch name
-      # see https://github.com/actions/checkout/issues/331
-      id: get-branch
-      run: echo ::set-output name=branch::$(gh pr view $PR_NO --repo $REPO --json headRefName --jq '.headRefName')
-      env:
-        REPO: ${{ github.repository }}
-        PR_NO: ${{ github.event.issue.number }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Checkout
       uses: actions/checkout@v4
       with:
         fetch-depth: 1
-        # grab the PR branch
-        ref: ${{ steps.get-branch.outputs.branch }}
+        # Use the commit SHA to ensure immutability
+        ref: ${{ github.event.pull_request.head.sha }}
         # We can't use GITHUB_TOKEN here because, github actions can't trigger actions
         # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
         # So this is a personal access token


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/smooth-app/security/code-scanning/2](https://github.com/openfoodfacts/smooth-app/security/code-scanning/2)

To fix the issue, we need to replace the mutable branch reference (`ref: ${{ steps.get-branch.outputs.branch }}`) with an immutable commit SHA. This ensures that the code being checked out is the exact version that was reviewed and approved. The commit SHA can be retrieved from the pull request event data (`github.event.pull_request.head.sha`) instead of dynamically fetching the branch name.

The changes will involve:
1. Replacing the `ref` value in the `actions/checkout@v4` step with `github.event.pull_request.head.sha`.
2. Removing the unnecessary step that dynamically retrieves the branch name (`Get branch name`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
