### PR TITLE
ci: Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/github-projects.yml
+++ b/.github/workflows/github-projects.yml
@@ -8,6 +8,9 @@ jobs:
   add-to-project:
     name: Add issue to project
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/add-to-project@main
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/smooth-app/security/code-scanning/8](https://github.com/openfoodfacts/smooth-app/security/code-scanning/8)

To fix the issue, a `permissions` block will be added to the workflow. This block will specify the minimal permissions required for the `add-to-project` job to function correctly. Based on the provided code snippet, the job interacts with GitHub Projects and issues. Therefore, the permissions will be set to `contents: read` and `issues: write` to allow reading repository contents and modifying issues while restricting other permissions. 

The `permissions` block can be added either at the workflow level (applying to all jobs) or specifically to the `add-to-project` job. Since this workflow contains only one job, adding the permissions at the job level will suffice.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
