### PR TITLE
fix: 6785 - no useless progress indicator

### DIFF
--- a/packages/smooth_app/lib/pages/prices/prices_page_header.dart
+++ b/packages/smooth_app/lib/pages/prices/prices_page_header.dart
@@ -46,7 +46,10 @@ class PricesHeader extends StatelessWidget {
             child: Row(
               spacing: SMALL_SPACE,
               children: <Widget>[
-                Expanded(child: _PricesPageCounter(count: pricesResult?.total)),
+                if (pricesResult?.total != null)
+                  Expanded(
+                    child: _PricesPageCounter(count: pricesResult!.total!),
+                  ),
                 Expanded(
                   child: _PricesHeaderAddPriceButton(onTap: model.addButton),
                 ),
@@ -62,7 +65,7 @@ class PricesHeader extends StatelessWidget {
 class _PricesPageCounter extends StatelessWidget {
   const _PricesPageCounter({required this.count});
 
-  final int? count;
+  final int count;
 
   @override
   Widget build(BuildContext context) {
@@ -101,18 +104,14 @@ class _PricesPageCounter extends StatelessWidget {
                   horizontal: LARGE_SPACE,
                   vertical: 2.0,
                 ),
-                child: count != null
-                    ? Text(
-                        count?.toString() ?? '-',
-                        style: TextStyle(
-                          fontWeight: FontWeight.w700,
-                          fontSize: 25.0,
-                          color: lightTheme
-                              ? Colors.white
-                              : extension.primaryBlack,
-                        ),
-                      )
-                    : const CircularProgressIndicator.adaptive(),
+                child: Text(
+                  count.toString(),
+                  style: TextStyle(
+                    fontWeight: FontWeight.w700,
+                    fontSize: 25.0,
+                    color: lightTheme ? Colors.white : extension.primaryBlack,
+                  ),
+                ),
               ),
             ),
             Text(


### PR DESCRIPTION
### What
- In the price list page related to a single product, there was a progress indicator that was misleading, as no data was expected.

### Screenshots
| before | after |
| -- | -- |
| <img width="1080" height="2400" alt="Screenshot_1752936293" src="https://github.com/user-attachments/assets/a9cc65d9-f9e7-4d7c-9ae2-eb1e6e836ab9" /> | <img width="1080" height="2400" alt="Screenshot_1752936333" src="https://github.com/user-attachments/assets/6abf25f6-694b-4d87-b31d-ce9a9395d83c" /> |

### Fixes bug(s)
- Fixes: #6785