### PR TITLE
fix: Error on the Open Prices guide

### DIFF
--- a/packages/smooth_app/lib/pages/preferences_v2/tiles/preference_tile.dart
+++ b/packages/smooth_app/lib/pages/preferences_v2/tiles/preference_tile.dart
@@ -155,8 +155,8 @@ class _PreferenceTileTitle extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final String? query = context
-        .watch<PreferencesRootSearchController>()
-        .query;
+        .watch<PreferencesRootSearchController?>()
+        ?.query;
 
     final TextStyle textStyle = TextStyle(
       color: context.lightTheme()
@@ -182,8 +182,8 @@ class _PreferenceTileSubtitle extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final String? query = context
-        .watch<PreferencesRootSearchController>()
-        .query;
+        .watch<PreferencesRootSearchController?>()
+        ?.query;
 
     if (query == null || query.isEmpty) {
       return Text(subtitle);


### PR DESCRIPTION
Hi everyone!

I don't know why, but the Open Prices guide uses the Preferences mechanism.
After #7179, there's a regression:

<img width="1080" height="2400" alt="Screenshot_1762719162" src="https://github.com/user-attachments/assets/fb117d98-d1e5-4c4e-8e09-bf89325887e1" />
