### PR TITLE
feat: 6790 - reuse price tokens

### DIFF
--- a/packages/smooth_app/lib/background/background_task_add_other_price.dart
+++ b/packages/smooth_app/lib/background/background_task_add_other_price.dart
@@ -151,14 +151,12 @@ class BackgroundTaskAddOtherPrice extends BackgroundTaskPrice {
 
   @override
   Future<void> execute(final LocalDatabase localDatabase) async {
-    final String bearerToken = await getBearerToken();
+    final String bearerToken = await getBearerToken(localDatabase);
 
     await addPrices(
       bearerToken: bearerToken,
       proofId: proofId,
       localDatabase: localDatabase,
     );
-
-    await closeSession(bearerToken: bearerToken);
   }
 }

--- a/packages/smooth_app/lib/background/background_task_add_price.dart
+++ b/packages/smooth_app/lib/background/background_task_add_price.dart
@@ -241,7 +241,7 @@ class BackgroundTaskAddPrice extends BackgroundTaskPrice {
       return;
     }
 
-    final String bearerToken = await getBearerToken();
+    final String bearerToken = await getBearerToken(localDatabase);
 
     // proof upload
     final Uri initialImageUri = Uri.parse(path);
@@ -281,7 +281,5 @@ class BackgroundTaskAddPrice extends BackgroundTaskPrice {
       prices: prices,
       pricesWithoutDiscount: pricesWithoutDiscount,
     );
-
-    await closeSession(bearerToken: bearerToken);
   }
 }

--- a/packages/smooth_app/lib/background/background_task_price.dart
+++ b/packages/smooth_app/lib/background/background_task_price.dart
@@ -192,14 +192,11 @@ abstract class BackgroundTaskPrice extends BackgroundTask {
   Future<void> preExecute(final LocalDatabase localDatabase) async {}
 
   @protected
-  Future<String> getBearerToken() async {
-    final User user = getUser();
-    final MaybeError<String> token =
-        await OpenPricesAPIClient.getAuthenticationToken(
-          username: user.userId,
-          password: user.password,
-          uriHelper: ProductQuery.uriPricesHelper,
-        );
+  Future<String> getBearerToken(final LocalDatabase localDatabase) async {
+    final MaybeError<String> token = await ProductQuery.getPriceToken(
+      getUser(),
+      localDatabase,
+    );
     if (token.isError) {
       throw Exception('Could not get token: ${token.error}');
     }
@@ -281,25 +278,6 @@ abstract class BackgroundTaskPrice extends BackgroundTask {
       }
     }
     localDatabase.notifyListeners();
-  }
-
-  @protected
-  Future<void> closeSession({required final String bearerToken}) async {
-    final MaybeError<bool> closedSession =
-        await OpenPricesAPIClient.deleteUserSession(
-          uriHelper: ProductQuery.uriPricesHelper,
-          bearerToken: bearerToken,
-        );
-    if (closedSession.isError) {
-      // TODO(monsieurtanuki): do we really care?
-      // throw Exception('Could not close session: ${closedSession.error}');
-      return;
-    }
-    if (!closedSession.value) {
-      // TODO(monsieurtanuki): do we really care?
-      // throw Exception('Could not really close session');
-      return;
-    }
   }
 
   @override

--- a/packages/smooth_app/lib/pages/prices/infinite_scroll_manager.dart
+++ b/packages/smooth_app/lib/pages/prices/infinite_scroll_manager.dart
@@ -47,7 +47,7 @@ abstract class InfiniteScrollManager<T> {
   int? get totalPages => _totalPages;
 
   @protected
-  Future<void> fetchInit() async {}
+  Future<void> fetchInit(final BuildContext context) async {}
 
   /// Fetches data for a specific page
   @protected
@@ -79,7 +79,7 @@ abstract class InfiniteScrollManager<T> {
 
   /// Load initial data only if the list is empty
   Future<void> loadInitiallyIfNeeded(BuildContext context) async {
-    await fetchInit();
+    await fetchInit(context);
     if (_items.isNotEmpty) {
       return;
     }
@@ -112,6 +112,7 @@ abstract class InfiniteScrollManager<T> {
     _isLoading = true;
 
     try {
+      await fetchInit(context);
       await fetchData(pageNumber);
     } catch (e) {
       if (context.mounted) {


### PR DESCRIPTION
### What
Now we cache price tokens, so that the price server won't have to deal with too many tokens:
- we never close a price session, as the token may be reused later
- every time we need a token, we first check if there's a cached token available for that user on that server, and we check if the session is still considered active by the price server
- if needed, we ask the price server to generate a new token and we cache it

### Fixes bug(s)
- Closes: #6790

### Impacted files
* `background_task_add_other_price.dart`: minor refactoring
* `background_task_add_price.dart`: minor refactoring
* `background_task_price.dart`: now using new method `ProductQuery.getPriceToken` to get the token; never closing the token session at the end
* `infinite_scroll_manager.dart`: minor refactoring
* `prices_proofs_page.dart`: minor refactoring
* `product_query.dart`: new method `getPriceToken` that caches the token