### PR TITLE
fix: Visual UI fixes (onboarding mainly)

### DIFF
--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_product_cards.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_product_cards.dart
@@ -5,9 +5,15 @@ import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels_builder.dart';
 
 class KnowledgePanelProductCards extends StatelessWidget {
-  const KnowledgePanelProductCards(this.knowledgePanelWidgets);
+  const KnowledgePanelProductCards(
+    this.knowledgePanelWidgets, {
+    this.template = false,
+  });
 
   final List<Widget> knowledgePanelWidgets;
+
+  /// Whether this is a template panel
+  final bool template;
 
   @override
   Widget build(BuildContext context) {
@@ -22,12 +28,15 @@ class KnowledgePanelProductCards extends StatelessWidget {
           if (hasTitle) {
             content = buildProductSmoothCard(
               title: Text((widget.children.first as KnowledgePanelTitle).title),
-              body: Padding(
-                padding: const EdgeInsetsDirectional.symmetric(
-                  horizontal: SMALL_SPACE,
-                  vertical: SMALL_SPACE,
+              body: Material(
+                color: Colors.white,
+                child: Padding(
+                  padding: const EdgeInsetsDirectional.symmetric(
+                    horizontal: SMALL_SPACE,
+                    vertical: SMALL_SPACE,
+                  ),
+                  child: Column(children: widget.children.sublist(1)),
                 ),
-                child: Column(children: widget.children.sublist(1)),
               ),
               padding: EdgeInsets.zero,
               margin: EdgeInsets.zero,

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_title_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_title_card.dart
@@ -114,7 +114,7 @@ class KnowledgePanelTitleCard extends StatelessWidget {
               child: LayoutBuilder(
                 builder: (BuildContext context, BoxConstraints constraints) {
                   final bool hasSubtitle =
-                      knowledgePanelTitleElement.subtitle != null;
+                      knowledgePanelTitleElement.subtitle?.isNotEmpty == true;
 
                   return Wrap(
                     direction: Axis.vertical,

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -5425,12 +5425,36 @@
       }
     }
   },
+  "item_count_with_total_string": "{count} of {total} items",
+  "@item_count_with_total_string": {
+    "description": "Item count showing current number of items and total items",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "description": "Current number of items loaded"
+      },
+      "total": {
+        "type": "String",
+        "description": "Total number of items available"
+      }
+    }
+  },
   "item_count": "{count} items",
   "@item_count": {
     "description": "Item count showing only current number of items when total is unknown",
     "placeholders": {
       "count": {
         "type": "int",
+        "description": "Current number of items loaded"
+      }
+    }
+  },
+  "item_count_string": "{count} items",
+  "@item_count_string": {
+    "description": "Item count showing only current number of items when total is unknown",
+    "placeholders": {
+      "count": {
+        "type": "String",
         "description": "Current number of items loaded"
       }
     }

--- a/packages/smooth_app/lib/l10n/app_localizations.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations.dart
@@ -10399,11 +10399,23 @@ abstract class AppLocalizations {
   /// **'{count} of {total} items'**
   String item_count_with_total(int count, int total);
 
+  /// Item count showing current number of items and total items
+  ///
+  /// In en, this message translates to:
+  /// **'{count} of {total} items'**
+  String item_count_with_total_string(String count, String total);
+
   /// Item count showing only current number of items when total is unknown
   ///
   /// In en, this message translates to:
   /// **'{count} items'**
   String item_count(int count);
+
+  /// Item count showing only current number of items when total is unknown
+  ///
+  /// In en, this message translates to:
+  /// **'{count} items'**
+  String item_count_string(String count);
 
   /// Message shown when there are no price statistics available to display
   ///

--- a/packages/smooth_app/lib/l10n/app_localizations_aa.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_aa.dart
@@ -6033,7 +6033,17 @@ class AppLocalizationsAa extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
+    return '$count items';
+  }
+
+  @override
+  String item_count_string(String count) {
     return '$count items';
   }
 

--- a/packages/smooth_app/lib/l10n/app_localizations_af.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_af.dart
@@ -6034,7 +6034,17 @@ class AppLocalizationsAf extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
+    return '$count items';
+  }
+
+  @override
+  String item_count_string(String count) {
     return '$count items';
   }
 

--- a/packages/smooth_app/lib/l10n/app_localizations_ak.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ak.dart
@@ -6033,7 +6033,17 @@ class AppLocalizationsAk extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
+    return '$count items';
+  }
+
+  @override
+  String item_count_string(String count) {
     return '$count items';
   }
 

--- a/packages/smooth_app/lib/l10n/app_localizations_am.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_am.dart
@@ -6000,8 +6000,18 @@ class AppLocalizationsAm extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count እቃዎች';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ar.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ar.dart
@@ -6015,8 +6015,18 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count عناصر';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_as.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_as.dart
@@ -6029,7 +6029,17 @@ class AppLocalizationsAs extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
+    return '$count items';
+  }
+
+  @override
+  String item_count_string(String count) {
     return '$count items';
   }
 

--- a/packages/smooth_app/lib/l10n/app_localizations_az.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_az.dart
@@ -6039,8 +6039,18 @@ class AppLocalizationsAz extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count əşyalar';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_be.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_be.dart
@@ -6068,8 +6068,18 @@ class AppLocalizationsBe extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count прадметаў';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_bg.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_bg.dart
@@ -6090,8 +6090,18 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count артикула';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_bm.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_bm.dart
@@ -6049,8 +6049,18 @@ class AppLocalizationsBm extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count fɛnw';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_bn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_bn.dart
@@ -6039,8 +6039,18 @@ class AppLocalizationsBn extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count আইটেম';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_bo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_bo.dart
@@ -6033,7 +6033,17 @@ class AppLocalizationsBo extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
+    return '$count items';
+  }
+
+  @override
+  String item_count_string(String count) {
     return '$count items';
   }
 

--- a/packages/smooth_app/lib/l10n/app_localizations_br.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_br.dart
@@ -6048,8 +6048,18 @@ class AppLocalizationsBr extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count elfennoù';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_bs.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_bs.dart
@@ -6043,8 +6043,18 @@ class AppLocalizationsBs extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count stavki';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ca.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ca.dart
@@ -6106,8 +6106,18 @@ class AppLocalizationsCa extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count elements';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ce.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ce.dart
@@ -6033,7 +6033,17 @@ class AppLocalizationsCe extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
+    return '$count items';
+  }
+
+  @override
+  String item_count_string(String count) {
     return '$count items';
   }
 

--- a/packages/smooth_app/lib/l10n/app_localizations_co.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_co.dart
@@ -6053,8 +6053,18 @@ class AppLocalizationsCo extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count articuli';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_cs.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_cs.dart
@@ -6066,8 +6066,18 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count položek';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_cv.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_cv.dart
@@ -6037,8 +6037,18 @@ class AppLocalizationsCv extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count япаласем';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_cy.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_cy.dart
@@ -6041,8 +6041,18 @@ class AppLocalizationsCy extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count eitemau';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_da.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_da.dart
@@ -6054,8 +6054,18 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count varer';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_de.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_de.dart
@@ -6138,8 +6138,18 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count Artikel';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_el.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_el.dart
@@ -6150,8 +6150,18 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count στοιχεία';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_en.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_en.dart
@@ -6032,7 +6032,17 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
+    return '$count items';
+  }
+
+  @override
+  String item_count_string(String count) {
     return '$count items';
   }
 

--- a/packages/smooth_app/lib/l10n/app_localizations_eo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_eo.dart
@@ -6042,8 +6042,18 @@ class AppLocalizationsEo extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count eroj';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_es.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_es.dart
@@ -6127,8 +6127,18 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count artículos';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_et.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_et.dart
@@ -6035,8 +6035,18 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count eset';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_eu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_eu.dart
@@ -6060,8 +6060,18 @@ class AppLocalizationsEu extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count elementuak';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_fa.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_fa.dart
@@ -6030,8 +6030,18 @@ class AppLocalizationsFa extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count موارد';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_fi.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_fi.dart
@@ -6034,8 +6034,18 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count tuotetta';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_fo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_fo.dart
@@ -6033,7 +6033,17 @@ class AppLocalizationsFo extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
+    return '$count items';
+  }
+
+  @override
+  String item_count_string(String count) {
     return '$count items';
   }
 

--- a/packages/smooth_app/lib/l10n/app_localizations_fr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_fr.dart
@@ -6163,8 +6163,18 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count articles';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ga.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ga.dart
@@ -6047,8 +6047,18 @@ class AppLocalizationsGa extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count míreanna';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_gd.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_gd.dart
@@ -6059,8 +6059,18 @@ class AppLocalizationsGd extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return 'nithean $count';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_gl.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_gl.dart
@@ -6051,8 +6051,18 @@ class AppLocalizationsGl extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count elementos';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_gu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_gu.dart
@@ -6034,8 +6034,18 @@ class AppLocalizationsGu extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count વસ્તુઓ';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ha.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ha.dart
@@ -6035,8 +6035,18 @@ class AppLocalizationsHa extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count abubuwa';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_he.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_he.dart
@@ -5986,8 +5986,18 @@ class AppLocalizationsHe extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return 'פריטים $count';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_hi.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_hi.dart
@@ -6033,8 +6033,18 @@ class AppLocalizationsHi extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count आइटम';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_hr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_hr.dart
@@ -6044,8 +6044,18 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count stavki';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ht.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ht.dart
@@ -6035,8 +6035,18 @@ class AppLocalizationsHt extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count atik';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_hu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_hu.dart
@@ -6089,8 +6089,18 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count elem';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_hy.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_hy.dart
@@ -6041,8 +6041,18 @@ class AppLocalizationsHy extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count տարրեր';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_id.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_id.dart
@@ -6081,8 +6081,18 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count item';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ii.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ii.dart
@@ -6033,7 +6033,17 @@ class AppLocalizationsIi extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
+    return '$count items';
+  }
+
+  @override
+  String item_count_string(String count) {
     return '$count items';
   }
 

--- a/packages/smooth_app/lib/l10n/app_localizations_is.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_is.dart
@@ -6035,8 +6035,18 @@ class AppLocalizationsIs extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count atriði';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_it.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_it.dart
@@ -6113,8 +6113,18 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count elementi';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_iu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_iu.dart
@@ -6033,7 +6033,17 @@ class AppLocalizationsIu extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
+    return '$count items';
+  }
+
+  @override
+  String item_count_string(String count) {
     return '$count items';
   }
 

--- a/packages/smooth_app/lib/l10n/app_localizations_ja.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ja.dart
@@ -5875,8 +5875,18 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count 個のアイテム';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_jv.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_jv.dart
@@ -6037,8 +6037,18 @@ class AppLocalizationsJv extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count item';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ka.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ka.dart
@@ -6047,8 +6047,18 @@ class AppLocalizationsKa extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count ერთეული';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_kk.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_kk.dart
@@ -6043,8 +6043,18 @@ class AppLocalizationsKk extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count элементтер';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_km.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_km.dart
@@ -6032,8 +6032,18 @@ class AppLocalizationsKm extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count ធាតុ';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_kn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_kn.dart
@@ -6047,8 +6047,18 @@ class AppLocalizationsKn extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count ವಸ್ತುಗಳು';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ko.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ko.dart
@@ -5922,8 +5922,18 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count 항목';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ku.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ku.dart
@@ -6045,8 +6045,18 @@ class AppLocalizationsKu extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count tişt';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_kw.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_kw.dart
@@ -6033,7 +6033,17 @@ class AppLocalizationsKw extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
+    return '$count items';
+  }
+
+  @override
+  String item_count_string(String count) {
     return '$count items';
   }
 

--- a/packages/smooth_app/lib/l10n/app_localizations_ky.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ky.dart
@@ -6045,8 +6045,18 @@ class AppLocalizationsKy extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count буюмдар';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_la.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_la.dart
@@ -6047,8 +6047,18 @@ class AppLocalizationsLa extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count res';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_lb.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_lb.dart
@@ -6046,8 +6046,18 @@ class AppLocalizationsLb extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count Artikelen';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_lo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_lo.dart
@@ -6030,8 +6030,18 @@ class AppLocalizationsLo extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count ລາຍການ';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_lt.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_lt.dart
@@ -6108,8 +6108,18 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count prekės';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_lv.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_lv.dart
@@ -6041,8 +6041,18 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count preces';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_mg.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_mg.dart
@@ -6050,8 +6050,18 @@ class AppLocalizationsMg extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count singa';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_mi.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_mi.dart
@@ -6051,8 +6051,18 @@ class AppLocalizationsMi extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count tūemi';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ml.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ml.dart
@@ -6043,8 +6043,18 @@ class AppLocalizationsMl extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count ഇനങ്ങൾ';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_mn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_mn.dart
@@ -6046,8 +6046,18 @@ class AppLocalizationsMn extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count зүйл';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_mr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_mr.dart
@@ -6033,8 +6033,18 @@ class AppLocalizationsMr extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count आयटम';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ms.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ms.dart
@@ -6040,8 +6040,18 @@ class AppLocalizationsMs extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count item';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_mt.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_mt.dart
@@ -6044,8 +6044,18 @@ class AppLocalizationsMt extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count oġġetti';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_my.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_my.dart
@@ -6059,8 +6059,18 @@ class AppLocalizationsMy extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count ပစ္စည်းများ';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_nb.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_nb.dart
@@ -6053,8 +6053,18 @@ class AppLocalizationsNb extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count objekter';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ne.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ne.dart
@@ -6039,7 +6039,17 @@ class AppLocalizationsNe extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
+    return '$count items';
+  }
+
+  @override
+  String item_count_string(String count) {
     return '$count items';
   }
 

--- a/packages/smooth_app/lib/l10n/app_localizations_nl.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_nl.dart
@@ -6093,7 +6093,17 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
+    return '$count items';
+  }
+
+  @override
+  String item_count_string(String count) {
     return '$count items';
   }
 

--- a/packages/smooth_app/lib/l10n/app_localizations_nn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_nn.dart
@@ -6035,8 +6035,18 @@ class AppLocalizationsNn extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count elementer';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_no.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_no.dart
@@ -6035,8 +6035,18 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count elementer';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_nr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_nr.dart
@@ -6033,7 +6033,17 @@ class AppLocalizationsNr extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
+    return '$count items';
+  }
+
+  @override
+  String item_count_string(String count) {
     return '$count items';
   }
 

--- a/packages/smooth_app/lib/l10n/app_localizations_oc.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_oc.dart
@@ -6058,8 +6058,18 @@ class AppLocalizationsOc extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count articles';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_or.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_or.dart
@@ -6045,8 +6045,18 @@ class AppLocalizationsOr extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count ଆଇଟମ୍';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_pa.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_pa.dart
@@ -6032,8 +6032,18 @@ class AppLocalizationsPa extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count ਆਈਟਮਾਂ';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_pl.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_pl.dart
@@ -6094,8 +6094,18 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count elementów';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_pt.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_pt.dart
@@ -6133,8 +6133,18 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count itens';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_qu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_qu.dart
@@ -6057,8 +6057,18 @@ class AppLocalizationsQu extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count imakuna';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_rm.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_rm.dart
@@ -6033,7 +6033,17 @@ class AppLocalizationsRm extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
+    return '$count items';
+  }
+
+  @override
+  String item_count_string(String count) {
     return '$count items';
   }
 

--- a/packages/smooth_app/lib/l10n/app_localizations_ro.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ro.dart
@@ -6105,8 +6105,18 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count articole';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ru.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ru.dart
@@ -6150,8 +6150,18 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count предметов';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_sa.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sa.dart
@@ -6040,8 +6040,18 @@ class AppLocalizationsSa extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count द्रव्यम्';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_sc.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sc.dart
@@ -6033,7 +6033,17 @@ class AppLocalizationsSc extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
+    return '$count items';
+  }
+
+  @override
+  String item_count_string(String count) {
     return '$count items';
   }
 

--- a/packages/smooth_app/lib/l10n/app_localizations_sd.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sd.dart
@@ -6026,8 +6026,18 @@ class AppLocalizationsSd extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count شيون';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_sg.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sg.dart
@@ -6033,7 +6033,17 @@ class AppLocalizationsSg extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
+    return '$count items';
+  }
+
+  @override
+  String item_count_string(String count) {
     return '$count items';
   }
 

--- a/packages/smooth_app/lib/l10n/app_localizations_si.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_si.dart
@@ -6038,8 +6038,18 @@ class AppLocalizationsSi extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count අයිතම';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_sk.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sk.dart
@@ -6083,8 +6083,18 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count položiek';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_sl.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sl.dart
@@ -6057,8 +6057,18 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count artiklov';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_sn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sn.dart
@@ -6034,8 +6034,18 @@ class AppLocalizationsSn extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count zvinhu';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_so.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_so.dart
@@ -6050,8 +6050,18 @@ class AppLocalizationsSo extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count alaab';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_sq.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sq.dart
@@ -6062,8 +6062,18 @@ class AppLocalizationsSq extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count artikuj';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_sr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sr.dart
@@ -6034,7 +6034,17 @@ class AppLocalizationsSr extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
+    return '$count items';
+  }
+
+  @override
+  String item_count_string(String count) {
     return '$count items';
   }
 

--- a/packages/smooth_app/lib/l10n/app_localizations_ss.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ss.dart
@@ -6055,8 +6055,18 @@ class AppLocalizationsSs extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count tintfo';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_st.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_st.dart
@@ -6046,8 +6046,18 @@ class AppLocalizationsSt extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count lintho';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_sv.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sv.dart
@@ -6057,8 +6057,18 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count föremål';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_sw.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sw.dart
@@ -6035,8 +6035,18 @@ class AppLocalizationsSw extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count vitu';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ta.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ta.dart
@@ -6068,8 +6068,18 @@ class AppLocalizationsTa extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count பொருட்கள்';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_te.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_te.dart
@@ -6039,8 +6039,18 @@ class AppLocalizationsTe extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count అంశాలు';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_tg.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tg.dart
@@ -6042,8 +6042,18 @@ class AppLocalizationsTg extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count ашё';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_th.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_th.dart
@@ -6020,8 +6020,18 @@ class AppLocalizationsTh extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count รายการ';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ti.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ti.dart
@@ -5996,8 +5996,18 @@ class AppLocalizationsTi extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count ነገራት';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_tl.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tl.dart
@@ -6052,8 +6052,18 @@ class AppLocalizationsTl extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count item';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_tn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tn.dart
@@ -6058,8 +6058,18 @@ class AppLocalizationsTn extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count dilwana';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_tr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tr.dart
@@ -6066,8 +6066,18 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count ürün';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ts.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ts.dart
@@ -6058,8 +6058,18 @@ class AppLocalizationsTs extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count swilo';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_tt.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tt.dart
@@ -6032,7 +6032,17 @@ class AppLocalizationsTt extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
+    return '$count items';
+  }
+
+  @override
+  String item_count_string(String count) {
     return '$count items';
   }
 

--- a/packages/smooth_app/lib/l10n/app_localizations_tw.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tw.dart
@@ -6048,8 +6048,18 @@ class AppLocalizationsTw extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count nneɛma';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ty.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ty.dart
@@ -6033,7 +6033,17 @@ class AppLocalizationsTy extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
+    return '$count items';
+  }
+
+  @override
+  String item_count_string(String count) {
     return '$count items';
   }
 

--- a/packages/smooth_app/lib/l10n/app_localizations_ug.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ug.dart
@@ -6037,7 +6037,17 @@ class AppLocalizationsUg extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
+    return '$count items';
+  }
+
+  @override
+  String item_count_string(String count) {
     return '$count items';
   }
 

--- a/packages/smooth_app/lib/l10n/app_localizations_uk.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_uk.dart
@@ -6107,8 +6107,18 @@ class AppLocalizationsUk extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count елементів';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ur.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ur.dart
@@ -6033,7 +6033,17 @@ class AppLocalizationsUr extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
+    return '$count items';
+  }
+
+  @override
+  String item_count_string(String count) {
     return '$count items';
   }
 

--- a/packages/smooth_app/lib/l10n/app_localizations_uz.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_uz.dart
@@ -6051,8 +6051,18 @@ class AppLocalizationsUz extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count buyumlar';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ve.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ve.dart
@@ -6033,7 +6033,17 @@ class AppLocalizationsVe extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
+    return '$count items';
+  }
+
+  @override
+  String item_count_string(String count) {
     return '$count items';
   }
 

--- a/packages/smooth_app/lib/l10n/app_localizations_vi.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_vi.dart
@@ -6063,8 +6063,18 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count mục';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_wa.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_wa.dart
@@ -6033,7 +6033,17 @@ class AppLocalizationsWa extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
+    return '$count items';
+  }
+
+  @override
+  String item_count_string(String count) {
     return '$count items';
   }
 

--- a/packages/smooth_app/lib/l10n/app_localizations_wo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_wo.dart
@@ -6033,7 +6033,17 @@ class AppLocalizationsWo extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
+    return '$count items';
+  }
+
+  @override
+  String item_count_string(String count) {
     return '$count items';
   }
 

--- a/packages/smooth_app/lib/l10n/app_localizations_xh.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_xh.dart
@@ -6048,8 +6048,18 @@ class AppLocalizationsXh extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count izinto';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_yi.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_yi.dart
@@ -6047,8 +6047,18 @@ class AppLocalizationsYi extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count זאכן';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_yo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_yo.dart
@@ -6031,8 +6031,18 @@ class AppLocalizationsYo extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count awọn nkan';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_zh.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_zh.dart
@@ -5764,8 +5764,18 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count 件';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_zu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_zu.dart
@@ -6046,8 +6046,18 @@ class AppLocalizationsZu extends AppLocalizations {
   }
 
   @override
+  String item_count_with_total_string(String count, String total) {
+    return '$count of $total items';
+  }
+
+  @override
   String item_count(int count) {
     return '$count izinto';
+  }
+
+  @override
+  String item_count_string(String count) {
+    return '$count items';
   }
 
   @override

--- a/packages/smooth_app/lib/pages/onboarding/knowledge_panel_page_template.dart
+++ b/packages/smooth_app/lib/pages/onboarding/knowledge_panel_page_template.dart
@@ -126,7 +126,7 @@ class _KnowledgePanelPageTemplateState
                                 crossAxisAlignment: CrossAxisAlignment.start,
                                 children: children,
                               ),
-                            ]),
+                            ], template: true),
                         ],
                       ),
                     ),

--- a/packages/smooth_app/lib/pages/onboarding/preferences_page.dart
+++ b/packages/smooth_app/lib/pages/onboarding/preferences_page.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -99,16 +100,25 @@ class _HelperState extends State<_Helper> {
       Padding(
         padding: const EdgeInsetsDirectional.only(
           bottom: LARGE_SPACE,
-          start: LARGE_SPACE,
-          end: LARGE_SPACE,
+          start: BALANCED_SPACE,
+          end: BALANCED_SPACE,
         ),
-        child: SummaryCard(
-          widget.product,
-          productPreferences,
-          isFullVersion: true,
-          isRemovable: false,
-          isSettingVisible: false,
-          isPictureVisible: false,
+        child: Material(
+          color: Colors.white,
+          borderRadius: ANGULAR_BORDER_RADIUS,
+          child: Padding(
+            padding: const EdgeInsetsDirectional.symmetric(
+              horizontal: BALANCED_SPACE,
+            ),
+            child: SummaryCard(
+              widget.product,
+              productPreferences,
+              isFullVersion: true,
+              isRemovable: false,
+              isSettingVisible: false,
+              isPictureVisible: false,
+            ),
+          ),
         ),
       ),
     ];
@@ -119,7 +129,18 @@ class _HelperState extends State<_Helper> {
         userPreferences: userPreferences,
         appLocalizations: appLocalizations,
         themeData: Theme.of(context),
-      ).getOnboardingContent(),
+      ).getOnboardingContent().mapIndexed((int position, Widget widget) {
+        Widget child = widget;
+
+        if (position == 0) {
+          child = Padding(
+            padding: const EdgeInsetsDirectional.only(top: VERY_LARGE_SPACE),
+            child: child,
+          );
+        }
+
+        return Material(child: child);
+      }),
     );
     return ColoredBox(
       color: widget.backgroundColor,

--- a/packages/smooth_app/lib/pages/onboarding/v2/onboarding_bottom_hills.dart
+++ b/packages/smooth_app/lib/pages/onboarding/v2/onboarding_bottom_hills.dart
@@ -76,13 +76,9 @@ class OnboardingBottomHills extends StatelessWidget {
                     ),
                   ),
                   elevation: WidgetStateProperty.all<double>(4.0),
-                  iconColor: WidgetStateProperty.all<Color>(
-                    colors.secondaryVibrant,
-                  ),
                   foregroundColor: WidgetStateProperty.all<Color>(
                     colors.secondaryVibrant,
                   ),
-                  iconSize: WidgetStateProperty.all<double>(21.0),
                   shape: WidgetStateProperty.all<OutlinedBorder>(
                     RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(20.0),
@@ -103,7 +99,13 @@ class OnboardingBottomHills extends StatelessWidget {
                       ),
                     ),
                     const SizedBox(width: LARGE_SPACE),
-                    const icons.Arrow.right(),
+                    icons.CircledArrow.right(
+                      type: icons.CircledArrowType.normal,
+                      color: Colors.white,
+                      circleColor: colors.secondaryVibrant,
+                      padding: const EdgeInsetsDirectional.all(6.0),
+                      size: 22.0,
+                    ),
                   ],
                 ),
               ),

--- a/packages/smooth_app/lib/pages/preferences_v2/tiles/preference_tile.dart
+++ b/packages/smooth_app/lib/pages/preferences_v2/tiles/preference_tile.dart
@@ -169,7 +169,12 @@ class _PreferenceTileTitle extends StatelessWidget {
     if (query == null || query.isEmpty) {
       return Text(title, style: textStyle);
     } else {
-      return TextHighlighter(text: title, textStyle: textStyle, filter: query);
+      return TextHighlighter(
+        text: title,
+        textStyle: textStyle,
+        filter: query,
+        softWrap: true,
+      );
     }
   }
 }

--- a/packages/smooth_app/lib/pages/prices/infinite_scroll_manager.dart
+++ b/packages/smooth_app/lib/pages/prices/infinite_scroll_manager.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:smooth_app/generic_lib/duration_constants.dart';
 import 'package:smooth_app/generic_lib/empty_screen_layout.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_snackbar.dart';
 import 'package:smooth_app/l10n/app_localizations.dart';
+import 'package:smooth_app/query/product_query.dart';
 
 /// A generic abstract class for handling infinite scrolling in lists.
 /// [T] is the type of items being displayed.
@@ -140,6 +142,10 @@ abstract class InfiniteScrollManager<T> {
     }
   }
 
+  final NumberFormat _numberFormat = NumberFormat.decimalPattern(
+    ProductQuery.getLocaleString(),
+  );
+
   /// Returns a formatted item count (e.g., "25 of 100 items")
   String formattedItemCount(
     BuildContext context,
@@ -148,7 +154,10 @@ abstract class InfiniteScrollManager<T> {
   ) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     return totalItems != null
-        ? appLocalizations.item_count_with_total(loadedItems, totalItems)
-        : appLocalizations.item_count(loadedItems);
+        ? appLocalizations.item_count_with_total_string(
+            _numberFormat.format(loadedItems),
+            _numberFormat.format(totalItems),
+          )
+        : appLocalizations.item_count_string(_numberFormat.format(loadedItems));
   }
 }

--- a/packages/smooth_app/lib/pages/product/product_page/new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/product_page/new_product_page.dart
@@ -130,6 +130,7 @@ class ProductPageState extends State<ProductPage>
             SliverPersistentHeader(
               delegate: ProductHeaderDelegate(
                 statusBarHeight: MediaQuery.viewPaddingOf(context).top,
+                backButtonType: widget.backButton,
               ),
               pinned: true,
               floating: false,

--- a/packages/smooth_app/lib/pages/scan/scan_product_card.dart
+++ b/packages/smooth_app/lib/pages/scan/scan_product_card.dart
@@ -54,7 +54,7 @@ class ScanProductCardFound extends StatelessWidget {
           productPreferences,
           heroTag: _heroTag,
           attributeGroupsClickable: false,
-          margin: EdgeInsets.zero,
+          margin: EdgeInsetsDirectional.zero,
           contentPadding: const EdgeInsets.symmetric(
             horizontal: LARGE_SPACE,
             vertical: VERY_SMALL_SPACE,


### PR DESCRIPTION
Hi everyone!

After my PR yesterday, some parts of the onboarding were broken (my bad 🥺).
Here's the list:

<img width="3240" height="2400" alt="Untitled" src="https://github.com/user-attachments/assets/33e7adab-c574-44b5-a754-2210432d8d5e" />

And some minor changes:

## Decimal format for the banner
<img width="1080" height="412" alt="Screenshot_1762777430" src="https://github.com/user-attachments/assets/f6ac278c-d1d4-4a02-a108-be89d954ffb2" />

## No subtitle, if the content is empty
May happen when the manufacturing location is empty

<img width="1080" height="390" alt="Screenshot_1762777546" src="https://github.com/user-attachments/assets/2f0c5585-d598-4a76-9b67-aadad75bbc58" />

## Product page: back button
Probably a regression introduced by the tabs mechanism

<img width="660" height="286" alt="Capture d’écran   2025-11-10 à 13 58 06" src="https://github.com/user-attachments/assets/d8f83e2d-69e0-47af-a5c0-3c06bef56722" />

## Search results: title on multiple lines
<img width="660" height="404" alt="IMG_4274" src="https://github.com/user-attachments/assets/d97255aa-b557-495a-a316-e5f1b1ceda3b" />


(It’s the last one, I promise 😅)
