### PR TITLE
feat: 7099 - clickable folksonomy URLs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,359 +1,359 @@
 # Add labels to any any pull request with changes to the specified paths
 Android:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/android/**/*'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/android/**/*'
 
 🖥️ MacOS:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/macos/**/*'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/macos/**/*'
 
 Assets cache:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/assets/cache/**/*'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/assets/cache/**/*'
 
 navigation:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/widgets/smooth_navigation_bar.dart'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/widgets/smooth_navigation_bar.dart'
 
 🔁 Background tasks:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/background/background_task_manager.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/offline_tasks_page.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/background/background_task_crop.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/background/background_task_image.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/background/background_task_upload.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/background/background_task_add_price.dart'
-  
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/background/background_task_manager.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/offline_tasks_page.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/background/background_task_crop.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/background/background_task_image.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/background/background_task_upload.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/background/background_task_add_price.dart'
+
 📚 Documentation:
-- changed-files:
-  - any-glob-to-any-file: 'README.md'
-  - any-glob-to-any-file: 'packages/smooth_app/android/fastlane/README.md'
-  - any-glob-to-any-file: 'packages/smooth_app/README.md'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/l10n/README.md'
+  - changed-files:
+      - any-glob-to-any-file: 'README.md'
+      - any-glob-to-any-file: 'packages/smooth_app/android/fastlane/README.md'
+      - any-glob-to-any-file: 'packages/smooth_app/README.md'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/l10n/README.md'
 
 Dependencies:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/pubspec.yaml'
-  - any-glob-to-any-file: 'packages/data_importer/pubspec.yaml'
-  - any-glob-to-any-file: 'packages/scanner/zxing/pubspec.yaml'
-  - any-glob-to-any-file: 'packages/scanner/ml_kit/pubspec.yaml'
-  - any-glob-to-any-file: 'packages/scanner/shared/pubspec.yaml'
-  - any-glob-to-any-file: 'packages/app_store/shared/pubspec.yaml'
-  - any-glob-to-any-file: 'packages/app_store/uri_store/pubspec.yaml'
-  - any-glob-to-any-file: 'packages/data_importer_shared/pubspec.yaml'
-  - any-glob-to-any-file: 'packages/app_store/google_play/pubspec.yaml'
-  - any-glob-to-any-file: 'packages/app_store/apple_app_store/pubspec.yaml'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/pubspec.yaml'
+      - any-glob-to-any-file: 'packages/data_importer/pubspec.yaml'
+      - any-glob-to-any-file: 'packages/scanner/zxing/pubspec.yaml'
+      - any-glob-to-any-file: 'packages/scanner/ml_kit/pubspec.yaml'
+      - any-glob-to-any-file: 'packages/scanner/shared/pubspec.yaml'
+      - any-glob-to-any-file: 'packages/app_store/shared/pubspec.yaml'
+      - any-glob-to-any-file: 'packages/app_store/uri_store/pubspec.yaml'
+      - any-glob-to-any-file: 'packages/data_importer_shared/pubspec.yaml'
+      - any-glob-to-any-file: 'packages/app_store/google_play/pubspec.yaml'
+      - any-glob-to-any-file: 'packages/app_store/apple_app_store/pubspec.yaml'
 
 🍎 iOS:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/ios/**/*'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/ios/**/*'
 
 ⚡️ Fastlane:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/ios/Gemfile.lock'
-  - any-glob-to-any-file: 'packages/smooth_app/android/Gemfile.lock'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/ios/Gemfile.lock'
+      - any-glob-to-any-file: 'packages/smooth_app/android/Gemfile.lock'
 
 Asset cache:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/assets/cache/**/*'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/assets/cache/**/*'
 
 Web:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/web/**/*'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/web/**/*'
 
 🧪 Tests:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/test/**/*.md'
-  - any-glob-to-any-file: 'packages/smooth_app/test/widget_test.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/test/basic_test.dart'
-  - any-glob-to-any-file: 'packages/scanner/shared/test/shared_test.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/integration_test/app_test.dart'
-  - any-glob-to-any-file: 'packages/data_importer/test/data_importer_test.dart'
-  - any-glob-to-any-file: 'packages/scanner/mlkit/test/scanner_mlkit_test.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/test/plural_translation_test.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/test/smooth_ui_library/basic_test.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/test/utils/string_extensions_test.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/test/dialogs/generic_lib/dialogs_test.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/test/pages/user_preferences_page_test.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/test/utils/text_input_formatters_tests.dart'
-  - any-glob-to-any-file: 'packages/data_importer_shared/test/data_importer_shared_test.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/test/tests_utils/mocks.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/test/tests_utils/goldens.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/test_driver/screenshot_driver.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/test/pages/generic_lib/widgets/smooth_error_card_test.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/test/smooth_ui_library/dialogs/smooth_category_picker_test.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/test/tests_utils/path_provider_mock.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/test/smooth_ui_library/animations/smooth_reveal_animation_test.dart'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/test/**/*.md'
+      - any-glob-to-any-file: 'packages/smooth_app/test/widget_test.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/test/basic_test.dart'
+      - any-glob-to-any-file: 'packages/scanner/shared/test/shared_test.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/integration_test/app_test.dart'
+      - any-glob-to-any-file: 'packages/data_importer/test/data_importer_test.dart'
+      - any-glob-to-any-file: 'packages/scanner/mlkit/test/scanner_mlkit_test.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/test/plural_translation_test.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/test/smooth_ui_library/basic_test.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/test/utils/string_extensions_test.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/test/dialogs/generic_lib/dialogs_test.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/test/pages/user_preferences_page_test.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/test/utils/text_input_formatters_tests.dart'
+      - any-glob-to-any-file: 'packages/data_importer_shared/test/data_importer_shared_test.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/test/tests_utils/mocks.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/test/tests_utils/goldens.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/test_driver/screenshot_driver.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/test/pages/generic_lib/widgets/smooth_error_card_test.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/test/smooth_ui_library/dialogs/smooth_category_picker_test.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/test/tests_utils/path_provider_mock.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/test/smooth_ui_library/animations/smooth_reveal_animation_test.dart'
 
 Database:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/database/**/*'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/database/**/*'
 
 🌐 l10n:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/l10n/**/*'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/l10n/**/*'
 
 History:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/history_page.dart'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/history_page.dart'
 
 ⚙️ Settings:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/user_preferences_page.dart'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/user_preferences_page.dart'
 
 ⚙️🥗 Food preferences:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/widgets/attribute_button.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/preferences/user_preferences_attribute_group.dart'
-  
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/widgets/attribute_button.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/preferences/user_preferences_attribute_group.dart'
+
 🤗 Onboarding:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/onboarding/**/*'
-  - any-glob-to-any-file: 'packages/smooth_app/assets/onboarding/**/*'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/data_models/onboarding_loader.dart'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/onboarding/**/*'
+      - any-glob-to-any-file: 'packages/smooth_app/assets/onboarding/**/*'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/data_models/onboarding_loader.dart'
 
 🤳🥫 Scan:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/scan/**/*'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/scan/continuous_scan_page.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/scan/scan_page.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/scan/abstract_camera_image_getter.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/scan/**/*'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/scan/continuous_scan_page.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/scan/scan_page.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/scan/abstract_camera_image_getter.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart'
 
 🤳🥫 MLKit:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/scan/ml_kit_scan_page.dart'
 
 Amazon Appstore:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/entrypoints/android/main_amazon_appstore.dart'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/entrypoints/android/main_amazon_appstore.dart'
 
 F-Droid:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/entrypoints/android/main_fdroid.dart'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/entrypoints/android/main_fdroid.dart'
 
 Huawei AppGallery:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/entrypoints/android/main_huawei_appgallery.dart'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/entrypoints/android/main_huawei_appgallery.dart'
 
 🤳🥫 ZXing:
-- changed-files:
-  - any-glob-to-any-file: 'packages/scanner/zxing/**/*'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/scanner/zxing/**/*'
 
 Product addition:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/add_new_product_page.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/new_product_page.dart'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/add_new_product_page.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/new_product_page.dart'
 
 🥫 Product page:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/**/*'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/**/*'
 
 📖 Knowledge panels:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/cards/product_cards/knowledge_panels/**/*'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/reorderable_knowledge_panel_page.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/reordered_knowledge_panel_cards.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/standard_knowledge_panel_cards.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_card.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_page.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_table_card.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_world_map_card.dart'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/cards/product_cards/knowledge_panels/**/*'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/reorderable_knowledge_panel_page.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/reordered_knowledge_panel_cards.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/standard_knowledge_panel_cards.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_card.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_page.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_table_card.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_world_map_card.dart'
 
 📖 Knowledge panels - Table widget:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_table_card.dart'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_table_card.dart'
 
 📖 Knowledge panels - Map widget:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_world_map_card.dart'
-  
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_world_map_card.dart'
+
 🤖 Robotoff:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/database/robotoff_questions_query.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/cards/product_cards/question_card.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/product_questions_widget.dart'
-  
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/database/robotoff_questions_query.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/cards/product_cards/question_card.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/product_questions_widget.dart'
+
 Hunger Games:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/hunger_games/question_answers_options.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/hunger_games/question_card.dart'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/hunger_games/question_answers_options.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/hunger_games/question_card.dart'
 
 Summary card:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/summary_card.dart'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/summary_card.dart'
 
 📈 Analytics:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/onboarding/consent_analytics_page.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/assets/onboarding/analytics.svg'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/helpers/analytics_helper.dart'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/onboarding/consent_analytics_page.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/assets/onboarding/analytics.svg'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/helpers/analytics_helper.dart'
 
 Goldens:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/test/pages/goldens'
-  - any-glob-to-any-file: 'packages/smooth_app/test/tests_utils/goldens.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/test/pages/goldens/user_preferences_page-dark.png'
-  - any-glob-to-any-file: 'packages/smooth_app/test/pages/goldens/user_preferences_page-light.png'
-  - any-glob-to-any-file: 'packages/smooth_app/test/smooth_ui_library/widgets/goldens/smooth_view_finder.png'
-  - any-glob-to-any-file: 'packages/smooth_app/test/smooth_ui_library/widgets/goldens/smooth_view_finder-animation.png'
-  - any-glob-to-any-file: 'packages/smooth_app/test/dialogs/generic_lib/goldens/user_preferences_page_dialogs_Improving-dark.png'
-  - any-glob-to-any-file: 'packages/smooth_app/test/dialogs/generic_lib/goldens/user_preferences_page_dialogs_Translate-dark.png'
-  - any-glob-to-any-file: 'packages/smooth_app/test/dialogs/generic_lib/goldens/user_preferences_page_dialogs_Improving-light.png'
-  - any-glob-to-any-file: 'packages/smooth_app/test/dialogs/generic_lib/goldens/user_preferences_page_dialogs_Translate-light.png'
-  - any-glob-to-any-file: 'packages/smooth_app/test/dialogs/generic_lib/goldens/user_preferences_page_dialogs_Software development-dark.png'
-  - any-glob-to-any-file: 'packages/smooth_app/test/dialogs/generic_lib/goldens/user_preferences_page_dialogs_Software development-light.png'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/test/pages/goldens'
+      - any-glob-to-any-file: 'packages/smooth_app/test/tests_utils/goldens.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/test/pages/goldens/user_preferences_page-dark.png'
+      - any-glob-to-any-file: 'packages/smooth_app/test/pages/goldens/user_preferences_page-light.png'
+      - any-glob-to-any-file: 'packages/smooth_app/test/smooth_ui_library/widgets/goldens/smooth_view_finder.png'
+      - any-glob-to-any-file: 'packages/smooth_app/test/smooth_ui_library/widgets/goldens/smooth_view_finder-animation.png'
+      - any-glob-to-any-file: 'packages/smooth_app/test/dialogs/generic_lib/goldens/user_preferences_page_dialogs_Improving-dark.png'
+      - any-glob-to-any-file: 'packages/smooth_app/test/dialogs/generic_lib/goldens/user_preferences_page_dialogs_Translate-dark.png'
+      - any-glob-to-any-file: 'packages/smooth_app/test/dialogs/generic_lib/goldens/user_preferences_page_dialogs_Improving-light.png'
+      - any-glob-to-any-file: 'packages/smooth_app/test/dialogs/generic_lib/goldens/user_preferences_page_dialogs_Translate-light.png'
+      - any-glob-to-any-file: 'packages/smooth_app/test/dialogs/generic_lib/goldens/user_preferences_page_dialogs_Software development-dark.png'
+      - any-glob-to-any-file: 'packages/smooth_app/test/dialogs/generic_lib/goldens/user_preferences_page_dialogs_Software development-light.png'
 
 GitHub:
-- changed-files:
-  - any-glob-to-any-file: '.github/**/*'
+  - changed-files:
+      - any-glob-to-any-file: '.github/**/*'
 
 👥 User management:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/user_management/login_page.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/user_management/forgot_password_page.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/user_management/sign_up_page.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/user_preferences_page.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/user_preferences_settings.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/user_preferences_food.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/user_preferences_dev_mode.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/user_preferences_attribute_group.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/helpers/user_management_helper.dart'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/user_management/login_page.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/user_management/forgot_password_page.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/user_management/sign_up_page.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/user_preferences_page.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/user_preferences_settings.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/user_preferences_food.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/user_preferences_dev_mode.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/user_preferences_attribute_group.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/helpers/user_management_helper.dart'
 
 Ranking:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/helpers/product_compatibility_helper.dart'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/helpers/product_compatibility_helper.dart'
 
 Generic lib:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/generic_lib'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/generic_lib'
 
 🖼️ Photos - Cropping:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/image_crop_page.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/crop_page.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/background/background_task_crop.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/product_image_crop_button.dart'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/image_crop_page.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/crop_page.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/background/background_task_crop.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/product_image_crop_button.dart'
 
 User lists:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product_list_user_dialog_helper.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/common/product_list_page.dart'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product_list_user_dialog_helper.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/common/product_list_page.dart'
 
 Product scan carousel:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/scan/carousel/scan_carousel.dart'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/scan/carousel/scan_carousel.dart'
 
 autocomplete:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/input/smooth_autocomplete_text_field.dart'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/input/smooth_autocomplete_text_field.dart'
 
 ✏️ Editing:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/edit_product_page.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/input/smooth_autocomplete_text_field.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/add_other_details_page.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/simple_input_page.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/simple_input_text_field.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/nutrition_page/widgets/edit_product_image_viewer.dart'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/edit_product_page.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/input/smooth_autocomplete_text_field.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/add_other_details_page.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/simple_input_page.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/simple_input_page_helpers.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/simple_input_text_field.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/nutrition_page/widgets/edit_product_image_viewer.dart'
 
 ✏️ Editing - Nutrition input:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/nutrition_page/nutrition_page.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/nutrition_page/nutrition_page_loader.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/nutrition_page/widgets/nutrition_add_nutrient_button.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/nutrition_page/widgets/nutrition_availability_container.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/nutrition_page/widgets/nutrition_availability_container.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/nutrition_page/widgets/nutrition_container_helper.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/nutrition_page/widgets/nutrition_facts_editor.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/nutrition_page/widgets/nutrition_serving_size.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/nutrition_page/widgets/nutrition_serving_switch.dart'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/nutrition_page/nutrition_page.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/nutrition_page/nutrition_page_loader.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/nutrition_page/widgets/nutrition_add_nutrient_button.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/nutrition_page/widgets/nutrition_availability_container.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/nutrition_page/widgets/nutrition_availability_container.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/nutrition_page/widgets/nutrition_container_helper.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/nutrition_page/widgets/nutrition_facts_editor.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/nutrition_page/widgets/nutrition_serving_size.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/nutrition_page/widgets/nutrition_serving_switch.dart'
 
 #tag picker:
 
 ✏️ Editing - Category picker:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/data_models/category_tree_supplier.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/example/smooth_category_picker_example.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/generic_lib/dialogs/smooth_category_picker.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/test/dialogs/smooth_category_picker_test.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/data_models/category_query_model.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/data_models/query_category_tree_supplier.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/data_models/smooth_category.dart'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/data_models/category_tree_supplier.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/example/smooth_category_picker_example.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/generic_lib/dialogs/smooth_category_picker.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/test/dialogs/smooth_category_picker_test.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/data_models/category_query_model.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/data_models/query_category_tree_supplier.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/data_models/smooth_category.dart'
 
 ✏️ Editing - 📦 Packaging input:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/edit_new_packagings.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/ocr_packaging_helper.dart'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/edit_new_packagings.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/ocr_packaging_helper.dart'
 
 ✏️ Editing - Basic info input:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/add_basic_details_page.dart'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/add_basic_details_page.dart'
 
 OCR page:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/edit_ocr/edit_ocr_main_action.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/edit_ocr/edit_ocr_page.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/edit_ocr/ocr_ingredients_helper.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/edit_ocr/ocr_packaging_helper.dart'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/edit_ocr/edit_ocr_main_action.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/edit_ocr/edit_ocr_page.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/edit_ocr/ocr_ingredients_helper.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/edit_ocr/ocr_packaging_helper.dart'
 
 Prices:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/background/background_task_add_price.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/data_models/location_list_supplier.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/database/dao_osm_location.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/locations/location_map_page.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/locations/search_location_preloaded_item.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/prices/get_prices_model.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/prices/price_amount_card.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/prices/price_amount_field.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/prices/price_button.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/prices/price_currency_card.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/prices/price_currency_selector.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/prices/price_data_widget.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/prices/price_date_card.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/prices/price_location_card.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/prices/price_model.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/prices/price_product_widget.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/prices/prices_page.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/prices/price_proof_card.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/prices/prices_card.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/prices/product_price_add_page.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/prices/price_add_product_card.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/prices/price_scan_page.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/onboarding/currency_selector.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/onboarding/currency_selector_helper.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/prices/prices_proofs_page.dart'
-  
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/background/background_task_add_price.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/data_models/location_list_supplier.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/database/dao_osm_location.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/locations/location_map_page.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/locations/search_location_preloaded_item.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/prices/get_prices_model.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/prices/price_amount_card.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/prices/price_amount_field.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/prices/price_button.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/prices/price_currency_card.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/prices/price_currency_selector.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/prices/price_data_widget.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/prices/price_date_card.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/prices/price_location_card.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/prices/price_model.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/prices/price_product_widget.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/prices/prices_page.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/prices/price_proof_card.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/prices/prices_card.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/prices/product_price_add_page.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/prices/price_add_product_card.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/prices/price_scan_page.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/onboarding/currency_selector.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/onboarding/currency_selector_helper.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/prices/prices_proofs_page.dart'
+
 router:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/navigator/app_navigator.dart'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/navigator/app_navigator.dart'
 
 🛣️ Road to scores:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/product_incomplete_card.dart'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/product_incomplete_card.dart'
 
 tagline:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/data_models/news_feed/newsfeed_json.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/data_models/news_feed/newsfeed_model.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/data_models/news_feed/newsfeed_provider.dart'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/data_models/news_feed/newsfeed_json.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/data_models/news_feed/newsfeed_model.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/data_models/news_feed/newsfeed_provider.dart'
 
 🖼️ Photos - Photo manager:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/image/product_image_gallery_other_view.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/image/product_image_other_page.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/gallery_view/product_image_gallery_view.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/gallery_view/product_image_gallery_tabs.dart'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/image/product_image_gallery_other_view.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/image/product_image_other_page.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/gallery_view/product_image_gallery_view.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/gallery_view/product_image_gallery_tabs.dart'
 
 moderation:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/report_product/report_product_header.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/report_product/report_product_page.dart'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/report_product/report_product_header.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/product/report_product/report_product_page.dart'
 
 folksonomy engine:
-- changed-files:
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/folksonomy/folksonomy_page.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/folksonomy/folksonomy_provider.dart'
-  - any-glob-to-any-file: 'packages/smooth_app/lib/pages/folksonomy/folksonomy_product_tag_helper.dart'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/folksonomy/folksonomy_page.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/folksonomy/folksonomy_provider.dart'
+      - any-glob-to-any-file: 'packages/smooth_app/lib/pages/folksonomy/folksonomy_product_tag_extension.dart'

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -2624,9 +2624,9 @@
     "description": "Very small text, in the context of prices, to say that the product is unknown"
   },
   "prices_menu_know_more": "Know more about Open Prices",
-    "@prices_menu_know_more": {
-        "description": "Menu item to open the Open Prices guide"
-    },
+  "@prices_menu_know_more": {
+    "description": "Menu item to open the Open Prices guide"
+  },
   "dev_preferences_import_history_result_success": "Done",
   "@dev_preferences_import_history_result_success": {
     "description": "User dev preferences - Import history - Result successful"
@@ -4534,6 +4534,14 @@
   "product_page_tab_folksonomy": "Folksonomy",
   "@product_page_tab_folksonomy": {
     "description": "Label of the folksonomy tab on the product page"
+  },
+  "folksonomy_action_external_link_title": "Open external link",
+  "@folksonomy_action_external_link_title": {
+    "description": "Label of the 'open external link' action on a folksonomy entry"
+  },
+  "folksonomy_action_external_link_warning": "External links may be unsafe. Do you really want to visit it?",
+  "@folksonomy_action_external_link_warning": {
+    "description": "Warning about the 'open external link' action on a folksonomy entry"
   },
   "prices_products_empty_title": "No price available",
   "prices_products_empty_explanation": "Be the first to contribute!",

--- a/packages/smooth_app/lib/l10n/app_localizations.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations.dart
@@ -9085,6 +9085,18 @@ abstract class AppLocalizations {
   /// **'Folksonomy'**
   String get product_page_tab_folksonomy;
 
+  /// Label of the 'open external link' action on a folksonomy entry
+  ///
+  /// In en, this message translates to:
+  /// **'Open external link'**
+  String get folksonomy_action_external_link_title;
+
+  /// Warning about the 'open external link' action on a folksonomy entry
+  ///
+  /// In en, this message translates to:
+  /// **'External links may be unsafe. Do you really want to visit it?'**
+  String get folksonomy_action_external_link_warning;
+
   /// No description provided for @prices_products_empty_title.
   ///
   /// In en, this message translates to:

--- a/packages/smooth_app/lib/l10n/app_localizations_aa.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_aa.dart
@@ -5280,6 +5280,13 @@ class AppLocalizationsAa extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'No price available';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_af.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_af.dart
@@ -5281,6 +5281,13 @@ class AppLocalizationsAf extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'No price available';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ak.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ak.dart
@@ -5280,6 +5280,13 @@ class AppLocalizationsAk extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'No price available';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_am.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_am.dart
@@ -5266,6 +5266,13 @@ class AppLocalizationsAm extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'ምንም ዋጋ አይገኝም';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ar.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ar.dart
@@ -5263,6 +5263,13 @@ class AppLocalizationsAr extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'لا يوجد سعر متاح';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_as.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_as.dart
@@ -5275,6 +5275,13 @@ class AppLocalizationsAs extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'কোনো মূল্য উপলব্ধ নহয়';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_az.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_az.dart
@@ -5279,6 +5279,13 @@ class AppLocalizationsAz extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Qiymət yoxdur';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_be.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_be.dart
@@ -5306,6 +5306,13 @@ class AppLocalizationsBe extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Кошт недаступны';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_bg.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_bg.dart
@@ -5320,6 +5320,13 @@ class AppLocalizationsBg extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Няма налична цена';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_bm.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_bm.dart
@@ -5284,6 +5284,13 @@ class AppLocalizationsBm extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Sɔngɔ si tɛ sɔrɔ';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_bn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_bn.dart
@@ -5278,6 +5278,13 @@ class AppLocalizationsBn extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'কোন দাম নেই';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_bo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_bo.dart
@@ -5280,6 +5280,13 @@ class AppLocalizationsBo extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'No price available';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_br.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_br.dart
@@ -5285,6 +5285,13 @@ class AppLocalizationsBr extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Priz ebet';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_bs.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_bs.dart
@@ -5281,6 +5281,13 @@ class AppLocalizationsBs extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Cijena nije dostupna';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ca.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ca.dart
@@ -5337,6 +5337,13 @@ class AppLocalizationsCa extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'No hi ha preu disponible';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ce.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ce.dart
@@ -5280,6 +5280,13 @@ class AppLocalizationsCe extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'No price available';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_co.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_co.dart
@@ -5287,6 +5287,13 @@ class AppLocalizationsCo extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Nisun prezzu dispunibule';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_cs.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_cs.dart
@@ -5303,6 +5303,13 @@ class AppLocalizationsCs extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomie';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Cena není k dispozici';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_cv.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_cv.dart
@@ -5277,6 +5277,13 @@ class AppLocalizationsCv extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Хак ҫук';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_cy.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_cy.dart
@@ -5282,6 +5282,13 @@ class AppLocalizationsCy extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Dim pris ar gael';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_da.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_da.dart
@@ -5296,6 +5296,13 @@ class AppLocalizationsDa extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Ingen pris tilgængelig';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_de.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_de.dart
@@ -5370,6 +5370,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Kein Preis verfügbar';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_el.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_el.dart
@@ -5384,6 +5384,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Δεν υπάρχει διαθέσιμη τιμή';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_en.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_en.dart
@@ -5279,6 +5279,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'No price available';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_eo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_eo.dart
@@ -5280,6 +5280,13 @@ class AppLocalizationsEo extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Neniu prezo havebla';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_es.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_es.dart
@@ -5361,6 +5361,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'No hay precio disponible';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_et.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_et.dart
@@ -5278,6 +5278,13 @@ class AppLocalizationsEt extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Hinda pole saadaval';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_eu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_eu.dart
@@ -5297,6 +5297,13 @@ class AppLocalizationsEu extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Ez dago preziorik eskuragarri';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_fa.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_fa.dart
@@ -5272,6 +5272,13 @@ class AppLocalizationsFa extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'قیمتی موجود نیست';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_fi.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_fi.dart
@@ -5276,6 +5276,13 @@ class AppLocalizationsFi extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Ei hintaa saatavilla';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_fo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_fo.dart
@@ -5280,6 +5280,13 @@ class AppLocalizationsFo extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'No price available';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_fr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_fr.dart
@@ -5387,6 +5387,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomie';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Aucun prix disponible';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ga.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ga.dart
@@ -5282,6 +5282,13 @@ class AppLocalizationsGa extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Níl aon phraghas ar fáil';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_gd.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_gd.dart
@@ -5287,6 +5287,13 @@ class AppLocalizationsGd extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Chan eil prìs ri fhaighinn';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_gl.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_gl.dart
@@ -5285,6 +5285,13 @@ class AppLocalizationsGl extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Non hai prezo dispoñible';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_gu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_gu.dart
@@ -5278,6 +5278,13 @@ class AppLocalizationsGu extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'કોઈ કિંમત ઉપલબ્ધ નથી';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ha.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ha.dart
@@ -5280,6 +5280,13 @@ class AppLocalizationsHa extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Babu farashi akwai';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_he.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_he.dart
@@ -5252,6 +5252,13 @@ class AppLocalizationsHe extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'אין מחיר זמין';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_hi.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_hi.dart
@@ -5278,6 +5278,13 @@ class AppLocalizationsHi extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'कोई मूल्य उपलब्ध नहीं';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_hr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_hr.dart
@@ -5280,6 +5280,13 @@ class AppLocalizationsHr extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Cijena nije dostupna';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ht.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ht.dart
@@ -5277,6 +5277,13 @@ class AppLocalizationsHt extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Pa gen pri disponib';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_hu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_hu.dart
@@ -5324,6 +5324,13 @@ class AppLocalizationsHu extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Nincs elérhető ár';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_hy.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_hy.dart
@@ -5279,6 +5279,13 @@ class AppLocalizationsHy extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Գին հասանելի չէ';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_id.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_id.dart
@@ -5316,6 +5316,13 @@ class AppLocalizationsId extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Tidak ada harga yang tersedia';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ii.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ii.dart
@@ -5280,6 +5280,13 @@ class AppLocalizationsIi extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'No price available';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_is.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_is.dart
@@ -5276,6 +5276,13 @@ class AppLocalizationsIs extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Ekkert verð tiltækt';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_it.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_it.dart
@@ -5350,6 +5350,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Nessun prezzo disponibile';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_iu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_iu.dart
@@ -5280,6 +5280,13 @@ class AppLocalizationsIu extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'No price available';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ja.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ja.dart
@@ -5167,6 +5167,13 @@ class AppLocalizationsJa extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => '価格はありません';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_jv.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_jv.dart
@@ -5278,6 +5278,13 @@ class AppLocalizationsJv extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Ora ana rega sing kasedhiya';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ka.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ka.dart
@@ -5280,6 +5280,13 @@ class AppLocalizationsKa extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'ფასი ხელმისაწვდომი არ არის';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_kk.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_kk.dart
@@ -5282,6 +5282,13 @@ class AppLocalizationsKk extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Бағасы жоқ';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_km.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_km.dart
@@ -5276,6 +5276,13 @@ class AppLocalizationsKm extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'គ្មានតម្លៃទេ។';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_kn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_kn.dart
@@ -5281,6 +5281,13 @@ class AppLocalizationsKn extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'ಯಾವುದೇ ಬೆಲೆ ಲಭ್ಯವಿಲ್ಲ.';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ko.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ko.dart
@@ -5208,6 +5208,13 @@ class AppLocalizationsKo extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => '가격이 없습니다';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ku.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ku.dart
@@ -5281,6 +5281,13 @@ class AppLocalizationsKu extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Bihayek berdest tune';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_kw.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_kw.dart
@@ -5280,6 +5280,13 @@ class AppLocalizationsKw extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'No price available';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ky.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ky.dart
@@ -5282,6 +5282,13 @@ class AppLocalizationsKy extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Баасы жок';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_la.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_la.dart
@@ -5281,6 +5281,13 @@ class AppLocalizationsLa extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Nullum pretium praesto est.';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_lb.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_lb.dart
@@ -5284,6 +5284,13 @@ class AppLocalizationsLb extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Kee Präis verfügbar';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_lo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_lo.dart
@@ -5275,6 +5275,13 @@ class AppLocalizationsLo extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'ບໍ່ມີລາຄາ';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_lt.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_lt.dart
@@ -5343,6 +5343,13 @@ class AppLocalizationsLt extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Kaina nežinoma';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_lv.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_lv.dart
@@ -5279,6 +5279,13 @@ class AppLocalizationsLv extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Cena nav pieejama';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_mg.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_mg.dart
@@ -5287,6 +5287,13 @@ class AppLocalizationsMg extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Tsy misy vidiny';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_mi.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_mi.dart
@@ -5286,6 +5286,13 @@ class AppLocalizationsMi extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Kaore he utu e waatea ana';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ml.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ml.dart
@@ -5280,6 +5280,13 @@ class AppLocalizationsMl extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'വില ലഭ്യമല്ല.';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_mn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_mn.dart
@@ -5284,6 +5284,13 @@ class AppLocalizationsMn extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Үнэ байхгүй';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_mr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_mr.dart
@@ -5277,6 +5277,13 @@ class AppLocalizationsMr extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'किंमत उपलब्ध नाही';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ms.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ms.dart
@@ -5281,6 +5281,13 @@ class AppLocalizationsMs extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Tiada harga tersedia';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_mt.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_mt.dart
@@ -5279,6 +5279,13 @@ class AppLocalizationsMt extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'L-ebda prezz disponibbli';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_my.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_my.dart
@@ -5289,6 +5289,13 @@ class AppLocalizationsMy extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'စျေးနှုန်းမရရှိနိုင်ပါ။';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_nb.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_nb.dart
@@ -5295,6 +5295,13 @@ class AppLocalizationsNb extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Ingen pris tilgjengelig';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ne.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ne.dart
@@ -5276,6 +5276,13 @@ class AppLocalizationsNe extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'कुनै मूल्य उपलब्ध छैन';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_nl.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_nl.dart
@@ -5328,6 +5328,13 @@ class AppLocalizationsNl extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Geen prijs beschikbaar';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_nn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_nn.dart
@@ -5278,6 +5278,13 @@ class AppLocalizationsNn extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Ingen pris tilgjengelig';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_no.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_no.dart
@@ -5278,6 +5278,13 @@ class AppLocalizationsNo extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Ingen pris tilgjengelig';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_nr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_nr.dart
@@ -5280,6 +5280,13 @@ class AppLocalizationsNr extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'No price available';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_oc.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_oc.dart
@@ -5288,6 +5288,13 @@ class AppLocalizationsOc extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Pas de prètz disponible';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_or.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_or.dart
@@ -5284,6 +5284,13 @@ class AppLocalizationsOr extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'କୌଣସି ମୂଲ୍ୟ ଉପଲବ୍ଧ ନାହିଁ';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_pa.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_pa.dart
@@ -5278,6 +5278,13 @@ class AppLocalizationsPa extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'ਕੋਈ ਕੀਮਤ ਉਪਲਬਧ ਨਹੀਂ ਹੈ';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_pl.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_pl.dart
@@ -5333,6 +5333,13 @@ class AppLocalizationsPl extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Brak dostępnej ceny';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_pt.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_pt.dart
@@ -5368,6 +5368,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomia';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Sem preço disponível';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_qu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_qu.dart
@@ -5290,6 +5290,13 @@ class AppLocalizationsQu extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Mana ima preciopas kanchu';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_rm.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_rm.dart
@@ -5280,6 +5280,13 @@ class AppLocalizationsRm extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'No price available';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ro.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ro.dart
@@ -5338,6 +5338,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Niciun preț disponibil';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ru.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ru.dart
@@ -5389,6 +5389,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Цена не указана';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_sa.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sa.dart
@@ -5278,6 +5278,13 @@ class AppLocalizationsSa extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'मूल्यं उपलब्धं नास्ति';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_sc.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sc.dart
@@ -5280,6 +5280,13 @@ class AppLocalizationsSc extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'No price available';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_sd.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sd.dart
@@ -5273,6 +5273,13 @@ class AppLocalizationsSd extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'ڪابه قيمت موجود ناهي';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_sg.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sg.dart
@@ -5280,6 +5280,13 @@ class AppLocalizationsSg extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'No price available';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_si.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_si.dart
@@ -5279,6 +5279,13 @@ class AppLocalizationsSi extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'මිලක් නොමැත.';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_sk.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sk.dart
@@ -5320,6 +5320,13 @@ class AppLocalizationsSk extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Nie je k dispozícii žiadna cena';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_sl.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sl.dart
@@ -5293,6 +5293,13 @@ class AppLocalizationsSl extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Cena ni na voljo';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_sn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sn.dart
@@ -5280,6 +5280,13 @@ class AppLocalizationsSn extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Hapana mutengo uripo';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_so.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_so.dart
@@ -5285,6 +5285,13 @@ class AppLocalizationsSo extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title =>
       'Wax qiimo ah oo la heli karo ma jiro';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_sq.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sq.dart
@@ -5297,6 +5297,13 @@ class AppLocalizationsSq extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Nuk ka çmim të disponueshëm';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_sr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sr.dart
@@ -5281,6 +5281,13 @@ class AppLocalizationsSr extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'No price available';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ss.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ss.dart
@@ -5290,6 +5290,13 @@ class AppLocalizationsSs extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Kute intsengo lekhonako';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_st.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_st.dart
@@ -5282,6 +5282,13 @@ class AppLocalizationsSt extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Ha ho theko e teng';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_sv.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sv.dart
@@ -5301,6 +5301,13 @@ class AppLocalizationsSv extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomi';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Inget pris tillgängligt';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_sw.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sw.dart
@@ -5280,6 +5280,13 @@ class AppLocalizationsSw extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Hakuna bei inayopatikana';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ta.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ta.dart
@@ -5297,6 +5297,13 @@ class AppLocalizationsTa extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'விலை எதுவும் கிடைக்கவில்லை.';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_te.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_te.dart
@@ -5280,6 +5280,13 @@ class AppLocalizationsTe extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'ధర అందుబాటులో లేదు';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_tg.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tg.dart
@@ -5279,6 +5279,13 @@ class AppLocalizationsTg extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Нарх дастрас нест';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_th.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_th.dart
@@ -5272,6 +5272,13 @@ class AppLocalizationsTh extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'ไม่มีราคาระบุ';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ti.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ti.dart
@@ -5265,6 +5265,13 @@ class AppLocalizationsTi extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'ዋጋ የለን';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_tl.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tl.dart
@@ -5287,6 +5287,13 @@ class AppLocalizationsTl extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Walang available na presyo';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_tn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tn.dart
@@ -5289,6 +5289,13 @@ class AppLocalizationsTn extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Ga go na tlhwatlhwa';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_tr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tr.dart
@@ -5303,6 +5303,13 @@ class AppLocalizationsTr extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Halkbilimi';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Fiyat mevcut değil';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ts.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ts.dart
@@ -5283,6 +5283,13 @@ class AppLocalizationsTs extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Ku hava nxavo lowu kumekaka';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_tt.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tt.dart
@@ -5275,6 +5275,13 @@ class AppLocalizationsTt extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Бәясе юк';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_tw.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tw.dart
@@ -5287,6 +5287,13 @@ class AppLocalizationsTw extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Bo biara nni hɔ a wobetumi anya';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ty.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ty.dart
@@ -5280,6 +5280,13 @@ class AppLocalizationsTy extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'No price available';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ug.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ug.dart
@@ -5278,6 +5278,13 @@ class AppLocalizationsUg extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'باھاسى يوق';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_uk.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_uk.dart
@@ -5333,6 +5333,13 @@ class AppLocalizationsUk extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Ціна недоступна';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ur.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ur.dart
@@ -5280,6 +5280,13 @@ class AppLocalizationsUr extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'No price available';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_uz.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_uz.dart
@@ -5282,6 +5282,13 @@ class AppLocalizationsUz extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Narx mavjud emas';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ve.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ve.dart
@@ -5280,6 +5280,13 @@ class AppLocalizationsVe extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'No price available';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_vi.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_vi.dart
@@ -5304,6 +5304,13 @@ class AppLocalizationsVi extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Không có giá nào có sẵn';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_wa.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_wa.dart
@@ -5280,6 +5280,13 @@ class AppLocalizationsWa extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'No price available';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_wo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_wo.dart
@@ -5280,6 +5280,13 @@ class AppLocalizationsWo extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'No price available';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_xh.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_xh.dart
@@ -5285,6 +5285,13 @@ class AppLocalizationsXh extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Akukho xabiso likhoyo';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_yi.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_yi.dart
@@ -5282,6 +5282,13 @@ class AppLocalizationsYi extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'קיין פרייז נישט פֿאַראַן';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_yo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_yo.dart
@@ -5277,6 +5277,13 @@ class AppLocalizationsYo extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Ko si owo to wa';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_zh.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_zh.dart
@@ -5070,6 +5070,13 @@ class AppLocalizationsZh extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'No price available';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_zu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_zu.dart
@@ -5283,6 +5283,13 @@ class AppLocalizationsZu extends AppLocalizations {
   String get product_page_tab_folksonomy => 'Folksonomy';
 
   @override
+  String get folksonomy_action_external_link_title => 'Open external link';
+
+  @override
+  String get folksonomy_action_external_link_warning =>
+      'External links may be unsafe. Do you really want to visit it?';
+
+  @override
   String get prices_products_empty_title => 'Ayikho intengo etholakalayo';
 
   @override

--- a/packages/smooth_app/lib/pages/folksonomy/folksonomy_page.dart
+++ b/packages/smooth_app/lib/pages/folksonomy/folksonomy_page.dart
@@ -13,6 +13,7 @@ import 'package:smooth_app/l10n/app_localizations.dart';
 import 'package:smooth_app/pages/folksonomy/folksonomy_create_edit_modal.dart';
 import 'package:smooth_app/pages/folksonomy/folksonomy_empty_page.dart';
 import 'package:smooth_app/pages/folksonomy/folksonomy_provider.dart';
+import 'package:smooth_app/pages/folksonomy/folksonomy_product_tag_helper.dart';
 import 'package:smooth_app/pages/product/common/product_refresher.dart';
 import 'package:smooth_app/resources/app_icons.dart' as icons;
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
@@ -123,6 +124,7 @@ class _FolksonomyContentState extends State<_FolksonomyContent> {
     ProductTag entry,
     Animation<double> animation,
   ) {
+    final FolksonomyProductTagHelper helper = FolksonomyProductTagHelper(entry);
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
 
     return SizeTransition(
@@ -169,6 +171,12 @@ class _FolksonomyContentState extends State<_FolksonomyContent> {
           buttonIcon: const Icon(Icons.more_vert),
           itemBuilder: (BuildContext context) {
             return <SmoothPopupMenuItem<FolksonomyAction>>[
+              if (helper.isAnUrl())
+                const SmoothPopupMenuItem<FolksonomyAction>(
+                  label: 'Open external link',
+                  value: FolksonomyAction.visitUrl,
+                  icon: const icons.ExternalLink(),
+                ),
               SmoothPopupMenuItem<FolksonomyAction>(
                 label: appLocalizations.edit_tag,
                 value: FolksonomyAction.edit,
@@ -182,6 +190,10 @@ class _FolksonomyContentState extends State<_FolksonomyContent> {
             ];
           },
           onSelected: (FolksonomyAction value) async {
+            if (value == FolksonomyAction.visitUrl) {
+              await helper.visitUrl(context);
+              return;
+            }
             if (value == FolksonomyAction.edit) {
               if (!await _checkIfLoggedIn()) {
                 return;

--- a/packages/smooth_app/lib/pages/folksonomy/folksonomy_page.dart
+++ b/packages/smooth_app/lib/pages/folksonomy/folksonomy_page.dart
@@ -12,7 +12,7 @@ import 'package:smooth_app/helpers/ui_helpers.dart';
 import 'package:smooth_app/l10n/app_localizations.dart';
 import 'package:smooth_app/pages/folksonomy/folksonomy_create_edit_modal.dart';
 import 'package:smooth_app/pages/folksonomy/folksonomy_empty_page.dart';
-import 'package:smooth_app/pages/folksonomy/folksonomy_product_tag_helper.dart';
+import 'package:smooth_app/pages/folksonomy/folksonomy_product_tag_extension.dart';
 import 'package:smooth_app/pages/folksonomy/folksonomy_provider.dart';
 import 'package:smooth_app/pages/product/common/product_refresher.dart';
 import 'package:smooth_app/resources/app_icons.dart' as icons;
@@ -124,12 +124,12 @@ class _FolksonomyContentState extends State<_FolksonomyContent> {
     ProductTag entry,
     Animation<double> animation,
   ) {
-    final FolksonomyProductTagHelper helper = FolksonomyProductTagHelper(entry);
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
 
     return SizeTransition(
       sizeFactor: animation,
       child: ListTile(
+        onTap: entry.isAnUrl() ? () async => entry.visitUrl(context) : null,
         title: Padding(
           padding: const EdgeInsetsDirectional.only(
             start: SMALL_SPACE,
@@ -159,7 +159,12 @@ class _FolksonomyContentState extends State<_FolksonomyContent> {
                       text: appLocalizations.tag_value_item,
                       style: const TextStyle(fontWeight: FontWeight.bold),
                     ),
-                    TextSpan(text: ' ${entry.value}'),
+                    TextSpan(
+                      text: ' ${entry.value}',
+                      style: entry.isAnUrl()
+                          ? const TextStyle(color: Colors.blue)
+                          : null,
+                    ),
                   ],
                   style: Theme.of(context).textTheme.bodyLarge,
                 ),
@@ -171,11 +176,11 @@ class _FolksonomyContentState extends State<_FolksonomyContent> {
           buttonIcon: const Icon(Icons.more_vert),
           itemBuilder: (BuildContext context) {
             return <SmoothPopupMenuItem<FolksonomyAction>>[
-              if (helper.isAnUrl())
-                const SmoothPopupMenuItem<FolksonomyAction>(
-                  label: 'Open external link',
+              if (entry.isAnUrl())
+                SmoothPopupMenuItem<FolksonomyAction>(
+                  label: appLocalizations.folksonomy_action_external_link_title,
                   value: FolksonomyAction.visitUrl,
-                  icon: icons.ExternalLink(),
+                  icon: const icons.ExternalLink(),
                 ),
               SmoothPopupMenuItem<FolksonomyAction>(
                 label: appLocalizations.edit_tag,
@@ -191,7 +196,7 @@ class _FolksonomyContentState extends State<_FolksonomyContent> {
           },
           onSelected: (FolksonomyAction value) async {
             if (value == FolksonomyAction.visitUrl) {
-              await helper.visitUrl(context);
+              await entry.visitUrl(context);
               return;
             }
             if (value == FolksonomyAction.edit) {

--- a/packages/smooth_app/lib/pages/folksonomy/folksonomy_page.dart
+++ b/packages/smooth_app/lib/pages/folksonomy/folksonomy_page.dart
@@ -12,8 +12,8 @@ import 'package:smooth_app/helpers/ui_helpers.dart';
 import 'package:smooth_app/l10n/app_localizations.dart';
 import 'package:smooth_app/pages/folksonomy/folksonomy_create_edit_modal.dart';
 import 'package:smooth_app/pages/folksonomy/folksonomy_empty_page.dart';
-import 'package:smooth_app/pages/folksonomy/folksonomy_provider.dart';
 import 'package:smooth_app/pages/folksonomy/folksonomy_product_tag_helper.dart';
+import 'package:smooth_app/pages/folksonomy/folksonomy_provider.dart';
 import 'package:smooth_app/pages/product/common/product_refresher.dart';
 import 'package:smooth_app/resources/app_icons.dart' as icons;
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
@@ -175,7 +175,7 @@ class _FolksonomyContentState extends State<_FolksonomyContent> {
                 const SmoothPopupMenuItem<FolksonomyAction>(
                   label: 'Open external link',
                   value: FolksonomyAction.visitUrl,
-                  icon: const icons.ExternalLink(),
+                  icon: icons.ExternalLink(),
                 ),
               SmoothPopupMenuItem<FolksonomyAction>(
                 label: appLocalizations.edit_tag,

--- a/packages/smooth_app/lib/pages/folksonomy/folksonomy_product_tag_extension.dart
+++ b/packages/smooth_app/lib/pages/folksonomy/folksonomy_product_tag_extension.dart
@@ -5,28 +5,25 @@ import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/helpers/launch_url_helper.dart';
 import 'package:smooth_app/l10n/app_localizations.dart';
 
-/// Helper around Folksonomy's [ProductTag].
-class FolksonomyProductTagHelper {
-  FolksonomyProductTagHelper(this.productTag);
-
-  final ProductTag productTag;
-
-  bool isAnUrl() => productTag.value.startsWith('https://');
+/// Extension on Folksonomy's [ProductTag].
+extension FolksonomyProductTagExtension on ProductTag {
+  bool isAnUrl() => value.startsWith('https://');
 
   Future<void> visitUrl(final BuildContext context) async {
+    if (!isAnUrl()) {
+      // Not supposed to happen
+      return;
+    }
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final bool? accepted = await showDialog<bool>(
       context: context,
       builder: (final BuildContext context) => SmoothAlertDialog(
-        title: 'Open external link',
+        title: appLocalizations.folksonomy_action_external_link_title,
         body: Column(
           spacing: SMALL_SPACE,
           children: <Widget>[
-            const Text('About to open the following external link:'),
-            Text(productTag.value),
-            const Text(
-              'External links may be unsafe. Do you really want to visit it?',
-            ),
+            Text(value, style: const TextStyle(color: Colors.blue)),
+            Text(appLocalizations.folksonomy_action_external_link_warning),
           ],
         ),
         negativeAction: SmoothActionButton(
@@ -42,6 +39,6 @@ class FolksonomyProductTagHelper {
     if (accepted != true) {
       return;
     }
-    await LaunchUrlHelper.launchURL(productTag.value);
+    await LaunchUrlHelper.launchURL(value);
   }
 }

--- a/packages/smooth_app/lib/pages/folksonomy/folksonomy_product_tag_helper.dart
+++ b/packages/smooth_app/lib/pages/folksonomy/folksonomy_product_tag_helper.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
+import 'package:smooth_app/helpers/launch_url_helper.dart';
+import 'package:smooth_app/l10n/app_localizations.dart';
+
+/// Helper around Folksonomy's [ProductTag].
+class FolksonomyProductTagHelper {
+  FolksonomyProductTagHelper(this.productTag);
+
+  final ProductTag productTag;
+
+  bool isAnUrl() => productTag.value.startsWith('https://');
+
+  Future<void> visitUrl(final BuildContext context) async {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final bool? accepted = await showDialog<bool>(
+      context: context,
+      builder: (final BuildContext context) => SmoothAlertDialog(
+        title: 'Open external link',
+        body: Column(
+          spacing: SMALL_SPACE,
+          children: [
+            Text('About to open the following external link:'),
+            Text(productTag.value),
+            Text(
+              'External links may be unsafe. Do you really want to visit it?',
+            ),
+          ],
+        ),
+        negativeAction: SmoothActionButton(
+          onPressed: () => Navigator.pop(context),
+          text: appLocalizations.cancel,
+        ),
+        positiveAction: SmoothActionButton(
+          onPressed: () => Navigator.pop(context, true),
+          text: appLocalizations.yes,
+        ),
+      ),
+    );
+    if (accepted != true) {
+      return;
+    }
+    await LaunchUrlHelper.launchURL(productTag.value);
+  }
+}

--- a/packages/smooth_app/lib/pages/folksonomy/folksonomy_product_tag_helper.dart
+++ b/packages/smooth_app/lib/pages/folksonomy/folksonomy_product_tag_helper.dart
@@ -21,10 +21,10 @@ class FolksonomyProductTagHelper {
         title: 'Open external link',
         body: Column(
           spacing: SMALL_SPACE,
-          children: [
-            Text('About to open the following external link:'),
+          children: <Widget>[
+            const Text('About to open the following external link:'),
             Text(productTag.value),
-            Text(
+            const Text(
               'External links may be unsafe. Do you really want to visit it?',
             ),
           ],

--- a/packages/smooth_app/lib/pages/folksonomy/folksonomy_provider.dart
+++ b/packages/smooth_app/lib/pages/folksonomy/folksonomy_provider.dart
@@ -355,4 +355,4 @@ class FolksonomyStateError extends FolksonomyState {
   final FolksonomyAction? action;
 }
 
-enum FolksonomyAction { add, edit, remove }
+enum FolksonomyAction { add, edit, remove, visitUrl }

--- a/packages/smooth_app/windows/flutter/CMakeLists.txt
+++ b/packages/smooth_app/windows/flutter/CMakeLists.txt
@@ -10,6 +10,11 @@ include(${EPHEMERAL_DIR}/generated_config.cmake)
 # https://github.com/flutter/flutter/issues/57146.
 set(WRAPPER_ROOT "${EPHEMERAL_DIR}/cpp_client_wrapper")
 
+# Set fallback configurations for older versions of the flutter tool.
+if (NOT DEFINED FLUTTER_TARGET_PLATFORM)
+  set(FLUTTER_TARGET_PLATFORM "windows-x64")
+endif()
+
 # === Flutter Library ===
 set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/flutter_windows.dll")
 
@@ -92,7 +97,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"
-      windows-x64 $<CONFIG>
+      ${FLUTTER_TARGET_PLATFORM} $<CONFIG>
   VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS


### PR DESCRIPTION
### What
- In the Folksonomy Page, there are all the items, with a "more" button and actions - typically "edit" and "remove".
- In this PR, a "open external link" action was added, only for "https://" values.
- As external URLs are dangerous, we systematically ask the user to confirm the action.

### Screenshots
| Folksonomy Page | New "visit URL" action |
| -- | -- |
| <img width="1080" height="1920" alt="Screenshot_1761932836" src="https://github.com/user-attachments/assets/8f29fc11-f2f6-4773-be30-41335a2ca766" /> | <img width="1080" height="1920" alt="Screenshot_1761932839" src="https://github.com/user-attachments/assets/789bd1f0-cd1e-48de-ac67-83d81f764601" /> |

| Confirmation dialog | Browser opened |
| -- | -- |
| <img width="1080" height="1920" alt="Screenshot_1761932915" src="https://github.com/user-attachments/assets/47364ac0-a9be-42c8-87da-5979cd63c769" /> | <img width="1080" height="1920" alt="Screenshot_1761932942" src="https://github.com/user-attachments/assets/e371ccc9-d616-4d5b-a9ab-48deadf76027" /> |

### Fixes bug(s)
- Closes: #7099

### Files
New file:
* `folksonomy_product_tag_helper.dart`: Helper around Folksonomy's ProductTag.

Impacted files:
* `folksonomy_page.dart`: new "visit url" option for folksonomy URL items
* `folksonomy_provider.dart`: added `FolksonomyAction.visitUrl`