### PR TITLE
feat: 5861 - Save folksonomy data locally for offline viewing

### DIFF
--- a/packages/smooth_app/lib/database/dao_folksonomy.dart
+++ b/packages/smooth_app/lib/database/dao_folksonomy.dart
@@ -1,0 +1,74 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/database/abstract_sql_dao.dart';
+import 'package:smooth_app/database/local_database.dart';
+import 'package:sqflite/sqflite.dart';
+
+class DaoFolksonomy extends AbstractSqlDao {
+  DaoFolksonomy(super.localDatabase);
+
+  static const String _table = 'folksonomy';
+  static const String _columnBarcode = 'barcode';
+  static const String _columnTags = 'tagsString';
+  static const String _columnLastUpdateTimestamp = 'lastUpdateTimeStamp';
+
+  static const List<String> _columns = <String>[
+    _columnBarcode,
+    _columnTags,
+    _columnLastUpdateTimestamp,
+  ];
+
+  static FutureOr<void> onUpgrade(
+    final Database db,
+    final int oldVersion,
+    final int newVersion,
+  ) async {
+    if (oldVersion < 9) {
+      await db.execute(
+        'create table $_table('
+        ' $_columnBarcode TEXT NOT NULL PRIMARY KEY ON CONFLICT REPLACE,'
+        ' $_columnTags TEXT NOT NULL,'
+        ' $_columnLastUpdateTimestamp INT NOT NULL'
+        ')',
+      );
+    }
+  }
+
+  Future<void> saveTags(
+    final String barcode,
+    final List<ProductTag> tags,
+  ) async {
+    final String tagsString = jsonEncode(
+      tags.map((ProductTag tag) => tag.toJson()).toList(),
+    );
+    await localDatabase.database.insert(_table, <String, dynamic>{
+      _columnBarcode: barcode,
+      _columnTags: tagsString,
+      _columnLastUpdateTimestamp: LocalDatabase.nowInMillis(),
+    });
+  }
+
+  Future<List<ProductTag>> getTags(final String barcode) async {
+    final List<Map<String, dynamic>> result = await localDatabase.database
+        .query(
+          _table,
+          columns: _columns,
+          where: '$_columnBarcode = ?',
+          whereArgs: <String>[barcode],
+        );
+
+    if (result.isEmpty) {
+      return <ProductTag>[];
+    }
+
+    final List<dynamic> tags =
+        jsonDecode(result.first[_columnTags] as String) as List<dynamic>;
+    return tags
+        .map(
+          (dynamic json) => ProductTag.fromJson(json as Map<String, dynamic>),
+        )
+        .toList();
+  }
+}

--- a/packages/smooth_app/lib/database/dao_folksonomy.dart
+++ b/packages/smooth_app/lib/database/dao_folksonomy.dart
@@ -36,10 +36,16 @@ class DaoFolksonomy extends AbstractSqlDao {
     }
   }
 
-  Future<void> saveTags(
-    final String barcode,
-    final List<ProductTag> tags,
-  ) async {
+  Future<void> put(final String barcode, final List<ProductTag>? tags) async {
+    if (tags == null) {
+      await localDatabase.database.delete(
+        _table,
+        where: '$_columnBarcode = ?',
+        whereArgs: <String>[barcode],
+      );
+      return;
+    }
+
     final String tagsString = jsonEncode(
       tags.map((ProductTag tag) => tag.toJson()).toList(),
     );
@@ -50,7 +56,7 @@ class DaoFolksonomy extends AbstractSqlDao {
     });
   }
 
-  Future<List<ProductTag>> getTags(final String barcode) async {
+  Future<List<ProductTag>?> get(final String barcode) async {
     final List<Map<String, dynamic>> result = await localDatabase.database
         .query(
           _table,
@@ -60,7 +66,7 @@ class DaoFolksonomy extends AbstractSqlDao {
         );
 
     if (result.isEmpty) {
-      return <ProductTag>[];
+      return null;
     }
 
     final List<dynamic> tags =

--- a/packages/smooth_app/lib/database/local_database.dart
+++ b/packages/smooth_app/lib/database/local_database.dart
@@ -9,6 +9,7 @@ import 'package:smooth_app/background/background_task_manager.dart';
 import 'package:smooth_app/data_models/up_to_date_product_list_provider.dart';
 import 'package:smooth_app/data_models/up_to_date_product_provider.dart';
 import 'package:smooth_app/database/abstract_dao.dart';
+import 'package:smooth_app/database/dao_folksonomy.dart';
 import 'package:smooth_app/database/dao_hive_product.dart';
 import 'package:smooth_app/database/dao_instant_string.dart';
 import 'package:smooth_app/database/dao_int.dart';
@@ -76,7 +77,7 @@ class LocalDatabase extends ChangeNotifier {
     final String databasePath = join(databasesRootPath, 'smoothie.db');
     final Database database = await openDatabase(
       databasePath,
-      version: 8,
+      version: 9,
       singleInstance: true,
       onUpgrade: _onUpgrade,
     );
@@ -121,5 +122,6 @@ class LocalDatabase extends ChangeNotifier {
     await DaoWorkBarcode.onUpgrade(db, oldVersion, newVersion);
     await DaoProductLastAccess.onUpgrade(db, oldVersion, newVersion);
     await DaoOsmLocation.onUpgrade(db, oldVersion, newVersion);
+    await DaoFolksonomy.onUpgrade(db, oldVersion, newVersion);
   }
 }

--- a/packages/smooth_app/lib/pages/folksonomy/folksonomy_card.dart
+++ b/packages/smooth_app/lib/pages/folksonomy/folksonomy_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
+import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/l10n/app_localizations.dart';
@@ -17,7 +18,8 @@ class FolksonomyCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider<FolksonomyProvider>(
-      create: (_) => FolksonomyProvider(product.barcode!),
+      create: (_) =>
+          FolksonomyProvider(product.barcode!, context.read<LocalDatabase>()),
       child: Provider<Product>.value(
         value: product,
         child: const _FolksonomyCard(),

--- a/packages/smooth_app/lib/pages/folksonomy/folksonomy_provider.dart
+++ b/packages/smooth_app/lib/pages/folksonomy/folksonomy_provider.dart
@@ -81,9 +81,11 @@ class FolksonomyProvider extends ValueNotifier<FolksonomyState> {
             barcode: barcode,
             uriHelper: ProductQuery.uriFolksonomyHelper,
           );
+      final List<ProductTag> remoteTags = tags.values.toList();
+      print('hehe remote tags - $remoteTags');
 
-      await daoFolksonomy.put(barcode, tags.values.toList());
-      _updateTags(tags.values.toList());
+      await daoFolksonomy.put(barcode, remoteTags);
+      _updateTags(remoteTags);
     } catch (e) {
       if (_tags.isEmpty) {
         value = FolksonomyStateError(error: e);
@@ -254,14 +256,28 @@ class FolksonomyProvider extends ValueNotifier<FolksonomyState> {
   ProductTag? _getTag(String key) =>
       _tags.firstWhereOrNull((ProductTag tag) => tag.key == key);
 
-  void _sortTags() {
-    _tags.sort((ProductTag a, ProductTag b) => a.key.compareTo(b.key));
-  }
-
   void _updateTags(final List<ProductTag> tags) {
+    if (_equals(tags)) {
+      if (value is FolksonomyStateLoading) {
+        value = FolksonomyStateLoaded(tags: _tags);
+      }
+      return;
+    }
     _tags.clear();
     _tags.addAll(tags);
+    _sortTags();
     value = FolksonomyStateLoaded(tags: _tags);
+  }
+
+  bool _equals(final List<ProductTag> tags) {
+    final List<ProductTag> sortedTags = List<ProductTag>.from(tags);
+    _sortTags(sortedTags);
+    return const DeepCollectionEquality().equals(_tags, sortedTags);
+  }
+
+  void _sortTags([List<ProductTag>? tags]) {
+    final List<ProductTag> toSort = tags ?? _tags;
+    toSort.sort((ProductTag a, ProductTag b) => a.key.compareTo(b.key));
   }
 }
 

--- a/packages/smooth_app/lib/pages/folksonomy/folksonomy_provider.dart
+++ b/packages/smooth_app/lib/pages/folksonomy/folksonomy_provider.dart
@@ -82,7 +82,6 @@ class FolksonomyProvider extends ValueNotifier<FolksonomyState> {
             uriHelper: ProductQuery.uriFolksonomyHelper,
           );
       final List<ProductTag> remoteTags = tags.values.toList();
-      print('hehe remote tags - $remoteTags');
 
       await daoFolksonomy.put(barcode, remoteTags);
       _updateTags(remoteTags);

--- a/packages/smooth_app/lib/pages/folksonomy/folksonomy_provider.dart
+++ b/packages/smooth_app/lib/pages/folksonomy/folksonomy_provider.dart
@@ -65,16 +65,15 @@ class FolksonomyProvider extends ValueNotifier<FolksonomyState> {
 
   // Display tags from local database first (to see it offline), then update from API.
   Future<void> fetchProductTags() async {
+    if (_tags.isEmpty) {
+      value = const FolksonomyStateLoading();
+    }
+
     try {
-      final List<ProductTag> localTags = await DaoFolksonomy(
-        localDatabase,
-      ).getTags(barcode);
-      if (localTags.isNotEmpty) {
-        _tags.clear();
-        _tags.addAll(localTags);
-        value = FolksonomyStateLoaded(tags: _tags);
-      } else {
-        value = const FolksonomyStateLoading();
+      final DaoFolksonomy daoFolksonomy = DaoFolksonomy(localDatabase);
+      final List<ProductTag>? localTags = await daoFolksonomy.get(barcode);
+      if (localTags != null) {
+        _updateTags(localTags);
       }
 
       final Map<String, ProductTag> tags =
@@ -83,14 +82,12 @@ class FolksonomyProvider extends ValueNotifier<FolksonomyState> {
             uriHelper: ProductQuery.uriFolksonomyHelper,
           );
 
-      _tags.clear();
-      _tags.addAll(tags.values);
-
-      unawaited(DaoFolksonomy(localDatabase).saveTags(barcode, _tags));
-
-      value = FolksonomyStateLoaded(tags: _tags);
+      await daoFolksonomy.put(barcode, tags.values.toList());
+      _updateTags(tags.values.toList());
     } catch (e) {
-      // value = FolksonomyStateError(error: e);
+      if (_tags.isEmpty) {
+        value = FolksonomyStateError(error: e);
+      }
     }
   }
 
@@ -259,6 +256,12 @@ class FolksonomyProvider extends ValueNotifier<FolksonomyState> {
 
   void _sortTags() {
     _tags.sort((ProductTag a, ProductTag b) => a.key.compareTo(b.key));
+  }
+
+  void _updateTags(final List<ProductTag> tags) {
+    _tags.clear();
+    _tags.addAll(tags);
+    value = FolksonomyStateLoaded(tags: _tags);
   }
 }
 

--- a/packages/smooth_app/lib/pages/folksonomy/folksonomy_provider.dart
+++ b/packages/smooth_app/lib/pages/folksonomy/folksonomy_provider.dart
@@ -1,15 +1,21 @@
+import 'dart:async';
+
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/database/dao_folksonomy.dart';
+import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/pages/product/common/product_refresher.dart';
 import 'package:smooth_app/query/product_query.dart';
 
 class FolksonomyProvider extends ValueNotifier<FolksonomyState> {
-  FolksonomyProvider(this.barcode) : super(const FolksonomyStateLoading()) {
+  FolksonomyProvider(this.barcode, this.localDatabase)
+    : super(const FolksonomyStateLoading()) {
     fetchProductTags();
   }
 
   final String barcode;
+  final LocalDatabase localDatabase;
   String? _bearerToken;
   final List<ProductTag> _tags = <ProductTag>[];
   final ProductRefresher _productRefresher = ProductRefresher();
@@ -57,9 +63,19 @@ class FolksonomyProvider extends ValueNotifier<FolksonomyState> {
     }
   }
 
+  // Display tags from local database first (to see it offline), then update from API.
   Future<void> fetchProductTags() async {
     try {
-      value = const FolksonomyStateLoading();
+      final List<ProductTag> localTags = await DaoFolksonomy(
+        localDatabase,
+      ).getTags(barcode);
+      if (localTags.isNotEmpty) {
+        _tags.clear();
+        _tags.addAll(localTags);
+        value = FolksonomyStateLoaded(tags: _tags);
+      } else {
+        value = const FolksonomyStateLoading();
+      }
 
       final Map<String, ProductTag> tags =
           await FolksonomyAPIClient.getProductTags(
@@ -70,9 +86,11 @@ class FolksonomyProvider extends ValueNotifier<FolksonomyState> {
       _tags.clear();
       _tags.addAll(tags.values);
 
+      unawaited(DaoFolksonomy(localDatabase).saveTags(barcode, _tags));
+
       value = FolksonomyStateLoaded(tags: _tags);
     } catch (e) {
-      value = FolksonomyStateError(error: e);
+      // value = FolksonomyStateError(error: e);
     }
   }
 

--- a/packages/smooth_app/lib/pages/product/product_page/footer/new_product_footer_add_product_properties.dart
+++ b/packages/smooth_app/lib/pages/product/product_page/footer/new_product_footer_add_product_properties.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
+import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/l10n/app_localizations.dart';
 import 'package:smooth_app/pages/folksonomy/folksonomy_page.dart';
 import 'package:smooth_app/pages/folksonomy/folksonomy_provider.dart';
@@ -36,7 +37,10 @@ class ProductFooterAddPropertyButton extends StatelessWidget {
       return;
     }
 
-    final FolksonomyProvider provider = FolksonomyProvider(product.barcode!);
+    final FolksonomyProvider provider = FolksonomyProvider(
+      product.barcode!,
+      context.read<LocalDatabase>(),
+    );
 
     await Navigator.of(context).push(
       MaterialPageRoute<void>(


### PR DESCRIPTION
### What
<!-- description of the PR -->
- Save folksonomy data in a new SQFLite table `folksonomy` locally for offline viewing.
<!-- 
Please name your pull request following this scheme: `type: What you did` this allows us to automatically generate the changelog
Following `type`s are allowed:
  - `feat`, for Features
  - `fix`, for Bug Fixes
  - `docs`, for Documentation
  - `ci`, for Automation
  - `refactor`, for code Refactoring
  - `chore`, for Miscellaneous things
-->
### Screenshot
[Screen_recording_20251026_024959.webm](https://github.com/user-attachments/assets/2a1a0b52-0d2c-478a-af8f-9b70a1ed33f8)

### Part of 
- #5861
