### PR TITLE
ci: Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,6 +12,9 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'openfoodfacts'
+    permissions:
+      contents: read
+      pull-requests: write
     outputs:
       release_created: ${{ steps.release_please.outputs.release_created }}
       major: ${{ steps.release_please.outputs.major }}
@@ -42,6 +45,9 @@ jobs:
       group: release
       cancel-in-progress: false
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
     outputs:
@@ -112,6 +118,9 @@ jobs:
       group: android-release
       cancel-in-progress: false
     uses: openfoodfacts/smooth-app/.github/workflows/android-release-to-org-openfoodfacts-scanner.yml@develop
+    permissions:
+      contents: read
+      packages: write
     needs: [release-please, create-release]
     if: ${{ needs.release-please.outputs.release_created }}
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/smooth-app/security/code-scanning/19](https://github.com/openfoodfacts/smooth-app/security/code-scanning/19)

To address the issue, we will add an explicit `permissions` block to the workflow file. For this workflow, the permissions can be set at the job-level for each job (`release-please`, `create-release`, `android-release`) to ensure each job has only the access it needs. For instance:
- The `release-please` job likely needs `contents: read` and `pull-requests: write`.
- The `create-release` job likely needs `contents: read` and `packages: write` for uploading version codes and release tags.
- The `android-release` job needs permissions related to its specific tasks.

We will modify the `.github/workflows/release-please.yml` file, adding explicit permissions for each job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
