### PR TITLE
fix: Potential fix for code scanning alert no. 27: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dartdoc.yml
+++ b/.github/workflows/dartdoc.yml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+  pages: write
 name: GitHub Pages Deploy Action
 on:
     push:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/smooth-app/security/code-scanning/27](https://github.com/openfoodfacts/smooth-app/security/code-scanning/27)

To fix the issue, we should add a `permissions` block at the root level of the workflow file to specify the minimum privileges required for the workflow. Since the workflow involves checking out code, setting up Flutter, generating documentation, and deploying to GitHub Pages, the contents must be readable, and `pages: write` permission is required for deployment.

The `permissions` block should look like this:
```yaml
permissions:
  contents: read
  pages: write
```

This ensures that the `GITHUB_TOKEN` used by the workflow has only the necessary permissions for its operations and adheres to the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
