### PR TITLE
fix: 6732 - price date displayed in local timezone

### DIFF
--- a/packages/smooth_app/lib/pages/prices/price_data_widget.dart
+++ b/packages/smooth_app/lib/pages/prices/price_data_widget.dart
@@ -29,11 +29,11 @@ class PriceDataWidget extends StatelessWidget {
 
     final DateFormat timeFormat = DateFormat('HH:mm');
 
+    final DateTime created = price.created.toLocal();
     final String date = MaterialLocalizations.of(
       context,
-    ).formatCompactDate(price.created);
-    final String time = timeFormat.format(price.created);
-
+    ).formatCompactDate(created);
+    final String time = timeFormat.format(created);
     final SmoothColorsThemeExtension extension = context
         .extension<SmoothColorsThemeExtension>();
     final bool lightTheme = context.lightTheme();


### PR DESCRIPTION
### What
- Now the price dates are displayed according to the device timezone.

### Screenshots
| before | after |
| -- | -- |
| <img width="1080" height="2400" alt="Screenshot_1752651380" src="https://github.com/user-attachments/assets/9f94e451-bc8a-4a3b-b82f-79be57b4b5a4" /> | <img width="1080" height="2400" alt="Screenshot_1752651392" src="https://github.com/user-attachments/assets/4eac6ecc-527b-4623-acaa-9813f2f4084d" /> |

### Fixes bug(s)
- Fixes: #6732