### PR TITLE
ci: Potential fix for code scanning alert no. 20: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/top-issues.yml
+++ b/.github/workflows/top-issues.yml
@@ -10,6 +10,9 @@ jobs:
   ShowAndLabelTopIssues:
     name: Display and label top issues.
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
     - name: Run top issues action
       uses: rickstaa/top-issues-action@v1


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/smooth-app/security/code-scanning/20](https://github.com/openfoodfacts/smooth-app/security/code-scanning/20)

To resolve the issue, we need to add an explicit `permissions` block to the workflow. Since the workflow is designed to read issues and label them, the `contents: read` and `issues: write` permissions are sufficient.  

The `permissions` block will be added at the root of the workflow (applies to all jobs) or within the job definition (`ShowAndLabelTopIssues`). To minimize changes and adhere to best practices, we will add the permissions at the job level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
