### PR TITLE
fix: 7109 - removed the empty "for me" tab

### DIFF
--- a/packages/smooth_app/lib/pages/product/product_page/header/product_page_tabs.dart
+++ b/packages/smooth_app/lib/pages/product/product_page/header/product_page_tabs.dart
@@ -161,6 +161,7 @@ class ProductPageTabsGenerator {
     Product product,
     List<ProductPageTab> tabs,
   ) {
+    /* until we have something interesting to put there
     tabs.insert(
       0,
       ProductPageTab(
@@ -173,6 +174,7 @@ class ProductPageTabsGenerator {
         ),
       ),
     );
+    */
     if (product.website?.trim().isNotEmpty == true) {
       tabs.add(
         ProductPageTab(

--- a/packages/smooth_app/lib/pages/product/product_page/product_page_tab_controller.dart
+++ b/packages/smooth_app/lib/pages/product/product_page/product_page_tab_controller.dart
@@ -31,7 +31,7 @@ class _ProductPageTabControllerState extends State<ProductPageTabController>
       _tabController = TabController(
         length: _tabs.length,
         vsync: this,
-        initialIndex: 1,
+        initialIndex: 0,
       );
       _isInitialized = true;
     }


### PR DESCRIPTION
### What
- Removed the empty "for me" tab

### Screenshots
| before | after |
| -- | -- |
| <img width="1080" height="1920" alt="Screenshot_1761835754" src="https://github.com/user-attachments/assets/09355b4f-4192-46e7-ab12-5d319dddbbcf" /> | <img width="1080" height="1920" alt="Screenshot_1761836677" src="https://github.com/user-attachments/assets/542a2957-a005-4f48-adb9-4c012239577a" /> |

### Fixes bug(s)
- Fixes: #7109