### PR TITLE
fix: 6654 - clean "delete" button for prices

### DIFF
--- a/packages/smooth_app/lib/pages/prices/price_amount_card.dart
+++ b/packages/smooth_app/lib/pages/prices/price_amount_card.dart
@@ -66,9 +66,12 @@ class _PriceAmountCardState extends State<PriceAmountCard> {
         children: <Widget>[
           PriceProductListTile(
             product: model.product,
-            trailingIconData: total == 1 ? null : Icons.clear,
-            onPressed:
-                total == 1 ? null : () => priceModel.removeAt(widget.index),
+            trailing: total == 1
+                ? null
+                : InkWell(
+                    onTap: () => priceModel.removeAt(widget.index),
+                    child: const Icon(Icons.clear),
+                  ),
           ),
           if (model.product.categoryTag.isNotEmpty)
             const SizedBox(height: SMALL_SPACE),

--- a/packages/smooth_app/lib/pages/prices/price_product_list_tile.dart
+++ b/packages/smooth_app/lib/pages/prices/price_product_list_tile.dart
@@ -7,20 +7,18 @@ import 'package:smooth_app/pages/prices/price_meta_product.dart';
 class PriceProductListTile extends StatelessWidget {
   const PriceProductListTile({
     required this.product,
-    this.trailingIconData,
-    this.onPressed,
+    this.trailing,
   });
 
   final PriceMetaProduct product;
-  final IconData? trailingIconData;
-  final VoidCallback? onPressed;
+  final Widget? trailing;
 
   @override
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final Size screenSize = MediaQuery.sizeOf(context);
     final double size = screenSize.width * 0.20;
-    final Widget child = Row(
+    return Row(
       mainAxisAlignment: MainAxisAlignment.start,
       crossAxisAlignment: CrossAxisAlignment.center,
       children: <Widget>[
@@ -41,15 +39,8 @@ class PriceProductListTile extends StatelessWidget {
             ],
           ),
         ),
-        if (trailingIconData != null) Icon(trailingIconData),
+        if (trailing != null) trailing!,
       ],
-    );
-    if (onPressed == null) {
-      return child;
-    }
-    return InkWell(
-      onTap: onPressed,
-      child: child,
     );
   }
 }


### PR DESCRIPTION
### What
- When adding prices, we sometimes have a "clear" button in order to remove individual prices.
- With this PR, the "clear" action is only triggered by a click on the "clear" icon. It used to be triggered by a click on the whole product title.

### Fixes bug(s)
- Fixes: #6654

### Impacted files
* `price_amount_card.dart`: minor refactoring
* `price_product_list_tile.dart`: minor refactoring with a trailing widget