### PR TITLE
fix: 6701 - correct price list from product page

### DIFF
--- a/packages/smooth_app/lib/pages/prices/infinite_scroll_manager.dart
+++ b/packages/smooth_app/lib/pages/prices/infinite_scroll_manager.dart
@@ -4,12 +4,17 @@ import 'package:smooth_app/l10n/app_localizations.dart';
 /// A generic abstract class for handling infinite scrolling in lists.
 /// [T] is the type of items being displayed.
 abstract class InfiniteScrollManager<T> {
-  /// Creates an instance of [InfiniteScrollManager] with optional initial items.
-  InfiniteScrollManager({List<T>? initialItems})
-    : _items = initialItems ?? <T>[],
-      _currentPage = initialItems != null && initialItems.isNotEmpty
-          ? _initialPage
-          : 0;
+  /// Creates an [InfiniteScrollManager] with optional initial state.
+  InfiniteScrollManager({
+    final List<T>? initialItems,
+    final int? totalItems,
+    final int? totalPages,
+  }) : _items = List<T>.from(initialItems ?? <T>[]),
+       _currentPage = initialItems != null && initialItems.isNotEmpty
+           ? _initialPage
+           : 0,
+       _totalPages = totalPages,
+       _totalItems = totalItems;
 
   static const int _initialPage = 1;
 

--- a/packages/smooth_app/lib/pages/prices/product_prices_list.dart
+++ b/packages/smooth_app/lib/pages/prices/product_prices_list.dart
@@ -49,7 +49,11 @@ class _InfiniteScrollPriceManager extends InfiniteScrollManager<Price> {
   _InfiniteScrollPriceManager({
     GetPricesResult? pricesResult,
     required this.model,
-  }) : super(initialItems: pricesResult?.items);
+  }) : super(
+         initialItems: pricesResult?.items,
+         totalItems: pricesResult?.total,
+         totalPages: pricesResult?.numberOfPages,
+       );
 
   /// The model containing price query parameters
   final GetPricesModel model;


### PR DESCRIPTION
### What
- When we display the product page, we compute the number of prices.
- In the process, we actually download the top 10 prices for that product.
- We reuse those prices if the user clicks on the button: we don't have to download the top 10 prices again, and the page will immediately display the prices.
- The fix here is to provide the product price page with even more information, so that it also knows how many items and pages are expected.
- The scroll down effect, that didn't work in that specific page (the only one with pre-loaded items), now works.

### Fixes bug(s)
- Fixes: #6701

### Impacted files
* `infinite_scroll_manager.dart`: added optional initial total number of items and pages
* `product_prices_list.dart`: populated the new  initial total number of items and pages parameters