### PR TITLE
feat: 7100 - added "edit folksonomy" to edit product page

### DIFF
--- a/packages/smooth_app/lib/pages/product/edit_product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product/edit_product_page.dart
@@ -10,6 +10,8 @@ import 'package:smooth_app/generic_lib/widgets/smooth_list_tile_card.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/l10n/app_localizations.dart';
+import 'package:smooth_app/pages/folksonomy/folksonomy_page.dart';
+import 'package:smooth_app/pages/folksonomy/folksonomy_provider.dart';
 import 'package:smooth_app/pages/onboarding/currency_selector_helper.dart';
 import 'package:smooth_app/pages/prices/price_meta_product.dart';
 import 'package:smooth_app/pages/prices/product_price_add_page.dart';
@@ -249,6 +251,22 @@ class _EditProductPageState extends State<EditProductPage> with UpToDateMixin {
                         ),
                       );
                     },
+              ),
+              _ListTitleItem(
+                title: appLocalizations.product_page_tab_folksonomy,
+                // TODO(g123k): find a proper icon for folksonomy
+                leading: const Icon(Icons.edit),
+                onTap: () async => Navigator.of(context).push(
+                  MaterialPageRoute<void>(
+                    builder: (BuildContext lContext) => FolksonomyPage(
+                      product: upToDateProduct,
+                      provider: FolksonomyProvider(
+                        upToDateProduct.barcode!,
+                        localDatabase,
+                      ),
+                    ),
+                  ),
+                ),
               ),
             ],
           ),


### PR DESCRIPTION
### What
- Added an "edit folksonomy" item in the Edit product page.

### Screenshots
| edit product page | folksonomy page |
| -- | -- |
| <img width="1080" height="1920" alt="Screenshot_1761929619" src="https://github.com/user-attachments/assets/1ce0ed2c-5adb-4fc2-8d24-d3787c441441" /> | <img width="1080" height="1920" alt="Screenshot_1761929691" src="https://github.com/user-attachments/assets/e0246bc7-22ef-4599-b9b0-40eb1a87d8e2" /> |

### Fixes bug(s)
- Closes: #7100