### PR TITLE
chore: Revert mobile_scanner to 6.0.10

### DIFF
--- a/packages/scanner/ml_kit/lib/src/scanner_ml_kit.dart
+++ b/packages/scanner/ml_kit/lib/src/scanner_ml_kit.dart
@@ -145,7 +145,7 @@ class _SmoothBarcodeScannerMLKitState extends State<_SmoothBarcodeScannerMLKit>
             MobileScanner(
               controller: _cameraController.controller,
               fit: BoxFit.cover,
-              errorBuilder: (_, _) => EMPTY_WIDGET,
+              errorBuilder: (_, _, _) => EMPTY_WIDGET,
               onDetect: (final BarcodeCapture capture) async {
                 for (final Barcode barcode in capture.barcodes) {
                   final String? string = barcode.displayValue;
@@ -293,7 +293,6 @@ class _ToggleCameraIcon extends StatelessWidget {
               return switch (state) {
                 CameraFacing.front => const Icon(Icons.camera_front),
                 CameraFacing.back => const Icon(Icons.camera_rear),
-                _ => throw UnimplementedError(),
               };
             },
           ),

--- a/packages/scanner/ml_kit/pubspec.yaml
+++ b/packages/scanner/ml_kit/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   async: 2.13.0
   provider: 6.1.5
 
-  mobile_scanner: 7.0.1
+  mobile_scanner: 6.0.10
   torch_light: 1.1.0
 
   scanner_shared:

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -1156,10 +1156,10 @@ packages:
     dependency: transitive
     description:
       name: mobile_scanner
-      sha256: "54005bdea7052d792d35b4fef0f84ec5ddc3a844b250ecd48dc192fb9b4ebc95"
+      sha256: f536c5b8cadcf73d764bdce09c94744f06aa832264730f8971b21a60c5666826
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.1"
+    version: "6.0.10"
   mobkit_dashed_border:
     dependency: "direct main"
     description:


### PR DESCRIPTION
Hi!

There is no activity on `mobile_scanner`, and the focus issue on the iOS device is a showstopper.
So let's go back to the previously working version.