### PR TITLE
fix: Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/on-demand.yml
+++ b/.github/workflows/on-demand.yml
@@ -1,5 +1,8 @@
 # This file contains actions that can be performed on PRs by issuing a comment
 name: 🕹️ On demand PR action
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   issue_comment:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/smooth-app/security/code-scanning/12](https://github.com/openfoodfacts/smooth-app/security/code-scanning/12)

To fix the issue, we need to add a `permissions` block to the workflow file. This block explicitly limits the permissions granted to the `GITHUB_TOKEN`. Since the workflow involves reading and writing to pull requests and repository contents, we will set `contents: read` and `pull-requests: write` as the minimal permissions required for the jobs to function correctly. The `permissions` block can be added at the root level to apply to all jobs or individually under each job to tailor permissions specifically.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
