### PR TITLE
fix: rive and ndk, again

### DIFF
--- a/packages/smooth_app/android/app/build.gradle.kts
+++ b/packages/smooth_app/android/app/build.gradle.kts
@@ -8,6 +8,8 @@ plugins {
 }
 
 android {
+    ndkVersion = "28.1.13356709"
+
     namespace = "org.openfoodfacts.app"
     compileSdk = flutter.compileSdkVersion
 


### PR DESCRIPTION
### What
```log
Your project is configured with Android NDK 27.0.12077973, but the following plugin(s) depend on a different Android NDK version:
- rive_common requires Android NDK 28.1.13356709
Fix this issue by using the highest Android NDK version (they are backward compatible).
Add the following to C:\Users\fabri\StudioProjects\smooth-app\packages\smooth_app\android\app\build.gradle.kts:

    android {
        ndkVersion = "28.1.13356709"
        ...
    }
```

### Part of 
- #7146
- #7154