### PR TITLE
fix: 6939 - Redirect products modified and prices added buttons to their resp. screens

### DIFF
--- a/packages/smooth_app/lib/generic_lib/widgets/app_bars/logged_in/logged_in_app_bar_body.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/app_bars/logged_in/logged_in_app_bar_body.dart
@@ -40,6 +40,7 @@ class LoggedInAppBarBody extends StatelessWidget {
                   children: <Widget>[
                     Expanded(
                       child: ContributionStatisticsCard(
+                        userId: userId,
                         autoSizeGroup: autoSizeGroup,
                       ),
                     ),

--- a/packages/smooth_app/lib/generic_lib/widgets/app_bars/logged_in/statistics_cards/app_bar_statistics_card.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/app_bars/logged_in/statistics_cards/app_bar_statistics_card.dart
@@ -10,7 +10,7 @@ import 'package:smooth_app/resources/app_icons.dart' as icons;
 import 'package:smooth_app/themes/smooth_theme.dart';
 import 'package:smooth_app/themes/smooth_theme_colors.dart';
 
-class AppBarStatisticsCard extends StatefulWidget {
+class AppBarStatisticsCard extends StatelessWidget {
   AppBarStatisticsCard({
     required this.imagePath,
     required this.description,
@@ -28,21 +28,16 @@ class AppBarStatisticsCard extends StatefulWidget {
   final AutoSizeGroup? autoSizeGroup;
 
   @override
-  State<StatefulWidget> createState() => _AppBarStatisticsCardState();
-}
-
-class _AppBarStatisticsCardState extends State<AppBarStatisticsCard> {
-  @override
   Widget build(BuildContext context) {
     final SmoothColorsThemeExtension themeExtension = context
         .extension<SmoothColorsThemeExtension>();
     final UserPreferences userPreferences = context.watch<UserPreferences>();
 
-    final int? count = widget.lazyCounter.getLocalCount(userPreferences);
+    final int? count = lazyCounter.getLocalCount(userPreferences);
 
     return InkWell(
       borderRadius: ROUNDED_BORDER_RADIUS,
-      onTap: widget.onTap,
+      onTap: onTap,
       child: SizedBox(
         height: STATISTICS_CARD_HEIGHT,
         child: Material(
@@ -51,7 +46,7 @@ class _AppBarStatisticsCardState extends State<AppBarStatisticsCard> {
           child: Row(
             children: <Widget>[
               const SizedBox(width: MEDIUM_SPACE),
-              SvgPicture.asset(widget.imagePath, height: 32.0),
+              SvgPicture.asset(imagePath, height: 32.0),
               const SizedBox(width: MEDIUM_SPACE),
               Expanded(
                 child: Column(
@@ -80,8 +75,8 @@ class _AppBarStatisticsCardState extends State<AppBarStatisticsCard> {
                       children: <Widget>[
                         Expanded(
                           child: AutoSizeText(
-                            widget.description,
-                            group: widget.autoSizeGroup,
+                            description,
+                            group: autoSizeGroup,
                             minFontSize: 8.0,
                             softWrap: false,
                             maxLines: 1,

--- a/packages/smooth_app/lib/generic_lib/widgets/app_bars/logged_in/statistics_cards/app_bar_statistics_card.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/app_bars/logged_in/statistics_cards/app_bar_statistics_card.dart
@@ -6,9 +6,9 @@ import 'package:smooth_app/data_models/preferences/user_preferences.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/app_bars/app_bar_constanst.dart';
 import 'package:smooth_app/pages/preferences/lazy_counter.dart';
+import 'package:smooth_app/resources/app_icons.dart' as icons;
 import 'package:smooth_app/themes/smooth_theme.dart';
 import 'package:smooth_app/themes/smooth_theme_colors.dart';
-import 'package:smooth_app/resources/app_icons.dart' as icons;
 
 class AppBarStatisticsCard extends StatefulWidget {
   AppBarStatisticsCard({

--- a/packages/smooth_app/lib/generic_lib/widgets/app_bars/logged_in/statistics_cards/app_bar_statistics_card.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/app_bars/logged_in/statistics_cards/app_bar_statistics_card.dart
@@ -6,9 +6,9 @@ import 'package:smooth_app/data_models/preferences/user_preferences.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/app_bars/app_bar_constanst.dart';
 import 'package:smooth_app/pages/preferences/lazy_counter.dart';
-import 'package:smooth_app/services/smooth_services.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
 import 'package:smooth_app/themes/smooth_theme_colors.dart';
+import 'package:smooth_app/resources/app_icons.dart' as icons;
 
 class AppBarStatisticsCard extends StatefulWidget {
   AppBarStatisticsCard({
@@ -32,8 +32,6 @@ class AppBarStatisticsCard extends StatefulWidget {
 }
 
 class _AppBarStatisticsCardState extends State<AppBarStatisticsCard> {
-  bool _loading = false;
-
   @override
   Widget build(BuildContext context) {
     final SmoothColorsThemeExtension themeExtension = context
@@ -72,21 +70,9 @@ class _AppBarStatisticsCardState extends State<AppBarStatisticsCard> {
                             ),
                           ),
                         ),
-                        InkWell(
-                          onTap: _loading ? null : _asyncLoad,
-                          child: Padding(
-                            padding: const EdgeInsets.all(VERY_SMALL_SPACE),
-                            child: _loading
-                                ? const SizedBox.square(
-                                    dimension: 16.0,
-                                    child: CircularProgressIndicator.adaptive(),
-                                  )
-                                : const Icon(
-                                    Icons.refresh,
-                                    color: Colors.white,
-                                    size: 16.0,
-                                  ),
-                          ),
+                        const icons.Chevron.right(
+                          size: 14.0,
+                          color: Colors.white,
                         ),
                       ],
                     ),
@@ -113,33 +99,5 @@ class _AppBarStatisticsCardState extends State<AppBarStatisticsCard> {
         ),
       ),
     );
-  }
-
-  Future<void> _asyncLoad() async {
-    if (_loading) {
-      return;
-    }
-    _loading = true;
-    final UserPreferences userPreferences = context.read<UserPreferences>();
-    if (mounted) {
-      setState(() {});
-    }
-    try {
-      final int? value = await widget.lazyCounter.getServerCount();
-      if (value != null) {
-        await widget.lazyCounter.setLocalCount(
-          value,
-          userPreferences,
-          notify: false,
-        );
-      }
-    } catch (e) {
-      Logs.e('Error loading data: $e');
-    } finally {
-      _loading = false;
-      if (mounted) {
-        setState(() {});
-      }
-    }
   }
 }

--- a/packages/smooth_app/lib/generic_lib/widgets/app_bars/logged_in/statistics_cards/app_bar_statistics_card.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/app_bars/logged_in/statistics_cards/app_bar_statistics_card.dart
@@ -15,6 +15,7 @@ class AppBarStatisticsCard extends StatefulWidget {
     required this.imagePath,
     required this.description,
     required this.lazyCounter,
+    required this.onTap,
     this.autoSizeGroup,
     super.key,
   }) : assert(imagePath.isNotEmpty, 'imagePath must not be empty.'),
@@ -23,6 +24,7 @@ class AppBarStatisticsCard extends StatefulWidget {
   final String imagePath;
   final String description;
   final LazyCounter lazyCounter;
+  final VoidCallback onTap;
   final AutoSizeGroup? autoSizeGroup;
 
   @override
@@ -42,7 +44,7 @@ class _AppBarStatisticsCardState extends State<AppBarStatisticsCard> {
 
     return InkWell(
       borderRadius: ROUNDED_BORDER_RADIUS,
-      onTap: () => _asyncLoad(),
+      onTap: widget.onTap,
       child: SizedBox(
         height: STATISTICS_CARD_HEIGHT,
         child: Material(
@@ -70,17 +72,22 @@ class _AppBarStatisticsCardState extends State<AppBarStatisticsCard> {
                             ),
                           ),
                         ),
-                        if (_loading)
-                          const SizedBox.square(
-                            dimension: 16.0,
-                            child: CircularProgressIndicator.adaptive(),
-                          )
-                        else
-                          const Icon(
-                            Icons.refresh,
-                            color: Colors.white,
-                            size: 16.0,
+                        InkWell(
+                          onTap: _loading ? null : _asyncLoad,
+                          child: Padding(
+                            padding: const EdgeInsets.all(VERY_SMALL_SPACE),
+                            child: _loading
+                                ? const SizedBox.square(
+                                    dimension: 16.0,
+                                    child: CircularProgressIndicator.adaptive(),
+                                  )
+                                : const Icon(
+                                    Icons.refresh,
+                                    color: Colors.white,
+                                    size: 16.0,
+                                  ),
                           ),
+                        ),
                       ],
                     ),
                     Row(

--- a/packages/smooth_app/lib/generic_lib/widgets/app_bars/logged_in/statistics_cards/contribution_statistics_card.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/app_bars/logged_in/statistics_cards/contribution_statistics_card.dart
@@ -1,24 +1,58 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:provider/provider.dart';
+import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/widgets/app_bars/logged_in/statistics_cards/app_bar_statistics_card.dart';
 import 'package:smooth_app/l10n/app_localizations.dart';
 import 'package:smooth_app/pages/preferences/lazy_counter.dart';
+import 'package:smooth_app/pages/product/common/product_query_page_helper.dart';
+import 'package:smooth_app/query/paged_product_query.dart';
 import 'package:smooth_app/query/paged_user_product_query.dart';
 
 class ContributionStatisticsCard extends StatelessWidget {
-  const ContributionStatisticsCard({this.autoSizeGroup, super.key});
+  const ContributionStatisticsCard({
+    required this.userId,
+    this.autoSizeGroup,
+    super.key,
+  });
 
+  final String userId;
   final AutoSizeGroup? autoSizeGroup;
 
   @override
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final LocalDatabase localDatabase = context.read<LocalDatabase>();
 
     return AppBarStatisticsCard(
       imagePath: 'assets/preferences/ingredients.svg',
       description: appLocalizations.preferences_app_bar_products_modified,
       lazyCounter: const LazyCounterUserSearch(UserSearchType.CONTRIBUTOR),
+      onTap: () async => _openProductQuery(
+        context: context,
+        localDatabase: localDatabase,
+        productQuery: PagedUserProductQuery(
+          userId: userId,
+          type: UserSearchType.INFORMER,
+          productType: ProductType.food,
+        ),
+        title: appLocalizations.user_search_informer_title,
+      ),
       autoSizeGroup: autoSizeGroup,
     );
   }
+
+  Future<void> _openProductQuery({
+    required BuildContext context,
+    required LocalDatabase localDatabase,
+    required PagedProductQuery productQuery,
+    required String title,
+  }) async => ProductQueryPageHelper.openBestChoice(
+    name: title,
+    localDatabase: localDatabase,
+    productQuery: productQuery,
+    context: context,
+    editableAppBarTitle: true,
+  );
 }

--- a/packages/smooth_app/lib/generic_lib/widgets/app_bars/logged_in/statistics_cards/prices_statistics_card.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/app_bars/logged_in/statistics_cards/prices_statistics_card.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:smooth_app/generic_lib/widgets/app_bars/logged_in/statistics_cards/app_bar_statistics_card.dart';
 import 'package:smooth_app/l10n/app_localizations.dart';
 import 'package:smooth_app/pages/preferences/lazy_counter.dart';
+import 'package:smooth_app/pages/prices/price_user_button.dart';
 
 class PricesStatisticsCard extends StatelessWidget {
   const PricesStatisticsCard({
@@ -22,6 +23,8 @@ class PricesStatisticsCard extends StatelessWidget {
       imagePath: 'assets/preferences/cash.svg',
       description: appLocalizations.preferences_app_bar_prices_added,
       lazyCounter: LazyCounterPrices(userId),
+      onTap: () async =>
+          PriceUserButton.showUserPrices(user: userId, context: context),
       autoSizeGroup: autoSizeGroup,
     );
   }


### PR DESCRIPTION
### What
<!-- description of the PR -->
- Redirect "Products I modified" and "Prices I added" buttons to their respective screens.
- The refresh icon on both buttons still refreshes the count.
<!-- 
Please name your pull request following this scheme: `type: What you did` this allows us to automatically generate the changelog
Following `type`s are allowed:
  - `feat`, for Features
  - `fix`, for Bug Fixes
  - `docs`, for Documentation
  - `ci`, for Automation
  - `refactor`, for code Refactoring
  - `chore`, for Miscellaneous things
-->
### Screenshot
https://github.com/user-attachments/assets/5b84572c-85e1-4351-9f76-c04ea5eaa260

### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes: #6939 

### Update 1:
- Following the discussion in this thread, the refresh icon and action is now removed.
<img width="450" alt="image" src="https://github.com/user-attachments/assets/e1434d9e-ce58-4c2a-b54f-60fdb6174b3f" />