### PR TITLE
ci: Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/internal-release.yml
+++ b/.github/workflows/internal-release.yml
@@ -2,6 +2,10 @@ name: Create internal releases of the Mobile app for Android & iOS
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  actions: write
+
 env:
  RUBY_VERSION: 3.2.0
 


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/smooth-app/security/code-scanning/13](https://github.com/openfoodfacts/smooth-app/security/code-scanning/13)

To fix the issue, we will add the `permissions` key at the root level of the workflow. This will ensure that all jobs in the workflow inherit these minimal permissions unless they specify their own `permissions` block. The minimal set of permissions required for this workflow includes `contents: read` (to read repository contents) and `actions: write` (for tagging commits). Additional permissions can be added if needed by specific jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
