### PR TITLE
feat: Allow to change the default language of a product

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -2822,6 +2822,19 @@
   "@add_basic_details_product_name_hint": {
     "description": "Placeholder when the product name text-field is empty"
   },
+  "add_basic_details_product_name_change_main_language_title": "Change the default language?",
+  "@add_basic_details_product_name_change_main_language_title": {
+    "description": "Title of the dialog to change the main language of the product name"
+  },
+  "add_basic_details_product_name_change_main_language_text": "Do you want the product's default language to be set to ‘{language}’?",
+  "@add_basic_details_product_name_change_main_language_text": {
+    "description": "Content of the dialog to change the main language of the product name. Please keep the language surrounded by ** and \"",
+    "placeholders": {
+      "language": {
+        "type": "String"
+      }
+    }
+  },
   "explanation_section_good_examples": "Good examples",
   "@explanation_section_good_examples": {
     "description": "Title for the section with good examples"

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -2798,7 +2798,7 @@
   },
   "basic_details": "Détails de base",
   "product_name": "Nom du produit",
-  "product_names": "Noms de produits",
+  "product_names": "Noms de produit",
   "@product_names": {
     "description": "Title for the section to edit the product name (in multiple languages)"
   },
@@ -2821,6 +2821,19 @@
   "add_basic_details_product_name_hint": "Saisir le nom du product (ex : Nutella)",
   "@add_basic_details_product_name_hint": {
     "description": "Placeholder when the product name text-field is empty"
+  },
+  "add_basic_details_product_name_change_main_language_title": "Changer la langue par défaut ?",
+  "@add_basic_details_product_name_change_main_language_title": {
+    "description": "Title of the dialog to change the main language of the product name"
+  },
+  "add_basic_details_product_name_change_main_language_text": "Voulez-vous que la langue par défaut du produit soit définie sur \"**{language}**\" ?",
+  "@add_basic_details_product_name_change_main_language_text": {
+    "description": "Content of the dialog to change the main language of the product name. Please keep the language surrounded by ** and \"",
+    "placeholders": {
+      "language": {
+        "type": "String"
+      }
+    }
   },
   "explanation_section_good_examples": "Bon exemple",
   "@explanation_section_good_examples": {

--- a/packages/smooth_app/lib/l10n/app_localizations.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations.dart
@@ -5459,6 +5459,20 @@ abstract class AppLocalizations {
   /// **'Input the name of the product (eg: Nutella)'**
   String get add_basic_details_product_name_hint;
 
+  /// Title of the dialog to change the main language of the product name
+  ///
+  /// In en, this message translates to:
+  /// **'Change the default language?'**
+  String get add_basic_details_product_name_change_main_language_title;
+
+  /// Content of the dialog to change the main language of the product name. Please keep the language surrounded by ** and "
+  ///
+  /// In en, this message translates to:
+  /// **'Do you want the product\'s default language to be set to ‘{language}’?'**
+  String add_basic_details_product_name_change_main_language_text(
+    String language,
+  );
+
   /// Title for the section with good examples
   ///
   /// In en, this message translates to:

--- a/packages/smooth_app/lib/pages/product/add_basic_details/add_basic_details_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_basic_details/add_basic_details_page.dart
@@ -264,6 +264,9 @@ class _AddBasicDetailsPageState extends State<AddBasicDetailsPage> {
 
     if (_productNameEditorProvider.hasChanged()) {
       hasChanged = true;
+      result.lang =
+          _productNameEditorProvider.value.defaultLanguageOverride ??
+          _product.lang;
       result.productNameInLanguages = _productNameEditorProvider
           .getChangedProductNames();
     }


### PR DESCRIPTION
Hi everyone!

This feature is finally here!
(Yuka contributions are very often in English, and we have to use the website).

The idea is to long-press on a language (This is intentional to avoid unwanted changes).

Demo: 

https://github.com/user-attachments/assets/99aa77f7-7ace-4752-8215-86b30a3b4700

P.S.: The API is slow as you can see on the video