### PR TITLE
fix: prevent app from closing when discarding edits

### DIFF
--- a/packages/smooth_app/lib/widgets/will_pop_scope.dart
+++ b/packages/smooth_app/lib/widgets/will_pop_scope.dart
@@ -38,8 +38,13 @@ class WillPopScope2 extends StatelessWidget {
                     GoRouter.of(context).pop(res);
                   } on GoError catch (error) {
                     if (error.message == 'There is nothing to pop') {
-                      // Force to kill the app
-                      SystemNavigator.pop();
+                      try {
+                        // Using regular Navigator as fallback
+                        Navigator.of(context).pop(res);
+                      } catch (navigatorError) {
+                        // Force to kill the app
+                        SystemNavigator.pop();
+                      }
                     }
                   }
                 });


### PR DESCRIPTION
### What
This PR prevents the app from unintentionally closing when discarding edits in the “Add a Receipt” and “Add Price Tags” flows and fixes #6959 .

#### Cause
Some flows (like Add a receipt, Add a price tags etc) are created with `Navigator.push(MaterialPageRoute...)` and are not part of GoRouter’s stack. 
In these cases:
- `Navigator.pop()` works correctly.
- `GoRouter.pop()` fails, which could lead to the app closing unexpectedly.

### Fix: 
- Updated WillPopScope2 to handle cases where the GoRouter stack has nothing to pop: 
 - Attempt `GoRouter.pop()` first.
 - Fall back to `Navigator.pop()` instead of calling `SystemNavigator.pop()` immediately.

This fallback prevents accidental app termination and makes back behavior consistent across both routing mechanisms.



### Fixes bug(s)
 
- Fixes: #6959 

 
