### PR TITLE
fix: 6657 - explicit utf8 data for Photon API

### DIFF
--- a/packages/smooth_app/lib/data_models/location_list_photon_supplier.dart
+++ b/packages/smooth_app/lib/data_models/location_list_photon_supplier.dart
@@ -60,7 +60,9 @@ class LocationListPhotonSupplier extends LocationListSupplier {
       if (response.statusCode != 200) {
         return 'Could not retrieve locations';
       }
-      final Map<String, dynamic> map = json.decode(response.body);
+      final Map<String, dynamic> map = jsonDecode(
+        utf8.decode(response.bodyBytes),
+      );
       if (map['type'] != 'FeatureCollection') {
         return 'Unexpected result type: ${map['type']}';
       }


### PR DESCRIPTION
### What
- Now we explicitly consider Photon API data as UTF8.

### Screenshots
| before | after |
| -- | -- |
| ![Screenshot_1750349467](https://github.com/user-attachments/assets/7a61393e-25a1-47c9-86d5-7605c9aefa94) | ![Screenshot_1750350106](https://github.com/user-attachments/assets/58e4987b-7656-455a-9478-c4afd3cee62c) |

### Fixes bug(s)
- Fixes: #6657