### PR TITLE
ci: Potential fix for code scanning alert no. 22: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-assets.yml
+++ b/.github/workflows/update-assets.yml
@@ -1,5 +1,9 @@
 name: Update assets
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   # Allow to be run manually
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/smooth-app/security/code-scanning/22](https://github.com/openfoodfacts/smooth-app/security/code-scanning/22)

To fix this problem, we need to explicitly define the `permissions` block at the workflow level or for the specific job. Since the workflow performs repository checkout, script execution, and pull request creation, it requires `contents: read` for accessing the repository and `pull-requests: write` for creating pull requests. These permissions can be added at the workflow level to apply to all jobs in the workflow (there is only one job here). This ensures the GITHUB_TOKEN has the least privileges necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
