### PR TITLE
feat: 6523 - upgrade to l10n_countries

### DIFF
--- a/packages/smooth_app/lib/pages/preferences/country_selector/country.dart
+++ b/packages/smooth_app/lib/pages/preferences/country_selector/country.dart
@@ -1,0 +1,37 @@
+import 'package:l10n_countries/l10n_countries.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+
+/// Extension on countries and their localizations.
+extension OpenFoodFactsCountryLocalization on OpenFoodFactsCountry {
+  /// Fallback language is English.
+  static const String _englishLanguageCode = 'en';
+
+  static String _latestLanguageCode = _englishLanguageCode;
+
+  static void setLocale(final String? languageCode) {
+    if (languageCode != null) {
+      _latestLanguageCode = languageCode;
+    }
+  }
+
+  String get name {
+    final String? result =
+        _getMapper().map[_latestLanguageCode]?.map[iso3Code] ??
+            _getMapper().map[_englishLanguageCode]?.map[iso3Code];
+    if (result != null) {
+      return result;
+    }
+    // lousy fallback version in English
+    final String countryName =
+        toString().replaceAll('OpenFoodFactsCountry.', '').replaceAll('_', ' ');
+    return '${countryName[0].toUpperCase()}'
+        '${countryName.substring(1).toLowerCase()}';
+  }
+
+  static CountriesLocaleMapper? _mapper;
+
+  static CountriesLocaleMapper _getMapper() =>
+      _mapper ??= CountriesLocaleMapper();
+}
+
+typedef Country = OpenFoodFactsCountry;

--- a/packages/smooth_app/lib/pages/preferences/country_selector/country_selector.dart
+++ b/packages/smooth_app/lib/pages/preferences/country_selector/country_selector.dart
@@ -1,18 +1,15 @@
 import 'package:auto_size_text/auto_size_text.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart' hide Listener;
-import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:iso_countries/iso_countries.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/preferences/user_preferences.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/helpers/provider_helper.dart';
+import 'package:smooth_app/pages/preferences/country_selector/country.dart';
 import 'package:smooth_app/pages/prices/emoji_helper.dart';
 import 'package:smooth_app/query/product_query.dart';
-import 'package:smooth_app/services/smooth_services.dart';
 import 'package:smooth_app/widgets/selector_screen/smooth_screen_list_choice.dart';
 import 'package:smooth_app/widgets/selector_screen/smooth_screen_selector_provider.dart';
 import 'package:smooth_app/widgets/smooth_text.dart';
@@ -123,8 +120,7 @@ class _CountrySelectorButton extends StatelessWidget {
                       SizedBox(
                         width: IconTheme.of(context).size! + LARGE_SPACE,
                         child: AutoSizeText(
-                          EmojiHelper.getEmojiByCountryCode(
-                              country.countryCode)!,
+                          EmojiHelper.getCountryEmoji(country)!,
                           textAlign: TextAlign.center,
                           style:
                               TextStyle(fontSize: IconTheme.of(context).size),
@@ -203,9 +199,7 @@ class _CountrySelectorButton extends StatelessWidget {
     final Country country,
   ) async {
     final UserPreferences userPreferences = context.read<UserPreferences>();
-    final OpenFoodFactsCountry? offCountry =
-        OpenFoodFactsCountry.fromOffTag(country.countryCode);
-    final String? possibleCurrencyCode = offCountry?.currency?.name;
+    final String? possibleCurrencyCode = country.currency?.name;
 
     if (possibleCurrencyCode == null) {
       return;
@@ -274,14 +268,14 @@ class _CountrySelectorScreen extends StatelessWidget {
             Expanded(
               flex: 1,
               child: Text(
-                EmojiHelper.getEmojiByCountryCode(country.countryCode) ?? '',
+                EmojiHelper.getCountryEmoji(country)!,
                 style: const TextStyle(fontSize: 25.0),
               ),
             ),
             Expanded(
               flex: 2,
               child: Text(
-                country.countryCode.toUpperCase(),
+                country.offTag.toUpperCase(),
                 textAlign: TextAlign.center,
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
@@ -328,7 +322,7 @@ class _CountrySelectorScreen extends StatelessWidget {
           country.name.toLowerCase().contains(
                 filter.toLowerCase(),
               ) ||
-          country.countryCode.toLowerCase().contains(
+          country.offTag.toLowerCase().contains(
                 filter.toLowerCase(),
               ),
     );

--- a/packages/smooth_app/lib/pages/preferences/country_selector/country_selector_provider.dart
+++ b/packages/smooth_app/lib/pages/preferences/country_selector/country_selector_provider.dart
@@ -36,7 +36,7 @@ class _CountrySelectorProvider extends PreferencesSelectorProvider<Country> {
 
         /// Reorder items
         final List<Country> countries = state.items;
-        _reorderCountries(countries, userCountryCode);
+        _reorderCountries(countries);
 
         value = state.copyWith(
           selectedItem: getSelectedValue(state.items),
@@ -48,102 +48,22 @@ class _CountrySelectorProvider extends PreferencesSelectorProvider<Country> {
 
   @override
   Future<List<Country>> onLoadValues() async {
-    final List<Country> localizedCountries = await CountriesHelper.getCountries(
-          userAppLanguageCode,
-        ) ??
-        <Country>[];
-
-    final List<Country> countries = await compute(
-      _reformatCountries,
-      (localizedCountries, userCountryCode),
-    );
-
-    return countries;
-  }
-
-  static Future<List<Country>> _reformatCountries(
-    (List<Country>, String?) localizedCountriesAndUserCountry,
-  ) async {
     final List<Country> countries =
-        _sanitizeCountriesList(localizedCountriesAndUserCountry.$1);
-    _reorderCountries(countries, localizedCountriesAndUserCountry.$2);
+        OpenFoodFactsCountry.values.toList(growable: false);
+    _reorderCountries(countries);
     return countries;
-  }
-
-  /// Sanitizes the country list, but without reordering it.
-  /// * by removing countries that are not in [OpenFoodFactsCountry]
-  /// * and providing a fallback English name for countries that are in
-  /// [OpenFoodFactsCountry] but not in [localizedCountries].
-  static List<Country> _sanitizeCountriesList(
-    List<Country> localizedCountries,
-  ) {
-    final List<Country> finalCountriesList = <Country>[];
-    final Map<String, OpenFoodFactsCountry> oFFIsoCodeToCountry =
-        <String, OpenFoodFactsCountry>{};
-    final Map<String, Country> localizedIsoCodeToCountry = <String, Country>{};
-    for (final OpenFoodFactsCountry c in OpenFoodFactsCountry.values) {
-      oFFIsoCodeToCountry[c.offTag.toLowerCase()] = c;
-    }
-    for (final Country c in localizedCountries) {
-      localizedIsoCodeToCountry.putIfAbsent(
-          c.countryCode.toLowerCase(), () => c);
-    }
-    for (final String countryCode in oFFIsoCodeToCountry.keys) {
-      final Country? localizedCountry = localizedIsoCodeToCountry[countryCode];
-      if (localizedCountry == null) {
-        // No localization for the country name was found, use English name as
-        // default.
-        String countryName = oFFIsoCodeToCountry[countryCode]
-            .toString()
-            .replaceAll('OpenFoodFactsCountry.', '')
-            .replaceAll('_', ' ');
-        countryName =
-            '${countryName[0].toUpperCase()}${countryName.substring(1).toLowerCase()}';
-        finalCountriesList.add(
-          Country(
-              name: _fixCountryName(countryName),
-              countryCode: _fixCountryCode(countryCode)),
-        );
-        continue;
-      }
-      final String fixedCountryCode = _fixCountryCode(countryCode);
-      final Country country = fixedCountryCode == countryCode
-          ? localizedCountry
-          : Country(name: localizedCountry.name, countryCode: countryCode);
-      finalCountriesList.add(country);
-    }
-
-    return finalCountriesList;
-  }
-
-  /// Fix the countryCode if needed so Backend can process it.
-  static String _fixCountryCode(String countryCode) {
-    // 'gb' is handled as 'uk' in the backend.
-    if (countryCode == 'gb') {
-      countryCode = 'uk';
-    }
-    return countryCode;
-  }
-
-  /// Fix the issues where United Kingdom appears with lowercase 'k'.
-  static String _fixCountryName(String countryName) {
-    if (countryName == 'United kingdom') {
-      countryName = 'United Kingdom';
-    }
-    return countryName;
   }
 
   /// Reorder countries alphabetically, bring user's locale country to top.
-  static void _reorderCountries(
+  void _reorderCountries(
     List<Country> countries,
-    String? userCountryCode,
   ) {
     countries.sort(
       (final Country a, final Country b) {
-        if (a.countryCode == userCountryCode) {
+        if (a.offTag == userCountryCode) {
           return -1;
         }
-        if (b.countryCode == userCountryCode) {
+        if (b.offTag == userCountryCode) {
           return 1;
         }
         return a.name.compareTo(b.name);
@@ -155,8 +75,7 @@ class _CountrySelectorProvider extends PreferencesSelectorProvider<Country> {
   Country getSelectedValue(List<Country> countries) {
     if (userCountryCode != null) {
       for (final Country country in countries) {
-        if (country.countryCode.toLowerCase() ==
-            userCountryCode?.toLowerCase()) {
+        if (country.offTag.toLowerCase() == userCountryCode?.toLowerCase()) {
           return country;
         }
       }
@@ -166,26 +85,5 @@ class _CountrySelectorProvider extends PreferencesSelectorProvider<Country> {
 
   @override
   Future<void> onSaveItem(Country country) =>
-      ProductQuery.setCountry(preferences, country.countryCode);
-}
-
-class CountriesHelper {
-  const CountriesHelper._();
-
-  static Future<List<Country>?> getCountries(String? userLanguageCode) async {
-    try {
-      return await IsoCountries.isoCountriesForLocale(userLanguageCode);
-    } on MissingPluginException catch (_) {
-      // Locales are not implemented on desktop and web
-      return <Country>[
-        const Country(name: 'United States', countryCode: 'US'),
-        const Country(name: 'France', countryCode: 'FR'),
-        const Country(name: 'Germany', countryCode: 'DE'),
-        const Country(name: 'India', countryCode: 'IN'),
-      ];
-    } catch (e) {
-      Logs.e('Failed to load countries', ex: e);
-      return null;
-    }
-  }
+      ProductQuery.setCountry(preferences, country.offTag);
 }

--- a/packages/smooth_app/lib/pages/preferences/language_selector/language_selector_provider.dart
+++ b/packages/smooth_app/lib/pages/preferences/language_selector/language_selector_provider.dart
@@ -102,8 +102,10 @@ class _LanguageSelectorProvider
   }
 
   @override
-  Future<void> onSaveItem(OpenFoodFactsLanguage country) =>
-      preferences.setAppLanguageCode(
-        country.offTag,
+  Future<void> onSaveItem(OpenFoodFactsLanguage language) async =>
+      ProductQuery.setLanguage(
+        null,
+        preferences,
+        languageCode: language.offTag,
       );
 }

--- a/packages/smooth_app/lib/pages/product/common/product_query_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_query_page.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:iso_countries/iso_countries.dart';
 import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
@@ -20,6 +19,7 @@ import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_error_card.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/pages/personalized_ranking_page.dart';
+import 'package:smooth_app/pages/preferences/country_selector/country.dart';
 import 'package:smooth_app/pages/product/common/loading_status.dart';
 import 'package:smooth_app/pages/product/common/product_list_item_simple.dart';
 import 'package:smooth_app/pages/product/common/product_query_page_helper.dart';
@@ -373,72 +373,50 @@ class _ProductQueryPageState extends State<ProductQueryPage>
     final PagedProductQuery pagedProductQuery = _model.supplier.productQuery;
     final PagedProductQuery? worldQuery = pagedProductQuery.getWorldQuery();
 
-    return FutureBuilder<String?>(
-      future: _getTranslatedCountry(),
-      builder: (
-        final BuildContext context,
-        final AsyncSnapshot<String?> snapshot,
-      ) {
-        final AppLocalizations appLocalizations = AppLocalizations.of(context);
-        final List<String> messages = <String>[];
-        String counting = appLocalizations.user_list_length(
-          _model.supplier.partialProductList.totalSize,
-        );
-        if (pagedProductQuery.hasDifferentCountryWorldData()) {
-          if (pagedProductQuery.world) {
-            counting += ' (${appLocalizations.world_results_label})';
-          } else {
-            if (snapshot.data != null) {
-              counting += ' (${snapshot.data})';
-            }
-          }
-        }
-        messages.add(counting);
-        final int? lastUpdate = _model.supplier.timestamp;
-        if (lastUpdate != null) {
-          final String lastTime =
-              ProductQueryPageHelper.getDurationStringFromTimestamp(
-                  lastUpdate, context);
-          messages.add('${appLocalizations.cached_results_from} $lastTime');
-        }
-        return SizedBox(
-          width: double.infinity,
-          child: SmoothCard(
-            child: Padding(
-              padding: const EdgeInsets.all(SMALL_SPACE),
-              child: Row(
-                children: <Widget>[
-                  Expanded(child: Text(messages.join('\n'))),
-                  if (pagedProductQuery.getWorldQuery() != null)
-                    _getIconButton(
-                      _getWorldAction(
-                        appLocalizations,
-                        worldQuery!,
-                        widget.includeAppBar,
-                      ),
-                    ),
-                ],
-              ),
-            ),
-          ),
-        );
-      },
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final List<String> messages = <String>[];
+    String counting = appLocalizations.user_list_length(
+      _model.supplier.partialProductList.totalSize,
     );
-  }
-
-  Future<String?> _getTranslatedCountry() async {
-    if (_country == null) {
-      return null;
-    }
-    final String locale = Localizations.localeOf(context).languageCode;
-    final List<Country> localizedCountries =
-        await IsoCountries.isoCountriesForLocale(locale);
-    for (final Country country in localizedCountries) {
-      if (country.countryCode.toLowerCase() == _country?.offTag.toLowerCase()) {
-        return country.name;
+    if (pagedProductQuery.hasDifferentCountryWorldData()) {
+      if (pagedProductQuery.world) {
+        counting += ' (${appLocalizations.world_results_label})';
+      } else {
+        final String? countryName = _country?.name;
+        if (countryName != null) {
+          counting += ' ($countryName)';
+        }
       }
     }
-    return null;
+    messages.add(counting);
+    final int? lastUpdate = _model.supplier.timestamp;
+    if (lastUpdate != null) {
+      final String lastTime =
+          ProductQueryPageHelper.getDurationStringFromTimestamp(
+              lastUpdate, context);
+      messages.add('${appLocalizations.cached_results_from} $lastTime');
+    }
+    return SizedBox(
+      width: double.infinity,
+      child: SmoothCard(
+        child: Padding(
+          padding: const EdgeInsets.all(SMALL_SPACE),
+          child: Row(
+            children: <Widget>[
+              Expanded(child: Text(messages.join('\n'))),
+              if (pagedProductQuery.getWorldQuery() != null)
+                _getIconButton(
+                  _getWorldAction(
+                    appLocalizations,
+                    worldQuery!,
+                    widget.includeAppBar,
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 
   Widget _getLargeButtonWithIcon(final _Action action) =>

--- a/packages/smooth_app/lib/pages/product/simple_input/simple_input_page_helpers.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input/simple_input_page_helpers.dart
@@ -1,7 +1,6 @@
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:iso_countries/country.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/background/background_task_details.dart';
 import 'package:smooth_app/data_models/preferences/user_preferences.dart';
@@ -9,7 +8,7 @@ import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/pages/image_crop_page.dart';
-import 'package:smooth_app/pages/preferences/country_selector/country_selector.dart';
+import 'package:smooth_app/pages/preferences/country_selector/country.dart';
 import 'package:smooth_app/pages/product/multilingual_helper.dart';
 import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/resources/app_icons.dart' as icons;
@@ -1051,13 +1050,7 @@ class SimpleInputPageCategoryNotFoodHelper
 /// Implementation for "Countries" of an [AbstractSimpleInputPageHelper].
 class SimpleInputPageCountryHelper extends AbstractSimpleInputPageHelper {
   SimpleInputPageCountryHelper(UserPreferences userPreferences)
-      : _userCountryCode = userPreferences.userCountryCode ?? 'en' {
-    CountriesHelper.getCountries(
-      getLanguage().offTag,
-    ).then((List<Country>? countries) {
-      _countries = countries ?? <Country>[];
-    });
-  }
+      : _userCountryCode = userPreferences.userCountryCode ?? 'fr';
 
   final String _userCountryCode;
 
@@ -1065,7 +1058,7 @@ class SimpleInputPageCountryHelper extends AbstractSimpleInputPageHelper {
       ValueNotifier<SimpleInputSuggestionsState>(
     const SimpleInputSuggestionsLoading(),
   );
-  List<Country>? _countries;
+  final List<Country> _countries = OpenFoodFactsCountry.values;
 
   @override
   List<String> initTerms(final Product product) =>
@@ -1116,16 +1109,8 @@ class SimpleInputPageCountryHelper extends AbstractSimpleInputPageHelper {
       _suggestionsNotifier;
 
   Future<void> _reloadSuggestions() async {
-    _countries ??= await CountriesHelper.getCountries(
-      getLanguage().offTag,
-    );
-    if (_countries == null) {
-      _suggestionsNotifier.value = const SimpleInputSuggestionsNoSuggestion();
-      return;
-    }
-
-    final Country? country = _countries!.firstWhereOrNull(
-      (Country country) => country.countryCode == _userCountryCode,
+    final Country? country = _countries.firstWhereOrNull(
+      (Country country) => country.offTag == _userCountryCode,
     );
 
     if (country == null || _terms.contains(country.name) == true) {

--- a/packages/smooth_app/lib/query/product_query.dart
+++ b/packages/smooth_app/lib/query/product_query.dart
@@ -7,6 +7,7 @@ import 'package:smooth_app/data_models/preferences/user_preferences.dart';
 import 'package:smooth_app/database/dao_string.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
+import 'package:smooth_app/pages/preferences/country_selector/country.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_dev_mode.dart';
 import 'package:smooth_app/pages/product/product_type_extensions.dart';
 import 'package:uuid/uuid.dart';
@@ -39,12 +40,13 @@ abstract class ProductQuery {
 
   /// Sets the global language for API queries.
   static void setLanguage(
-    final BuildContext context,
+    final BuildContext? context,
     final UserPreferences userPreferences, {
     String? languageCode,
   }) {
     languageCode ??= userPreferences.appLanguageCode ??
-        Localizations.localeOf(context).languageCode;
+        (context == null ? 'en' : Localizations.localeOf(context).languageCode);
+    OpenFoodFactsCountryLocalization.setLocale(languageCode);
 
     final OpenFoodFactsLanguage language =
         LanguageHelper.fromJson(languageCode);

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -941,14 +941,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.19.0"
-  iso_countries:
-    dependency: "direct main"
-    description:
-      name: iso_countries
-      sha256: efb2f1c69191c8071cf94d88e961501bfefead6753011544896cd2a3f504821e
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.2.0"
   js:
     dependency: transitive
     description:
@@ -965,6 +957,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.9.0"
+  l10n_countries:
+    dependency: "direct main"
+    description:
+      name: l10n_countries
+      sha256: "3ce25e801479534de4c0e8ac964e1a0f3bd53837f7b06db24407c4673e9ba289"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   latlong2:
     dependency: "direct main"
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   http: 1.3.0
   http_parser: 4.1.2
   image_picker: 1.1.2
-  iso_countries: 2.2.0
+  l10n_countries: 1.0.0
   latlong2: 0.9.1
   matomo_tracker: 5.1.0
   package_info_plus: 8.2.1


### PR DESCRIPTION
### What
- Here we use a different package for country name translations.
- With this package we can upgrade the flutter version.

### Fixes bug(s)
- Closes: #6523

### Files
New file:
* `country.dart`: Extension on countries and their localisations.

Impacted files:
* `country_selector.dart`: minor refactoring
* `country_selector_provider.dart`: removed now useless code
* `language_selector_provider.dart`: fixed a bug around setting the app language
* `product_query.dart`: minor refactoring
* `product_query_page.dart`: removed a now useless `FutureBuilder`.
* `pubspec.lock`: wtf
* `pubspec.yaml`: now using `l10n_countries` instead of `iso_countries`
* `simple_input_page_helpers.dart`: fixed fallback country code; now using all countries