### PR TITLE
fix: 7101 - nutripatrol now using flavor instead of product type

### DIFF
--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_action_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_action_card.dart
@@ -88,7 +88,7 @@ class KnowledgePanelActionCard extends StatelessWidget {
           'https://nutripatrol.openfoodfacts.org/flag/product/'
           '?barcode=${product.barcode}'
           '&source=mobile'
-          '&flavor=${product.productType?.offTag}',
+          '&flavor=${product.productType?.flavor.offTag}',
         ),
       );
     }
@@ -142,4 +142,14 @@ class KnowledgePanelActionCard extends StatelessWidget {
     properties.add(StringProperty('html', element.html));
     properties.add(IterableProperty<String>('actions', element.actions));
   }
+}
+
+// TODO(monsieurtanuki): move code to off-dart
+extension ProductTypeFlavorExtension on ProductType {
+  Flavor get flavor => switch (this) {
+    ProductType.food => Flavor.openFoodFacts,
+    ProductType.beauty => Flavor.openBeautyFacts,
+    ProductType.petFood => Flavor.openPetFoodFacts,
+    ProductType.product => Flavor.openProductFacts,
+  };
 }


### PR DESCRIPTION
### What
- The calls to nutripatrol URLs now use flavor (`'obf'`) instead of product type (`'beauty'`)

### Fixes bug(s)
- Fixes: #7101