### PR TITLE
fix: Fix bottom overflow in search component on community page when logged in

### DIFF
--- a/packages/smooth_app/lib/generic_lib/widgets/app_bars/logged_in/logged_in_app_bar.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/app_bars/logged_in/logged_in_app_bar.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
-import 'package:smooth_app/generic_lib/widgets/app_bars/app_bar_constanst.dart';
 import 'package:smooth_app/generic_lib/widgets/app_bars/logged_in/all_statistics_button.dart';
 import 'package:smooth_app/generic_lib/widgets/app_bars/logged_in/logged_in_app_bar_body.dart';
 import 'package:smooth_app/generic_lib/widgets/app_bars/logged_in/logged_in_app_bar_header.dart';
 import 'package:smooth_app/generic_lib/widgets/app_bars/logged_in/statistics_cards/app_bar_statistics_card.dart';
 import 'package:smooth_app/generic_lib/widgets/app_bars/profile_app_bar.dart';
+import 'package:smooth_app/generic_lib/widgets/app_bars/search_bottom_bar.dart';
 
 class LoggedInAppBar extends StatelessWidget {
   const LoggedInAppBar({required this.userId, super.key})
@@ -22,7 +22,7 @@ class LoggedInAppBar extends StatelessWidget {
           AllStatisticsButton.MIN_HEIGHT,
       title: LoggedInAppBarHeader(userId: userId),
       content: LoggedInAppBarBody(userId: userId),
-      progressOffset: SEARCH_BOTTOM_HEIGHT,
+      progressOffset: SearchBottomBar.totalHeight,
     );
   }
 }

--- a/packages/smooth_app/lib/generic_lib/widgets/app_bars/profile_app_bar.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/app_bars/profile_app_bar.dart
@@ -29,7 +29,7 @@ class ProfileAppBar extends StatelessWidget {
         (Platform.isAndroid ? VERY_SMALL_SPACE : 0.0) +
         PROFILE_PICTURE_SIZE +
         MEDIUM_SPACE +
-        SEARCH_BOTTOM_HEIGHT;
+        SearchBottomBar.totalHeight;
 
     final double maxHeight = minHeight + LARGE_SPACE + contentHeight;
 
@@ -84,10 +84,10 @@ class _ProfileAppBarDelegate extends SliverPersistentHeaderDelegate {
       height: maxHeight,
       child: AppBarBackground(
         scrollOffset: progress * (maxHeight - minHeight),
-        bodyHeight: maxHeight - SEARCH_BOTTOM_HEIGHT,
+        bodyHeight: maxHeight - SearchBottomBar.totalHeight,
         minHeight: minHeight,
         maxHeight: maxHeight,
-        footerHeight: SEARCH_BOTTOM_HEIGHT,
+        footerHeight: SearchBottomBar.totalHeight,
         child: Column(
           children: <Widget>[
             Padding(


### PR DESCRIPTION
### What
- Fixed "BOTTOM OVERFLOWED BY 11 PIXELS" error in search component of community page after login
- Updated height calculations in ProfileAppBar to use correct SearchBottomBar.totalHeight instead of SEARCH_BOTTOM_HEIGHT

 
### Screenshot
Before: 
<img width="403" height="891" alt="Screenshot 2025-10-07 at 3 05 41 PM" src="https://github.com/user-attachments/assets/51c59a5c-50c9-48a2-9224-50401d1daee0" />

After: 
<img width="402" height="893" alt="image" src="https://github.com/user-attachments/assets/57cfbce6-1c5a-47ec-a78a-cf61f03f7c06" />

 
### Fixes bug(s)
- [Bottom overflow issue in search component of community page after login](https://github.com/openfoodfacts/smooth-app/issues/7041)

### Part of 
- Community page improvements 
- Closes #7041 
