### PR TITLE
feat: 6955 - price location is now null by default

### DIFF
--- a/packages/smooth_app/lib/pages/prices/price_add_helper.dart
+++ b/packages/smooth_app/lib/pages/prices/price_add_helper.dart
@@ -2,8 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/preferences/user_preferences.dart';
-import 'package:smooth_app/database/dao_osm_location.dart';
-import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/bottom_sheets/smooth_bottom_sheet.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
@@ -21,11 +19,6 @@ class PriceAddHelper {
   const PriceAddHelper(this.context);
 
   final BuildContext context;
-
-  Future<List<OsmLocation>> getLocations() async {
-    final LocalDatabase localDatabase = context.read<LocalDatabase>();
-    return DaoOsmLocation(localDatabase).getAll();
-  }
 
   Currency getCurrency() {
     final UserPreferences userPreferences = context.read<UserPreferences>();
@@ -79,11 +72,8 @@ class PriceAddHelper {
     return true;
   }
 
-  Future<void> updateCurrency(
-    OsmLocation? oldLocation,
-    OsmLocation location,
-    PriceModel model,
-  ) async {
+  Future<void> updateCurrency(OsmLocation location, PriceModel model) async {
+    model.location = location;
     if (location.countryCode == null) {
       return;
     }

--- a/packages/smooth_app/lib/pages/prices/price_location_card.dart
+++ b/packages/smooth_app/lib/pages/prices/price_location_card.dart
@@ -17,8 +17,7 @@ import 'package:smooth_app/pages/search/search_page.dart';
 class PriceLocationCard extends StatelessWidget {
   const PriceLocationCard({required this.onLocationChanged});
 
-  final Function(OsmLocation? oldLocation, OsmLocation location)
-  onLocationChanged;
+  final Function(OsmLocation location) onLocationChanged;
 
   @override
   Widget build(BuildContext context) {
@@ -49,7 +48,13 @@ class PriceLocationCard extends StatelessWidget {
                     .read<LocalDatabase>();
                 final List<SearchLocationPreloadedItem> preloadedList =
                     <SearchLocationPreloadedItem>[];
-                for (final OsmLocation osmLocation in model.locations!) {
+                final List<OsmLocation> locations = await DaoOsmLocation(
+                  localDatabase,
+                ).getAll();
+                if (!context.mounted) {
+                  return;
+                }
+                for (final OsmLocation osmLocation in locations) {
                   preloadedList.add(
                     SearchLocationPreloadedItem(osmLocation, popFirst: false),
                   );
@@ -72,11 +77,8 @@ class PriceLocationCard extends StatelessWidget {
                   localDatabase,
                 );
                 await daoOsmLocation.put(osmLocation);
-                final List<OsmLocation> newOsmLocations = await daoOsmLocation
-                    .getAll();
-                model.locations = newOsmLocations;
 
-                onLocationChanged.call(location, model.location!);
+                onLocationChanged.call(osmLocation);
               },
       ),
     );

--- a/packages/smooth_app/lib/pages/prices/price_model.dart
+++ b/packages/smooth_app/lib/pages/prices/price_model.dart
@@ -16,7 +16,6 @@ import 'package:smooth_app/pages/prices/price_meta_product.dart';
 class PriceModel with ChangeNotifier {
   PriceModel({
     required final ProofType proofType,
-    required final List<OsmLocation>? locations,
     required final Currency currency,
     required this.multipleProducts,
     final PriceMetaProduct? initialProduct,
@@ -26,7 +25,6 @@ class PriceModel with ChangeNotifier {
        _proofType = proofType,
        _date = DateTime.now(),
        _currency = currency,
-       _locations = locations,
        _readyForPriceTagValidation = readyForPriceTagValidation,
        _priceAmountModels = <PriceAmountModel>[
          if (initialProduct != null) PriceAmountModel(product: initialProduct),
@@ -74,7 +72,6 @@ class PriceModel with ChangeNotifier {
     _cropParameters = null;
     _proofType = proof.type!;
     _date = proof.date!;
-    _locations = null;
     _currency = proof.currency!;
     if (!init) {
       notifyListeners();
@@ -163,19 +160,17 @@ class PriceModel with ChangeNotifier {
   final DateTime today = DateTime.now();
   final DateTime firstDate = DateTime.utc(2020, 1, 1);
 
-  List<OsmLocation>? _locations;
+  OsmLocation? _location;
 
-  List<OsmLocation>? get locations => _locations;
-
-  set locations(final List<OsmLocation>? locations) {
+  set location(final OsmLocation location) {
     _hasChanged = true;
-    _locations = locations;
+    _location = location;
     notifyListeners();
   }
 
   OsmLocation? get location => proof?.location?.osmId != null
       ? OsmLocation.fromPrice(proof!.location!)
-      : _locations!.firstOrNull;
+      : _location;
 
   late Currency _currency;
 

--- a/packages/smooth_app/lib/pages/prices/product_price_add_page.dart
+++ b/packages/smooth_app/lib/pages/prices/product_price_add_page.dart
@@ -49,10 +49,6 @@ class ProductPriceAddPage extends StatefulWidget {
     }
 
     final PriceAddHelper priceAddHelper = PriceAddHelper(context);
-    final List<OsmLocation> osmLocations = await priceAddHelper.getLocations();
-    if (!context.mounted) {
-      return;
-    }
 
     final Currency currency = priceAddHelper.getCurrency();
 
@@ -63,7 +59,6 @@ class ProductPriceAddPage extends StatefulWidget {
         builder: (BuildContext context) => ProductPriceAddPage(
           PriceModel(
             proofType: proofType,
-            locations: osmLocations,
             initialProduct: product,
             currency: currency,
             multipleProducts: multipleProducts,
@@ -139,11 +134,10 @@ class _ProductPriceAddPageState extends State<ProductPriceAddPage>
                       const PriceDateCard(),
                       const SizedBox(height: LARGE_SPACE),
                       PriceLocationCard(
-                        onLocationChanged:
-                            (OsmLocation? oldLocation, OsmLocation location) =>
-                                PriceAddHelper(
-                                  context,
-                                ).updateCurrency(oldLocation, location, model),
+                        onLocationChanged: (OsmLocation location) =>
+                            PriceAddHelper(
+                              context,
+                            ).updateCurrency(location, model),
                       ),
                       const SizedBox(height: LARGE_SPACE),
                       const PriceCurrencyCard(),

--- a/packages/smooth_app/lib/pages/prices/proof_bulk_add_page.dart
+++ b/packages/smooth_app/lib/pages/prices/proof_bulk_add_page.dart
@@ -40,16 +40,11 @@ class ProofBulkAddPage extends StatefulWidget {
     }
 
     final PriceAddHelper priceAddHelper = PriceAddHelper(context);
-    final List<OsmLocation> osmLocations = await priceAddHelper.getLocations();
-    if (!context.mounted) {
-      return null;
-    }
 
     final Currency currency = priceAddHelper.getCurrency();
 
     return PriceModel(
       proofType: ProofType.priceTag,
-      locations: osmLocations,
       currency: currency,
       multipleProducts: true,
       readyForPriceTagValidation:
@@ -114,11 +109,8 @@ class _ProofBulkAddPageState extends State<ProofBulkAddPage>
                   const PriceDateCard(),
                   const SizedBox(height: LARGE_SPACE),
                   PriceLocationCard(
-                    onLocationChanged:
-                        (OsmLocation? oldLocation, OsmLocation location) =>
-                            PriceAddHelper(
-                              context,
-                            ).updateCurrency(oldLocation, location, model),
+                    onLocationChanged: (OsmLocation location) =>
+                        PriceAddHelper(context).updateCurrency(location, model),
                   ),
                   const SizedBox(height: LARGE_SPACE),
                   const PriceCurrencyCard(),


### PR DESCRIPTION
### What
- Now when we land on a "new price" page ("add prices" or "bulk prices"), the location is null by default.
- This was needed by several users that didn't change the location though they would have needed to. With a default empty location, they'll be forced to set the location as it's mandatory.
- It's still easy to keep the same location as the latest price: the locations are ordered by usage timestamp.

### Fixes bug(s)
- Closes: #6955

### Part of 
- #6841

### Impacted files
* `price_add_helper.dart`: minor refactoring
* `price_location_card.dart`: getting ordered locations right-on-time; minor refactoring
* `price_model.dart`: now we store only the selected location, null by default
* `product_price_add_page.dart`: no default location; minor refactoring
* `proof_bulk_add_page.dart`: no default location; minor refactoring