### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/internal-release.yml
+++ b/.github/workflows/internal-release.yml
@@ -1,4 +1,6 @@
 name: Create internal releases of the Mobile app for Android & iOS
+permissions:
+  contents: read
 on:
   workflow_dispatch:
 
@@ -7,6 +9,8 @@ env:
 
 jobs:
   tag-commit:
+    permissions:
+      contents: write
     concurrency: 
       group: release
       cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/smooth-app/security/code-scanning/11](https://github.com/openfoodfacts/smooth-app/security/code-scanning/11)

To fix the issue, add an explicit `permissions` block to the workflow. This can be set at the top level (applies to all jobs unless overridden) or per job. The recommended starting point is to set `contents: read` (allows read-only access to repository contents) and escalate permissions only where necessary. Since the `tag-commit` job creates tags (modifies repo), it needs `contents: write`, while the other jobs likely only require `contents: read` (unless they perform write operations themselves). 

The single best practical fix, minimizing privilege, is to:
- Add a global `permissions` block at line 2, specifying `contents: read`.
- Override in the `tag-commit` job with job-level `permissions: contents: write` since it creates tags (modifies repo).
- Leave other jobs using the global default unless they require escalation (in this case, they are external workflow calls and don't seem to affect repo contents).

No external packages or libraries are required; only YAML modification in `.github/workflows/internal-release.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
