### PR TITLE
fix: Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -3,6 +3,9 @@ name: Crowdin Action
 on:
   push:
     branches: [ crowdin-trigger ]
+permissions:
+  contents: read
+  pull-requests: write
 jobs:
   synchronize-with-crowdin:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/smooth-app/security/code-scanning/5](https://github.com/openfoodfacts/smooth-app/security/code-scanning/5)

To fix the issue, we need to add a `permissions` block to the workflow. Based on the actions performed in the workflow, the following permissions are required:
- `contents: read` to allow the workflow to read repository contents.
- `pull-requests: write` to allow the workflow to create and manage pull requests.

The `permissions` block should be added at the root level of the workflow to apply to all jobs. This ensures that the `GITHUB_TOKEN` has only the necessary permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
