### PR TITLE
fix: M2 - Tab Bar overflow indictor on the product page

### DIFF
--- a/packages/smooth_app/lib/pages/product/product_page/header/product_page_tabs.dart
+++ b/packages/smooth_app/lib/pages/product/product_page/header/product_page_tabs.dart
@@ -11,6 +11,7 @@ import 'package:smooth_app/pages/folksonomy/folksonomy_card.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_dev_mode.dart';
 import 'package:smooth_app/pages/prices/prices_card.dart';
 import 'package:smooth_app/pages/product/website_card.dart';
+import 'package:smooth_app/themes/theme_provider.dart';
 import 'package:smooth_app/widgets/smooth_circle.dart';
 import 'package:smooth_app/widgets/smooth_tabbar.dart';
 
@@ -66,6 +67,9 @@ class ProductPageTabBar extends StatelessWidget {
                 .map((ProductPageTab tab) => tab.prefix)
                 .toList(growable: false),
             onTabChanged: (_) {},
+            overflowMainColor: context.lightTheme()
+                ? Theme.of(context).tabBarTheme.unselectedLabelColor
+                : Theme.of(context).scaffoldBackgroundColor,
           ),
         ),
       ),

--- a/packages/smooth_app/lib/widgets/smooth_tabbar.dart
+++ b/packages/smooth_app/lib/widgets/smooth_tabbar.dart
@@ -17,6 +17,7 @@ class SmoothTabBar<T> extends StatefulWidget {
     this.padding,
     this.leadingItems,
     this.trailingItems,
+    this.overflowMainColor,
     super.key,
   }) : assert(items.length > 0);
 
@@ -28,6 +29,7 @@ class SmoothTabBar<T> extends StatefulWidget {
   final Iterable<Widget?>? trailingItems;
   final Function(T) onTabChanged;
   final EdgeInsetsGeometry? padding;
+  final Color? overflowMainColor;
 
   @override
   State<SmoothTabBar<T>> createState() => _SmoothTabBarState<T>();
@@ -43,15 +45,14 @@ class _SmoothTabBarState<T> extends State<SmoothTabBar<T>> {
     final bool lightTheme = context.lightTheme();
 
     return CustomPaint(
-      painter: _ProductHeaderTabBarPainter(
+      foregroundPainter: _ProductHeaderTabBarPainter(
         progress: _horizontalProgress,
-        primaryColor: lightTheme ? theme.primaryLight : theme.primaryDark,
+        primaryColor:
+            widget.overflowMainColor ??
+            (lightTheme ? theme.primaryLight : theme.primaryDark),
         bottomSeparatorColor: lightTheme
             ? theme.primaryBlack
             : theme.primaryNormal,
-        backgroundColor:
-            AppBarTheme.of(context).backgroundColor ??
-            Theme.of(context).scaffoldBackgroundColor,
       ),
       child: SizedBox(
         height: SmoothTabBar.TAB_BAR_HEIGHT,
@@ -180,18 +181,17 @@ class _ProductHeaderTabBarPainter extends CustomPainter {
     required this.progress,
     required this.primaryColor,
     required this.bottomSeparatorColor,
-    required this.backgroundColor,
   });
 
   final double progress;
   final Color primaryColor;
   final Color bottomSeparatorColor;
-  final Color backgroundColor;
   final Paint _paint = Paint();
 
   @override
   void paint(Canvas canvas, Size size) {
     final double gradientSize = size.width * 0.1;
+    final Color backgroundColor = primaryColor.withValues(alpha: 0.0);
 
     if (progress > 0.0) {
       _paint.shader =


### PR DESCRIPTION
Hi everyone!

The TabBar "overflow" indicator is ugly in dark mode.
This PR fixes:
- This overflow is now above a tab
- Better gradient in dark mode
- Visible gradient in light mode

Before/After:
<img width="2615" height="399" alt="Untitled" src="https://github.com/user-attachments/assets/7eb33a2e-d927-4bc5-893d-0439070947fe" />

