### PR TITLE
fix: 6984 - Correct contribution count in products added title

### DIFF
--- a/packages/smooth_app/lib/pages/preferences_v2/roots/contributions_root.dart
+++ b/packages/smooth_app/lib/pages/preferences_v2/roots/contributions_root.dart
@@ -67,7 +67,7 @@ class ContributionsRoot extends PreferencesRoot {
   ) {
     return PreferenceTile(
       icon: Icons.add_circle_outline,
-      title: appLocalizations.preferences_contributions_new_products_title,
+      title: appLocalizations.user_search_contributor_title,
       subtitleText:
           appLocalizations.preferences_contributions_new_products_subtitle,
       padding: const EdgeInsetsDirectional.only(


### PR DESCRIPTION
### What
<!-- description of the PR -->
- Display the correct products added count instead of 0 in the corresponding title on the Contribution page.
<!-- 
Please name your pull request following this scheme: `type: What you did` this allows us to automatically generate the changelog
Following `type`s are allowed:
  - `feat`, for Features
  - `fix`, for Bug Fixes
  - `docs`, for Documentation
  - `ci`, for Automation
  - `refactor`, for code Refactoring
  - `chore`, for Miscellaneous things
-->
### Screenshot
| Before      | After |
| ----------- | ----------- |
| <img width="250" alt="image" src="https://github.com/user-attachments/assets/cb3d3f09-d0fe-4a58-a927-4952b0a93037" />     | <img width="250" alt="image" src="https://github.com/user-attachments/assets/bc3f80f8-8853-42fd-aca5-bb7135b5ec13" />      |

### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes: #6984 