### PR TITLE
feat: 6700 - display of "no barcode" data

### DIFF
--- a/packages/smooth_app/lib/pages/prices/price_category_repository.dart
+++ b/packages/smooth_app/lib/pages/prices/price_category_repository.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/foundation.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/pages/prices/price_taxonomy_repository.dart';
+
+/// Helper for "Category" tag localization.
+class PriceCategoryRepository
+    extends PriceTaxonomyRepository<TaxonomyCategory> {
+  static final Map<String, String> _cachedMap = <String, String>{};
+
+  @protected
+  @override
+  Map<String, String> getCachedMap() => _cachedMap;
+
+  @protected
+  @override
+  Map<OpenFoodFactsLanguage, String>? getTaxonomyNames(
+    final TaxonomyCategory item,
+  ) => item.name;
+
+  @protected
+  @override
+  Future<Map<String, TaxonomyCategory>?> download(
+    final List<String> tags,
+  ) async => OpenFoodAPIClient.getTaxonomyCategories(
+    TaxonomyCategoryQueryConfiguration(
+      tags: tags,
+      country: getCountry(),
+      languages: <OpenFoodFactsLanguage>[getLanguage()],
+      fields: <TaxonomyCategoryField>[TaxonomyCategoryField.NAME],
+      includeChildren: false,
+    ),
+  );
+}

--- a/packages/smooth_app/lib/pages/prices/price_category_widget.dart
+++ b/packages/smooth_app/lib/pages/prices/price_category_widget.dart
@@ -1,0 +1,77 @@
+import 'package:auto_size_text/auto_size_text.dart';
+import 'package:flutter/material.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/pages/prices/price_button.dart';
+import 'package:smooth_app/pages/prices/price_l10n_helper.dart';
+
+/// Price Category display (no price data here).
+///
+/// See also [PriceProductWidget], that deals with "barcode" products.
+class PriceCategoryWidget extends StatefulWidget {
+  const PriceCategoryWidget(this.price);
+
+  final Price price;
+
+  @override
+  State<PriceCategoryWidget> createState() => _PriceCategoryWidgetState();
+}
+
+class _PriceCategoryWidgetState extends State<PriceCategoryWidget> {
+  final PriceL10nHelper _helper = PriceL10nHelper();
+
+  @override
+  void initState() {
+    super.initState();
+    _helper.localizeTags(widget.price, () {
+      if (mounted) {
+        setState(() {});
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: _generateSemanticsLabel(),
+      container: true,
+      excludeSemantics: true,
+      child: Padding(
+        padding: const EdgeInsetsGeometry.directional(start: 12.0),
+        child: Wrap(
+          spacing: VERY_SMALL_SPACE,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          runSpacing: 0,
+          children: <Widget>[
+            if (_helper.getCategory() != null)
+              AutoSizeText(
+                _helper.getCategory()!,
+                maxLines: 2,
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+            if (_helper.getOrigins() != null)
+              for (final String tag in _helper.getOrigins()!)
+                PriceButton(title: tag, onPressed: () {}),
+            if (_helper.getLabels() != null)
+              for (final String tag in _helper.getLabels()!)
+                PriceButton(title: tag, onPressed: () {}),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _generateSemanticsLabel() {
+    final StringBuffer result = StringBuffer();
+    if (_helper.getCategory() != null) {
+      result.write(_helper.getCategory());
+    }
+    if (_helper.getOrigins()?.isNotEmpty == true) {
+      result.write(' - ${_helper.getOrigins()!.join(', ')}');
+    }
+    if (_helper.getLabels()?.isNotEmpty == true) {
+      result.write(' - ${_helper.getLabels()!.join(', ')}');
+    }
+    return result.toString();
+  }
+}

--- a/packages/smooth_app/lib/pages/prices/price_data_value.dart
+++ b/packages/smooth_app/lib/pages/prices/price_data_value.dart
@@ -3,6 +3,8 @@ import 'package:intl/intl.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/helpers/strike_through_text_helper.dart';
+import 'package:smooth_app/l10n/app_localizations.dart';
+import 'package:smooth_app/pages/prices/price_per_extension.dart';
 import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/resources/app_icons.dart' as icons;
 import 'package:smooth_app/themes/smooth_theme.dart';
@@ -20,6 +22,7 @@ class PriceDataValue extends StatelessWidget {
       locale: ProductQuery.getLocaleString(),
       name: price.currency.name,
     );
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
 
     final SmoothColorsThemeExtension extension = context
         .extension<SmoothColorsThemeExtension>();
@@ -32,7 +35,11 @@ class PriceDataValue extends StatelessWidget {
           children: <Widget>[
             if (_hasDiscount(price)) ...<Widget>[
               _PriceDataContainer(
-                value: currencyFormat.format(price.priceWithoutDiscount),
+                value: _formatPrice(
+                  currencyFormat,
+                  price.priceWithoutDiscount!,
+                  appLocalizations,
+                ),
                 backgroundColor: extension.primaryLight,
                 textColor: extension.primaryBlack,
                 strikeThroughColor: const Color(0x80341100),
@@ -40,7 +47,11 @@ class PriceDataValue extends StatelessWidget {
               const icons.Arrow.right(size: 15.0),
             ],
             _PriceDataContainer(
-              value: currencyFormat.format(price.price),
+              value: _formatPrice(
+                currencyFormat,
+                price.price,
+                appLocalizations,
+              ),
               backgroundColor: extension.primarySemiDark,
               textColor: Colors.white,
             ),
@@ -48,6 +59,18 @@ class PriceDataValue extends StatelessWidget {
         ),
       ],
     );
+  }
+
+  String _formatPrice(
+    final NumberFormat currencyFormat,
+    final num value,
+    final AppLocalizations appLocalizations,
+  ) {
+    final String formatted = currencyFormat.format(value);
+    if (price.pricePer == null) {
+      return formatted;
+    }
+    return '$formatted${price.pricePer!.getShortTitle(appLocalizations)}';
   }
 }
 

--- a/packages/smooth_app/lib/pages/prices/price_l10n_helper.dart
+++ b/packages/smooth_app/lib/pages/prices/price_l10n_helper.dart
@@ -1,0 +1,73 @@
+import 'dart:async';
+import 'dart:ui';
+
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/pages/prices/price_category_repository.dart';
+import 'package:smooth_app/pages/prices/price_label_repository.dart';
+import 'package:smooth_app/pages/prices/price_origin_repository.dart';
+
+/// Localization helper for prices, managing static cache and downloads.
+class PriceL10nHelper {
+  PriceL10nHelper();
+
+  final PriceCategoryRepository _categoryRepository = PriceCategoryRepository();
+  late final String? _categoryTag;
+  String? _categoryName;
+  final PriceOriginRepository _originRepository = PriceOriginRepository();
+  late final List<String>? _originsTags;
+  List<String>? _originsNames;
+  final PriceLabelRepository _labelRepository = PriceLabelRepository();
+  late final List<String>? _labelsTags;
+  List<String>? _labelsNames;
+
+  String? getCategory() => _categoryName ?? _categoryTag;
+
+  List<String>? getLabels() => _labelsNames ?? _labelsTags;
+
+  List<String>? getOrigins() => _originsNames ?? _originsTags;
+
+  void localizeTags(final Price price, final VoidCallback refresh) {
+    _categoryTag = price.categoryTag;
+    _originsTags = price.originsTags;
+    _labelsTags = price.labelsTags;
+    if (_categoryTag != null) {
+      _categoryName = _categoryRepository.getCachedName(_categoryTag);
+      if (_categoryName == null) {
+        unawaited(_loadCategoryName(refresh));
+      }
+    }
+    if (_originsTags?.isNotEmpty == true) {
+      _originsNames = _originRepository.getCachedNames(_originsTags!);
+      if (_originsNames == null) {
+        unawaited(_loadOriginsNames(refresh));
+      }
+    }
+    if (_labelsTags?.isNotEmpty == true) {
+      _labelsNames = _labelRepository.getCachedNames(_labelsTags!);
+      if (_labelsNames == null) {
+        unawaited(_loadLabelsNames(refresh));
+      }
+    }
+  }
+
+  Future<void> _loadCategoryName(final VoidCallback refresh) async {
+    _categoryName = await _categoryRepository.getDownloadedName(_categoryTag!);
+    if (_categoryName != null) {
+      refresh.call();
+    }
+  }
+
+  Future<void> _loadOriginsNames(final VoidCallback refresh) async {
+    _originsNames = await _originRepository.getDownloadedNames(_originsTags!);
+    if (_originsNames != null) {
+      refresh.call();
+    }
+  }
+
+  Future<void> _loadLabelsNames(final VoidCallback refresh) async {
+    _labelsNames = await _labelRepository.getDownloadedNames(_labelsTags!);
+    if (_labelsNames != null) {
+      refresh.call();
+    }
+  }
+}

--- a/packages/smooth_app/lib/pages/prices/price_label_repository.dart
+++ b/packages/smooth_app/lib/pages/prices/price_label_repository.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/foundation.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/pages/prices/price_taxonomy_repository.dart';
+
+/// Helper for "Labels" tag localization.
+class PriceLabelRepository extends PriceTaxonomyRepository<TaxonomyLabel> {
+  static final Map<String, String> _cachedMap = <String, String>{};
+
+  @protected
+  @override
+  Map<String, String> getCachedMap() => _cachedMap;
+
+  @protected
+  @override
+  Map<OpenFoodFactsLanguage, String>? getTaxonomyNames(
+    final TaxonomyLabel item,
+  ) => item.name;
+
+  @protected
+  @override
+  Future<Map<String, TaxonomyLabel>?> download(final List<String> tags) async =>
+      OpenFoodAPIClient.getTaxonomyLabels(
+        TaxonomyLabelQueryConfiguration(
+          tags: tags,
+          country: getCountry(),
+          languages: <OpenFoodFactsLanguage>[getLanguage()],
+          fields: <TaxonomyLabelField>[TaxonomyLabelField.NAME],
+        ),
+      );
+}

--- a/packages/smooth_app/lib/pages/prices/price_origin_repository.dart
+++ b/packages/smooth_app/lib/pages/prices/price_origin_repository.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/foundation.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/pages/prices/price_taxonomy_repository.dart';
+
+/// Helper for "Origins" tag localization.
+class PriceOriginRepository extends PriceTaxonomyRepository<TaxonomyOrigin> {
+  static final Map<String, String> _cachedMap = <String, String>{};
+
+  @protected
+  @override
+  Map<String, String> getCachedMap() => _cachedMap;
+
+  @protected
+  @override
+  Map<OpenFoodFactsLanguage, String>? getTaxonomyNames(
+    final TaxonomyOrigin item,
+  ) => item.name;
+
+  @protected
+  @override
+  Future<Map<String, TaxonomyOrigin>?> download(
+    final List<String> tags,
+  ) async => OpenFoodAPIClient.getTaxonomyOrigins(
+    TaxonomyOriginQueryConfiguration(
+      tags: tags,
+      country: getCountry(),
+      languages: <OpenFoodFactsLanguage>[getLanguage()],
+      fields: <TaxonomyOriginField>[TaxonomyOriginField.NAME],
+      includeChildren: false,
+    ),
+  );
+}

--- a/packages/smooth_app/lib/pages/prices/price_product_widget.dart
+++ b/packages/smooth_app/lib/pages/prices/price_product_widget.dart
@@ -14,6 +14,8 @@ import 'package:smooth_app/pages/prices/price_meta_product.dart';
 import 'package:smooth_app/pages/prices/prices_page.dart';
 
 /// Price Product display (no price data here).
+///
+/// See also [PriceCategoryWidget], that deals with "no barcode" products.
 class PriceProductWidget extends StatelessWidget {
   const PriceProductWidget(
     this.priceProduct, {

--- a/packages/smooth_app/lib/pages/prices/price_taxonomy_repository.dart
+++ b/packages/smooth_app/lib/pages/prices/price_taxonomy_repository.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/foundation.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/query/product_query.dart';
+
+/// Helper for tag localization using taxonomy.
+abstract class PriceTaxonomyRepository<T> {
+  /// Downloads the taxonomy for the given [tags].
+  @protected
+  Future<Map<String, T>?> download(final List<String> tags);
+
+  @protected
+  Map<OpenFoodFactsLanguage, String>? getTaxonomyNames(final T item);
+
+  @protected
+  Map<String, String> getCachedMap();
+
+  Future<String?> getDownloadedName(final String tag) async {
+    final List<String>? result = await getDownloadedNames(<String>[tag]);
+    if (result == null) {
+      return null;
+    }
+    return result.firstOrNull;
+  }
+
+  Future<List<String>?> getDownloadedNames(final List<String> tags) async {
+    if (tags.isEmpty) {
+      return null;
+    }
+    final OpenFoodFactsLanguage language = getLanguage();
+    final Map<String, T>? map = await download(tags);
+    if (map == null) {
+      return null;
+    }
+    final List<String> result = <String>[];
+    for (final String tag in tags) {
+      String? toBeAdded;
+      final T? item = map[tag];
+      if (item != null) {
+        final Map<OpenFoodFactsLanguage, String>? names = getTaxonomyNames(
+          item,
+        );
+        if (names != null && names.isNotEmpty) {
+          final String? label = names[language];
+          if (label != null) {
+            _setCachedName(tag, label);
+            toBeAdded = label;
+          }
+        }
+      }
+      toBeAdded ??= tag;
+      result.add(toBeAdded);
+    }
+    return result;
+  }
+
+  void _setCachedName(final String tag, final String label) =>
+      getCachedMap()[_getKey(getLanguage(), getCountry(), tag)] = label;
+
+  String? getCachedName(final String tag) {
+    final List<String>? result = getCachedNames(<String>[tag]);
+    if (result == null) {
+      return null;
+    }
+    return result.firstOrNull;
+  }
+
+  /// Returns the cached names if all are present, or null.
+  List<String>? getCachedNames(final List<String> tags) {
+    final Map<String, String> map = getCachedMap();
+    final OpenFoodFactsLanguage language = getLanguage();
+    final OpenFoodFactsCountry country = getCountry();
+    final List<String> result = <String>[];
+    for (final String tag in tags) {
+      final String key = _getKey(language, country, tag);
+      final String? cached = map[key];
+      if (cached == null) {
+        return null;
+      }
+      result.add(cached);
+    }
+    return result;
+  }
+
+  @protected
+  OpenFoodFactsLanguage getLanguage() => ProductQuery.getLanguage();
+
+  @protected
+  OpenFoodFactsCountry getCountry() => ProductQuery.getCountry();
+
+  String _getKey(
+    final OpenFoodFactsLanguage language,
+    final OpenFoodFactsCountry country,
+    final String tag,
+  ) => '${language.offTag}_${country.offTag}:$tag';
+}

--- a/packages/smooth_app/lib/pages/prices/product_prices_list.dart
+++ b/packages/smooth_app/lib/pages/prices/product_prices_list.dart
@@ -12,6 +12,7 @@ import 'package:smooth_app/l10n/app_localizations.dart';
 import 'package:smooth_app/pages/prices/get_prices_model.dart';
 import 'package:smooth_app/pages/prices/infinite_scroll_manager.dart';
 import 'package:smooth_app/pages/prices/infinite_scroll_sliver_list.dart';
+import 'package:smooth_app/pages/prices/price_category_widget.dart';
 import 'package:smooth_app/pages/prices/price_data_widget.dart';
 import 'package:smooth_app/pages/prices/price_location_widget.dart';
 import 'package:smooth_app/pages/prices/price_product_widget.dart';
@@ -123,7 +124,9 @@ class _InfiniteScrollPriceManager extends InfiniteScrollManager<Price> {
                 PriceProductWidget(
                   priceProduct,
                   enableCountButton: model.enableCountButton,
-                ),
+                )
+              else if (model.displayEachProduct)
+                PriceCategoryWidget(item),
               PriceDataWidget(
                 item,
                 model: model,

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -1933,4 +1933,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.8.1 <4.0.0"
-  flutter: ">=3.29.0"
+  flutter: ">=3.32.0"


### PR DESCRIPTION
### What
- Now we display "product" data for "no barcode" products, that is, categories like fruits.
- As we get tags from "Prices" we need to localize data (using taxonomies), and we cache the results in static fields.
- We also display the "price per" data.
- If needed, we could cache the localizations in the local database.

### Screenshots
| before | after |
| -- | -- |
| <img width="1080" height="2400" alt="Screenshot_1752934193" src="https://github.com/user-attachments/assets/5b0c689e-1d6b-4558-9037-1c64ac63d5da" /> | <img width="1080" height="2400" alt="Screenshot_1752934142" src="https://github.com/user-attachments/assets/11299148-4fb6-487c-9f2b-322eed63eddd" /> |

### Fixes bug(s)
- Closes: #6700

### Files
New files:
* `price_category_repository.dart`: Helper for "Category" tag localization.
* `price_category_widget.dart`: Price Category display (no price data here).
* `price_l10n_helper.dart`: Localization helper for prices, managing static cache and downloads.
* `price_label_repository.dart`: Helper for "Labels" tag localization.
* `price_origin_repository.dart`: Helper for "Origins" tag localization.
* `price_taxonomy_repository.dart`: Helper for tag localization using taxonomy.

Impacted files:
* `price_data_value.dart`: now displaying "pricePer" when relevant
* `price_existing_amount_card.dart`: refactored the display of localized tags now using new class `PriceL10nHelper`
* `price_product_widget.dart`: minor refactoring
* `product_prices_list.dart`: now displaying new `PriceCategoryWidget` widget when relevant
* `pubspec.lock`: wtf