### PR TITLE
feat: 7012 - localization for 4 URLs

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -268,10 +268,6 @@
   "@sign_up_page_terms_text": {
     "description": "terms of use and contribution is preceded by sign_up_page_agree_text"
   },
-  "sign_up_page_agree_url": "https://world-en.openfoodfacts.org/terms-of-use",
-  "@sign_up_page_agree_url": {
-    "description": "Please insert the right url here. Go to the Open Food Facts homepage, switch to your country and then on the bottom left footer is Terms of use from which the url should be taken"
-  },
   "donate_url": "https://donate.openfoodfacts.org/",
   "@donate_url": {
     "description": "Please insert the right url from the website here."
@@ -3889,7 +3885,6 @@
   "guide_nutriscore_v2_unchanged_title": "What doesn't change",
   "guide_nutriscore_v2_unchanged_paragraph1": "The Nutri-Score is a score designed to **measure nutritional quality**. It is **complementary to the NOVA group** on **ultra-processed foods** (also present in the application).",
   "guide_nutriscore_v2_unchanged_paragraph2": "For manufacturers, the display of the Nutri-Score **remains optional**.",
-  "guide_nutriscore_v2_share_link": "https://world.openfoodfacts.org/nutriscore-v2",
   "guide_greenscore_title": "Green-Score",
   "@guide_greenscore_title": {
     "description": "The title of the guide (please don't forget the use of non-breaking spaces)"
@@ -3951,7 +3946,6 @@
   "guide_greenscore_better_product_arg3_text": "Choosing sustainable food can feel complex. Labels are confusing and information is often missing. The Green-Score was created to make it simple, giving you a **clear**, **science-based**, and **transparent** environmental rating for food products, right where you need it: while you shop.",
   "guide_greenscore_better_product_arg4_title": "Transparency",
   "guide_greenscore_better_product_arg4_text": "Unlike proprietary labels, the Green-Score calculation is **completely open** and can be **verified by anyone**.",
-  "guide_greenscore_share_link": "https://en.openfoodfacts.org/green-score",
   "guide_nova_title": "Ultra-processed foods",
   "@guide_nova_title": {
     "description": "The title of the guide (please don't forget the use of non-breaking spaces)"
@@ -3985,7 +3979,6 @@
   "guide_nova_explanations_arg3_text": "A multitude of sequences of processes is used to combine the usually many ingredients and to create the final product (hence 'ultra-processed'). The processes include several with no domestic equivalents, such as hydrogenation and hydrolysation, extrusion and moulding, and pre-processing for frying.",
   "guide_nova_explanations_arg4_title": "The predatory and financial aspects of ultra-processing",
   "guide_nova_explanations_arg4_text": "The overall purpose of ultra-processing is to create branded, convenient (durable, ready to consume), attractive (hyper-palatable) and highly profitable (low-cost ingredients) food products designed to displace all other food groups. Ultra-processed food products are usually packaged attractively and marketed intensively.",
-  "guide_nova_share_link": "https://en.openfoodfacts.org/nova",
   "preview_badge": "Preview",
   "@preview_badge": {
     "description": "Badge to indicate that the product is in preview mode (Be careful with this translation)"

--- a/packages/smooth_app/lib/l10n/app_localizations.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations.dart
@@ -929,12 +929,6 @@ abstract class AppLocalizations {
   /// **'terms of use and contribution'**
   String get sign_up_page_terms_text;
 
-  /// Please insert the right url here. Go to the Open Food Facts homepage, switch to your country and then on the bottom left footer is Terms of use from which the url should be taken
-  ///
-  /// In en, this message translates to:
-  /// **'https://world-en.openfoodfacts.org/terms-of-use'**
-  String get sign_up_page_agree_url;
-
   /// Please insert the right url from the website here.
   ///
   /// In en, this message translates to:
@@ -7303,12 +7297,6 @@ abstract class AppLocalizations {
   /// **'For manufacturers, the display of the Nutri-Score **remains optional**.'**
   String get guide_nutriscore_v2_unchanged_paragraph2;
 
-  /// No description provided for @guide_nutriscore_v2_share_link.
-  ///
-  /// In en, this message translates to:
-  /// **'https://world.openfoodfacts.org/nutriscore-v2'**
-  String get guide_nutriscore_v2_share_link;
-
   /// The title of the guide (please don't forget the use of non-breaking spaces)
   ///
   /// In en, this message translates to:
@@ -7621,12 +7609,6 @@ abstract class AppLocalizations {
   /// **'Unlike proprietary labels, the Green-Score calculation is **completely open** and can be **verified by anyone**.'**
   String get guide_greenscore_better_product_arg4_text;
 
-  /// No description provided for @guide_greenscore_share_link.
-  ///
-  /// In en, this message translates to:
-  /// **'https://en.openfoodfacts.org/green-score'**
-  String get guide_greenscore_share_link;
-
   /// The title of the guide (please don't forget the use of non-breaking spaces)
   ///
   /// In en, this message translates to:
@@ -7770,12 +7752,6 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'The overall purpose of ultra-processing is to create branded, convenient (durable, ready to consume), attractive (hyper-palatable) and highly profitable (low-cost ingredients) food products designed to displace all other food groups. Ultra-processed food products are usually packaged attractively and marketed intensively.'**
   String get guide_nova_explanations_arg4_text;
-
-  /// No description provided for @guide_nova_share_link.
-  ///
-  /// In en, this message translates to:
-  /// **'https://en.openfoodfacts.org/nova'**
-  String get guide_nova_share_link;
 
   /// Badge to indicate that the product is in preview mode (Be careful with this translation)
   ///

--- a/packages/smooth_app/lib/l10n/app_localizations_aa.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_aa.dart
@@ -321,10 +321,6 @@ class AppLocalizationsAa extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4204,10 +4200,6 @@ class AppLocalizationsAa extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4397,10 +4389,6 @@ class AppLocalizationsAa extends AppLocalizations {
       'Unlike proprietary labels, the Green-Score calculation is **completely open** and can be **verified by anyone**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4488,9 +4476,6 @@ class AppLocalizationsAa extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'The overall purpose of ultra-processing is to create branded, convenient (durable, ready to consume), attractive (hyper-palatable) and highly profitable (low-cost ingredients) food products designed to displace all other food groups. Ultra-processed food products are usually packaged attractively and marketed intensively.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_af.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_af.dart
@@ -321,10 +321,6 @@ class AppLocalizationsAf extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4205,10 +4201,6 @@ class AppLocalizationsAf extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4398,10 +4390,6 @@ class AppLocalizationsAf extends AppLocalizations {
       'Unlike proprietary labels, the Green-Score calculation is **completely open** and can be **verified by anyone**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4489,9 +4477,6 @@ class AppLocalizationsAf extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'The overall purpose of ultra-processing is to create branded, convenient (durable, ready to consume), attractive (hyper-palatable) and highly profitable (low-cost ingredients) food products designed to displace all other food groups. Ultra-processed food products are usually packaged attractively and marketed intensively.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_ak.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ak.dart
@@ -321,10 +321,6 @@ class AppLocalizationsAk extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4204,10 +4200,6 @@ class AppLocalizationsAk extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4397,10 +4389,6 @@ class AppLocalizationsAk extends AppLocalizations {
       'Unlike proprietary labels, the Green-Score calculation is **completely open** and can be **verified by anyone**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4488,9 +4476,6 @@ class AppLocalizationsAk extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'The overall purpose of ultra-processing is to create branded, convenient (durable, ready to consume), attractive (hyper-palatable) and highly profitable (low-cost ingredients) food products designed to displace all other food groups. Ultra-processed food products are usually packaged attractively and marketed intensively.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_am.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_am.dart
@@ -321,10 +321,6 @@ class AppLocalizationsAm extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4202,10 +4198,6 @@ class AppLocalizationsAm extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4386,10 +4378,6 @@ class AppLocalizationsAm extends AppLocalizations {
       'ከባለቤትነት መለያዎች በተለየ የአረንጓዴው ነጥብ ስሌት **ሙሉ በሙሉ ክፍት ነው** እና **በማንኛውም ሰው ሊረጋገጥ ይችላል**።';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4474,9 +4462,6 @@ class AppLocalizationsAm extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'የ ultra-processing አጠቃላይ ዓላማ ሁሉንም ሌሎች የምግብ ቡድኖችን ለማፈናቀል የተነደፉ ብራንድ ያላቸው ፣ ምቹ (የሚበረክት ፣ ለመጠጣት ዝግጁ) ፣ ማራኪ (ከፍተኛ-የሚወደድ) እና ከፍተኛ ትርፋማ (ዝቅተኛ ዋጋ ያላቸው ንጥረ ነገሮች) የምግብ ምርቶችን መፍጠር ነው። እጅግ በጣም የተቀነባበሩ የምግብ ምርቶች በአብዛኛው በማራኪ የታሸጉ እና በከፍተኛ ሁኔታ ለገበያ ይቀርባሉ።';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_ar.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ar.dart
@@ -320,10 +320,6 @@ class AppLocalizationsAr extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use\n';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4195,10 +4191,6 @@ class AppLocalizationsAr extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'النتيجة البيئية';
 
   @override
@@ -4381,10 +4373,6 @@ class AppLocalizationsAr extends AppLocalizations {
       'على عكس العلامات التجارية المسجلة الملكية، فإن حساب Green-Score هو **مفتوح تمامًا** ويمكن **التحقق منه من قبل أي شخص**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4472,9 +4460,6 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'الهدف العام من المعالجة الفائقة هو إنتاج منتجات غذائية تحمل علامة تجارية، سهلة الاستخدام (متينة، جاهزة للاستهلاك)، جذابة (شهية للغاية)، ومربحة للغاية (بمكونات منخفضة التكلفة)، مصممة لتحل محل جميع المجموعات الغذائية الأخرى. عادةً ما تُعبأ المنتجات الغذائية فائقة المعالجة بشكل جذاب وتُسوّق بكثافة.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_as.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_as.dart
@@ -321,10 +321,6 @@ class AppLocalizationsAs extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4205,10 +4201,6 @@ class AppLocalizationsAs extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4395,10 +4387,6 @@ class AppLocalizationsAs extends AppLocalizations {
       'মালিকানাধীন লেবেলৰ দৰে নহয়, সেউজ-স্ক\'ৰ গণনা **সম্পূৰ্ণভাৱে মুকলি** আৰু ইয়াক **যিকোনো ব্যক্তিয়ে পৰীক্ষা কৰিব পাৰে**।';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://as.openfoodfacts.org/সেউজীয়া-স্ক\'ৰ';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4484,10 +4472,6 @@ class AppLocalizationsAs extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'আল্ট্ৰা-প্ৰচেছিঙৰ সামগ্ৰিক উদ্দেশ্য হৈছে আন সকলো খাদ্য গোটক স্থানচ্যুত কৰিব পৰাকৈ ডিজাইন কৰা ব্ৰেণ্ডেড, সুবিধাজনক (টেকসই, ব্যৱহাৰৰ বাবে সাজু), আকৰ্ষণীয় (অতি-স্বাদু) আৰু অতি লাভজনক (কম খৰচী উপাদান) খাদ্য সামগ্ৰী সৃষ্টি কৰা। আল্ট্ৰা-প্ৰচেছড খাদ্য সামগ্ৰী সাধাৰণতে আকৰ্ষণীয়ভাৱে পেকেজ কৰা হয় আৰু ইয়াৰ বজাৰ তীব্ৰভাৱে কৰা হয়।';
-
-  @override
-  String get guide_nova_share_link =>
-      'https://as.openfoodfacts.org/nova ৰ দ্বাৰা প্ৰকাশিত';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_az.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_az.dart
@@ -321,10 +321,6 @@ class AppLocalizationsAz extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4206,10 +4202,6 @@ class AppLocalizationsAz extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4397,10 +4389,6 @@ class AppLocalizationsAz extends AppLocalizations {
       'Mülkiyyət etiketlərindən fərqli olaraq, Yaşıl Xal hesablanması **tamamilə açıqdır** və **hər kəs tərəfindən təsdiqlənə bilər**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4486,9 +4474,6 @@ class AppLocalizationsAz extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Ultra emalın ümumi məqsədi bütün digər qida qruplarını sıxışdırmaq üçün nəzərdə tutulmuş markalı, rahat (davamlı, istehlaka hazır), cəlbedici (hiper dadlı) və yüksək gəlirli (az qiymətli maddələr) qida məhsulları yaratmaqdır. Ultra emal edilmiş qida məhsulları adətən cəlbedici şəkildə qablaşdırılır və intensiv şəkildə bazara çıxarılır.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_be.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_be.dart
@@ -325,10 +325,6 @@ class AppLocalizationsBe extends AppLocalizations {
       'умовамі выкарыстання і ўнёску ў Open Food Facts';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4232,10 +4228,6 @@ class AppLocalizationsBe extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4423,10 +4415,6 @@ class AppLocalizationsBe extends AppLocalizations {
       'У адрозненне ад запатэнтаваных маркіровак, разлік Green-Score **цалкам адкрыты** і можа быць **правераны кім заўгодна**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4513,9 +4501,6 @@ class AppLocalizationsBe extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Агульная мэта ультраапрацоўкі — стварэнне брэндаваных, зручных (трывалых, гатовых да ўжывання), прывабных (вельмі смачных) і высокапрыбытковых (з недарагіх інгрэдыентаў) харчовых прадуктаў, прызначаных для выцяснення ўсіх іншых груп прадуктаў харчавання. Ультраапрацоўчаныя харчовыя прадукты звычайна прывабна ўпакоўваюцца і актыўна прадаюцца.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_bg.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_bg.dart
@@ -325,10 +325,6 @@ class AppLocalizationsBg extends AppLocalizations {
       ' условията за ползване и принос на Open Food Facts';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://bg.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4244,10 +4240,6 @@ class AppLocalizationsBg extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Зелен-Резултат';
 
   @override
@@ -4436,10 +4428,6 @@ class AppLocalizationsBg extends AppLocalizations {
       'За разлика от патентованите етикети, изчислението на Green-Score е **напълно отворено** и може да бъде **проверено от всеки**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Свръхпреработени храни';
 
   @override
@@ -4526,9 +4514,6 @@ class AppLocalizationsBg extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Общата цел на ултрапреработката е да се създадат маркови, удобни (трайни, готови за консумация), атрактивни (свръхвкусни) и високорентабилни (с евтини съставки) хранителни продукти, предназначени да изместят всички останали хранителни групи. Ултрапреработените хранителни продукти обикновено са атрактивно опаковани и се предлагат на пазара интензивно.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_bm.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_bm.dart
@@ -321,10 +321,6 @@ class AppLocalizationsBm extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4208,10 +4204,6 @@ class AppLocalizationsBm extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4401,10 +4393,6 @@ class AppLocalizationsBm extends AppLocalizations {
       'A tɛ i n’a fɔ labeli propriétaires, Green-Score jatebɔ ye **da wuli pewu** wa a bɛ se ka **sɛgɛsɛgɛ mɔgɔ bɛɛ fɛ**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/jatebɔ-sɛbɛn ɲɛ jɛman';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4491,9 +4479,6 @@ class AppLocalizationsBm extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Ultra-processing kun bɛɛ ye ka dumunifɛnw dilan minnu tɔgɔ sɛbɛnnen don, minnu bɛ se ka mɛn, minnu bɛ mɛn, minnu bɛ se ka dun, minnu bɛ mɔgɔ ɲɛnajɛ (min ka di kosɛbɛ) ani minnu nafa ka bon kosɛbɛ (fɛn minnu musaka ka dɔgɔ) minnu dabɔra ka dumuni kulu tɔw bɛɛ bɔ u nɔ na. A ka c’a la, dumunifɛnw minnu dilannen don ni ultra-processed ye, olu bɛ kɛ pake kɔnɔ cogo la min bɛ mɔgɔ ɲɛnajɛ, wa u bɛ feere kosɛbɛ.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.dumuniw dafalenw.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_bn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_bn.dart
@@ -324,10 +324,6 @@ class AppLocalizationsBn extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4207,10 +4203,6 @@ class AppLocalizationsBn extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4397,10 +4389,6 @@ class AppLocalizationsBn extends AppLocalizations {
       'মালিকানাধীন লেবেলের বিপরীতে, গ্রিন-স্কোর গণনা **সম্পূর্ণ উন্মুক্ত** এবং **যে কেউ** যাচাই করতে পারে**।';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4487,9 +4475,6 @@ class AppLocalizationsBn extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'অতি-প্রক্রিয়াকরণের সামগ্রিক উদ্দেশ্য হল ব্র্যান্ডেড, সুবিধাজনক (টেকসই, খাওয়ার জন্য প্রস্তুত), আকর্ষণীয় (অতি-সুস্বাদু) এবং অত্যন্ত লাভজনক (কম দামের উপাদান) খাদ্য পণ্য তৈরি করা যা অন্যান্য সমস্ত খাদ্য গোষ্ঠীকে স্থানচ্যুত করার জন্য ডিজাইন করা হয়েছে। অতি-প্রক্রিয়াজাত খাদ্য পণ্যগুলি সাধারণত আকর্ষণীয়ভাবে প্যাকেজ করা হয় এবং নিবিড়ভাবে বাজারজাত করা হয়।';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_bo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_bo.dart
@@ -321,10 +321,6 @@ class AppLocalizationsBo extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4204,10 +4200,6 @@ class AppLocalizationsBo extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4397,10 +4389,6 @@ class AppLocalizationsBo extends AppLocalizations {
       'Unlike proprietary labels, the Green-Score calculation is **completely open** and can be **verified by anyone**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4488,9 +4476,6 @@ class AppLocalizationsBo extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'The overall purpose of ultra-processing is to create branded, convenient (durable, ready to consume), attractive (hyper-palatable) and highly profitable (low-cost ingredients) food products designed to displace all other food groups. Ultra-processed food products are usually packaged attractively and marketed intensively.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_br.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_br.dart
@@ -321,10 +321,6 @@ class AppLocalizationsBr extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4207,10 +4203,6 @@ class AppLocalizationsBr extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4400,10 +4392,6 @@ class AppLocalizationsBr extends AppLocalizations {
       'Er c\'hontrol d\'an tikedennoù perc\'hennet, ar jediñ Green-Score a zo **digor penn-da-benn** ha gallout a ra bezañ **gwiriekaet gant piv bennak**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://br.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4491,9 +4479,6 @@ class AppLocalizationsBr extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Pal hollek an ultra-treuzfurmiñ eo krouiñ produioù boued merket, aes (padus, prest da zebriñ), dedennus (tre-blev) ha gounezus-kenañ (elfennoù izel) savet evit dilec\'hiañ an holl strolladoù boued all. Ar produioù boued ultra-treuzfurmet a vez paket en un doare dedennus ha marc\'hataet kalz peurliesañ.';
-
-  @override
-  String get guide_nova_share_link => 'https://br.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_bs.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_bs.dart
@@ -322,10 +322,6 @@ class AppLocalizationsBs extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4207,10 +4203,6 @@ class AppLocalizationsBs extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4398,10 +4390,6 @@ class AppLocalizationsBs extends AppLocalizations {
       'Za razliku od vlasničkih oznaka, izračun Green-Scorea je **potpuno otvoren** i može ga **provjeriti bilo ko**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4488,9 +4476,6 @@ class AppLocalizationsBs extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Opća svrha ultra-prerade je stvaranje brendiranih, praktičnih (izdržljivih, spremnih za konzumaciju), atraktivnih (hiper-ukusnih) i visoko profitabilnih (jeftini sastojci) prehrambenih proizvoda dizajniranih da istisnu sve ostale grupe hrane. Ultra-prerađeni prehrambeni proizvodi obično su atraktivno pakirani i intenzivno se plasiraju na tržište.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_ca.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ca.dart
@@ -326,10 +326,6 @@ class AppLocalizationsCa extends AppLocalizations {
   String get sign_up_page_terms_text => 'termes d\'ús i contribució';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://es-ca.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url =>
       'https://es-ca.openfoodfacts.org/donate-to-open-food-facts';
 
@@ -4259,10 +4255,6 @@ class AppLocalizationsCa extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4452,10 +4444,6 @@ class AppLocalizationsCa extends AppLocalizations {
       'A diferència de les etiquetes pròpies, el càlcul de Green-Score és **completament obert** i qualsevol persona pot **verificar-lo**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Aliments ultraprocessats';
 
   @override
@@ -4543,9 +4531,6 @@ class AppLocalizationsCa extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'L\'objectiu general de l\'ultraprocessament és crear productes alimentaris de marca, pràctics (duradors, llestos per consumir), atractius (hiperpalatables) i altament rendibles (ingredients de baix cost), dissenyats per desplaçar tots els altres grups d\'aliments. Els productes alimentaris ultraprocessats solen envasar-se de manera atractiva i comercialitzar-se intensivament.';
-
-  @override
-  String get guide_nova_share_link => 'https://ca.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_ce.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ce.dart
@@ -321,10 +321,6 @@ class AppLocalizationsCe extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4204,10 +4200,6 @@ class AppLocalizationsCe extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4397,10 +4389,6 @@ class AppLocalizationsCe extends AppLocalizations {
       'Unlike proprietary labels, the Green-Score calculation is **completely open** and can be **verified by anyone**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4488,9 +4476,6 @@ class AppLocalizationsCe extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'The overall purpose of ultra-processing is to create branded, convenient (durable, ready to consume), attractive (hyper-palatable) and highly profitable (low-cost ingredients) food products designed to displace all other food groups. Ultra-processed food products are usually packaged attractively and marketed intensively.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_co.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_co.dart
@@ -321,10 +321,6 @@ class AppLocalizationsCo extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4208,10 +4204,6 @@ class AppLocalizationsCo extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4401,10 +4393,6 @@ class AppLocalizationsCo extends AppLocalizations {
       'À u cuntrariu di l\'etichette pruprietarie, u calculu di u Green-Score hè **cumpletamente apertu** è pò esse **verificatu da qualchissia**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4493,9 +4481,6 @@ class AppLocalizationsCo extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'U scopu generale di l\'ultra-trasfurmazione hè di creà prudutti alimentari di marca, pratichi (durevuli, pronti à cunsumà), attraenti (iper-appetibili) è assai redditizi (ingredienti à bassu costu) cuncepiti per rimpiazzà tutti l\'altri gruppi alimentari. I prudutti alimentari ultra-trasfurmati sò generalmente imballati in modu attraente è cummercializati intensivamente.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_cs.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_cs.dart
@@ -326,10 +326,6 @@ class AppLocalizationsCs extends AppLocalizations {
   String get sign_up_page_terms_text => 'podmínky použití a příspěvek';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://cz.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4229,10 +4225,6 @@ class AppLocalizationsCs extends AppLocalizations {
       'Pro výrobce zůstává zobrazení Nutri-Score **nepovinné**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world-cs.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Eco-score';
 
   @override
@@ -4417,10 +4409,6 @@ class AppLocalizationsCs extends AppLocalizations {
       'Na rozdíl od proprietárních značek je výpočet Green-Score **zcela otevřený** a může být **ověřen kýmkoli**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://cs.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra zpracované potraviny';
 
   @override
@@ -4508,9 +4496,6 @@ class AppLocalizationsCs extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Celkovým účelem ultrazpracování je vytvořit značkové, pohodlné (trvanlivé, připravené ke konzumaci), atraktivní (hyperchutné) a vysoce ziskové (levné ingredience) potravinářské výrobky určené k nahrazení všech ostatních skupin potravin. Ultrazpracované potraviny jsou obvykle atraktivně baleny a intenzivně uváděny na trh.';
-
-  @override
-  String get guide_nova_share_link => 'https://cs.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Náhled';

--- a/packages/smooth_app/lib/l10n/app_localizations_cv.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_cv.dart
@@ -321,10 +321,6 @@ class AppLocalizationsCv extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4204,10 +4200,6 @@ class AppLocalizationsCv extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4395,10 +4387,6 @@ class AppLocalizationsCv extends AppLocalizations {
       'Проприетарлӑ ярлыксенчен уйрӑлса тӑракан Green-Score шутлавӗ **пӗтӗмпех уҫӑ** тата ӑна **кирек кам та тӗрӗслеме пултарать**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4485,9 +4473,6 @@ class AppLocalizationsCv extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Ультра-тирпейлессин пӗтӗмӗшле тӗллевӗ — ытти апат-ҫимӗҫ ушкӑнӗсене улӑштарма хатӗрленӗ брендлӑ, меллӗ (тӗрӗс, ҫиме хатӗр), илӗртӳллӗ (питӗ тутлӑ) тата пысӑк тупӑшлӑ (йӳнӗ ингредиентсем) апат-ҫимӗҫ продукчӗсем туса кӑларасси. Ультра-тирпейленӗ апат-ҫимӗҫ продукцийӗсене ытларах чухне илӗртӳллӗн пуҫтараҫҫӗ тата вӗсене хӗрӳллӗн сутаҫҫӗ.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_cy.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_cy.dart
@@ -321,10 +321,6 @@ class AppLocalizationsCy extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4206,10 +4202,6 @@ class AppLocalizationsCy extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4399,10 +4391,6 @@ class AppLocalizationsCy extends AppLocalizations {
       'Yn wahanol i labeli perchnogol, mae cyfrifiad y Sgôr Werdd yn **hollol agored** a gellir ei **wirio gan unrhyw un**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://cy.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4489,9 +4477,6 @@ class AppLocalizationsCy extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Pwrpas cyffredinol prosesu uwch-dechnolegol yw creu cynhyrchion bwyd brand, cyfleus (gwydn, parod i\'w bwyta), deniadol (hyper-flasus) a hynod broffidiol (cynhwysion cost isel) sydd wedi\'u cynllunio i ddisodli pob grŵp bwyd arall. Fel arfer, mae cynhyrchion bwyd wedi\'u prosesu\'n uwch-dechnolegol yn cael eu pecynnu\'n ddeniadol a\'u marchnata\'n ddwys.';
-
-  @override
-  String get guide_nova_share_link => 'https://cy.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_da.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_da.dart
@@ -320,10 +320,6 @@ class AppLocalizationsDa extends AppLocalizations {
   String get sign_up_page_terms_text => 'vilkår for brug og bidrag';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4218,10 +4214,6 @@ class AppLocalizationsDa extends AppLocalizations {
       'For producenter er visningen af Nutri-Score ** fortsat valgfri**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Øko-Score';
 
   @override
@@ -4408,10 +4400,6 @@ class AppLocalizationsDa extends AppLocalizations {
       'I modsætning til proprietære etiketter er Green-Score-beregningen **fuldstændig åben** og kan **verificeres af alle**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultraforarbejdede fødevarer';
 
   @override
@@ -4500,9 +4488,6 @@ class AppLocalizationsDa extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Det overordnede formål med ultraforarbejdning er at skabe mærkevareprodukter, der er bekvemme (holdbare, klar til forbrug), attraktive (hypervelsmagende) og yderst rentable (billige ingredienser) og er designet til at fortrænge alle andre fødevaregrupper. Ultraforarbejdede fødevarer er normalt pakket attraktivt og markedsføres intensivt.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Forhåndsvisning';

--- a/packages/smooth_app/lib/l10n/app_localizations_de.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_de.dart
@@ -330,10 +330,6 @@ class AppLocalizationsDe extends AppLocalizations {
       'Nutzungsbedingungen von Open Food Facts zu';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://de.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://world-de.openfoodfacts.org/spenden';
 
   @override
@@ -4288,10 +4284,6 @@ class AppLocalizationsDe extends AppLocalizations {
       'Für die Hersteller ist die Angabe des Nutri-Score **weiterhin optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://de.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4477,10 +4469,6 @@ class AppLocalizationsDe extends AppLocalizations {
       'Im Gegensatz zu proprietären Labels ist die Green-Score-Berechnung **völlig offen** und kann **von jedem überprüft** werden.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Sehr hoch verarbeitete Lebensmittel';
 
   @override
@@ -4570,9 +4558,6 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Der Hauptzweck der Ultra-Verarbeitung besteht darin, Marken-Lebensmittel zu schaffen, die praktisch (haltbar, verzehrfertig), attraktiv (überaus schmackhaft) und hochprofitabel (preiswerte Zutaten) sind und alle anderen Lebensmittelgruppen verdrängen sollen. Ultra-verarbeitete Lebensmittel werden in der Regel attraktiv verpackt und intensiv vermarktet.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Vorschau';

--- a/packages/smooth_app/lib/l10n/app_localizations_el.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_el.dart
@@ -328,10 +328,6 @@ class AppLocalizationsEl extends AppLocalizations {
   String get sign_up_page_terms_text => 'τους όρους χρήσης και συνεισφοράς';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://gr.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4296,10 +4292,6 @@ class AppLocalizationsEl extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://gr.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4490,10 +4482,6 @@ class AppLocalizationsEl extends AppLocalizations {
       'Σε αντίθεση με τις ιδιόκτητες ετικέτες, ο υπολογισμός του Green-Score είναι **εντελώς ανοιχτός** και μπορεί να **επαληθευτεί από οποιονδήποτε**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Υπερεπεξεργασμένα τρόφιμα';
 
   @override
@@ -4582,9 +4570,6 @@ class AppLocalizationsEl extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Ο γενικός σκοπός της υπερεπεξεργασίας είναι η δημιουργία επώνυμων, βολικών (ανθεκτικών, έτοιμων προς κατανάλωση), ελκυστικών (υπερεύγευστων) και εξαιρετικά κερδοφόρων (χαμηλού κόστους συστατικά) τροφίμων, σχεδιασμένων να εκτοπίσουν όλες τις άλλες ομάδες τροφίμων. Τα υπερεπεξεργασμένα τρόφιμα συνήθως συσκευάζονται ελκυστικά και διατίθενται στην αγορά εντατικά.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Προεπισκόπηση';

--- a/packages/smooth_app/lib/l10n/app_localizations_en.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_en.dart
@@ -321,10 +321,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4203,10 +4199,6 @@ class AppLocalizationsEn extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4396,10 +4388,6 @@ class AppLocalizationsEn extends AppLocalizations {
       'Unlike proprietary labels, the Green-Score calculation is **completely open** and can be **verified by anyone**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4487,9 +4475,6 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'The overall purpose of ultra-processing is to create branded, convenient (durable, ready to consume), attractive (hyper-palatable) and highly profitable (low-cost ingredients) food products designed to displace all other food groups. Ultra-processed food products are usually packaged attractively and marketed intensively.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_eo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_eo.dart
@@ -321,10 +321,6 @@ class AppLocalizationsEo extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4206,10 +4202,6 @@ class AppLocalizationsEo extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4396,10 +4388,6 @@ class AppLocalizationsEo extends AppLocalizations {
       'Male al proprietaj etikedoj, la kalkulo de Green-Score estas **tute malferma** kaj povas esti **kontrolita de iu ajn**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://eopenfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4487,9 +4475,6 @@ class AppLocalizationsEo extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'La ĝenerala celo de ultra-prilaborado estas krei markitajn, oportunajn (daŭremajn, pretajn por konsumo), allogajn (hiper-bongustajn) kaj tre profitodonajn (malaltkostajn ingrediencojn) manĝaĵojn, desegnitajn por anstataŭigi ĉiujn aliajn nutraĵgrupojn. Ultra-prilaboritaj manĝaĵoj kutime estas alloge pakitaj kaj intense surmerkatigitaj.';
-
-  @override
-  String get guide_nova_share_link => 'https://eopenfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_es.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_es.dart
@@ -335,10 +335,6 @@ class AppLocalizationsEs extends AppLocalizations {
       'las condiciones de uso y contribución de Open Food Facts';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-es.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url =>
       'https://world-es.openfoodfacts.org/dar-a-open-food-facts';
 
@@ -4280,10 +4276,6 @@ class AppLocalizationsEs extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/guide/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4474,10 +4466,6 @@ class AppLocalizationsEs extends AppLocalizations {
       'A diferencia de las etiquetas propietarias, el cálculo de Green-Score es **completamente abierto** y puede ser **verificado por cualquier persona**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Alimentos ultraprocesados';
 
   @override
@@ -4566,9 +4554,6 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'El objetivo general del ultraprocesamiento es crear productos alimenticios de marca, prácticos (duraderos, listos para consumir), atractivos (hiperpalatables) y altamente rentables (con ingredientes de bajo costo), diseñados para desplazar a todos los demás grupos de alimentos. Los productos ultraprocesados suelen presentar envases atractivos y una comercialización intensiva.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_et.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_et.dart
@@ -322,10 +322,6 @@ class AppLocalizationsEt extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4204,10 +4200,6 @@ class AppLocalizationsEt extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4395,10 +4387,6 @@ class AppLocalizationsEt extends AppLocalizations {
       'Erinevalt omandiõigusega kaitstud märgistest on rohelise skoori arvutus **täiesti avatud** ja seda saab **kõik** kontrollida.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4486,9 +4474,6 @@ class AppLocalizationsEt extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Ülitöötlemise üldine eesmärk on luua kaubamärgiga, mugavaid (vastupidavaid, tarbimisvalmis), atraktiivseid (ülimaitselisi) ja väga tulusaid (odavate koostisosadega) toiduaineid, mis on loodud kõigi teiste toidugruppide väljatõrjumiseks. Ülitöödeldud toiduained on tavaliselt atraktiivselt pakendatud ja turustatakse intensiivselt.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_eu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_eu.dart
@@ -323,10 +323,6 @@ class AppLocalizationsEu extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4217,10 +4213,6 @@ class AppLocalizationsEu extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4412,10 +4404,6 @@ class AppLocalizationsEu extends AppLocalizations {
       'Etiketa jabedunen aldean, Green-Score kalkulua **guztiz irekia** da eta edonork **egiaztatu** dezake.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4503,9 +4491,6 @@ class AppLocalizationsEu extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Ultraprozesamenduaren helburu nagusia markako, erosoko (iraunkorrak, kontsumitzeko prest), erakargarriak (hiper-ahogozoak) eta oso errentagarriak (kostu baxuko osagaiak) diren elikagaiak sortzea da, gainerako elikagai-talde guztiak ordezkatzeko diseinatuta. Ultraprozesatutako elikagaiak normalean modu erakargarrian ontziratzen dira eta modu intentsiboan merkaturatzen dira.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_fa.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_fa.dart
@@ -321,10 +321,6 @@ class AppLocalizationsFa extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4203,10 +4199,6 @@ class AppLocalizationsFa extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4390,10 +4382,6 @@ class AppLocalizationsFa extends AppLocalizations {
       'برخلاف برچسب‌های اختصاصی، محاسبه امتیاز سبز **کاملاً باز** است و هر کسی می‌تواند آن را **تأیید** کند.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4479,9 +4467,6 @@ class AppLocalizationsFa extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'هدف کلی فرافرآوری، ایجاد محصولات غذایی برنددار، مناسب (بادوام، آماده مصرف)، جذاب (بسیار خوش‌طعم) و بسیار سودآور (با مواد اولیه کم‌هزینه) است که برای جایگزینی سایر گروه‌های غذایی طراحی شده‌اند. محصولات غذایی فرافرآوری شده معمولاً به صورت جذاب بسته‌بندی و به صورت فشرده به بازار عرضه می‌شوند.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_fi.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_fi.dart
@@ -326,10 +326,6 @@ class AppLocalizationsFi extends AppLocalizations {
   String get sign_up_page_terms_text => 'käyttö- ja osallistumisehdot';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-fi.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org';
 
   @override
@@ -4202,10 +4198,6 @@ class AppLocalizationsFi extends AppLocalizations {
       'Valmistajille Nutri-Score-näyttö **pysyy valinnaisena**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world-fi.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4393,10 +4385,6 @@ class AppLocalizationsFi extends AppLocalizations {
       'Toisin kuin omat merkinnät, Green-Score-laskenta on **täysin avoin** ja **kuka tahansa voi tarkistaa sen**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://fi.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultrajalostetut ruoat';
 
   @override
@@ -4483,9 +4471,6 @@ class AppLocalizationsFi extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Ultraprosessoinnin yleisenä tarkoituksena on luoda brändättyjä, käteviä (kestäviä, valmiita kuluttamaan), houkuttelevia (hypermaukkaita) ja erittäin kannattavia (edullisia ainesosia) elintarvikkeita, joiden on tarkoitus syrjäyttää kaikki muut elintarvikeryhmät. Ultraprosessoidut elintarvikkeet pakataan yleensä houkuttelevasti ja niitä markkinoidaan intensiivisesti.';
-
-  @override
-  String get guide_nova_share_link => 'https://fi.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Esikatselu';

--- a/packages/smooth_app/lib/l10n/app_localizations_fo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_fo.dart
@@ -321,10 +321,6 @@ class AppLocalizationsFo extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4204,10 +4200,6 @@ class AppLocalizationsFo extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4397,10 +4389,6 @@ class AppLocalizationsFo extends AppLocalizations {
       'Unlike proprietary labels, the Green-Score calculation is **completely open** and can be **verified by anyone**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4488,9 +4476,6 @@ class AppLocalizationsFo extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'The overall purpose of ultra-processing is to create branded, convenient (durable, ready to consume), attractive (hyper-palatable) and highly profitable (low-cost ingredients) food products designed to displace all other food groups. Ultra-processed food products are usually packaged attractively and marketed intensively.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_fr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_fr.dart
@@ -332,10 +332,6 @@ class AppLocalizationsFr extends AppLocalizations {
       'conditions d\'utilisation et de contribution d\'Open Food Facts';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-fr.openfoodfacts.org/conditions-d-utilisation';
-
-  @override
   String get donate_url => 'https://donner.openfoodfacts.org/';
 
   @override
@@ -4300,10 +4296,6 @@ class AppLocalizationsFr extends AppLocalizations {
       'Pour les fabricants, l\'affichage du Nutri-Score **reste optionnel**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://fr.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4495,10 +4487,6 @@ class AppLocalizationsFr extends AppLocalizations {
       'Contrairement aux labels propriétaires, le calcul du Green-Score est **complètement ouvert** et peut être **vérifié par n\'importe qui**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Aliments ultra-transformés';
 
   @override
@@ -4587,9 +4575,6 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'L\'objectif général de l\'ultratransformation est de créer des produits alimentaires de marque, pratiques (durables, prêts à consommer), attrayants (hyper appétissants) et très rentables (ingrédients à faible coût), destinés à supplanter tous les autres groupes alimentaires. Les produits alimentaires ultratransformés sont généralement emballés de manière attrayante et font l\'objet d\'une commercialisation intensive.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Aperçu';

--- a/packages/smooth_app/lib/l10n/app_localizations_ga.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ga.dart
@@ -321,10 +321,6 @@ class AppLocalizationsGa extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4207,10 +4203,6 @@ class AppLocalizationsGa extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4398,10 +4390,6 @@ class AppLocalizationsGa extends AppLocalizations {
       'Murab ionann agus lipéid dhílseánaigh, tá ríomh an Scóir Ghlais **oscailte go hiomlán** agus is féidir le duine ar bith é a fhíorú.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4488,9 +4476,6 @@ class AppLocalizationsGa extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Is é cuspóir foriomlán an ultraphróiseála táirgí bia brandáilte, áisiúla (marthanacha, réidh le hithe), tarraingteacha (an-bhlasta) agus an-bhrabúsacha (comhábhair ar chostas íseal) a chruthú atá deartha chun gach grúpa bia eile a dhíláithriú. De ghnáth, bíonn táirgí bia ultraphróiseáilte pacáistithe go tarraingteach agus margaíocht dhian orthu.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_gd.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_gd.dart
@@ -321,10 +321,6 @@ class AppLocalizationsGd extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4208,10 +4204,6 @@ class AppLocalizationsGd extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4401,10 +4393,6 @@ class AppLocalizationsGd extends AppLocalizations {
       'Eu-coltach ri bileagan seilbhe, tha àireamhachadh an Sgòr Uaine **gu tur fosgailte** agus faodar a **dhearbhachadh le duine sam bith**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4493,9 +4481,6 @@ class AppLocalizationsGd extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Is e prìomh adhbhar giollachd-bhìdh toraidhean bìdh branndaichte, goireasach (maireannach, deiseil airson ithe), tarraingeach (ro-bhlasta) agus air leth prothaideach (tàthchuid aig prìs ìseal) a chruthachadh, air an dealbhadh gus a h-uile buidheann bìdh eile a chuir às. Mar as trice bidh toraidhean bìdh air an giollachd-bhìdh air am pacadh ann an dòigh tharraingeach agus air am margaidheachd gu dian.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_gl.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_gl.dart
@@ -321,10 +321,6 @@ class AppLocalizationsGl extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4207,10 +4203,6 @@ class AppLocalizationsGl extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4400,10 +4392,6 @@ class AppLocalizationsGl extends AppLocalizations {
       'A diferenza das etiquetas propietarias, o cálculo da puntuación verde é **completamente aberto** e calquera pode **verificalo**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4491,9 +4479,6 @@ class AppLocalizationsGl extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'O obxectivo xeral do ultraprocesamento é crear produtos alimenticios de marca, prácticos (duradeiros, listos para consumir), atractivos (hiperpalatables) e altamente rendibles (ingredientes de baixo custo) deseñados para desprazar a todos os demais grupos de alimentos. Os produtos alimenticios ultraprocesados adoitan envasarse de forma atractiva e comercializarse de forma intensiva.';
-
-  @override
-  String get guide_nova_share_link => 'https://gl.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_gu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_gu.dart
@@ -321,10 +321,6 @@ class AppLocalizationsGu extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4206,10 +4202,6 @@ class AppLocalizationsGu extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4396,10 +4388,6 @@ class AppLocalizationsGu extends AppLocalizations {
       'માલિકીના લેબલોથી વિપરીત, ગ્રીન-સ્કોર ગણતરી **સંપૂર્ણપણે ખુલ્લી** છે** અને તેને **કોઈપણ વ્યક્તિ દ્વારા ચકાસી શકાય છે**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4486,9 +4474,6 @@ class AppLocalizationsGu extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'અલ્ટ્રા-પ્રોસેસિંગનો એકંદર હેતુ બ્રાન્ડેડ, અનુકૂળ (ટકાઉ, વપરાશ માટે તૈયાર), આકર્ષક (અતિ-સ્વાદિષ્ટ) અને અત્યંત નફાકારક (ઓછી કિંમતના ઘટકો) ખાદ્ય ઉત્પાદનો બનાવવાનો છે જે અન્ય તમામ ખાદ્ય જૂથોને સ્થાનાંતરિત કરવા માટે રચાયેલ છે. અલ્ટ્રા-પ્રોસેસ્ડ ખાદ્ય ઉત્પાદનો સામાન્ય રીતે આકર્ષક રીતે પેક કરવામાં આવે છે અને સઘન રીતે માર્કેટિંગ કરવામાં આવે છે.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_ha.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ha.dart
@@ -321,10 +321,6 @@ class AppLocalizationsHa extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4206,10 +4202,6 @@ class AppLocalizationsHa extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4395,10 +4387,6 @@ class AppLocalizationsHa extends AppLocalizations {
       'Ba kamar alamun mallakar mallaka ba, lissafin Green-Score ** gaba ɗaya buɗe yake ** kuma kowa zai iya tabbatar da shi **.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4486,9 +4474,6 @@ class AppLocalizationsHa extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Babban manufar aiwatar da matsananciyar aiki shine ƙirƙirar alama, dacewa (mai ɗorewa, shirye don cinyewa), kyakkyawa (mai daɗi mai daɗi) da riba mai fa\'ida (kayan abinci masu ƙarancin farashi) samfuran abinci waɗanda aka tsara don korar duk sauran rukunin abinci. Kayan abinci da aka sarrafa sosai yawanci ana tattara su cikin kayatarwa kuma ana sayar da su sosai.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_he.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_he.dart
@@ -316,10 +316,6 @@ class AppLocalizationsHe extends AppLocalizations {
       'תנאי השימוש והתרומה של Open Food Facts';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-he.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://world-he.openfoodfacts.org/donate';
 
   @override
@@ -4192,10 +4188,6 @@ class AppLocalizationsHe extends AppLocalizations {
       'ליצרנים, התצוגה של Nutri-Score **נותרת בגדר רשות**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4376,10 +4368,6 @@ class AppLocalizationsHe extends AppLocalizations {
       'בניגוד לתוויות קנייניות, חישוב ה-Green-Score הוא **פתוח לחלוטין** וניתן לאמת אותו על ידי כל אחד**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'מזון אולטרה מעובד';
 
   @override
@@ -4465,9 +4453,6 @@ class AppLocalizationsHe extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'המטרה הכוללת של עיבוד אולטרה-מעובד היא ליצור מוצרי מזון ממותגים, נוחים (עמידים, מוכנים לצריכה), אטרקטיביים (טעימים במיוחד) ורווחיים ביותר (מרכיבים זולים) שנועדו להחליף את כל קבוצות המזון האחרות. מוצרי מזון אולטרה-מעובדים ארוזים בדרך כלל בצורה אטרקטיבית ומשווקים באופן אינטנסיבי.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'תצוגה מקדימה';

--- a/packages/smooth_app/lib/l10n/app_localizations_hi.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_hi.dart
@@ -321,10 +321,6 @@ class AppLocalizationsHi extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4204,10 +4200,6 @@ class AppLocalizationsHi extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4394,10 +4386,6 @@ class AppLocalizationsHi extends AppLocalizations {
       'स्वामित्व लेबल के विपरीत, ग्रीन-स्कोर गणना **पूरी तरह से खुली** है और इसे **किसी के द्वारा भी सत्यापित किया जा सकता है**।';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'अल्ट्रा-प्रसंस्कृत खाद्य पदार्थ';
 
   @override
@@ -4485,9 +4473,6 @@ class AppLocalizationsHi extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'अल्ट्रा-प्रोसेसिंग का समग्र उद्देश्य ब्रांडेड, सुविधाजनक (टिकाऊ, उपभोग के लिए तैयार), आकर्षक (अति-स्वादिष्ट) और अत्यधिक लाभदायक (कम लागत वाली सामग्री) खाद्य उत्पाद बनाना है जो अन्य सभी खाद्य समूहों को विस्थापित करने के लिए डिज़ाइन किए गए हों। अल्ट्रा-प्रोसेस्ड खाद्य उत्पादों को आमतौर पर आकर्षक ढंग से पैक किया जाता है और उनका गहन विपणन किया जाता है।';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_hr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_hr.dart
@@ -322,10 +322,6 @@ class AppLocalizationsHr extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4207,10 +4203,6 @@ class AppLocalizationsHr extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4398,10 +4390,6 @@ class AppLocalizationsHr extends AppLocalizations {
       'Za razliku od vlasničkih oznaka, izračun Green-Scorea je **potpuno otvoren** i svatko ga može **provjeriti**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Industrijski prerađena hrana';
 
   @override
@@ -4488,9 +4476,6 @@ class AppLocalizationsHr extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Opća svrha ultra-prerade je stvaranje brendiranih, praktičnih (izdržljivih, spremnih za konzumaciju), atraktivnih (hiper-ukusnih) i visoko profitabilnih (jeftini sastojci) prehrambenih proizvoda osmišljenih da istisnu sve ostale skupine hrane. Ultra-prerađeni prehrambeni proizvodi obično su atraktivno pakirani i intenzivno se prodaju.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_ht.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ht.dart
@@ -321,10 +321,6 @@ class AppLocalizationsHt extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4202,10 +4198,6 @@ class AppLocalizationsHt extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4393,10 +4385,6 @@ class AppLocalizationsHt extends AppLocalizations {
       'Kontrèman ak etikèt propriétaires yo, kalkil Green-Score la **konplètman ouvè** epi nenpòt moun ka **verifye li**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4483,9 +4471,6 @@ class AppLocalizationsHt extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Objektif jeneral ultra-pwosesis la se kreye pwodui alimantè ki gen mak, pratik (dirab, pare pou konsome), atiran (ipè-gou) epi trè pwofitab (engredyan ki pa koute chè), ki fèt pou ranplase tout lòt gwoup alimantè yo. Pwodui alimantè ultra-pwosesis yo anjeneral anbale yon fason atiran epi yo vann yo yon fason entansif.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_hu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_hu.dart
@@ -326,10 +326,6 @@ class AppLocalizationsHu extends AppLocalizations {
       'felhasználási és hozzájárulási feltételeivel';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://hu.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url =>
       'https://hu.openfoodfacts.org/donate-to-open-food-facts';
 
@@ -4243,10 +4239,6 @@ class AppLocalizationsHu extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://hu.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4434,10 +4426,6 @@ class AppLocalizationsHu extends AppLocalizations {
       'A saját fejlesztésű címkékkel ellentétben a Green-Score számítás **teljesen nyílt**, és **bárki által ellenőrizhető**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Többszörösen feldolgozott élelmiszerek';
 
   @override
@@ -4526,9 +4514,6 @@ class AppLocalizationsHu extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Az ultrafeldolgozott élelmiszerek átfogó célja márkás, kényelmes (tartós, fogyasztásra kész), vonzó (hiperízletes) és rendkívül jövedelmező (alacsony költségű összetevőkből álló) élelmiszertermékek létrehozása, amelyek célja, hogy kiszorítsanak minden más élelmiszercsoportot. Az ultrafeldolgozott élelmiszereket általában vonzó csomagolásban csomagolják és intenzíven forgalmazzák.';
-
-  @override
-  String get guide_nova_share_link => 'https://hu.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Előnézet';

--- a/packages/smooth_app/lib/l10n/app_localizations_hy.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_hy.dart
@@ -321,10 +321,6 @@ class AppLocalizationsHy extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4204,10 +4200,6 @@ class AppLocalizationsHy extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4396,10 +4388,6 @@ class AppLocalizationsHy extends AppLocalizations {
       'Ի տարբերություն սեփական պիտակների, Green-Score հաշվարկը **լիովին բաց** է և կարող է **ստուգվել ցանկացած անձի կողմից**:';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4487,9 +4475,6 @@ class AppLocalizationsHy extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Գերմշակման ընդհանուր նպատակն է ստեղծել ապրանքանիշային, հարմար (ամուր, սպառման համար պատրաստ), գրավիչ (գերհամեղ) և բարձր եկամտաբեր (ցածր գնով բաղադրիչներ) սննդամթերք, որոնք նախատեսված են մյուս բոլոր սննդային խմբերը դուրս մղելու համար: Գերմշակված սննդամթերքը սովորաբար գրավիչ փաթեթավորվում է և ինտենսիվորեն շուկայավարվում:';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_id.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_id.dart
@@ -325,10 +325,6 @@ class AppLocalizationsId extends AppLocalizations {
   String get sign_up_page_terms_text => 'syarat penggunaan dan kontribusi';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4242,10 +4238,6 @@ class AppLocalizationsId extends AppLocalizations {
       'Bagi produsen, tampilan Nutri-Score **tetap opsional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4430,10 +4422,6 @@ class AppLocalizationsId extends AppLocalizations {
       'Tidak seperti label hak milik, perhitungan Green-Score **sepenuhnya terbuka** dan dapat **diverifikasi oleh siapa saja**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Makanan ultraproses';
 
   @override
@@ -4520,9 +4508,6 @@ class AppLocalizationsId extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Tujuan utama ultra-proses adalah menciptakan produk pangan bermerek, praktis (tahan lama, siap konsumsi), menarik (sangat lezat), dan sangat menguntungkan (bahan-bahan berbiaya rendah) yang dirancang untuk menggantikan semua kelompok pangan lainnya. Produk pangan ultra-proses biasanya dikemas secara menarik dan dipasarkan secara intensif.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Pratinjau';

--- a/packages/smooth_app/lib/l10n/app_localizations_ii.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ii.dart
@@ -321,10 +321,6 @@ class AppLocalizationsIi extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4204,10 +4200,6 @@ class AppLocalizationsIi extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4397,10 +4389,6 @@ class AppLocalizationsIi extends AppLocalizations {
       'Unlike proprietary labels, the Green-Score calculation is **completely open** and can be **verified by anyone**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4488,9 +4476,6 @@ class AppLocalizationsIi extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'The overall purpose of ultra-processing is to create branded, convenient (durable, ready to consume), attractive (hyper-palatable) and highly profitable (low-cost ingredients) food products designed to displace all other food groups. Ultra-processed food products are usually packaged attractively and marketed intensively.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_is.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_is.dart
@@ -321,10 +321,6 @@ class AppLocalizationsIs extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4203,10 +4199,6 @@ class AppLocalizationsIs extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4394,10 +4386,6 @@ class AppLocalizationsIs extends AppLocalizations {
       'Ólíkt einkaleyfisvernduðum merkjum er útreikningur Græna stigsins **algjörlega opinn** og hver sem er getur **staðfest hann**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4483,9 +4471,6 @@ class AppLocalizationsIs extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Megintilgangur öfgavinnslu er að skapa vörumerkjaðar, þægilegar (endingargóðar, tilbúnar til neyslu), aðlaðandi (ofurbragðgóðar) og mjög arðbærar (ódýr hráefni) matvörur sem eru hannaðar til að koma í stað allra annarra matvælaflokka. Ofurunnar matvörur eru yfirleitt pakkaðar á aðlaðandi hátt og markaðssettar á öflugan hátt.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_it.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_it.dart
@@ -324,10 +324,6 @@ class AppLocalizationsIt extends AppLocalizations {
   String get sign_up_page_terms_text => 'contributo di Open Food Facts';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://it.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4267,10 +4263,6 @@ class AppLocalizationsIt extends AppLocalizations {
       'Per i produttori, l\'esposizione del Nutri-Score **rimane facoltativa**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world-it.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4460,10 +4452,6 @@ class AppLocalizationsIt extends AppLocalizations {
       'A differenza delle etichette proprietarie, il calcolo del Green-Score è **completamente aperto** e può essere **verificato da chiunque**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Prodotti alimentari ultra-elaborati';
 
   @override
@@ -4552,9 +4540,6 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'L\'obiettivo generale dell\'ultra-processing è creare prodotti alimentari di marca, convenienti (durevoli, pronti al consumo), attraenti (iper-appetibili) e altamente redditizi (con ingredienti a basso costo), progettati per sostituire tutti gli altri gruppi alimentari. I prodotti alimentari ultra-processati sono solitamente confezionati in modo accattivante e commercializzati in modo intensivo.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Anteprima';

--- a/packages/smooth_app/lib/l10n/app_localizations_iu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_iu.dart
@@ -321,10 +321,6 @@ class AppLocalizationsIu extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4204,10 +4200,6 @@ class AppLocalizationsIu extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4397,10 +4389,6 @@ class AppLocalizationsIu extends AppLocalizations {
       'Unlike proprietary labels, the Green-Score calculation is **completely open** and can be **verified by anyone**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4488,9 +4476,6 @@ class AppLocalizationsIu extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'The overall purpose of ultra-processing is to create branded, convenient (durable, ready to consume), attractive (hyper-palatable) and highly profitable (low-cost ingredients) food products designed to displace all other food groups. Ultra-processed food products are usually packaged attractively and marketed intensively.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_ja.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ja.dart
@@ -313,10 +313,6 @@ class AppLocalizationsJa extends AppLocalizations {
   String get sign_up_page_terms_text => '利用と貢献規約';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://jp.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4111,10 +4107,6 @@ class AppLocalizationsJa extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4291,10 +4283,6 @@ class AppLocalizationsJa extends AppLocalizations {
       '独自のラベルとは異なり、グリーン スコアの計算は **完全にオープン** であり、**誰でも検証できます**。';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4376,9 +4364,6 @@ class AppLocalizationsJa extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       '超加工の全体的な目的は、ブランド力があり、利便性（耐久性があり、すぐに食べられる）、魅力（非常に美味しい）、そして収益性（低コストの原材料）に優れた食品を製造し、他のすべての食品群に取って代わることです。超加工食品は通常、魅力的なパッケージで包装され、集中的に販売されます。';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'プレビュー';

--- a/packages/smooth_app/lib/l10n/app_localizations_jv.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_jv.dart
@@ -321,10 +321,6 @@ class AppLocalizationsJv extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4205,10 +4201,6 @@ class AppLocalizationsJv extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4396,10 +4388,6 @@ class AppLocalizationsJv extends AppLocalizations {
       'Ora kaya label kepemilikan, pitungan Green-Score **rampung mbukak** lan bisa **diverifikasi dening sapa wae**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4486,9 +4474,6 @@ class AppLocalizationsJv extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Tujuan sakabèhé saka ultra-processing yaiku kanggo nggawe produk pangan bermerek, trep (awet, siap dikonsumsi), menarik (hiper enak) lan duwe bathi (bahan murah) sing dirancang kanggo ngganti kabeh kelompok panganan liyane. Produk panganan sing wis diproses biasane dikemas kanthi apik lan dipasarake kanthi intensif.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_ka.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ka.dart
@@ -321,10 +321,6 @@ class AppLocalizationsKa extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4205,10 +4201,6 @@ class AppLocalizationsKa extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4397,10 +4389,6 @@ class AppLocalizationsKa extends AppLocalizations {
       'საკუთრების ეტიკეტებისგან განსხვავებით, მწვანე ქულის გამოთვლა **სრულიად ღიაა** და მისი **გადამოწმება ნებისმიერს** შეუძლია.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4487,9 +4475,6 @@ class AppLocalizationsKa extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'ულტრა-დამუშავების საერთო მიზანია ბრენდირებული, მოსახერხებელი (ხანგრძლივი, მოხმარებისთვის მზა), მიმზიდველი (ჰიპერ-გემრიელი) და მაღალმომგებიანი (დაბალი ღირებულების ინგრედიენტები) საკვები პროდუქტების შექმნა, რომლებიც შექმნილია ყველა სხვა საკვები ჯგუფის ჩასანაცვლებლად. ულტრა-დამუშავებული საკვები პროდუქტები, როგორც წესი, მიმზიდველად არის შეფუთული და ინტენსიურად იყიდება ბაზარზე.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_kk.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_kk.dart
@@ -321,10 +321,6 @@ class AppLocalizationsKk extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4206,10 +4202,6 @@ class AppLocalizationsKk extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4399,10 +4391,6 @@ class AppLocalizationsKk extends AppLocalizations {
       'Меншікті белгілерден айырмашылығы, Green-Score есебі **толығымен ашық** болып табылады және оны **кез келген адам тексере алады**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4489,9 +4477,6 @@ class AppLocalizationsKk extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Ультра өңдеудің жалпы мақсаты барлық басқа азық-түлік топтарын ығыстыруға арналған брендті, ыңғайлы (тозуға төзімді, тұтынуға дайын), тартымды (гипер-дәмді) және жоғары табысты (құны төмен ингредиенттер) азық-түлік өнімдерін жасау болып табылады. Ультра өңделген тамақ өнімдері әдетте тартымды түрде оралып, қарқынды түрде сатылады.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_km.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_km.dart
@@ -321,10 +321,6 @@ class AppLocalizationsKm extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4203,10 +4199,6 @@ class AppLocalizationsKm extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4394,10 +4386,6 @@ class AppLocalizationsKm extends AppLocalizations {
       'មិនដូចស្លាកកម្មសិទ្ធិទេ ការគណនាពិន្ទុបៃតងគឺ **បើកទាំងស្រុង** ហើយអាចត្រូវបាន **ផ្ទៀងផ្ទាត់ដោយនរណាម្នាក់**។';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4483,9 +4471,6 @@ class AppLocalizationsKm extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'គោលបំណងរួមនៃការកែច្នៃជ្រុលគឺដើម្បីបង្កើតម៉ាកយីហោ ងាយស្រួល (ជាប់លាប់ ត្រៀមខ្លួនជាស្រេចក្នុងការប្រើប្រាស់) ភាពទាក់ទាញ (គួរឱ្យចង់ញ៉ាំ) និងទទួលបានផលចំណេញខ្ពស់ (គ្រឿងផ្សំតម្លៃទាប) ផលិតផលអាហារដែលត្រូវបានរចនាឡើងដើម្បីផ្លាស់ប្តូរក្រុមអាហារផ្សេងទៀតទាំងអស់។ ផលិតផលអាហារកែច្នៃជ្រុល ជាធម្មតាត្រូវបានវេចខ្ចប់យ៉ាងទាក់ទាញ និងទីផ្សារខ្លាំង។';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_kn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_kn.dart
@@ -321,10 +321,6 @@ class AppLocalizationsKn extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4208,10 +4204,6 @@ class AppLocalizationsKn extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4398,10 +4390,6 @@ class AppLocalizationsKn extends AppLocalizations {
       'ಸ್ವಾಮ್ಯದ ಲೇಬಲ್‌ಗಳಿಗಿಂತ ಭಿನ್ನವಾಗಿ, ಗ್ರೀನ್-ಸ್ಕೋರ್ ಲೆಕ್ಕಾಚಾರವು **ಸಂಪೂರ್ಣವಾಗಿ ಮುಕ್ತವಾಗಿದೆ** ಮತ್ತು ಇದನ್ನು **ಯಾರಾದರೂ ಪರಿಶೀಲಿಸಬಹುದು**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4488,9 +4476,6 @@ class AppLocalizationsKn extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'ಅಲ್ಟ್ರಾ-ಪ್ರೊಸೆಸಿಂಗ್‌ನ ಒಟ್ಟಾರೆ ಉದ್ದೇಶವೆಂದರೆ ಇತರ ಎಲ್ಲಾ ಆಹಾರ ಗುಂಪುಗಳನ್ನು ಬದಲಿಸಲು ವಿನ್ಯಾಸಗೊಳಿಸಲಾದ ಬ್ರ್ಯಾಂಡೆಡ್, ಅನುಕೂಲಕರ (ಬಾಳಿಕೆ ಬರುವ, ಸೇವಿಸಲು ಸಿದ್ಧ), ಆಕರ್ಷಕ (ಅತಿ-ರುಚಿಕರ) ಮತ್ತು ಹೆಚ್ಚು ಲಾಭದಾಯಕ (ಕಡಿಮೆ-ವೆಚ್ಚದ ಪದಾರ್ಥಗಳು) ಆಹಾರ ಉತ್ಪನ್ನಗಳನ್ನು ರಚಿಸುವುದು. ಅಲ್ಟ್ರಾ-ಪ್ರೊಸೆಸ್ಡ್ ಆಹಾರ ಉತ್ಪನ್ನಗಳನ್ನು ಸಾಮಾನ್ಯವಾಗಿ ಆಕರ್ಷಕವಾಗಿ ಪ್ಯಾಕ್ ಮಾಡಲಾಗುತ್ತದೆ ಮತ್ತು ತೀವ್ರವಾಗಿ ಮಾರಾಟ ಮಾಡಲಾಗುತ್ತದೆ.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_ko.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ko.dart
@@ -313,10 +313,6 @@ class AppLocalizationsKo extends AppLocalizations {
   String get sign_up_page_terms_text => '이용 및 기여 약관';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-ko.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4150,10 +4146,6 @@ class AppLocalizationsKo extends AppLocalizations {
       '제조업체의 경우 Nutri-Score 표시 여부는 **선택 사항**입니다.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => '친환경 점수';
 
   @override
@@ -4332,10 +4324,6 @@ class AppLocalizationsKo extends AppLocalizations {
       '독점 라벨과 달리 Green-Score 계산은 **완전히 공개**되어 **누구나 검증**할 수 있습니다.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => '가공 식품';
 
   @override
@@ -4417,9 +4405,6 @@ class AppLocalizationsKo extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       '초가공 식품의 전반적인 목적은 브랜드 인지도가 높고, 편리하며(내구성이 뛰어나고, 바로 섭취할 수 있으며), 매력적이며(매우 맛있으며), 수익성이 높은(저렴한 재료 사용) 식품을 개발하여 다른 모든 식품군을 대체하는 것입니다. 초가공 식품은 일반적으로 매력적인 포장과 집중적인 마케팅을 통해 판매됩니다.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_ku.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ku.dart
@@ -321,10 +321,6 @@ class AppLocalizationsKu extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4205,10 +4201,6 @@ class AppLocalizationsKu extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4395,10 +4387,6 @@ class AppLocalizationsKu extends AppLocalizations {
       'Berevajî etîketên taybet, hesabkirina Green-Score **bi tevahî vekirî** ye û dikare ji hêla **her kesî** ve were verast kirin.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4486,9 +4474,6 @@ class AppLocalizationsKu extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Armanca giştî ya ultra-proseskirinê ew e ku berhemên xwarinê yên bi marqe, hêsan (mayînde, amade ne ji bo vexwarinê), balkêş (pir xweş) û pir qezenckar (malzemeyên erzan) biafirînin ku ji bo cîhê hemû komên xwarinên din hatine çêkirin. Berhemên xwarinê yên ultra-proseskirî bi gelemperî bi rengek balkêş têne pakêt kirin û bi giranî têne bazar kirin.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_kw.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_kw.dart
@@ -321,10 +321,6 @@ class AppLocalizationsKw extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4204,10 +4200,6 @@ class AppLocalizationsKw extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4397,10 +4389,6 @@ class AppLocalizationsKw extends AppLocalizations {
       'Unlike proprietary labels, the Green-Score calculation is **completely open** and can be **verified by anyone**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4488,9 +4476,6 @@ class AppLocalizationsKw extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'The overall purpose of ultra-processing is to create branded, convenient (durable, ready to consume), attractive (hyper-palatable) and highly profitable (low-cost ingredients) food products designed to displace all other food groups. Ultra-processed food products are usually packaged attractively and marketed intensively.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_ky.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ky.dart
@@ -321,10 +321,6 @@ class AppLocalizationsKy extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4206,10 +4202,6 @@ class AppLocalizationsKy extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4398,10 +4390,6 @@ class AppLocalizationsKy extends AppLocalizations {
       'Проприетардык энбелгилерден айырмаланып, Green-Score эсептөөсү **толугу менен ачык** жана **ар ким тарабынан текшерилиши мүмкүн**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4488,9 +4476,6 @@ class AppLocalizationsKy extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Ультра кайра иштетүүнүн жалпы максаты – бренддүү, ыңгайлуу (узак, колдонууга даяр), жагымдуу (гипер даамдуу) жана жогорку рентабелдүү (арзан ингредиенттер) тамак-аш азыктарынын бардык башка тамак-аш топторун алмаштырууга багытталган. Ультра иштетилген тамак-аш азыктары, адатта, жагымдуу таңгакталган жана интенсивдүү сатылат.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_la.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_la.dart
@@ -321,10 +321,6 @@ class AppLocalizationsLa extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4204,10 +4200,6 @@ class AppLocalizationsLa extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4397,10 +4389,6 @@ class AppLocalizationsLa extends AppLocalizations {
       'Dissimilis notis propriis, computatio Green-Score **omnino aperta** est et ab quolibet **verificari** potest.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4488,9 +4476,6 @@ class AppLocalizationsLa extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Propositum generale ultra-processus est creare cibos nobiles, commodos (durabiles, ad consumendum paratos), attractivos (hyper-sapidos) et valde lucrativos (ingredientibus vilis) destinatos ad omnes alias genera ciborum substituenda. Cibi ultra-processi plerumque attractive involucris involuuntur et intensive venduntur.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_lb.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_lb.dart
@@ -321,10 +321,6 @@ class AppLocalizationsLb extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4207,10 +4203,6 @@ class AppLocalizationsLb extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4398,10 +4390,6 @@ class AppLocalizationsLb extends AppLocalizations {
       'Am Géigesaz zu proprietäre Labelen ass d\'Green-Score Berechnung **komplett oppen** a kann vun jidderengem **verifizéiert** ginn.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4489,9 +4477,6 @@ class AppLocalizationsLb extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Den allgemengen Zweck vun der Ultraveraarbechtung ass et, Marken-, praktesch (haltbar, konsuméierbar), attraktiv (hyper-schmackhaft) a ganz rentabel (bëlleg Zutaten) Liewensmëttelprodukter ze kreéieren, déi all aner Liewensmëttelgruppen ersetzen sollen. Ultraveraarbechte Liewensmëttelprodukter gi meeschtens attraktiv verpackt a intensiv vermaart.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_lo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_lo.dart
@@ -321,10 +321,6 @@ class AppLocalizationsLo extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4203,10 +4199,6 @@ class AppLocalizationsLo extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4394,10 +4386,6 @@ class AppLocalizationsLo extends AppLocalizations {
       'ບໍ່ຄືກັບປ້າຍກຳກັບທີ່ເປັນເຈົ້າຂອງ, ການຄຳນວນ Green-Score ແມ່ນ **ເປີດຢ່າງຄົບຖ້ວນ** ແລະສາມາດຖືກກວດສອບໄດ້ໂດຍທຸກຄົນ**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4484,9 +4472,6 @@ class AppLocalizationsLo extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'ຈຸດປະສົງໂດຍລວມຂອງການປຸງແຕ່ງແບບພິເສດແມ່ນເພື່ອສ້າງຍີ່ຫໍ້, ສະດວກ (ທົນທານ, ພ້ອມທີ່ຈະບໍລິໂພກ), ດຶງດູດໃຈ (hyper-palatable) ແລະຜະລິດຕະພັນອາຫານທີ່ມີກໍາໄລສູງ (ຄ່າໃຊ້ຈ່າຍຕ່ໍາ) ທີ່ຖືກອອກແບບມາເພື່ອຍ້າຍກຸ່ມອາຫານອື່ນໆທັງຫມົດ. ຜະລິດຕະພັນອາຫານທີ່ປຸງແຕ່ງແບບພິເສດແມ່ນປົກກະຕິແລ້ວຖືກຫຸ້ມຫໍ່ຢ່າງດຶງດູດ ແລະ ຕະຫຼາດຢ່າງເຂັ້ມງວດ.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_lt.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_lt.dart
@@ -328,10 +328,6 @@ class AppLocalizationsLt extends AppLocalizations {
   String get sign_up_page_terms_text => 'naudojimo ir įnašo sąlygomis';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-lt.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4262,10 +4258,6 @@ class AppLocalizationsLt extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4454,10 +4446,6 @@ class AppLocalizationsLt extends AppLocalizations {
       'Kitaip nei patentuotų etikečių atveju, „Green-Score“ skaičiavimas yra **visiškai atviras** ir jį gali **patvirtinti bet kas**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://lt.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4544,9 +4532,6 @@ class AppLocalizationsLt extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Bendras ultraperdirbimo tikslas – kurti firminius, patogius (patvarius, paruoštus vartoti), patrauklius (itin skanius) ir labai pelningus (su pigiais ingredientais) maisto produktus, skirtus išstumti visas kitas maisto grupes. Ultraperdirbti maisto produktai paprastai yra patraukliai supakuoti ir intensyviai parduodami.';
-
-  @override
-  String get guide_nova_share_link => 'https://lt.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_lv.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_lv.dart
@@ -321,10 +321,6 @@ class AppLocalizationsLv extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4205,10 +4201,6 @@ class AppLocalizationsLv extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4396,10 +4388,6 @@ class AppLocalizationsLv extends AppLocalizations {
       'Atšķirībā no patentētām etiķetēm, Green-Score aprēķins ir **pilnīgi atvērts** un to var **pārbaudīt jebkurš**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://lv.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4486,9 +4474,6 @@ class AppLocalizationsLv extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Ultraapstrādes vispārējais mērķis ir radīt firmas zīmola, ērtus (izturīgus, gatavus patēriņam), pievilcīgus (ļoti garšīgus) un ļoti ienesīgus (ar zemām sastāvdaļām) pārtikas produktus, kas paredzēti, lai aizstātu visas pārējās pārtikas grupas. Ultraapstrādāti pārtikas produkti parasti tiek pievilcīgi iepakoti un intensīvi tirgoti.';
-
-  @override
-  String get guide_nova_share_link => 'https://lv.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_mg.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_mg.dart
@@ -321,10 +321,6 @@ class AppLocalizationsMg extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4208,10 +4204,6 @@ class AppLocalizationsMg extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4401,10 +4393,6 @@ class AppLocalizationsMg extends AppLocalizations {
       'Tsy toy ny etikety tompon\'andraikitra, ny kajy Green-Score dia ** misokatra tanteraka** ary azo **hamarinin\'ny olona**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4493,9 +4481,6 @@ class AppLocalizationsMg extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Ny tanjona ankapoben\'ny fanodinana ultra dia ny hamorona vokatra sakafo misy marika, mety (maharitra, vonona hohanina), mahasarika (hiper-mahafinaritra) ary tena mahazo tombony (engaron\'ny vidiny mora) natao hamindrana ireo vondrona sakafo hafa rehetra. Ny vokatra sakafo vita amin\'ny fomba faran\'izay bitika dia mazàna nofonosina amin\'ny fomba mahasarika sy amidin\'ny tsena.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_mi.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_mi.dart
@@ -321,10 +321,6 @@ class AppLocalizationsMi extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4209,10 +4205,6 @@ class AppLocalizationsMi extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4401,10 +4393,6 @@ class AppLocalizationsMi extends AppLocalizations {
       'Kare i rite ki nga tapanga rangatira, ko te tatauranga Kakariki-Score he **tuwhera rawa** ka taea **manatokohia e tetahi**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4492,9 +4480,6 @@ class AppLocalizationsMi extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Ko te kaupapa katoa o te tukatuka ultra ko te hanga parani, watea (te roa, kua rite ki te kai), ataahua (he tino reka) me te tino whai hua (nga kai iti-utu) i hangaia hei whakakore i nga roopu kai katoa. Ko nga hua kai kua oti te tukatuka i te nuinga o te waa he tino ataahua, ka kaha te maakete.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_ml.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ml.dart
@@ -321,10 +321,6 @@ class AppLocalizationsMl extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4205,10 +4201,6 @@ class AppLocalizationsMl extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4397,10 +4389,6 @@ class AppLocalizationsMl extends AppLocalizations {
       'പ്രൊപ്രൈറ്ററി ലേബലുകളിൽ നിന്ന് വ്യത്യസ്തമായി, ഗ്രീൻ-സ്കോർ കണക്കുകൂട്ടൽ **പൂർണ്ണമായും തുറന്നിരിക്കുന്നു** കൂടാതെ ആർക്കും **പരിശോധിക്കാൻ കഴിയും**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4488,9 +4476,6 @@ class AppLocalizationsMl extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'അൾട്രാ-പ്രോസസ്സിംഗിന്റെ മൊത്തത്തിലുള്ള ലക്ഷ്യം, മറ്റെല്ലാ ഭക്ഷ്യ ഗ്രൂപ്പുകളെയും മാറ്റിസ്ഥാപിക്കുന്നതിനായി രൂപകൽപ്പന ചെയ്ത ബ്രാൻഡഡ്, സൗകര്യപ്രദമായ (ഈടുനിൽക്കുന്ന, കഴിക്കാൻ തയ്യാറായ), ആകർഷകമായ (അമിത-സ്വാദിഷ്ടമായ) ഉയർന്ന ലാഭകരമായ (കുറഞ്ഞ വിലയുള്ള ചേരുവകൾ) ഭക്ഷ്യ ഉൽപ്പന്നങ്ങൾ സൃഷ്ടിക്കുക എന്നതാണ്. അൾട്രാ-പ്രോസസ് ചെയ്ത ഭക്ഷ്യ ഉൽപ്പന്നങ്ങൾ സാധാരണയായി ആകർഷകമായ രീതിയിൽ പാക്കേജുചെയ്യുകയും തീവ്രമായി വിപണനം ചെയ്യുകയും ചെയ്യുന്നു.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_mn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_mn.dart
@@ -321,10 +321,6 @@ class AppLocalizationsMn extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4206,10 +4202,6 @@ class AppLocalizationsMn extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4398,10 +4390,6 @@ class AppLocalizationsMn extends AppLocalizations {
       'Өмчлөлийн шошгуудаас ялгаатай нь Ногоон онооны тооцоолол нь **бүрэн нээлттэй** бөгөөд **бүх хүн баталгаажуулах боломжтой**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4489,9 +4477,6 @@ class AppLocalizationsMn extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Хэт боловсруулалтын ерөнхий зорилго нь бусад бүх хүнсний бүлгийг нүүлгэн шилжүүлэх зориулалттай брендийн, тохиромжтой (удаан эдэлгээтэй, хэрэглэхэд бэлэн), сэтгэл татам (хэт амттай) болон өндөр ашигтай (хямд өртөгтэй найрлагатай) хүнсний бүтээгдэхүүнийг бий болгох явдал юм. Хэт боловсруулсан хүнсний бүтээгдэхүүнийг ихэвчлэн сэтгэл татам байдлаар савлаж, эрчимтэй зах зээлд гаргадаг.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_mr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_mr.dart
@@ -322,10 +322,6 @@ class AppLocalizationsMr extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4206,10 +4202,6 @@ class AppLocalizationsMr extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4396,10 +4388,6 @@ class AppLocalizationsMr extends AppLocalizations {
       'मालकीच्या लेबल्सच्या विपरीत, ग्रीन-स्कोअर गणना **पूर्णपणे खुली** आहे** आणि **कोणीही ती सत्यापित** करू शकते.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4486,9 +4474,6 @@ class AppLocalizationsMr extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'अल्ट्रा-प्रोसेसिंगचा एकंदर उद्देश म्हणजे ब्रँडेड, सोयीस्कर (टिकाऊ, वापरण्यास तयार), आकर्षक (अति-रुचिकर) आणि अत्यंत फायदेशीर (कमी किमतीचे घटक) अन्न उत्पादने तयार करणे जे इतर सर्व अन्न गटांना विस्थापित करण्यासाठी डिझाइन केलेले आहेत. अल्ट्रा-प्रोसेस्ड अन्न उत्पादने सहसा आकर्षकपणे पॅक केली जातात आणि त्यांची सघन विक्री केली जाते.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_ms.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ms.dart
@@ -321,10 +321,6 @@ class AppLocalizationsMs extends AppLocalizations {
   String get sign_up_page_terms_text => 'syarat penggunaan dan sumbangan';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4207,10 +4203,6 @@ class AppLocalizationsMs extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4398,10 +4390,6 @@ class AppLocalizationsMs extends AppLocalizations {
       'Tidak seperti label proprietari, pengiraan Green-Score **terbuka sepenuhnya** dan boleh **disahkan oleh sesiapa sahaja**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4489,9 +4477,6 @@ class AppLocalizationsMs extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Tujuan keseluruhan pemprosesan ultra adalah untuk mencipta produk makanan berjenama, mudah (tahan lama, sedia untuk dimakan), menarik (hiper sedap) dan sangat menguntungkan (ramuan kos rendah) yang direka untuk menggantikan semua kumpulan makanan lain. Produk makanan ultra-proses biasanya dibungkus dengan menarik dan dipasarkan secara intensif.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_mt.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_mt.dart
@@ -321,10 +321,6 @@ class AppLocalizationsMt extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4205,10 +4201,6 @@ class AppLocalizationsMt extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4397,10 +4389,6 @@ class AppLocalizationsMt extends AppLocalizations {
       'B\'differenza mit-tikketti proprjetarji, il-kalkolu tal-Green-Score huwa **kompletament miftuħ** u jista\' jiġi **verifikat minn kulħadd**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4487,9 +4475,6 @@ class AppLocalizationsMt extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'L-iskop ġenerali tal-ultra-proċessar huwa li jinħolqu prodotti tal-ikel tad-ditta, konvenjenti (durabbli, lesti biex jiġu kkunsmati), attraenti (iper-palatabbli) u profittabbli ħafna (ingredjenti bi prezz baxx) iddisinjati biex jieħdu post il-gruppi tal-ikel l-oħra kollha. Prodotti tal-ikel ultra-proċessati ġeneralment ikunu ppakkjati b\'mod attraenti u kkummerċjalizzati b\'mod intensiv.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_my.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_my.dart
@@ -321,10 +321,6 @@ class AppLocalizationsMy extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4211,10 +4207,6 @@ class AppLocalizationsMy extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4403,10 +4395,6 @@ class AppLocalizationsMy extends AppLocalizations {
       'မူပိုင်အညွှန်းများနှင့်မတူဘဲ၊ Green-Score တွက်ချက်မှုသည် **လုံးဝဖွင့်ထားသည်** ဖြစ်ပြီး မည်သူမဆို **စစ်ဆေးနိုင်ပါသည်။**';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4495,9 +4483,6 @@ class AppLocalizationsMy extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'လွန်ကဲစွာ စီမံဆောင်ရွက်ပေးခြင်း၏ အလုံးစုံရည်ရွယ်ချက်မှာ အခြားအစားအစာအုပ်စုအားလုံးကို ရွှေ့ပြောင်းရန် ဒီဇိုင်းထုတ်ထားသော အမှတ်တံဆိပ်ပါသော၊ အဆင်ပြေသော (တာရှည်ခံ၊ စားသုံးရန်အသင့်)၊ ဆွဲဆောင်မှု (hyper-palatable) နှင့် အလွန်အမြတ်အစွန်းရနိုင်သော (ကုန်ကျစရိတ်သက်သာသော ပါဝင်ပစ္စည်းများ) အစားအသောက်ထုတ်ကုန်များကို ဖန်တီးရန်ဖြစ်သည်။ လွန်လွန်ကဲကဲ ပြုပြင်ထားသော အစားအသောက်ထုတ်ကုန်များကို အများအားဖြင့် ဆွဲဆောင်မှုရှိရှိ ထုပ်ပိုးပြီး စျေးကွက်တွင် အလေးအနက်ထားကြသည်။';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_nb.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_nb.dart
@@ -323,10 +323,6 @@ class AppLocalizationsNb extends AppLocalizations {
   String get sign_up_page_terms_text => 'vilkår for bruk og bidrag';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4219,10 +4215,6 @@ class AppLocalizationsNb extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4410,10 +4402,6 @@ class AppLocalizationsNb extends AppLocalizations {
       'I motsetning til proprietære merker, er beregningen av \"Green-Score **helt åpen\"** og kan **verifiseres av hvem som helst**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://no.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultrabearbeidet mat';
 
   @override
@@ -4502,9 +4490,6 @@ class AppLocalizationsNb extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Det overordnede formålet med ultraprosessering er å skape merkevareprodukter som er praktiske (holdbare, klare til konsum), attraktive (hyper-velsmakende) og svært lønnsomme (lavkostingredienser) og er utformet for å erstatte alle andre matvaregrupper. Ultraprosesserte matvarer pakkes vanligvis attraktivt og markedsføres intensivt.';
-
-  @override
-  String get guide_nova_share_link => 'https://no.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_ne.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ne.dart
@@ -321,10 +321,6 @@ class AppLocalizationsNe extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4204,10 +4200,6 @@ class AppLocalizationsNe extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4394,10 +4386,6 @@ class AppLocalizationsNe extends AppLocalizations {
       'स्वामित्व लेबलहरू भन्दा फरक, ग्रीन-स्कोर गणना **पूर्ण रूपमा खुला** छ** र **जो कोही पनि द्वारा प्रमाणित** गर्न सकिन्छ।';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4483,9 +4471,6 @@ class AppLocalizationsNe extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'अल्ट्रा-प्रशोधनको समग्र उद्देश्य ब्रान्डेड, सुविधाजनक (टिकाउ, उपभोग गर्न तयार), आकर्षक (अति-स्वादिष्ट) र अत्यधिक लाभदायक (कम लागत सामग्री) खाद्य उत्पादनहरू सिर्जना गर्नु हो जुन अन्य सबै खाद्य समूहहरूलाई विस्थापित गर्न डिजाइन गरिएको हो। अल्ट्रा-प्रशोधित खाद्य उत्पादनहरू सामान्यतया आकर्षक रूपमा प्याकेज गरिन्छ र गहन रूपमा बजारमा ल्याइन्छ।';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_nl.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_nl.dart
@@ -325,10 +325,6 @@ class AppLocalizationsNl extends AppLocalizations {
   String get sign_up_page_terms_text => 'gebruiksvoorwaarden en bijdrage';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4255,10 +4251,6 @@ class AppLocalizationsNl extends AppLocalizations {
       'Voor fabrikanten blijft de weergave van de Nutri-Score **optioneel**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4444,10 +4436,6 @@ class AppLocalizationsNl extends AppLocalizations {
       'In tegenstelling tot merkgebonden labels is de Green-Score-berekening **volledig open** en kan deze **door iedereen** worden geverifieerd.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-verwerkte voedingsmiddelen';
 
   @override
@@ -4535,9 +4523,6 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Het algemene doel van ultra-bewerking is het creëren van merkproducten die gemakkelijk te consumeren (klaar voor consumptie), aantrekkelijk (superlekker) en zeer winstgevend (met goedkope ingrediënten) zijn, ontworpen om alle andere voedselgroepen te verdringen. Ultra-bewerkte voedselproducten worden meestal aantrekkelijk verpakt en intensief op de markt gebracht.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Voorbeeld';

--- a/packages/smooth_app/lib/l10n/app_localizations_nn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_nn.dart
@@ -321,10 +321,6 @@ class AppLocalizationsNn extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4204,10 +4200,6 @@ class AppLocalizationsNn extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4394,10 +4386,6 @@ class AppLocalizationsNn extends AppLocalizations {
       'I motsetning til proprietære etiketter er Green-Score-beregningen **helt åpen** og kan **verifiseres av hvem som helst**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4485,9 +4473,6 @@ class AppLocalizationsNn extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Det overordnede formålet med ultraprosessering er å skape merkevareprodukter som er praktiske (holdbare, klare til konsum), attraktive (hyper-velsmakende) og svært lønnsomme (lavkostingredienser) og er utformet for å erstatte alle andre matvaregrupper. Ultraprosesserte matvarer pakkes vanligvis attraktivt og markedsføres intensivt.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_no.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_no.dart
@@ -321,10 +321,6 @@ class AppLocalizationsNo extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4204,10 +4200,6 @@ class AppLocalizationsNo extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4394,10 +4386,6 @@ class AppLocalizationsNo extends AppLocalizations {
       'I motsetning til proprietære etiketter er Green-Score-beregningen **helt åpen** og kan **verifiseres av hvem som helst**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4485,9 +4473,6 @@ class AppLocalizationsNo extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Det overordnede formålet med ultraprosessering er å skape merkevareprodukter som er praktiske (holdbare, klare til konsum), attraktive (hyper-velsmakende) og svært lønnsomme (lavkostingredienser) og er utformet for å erstatte alle andre matvaregrupper. Ultraprosesserte matvarer pakkes vanligvis attraktivt og markedsføres intensivt.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_nr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_nr.dart
@@ -321,10 +321,6 @@ class AppLocalizationsNr extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4204,10 +4200,6 @@ class AppLocalizationsNr extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4397,10 +4389,6 @@ class AppLocalizationsNr extends AppLocalizations {
       'Unlike proprietary labels, the Green-Score calculation is **completely open** and can be **verified by anyone**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4488,9 +4476,6 @@ class AppLocalizationsNr extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'The overall purpose of ultra-processing is to create branded, convenient (durable, ready to consume), attractive (hyper-palatable) and highly profitable (low-cost ingredients) food products designed to displace all other food groups. Ultra-processed food products are usually packaged attractively and marketed intensively.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_oc.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_oc.dart
@@ -321,10 +321,6 @@ class AppLocalizationsOc extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4208,10 +4204,6 @@ class AppLocalizationsOc extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4403,10 +4395,6 @@ class AppLocalizationsOc extends AppLocalizations {
       'A la diferéncia de las etiquetas proprietàrias, lo calcul Green-Score es **completament dobèrt** e pòt èsser **verificat per qual que siá**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://oc.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4494,9 +4482,6 @@ class AppLocalizationsOc extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'L\'objectiu global de l\'ultra-transformacion es de crear de produches alimentaris de marca, convenents (durables, prèstes a consomar), atractius (iper-saborós) e fòrça rentables (ingredients de bas còst) concebuts per desplaçar totes los autres grops alimentaris. Los produches alimentaris ultratransformats son generalament embalats de manièra atractiva e comercializats intensivament.';
-
-  @override
-  String get guide_nova_share_link => 'https://oc.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_or.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_or.dart
@@ -323,10 +323,6 @@ class AppLocalizationsOr extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4210,10 +4206,6 @@ class AppLocalizationsOr extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4400,10 +4392,6 @@ class AppLocalizationsOr extends AppLocalizations {
       'ମାଲିକାନା ଲେବଲଗୁଡ଼ିକ ପରି ନୁହେଁ, ସବୁଜ-ସ୍କୋର ଗଣନା **ସମ୍ପୂର୍ଣ୍ଣ ଭାବରେ ଖୋଲା** ଏବଂ ଏହାକୁ **ଯେକୌଣସି ବ୍ୟକ୍ତିଙ୍କ ଦ୍ୱାରା ଯାଞ୍ଚ କରାଯାଇପାରିବ**।';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4491,9 +4479,6 @@ class AppLocalizationsOr extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'ଅଲ୍ଟ୍ରା-ପ୍ରକ୍ରିୟାକରଣର ସାମଗ୍ରିକ ଉଦ୍ଦେଶ୍ୟ ହେଉଛି ବ୍ରାଣ୍ଡେଡ୍, ସୁବିଧାଜନକ (ସ୍ଥାୟୀ, ବ୍ୟବହାର ପାଇଁ ପ୍ରସ୍ତୁତ), ଆକର୍ଷଣୀୟ (ଅତ୍ୟଧିକ ସ୍ୱାଦିଷ୍ଟ) ଏବଂ ଅତ୍ୟନ୍ତ ଲାଭଦାୟକ (କମ୍ ମୂଲ୍ୟର ଉପାଦାନ) ଖାଦ୍ୟ ଉତ୍ପାଦ ସୃଷ୍ଟି କରିବା ଯାହା ଅନ୍ୟ ସମସ୍ତ ଖାଦ୍ୟ ଗୋଷ୍ଠୀକୁ ସ୍ଥାନାନ୍ତରିତ କରିବା ପାଇଁ ଡିଜାଇନ୍ କରାଯାଇଛି। ଅଲ୍ଟ୍ରା-ପ୍ରକ୍ରିୟାକରଣ ଖାଦ୍ୟ ଉତ୍ପାଦଗୁଡ଼ିକ ସାଧାରଣତଃ ଆକର୍ଷଣୀୟ ଭାବରେ ପ୍ୟାକେଜ୍ କରାଯାଇଥାଏ ଏବଂ ଘନତାର ସହିତ ବଜାରରେ ବିପଣନ କରାଯାଏ।';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_pa.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_pa.dart
@@ -321,10 +321,6 @@ class AppLocalizationsPa extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4205,10 +4201,6 @@ class AppLocalizationsPa extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4395,10 +4387,6 @@ class AppLocalizationsPa extends AppLocalizations {
       'ਮਲਕੀਅਤ ਲੇਬਲਾਂ ਦੇ ਉਲਟ, ਗ੍ਰੀਨ-ਸਕੋਰ ਗਣਨਾ **ਪੂਰੀ ਤਰ੍ਹਾਂ ਖੁੱਲ੍ਹੀ** ਹੈ** ਅਤੇ ਇਸਨੂੰ **ਕਿਸੇ ਵੀ ਵਿਅਕਤੀ ਦੁਆਰਾ ਤਸਦੀਕ ਕੀਤਾ ਜਾ ਸਕਦਾ ਹੈ**।';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4485,9 +4473,6 @@ class AppLocalizationsPa extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'ਅਲਟਰਾ-ਪ੍ਰੋਸੈਸਿੰਗ ਦਾ ਸਮੁੱਚਾ ਉਦੇਸ਼ ਬ੍ਰਾਂਡੇਡ, ਸੁਵਿਧਾਜਨਕ (ਟਿਕਾਊ, ਖਪਤ ਲਈ ਤਿਆਰ), ਆਕਰਸ਼ਕ (ਬਹੁਤ ਸੁਆਦੀ) ਅਤੇ ਬਹੁਤ ਜ਼ਿਆਦਾ ਲਾਭਦਾਇਕ (ਘੱਟ ਕੀਮਤ ਵਾਲੀਆਂ ਸਮੱਗਰੀਆਂ) ਭੋਜਨ ਉਤਪਾਦ ਬਣਾਉਣਾ ਹੈ ਜੋ ਹੋਰ ਸਾਰੇ ਭੋਜਨ ਸਮੂਹਾਂ ਨੂੰ ਵਿਸਥਾਪਿਤ ਕਰਨ ਲਈ ਤਿਆਰ ਕੀਤੇ ਗਏ ਹਨ। ਅਲਟਰਾ-ਪ੍ਰੋਸੈਸਡ ਭੋਜਨ ਉਤਪਾਦਾਂ ਨੂੰ ਆਮ ਤੌਰ \'ਤੇ ਆਕਰਸ਼ਕ ਢੰਗ ਨਾਲ ਪੈਕ ਕੀਤਾ ਜਾਂਦਾ ਹੈ ਅਤੇ ਤੀਬਰਤਾ ਨਾਲ ਮਾਰਕੀਟ ਕੀਤਾ ਜਾਂਦਾ ਹੈ।';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_pl.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_pl.dart
@@ -328,10 +328,6 @@ class AppLocalizationsPl extends AppLocalizations {
       'warunkami użytkowania i wkładu w Open Food Facts';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-pl.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4257,10 +4253,6 @@ class AppLocalizationsPl extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4448,10 +4440,6 @@ class AppLocalizationsPl extends AppLocalizations {
       'W przeciwieństwie do zastrzeżonych etykiet, sposób obliczania Green-Score jest **całkowicie otwarty** i może zostać **zweryfikowany przez każdego**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Żywność wysoko przetworzona';
 
   @override
@@ -4538,9 +4526,6 @@ class AppLocalizationsPl extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Głównym celem ultraprzetwarzania jest tworzenie markowych, wygodnych (trwałych, gotowych do spożycia), atrakcyjnych (hipersmakowitych) i wysoce dochodowych (z tanich składników) produktów spożywczych, które mają zastąpić wszystkie inne grupy żywności. Produkty ultraprzetworzone są zazwyczaj atrakcyjnie pakowane i intensywnie promowane.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_pt.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_pt.dart
@@ -329,10 +329,6 @@ class AppLocalizationsPt extends AppLocalizations {
       'termos de utilização e contribuição do Open Food Facts';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://br.openfoodfacts.org/termos-de-uso';
-
-  @override
   String get donate_url =>
       'https://world-pt.openfoodfacts.org/fazer-um-donativo-ao-open-food-facts';
 
@@ -4287,10 +4283,6 @@ class AppLocalizationsPt extends AppLocalizations {
       'Para os fabricantes, a indicação do Nutri-Score **continua a ser facultativa**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4479,10 +4471,6 @@ class AppLocalizationsPt extends AppLocalizations {
       'Ao contrário dos rótulos proprietários, o cálculo do Green-Score é **completamente aberto** e pode ser **verificado por qualquer pessoa**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://pt.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Alimentos ultra-processados';
 
   @override
@@ -4571,9 +4559,6 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'O objetivo geral do ultraprocessamento é criar produtos alimentares de marca, práticos (duráveis, prontos a consumir), atraentes (hiperpalatáveis) e altamente rentáveis (ingredientes de baixo custo), concebidos para substituir todos os outros grupos alimentares. Os produtos alimentares ultraprocessados são geralmente embalados de forma atrativa e comercializados de forma intensiva.';
-
-  @override
-  String get guide_nova_share_link => 'https://pt.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Pré-visualizar';
@@ -5948,10 +5933,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String get sign_up_page_terms_text => 'termos de uso e contribuição';
-
-  @override
-  String get sign_up_page_agree_url =>
-      'https://br.openfoodfacts.org/termos-de-uso';
 
   @override
   String get donate_url =>
@@ -9904,10 +9885,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
       'Para os fabricantes, a exibição do Nutri-Score **continua opcional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Eco-Pontuação';
 
   @override
@@ -10096,10 +10073,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
       'Ao contrário dos rótulos proprietários, o cálculo do Green-Score é **completamente aberto** e pode ser **verificado por qualquer pessoa**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Alimentos ultraprocessados';
 
   @override
@@ -10188,9 +10161,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   @override
   String get guide_nova_explanations_arg4_text =>
       'O objetivo geral do ultraprocessamento é criar produtos alimentícios de marca, práticos (duráveis, prontos para consumo), atraentes (hiperpalatáveis) e altamente lucrativos (ingredientes de baixo custo), projetados para substituir todos os outros grupos alimentares. Produtos alimentícios ultraprocessados geralmente são embalados de forma atraente e comercializados de forma intensiva.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Pré-visualizar';

--- a/packages/smooth_app/lib/l10n/app_localizations_qu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_qu.dart
@@ -321,10 +321,6 @@ class AppLocalizationsQu extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4208,10 +4204,6 @@ class AppLocalizationsQu extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4404,10 +4396,6 @@ class AppLocalizationsQu extends AppLocalizations {
       'Mana propiedad etiquetakuna hinachu, Verde-Puntuación yupayqa **tukuy kichasqa** chaymanta **pillapas chiqaqchasqa kayta atin**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://qu.kichasqa mikhuykuna.org/verde-puntuación';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4496,10 +4484,6 @@ class AppLocalizationsQu extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Ultra-procesamiento nisqapa tukuy ima munayninqa, markayuq, allin (unaypaq, mikuypaq listo), munay (hiper-palatable) hinaspa ancha gananciayuq (ingredientekuna pisi qullqiyuq) mikhuy rurukuna ruwaymi, llapan huk mikhuy huñukunata qarqunapaq ruwasqa. Ultra-procesado nisqa mikhuy rurukunaqa sumaqllatam paqueteasqa kanku, hinaspapas anchatam qhatunku.';
-
-  @override
-  String get guide_nova_share_link =>
-      'https://qu.kichasqa mikhuykuna.org/nova nisqapi';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_rm.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_rm.dart
@@ -321,10 +321,6 @@ class AppLocalizationsRm extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4204,10 +4200,6 @@ class AppLocalizationsRm extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4397,10 +4389,6 @@ class AppLocalizationsRm extends AppLocalizations {
       'Unlike proprietary labels, the Green-Score calculation is **completely open** and can be **verified by anyone**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4488,9 +4476,6 @@ class AppLocalizationsRm extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'The overall purpose of ultra-processing is to create branded, convenient (durable, ready to consume), attractive (hyper-palatable) and highly profitable (low-cost ingredients) food products designed to displace all other food groups. Ultra-processed food products are usually packaged attractively and marketed intensively.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_ro.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ro.dart
@@ -328,10 +328,6 @@ class AppLocalizationsRo extends AppLocalizations {
   String get sign_up_page_terms_text => 'termeni de utilizare și contribuție';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-ro.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4262,10 +4258,6 @@ class AppLocalizationsRo extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Scor Ecologic';
 
   @override
@@ -4455,10 +4447,6 @@ class AppLocalizationsRo extends AppLocalizations {
       'Spre deosebire de etichetele proprietare, calculul Green-Score este **complet deschis** și poate fi **verificat de oricine**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Alimente ultraprocesate';
 
   @override
@@ -4545,9 +4533,6 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Scopul general al ultra-procesării este de a crea produse alimentare de marcă, convenabile (durabile, gata de consum), atractive (hiper-palatabile) și extrem de profitabile (ingrediente cu costuri reduse), concepute pentru a înlocui toate celelalte grupe de alimente. Produsele alimentare ultra-procesate sunt de obicei ambalate atractiv și comercializate intensiv.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_ru.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ru.dart
@@ -326,10 +326,6 @@ class AppLocalizationsRu extends AppLocalizations {
   String get sign_up_page_terms_text => 'условия использования и вклад';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url =>
       'https://world-ru.openfoodfacts.org/pozhertvovat-open-food-facts';
 
@@ -4308,10 +4304,6 @@ class AppLocalizationsRu extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4499,10 +4491,6 @@ class AppLocalizationsRu extends AppLocalizations {
       'В отличие от фирменных лейблов, расчет Green-Score **полностью открыт** и может быть **проверен любым**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ультра-обработанные продукты';
 
   @override
@@ -4590,9 +4578,6 @@ class AppLocalizationsRu extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Основная цель ультрапереработки — создание фирменных, удобных (долговечных, готовых к употреблению), привлекательных (очень вкусных) и высокорентабельных (с использованием недорогих ингредиентов) пищевых продуктов, призванных вытеснить все другие группы продуктов питания. Ультрапереработанные продукты обычно имеют привлекательную упаковку и активно продвигаются на рынке.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Предварительный просмотр';

--- a/packages/smooth_app/lib/l10n/app_localizations_sa.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sa.dart
@@ -321,10 +321,6 @@ class AppLocalizationsSa extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4204,10 +4200,6 @@ class AppLocalizationsSa extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4395,10 +4387,6 @@ class AppLocalizationsSa extends AppLocalizations {
       'स्वामित्वलेबलस्य विपरीतम्, Green-Score गणना **पूर्णतया उद्घाटिता** अस्ति तथा च **केनापि सत्यापितुं शक्यते** ।';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://hi.openfoodfacts.org/ग्रीन-स्कोर इति वृत्तान्तः';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4485,10 +4473,6 @@ class AppLocalizationsSa extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'अति-प्रक्रियाकरणस्य समग्रं उद्देश्यं अन्येषां सर्वेषां खाद्यसमूहानां विस्थापनार्थं डिजाइनं कृत्वा ब्राण्ड्-कृतं, सुविधाजनकं (स्थायित्वं, उपभोगार्थं सज्जं), आकर्षकं (अति-स्वादयुक्तं) अत्यन्तं लाभप्रदं (कम-लाभयुक्तं घटकं) च खाद्यपदार्थानां निर्माणं भवति अल्ट्रा-प्रोसेस्ड् खाद्यपदार्थाः प्रायः आकर्षकरूपेण पैकेज्ड् भवन्ति, गहनतया च विपणनं कुर्वन्ति ।';
-
-  @override
-  String get guide_nova_share_link =>
-      'https://hi.openfoodfacts.org/nova इति वृत्तान्तः';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_sc.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sc.dart
@@ -321,10 +321,6 @@ class AppLocalizationsSc extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4204,10 +4200,6 @@ class AppLocalizationsSc extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4397,10 +4389,6 @@ class AppLocalizationsSc extends AppLocalizations {
       'Unlike proprietary labels, the Green-Score calculation is **completely open** and can be **verified by anyone**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4488,9 +4476,6 @@ class AppLocalizationsSc extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'The overall purpose of ultra-processing is to create branded, convenient (durable, ready to consume), attractive (hyper-palatable) and highly profitable (low-cost ingredients) food products designed to displace all other food groups. Ultra-processed food products are usually packaged attractively and marketed intensively.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_sd.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sd.dart
@@ -321,10 +321,6 @@ class AppLocalizationsSd extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4202,10 +4198,6 @@ class AppLocalizationsSd extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4391,10 +4383,6 @@ class AppLocalizationsSd extends AppLocalizations {
       'ملڪيتي ليبلن جي برعڪس، گرين-اسڪور حساب ڪتاب **مڪمل طور تي کليل** آهي** ۽ **ڪنهن به طرفان تصديق ڪري سگهجي ٿو**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4481,9 +4469,6 @@ class AppLocalizationsSd extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'الٽرا پروسيسنگ جو مجموعي مقصد برانڊيڊ، آسان (پائيدار، استعمال لاءِ تيار)، پرڪشش (هائپر-لذيذ) ۽ انتهائي منافعي بخش (گهٽ قيمت وارا اجزا) کاڌي جون شيون ٺاهڻ آهي جيڪي ٻين سڀني کاڌي جي گروپن کي هٽائڻ لاءِ ٺهيل آهن. الٽرا پروسيس ٿيل کاڌي جون شيون عام طور تي پرڪشش پيڪيج ڪيون وينديون آهن ۽ شدت سان مارڪيٽ ڪيون وينديون آهن.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_sg.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sg.dart
@@ -321,10 +321,6 @@ class AppLocalizationsSg extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4204,10 +4200,6 @@ class AppLocalizationsSg extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4397,10 +4389,6 @@ class AppLocalizationsSg extends AppLocalizations {
       'Unlike proprietary labels, the Green-Score calculation is **completely open** and can be **verified by anyone**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4488,9 +4476,6 @@ class AppLocalizationsSg extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'The overall purpose of ultra-processing is to create branded, convenient (durable, ready to consume), attractive (hyper-palatable) and highly profitable (low-cost ingredients) food products designed to displace all other food groups. Ultra-processed food products are usually packaged attractively and marketed intensively.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_si.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_si.dart
@@ -321,10 +321,6 @@ class AppLocalizationsSi extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4206,10 +4202,6 @@ class AppLocalizationsSi extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4396,10 +4388,6 @@ class AppLocalizationsSi extends AppLocalizations {
       'හිමිකාර ලේබල මෙන් නොව, හරිත ලකුණු ගණනය කිරීම **සම්පූර්ණයෙන්ම විවෘතයි** සහ ඕනෑම කෙනෙකුට **සත්‍යාපනය කළ හැක**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4485,9 +4473,6 @@ class AppLocalizationsSi extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'අල්ට්‍රා-සැකසීමේ සමස්ත අරමුණ වන්නේ අනෙකුත් සියලුම ආහාර කාණ්ඩ විස්ථාපනය කිරීම සඳහා නිර්මාණය කර ඇති සන්නාමගත, පහසු (කල් පවතින, පරිභෝජනයට සූදානම්), ආකර්ශනීය (අධි-රසවත්) සහ ඉහළ ලාභදායී (අඩු වියදම් අමුද්‍රව්‍ය) ආහාර නිෂ්පාදන නිර්මාණය කිරීමයි. අල්ට්‍රා-සැකසූ ආහාර නිෂ්පාදන සාමාන්‍යයෙන් ආකර්ශනීය ලෙස ඇසුරුම් කර දැඩි ලෙස අලෙවි කරනු ලැබේ.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_sk.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sk.dart
@@ -328,10 +328,6 @@ class AppLocalizationsSk extends AppLocalizations {
   String get sign_up_page_terms_text => 'podmienkami používania a prispievaním';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://sk.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4244,10 +4240,6 @@ class AppLocalizationsSk extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Eko-skóre';
 
   @override
@@ -4433,10 +4425,6 @@ class AppLocalizationsSk extends AppLocalizations {
       'Na rozdiel od proprietárnych značiek je výpočet Green-Score **úplne otvorený** a môže ho **overiť ktokoľvek**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra spracované potraviny';
 
   @override
@@ -4523,9 +4511,6 @@ class AppLocalizationsSk extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Celkovým cieľom ultraspracovania je vytvoriť značkové, pohodlné (trvanlivé, pripravené na konzumáciu), atraktívne (hyperchutné) a vysoko ziskové (lacné zložky) potravinárske výrobky určené na nahradenie všetkých ostatných skupín potravín. Ultraspracované potraviny sú zvyčajne atraktívne balené a intenzívne predávané.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Náhľad';

--- a/packages/smooth_app/lib/l10n/app_localizations_sl.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sl.dart
@@ -322,10 +322,6 @@ class AppLocalizationsSl extends AppLocalizations {
   String get sign_up_page_terms_text => 'pogoji uporabe in prispevki';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4222,10 +4218,6 @@ class AppLocalizationsSl extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4413,10 +4405,6 @@ class AppLocalizationsSl extends AppLocalizations {
       'Za razliko od lastniških oznak je izračun Green-Score **popolnoma odprt** in ga lahko **preveri kdorkoli**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra predelana živila';
 
   @override
@@ -4503,9 +4491,6 @@ class AppLocalizationsSl extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Splošni namen ultra predelave je ustvariti blagovne znamke, priročne (trajne, takojšnje za uživanje), privlačne (hiper okusne) in zelo donosne (cenovno nizke sestavine) živilske izdelke, namenjene izpodrivanju vseh drugih skupin živil. Ultra predelana živila so običajno privlačno pakirana in se intenzivno tržijo.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_sn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sn.dart
@@ -321,10 +321,6 @@ class AppLocalizationsSn extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4204,10 +4200,6 @@ class AppLocalizationsSn extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4396,10 +4388,6 @@ class AppLocalizationsSn extends AppLocalizations {
       'Kusiyana nemalebula evaridzi, iyo Green-Score kuverenga iri ** yakavhurika zvachose ** uye inogona ** kusimbiswa nemunhu wese **.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4487,9 +4475,6 @@ class AppLocalizationsSn extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Chinangwa chese chekupedzisira-kugadzirisa ndechekugadzira mabhii, akakodzera (akasimba, akagadzirira kudyiwa), anoyevedza (hyper-palatable) uye ane pundutso yakawanda (yakaderera-inodhura zvinongedzo) zvigadzirwa zvechikafu zvakagadzirirwa kubvisa mamwe mapoka ese echikafu. Zvigadzirwa zvechikafu zveUltra-processed zvinowanzo kuiswa zvinoyevedza uye zvinotengeswa zvakanyanya.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_so.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_so.dart
@@ -321,10 +321,6 @@ class AppLocalizationsSo extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4207,10 +4203,6 @@ class AppLocalizationsSo extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4401,10 +4393,6 @@ class AppLocalizationsSo extends AppLocalizations {
       'Si ka duwan calaamadaha lahaanshaha, xisaabinta Green-Score waa ** si buuxda u furan *** oo waxaa xaqiijin kara *** qof kasta.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4492,9 +4480,6 @@ class AppLocalizationsSo extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Ujeedada guud ee hab-socodka aadka u sarreeya waa in la abuuro summad leh, habboon (raagi karta, diyaar u ah in la isticmaalo), soo jiidasho leh (sare-u-qaadi karo) iyo faa\'iido sare leh (waxyaabaha qiimahoodu jaban yahay) alaabta cuntada loogu talagalay in lagu baro dhammaan kooxaha kale ee cuntada. Alaabooyinka cuntada sida aadka ah loo farsameeyay ayaa inta badan loo baakadeeyaa si soo jiidasho leh waxaana si xoogan loo suuq geeyaa.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_sq.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sq.dart
@@ -327,10 +327,6 @@ class AppLocalizationsSq extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4219,10 +4215,6 @@ class AppLocalizationsSq extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4413,10 +4405,6 @@ class AppLocalizationsSq extends AppLocalizations {
       'Ndryshe nga etiketat pronësore, llogaritja e Green-Score është **plotësisht e hapur** dhe mund të **verifikohet nga kushdo**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4503,9 +4491,6 @@ class AppLocalizationsSq extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Qëllimi i përgjithshëm i ultra-përpunimit është të krijojë produkte ushqimore të markës, të përshtatshme (të qëndrueshme, të gatshme për t’u konsumuar), tërheqëse (hiper-të shijshme) dhe shumë fitimprurëse (me përbërës me kosto të ulët), të dizajnuara për të zëvendësuar të gjitha grupet e tjera ushqimore. Produktet ushqimore të ultra-përpunuara zakonisht paketohen në mënyrë tërheqëse dhe tregtohen intensivisht.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_sr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sr.dart
@@ -321,10 +321,6 @@ class AppLocalizationsSr extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4205,10 +4201,6 @@ class AppLocalizationsSr extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4398,10 +4390,6 @@ class AppLocalizationsSr extends AppLocalizations {
       'Unlike proprietary labels, the Green-Score calculation is **completely open** and can be **verified by anyone**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4489,9 +4477,6 @@ class AppLocalizationsSr extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'The overall purpose of ultra-processing is to create branded, convenient (durable, ready to consume), attractive (hyper-palatable) and highly profitable (low-cost ingredients) food products designed to displace all other food groups. Ultra-processed food products are usually packaged attractively and marketed intensively.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_ss.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ss.dart
@@ -321,10 +321,6 @@ class AppLocalizationsSs extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4208,10 +4204,6 @@ class AppLocalizationsSs extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4405,10 +4397,6 @@ class AppLocalizationsSs extends AppLocalizations {
       'Ngalokwehlukile kumalebuli emphahla, kubalwa kwe-Green-Score **kuvulekile ngalokuphelele** futsi kungacinisekiswa **ngunobe ngubani**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://si.emaciniso ekudla lavulekile.org/emaphuzu-laluhlata';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4495,10 +4483,6 @@ class AppLocalizationsSs extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Inhloso jikelele ye ultra-processing kwenta imikhicito yekudla leneluphawu, lelula (lehlala sikhatsi lesidze, lekulungele kudliwa), lekhangako (hyper-palatable) kanye nenzuzo lenkhulu (titsako letibita kancane) leyentelwe kususa onkhe lamanye emacembu ekudla. Imikhicito yekudla lecubunguliwe kakhulu ivame kupakishwa ngendlela lekhangako futsi itsengiswe kakhulu.';
-
-  @override
-  String get guide_nova_share_link =>
-      'https://si.emaciniso ekudla lavulekile.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_st.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_st.dart
@@ -321,10 +321,6 @@ class AppLocalizationsSt extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4207,10 +4203,6 @@ class AppLocalizationsSt extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4399,10 +4391,6 @@ class AppLocalizationsSt extends AppLocalizations {
       'Ho fapana le lileibole tsa mong\'a ntlo, lipalo tsa Green-Score li ** bulehile ka botlalo ** \'me li ka ** netefatsoa ke mang kapa mang**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4489,9 +4477,6 @@ class AppLocalizationsSt extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Morero o akaretsang oa ts\'ebetso ea morao-rao ke ho theha lihlahisoa tsa lijo tse nang le lebitso, tse loketseng (tse tšoarellang, tse loketseng ho jeoa), tse khahlehang (li-hyper-latable) le tse fanang ka chelete e ngata (lisebelisoa tsa theko e tlase) tse etselitsoeng ho tlosa lihlopha tse ling tsohle tsa lijo. Hangata lihlahisoa tsa lijo tse entsoeng ka mokhoa o phahameng ka ho fetesisa li pakoa ka mokhoa o khahlang le ho rekisoa ka matla.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_sv.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sv.dart
@@ -321,10 +321,6 @@ class AppLocalizationsSv extends AppLocalizations {
   String get sign_up_page_terms_text => 'användarvillkor och bidrag';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://se.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4226,10 +4222,6 @@ class AppLocalizationsSv extends AppLocalizations {
       'För tillverkarna är visning av Nutri-Score **fortsatt valfri**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4417,10 +4409,6 @@ class AppLocalizationsSv extends AppLocalizations {
       'Till skillnad från proprietära etiketter är Green-Score-beräkningen **helt öppen** och kan **verifieras av vem som helst**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4508,9 +4496,6 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Det övergripande syftet med ultraprocessning är att skapa märkesvaror som är bekväma (hållbara, färdiga att konsumeras), attraktiva (hypervälsmakande) och mycket lönsamma (billiga ingredienser) livsmedelsprodukter, utformade för att ersätta alla andra livsmedelsgrupper. Ultraprocessade livsmedelsprodukter är vanligtvis attraktivt förpackade och marknadsförs intensivt.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_sw.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sw.dart
@@ -321,10 +321,6 @@ class AppLocalizationsSw extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4204,10 +4200,6 @@ class AppLocalizationsSw extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4396,10 +4388,6 @@ class AppLocalizationsSw extends AppLocalizations {
       'Tofauti na lebo za wamiliki, hesabu ya Alama ya Kijani ni **imefunguliwa kabisa** na inaweza **kuthibitishwa na mtu yeyote**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4488,9 +4476,6 @@ class AppLocalizationsSw extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Madhumuni ya jumla ya usindikaji wa hali ya juu ni kuunda bidhaa za chakula zenye chapa, zinazofaa (zinazodumu, tayari kutumika), zinazovutia (zinazopendeza) na zenye faida kubwa (za bei ya chini) zilizoundwa kuondoa vikundi vingine vyote vya chakula. Bidhaa za chakula zilizochakatwa kwa kiwango cha juu huwekwa kwenye vifurushi vya kuvutia na kuuzwa kwa kasi.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_ta.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ta.dart
@@ -321,10 +321,6 @@ class AppLocalizationsTa extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4220,10 +4216,6 @@ class AppLocalizationsTa extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'பச்சை-ஸ்கோர்';
 
   @override
@@ -4412,10 +4404,6 @@ class AppLocalizationsTa extends AppLocalizations {
       'தனியுரிம லேபிள்களைப் போலன்றி, கிரீன்-ஸ்கோர் கணக்கீடு **முற்றிலும் திறந்திருக்கும்** மற்றும் **எவராலும் சரிபார்க்கப்படலாம்**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4503,9 +4491,6 @@ class AppLocalizationsTa extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'அல்ட்ரா-பதப்படுத்தலின் ஒட்டுமொத்த நோக்கம், மற்ற அனைத்து உணவுக் குழுக்களையும் மாற்றுவதற்காக வடிவமைக்கப்பட்ட பிராண்டட், வசதியான (நீடித்த, உட்கொள்ளத் தயாராக), கவர்ச்சிகரமான (மிகவும் சுவையான) மற்றும் அதிக லாபகரமான (குறைந்த விலை பொருட்கள்) உணவுப் பொருட்களை உருவாக்குவதாகும். அல்ட்ரா-பதப்படுத்தப்பட்ட உணவுப் பொருட்கள் பொதுவாக கவர்ச்சிகரமான முறையில் பேக் செய்யப்பட்டு தீவிரமாக சந்தைப்படுத்தப்படுகின்றன.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_te.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_te.dart
@@ -321,10 +321,6 @@ class AppLocalizationsTe extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4207,10 +4203,6 @@ class AppLocalizationsTe extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4397,10 +4389,6 @@ class AppLocalizationsTe extends AppLocalizations {
       'యాజమాన్య లేబుల్‌ల మాదిరిగా కాకుండా, గ్రీన్-స్కోర్ గణన **పూర్తిగా తెరిచి ఉంటుంది** మరియు ఎవరైనా **ధృవీకరించవచ్చు**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4487,9 +4475,6 @@ class AppLocalizationsTe extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'అల్ట్రా-ప్రాసెసింగ్ యొక్క మొత్తం ఉద్దేశ్యం ఏమిటంటే, బ్రాండెడ్, సౌకర్యవంతమైన (మన్నికైన, తినడానికి సిద్ధంగా), ఆకర్షణీయమైన (అధిక-రుచికరమైన) మరియు అధిక లాభదాయకమైన (తక్కువ-ధర పదార్థాలు) ఆహార ఉత్పత్తులను అన్ని ఇతర ఆహార సమూహాలను స్థానభ్రంశం చేయడానికి రూపొందించడం. అల్ట్రా-ప్రాసెసింగ్ చేయబడిన ఆహార ఉత్పత్తులు సాధారణంగా ఆకర్షణీయంగా ప్యాక్ చేయబడతాయి మరియు విస్తృతంగా మార్కెట్ చేయబడతాయి.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_tg.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tg.dart
@@ -321,10 +321,6 @@ class AppLocalizationsTg extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4206,10 +4202,6 @@ class AppLocalizationsTg extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4395,10 +4387,6 @@ class AppLocalizationsTg extends AppLocalizations {
       'Баръакси тамғакоғазҳои хусусӣ, ҳисоби Green-Score **комилан кушода аст** ва метавонад **аз ҷониби ҳар кас тасдиқ карда шавад**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4485,9 +4473,6 @@ class AppLocalizationsTg extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Мақсади умумии коркарди ултра-коркард аз он иборат аст, ки маҳсулоти бренди, қулай (устувор, барои истеъмол омода), ҷолиб (гипер хушбӯй) ва сердаромад (компонентҳои камхарҷ), ки барои иваз кардани ҳама гурӯҳҳои дигари ғизо пешбинӣ шудаанд. Маҳсулоти хӯроквории ултра коркардшуда одатан ба таври ҷолиб бастабандӣ карда мешаванд ва ба таври интенсивӣ ба фурӯш бароварда мешаванд.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_th.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_th.dart
@@ -317,10 +317,6 @@ class AppLocalizationsTh extends AppLocalizations {
   String get sign_up_page_terms_text => 'ข้อมูลและเงื่อนไขการใช้งาน';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4199,10 +4195,6 @@ class AppLocalizationsTh extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4390,10 +4382,6 @@ class AppLocalizationsTh extends AppLocalizations {
       'ต่างจากฉลากที่เป็นกรรมสิทธิ์ การคำนวณ Green-Score นั้น **เปิดกว้างอย่างสมบูรณ์** และใครๆ ก็สามารถ **ตรวจสอบได้**';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/คะแนนสีเขียว';
-
-  @override
   String get guide_nova_title => 'อาหารที่ผ่านการแปรรูประดับสูง';
 
   @override
@@ -4480,9 +4468,6 @@ class AppLocalizationsTh extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'วัตถุประสงค์โดยรวมของการแปรรูปขั้นสูง (Ultra-Processing) คือการสร้างผลิตภัณฑ์อาหารที่มีตราสินค้า สะดวก (ทนทาน พร้อมบริโภค) น่าดึงดูด (น่ารับประทานมาก) และสร้างกำไรสูง (ใช้วัตถุดิบราคาถูก) ซึ่งออกแบบมาเพื่อแทนที่กลุ่มอาหารอื่นๆ ทั้งหมด ผลิตภัณฑ์อาหารแปรรูปขั้นสูงมักมีบรรจุภัณฑ์ที่สวยงามและจำหน่ายอย่างแพร่หลาย';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_ti.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ti.dart
@@ -321,10 +321,6 @@ class AppLocalizationsTi extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4201,10 +4197,6 @@ class AppLocalizationsTi extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4386,10 +4378,6 @@ class AppLocalizationsTi extends AppLocalizations {
       'ዘይከም ዋንነት ዘለዎም ምልክታት፡ ስሌት ቀጠልያ-ነጥቢ **ምሉእ ብምሉእ ክፉት** ኮይኑ **ብዝኾነ ሰብ** ክረጋገጽ ይኽእል።';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://ti.openfoodfacts.org/ሓምላይ-ነጥቢ';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4473,10 +4461,6 @@ class AppLocalizationsTi extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'ሓፈሻዊ ዕላማ ኣልትራ-ፕሮሰሲንግ ንኹሎም ካልኦት ጉጅለታት መግቢ ንምፍንቓል ዝተዳለዉ ምልክት ዘለዎም፣ ምቹኣት (ነባሪ፣ ንሃልኪ ድሉዋት)፣ ሰሓብቲ (ልዕሊ ዓቐን ጣዕሚ ዘለዎም)ን ልዑል መኽሰብ ዘለዎምን (ትሑት ዋጋ ዘለዎም ቀመማት) ፍርያት መግቢ ምፍጣር እዩ። መብዛሕትኡ ግዜ ኣዝዮም ዝተመስርሑ ፍርያት መግቢ ብሰሓቢ መንገዲ ይዕሸጉን ብጽዑቕ ዕዳጋ ይቐርቡን።';
-
-  @override
-  String get guide_nova_share_link =>
-      'https://ti.openfoodfacts.org/nova ዝብል ጽሑፍ ኣሎ።';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_tl.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tl.dart
@@ -321,10 +321,6 @@ class AppLocalizationsTl extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4209,10 +4205,6 @@ class AppLocalizationsTl extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4403,10 +4395,6 @@ class AppLocalizationsTl extends AppLocalizations {
       'Hindi tulad ng mga proprietary label, ang pagkalkula ng Green-Score ay **ganap na bukas** at maaaring **ma-verify ng sinuman**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4494,9 +4482,6 @@ class AppLocalizationsTl extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Ang pangkalahatang layunin ng ultra-processing ay lumikha ng mga produktong pagkain na may tatak, maginhawa (matibay, handang ubusin), kaakit-akit (hyper-palatable) at lubos na kumikita (mababa ang halaga) na idinisenyo upang palitan ang lahat ng iba pang pangkat ng pagkain. Ang mga produktong ultra-processed na pagkain ay karaniwang nakabalot nang kaakit-akit at masinsinang ibinebenta.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_tn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tn.dart
@@ -321,10 +321,6 @@ class AppLocalizationsTn extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4209,10 +4205,6 @@ class AppLocalizationsTn extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4403,10 +4395,6 @@ class AppLocalizationsTn extends AppLocalizations {
       'Go farologana le dileibole tsa mong, palo ya Green-Score e **bulegile gotlhelele** mme e ka **tlhomamisiwa ke mongwe le mongwe**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://tn.dintlha tsa dijo tse di bulegileng.org/maduo a matala';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4495,10 +4483,6 @@ class AppLocalizationsTn extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Maikaelelo a kakaretso a ultra-processing ke go tlhama ditlhagiswa tsa dijo tse di nang le letshwaokgwebo, tse di siameng (tse di tshwarelelang, tse di siametseng go jewa), tse di kgatlhang (tse di monate thata) le tse di nang le dipoelo tse di kwa godimo (metswako e e tlhwatlhwatlase) tse di diretsweng go emisetsa ditlhopha tse dingwe tsotlhe tsa dijo. Dikumo tsa dijo tse di dirilweng ka tsela e e feteletseng gantsi di phuthelwa ka tsela e e kgatlhang mme di bapadiwa thata.';
-
-  @override
-  String get guide_nova_share_link =>
-      'https://tn.dintlha tsa dijo tse di bulegileng.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_tr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tr.dart
@@ -324,10 +324,6 @@ class AppLocalizationsTr extends AppLocalizations {
   String get sign_up_page_terms_text => 'kullanım ve katılım koşulları';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://tr.openfoodfacts.org/';
 
   @override
@@ -4229,10 +4225,6 @@ class AppLocalizationsTr extends AppLocalizations {
       'Üreticiler için Nutri-Score\'un görüntülenmesi **isteğe bağlı** kalmaktadır.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4418,10 +4410,6 @@ class AppLocalizationsTr extends AppLocalizations {
       'Tescilli etiketlerin aksine, Yeşil Puan hesaplaması **tamamen açıktır** ve **herkes tarafından doğrulanabilir**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Aşırı işlenmiş gıdalar';
 
   @override
@@ -4508,9 +4496,6 @@ class AppLocalizationsTr extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Ultra işlemenin genel amacı, diğer tüm gıda gruplarının yerini alacak şekilde tasarlanmış, markalı, kullanışlı (dayanıklı, tüketime hazır), çekici (aşırı lezzetli) ve oldukça kârlı (düşük maliyetli içerikler) gıda ürünleri yaratmaktır. Ultra işlenmiş gıda ürünleri genellikle çekici bir şekilde paketlenir ve yoğun bir şekilde pazarlanır.';
-
-  @override
-  String get guide_nova_share_link => 'https://tr.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Ön izleme';

--- a/packages/smooth_app/lib/l10n/app_localizations_ts.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ts.dart
@@ -321,10 +321,6 @@ class AppLocalizationsTs extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4206,10 +4202,6 @@ class AppLocalizationsTs extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4399,10 +4391,6 @@ class AppLocalizationsTs extends AppLocalizations {
       'Ku hambana na malebvu ya vulawuri, xibalo xa Green-Score xi **vulekile hi ku helela** naswona xi nga **tiyisisiwa hi mani na mani**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://ts.openfoodfacts.org/xikoro-xikoro xa rihlaza';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4489,10 +4477,6 @@ class AppLocalizationsTs extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Xikongomelo hinkwaxo xa ultra-processing iku tumbuluxa switirhisiwa swa swakudya leswinga na branded, leswi olovaka (leswi tiyeke, leswi lulameleke ku dyiwa), leswi kokaka rinoko (hyper-palatable) na leswi vuyerisaka swinene (swiaki swa ntsengo wale hansi) leswi endleriweke ku susa mintlawa yin’wana hinkwayo ya swakudya. Switirhisiwa swa swakudya leswi endliweke hi ultra-processed hi ntolovelo swi pakiwa hi ndlela yo koka rinoko naswona swi xavisiwa ngopfu.';
-
-  @override
-  String get guide_nova_share_link =>
-      'https://ts.swilo swa swakudya leswi pfulekeke.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_tt.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tt.dart
@@ -321,10 +321,6 @@ class AppLocalizationsTt extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4204,10 +4200,6 @@ class AppLocalizationsTt extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4394,10 +4386,6 @@ class AppLocalizationsTt extends AppLocalizations {
       'Хуҗалык этикеткаларыннан аермалы буларак, Яшел-Счетны исәпләү ** бөтенләй ачык ** һәм аны ** теләсә кем раслый ала **.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4483,9 +4471,6 @@ class AppLocalizationsTt extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Ультра эшкәртүнең гомуми максаты - маркалы, уңайлы (чыдам, кулланырга әзер), җәлеп итүчән (гипер-тәмле) һәм югары керемле (аз чыгымлы ингредиентлар) азык-төлек продуктларын барлыкка китерү. Ультра эшкәртелгән азык продуктлары гадәттә җәлеп ителә һәм интенсив базарда сатыла.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_tw.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tw.dart
@@ -321,10 +321,6 @@ class AppLocalizationsTw extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4207,10 +4203,6 @@ class AppLocalizationsTw extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4404,10 +4396,6 @@ class AppLocalizationsTw extends AppLocalizations {
       'Nea ɛnte sɛ proprietary labels no, Green-Score akontabuo no **bue koraa** na **obiara betumi **agye atom**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/asɛmfua a ɛyɛ ahabammono';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4495,9 +4483,6 @@ class AppLocalizationsTw extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Atirimpɔw titiriw a ɛwɔ ultra-processing mu ne sɛ wɔbɛyɛ nnuan a wɔakyerɛw so, ɛyɛ mmerɛw (ɛtra hɔ kyɛ, ɛyɛ krado sɛ wobedi), ɛyɛ fɛ (ɛyɛ dɛ dodo) na mfaso wɔ so kɛse (nneɛma a ne bo nyɛ den) a wɔayɛ sɛ ɛbɛma wɔatu nnuan akuw afoforo nyinaa afi hɔ. Mpɛn pii no, wɔkyekyere nnuan a wɔayɛ no yiye kɛse wɔ ɔkwan a ɛyɛ fɛ so na wɔtɔn no kɛse.';
-
-  @override
-  String get guide_nova_share_link => 'https://tw.bue aduan ho nsɛm.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_ty.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ty.dart
@@ -321,10 +321,6 @@ class AppLocalizationsTy extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4204,10 +4200,6 @@ class AppLocalizationsTy extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4397,10 +4389,6 @@ class AppLocalizationsTy extends AppLocalizations {
       'Unlike proprietary labels, the Green-Score calculation is **completely open** and can be **verified by anyone**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4488,9 +4476,6 @@ class AppLocalizationsTy extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'The overall purpose of ultra-processing is to create branded, convenient (durable, ready to consume), attractive (hyper-palatable) and highly profitable (low-cost ingredients) food products designed to displace all other food groups. Ultra-processed food products are usually packaged attractively and marketed intensively.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_ug.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ug.dart
@@ -321,10 +321,6 @@ class AppLocalizationsUg extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4205,10 +4201,6 @@ class AppLocalizationsUg extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4395,10 +4387,6 @@ class AppLocalizationsUg extends AppLocalizations {
       'ئىگىدارلىق بەلگىسىگە ئوخشىمايدىغىنى ، يېشىل نومۇر ھېسابلاش ** پۈتۈنلەي ئوچۇق ** بولۇپ ، ** ھەر قانداق ئادەم تەرىپىدىن ** دەلىللىيەلەيدۇ.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4487,9 +4475,6 @@ class AppLocalizationsUg extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'دەرىجىدىن تاشقىرى پىششىقلاپ ئىشلەشنىڭ ئومۇمىي مەقسىتى باشقا بارلىق يېمەكلىك گۇرۇپپىلىرىنى يۆتكەش ئۈچۈن لايىھەلەنگەن داڭلىق ، قۇلايلىق (چىداملىق ، ئىستېمال قىلىشقا تەييار) ، جەلپكار (يۇقىرى يېيىشلىك) ۋە كىرىمى يۇقىرى (ئەرزان باھالىق تەركىبلەر) يېمەكلىك مەھسۇلاتلىرىنى بارلىققا كەلتۈرۈش. دەرىجىدىن تاشقىرى پىششىقلاپ ئىشلەنگەن يېمەكلىك مەھسۇلاتلىرى ئادەتتە جەلپكار ئورالغان ۋە قويۇق بازارغا سېلىنىدۇ.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_uk.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_uk.dart
@@ -325,10 +325,6 @@ class AppLocalizationsUk extends AppLocalizations {
   String get sign_up_page_terms_text => 'умови використання та внесок';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4257,10 +4253,6 @@ class AppLocalizationsUk extends AppLocalizations {
       'Для постачальників зображення Nutri-Score **залишається необов’язковим**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore';
-
-  @override
   String get guide_greenscore_title =>
       'Green-Score (показник впливу на довкілля)';
 
@@ -4448,10 +4440,6 @@ class AppLocalizationsUk extends AppLocalizations {
       'На відміну від власних позначок, розрахунок Green-Score є **повністю відкритим** і може бути **перевірений будь-ким**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ультраоброблені продукти';
 
   @override
@@ -4538,9 +4526,6 @@ class AppLocalizationsUk extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Загальна мета ультраобробки полягає у створенні брендованих, зручних (міцних, готових до вживання), привабливих (надто смачних) та високоприбуткових (з низькими витратами на інгредієнти) харчових продуктів, призначених для витіснення всіх інших груп продуктів харчування. Ультраоброблені харчові продукти зазвичай привабливо упаковуються та інтенсивно просуваються на ринку.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Попередній перегляд';

--- a/packages/smooth_app/lib/l10n/app_localizations_ur.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ur.dart
@@ -321,10 +321,6 @@ class AppLocalizationsUr extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4204,10 +4200,6 @@ class AppLocalizationsUr extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4397,10 +4389,6 @@ class AppLocalizationsUr extends AppLocalizations {
       'Unlike proprietary labels, the Green-Score calculation is **completely open** and can be **verified by anyone**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4488,9 +4476,6 @@ class AppLocalizationsUr extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'The overall purpose of ultra-processing is to create branded, convenient (durable, ready to consume), attractive (hyper-palatable) and highly profitable (low-cost ingredients) food products designed to displace all other food groups. Ultra-processed food products are usually packaged attractively and marketed intensively.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_uz.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_uz.dart
@@ -321,10 +321,6 @@ class AppLocalizationsUz extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4206,10 +4202,6 @@ class AppLocalizationsUz extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4398,10 +4390,6 @@ class AppLocalizationsUz extends AppLocalizations {
       'Xususiy yorliqlardan farqli o\'laroq, Green-Score hisobi **to\'liq ochiq** va **har kim tomonidan tasdiqlanishi mumkin**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4489,9 +4477,6 @@ class AppLocalizationsUz extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Ultra-qayta ishlashning umumiy maqsadi boshqa barcha oziq-ovqat guruhlarini siqib chiqarishga mo\'ljallangan markali, qulay (bardoshli, iste\'mol qilishga tayyor), jozibali (giper mazali) va yuqori rentabellikga ega (arzon ingredientlar) oziq-ovqat mahsulotlarini yaratishdir. Ultra qayta ishlangan oziq-ovqat mahsulotlari odatda jozibali tarzda qadoqlanadi va intensiv ravishda sotiladi.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_ve.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ve.dart
@@ -321,10 +321,6 @@ class AppLocalizationsVe extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4204,10 +4200,6 @@ class AppLocalizationsVe extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4397,10 +4389,6 @@ class AppLocalizationsVe extends AppLocalizations {
       'Unlike proprietary labels, the Green-Score calculation is **completely open** and can be **verified by anyone**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4488,9 +4476,6 @@ class AppLocalizationsVe extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'The overall purpose of ultra-processing is to create branded, convenient (durable, ready to consume), attractive (hyper-palatable) and highly profitable (low-cost ingredients) food products designed to displace all other food groups. Ultra-processed food products are usually packaged attractively and marketed intensively.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_vi.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_vi.dart
@@ -323,10 +323,6 @@ class AppLocalizationsVi extends AppLocalizations {
   String get sign_up_page_terms_text => 'điều khoản sử dụng và đóng góp';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4229,10 +4225,6 @@ class AppLocalizationsVi extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Điểm sinh thái';
 
   @override
@@ -4418,10 +4410,6 @@ class AppLocalizationsVi extends AppLocalizations {
       'Không giống như các nhãn hiệu độc quyền, phép tính Điểm Xanh **hoàn toàn mở** và có thể được **xác minh bởi bất kỳ ai**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Thức ăn siêu chế biến';
 
   @override
@@ -4510,9 +4498,6 @@ class AppLocalizationsVi extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Mục đích chung của siêu chế biến là tạo ra các sản phẩm thực phẩm có thương hiệu, tiện lợi (bền, dễ tiêu thụ), hấp dẫn (siêu ngon miệng) và có lợi nhuận cao (nguyên liệu giá rẻ) được thiết kế để thay thế tất cả các nhóm thực phẩm khác. Các sản phẩm thực phẩm siêu chế biến thường được đóng gói hấp dẫn và tiếp thị rầm rộ.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_wa.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_wa.dart
@@ -321,10 +321,6 @@ class AppLocalizationsWa extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4204,10 +4200,6 @@ class AppLocalizationsWa extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4397,10 +4389,6 @@ class AppLocalizationsWa extends AppLocalizations {
       'Unlike proprietary labels, the Green-Score calculation is **completely open** and can be **verified by anyone**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4488,9 +4476,6 @@ class AppLocalizationsWa extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'The overall purpose of ultra-processing is to create branded, convenient (durable, ready to consume), attractive (hyper-palatable) and highly profitable (low-cost ingredients) food products designed to displace all other food groups. Ultra-processed food products are usually packaged attractively and marketed intensively.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_wo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_wo.dart
@@ -321,10 +321,6 @@ class AppLocalizationsWo extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4204,10 +4200,6 @@ class AppLocalizationsWo extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4397,10 +4389,6 @@ class AppLocalizationsWo extends AppLocalizations {
       'Unlike proprietary labels, the Green-Score calculation is **completely open** and can be **verified by anyone**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4488,9 +4476,6 @@ class AppLocalizationsWo extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'The overall purpose of ultra-processing is to create branded, convenient (durable, ready to consume), attractive (hyper-palatable) and highly profitable (low-cost ingredients) food products designed to displace all other food groups. Ultra-processed food products are usually packaged attractively and marketed intensively.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_xh.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_xh.dart
@@ -321,10 +321,6 @@ class AppLocalizationsXh extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4206,10 +4202,6 @@ class AppLocalizationsXh extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4400,10 +4392,6 @@ class AppLocalizationsXh extends AppLocalizations {
       'Ngokungafaniyo neelebhile zobunini, ukubalwa kweGreen-Score**kuvulwe ngokupheleleyo** kwaye **kunokuqinisekiswa nguye nabani na**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4490,9 +4478,6 @@ class AppLocalizationsXh extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Injongo iyonke ye-ultra-processing kukudala i-brand, elula (ehlala ixesha elide, ekulungele ukusetyenziswa), enomtsalane (i-hyper-palatable) kunye nenzuzo ephezulu (izithako ezinexabiso eliphantsi) iimveliso zokutya ezenzelwe ukususa onke amanye amaqela okutya. Iimveliso zokutya ezicutshungulwayo zidla ngokupakishwa ngendlela enomtsalane kwaye zithengiswe ngamandla.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_yi.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_yi.dart
@@ -321,10 +321,6 @@ class AppLocalizationsYi extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4204,10 +4200,6 @@ class AppLocalizationsYi extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4396,10 +4388,6 @@ class AppLocalizationsYi extends AppLocalizations {
       'אנדערש ווי אייגענע לייבלס, איז די גרין-סקאָר קאַלקולאַציע **גאָר אָפן** און קען ווערן **וועריפֿיצירט דורך ווער עס יז**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4487,9 +4475,6 @@ class AppLocalizationsYi extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'דער הויפּט ציל פון אולטראַ-פּראַסעסינג איז צו שאַפֿן בראַנדיד, באַקוועם (דויערהאפט, גרייט צו קאָנסומירן), אַטראַקטיוו (היפּער-פּאַסיקע) און העכסט פּראָפיטאַבלע (נידעריק-קאָסט ינגרידיאַנץ) עסנוואַרג פּראָדוקטן דיזיינד צו פאַרבייַטן אַלע אנדערע עסנוואַרג גרופּעס. אולטראַ-פּראַסעסט עסנוואַרג פּראָדוקטן זענען געוויינטלעך פּאַקידזשד אַטראַקטיוולי און פֿאַרקויפֿט אינטענסיוו.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_yo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_yo.dart
@@ -321,10 +321,6 @@ class AppLocalizationsYo extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4205,10 +4201,6 @@ class AppLocalizationsYo extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4396,10 +4388,6 @@ class AppLocalizationsYo extends AppLocalizations {
       'Ko dabi awọn aami ohun-ini, iṣiro Green-Score jẹ ṣiṣi silẹ patapata *** ati pe o le jẹri ** jẹri nipasẹ ẹnikẹni ***.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4486,9 +4474,6 @@ class AppLocalizationsYo extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Idi gbogbogbo ti iṣelọpọ olekenka ni lati ṣẹda iyasọtọ, irọrun (ti o tọ, ṣetan lati jẹ), ẹwa (hyper-palatable) ati ere pupọ (awọn eroja idiyele kekere) awọn ọja ounjẹ ti a ṣe apẹrẹ lati yi gbogbo awọn ẹgbẹ ounjẹ miiran pada. Awọn ọja ounjẹ ti a ṣe ilana Ultra ni a maa n ṣajọ ni ẹwa ati tita ni itara.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_zh.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_zh.dart
@@ -304,10 +304,6 @@ class AppLocalizationsZh extends AppLocalizations {
   String get sign_up_page_terms_text => '使用条款和贡献';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4013,10 +4009,6 @@ class AppLocalizationsZh extends AppLocalizations {
       '对于制造商来说，Nutri-Score 的显示**仍然是可选的**。';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => '生态得分';
 
   @override
@@ -4190,10 +4182,6 @@ class AppLocalizationsZh extends AppLocalizations {
       '与专有标签不同，Green-Score 计算**完全开放**，并且**任何人都可以验证**。';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => '超加工食品';
 
   @override
@@ -4273,9 +4261,6 @@ class AppLocalizationsZh extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       '超加工的总体目标是打造品牌化、便捷化（耐用、即食）、吸引力（超级美味）和高利润（低成本原料）的食品，旨在取代所有其他食品类别。超加工食品通常包装精美，营销力度强。';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_localizations_zu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_zu.dart
@@ -321,10 +321,6 @@ class AppLocalizationsZu extends AppLocalizations {
   String get sign_up_page_terms_text => 'terms of use and contribution';
 
   @override
-  String get sign_up_page_agree_url =>
-      'https://world-en.openfoodfacts.org/terms-of-use';
-
-  @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
@@ -4204,10 +4200,6 @@ class AppLocalizationsZu extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_nutriscore_v2_share_link =>
-      'https://world.openfoodfacts.org/nutriscore-v2';
-
-  @override
   String get guide_greenscore_title => 'Green-Score';
 
   @override
@@ -4399,10 +4391,6 @@ class AppLocalizationsZu extends AppLocalizations {
       'Ngokungafani namalebula obunikazi, ukubala kwe-Green-Score **kuvulwe ngokuphelele** futhi **kungaqinisekiswa yinoma ubani**.';
 
   @override
-  String get guide_greenscore_share_link =>
-      'https://en.openfoodfacts.org/green-score';
-
-  @override
   String get guide_nova_title => 'Ultra-processed foods';
 
   @override
@@ -4489,9 +4477,6 @@ class AppLocalizationsZu extends AppLocalizations {
   @override
   String get guide_nova_explanations_arg4_text =>
       'Inhloso iyonke yokucubungula okuphezulu ukudala imikhiqizo yokudla ebhalwe uphawu, elula (ehlala isikhathi eside, elungele ukusetshenziswa), ekhangayo (e-hyper-flatable) futhi enenzuzo enkulu (izithako ezingabizi kakhulu) eklanyelwe ukususa wonke amanye amaqembu okudla. Imikhiqizo yokudla okucutshungulwe kakhulu ivamise ukupakishwa ngendlela ekhangayo futhi imakethwe kakhulu.';
-
-  @override
-  String get guide_nova_share_link => 'https://en.openfoodfacts.org/nova';
 
   @override
   String get preview_badge => 'Preview';

--- a/packages/smooth_app/lib/l10n/app_nl.arb
+++ b/packages/smooth_app/lib/l10n/app_nl.arb
@@ -2335,7 +2335,7 @@
   },
   "prices_generic_title": "Prijzen",
   "prices_add_n_prices": "{count,plural, =1{Voeg een prijs toe} other{Voeg {count} prijzen toe}}",
-  "prices_send_n_prices": "{count,plural, one {}=1{Verstuur 1 prijs} other{Verstuur {count} prijzen}}",
+  "prices_send_n_prices": "{count,plural, =1{Verstuur 1 prijs} other{Verstuur {count} prijzen}}",
   "prices_add_an_item": "Item toevoegen",
   "prices_add_a_price": "Voeg een prijs toe",
   "prices_add_a_receipt": "Een ontvangstbewijs toevoegen",

--- a/packages/smooth_app/lib/pages/guides/guide/guide_green_score.dart
+++ b/packages/smooth_app/lib/pages/guides/guide/guide_green_score.dart
@@ -5,6 +5,7 @@ import 'package:smooth_app/l10n/app_localizations.dart';
 import 'package:smooth_app/pages/guides/helpers/guides_content.dart';
 import 'package:smooth_app/pages/guides/helpers/guides_footer.dart';
 import 'package:smooth_app/pages/guides/helpers/guides_header.dart';
+import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/resources/app_icons.dart' as icons;
 import 'package:smooth_app/themes/theme_provider.dart';
 import 'package:vector_graphics/vector_graphics.dart';
@@ -14,8 +15,6 @@ class GuideGreenScore extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final AppLocalizations appLocalizations = AppLocalizations.of(context);
-
     return GuidesPage(
       pageName: 'GreenScore',
       header: const _GreenScoreHeader(),
@@ -28,7 +27,9 @@ class GuideGreenScore extends StatelessWidget {
       ],
       footer: SliverToBoxAdapter(
         child: GuidesFooter(
-          shareUrl: appLocalizations.guide_greenscore_share_link,
+          shareUrl: ProductQuery.replaceSubdomain(
+            'https://world.openfoodfacts.org/green-score',
+          ),
         ),
       ),
     );

--- a/packages/smooth_app/lib/pages/guides/guide/guide_nova.dart
+++ b/packages/smooth_app/lib/pages/guides/guide/guide_nova.dart
@@ -5,6 +5,7 @@ import 'package:smooth_app/l10n/app_localizations.dart';
 import 'package:smooth_app/pages/guides/helpers/guides_content.dart';
 import 'package:smooth_app/pages/guides/helpers/guides_footer.dart';
 import 'package:smooth_app/pages/guides/helpers/guides_header.dart';
+import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/resources/app_icons.dart' as icons;
 import 'package:vector_graphics/vector_graphics.dart';
 
@@ -13,14 +14,16 @@ class GuideNOVA extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final AppLocalizations appLocalizations = AppLocalizations.of(context);
-
     return GuidesPage(
       pageName: 'NOVA',
       header: const _NOVAHeader(),
       body: const <Widget>[_NOVASection1(), _NOVASection2(), _NOVASection3()],
       footer: SliverToBoxAdapter(
-        child: GuidesFooter(shareUrl: appLocalizations.guide_nova_share_link),
+        child: GuidesFooter(
+          shareUrl: ProductQuery.replaceSubdomain(
+            'https://world.openfoodfacts.org/nova',
+          ),
+        ),
       ),
     );
   }

--- a/packages/smooth_app/lib/pages/guides/guide/guide_nutriscore_v2.dart
+++ b/packages/smooth_app/lib/pages/guides/guide/guide_nutriscore_v2.dart
@@ -5,6 +5,7 @@ import 'package:smooth_app/l10n/app_localizations.dart';
 import 'package:smooth_app/pages/guides/helpers/guides_content.dart';
 import 'package:smooth_app/pages/guides/helpers/guides_footer.dart';
 import 'package:smooth_app/pages/guides/helpers/guides_header.dart';
+import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/resources/app_icons.dart' as icons;
 
 class GuideNutriscoreV2 extends StatelessWidget {
@@ -12,8 +13,6 @@ class GuideNutriscoreV2 extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final AppLocalizations appLocalizations = AppLocalizations.of(context);
-
     return GuidesPage(
       pageName: 'NutriscoreV2',
       header: const _NutriscoreHeader(),
@@ -26,7 +25,9 @@ class GuideNutriscoreV2 extends StatelessWidget {
       ],
       footer: SliverToBoxAdapter(
         child: GuidesFooter(
-          shareUrl: appLocalizations.guide_nutriscore_v2_share_link,
+          shareUrl: ProductQuery.replaceSubdomain(
+            'https://world.openfoodfacts.org/nutriscore-v2',
+          ),
         ),
       ),
     );

--- a/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
+++ b/packages/smooth_app/lib/pages/user_management/sign_up_page.dart
@@ -551,10 +551,15 @@ class _TermsOfUseCheckbox extends StatelessWidget {
   }
 
   Future<void> _onTermsClicked(AppLocalizations appLocalizations) async {
-    final String url = appLocalizations.sign_up_page_agree_url;
-
     try {
-      await launchUrl(Uri.parse(url), mode: LaunchMode.platformDefault);
+      await launchUrl(
+        Uri.parse(
+          ProductQuery.replaceSubdomain(
+            'https://world.openfoodfacts.org/terms-of-use',
+          ),
+        ),
+        mode: LaunchMode.platformDefault,
+      );
     } catch (_) {}
   }
 }


### PR DESCRIPTION
### What
Automatic localization of the following URLs, found in the code, with the current language and country:
* https://world-en.openfoodfacts.org/terms-of-use
* https://world.openfoodfacts.org/nutriscore-v2
* https://en.openfoodfacts.org/green-score
* https://en.openfoodfacts.org/nova

### Fixes bug(s)
- Closes: #7012

### Impacted files:
* `app_en.arb`: removed 4 now useless entries
* `app_nl.arb`: unrelated minor fix
* `app_localizations*.dart`: generated without the 4 entries
* `guide_green_score.dart`: automatically localized the URL
* `guide_nova.dart`: automatically localized the URL
* `guide_nutriscore_v2.dart`: automatically localized the URL
* `sign_up_page.dart`: automatically localized the URL