### PR TITLE
ci: Potential fix for code scanning alert no. 27: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dartdoc.yml
+++ b/.github/workflows/dartdoc.yml
@@ -1,7 +1,7 @@
-#permissions:
-#  contents: read
-#  pages: write
 name: GitHub Pages Deploy Action
+permissions:
+  contents: read
+  pages: write
 on:
     push:
         branches:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/smooth-app/security/code-scanning/27](https://github.com/openfoodfacts/smooth-app/security/code-scanning/27)

To fix the problem, add an explicit `permissions` block to the workflow file, specifying only those permission scopes required. For deploying to GitHub Pages, `contents: read` is needed for reading repo contents, and `pages: write` is needed to update (deploy) the documentation to GitHub Pages. The best way to do this is to add:

```yaml
permissions:
  contents: read
  pages: write
```
directly after the `name:` field and before `on:`, so that the permissions apply to all jobs in the workflow. Edit `.github/workflows/dartdoc.yml`, and uncomment and move the commented block from the top (or simply add a new one) right before the workflow's trigger (`on:`).

No additional imports or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
