### PR TITLE
fix: 7070 - 12-digit barcodes now displayed as UPC-A instead of EAN13

### DIFF
--- a/packages/smooth_app/lib/widgets/smooth_barcode_widget.dart
+++ b/packages/smooth_app/lib/widgets/smooth_barcode_widget.dart
@@ -32,6 +32,8 @@ class SmoothBarcodeWidget extends StatelessWidget {
     final Color contentColor =
         color ?? (context.lightTheme() ? Colors.black : Colors.white);
 
+    print('barcode2: $barcode');
+    print('barcodeType; $_barcodeType');
     return Semantics(
       label: AppLocalizations.of(context).barcode_accessibility_label(barcode),
       excludeSemantics: true,
@@ -87,6 +89,7 @@ class SmoothBarcodeWidget extends StatelessWidget {
       case 8:
         return Barcode.ean8();
       case 12:
+        return Barcode.upcA();
       case 13:
         return Barcode.ean13();
       default:

--- a/packages/smooth_app/lib/widgets/smooth_barcode_widget.dart
+++ b/packages/smooth_app/lib/widgets/smooth_barcode_widget.dart
@@ -32,8 +32,6 @@ class SmoothBarcodeWidget extends StatelessWidget {
     final Color contentColor =
         color ?? (context.lightTheme() ? Colors.black : Colors.white);
 
-    print('barcode2: $barcode');
-    print('barcodeType; $_barcodeType');
     return Semantics(
       label: AppLocalizations.of(context).barcode_accessibility_label(barcode),
       excludeSemantics: true,


### PR DESCRIPTION
### What
- 12-digit barcodes now displayed as UPC-A instead of EAN13
- cc. @computerstimulation

### Screenshots
| before | after |
| -- | -- |
| <img width="1080" height="1920" alt="Screenshot_1760951345" src="https://github.com/user-attachments/assets/38a1b6fb-9c3b-469f-adad-832e2a2ef76f" /> | <img width="1080" height="1920" alt="Screenshot_1760951358" src="https://github.com/user-attachments/assets/6239cb17-d710-451a-b31f-e84d34f4f75a" /> |

### Fixes bug(s)
- Fixes: #7070