### PR TITLE
fix: non-vectorial images show an infinite loader in the tagline

### DIFF
--- a/packages/smooth_app/lib/generic_lib/widgets/images/smooth_image.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/images/smooth_image.dart
@@ -19,6 +19,7 @@ class SmoothImage extends StatelessWidget {
     this.heroTag,
     this.cacheWidth,
     this.cacheHeight,
+    this.semanticsLabel,
   }) : assert(
          cacheWidth == null || imageProvider is NetworkImage,
          'cacheWidth requires a NetworkImage',
@@ -38,6 +39,7 @@ class SmoothImage extends StatelessWidget {
   final bool rounded;
   final int? cacheWidth;
   final int? cacheHeight;
+  final String? semanticsLabel;
 
   @override
   Widget build(BuildContext context) {
@@ -45,6 +47,7 @@ class SmoothImage extends StatelessWidget {
       NetworkImage(url: final String url) => Image.network(
         url,
         fit: fit,
+        semanticLabel: semanticsLabel,
         loadingBuilder: _loadingBuilder,
         errorBuilder: _errorBuilder,
         frameBuilder: (_, Widget child, int? frame, _) {
@@ -60,6 +63,7 @@ class SmoothImage extends StatelessWidget {
       ImageProvider<Object>() => Image(
         image: imageProvider!,
         fit: fit,
+        semanticLabel: semanticsLabel,
         loadingBuilder: _loadingBuilder,
         errorBuilder: _errorBuilder,
       ),

--- a/packages/smooth_app/lib/pages/scan/carousel/main_card/bottom_cards/news/scan_news_card.dart
+++ b/packages/smooth_app/lib/pages/scan/carousel/main_card/bottom_cards/news/scan_news_card.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import 'package:smooth_app/cards/category_cards/svg_cache.dart';
 import 'package:smooth_app/data_models/news_feed/newsfeed_model.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/generic_lib/widgets/images/smooth_image.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_app_logo.dart';
 import 'package:smooth_app/helpers/launch_url_helper.dart';
 import 'package:smooth_app/l10n/app_localizations.dart';
@@ -194,17 +195,9 @@ class _TagLineContentBodyState extends State<_TagLineContentBody> {
         errorBuilder: (_, _) => _onError(),
       );
     } else {
-      return Image.network(
-        semanticLabel: image.alt,
-        loadingBuilder: (_, Widget child, ImageChunkEvent? loadingProgress) {
-          if (loadingProgress == null) {
-            return _onLoading();
-          }
-
-          return child;
-        },
-        errorBuilder: (_, _, _) => _onError(),
-        image.src ?? '-',
+      return SmoothImage(
+        semanticsLabel: image.alt,
+        imageProvider: NetworkImage(image.src ?? '-'),
       );
     }
   }


### PR DESCRIPTION
<img width="720" height="429" alt="Screenshot_1760961863" src="https://github.com/user-attachments/assets/1c6da448-8093-4b07-8a54-6b6c26b155e6" />
