### PR TITLE
ci: Potential fix for code scanning alert no. 21: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/waldo_sessions.yml
+++ b/.github/workflows/waldo_sessions.yml
@@ -12,6 +12,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: macos-latest


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/smooth-app/security/code-scanning/21](https://github.com/openfoodfacts/smooth-app/security/code-scanning/21)

To fix the issue, add a `permissions` block to the workflow file. The permissions should be set at the root level of the workflow to apply to all jobs unless specific jobs need additional permissions. For this workflow:
- The `contents: read` permission is required for code checkout.
- The workflow doesn't perform actions that require write permissions, so no additional permissions are needed.

The fix involves adding a `permissions` block at the root of the workflow file, specifying `contents: read` to limit the scope of the `GITHUB_TOKEN`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
