### PR TITLE
fix: Missing data on the Product page

### DIFF
--- a/packages/smooth_app/lib/pages/product/product_page/header/product_page_tabs.dart
+++ b/packages/smooth_app/lib/pages/product/product_page/header/product_page_tabs.dart
@@ -119,7 +119,7 @@ class ProductPageTabBar extends StatelessWidget {
           prefix: _extractPrefix(product, knowledgePanelTitle),
           builder: (_, _) => ListView.builder(
             padding: EdgeInsetsDirectional.zero,
-            itemCount: children.length - 1,
+            itemCount: children.length,
             itemBuilder: (BuildContext context, int index) => children[index],
           ),
         ),


### PR DESCRIPTION
The last item of all tabs was always removed
<img width="1080" height="2424" alt="Screenshot_1758014248" src="https://github.com/user-attachments/assets/9f555765-7e05-493b-b738-72939bff684f" />
<img width="1080" height="2424" alt="Screenshot_1758014252" src="https://github.com/user-attachments/assets/edbf0253-2924-44cf-87c9-a2ffde1290bb" />
