### PR TITLE
fix: 6937 - use "Smooth" scaffold for "Hunger Games"

### DIFF
--- a/packages/smooth_app/lib/pages/hunger_games/question_page.dart
+++ b/packages/smooth_app/lib/pages/hunger_games/question_page.dart
@@ -17,6 +17,7 @@ import 'package:smooth_app/pages/hunger_games/question_card.dart';
 import 'package:smooth_app/query/product_questions_query.dart';
 import 'package:smooth_app/query/questions_query.dart';
 import 'package:smooth_app/query/random_questions_query.dart';
+import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
 class QuestionsPage extends StatefulWidget {
   const QuestionsPage({this.product, this.questions});
@@ -114,7 +115,7 @@ class _QuestionsPageState extends State<QuestionsPage>
   Widget build(BuildContext context) {
     return ChangeNotifierProvider<_QuestionsAnsweredNotifier>(
       create: (BuildContext context) => _QuestionsAnsweredNotifier(),
-      child: Scaffold(
+      child: SmoothScaffold(
         appBar: AppBar(
           title: const Text('Hunger Games'),
           leading: IconButton(


### PR DESCRIPTION
### What
- For Hunger Games, now using the app standard `Scaffold` instead of the flutter standard `Scaffold`.

### Screenshot
| dark mode | light mode |
| -- | -- |
| <img width="1080" height="1920" alt="Screenshot_1759408641" src="https://github.com/user-attachments/assets/66a5467f-eab6-4d01-a283-b72e331f390c" /> | <img width="1080" height="1920" alt="Screenshot_1759408608" src="https://github.com/user-attachments/assets/fad5f97f-4824-4928-87ae-eb31ada8d300" /> |

### Fixes bug(s)
- Fixes: #6937