### PR TITLE
fix: Potential fix for code scanning alert no. 1: Untrusted Checkout TOCTOU

### DIFF
--- a/.github/workflows/on-demand.yml
+++ b/.github/workflows/on-demand.yml
@@ -17,8 +17,8 @@ jobs:
     steps:
     - name: Get branch name
       # see https://github.com/actions/checkout/issues/331
-      id: get-branch
-      run: echo ::set-output name=branch::$(gh pr view $PR_NO --repo $REPO --json headRefName --jq '.headRefName')
+      id: get-commit-sha
+      run: echo ::set-output name=sha::$(gh pr view $PR_NO --repo $REPO --json headRefOid --jq '.headRefOid')
       env:
         REPO: ${{ github.repository }}
         PR_NO: ${{ github.event.issue.number }}
@@ -27,8 +27,8 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 1
-        # grab the PR branch
-        ref: ${{ steps.get-branch.outputs.branch }}
+        # grab the PR commit SHA
+        ref: ${{ steps.get-commit-sha.outputs.sha }}
         # We can't use GITHUB_TOKEN here because, github actions can't trigger actions
         # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
         # So this is a personal access token


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/smooth-app/security/code-scanning/1](https://github.com/openfoodfacts/smooth-app/security/code-scanning/1)

To fix the issue, we need to replace the mutable branch reference (`steps.get-branch.outputs.branch`) with an immutable reference, such as the commit SHA of the pull request head. This ensures that the code being checked out is the exact version that was reviewed and approved, preventing any TOCTOU vulnerabilities.

The fix involves:
1. Modifying the `get-branch` step to retrieve the commit SHA (`head.sha`) of the pull request instead of the branch name.
2. Updating the `ref` parameter in the `actions/checkout` step to use the retrieved commit SHA instead of the branch name.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
