### PR TITLE
fix: 6285 - OxF filter

### DIFF
--- a/packages/smooth_app/lib/pages/search/search_product_helper.dart
+++ b/packages/smooth_app/lib/pages/search/search_product_helper.dart
@@ -122,8 +122,8 @@ class SearchProductHelper extends SearchHelper {
             productType:
                 UserPreferences.getUserPreferencesSync()
                     .searchProductTypeFilterVisible
-                ? ProductType.food
-                : _productType,
+                ? _productType
+                : ProductType.food,
           ),
           context: context,
           editableAppBarTitle: false,


### PR DESCRIPTION
### What
- Fixes the optional OxF filter
- Btw "food filter" and "no OxF filter" mean the same thing.
- The UI is still ugly, I may try a quick improvement.

### Screenshots
| no filter | filter: food |
| -- | -- |
| ![Screenshot_1751273010](https://github.com/user-attachments/assets/a1b2d68c-2f8d-4bfb-b55b-2e8ee694030f) | ![Screenshot_1751273849](https://github.com/user-attachments/assets/6482addc-9a2e-4ef7-9946-5e47bbf02b5e) |

| beauty | pet food | products |
| -- | -- | -- |
| ![Screenshot_1751273865](https://github.com/user-attachments/assets/b7d29a34-d567-454a-ac78-04c55087117a) | ![Screenshot_1751273869](https://github.com/user-attachments/assets/e5113cf1-82d2-41e9-a926-7d2fe4ffcc0e) | ![Screenshot_1751273878](https://github.com/user-attachments/assets/97f8ea3a-9aa9-4398-9c06-d35b903fddc2) |

### Fixes bug(s)
- Fixes: #6285