### PR TITLE
ci: Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -1,5 +1,9 @@
 name: Crowdin Action
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   push:
     branches: [ crowdin-trigger ]


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/smooth-app/security/code-scanning/5](https://github.com/openfoodfacts/smooth-app/security/code-scanning/5)

The best way to fix the issue is to add a `permissions` block at the root level of the workflow. This will apply to all jobs that do not have their own `permissions` block. Since the workflow creates pull requests and interacts with repository contents, it needs specific permissions like `contents: read` and `pull-requests: write`. Adding this permissions block ensures that the GITHUB_TOKEN's access is limited to only the required scopes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
