### PR TITLE
feat: 5689 - separate tasks (proof upload and prices adding)

### DIFF
--- a/packages/smooth_app/lib/background/background_task_add_price.dart
+++ b/packages/smooth_app/lib/background/background_task_add_price.dart
@@ -5,6 +5,7 @@ import 'package:http_parser/http_parser.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/background/background_task.dart';
+import 'package:smooth_app/background/background_task_add_other_price.dart';
 import 'package:smooth_app/background/background_task_image.dart';
 import 'package:smooth_app/background/background_task_price.dart';
 import 'package:smooth_app/background/background_task_queue.dart';
@@ -263,10 +264,22 @@ class BackgroundTaskAddPrice extends BackgroundTaskPrice {
       throw Exception('Could not upload proof: ${uploadProof.error}');
     }
 
-    await addPrices(
-      bearerToken: bearerToken,
-      proofId: uploadProof.value.id,
+    await BackgroundTaskAddOtherPrice.addTask(
+      context: null,
       localDatabase: localDatabase,
+      proofId: uploadProof.value.id,
+      date: date,
+      currency: currency,
+      locationOSMId: locationOSMId,
+      locationOSMType: locationOSMType,
+      barcodes: barcodes,
+      categories: categories,
+      origins: origins,
+      labels: labels,
+      pricePers: pricePers,
+      pricesAreDiscounted: pricesAreDiscounted,
+      prices: prices,
+      pricesWithoutDiscount: pricesWithoutDiscount,
     );
 
     await closeSession(bearerToken: bearerToken);


### PR DESCRIPTION
### What
- Today, when we add prices, for instance as a receipt, we upload an image as the proof and we add prices linked to that proof.
- We do that in a single task.
- The problem is when there's an error - for some reason - somewhere when adding a price. In that case, the whole task is rejected and played again. As a consequence, the same image is uploaded again and again.
- The point of this PR is to split that task into an "upload proof" task, that calls an "add prices" task, in order to avoid those multiple uploads.
- Here we also split the "add prices" task into single "add single price" tasks. Doing so, all the "correct" prices will be added and the "flawed" prices will still be rejected but without any impact on the rest (proof upload and correct prices). That's also an opportunity to have tasks explicitly linked to a barcode, and it's displayed accordingly in the task list.

### Screenshot
<img width="1080" height="2400" alt="Screenshot_1752770333" src="https://github.com/user-attachments/assets/536d828c-1701-4912-bb85-c78bd817ae84" />


### Fixes bug(s)
- Closes: #5689

### Impacted files
* `background_task_add_other_price.dart`: can be called silently from another task
* `background_task_add_price.dart`: now splitting price adding into one-price-one-task
* `background_task_price.dart`: if successful, the proof upload calls another task and that's it
* `price_to_oxf.dart`: slightly unrelated patch about multiproduct search being crap