### PR TITLE
feat: Photos: Merge English and Unknown Language

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_image.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_image.dart
@@ -210,6 +210,7 @@ class _ProductPictureState extends State<ProductPicture> {
       widget.product,
       widget.transientFile,
       widget.imageProvider,
+      widget.language ?? ProductQuery.getLanguage(),
       widget.allowAlternativeLanguage,
     );
 
@@ -311,21 +312,33 @@ class _ProductPictureState extends State<ProductPicture> {
     Product? product,
     TransientFile? transientFile,
     ImageProvider? imageProvider,
+    OpenFoodFactsLanguage language,
     bool allowAlternativeLanguage,
   ) {
     if (imageProvider != null) {
       return (imageProvider, false);
     } else if (transientFile != null) {
-      return (transientFile.getImageProvider(), transientFile.expired);
+      final ImageProvider<Object>? provider = transientFile.getImageProvider();
+
+      // Special case: Unknown language and English are considered equivalent
+      if (provider == null && language == OpenFoodFactsLanguage.ENGLISH) {
+        return _getImageProvider(
+          product,
+          null,
+          null,
+          OpenFoodFactsLanguage.UNKNOWN_LANGUAGE,
+          allowAlternativeLanguage,
+        );
+      }
+      return (provider, transientFile.expired);
     }
 
     final TransientFile productTransientFile = TransientFile.fromProduct(
       product!,
       widget.imageField!,
-      widget.language ?? ProductQuery.getLanguage(),
+      language,
     );
     final ImageProvider? provider = productTransientFile.getImageProvider();
-
     if (provider != null) {
       return (provider, productTransientFile.expired);
     }

--- a/packages/smooth_app/lib/pages/image/product_image_other_page.dart
+++ b/packages/smooth_app/lib/pages/image/product_image_other_page.dart
@@ -356,9 +356,7 @@ class _ProductImageDetailsButton extends StatelessWidget {
         type: MaterialType.transparency,
         child: InkWell(
           borderRadius: CIRCULAR_BORDER_RADIUS,
-          onTap: () {
-            _showDetails(context, appLocalizations, url);
-          },
+          onTap: () => _showDetails(context, appLocalizations, url),
           child: Padding(
             padding: const EdgeInsetsDirectional.only(
               start: SMALL_SPACE,

--- a/packages/smooth_app/lib/pages/product/gallery_view/product_image_gallery_photo_row.dart
+++ b/packages/smooth_app/lib/pages/product/gallery_view/product_image_gallery_photo_row.dart
@@ -111,7 +111,7 @@ class _ImageGalleryPhotoRowState extends State<ImageGalleryPhotoRow> {
                         _PhotoRowIndicator(transientFile: transientFile),
                         Expanded(
                           child: Padding(
-                            padding: const EdgeInsets.symmetric(
+                            padding: const EdgeInsetsDirectional.symmetric(
                               horizontal: SMALL_SPACE,
                             ),
                             child: Row(

--- a/packages/smooth_app/lib/pages/product/gallery_view/product_image_gallery_tabs.dart
+++ b/packages/smooth_app/lib/pages/product/gallery_view/product_image_gallery_tabs.dart
@@ -21,18 +21,51 @@ class ProductImageGalleryTabBar extends StatelessWidget
   }
 
   List<ProductLanguageWithState> productLanguages(Product product) {
-    return <OpenFoodFactsLanguage>{
-          ...getProductImageLanguages(product, ImageField.FRONT),
-          ...getProductImageLanguages(product, ImageField.INGREDIENTS),
-          ...getProductImageLanguages(product, ImageField.NUTRITION),
-          ...getProductImageLanguages(product, ImageField.PACKAGING),
-        }
-        .map(
-          (OpenFoodFactsLanguage l) =>
-              ProductLanguageWithState.normal(language: l),
-        )
-        .toList(growable: false);
+    final List<ProductLanguageWithState> languages =
+        <OpenFoodFactsLanguage>{
+              ...getProductImageLanguages(product, ImageField.FRONT),
+              ...getProductImageLanguages(product, ImageField.INGREDIENTS),
+              ...getProductImageLanguages(product, ImageField.NUTRITION),
+              ...getProductImageLanguages(product, ImageField.PACKAGING),
+            }
+            .map(
+              (OpenFoodFactsLanguage l) =>
+                  ProductLanguageWithState.normal(language: l),
+            )
+            .toList();
+
+    _removeUnknownLanguage(languages);
+
+    return languages;
   }
+
+  /// If we have both unknown language and English, we merge them
+  void _removeUnknownLanguage(List<ProductLanguageWithState> languages) {
+    final bool hasUnknownLanguage = _hasLanguage(
+      languages,
+      OpenFoodFactsLanguage.UNKNOWN_LANGUAGE,
+    );
+    if (hasUnknownLanguage) {
+      final bool hasEnglish = _hasLanguage(
+        languages,
+        OpenFoodFactsLanguage.ENGLISH,
+      );
+
+      if (hasEnglish) {
+        languages.removeWhere(
+          (ProductLanguageWithState lang) =>
+              lang.language == OpenFoodFactsLanguage.UNKNOWN_LANGUAGE,
+        );
+      }
+    }
+  }
+
+  bool _hasLanguage(
+    List<ProductLanguageWithState> languages,
+    OpenFoodFactsLanguage language,
+  ) => languages.any(
+    (ProductLanguageWithState lang) => lang.language == language,
+  );
 
   bool productEquality(Product oldProduct, Product product) {
     return product.barcode == oldProduct.barcode &&


### PR DESCRIPTION
Hi everyone!

<img width="660" height="254" alt="Photo from Google Photos" src="https://github.com/user-attachments/assets/0038244f-295b-4823-98a8-eaedb9c116e1" />

I've discovered the following issue on a specific product: English is written twice.
This is because "Unknown Language" photos are labelled as English.

To prevent this weird behavior, the fake English tab (= Unknown language) is never displayed if English is already visible.
Also, in the English screen, we use Unknown language content if nothing is available in English.