### PR TITLE
fix: 7022 - simplified app bar statistics UI/UX

### DIFF
--- a/packages/smooth_app/lib/data_models/query_product_list_supplier.dart
+++ b/packages/smooth_app/lib/data_models/query_product_list_supplier.dart
@@ -1,8 +1,12 @@
+import 'dart:async';
+
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/data_models/preferences/user_preferences.dart';
 import 'package:smooth_app/data_models/product_list.dart';
 import 'package:smooth_app/data_models/product_list_supplier.dart';
 import 'package:smooth_app/database/dao_product.dart';
 import 'package:smooth_app/database/dao_product_list.dart';
+import 'package:smooth_app/pages/preferences/lazy_counter.dart';
 
 /// [ProductListSupplier] with a server query flavor
 class QueryProductListSupplier extends ProductListSupplier {
@@ -16,7 +20,19 @@ class QueryProductListSupplier extends ProductListSupplier {
       partialProductList.clear();
       if (searchResult.products != null) {
         productList.setAll(searchResult.products!);
-        productList.totalSize = searchResult.count ?? 0;
+        final int? total = searchResult.count;
+        productList.totalSize = total ?? 0;
+        final LazyCounter? lazyCounter = productQuery.getLazyCounter();
+        if (lazyCounter != null && total != null) {
+          final UserPreferences userPreferences =
+              UserPreferences.getUserPreferencesSync();
+          final int? before = lazyCounter.getLocalCount(userPreferences);
+          if (before != total) {
+            unawaited(
+              lazyCounter.setLocalCount(total, userPreferences, notify: true),
+            );
+          }
+        }
         partialProductList.add(productList);
         await DaoProduct(localDatabase).putAll(
           searchResult.products!,

--- a/packages/smooth_app/lib/generic_lib/widgets/app_bars/logged_in/statistics_cards/app_bar_statistics_card.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/app_bars/logged_in/statistics_cards/app_bar_statistics_card.dart
@@ -5,10 +5,8 @@ import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/preferences/user_preferences.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
-import 'package:smooth_app/l10n/app_localizations.dart';
 import 'package:smooth_app/pages/preferences/lazy_counter.dart';
 import 'package:smooth_app/query/product_query.dart';
-import 'package:smooth_app/resources/app_icons.dart' as icons;
 import 'package:smooth_app/themes/smooth_theme.dart';
 import 'package:smooth_app/themes/smooth_theme_colors.dart';
 import 'package:vector_graphics/vector_graphics.dart';
@@ -143,91 +141,4 @@ class _AppBarStaticsCardLayout extends MultiChildLayoutDelegate {
 
   @override
   bool shouldRelayout(_AppBarStaticsCardLayout oldDelegate) => true;
-}
-
-class _AppBarStatisticsCardProgressBar extends StatefulWidget {
-  const _AppBarStatisticsCardProgressBar({
-    required this.animate,
-    required this.onTap,
-  });
-
-  final bool animate;
-  final VoidCallback onTap;
-
-  @override
-  State<_AppBarStatisticsCardProgressBar> createState() =>
-      _AppBarStatisticsCardProgressBarState();
-}
-
-class _AppBarStatisticsCardProgressBarState
-    extends State<_AppBarStatisticsCardProgressBar>
-    with SingleTickerProviderStateMixin {
-  late final AnimationController _controller;
-  late final Animation<double> _animation;
-
-  @override
-  void initState() {
-    super.initState();
-    _controller =
-        AnimationController(
-          vsync: this,
-          duration: const Duration(milliseconds: 800),
-        )..addStatusListener((AnimationStatus status) {
-          if (status == AnimationStatus.completed && widget.animate) {
-            Future<void>.delayed(const Duration(milliseconds: 100), () {
-              if (widget.animate) {
-                _controller.forward(from: 0.0);
-              }
-            });
-          }
-        });
-
-    _animation = Tween<double>(
-      begin: 0.0,
-      end: 1.0,
-    ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeInOut));
-    _updateAnimationController();
-  }
-
-  @override
-  void didUpdateWidget(_AppBarStatisticsCardProgressBar oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.animate == widget.animate) {
-      return;
-    }
-
-    _updateAnimationController();
-  }
-
-  void _updateAnimationController() {
-    if (widget.animate || _controller.isAnimating) {
-      _controller.forward(from: widget.animate ? 0.0 : null);
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final AppLocalizations appLocalizations = AppLocalizations.of(context);
-
-    return Tooltip(
-      message: appLocalizations.label_reload,
-      child: RotationTransition(
-        turns: _animation,
-        child: InkWell(
-          customBorder: const CircleBorder(),
-          onTap: widget.onTap,
-          child: const Padding(
-            padding: EdgeInsetsDirectional.all(MEDIUM_SPACE),
-            child: icons.Reload(color: Colors.white, size: 16.0),
-          ),
-        ),
-      ),
-    );
-  }
-
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
 }

--- a/packages/smooth_app/lib/generic_lib/widgets/app_bars/logged_in/statistics_cards/app_bar_statistics_card.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/app_bars/logged_in/statistics_cards/app_bar_statistics_card.dart
@@ -9,12 +9,11 @@ import 'package:smooth_app/l10n/app_localizations.dart';
 import 'package:smooth_app/pages/preferences/lazy_counter.dart';
 import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/resources/app_icons.dart' as icons;
-import 'package:smooth_app/services/smooth_services.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
 import 'package:smooth_app/themes/smooth_theme_colors.dart';
 import 'package:vector_graphics/vector_graphics.dart';
 
-class AppBarStatisticsCard extends StatefulWidget {
+class AppBarStatisticsCard extends StatelessWidget {
   AppBarStatisticsCard({
     required this.imagePath,
     required this.description,
@@ -35,37 +34,27 @@ class AppBarStatisticsCard extends StatefulWidget {
   static const double HEIGHT = 68.0;
 
   @override
-  State<StatefulWidget> createState() => _AppBarStatisticsCardState();
-}
-
-class _AppBarStatisticsCardState extends State<AppBarStatisticsCard> {
-  bool _loading = false;
-
-  @override
   Widget build(BuildContext context) {
     final SmoothColorsThemeExtension themeExtension = context
         .extension<SmoothColorsThemeExtension>();
     final UserPreferences userPreferences = context.watch<UserPreferences>();
 
-    final int? count = widget.lazyCounter.getLocalCount(userPreferences);
+    final int? count = lazyCounter.getLocalCount(userPreferences);
 
     return Material(
       borderRadius: ROUNDED_BORDER_RADIUS,
       color: themeExtension.secondaryVibrant.withValues(alpha: 0.8),
       child: SizedBox(
-        height: AppBarStatisticsCard.HEIGHT,
+        height: HEIGHT,
         child: InkWell(
           borderRadius: ROUNDED_BORDER_RADIUS,
-          onTap: widget.onTap,
+          onTap: onTap,
           child: CustomMultiChildLayout(
             delegate: _AppBarStaticsCardLayout(MEDIUM_SPACE),
             children: <Widget>[
               LayoutId(
                 id: _AppBarStatisticsCardLayoutItem.illustration,
-                child: SvgPicture(
-                  AssetBytesLoader(widget.imagePath),
-                  height: 32.0,
-                ),
+                child: SvgPicture(AssetBytesLoader(imagePath), height: 32.0),
               ),
               LayoutId(
                 id: _AppBarStatisticsCardLayoutItem.counter,
@@ -85,19 +74,12 @@ class _AppBarStatisticsCardState extends State<AppBarStatisticsCard> {
               LayoutId(
                 id: _AppBarStatisticsCardLayoutItem.description,
                 child: AutoSizeText(
-                  widget.description,
-                  group: widget.autoSizeGroup,
+                  description,
+                  group: autoSizeGroup,
                   minFontSize: 8.0,
                   softWrap: false,
                   maxLines: 1,
                   style: const TextStyle(color: Colors.white),
-                ),
-              ),
-              LayoutId(
-                id: _AppBarStatisticsCardLayoutItem.refreshButton,
-                child: _AppBarStatisticsCardProgressBar(
-                  onTap: () => _asyncLoad(),
-                  animate: _loading,
                 ),
               ),
             ],
@@ -106,42 +88,9 @@ class _AppBarStatisticsCardState extends State<AppBarStatisticsCard> {
       ),
     );
   }
-
-  Future<void> _asyncLoad() async {
-    if (_loading) {
-      return;
-    }
-    _loading = true;
-    final UserPreferences userPreferences = context.read<UserPreferences>();
-    if (mounted) {
-      setState(() {});
-    }
-    try {
-      final int? value = await widget.lazyCounter.getServerCount();
-      if (value != null) {
-        await widget.lazyCounter.setLocalCount(
-          value,
-          userPreferences,
-          notify: false,
-        );
-      }
-    } catch (e) {
-      Logs.e('Error loading data: $e');
-    } finally {
-      _loading = false;
-      if (mounted) {
-        setState(() {});
-      }
-    }
-  }
 }
 
-enum _AppBarStatisticsCardLayoutItem {
-  illustration,
-  counter,
-  description,
-  refreshButton,
-}
+enum _AppBarStatisticsCardLayoutItem { illustration, counter, description }
 
 class _AppBarStaticsCardLayout extends MultiChildLayoutDelegate {
   _AppBarStaticsCardLayout(this.padding);
@@ -159,13 +108,10 @@ class _AppBarStaticsCardLayout extends MultiChildLayoutDelegate {
       availableSize,
     );
 
-    final double buttonWidth = size.height * 0.6;
     final Size counterSize = layoutChild(
       _AppBarStatisticsCardLayoutItem.counter,
       availableSize.deflate(
-        EdgeInsetsDirectional.only(
-          start: illustrationSize.width + padding * 2 + buttonWidth,
-        ),
+        EdgeInsetsDirectional.only(start: illustrationSize.width + padding * 2),
       ),
     );
     final Size descriptionSize = layoutChild(
@@ -178,17 +124,6 @@ class _AppBarStaticsCardLayout extends MultiChildLayoutDelegate {
     final double verticalSpacing =
         (size.height - counterSize.height - descriptionSize.height) / 2;
 
-    final Size refreshButtonSize = layoutChild(
-      _AppBarStatisticsCardLayoutItem.refreshButton,
-      BoxConstraints.tight(
-        Size(buttonWidth, verticalSpacing + counterSize.height),
-      ),
-    );
-
-    positionChild(
-      _AppBarStatisticsCardLayoutItem.refreshButton,
-      Offset(size.width - refreshButtonSize.width, verticalSpacing * 0.5),
-    );
     positionChild(
       _AppBarStatisticsCardLayoutItem.illustration,
       Offset(padding, illustrationSize.height / 2),

--- a/packages/smooth_app/lib/pages/prices/product_prices_list.dart
+++ b/packages/smooth_app/lib/pages/prices/product_prices_list.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
+import 'package:smooth_app/data_models/preferences/user_preferences.dart';
 import 'package:smooth_app/database/dao_product.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/bottom_sheets/smooth_bottom_sheet.dart';
@@ -45,9 +46,11 @@ class _ProductPricesListState extends State<ProductPricesList>
   @override
   void initState() {
     super.initState();
+    final UserPreferences userPreferences = context.read<UserPreferences>();
     _priceManager = _InfiniteScrollPriceManager(
       pricesResult: widget.pricesResult,
       model: widget.model,
+      userPreferences: userPreferences,
     );
   }
 
@@ -62,6 +65,7 @@ class _ProductPricesListState extends State<ProductPricesList>
 class _InfiniteScrollPriceManager extends InfiniteScrollManager<Price> {
   _InfiniteScrollPriceManager({
     required this.model,
+    required this.userPreferences,
     GetPricesResult? pricesResult,
   }) : super(
          initialItems: pricesResult?.items,
@@ -71,6 +75,8 @@ class _InfiniteScrollPriceManager extends InfiniteScrollManager<Price> {
 
   /// The model containing price query parameters
   final GetPricesModel model;
+
+  final UserPreferences userPreferences;
 
   @override
   Future<void> fetchData(int pageNumber) async {
@@ -88,12 +94,28 @@ class _InfiniteScrollPriceManager extends InfiniteScrollManager<Price> {
     }
 
     final GetPricesResult value = result.value;
+    final int? total = value.total;
     updateItems(
       newItems: value.items,
       pageNumber: value.pageNumber,
-      totalItems: value.total,
+      totalItems: total,
       totalPages: value.numberOfPages,
     );
+
+    if (model.lazyCounterPrices != null && total != null) {
+      final int? before = model.lazyCounterPrices!.getLocalCount(
+        userPreferences,
+      );
+      if (before != total) {
+        unawaited(
+          model.lazyCounterPrices!.setLocalCount(
+            total,
+            userPreferences,
+            notify: true,
+          ),
+        );
+      }
+    }
   }
 
   @override

--- a/packages/smooth_app/lib/query/paged_product_query.dart
+++ b/packages/smooth_app/lib/query/paged_product_query.dart
@@ -1,5 +1,6 @@
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/data_models/product_list.dart';
+import 'package:smooth_app/pages/preferences/lazy_counter.dart';
 import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/query/search_products_manager.dart';
 
@@ -16,6 +17,7 @@ abstract class PagedProductQuery {
   int get pageNumber => _pageNumber;
 
   final OpenFoodFactsLanguage language = ProductQuery.getLanguage();
+
   OpenFoodFactsCountry? get country => world ? null : ProductQuery.getCountry();
 
   /// Is that the world mode (true), or the standard country mode (false).
@@ -28,6 +30,8 @@ abstract class PagedProductQuery {
 
   /// Is that a query that has potentially different data for country and world?
   bool hasDifferentCountryWorldData() => false;
+
+  LazyCounter? getLazyCounter() => null;
 
   static const int _typicalPageSize = 25;
   static const int _startPageNumber = 1;

--- a/packages/smooth_app/lib/query/paged_user_product_query.dart
+++ b/packages/smooth_app/lib/query/paged_user_product_query.dart
@@ -1,5 +1,6 @@
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/data_models/product_list.dart';
+import 'package:smooth_app/pages/preferences/lazy_counter.dart';
 import 'package:smooth_app/query/paged_product_query.dart';
 import 'package:smooth_app/query/product_query.dart';
 
@@ -54,6 +55,12 @@ class PagedUserProductQuery extends PagedProductQuery {
 
   final String userId;
   final UserSearchType type;
+
+  @override
+  LazyCounter? getLazyCounter() =>
+      (type == UserSearchType.INFORMER && productType == ProductType.food)
+      ? const LazyCounterUserSearch(UserSearchType.INFORMER)
+      : null;
 
   @override
   AbstractQueryConfiguration getQueryConfiguration() => type.getConfiguration(


### PR DESCRIPTION
### What
- The statistics on the app bar weren't displayed correctly - the count display was impacted by the presence of a slightly useless refresh button.
- When we get rid of that refresh button, the display is correct.

### Screenshots
| before | after |
| -- | -- |
| <img width="1080" height="1920" alt="Screenshot_1759856860" src="https://github.com/user-attachments/assets/b50bb3f0-99e2-4631-8fe7-8cfb4cdf508d" /> | <img width="1080" height="1920" alt="Screenshot_1759857252" src="https://github.com/user-attachments/assets/b921a7ee-349c-464e-ab1b-ab62eb0d97f4" /> |

### Fixes bug(s)
- Fixes: #7022