### PR TITLE
feat: Add price: Product's name in the AppBar

### DIFF
--- a/packages/smooth_app/lib/pages/prices/product_price_add_page.dart
+++ b/packages/smooth_app/lib/pages/prices/product_price_add_page.dart
@@ -114,6 +114,7 @@ class _ProductPriceAddPageState extends State<ProductPriceAddPage>
                   title: Text(
                     appLocalizations.prices_add_n_prices(model.length),
                   ),
+                  subTitle: _generateSubtitle(appLocalizations),
                   actions: <Widget>[
                     IconButton(
                       icon: const Icon(Icons.info),
@@ -246,5 +247,20 @@ class _ProductPriceAddPageState extends State<ProductPriceAddPage>
   void dispose() {
     _willPopScope2Controller.dispose();
     super.dispose();
+  }
+
+  Text? _generateSubtitle(AppLocalizations appLocalizations) {
+    if (widget.model.length == 0) {
+      return null;
+    }
+
+    final String text;
+    if (!widget.model.multipleProducts && widget.model.length > 0) {
+      text = widget.model.elementAt(0).product.getName(appLocalizations);
+    } else {
+      text = appLocalizations.prices_button_count_product(widget.model.length);
+    }
+
+    return Text(text);
   }
 }


### PR DESCRIPTION
Hi everyone!

The price addition page lacks some context, as it forces the user to scroll to find out which product it’s about.
This PR adds the information in the AppBar.
<img width="2580" height="507" alt="Untitled" src="https://github.com/user-attachments/assets/ced10a1d-f4fa-4bae-92e5-db77bfa00da2" />
