### PR TITLE
fix: 6649 - several "no barcode" products can be added in the same page

### DIFF
--- a/packages/smooth_app/lib/pages/prices/product_price_add_page.dart
+++ b/packages/smooth_app/lib/pages/prices/product_price_add_page.dart
@@ -167,7 +167,7 @@ class _ProductPriceAddPageState extends State<ProductPriceAddPage>
                           PriceExistingAmountCard(price),
                       for (int i = 0; i < model.length; i++)
                         PriceAmountCard(
-                          key: Key(model.elementAt(i).product.barcode),
+                          key: UniqueKey(),
                           index: i,
                         ),
                       const SizedBox(height: LARGE_SPACE),


### PR DESCRIPTION
### What
- We could not display more that one "no barcode" product in an "add price" page.
- The reason being that unique keys are needed, and "no barcode" products have no intrinsic unique keys. For the record barcode products do have intrinsic unique keys: their barcodes.
- The fix was to use external unique keys for all items.

### Fixes bug(s)
- Fixes: #6649