### PR TITLE
feat: Support for dark mode for tagline images

### DIFF
--- a/packages/smooth_app/lib/data_models/news_feed/newsfeed_json.dart
+++ b/packages/smooth_app/lib/data_models/news_feed/newsfeed_json.dart
@@ -199,6 +199,9 @@ class _TagLineItemNewsItem {
       image: translation.image?.overridesContent == true
           ? translation.image?.toTagLineImage()
           : null,
+      darkImage: translation.darkImage?.overridesContent == true
+          ? translation.darkImage?.toTagLineImage()
+          : null,
     );
   }
 
@@ -236,6 +239,7 @@ class _TagLineItemNewsTranslation {
     this.url,
     this.buttonLabel,
     this.image,
+    this.darkImage,
   });
 
   _TagLineItemNewsTranslation.fromJson(Map<dynamic, dynamic> json)
@@ -251,12 +255,16 @@ class _TagLineItemNewsTranslation {
         buttonLabel = json['button_label'],
         image = json['image'] == null
             ? null
-            : _TagLineNewsImage.fromJson(json['image']);
+            : _TagLineNewsImage.fromJson(json['image']),
+        darkImage = json['image_dark'] == null
+            ? null
+            : _TagLineNewsImage.fromJson(json['image_dark']);
   final String? title;
   final String? message;
   final String? url;
   final String? buttonLabel;
   final _TagLineNewsImage? image;
+  final _TagLineNewsImage? darkImage;
 
   _TagLineItemNewsTranslation copyWith({
     String? title,
@@ -264,6 +272,7 @@ class _TagLineItemNewsTranslation {
     String? url,
     String? buttonLabel,
     _TagLineNewsImage? image,
+    _TagLineNewsImage? darkImage,
   }) {
     return _TagLineItemNewsTranslation._(
       title: title ?? this.title,
@@ -271,6 +280,7 @@ class _TagLineItemNewsTranslation {
       url: url ?? this.url,
       buttonLabel: buttonLabel ?? this.buttonLabel,
       image: image ?? this.image,
+      darkImage: darkImage ?? this.darkImage,
     );
   }
 
@@ -285,6 +295,7 @@ class _TagLineItemNewsTranslation {
       url: other.url,
       buttonLabel: other.buttonLabel,
       image: other.image,
+      darkImage: other.darkImage,
     );
   }
 }
@@ -295,6 +306,9 @@ class _TagLineItemNewsTranslationDefault extends _TagLineItemNewsTranslation {
         assert((json['message'] as String).isNotEmpty),
         assert(json['image'] == null ||
             ((json['image'] as Map<String, dynamic>)['url'] as String)
+                .isNotEmpty),
+        assert(json['image_dark'] == null ||
+            ((json['image_dark'] as Map<String, dynamic>)['url'] as String)
                 .isNotEmpty),
         super.fromJson();
 }

--- a/packages/smooth_app/lib/data_models/news_feed/newsfeed_model.dart
+++ b/packages/smooth_app/lib/data_models/news_feed/newsfeed_model.dart
@@ -43,6 +43,7 @@ class AppNewsItem {
     this.minAppVersion,
     this.maxAppVersion,
     this.image,
+    this.darkImage,
     this.style,
   });
 
@@ -57,11 +58,12 @@ class AppNewsItem {
   final String? minAppVersion;
   final String? maxAppVersion;
   final AppNewsImage? image;
+  final AppNewsImage? darkImage;
   final AppNewsStyle? style;
 
   @override
   String toString() {
-    return 'AppNewsItem{id: $id, title: $title, message: $message, url: $url, buttonLabel: $buttonLabel, minLaunches: $minLaunches, startDate: $startDate, endDate: $endDate, minAppVersion: $minAppVersion, maxAppVersion: $maxAppVersion, image: $image, style: $style}';
+    return 'AppNewsItem{id: $id, title: $title, message: $message, url: $url, buttonLabel: $buttonLabel, minLaunches: $minLaunches, startDate: $startDate, endDate: $endDate, minAppVersion: $minAppVersion, maxAppVersion: $maxAppVersion, image: $image, darkImage: $darkImage, style: $style}';
   }
 }
 

--- a/packages/smooth_app/lib/pages/scan/carousel/main_card/bottom_cards/news/scan_news_card.dart
+++ b/packages/smooth_app/lib/pages/scan/carousel/main_card/bottom_cards/news/scan_news_card.dart
@@ -79,6 +79,7 @@ class _ScanNewsCardState extends State<ScanNewsCard> {
                 message: currentNews.message,
                 textColor: currentNews.style?.messageTextColor,
                 image: currentNews.image,
+                darkImage: currentNews.darkImage,
                 dense: dense,
               ),
               SizedBox(height: dense ? VERY_SMALL_SPACE : SMALL_SPACE),
@@ -111,12 +112,14 @@ class _TagLineContentBody extends StatefulWidget {
     required this.dense,
     this.textColor,
     this.image,
+    this.darkImage,
   });
 
   final String message;
   final bool dense;
   final Color? textColor;
   final AppNewsImage? image;
+  final AppNewsImage? darkImage;
 
   @override
   State<_TagLineContentBody> createState() => _TagLineContentBodyState();
@@ -132,7 +135,6 @@ class _TagLineContentBodyState extends State<_TagLineContentBody> {
 
   @override
   Widget build(BuildContext context) {
-    final ThemeProvider themeProvider = context.watch<ThemeProvider>();
     final SmoothColorsThemeExtension theme =
         Theme.of(context).extension<SmoothColorsThemeExtension>()!;
 
@@ -144,13 +146,14 @@ class _TagLineContentBodyState extends State<_TagLineContentBody> {
       overflow: widget.dense ? TextOverflow.ellipsis : null,
       textStyle: TextStyle(
         color: widget.textColor ??
-            (!themeProvider.isDarkMode(context)
+            (context.lightTheme(listen: true)
                 ? theme.primaryBlack
                 : theme.primaryLight),
         fontSize: 15.0,
       ),
     );
 
+    // There's no check for the dark image, as it's optional.
     if (widget.image == null || _imageError) {
       return Padding(
         padding: _contentPadding,
@@ -188,16 +191,20 @@ class _TagLineContentBodyState extends State<_TagLineContentBody> {
   }
 
   Widget _image() {
-    if (widget.image!.src?.endsWith('svg') == true) {
+    final AppNewsImage image = widget.darkImage == null
+        ? widget.image!
+        : (context.darkTheme() ? widget.darkImage! : widget.image!);
+
+    if (image.src?.endsWith('svg') == true) {
       return SvgCache(
-        widget.image!.src,
-        semanticsLabel: widget.image!.alt,
+        image.src,
+        semanticsLabel: image.alt,
         loadingBuilder: (_) => _onLoading(),
         errorBuilder: (_, __) => _onError(),
       );
     } else {
       return Image.network(
-        semanticLabel: widget.image!.alt,
+        semanticLabel: image.alt,
         loadingBuilder: (
           _,
           Widget child,
@@ -210,7 +217,7 @@ class _TagLineContentBodyState extends State<_TagLineContentBody> {
           return child;
         },
         errorBuilder: (_, __, ___) => _onError(),
-        widget.image!.src ?? '-',
+        image.src ?? '-',
       );
     }
   }


### PR DESCRIPTION
Hi everyone!

The OFF logo is orange and black by default.
However, in dark mode, the black part is invisible.

This PR allows to differentiate the image in dark mode.