### PR TITLE
fix: Background tasks and support dirs on iOS devices

### DIFF
--- a/packages/smooth_app/lib/background/background_task_add_price.dart
+++ b/packages/smooth_app/lib/background/background_task_add_price.dart
@@ -216,7 +216,7 @@ class BackgroundTaskAddPrice extends BackgroundTaskPrice {
     }
     try {
       (await BackgroundTaskUpload.getFile(
-        BackgroundTaskImage.getCroppedPath(fullPath),
+        await BackgroundTaskImage.getCroppedPath(fullPath),
       )).deleteSync();
     } catch (e) {
       // possible, but let's not spoil the task for that either.

--- a/packages/smooth_app/lib/background/background_task_image.dart
+++ b/packages/smooth_app/lib/background/background_task_image.dart
@@ -332,20 +332,22 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
   }
 
   static Future<String> getCroppedPath(final String fullPath) async {
-    String croppedPath = '$fullPath.cropped.jpg';
+    final String croppedPath = '$fullPath.cropped.jpg';
 
-    if (!_isFileWritable(File(croppedPath))) {
-      // The directory may have changed
-
-      // This issue is mainly on iOS devices, when the support directory has
-      // changed and is not writable anymore, but is still readable.
-      croppedPath = join(
-        (await BackgroundTaskUpload.getDirectory()).path,
-        Uri.file(fullPath).pathSegments.last,
-      );
+    if (_isFileWritable(File(croppedPath))) {
+      return croppedPath;
     }
 
-    return croppedPath;
+    // In some cases, the location of the directory from
+    // [BackgroundTaskUpload.getDirectory()] (= "application support" dir)
+    // may have changed
+    //
+    // This issue is mainly on iOS devices, when a support directory can become
+    // not writable anymore, but is still readable.
+    return join(
+      (await BackgroundTaskUpload.getDirectory()).path,
+      Uri.file(croppedPath).pathSegments.last,
+    );
   }
 
   /// Uploads the product image.

--- a/packages/smooth_app/lib/background/background_task_image.dart
+++ b/packages/smooth_app/lib/background/background_task_image.dart
@@ -6,6 +6,7 @@ import 'dart:ui' as ui;
 import 'package:crop_image/crop_image.dart';
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:path/path.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/background/background_task_barcode.dart';
 import 'package:smooth_app/background/background_task_price.dart';
@@ -188,7 +189,7 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
     }
     try {
       (await BackgroundTaskUpload.getFile(
-        getCroppedPath(fullPath),
+        await getCroppedPath(fullPath),
       )).deleteSync();
     } catch (e) {
       // possible, but let's not spoil the task for that either.
@@ -256,7 +257,8 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
     required final bool forceCompression,
     required final List<double>? eraserCoordinates,
   }) async {
-    final String croppedPath = getCroppedPath(fullPath);
+    final String croppedPath = await getCroppedPath(fullPath);
+
     final CustomPainter? overlayPainter =
         eraserCoordinates == null || eraserCoordinates.isEmpty
         ? null
@@ -329,8 +331,22 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
     return croppedPath;
   }
 
-  static String getCroppedPath(final String fullPath) =>
-      '$fullPath.cropped.jpg';
+  static Future<String> getCroppedPath(final String fullPath) async {
+    String croppedPath = '$fullPath.cropped.jpg';
+
+    if (!_isFileWritable(File(croppedPath))) {
+      // The directory may have changed
+
+      // This issue is mainly on iOS devices, when the support directory has
+      // changed and is not writable anymore, but is still readable.
+      croppedPath = join(
+        (await BackgroundTaskUpload.getDirectory()).path,
+        Uri.file(fullPath).pathSegments.last,
+      );
+    }
+
+    return croppedPath;
+  }
 
   /// Uploads the product image.
   @override
@@ -390,5 +406,19 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
     throw Exception(
       'Could not upload picture: ${status.status} / ${status.error}',
     );
+  }
+
+  static bool _isFileWritable(File file) {
+    try {
+      final FileStat stat = file.statSync();
+
+      final bool isOwnerWritable = (stat.mode & 0x0080) != 0;
+      final bool isGroupWritable = (stat.mode & 0x0010) != 0;
+      final bool isOtherWritable = (stat.mode & 0x0002) != 0;
+
+      return isOwnerWritable || isGroupWritable || isOtherWritable;
+    } catch (_) {
+      return false;
+    }
   }
 }


### PR DESCRIPTION
Hi everyone!

I've finally found why some background tasks always fail on iOS.
This is always when a picture is attached to the request.

The issue is how iOS handles the application support directory. After an app relaunch, the path to this directory can change. The old directory becomes read-only, while a new one is created with read+write permissions.

The problem was that our code continued to use the old directory (potentially read-only) to save temporary cropped images for uploads. 

My fix resolves this by checking if the support directory is writable. If it isn't, it will ask for the new support directory.

@monsieurtanuki Could you confirm that the correct way/location in the code to fix it?
- Will fix #6283