### PR TITLE
Potential fix for code scanning alert no. 32: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -1,4 +1,6 @@
 name: SmoothApp Post-Submit Tests
+permissions:
+  contents: read
 
 on: 
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/smooth-app/security/code-scanning/32](https://github.com/openfoodfacts/smooth-app/security/code-scanning/32)

To fix the issue, add a `permissions` block to the workflow to restrict what the GITHUB_TOKEN can do. The best practice is to place it at the top-level of the workflow (below `name:` but above `on:`), so it applies to all jobs, unless specific jobs need broader access. Given the steps taken in this workflow, the minimum necessary permissions would be `contents: read` (for code checkout), and optionally, if upload-artifact or similar Actions require it, `actions: write` or `id-token: write`, but most often `contents: read` suffices. The `actions/upload-artifact` and `codecov/codecov-action` do not require write privileges on repository contents, just access to files in the workflow run. Thus, as a minimal fix, add:

```yaml
permissions:
  contents: read
```

Place this between the `name:` and `on:` keys at the top of the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
