### PR TITLE
fix: 6759 - changed bulk proof uploading display

### DIFF
--- a/packages/smooth_app/lib/background/background_task_add_price.dart
+++ b/packages/smooth_app/lib/background/background_task_add_price.dart
@@ -11,6 +11,7 @@ import 'package:smooth_app/background/background_task_queue.dart';
 import 'package:smooth_app/background/background_task_upload.dart';
 import 'package:smooth_app/background/operation_type.dart';
 import 'package:smooth_app/database/local_database.dart';
+import 'package:smooth_app/l10n/app_localizations.dart';
 import 'package:smooth_app/pages/crop_parameters.dart';
 import 'package:smooth_app/query/product_query.dart';
 
@@ -30,6 +31,7 @@ class BackgroundTaskAddPrice extends BackgroundTaskPrice {
     required this.cropY2,
     required this.proofType,
     required this.eraserCoordinates,
+    required this.displaySnackbar,
     // single
     required super.date,
     required super.currency,
@@ -57,6 +59,7 @@ class BackgroundTaskAddPrice extends BackgroundTaskPrice {
       eraserCoordinates = BackgroundTaskPrice.fromJsonListDouble(
         json[_jsonTagEraserCoordinates],
       ),
+      displaySnackbar = json[_jsonTagDisplaySnackbar] as bool? ?? true,
       super.fromJson();
 
   static const String _jsonTagImagePath = 'imagePath';
@@ -67,6 +70,7 @@ class BackgroundTaskAddPrice extends BackgroundTaskPrice {
   static const String _jsonTagY2 = 'y2';
   static const String _jsonTagProofType = 'proofType';
   static const String _jsonTagEraserCoordinates = 'eraserCoordinates';
+  static const String _jsonTagDisplaySnackbar = 'displaySnackbar';
 
   static const OperationType _operationType = OperationType.addPrice;
 
@@ -78,6 +82,7 @@ class BackgroundTaskAddPrice extends BackgroundTaskPrice {
   final int cropY2;
   final ProofType proofType;
   final List<double>? eraserCoordinates;
+  final bool displaySnackbar;
 
   @override
   Map<String, dynamic> toJson() {
@@ -90,6 +95,7 @@ class BackgroundTaskAddPrice extends BackgroundTaskPrice {
     result[_jsonTagY2] = cropY2;
     result[_jsonTagProofType] = proofType.offTag;
     result[_jsonTagEraserCoordinates] = eraserCoordinates;
+    result[_jsonTagDisplaySnackbar] = displaySnackbar;
     return result;
   }
 
@@ -110,6 +116,7 @@ class BackgroundTaskAddPrice extends BackgroundTaskPrice {
     required final List<bool> pricesAreDiscounted,
     required final List<double> prices,
     required final List<double?> pricesWithoutDiscount,
+    required final bool displaySnackbar,
   }) async {
     final LocalDatabase localDatabase = context.read<LocalDatabase>();
     final String uniqueId = await _operationType.getNewKey(localDatabase);
@@ -129,6 +136,7 @@ class BackgroundTaskAddPrice extends BackgroundTaskPrice {
       pricesAreDiscounted: pricesAreDiscounted,
       prices: prices,
       pricesWithoutDiscount: pricesWithoutDiscount,
+      displaySnackbar: displaySnackbar,
     );
     if (!context.mounted) {
       return;
@@ -157,6 +165,7 @@ class BackgroundTaskAddPrice extends BackgroundTaskPrice {
     required final List<bool> pricesAreDiscounted,
     required final List<double> prices,
     required final List<double?> pricesWithoutDiscount,
+    required final bool displaySnackbar,
   }) => BackgroundTaskAddPrice._(
     uniqueId: uniqueId,
     processName: _operationType.processName,
@@ -185,7 +194,13 @@ class BackgroundTaskAddPrice extends BackgroundTaskPrice {
       locationOSMId: locationOSMId,
       locationOSMType: locationOSMType,
     ),
+    displaySnackbar: displaySnackbar,
   );
+
+  @override
+  (String, AlignmentGeometry)? getFloatingMessage(
+    final AppLocalizations appLocalizations,
+  ) => displaySnackbar ? super.getFloatingMessage(appLocalizations) : null;
 
   @override
   Future<void> postExecute(

--- a/packages/smooth_app/lib/pages/prices/price_model.dart
+++ b/packages/smooth_app/lib/pages/prices/price_model.dart
@@ -204,7 +204,10 @@ class PriceModel with ChangeNotifier {
   }
 
   /// Adds the related background task.
-  Future<void> addTask(final BuildContext context) async {
+  Future<void> addTask(
+    final BuildContext context, {
+    required final bool displaySnackbar,
+  }) async {
     final List<String> barcodes = <String>[];
     final List<String> categories = <String>[];
     final List<List<String>> origins = <List<String>>[];
@@ -263,6 +266,7 @@ class PriceModel with ChangeNotifier {
       pricesAreDiscounted: pricesAreDiscounted,
       prices: prices,
       pricesWithoutDiscount: pricesWithoutDiscount,
+      displaySnackbar: displaySnackbar,
     );
   }
 }

--- a/packages/smooth_app/lib/pages/prices/product_price_add_page.dart
+++ b/packages/smooth_app/lib/pages/prices/product_price_add_page.dart
@@ -237,7 +237,7 @@ class _ProductPriceAddPageState extends State<ProductPriceAddPage>
       return true;
     }
 
-    await model.addTask(context);
+    await model.addTask(context, displaySnackbar: true);
 
     return true;
   }


### PR DESCRIPTION
### What
- Changes in the "bulk proof" page:
  - now we don't display the "green" snackbar
  - while we're uploading, we're replacing the "select images" button with a display of the current step 

### Screenshots
| button | uploading |
| -- | -- |
| <img width="1080" height="2400" alt="Screenshot_1752423982" src="https://github.com/user-attachments/assets/5ff63cf7-0d89-472b-bb12-eaa5d61f0413" /> | <img width="1080" height="2400" alt="Screenshot_1752423286" src="https://github.com/user-attachments/assets/7ddc6f74-221c-463f-8c6f-4915a1ebac6a" />|

### Fixes bug(s)
- Fixes: #6759

### Impacted files
* `background_task_add_price.dart`: snackbar display is now optional
* `price_bulk_proof_card.dart`: changed the display of the upload process - no snackbar, text replacing the button
* `price_model.dart`: minor refactoring
* `product_price_add_page.dart`: minor refactoring