### PR TITLE
fix: 7073 - moved "user ordered KP" option in DEV MODE

### DIFF
--- a/packages/smooth_app/lib/pages/preferences_v2/roots/dev_mode_root.dart
+++ b/packages/smooth_app/lib/pages/preferences_v2/roots/dev_mode_root.dart
@@ -78,6 +78,7 @@ class DevModeRoot extends PreferencesRoot {
         title: appLocalizations.dev_mode_section_product_page,
         tiles: <PreferenceTile>[
           _buildEditIngredientsTile(context, appLocalizations, userPreferences),
+          _buildUserOrderedKpTile(context, appLocalizations, userPreferences),
         ],
       ),
       PreferenceCard(
@@ -105,7 +106,6 @@ class DevModeRoot extends PreferencesRoot {
             appLocalizations,
             userPreferences,
           ),
-          _buildUserOrderedKpTile(context, appLocalizations, userPreferences),
         ],
       ),
       PreferenceCard(


### PR DESCRIPTION
### What
- Moved "user ordered KP" option in DEV MODE

### Screenshot
<img width="1080" height="1920" alt="Screenshot_1760967328" src="https://github.com/user-attachments/assets/205a03f1-b765-4359-870c-cb635c226c50" />

### Fixes bug(s)
- Fixes: #7073