### PR TITLE
fix: 7146 - support google play 16k memory page

### DIFF
--- a/packages/smooth_app/android/gradle.properties
+++ b/packages/smooth_app/android/gradle.properties
@@ -1,4 +1,7 @@
 org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=2G -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
-kotlin.jvm.target.validation.mode = IGNORE
+kotlin.jvm.target.validation.mode=IGNORE
+# cf. https://github.com/rive-app/rive-flutter/issues/553
+rive.ndk.version=28.1.13356709
+android.ndk.suppressMinSdkVersionError=21


### PR DESCRIPTION
### What
* The problem with 16k memory page was only coming from rive, as a "Build/Analyze APK" check suggested, cf. https://medium.com/easy-flutter/androids-16kb-page-size-explained-flutter-migration-made-simple-c9af18d756c1
* The fix was found in rive's github, cf. https://github.com/rive-app/rive-flutter/issues/553

### Screenshots
Before
<img width="541" height="201" alt="Image" src="https://github.com/user-attachments/assets/87dd366e-527b-4399-a0af-c7bfc525e2bf" />

After
<img width="639" height="175" alt="Image" src="https://github.com/user-attachments/assets/6e5f2695-b30b-4c12-b30d-fb57a2897f08" />

### Fixes bug(s)
- Fixes: #7146