### PR TITLE
fix: 6967 - Redirect compatibility score to food preferences page

### DIFF
--- a/packages/smooth_app/lib/pages/navigator/app_navigator.dart
+++ b/packages/smooth_app/lib/pages/navigator/app_navigator.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
@@ -16,7 +17,6 @@ import 'package:smooth_app/pages/navigator/external_page_webview.dart';
 import 'package:smooth_app/pages/navigator/slide_up_transition.dart';
 import 'package:smooth_app/pages/onboarding/onboarding_flow_navigator.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_page.dart';
-import 'package:smooth_app/pages/preferences_v2/preferences_page.dart';
 import 'package:smooth_app/pages/product/add_new_product/add_new_product_page.dart';
 import 'package:smooth_app/pages/product/edit_product/edit_product_page.dart';
 import 'package:smooth_app/pages/product/product_loader_page.dart';
@@ -213,8 +213,15 @@ class _SmoothGoRouter {
             ),
             GoRoute(
               path: '${_InternalAppRoutes.PREFERENCES_PAGE}/:preferenceType',
-              builder: (BuildContext context, GoRouterState state) =>
-                  PreferencesPage(),
+              builder: (BuildContext context, GoRouterState state) {
+                final String preferenceType =
+                    state.pathParameters['preferenceType']!;
+                return UserPreferencesPage(
+                  type: PreferencePageType.values.firstWhereOrNull(
+                    (PreferencePageType type) => type.name == preferenceType,
+                  ),
+                );
+              },
             ),
             GoRoute(
               path: _InternalAppRoutes.SEARCH_PAGE,


### PR DESCRIPTION
### What
<!-- description of the PR -->
- Clicking compatibility score in product page header now redirects to food preferences page.
- Fixes dynamic preference type page route in general.
<!-- 
Please name your pull request following this scheme: `type: What you did` this allows us to automatically generate the changelog
Following `type`s are allowed:
  - `feat`, for Features
  - `fix`, for Bug Fixes
  - `docs`, for Documentation
  - `ci`, for Automation
  - `refactor`, for code Refactoring
  - `chore`, for Miscellaneous things
-->
### Screenshot
https://github.com/user-attachments/assets/23520e23-a60b-4db5-bf82-a8f28a139858



### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes: #6967