### PR TITLE
fix: 6150 - more generous limit to location look-ups

### DIFF
--- a/packages/smooth_app/lib/data_models/location_list_photon_supplier.dart
+++ b/packages/smooth_app/lib/data_models/location_list_photon_supplier.dart
@@ -52,6 +52,7 @@ class LocationListPhotonSupplier extends LocationListSupplier {
           query:
               'q=${Uri.encodeComponent(query)}'
               '&lang=${getQueryLanguage().offTag}'
+              '&limit=100'
               '${_getAdditionalParameters()}',
         ),
       );


### PR DESCRIPTION
### What
- We used the default limit in the location look-ups (seemed to be 15)
- Now we explicitly set this limit to 100, so that more meaningful locations are returned

### Screenshots
Now we can find the "Rue Yitzhak Rabin" supermarket
|  |  |
| -- | -- |
| ![Screenshot_1751448931](https://github.com/user-attachments/assets/ac86b74e-8b09-45da-a306-96c2aa25c3a6) | ![Screenshot_1751448926](https://github.com/user-attachments/assets/a90f7275-cab6-4054-ab3f-cdd686fb3564) |
| ![Screenshot_1751448977](https://github.com/user-attachments/assets/e940234f-94e3-4022-ae85-eaed992c2872) | ![Screenshot_1751448992](https://github.com/user-attachments/assets/3006d186-d9de-471f-9034-0ae68f6ca938) |

### Fixes bug(s)
- Fixes: #6150