### PR TITLE
feat: 7055 - Price Proof Bulk upload always available

### DIFF
--- a/packages/smooth_app/lib/pages/preferences/user_preferences_dev_mode.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_dev_mode.dart
@@ -59,7 +59,6 @@ class UserPreferencesDevMode extends AbstractUserPreferences {
       '__pricesReceiptMultiSelection';
   static const String userPreferencesFlagSpellCheckerOnOcr =
       '__spellcheckerOcr';
-  static const String userPreferencesFlagBulkProofUpload = '__bulkProofUpload';
   static const String userPreferencesCustomNewsJSONURI = '__newsJsonURI';
 
   final TextEditingController _textFieldController = TextEditingController();
@@ -398,13 +397,6 @@ class UserPreferencesDevMode extends AbstractUserPreferences {
     ),
     UserPreferencesItemSection(
       label: appLocalizations.dev_mode_section_experimental_features,
-    ),
-    UserPreferencesItemSwitch(
-      title: appLocalizations.prices_bulk_proof_upload_title,
-      value:
-          userPreferences.getFlag(userPreferencesFlagBulkProofUpload) ?? false,
-      onChanged: (bool value) async =>
-          userPreferences.setFlag(userPreferencesFlagBulkProofUpload, value),
     ),
     UserPreferencesItemSwitch(
       title: 'Multi-products selection for prices',

--- a/packages/smooth_app/lib/pages/preferences/user_preferences_prices.dart
+++ b/packages/smooth_app/lib/pages/preferences/user_preferences_prices.dart
@@ -6,7 +6,6 @@ import 'package:smooth_app/pages/navigator/app_navigator.dart';
 import 'package:smooth_app/pages/preferences/abstract_user_preferences.dart';
 import 'package:smooth_app/pages/preferences/lazy_counter.dart';
 import 'package:smooth_app/pages/preferences/lazy_counter_widget.dart';
-import 'package:smooth_app/pages/preferences/user_preferences_dev_mode.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_item.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_list_tile.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_page.dart';
@@ -138,15 +137,11 @@ class UserPreferencesPrices extends AbstractUserPreferences {
         ),
         Icons.bar_chart,
       ),
-      if (userPreferences.getFlag(
-            UserPreferencesDevMode.userPreferencesFlagBulkProofUpload,
-          ) ??
-          false)
-        _getListTile(
-          appLocalizations.prices_bulk_proof_upload_title,
-          () async => ProofBulkAddPage.showPage(context: context),
-          Icons.upload_file,
-        ),
+      _getListTile(
+        appLocalizations.prices_bulk_proof_upload_title,
+        () async => ProofBulkAddPage.showPage(context: context),
+        Icons.upload_file,
+      ),
       _getListTile(
         appLocalizations.prices_contribution_assistant,
         () async => LaunchUrlHelper.launchURL(

--- a/packages/smooth_app/lib/pages/preferences_v2/roots/dev_mode_root.dart
+++ b/packages/smooth_app/lib/pages/preferences_v2/roots/dev_mode_root.dart
@@ -104,7 +104,6 @@ class DevModeRoot extends PreferencesRoot {
       PreferenceCard(
         title: 'Open Prices',
         tiles: <PreferenceTile>[
-          _buildBulkProofUploadTile(appLocalizations, userPreferences),
           _buildMultiProductsSelectionTile(
             context,
             appLocalizations,
@@ -419,25 +418,6 @@ class DevModeRoot extends PreferencesRoot {
   }
 
   // Open Prices section methods
-  TogglePreferenceTile _buildBulkProofUploadTile(
-    AppLocalizations appLocalizations,
-    UserPreferences userPreferences,
-  ) {
-    return TogglePreferenceTile(
-      title: appLocalizations.prices_bulk_proof_upload_title,
-      icon: const icons.Upload.bulk(),
-      state:
-          userPreferences.getFlag(
-            UserPreferencesDevMode.userPreferencesFlagBulkProofUpload,
-          ) ??
-          false,
-      onToggle: (bool value) async => userPreferences.setFlag(
-        UserPreferencesDevMode.userPreferencesFlagBulkProofUpload,
-        value,
-      ),
-    );
-  }
-
   TogglePreferenceTile _buildMultiProductsSelectionTile(
     BuildContext context,
     AppLocalizations appLocalizations,

--- a/packages/smooth_app/lib/pages/preferences_v2/roots/prices_root.dart
+++ b/packages/smooth_app/lib/pages/preferences_v2/roots/prices_root.dart
@@ -1,12 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
-import 'package:provider/provider.dart';
-import 'package:smooth_app/data_models/preferences/user_preferences.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/l10n/app_localizations.dart';
 import 'package:smooth_app/pages/preferences/lazy_counter.dart';
 import 'package:smooth_app/pages/preferences/lazy_counter_widget.dart';
-import 'package:smooth_app/pages/preferences/user_preferences_dev_mode.dart';
 import 'package:smooth_app/pages/preferences_v2/cards/preference_card.dart';
 import 'package:smooth_app/pages/preferences_v2/roots/preferences_root.dart';
 import 'package:smooth_app/pages/preferences_v2/tiles/preference_tile.dart';
@@ -32,7 +29,6 @@ class PricesRoot extends PreferencesRoot {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final String userId = ProductQuery.getWriteUser().userId;
     final bool isConnected = OpenFoodAPIConfiguration.globalUser != null;
-    final UserPreferences userPreferences = context.read<UserPreferences>();
 
     return <PreferenceCard>[
       if (isConnected) ...<PreferenceCard>[
@@ -64,11 +60,7 @@ class PricesRoot extends PreferencesRoot {
       PreferenceCard(
         title: appLocalizations.preferences_prices_ways_contribute_title,
         tiles: <PreferenceTile>[
-          if (userPreferences.getFlag(
-                UserPreferencesDevMode.userPreferencesFlagBulkProofUpload,
-              ) ??
-              false)
-            _buildBulkProofUploadTile(context, appLocalizations),
+          _buildBulkProofUploadTile(context, appLocalizations),
           _buildContributionAssistantTile(appLocalizations),
           _buildValidationAssistantTile(appLocalizations),
           _buildMultipleProofTile(appLocalizations),


### PR DESCRIPTION
### What
- Prices Proof Bulk Upload was an option.
- Now it's always available.

### Fixes bug(s)
- Closes: #7055

### Impacted files
* `dev_mode_root.dart`: removed the "bulk upload" toggle
* `prices_root.dart`: always display the "bulk upload" button
* `user_preferences_dev_mode.dart`: removed the "bulk upload" toggle
* `user_preferences_prices.dart`: always display the "bulk upload" button