### PR TITLE
fix: 6761 - improved number format for discount

### DIFF
--- a/packages/smooth_app/lib/pages/prices/price_data_value.dart
+++ b/packages/smooth_app/lib/pages/prices/price_data_value.dart
@@ -69,7 +69,7 @@ class PriceDataDiscountedValue extends StatelessWidget {
     }
 
     return _PriceDataContainer(
-      value: NumberFormat('00%').format(
+      value: NumberFormat('#0%').format(
         (price.price - price.priceWithoutDiscount!) /
             price.priceWithoutDiscount!,
       ),


### PR DESCRIPTION
### What
- The discount display was awkward for percentages below10. For instance, it displayed '-09%' instead of '-9%'
- The current PR fixes that.

### Screenshots
| before: -09% |  after: -9% | after: -25% |
| -- | -- | -- |
| <img width="1080" height="2400" alt="Screenshot_1752649147" src="https://github.com/user-attachments/assets/93baa5e0-8e44-4ca2-a84e-aa908484e762" /> | <img width="1080" height="2400" alt="Screenshot_1752649140" src="https://github.com/user-attachments/assets/d4866403-0289-4308-87c5-7e6e39708bb1" /> | <img width="1080" height="2400" alt="Screenshot_1752649330" src="https://github.com/user-attachments/assets/c6eef18d-9cfa-4759-8f47-a8e08ebc07aa" /> |

### Part of 
- #6761
