### PR TITLE
feat: 6847 - explicit "popularity" order for Hunger Games

### DIFF
--- a/packages/smooth_app/lib/query/random_questions_query.dart
+++ b/packages/smooth_app/lib/query/random_questions_query.dart
@@ -16,7 +16,7 @@ class RandomQuestionsQuery extends QuestionsQuery {
       user: ProductQuery.getReadUser(),
       countries: <OpenFoodFactsCountry>[ProductQuery.getCountry()],
       count: count,
-      questionOrder: RobotoffQuestionOrder.random,
+      questionOrder: RobotoffQuestionOrder.popularity,
     );
 
     if (result.questions?.isNotEmpty != true) {


### PR DESCRIPTION
### What
- Changed the Hunger Games question order from "random" to 'popularity", in the only place we may use that parameter.

### Fixes bug(s)
- Closes: #6847