### PR TITLE
ci: Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/merge-conflict-autolabel.yml
+++ b/.github/workflows/merge-conflict-autolabel.yml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+  pull-requests: write
 name: "Maintenance"
 on:
   # So that PRs touching the same files as the push are updated


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/smooth-app/security/code-scanning/10](https://github.com/openfoodfacts/smooth-app/security/code-scanning/10)

The best fix is to add a `permissions` block to the workflow file to explicitly set the least privileges required for the workflow. Since the workflow interacts with pull requests (e.g., adding or removing labels) and uses the `GITHUB_TOKEN`, it requires the `contents: read` and `pull-requests: write` permissions. These permissions ensure the workflow can read the repository contents and modify pull request metadata without granting unnecessary access.

The fix involves adding the `permissions` key to the root of the workflow file, applying it to all jobs unless overridden. No other functionality in the workflow is modified.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
