### PR TITLE
fix: Scroll inside bottom sheet

### DIFF
--- a/packages/smooth_app/lib/generic_lib/bottom_sheets/smooth_bottom_sheet.dart
+++ b/packages/smooth_app/lib/generic_lib/bottom_sheets/smooth_bottom_sheet.dart
@@ -345,6 +345,8 @@ class SmoothModalSheet extends StatelessWidget {
 
     if (expandBody) {
       bodyChild = Expanded(child: bodyChild);
+    } else {
+      bodyChild = Flexible(child: SingleChildScrollView(child: bodyChild));
     }
 
     return ClipRRect(
@@ -353,11 +355,9 @@ class SmoothModalSheet extends StatelessWidget {
         decoration: const BoxDecoration(
           borderRadius: BorderRadius.vertical(top: ROUNDED_RADIUS),
         ),
-        child: SingleChildScrollView(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: <Widget>[header, bodyChild],
-          ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[header, bodyChild],
         ),
       ),
     );

--- a/packages/smooth_app/lib/pages/product/product_page/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/product_page/new_product_page.dart
@@ -12,6 +12,7 @@ import 'package:smooth_app/database/dao_product_list.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/helpers/product_compatibility_helper.dart';
+import 'package:smooth_app/pages/prices/price_add_helper.dart';
 import 'package:smooth_app/pages/product/product_page/footer/new_product_footer.dart';
 import 'package:smooth_app/pages/product/product_page/header/product_page_tabs.dart';
 import 'package:smooth_app/pages/product/product_page/new_product_header.dart';

--- a/packages/smooth_app/lib/pages/product/product_page/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/product_page/new_product_page.dart
@@ -12,7 +12,6 @@ import 'package:smooth_app/database/dao_product_list.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/helpers/product_compatibility_helper.dart';
-import 'package:smooth_app/pages/prices/price_add_helper.dart';
 import 'package:smooth_app/pages/product/product_page/footer/new_product_footer.dart';
 import 'package:smooth_app/pages/product/product_page/header/product_page_tabs.dart';
 import 'package:smooth_app/pages/product/product_page/new_product_header.dart';


### PR DESCRIPTION
### What
This PR proposes a solution to making overflowing content scrollable inside bottom sheet.
The current implementation breaks the `expandBody` behavior, thus the need for this PR.

### Part of 
- #6565
- #6402
