### PR TITLE
ci: Potential fix for code scanning alert no. 18: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,5 +1,8 @@
 name: "Semantic PRs"
 
+permissions:
+  contents: read
+
 on:
   pull_request_target:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/smooth-app/security/code-scanning/18](https://github.com/openfoodfacts/smooth-app/security/code-scanning/18)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the least privileges required for the workflow to function correctly. Since the workflow only validates PR titles, it likely only needs `contents: read` permissions. This ensures that the `GITHUB_TOKEN` is restricted to read-only access to repository contents, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
