### PR TITLE
feat: 6479 - price count as badge for proof images

### DIFF
--- a/packages/smooth_app/lib/pages/prices/price_proof_page.dart
+++ b/packages/smooth_app/lib/pages/prices/price_proof_page.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/helpers/launch_url_helper.dart';
 import 'package:smooth_app/l10n/app_localizations.dart';
 import 'package:smooth_app/pages/prices/price_model.dart';
@@ -77,26 +78,32 @@ class _PriceProofPageState extends State<PriceProofPage> {
         ],
       ),
       body: Center(
-        child: Image.network(
-          _getUrl(false),
-          fit: BoxFit.cover,
-          loadingBuilder:
-              (
-                BuildContext context,
-                Widget child,
-                ImageChunkEvent? loadingProgress,
-              ) {
-                if (loadingProgress == null) {
-                  return child;
-                }
-                return Center(
-                  child: SizedBox(
-                    width: double.maxFinite,
-                    height: double.maxFinite,
-                    child: Image.network(_getUrl(true), fit: BoxFit.contain),
-                  ),
-                );
-              },
+        child: Badge.count(
+          count: widget.proof.priceCount,
+          alignment: Alignment.topRight,
+          offset: const Offset(-MEDIUM_SPACE, MEDIUM_SPACE),
+          padding: const EdgeInsetsDirectional.all(VERY_SMALL_SPACE),
+          child: Image.network(
+            _getUrl(false),
+            fit: BoxFit.cover,
+            loadingBuilder:
+                (
+                  BuildContext context,
+                  Widget child,
+                  ImageChunkEvent? loadingProgress,
+                ) {
+                  if (loadingProgress == null) {
+                    return child;
+                  }
+                  return Center(
+                    child: SizedBox(
+                      width: double.maxFinite,
+                      height: double.maxFinite,
+                      child: Image.network(_getUrl(true), fit: BoxFit.contain),
+                    ),
+                  );
+                },
+          ),
         ),
       ),
     );

--- a/packages/smooth_app/lib/pages/prices/prices_proofs_page.dart
+++ b/packages/smooth_app/lib/pages/prices/prices_proofs_page.dart
@@ -161,18 +161,24 @@ class _PriceProofListItem extends StatelessWidget {
       padding: const EdgeInsets.all(SMALL_SPACE),
       child: Row(
         children: <Widget>[
-          SmoothImage(
-            width: imageSize,
-            height: imageSize,
-            imageProvider: NetworkImage(
-              proof
-                  .getFileUrl(
-                    uriProductHelper: ProductQuery.uriPricesHelper,
-                    isThumbnail: true,
-                  )
-                  .toString(),
+          Badge.count(
+            count: proof.priceCount,
+            alignment: Alignment.topRight,
+            offset: const Offset(-MEDIUM_SPACE, MEDIUM_SPACE),
+            padding: const EdgeInsetsDirectional.all(VERY_SMALL_SPACE),
+            child: SmoothImage(
+              width: imageSize,
+              height: imageSize,
+              imageProvider: NetworkImage(
+                proof
+                    .getFileUrl(
+                      uriProductHelper: ProductQuery.uriPricesHelper,
+                      isThumbnail: true,
+                    )
+                    .toString(),
+              ),
+              rounded: false,
             ),
-            rounded: false,
           ),
           const SizedBox(width: MEDIUM_SPACE),
           Expanded(child: Column(children: <Widget>[Text(date)])),


### PR DESCRIPTION
### What
- On proof images we display the price count with a badge.

### Screenshots
| proof list | single proof |
| -- | -- |
| <img width="1080" height="2400" alt="Screenshot_1753116643" src="https://github.com/user-attachments/assets/7fac45f0-ce98-493d-b9c3-7216cc3e9f67" /> | <img width="1080" height="2400" alt="Screenshot_1753116649" src="https://github.com/user-attachments/assets/4696b1fe-130b-4fa1-a439-e84ac2c5679c" /> |

### Fixes bug(s)
- Closes: #6479