### PR TITLE
fix: Last minute fixes 2

### DIFF
--- a/packages/smooth_app/lib/generic_lib/bottom_sheets/smooth_bottom_sheet.dart
+++ b/packages/smooth_app/lib/generic_lib/bottom_sheets/smooth_bottom_sheet.dart
@@ -116,6 +116,7 @@ Future<T?> showSmoothListOfChoicesModalSheet<T>({
   double footerSpace = 0.0,
   SmoothModalSheetType type = SmoothModalSheetType.info,
   bool safeArea = false,
+  bool? useRootNavigator,
 }) {
   assert(labels.length == values.length);
   assert(prefixIcons == null || values.length == prefixIcons.length);
@@ -212,6 +213,7 @@ Future<T?> showSmoothListOfChoicesModalSheet<T>({
 
   return showSmoothModalSheet<T>(
     context: context,
+    useRootNavigator: useRootNavigator,
     builder: (BuildContext context) => SmoothModalSheet(
       title: title,
       type: type,

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -1419,6 +1419,7 @@
       "count": {}
     }
   },
+  "product_list_compare_side_by_side": "Compare side by side",
   "loading_dialog_default_title": "Downloading data",
   "@loading_dialog_default_title": {
     "description": "Default loading dialog title"

--- a/packages/smooth_app/lib/l10n/app_localizations.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations.dart
@@ -3240,6 +3240,12 @@ abstract class AppLocalizations {
   /// **'{count,plural,  =0{Product} =1{Product} other{Products}} refresh complete'**
   String product_list_reloading_success_multiple(num count);
 
+  /// No description provided for @product_list_compare_side_by_side.
+  ///
+  /// In en, this message translates to:
+  /// **'Compare side by side'**
+  String get product_list_compare_side_by_side;
+
   /// Default loading dialog title
   ///
   /// In en, this message translates to:

--- a/packages/smooth_app/lib/l10n/app_localizations_aa.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_aa.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsAa extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_af.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_af.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsAf extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ak.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ak.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsAk extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_am.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_am.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsAm extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ar.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ar.dart
@@ -1699,6 +1699,9 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'تحميل البيانات';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_as.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_as.dart
@@ -1710,6 +1710,9 @@ class AppLocalizationsAs extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_az.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_az.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsAz extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_be.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_be.dart
@@ -1728,6 +1728,9 @@ class AppLocalizationsBe extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Спампоўванне даных';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_bg.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_bg.dart
@@ -1735,6 +1735,9 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Изтегляне на данни';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_bm.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_bm.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsBm extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_bn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_bn.dart
@@ -1713,6 +1713,9 @@ class AppLocalizationsBn extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_bo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_bo.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsBo extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_br.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_br.dart
@@ -1711,6 +1711,9 @@ class AppLocalizationsBr extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_bs.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_bs.dart
@@ -1710,6 +1710,9 @@ class AppLocalizationsBs extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ca.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ca.dart
@@ -1736,6 +1736,9 @@ class AppLocalizationsCa extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Descàrregant les dades';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ce.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ce.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsCe extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_co.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_co.dart
@@ -1710,6 +1710,9 @@ class AppLocalizationsCo extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_cs.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_cs.dart
@@ -1731,6 +1731,9 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Stahování dat';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_cv.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_cv.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsCv extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_cy.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_cy.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsCy extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_da.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_da.dart
@@ -1716,6 +1716,9 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloader data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_de.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_de.dart
@@ -1743,6 +1743,9 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Daten werden heruntergeladen';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_el.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_el.dart
@@ -1752,6 +1752,9 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Λήψη δεδομένων';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_en.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_en.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_eo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_eo.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsEo extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_es.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_es.dart
@@ -1744,6 +1744,9 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Descargando datos';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_et.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_et.dart
@@ -1715,6 +1715,9 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Andmete allalaadimine';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_eu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_eu.dart
@@ -1713,6 +1713,9 @@ class AppLocalizationsEu extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Datuak deskargatzen';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_fa.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_fa.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsFa extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_fi.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_fi.dart
@@ -1711,6 +1711,9 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Ladataan tietoja';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_fo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_fo.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsFo extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_fr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_fr.dart
@@ -1750,6 +1750,9 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Téléchargement des données';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ga.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ga.dart
@@ -1710,6 +1710,9 @@ class AppLocalizationsGa extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_gd.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_gd.dart
@@ -1710,6 +1710,9 @@ class AppLocalizationsGd extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_gl.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_gl.dart
@@ -1710,6 +1710,9 @@ class AppLocalizationsGl extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_gu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_gu.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsGu extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ha.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ha.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsHa extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_he.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_he.dart
@@ -1702,6 +1702,9 @@ class AppLocalizationsHe extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'הנתונים מתקבלים';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_hi.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_hi.dart
@@ -1714,6 +1714,9 @@ class AppLocalizationsHi extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'डेटा डाउनलोड करना';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_hr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_hr.dart
@@ -1710,6 +1710,9 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ht.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ht.dart
@@ -1710,6 +1710,9 @@ class AppLocalizationsHt extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_hu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_hu.dart
@@ -1726,6 +1726,9 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Adatok letöltése';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_hy.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_hy.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsHy extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_id.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_id.dart
@@ -1729,6 +1729,9 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Mengunduh data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ii.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ii.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsIi extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_is.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_is.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsIs extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_it.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_it.dart
@@ -1734,6 +1734,9 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Scaricamento dati';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_iu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_iu.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsIu extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ja.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ja.dart
@@ -1649,6 +1649,9 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'データをダウンロード中';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_jv.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_jv.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsJv extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ka.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ka.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsKa extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_kk.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_kk.dart
@@ -1710,6 +1710,9 @@ class AppLocalizationsKk extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_km.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_km.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsKm extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_kn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_kn.dart
@@ -1711,6 +1711,9 @@ class AppLocalizationsKn extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ko.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ko.dart
@@ -1651,6 +1651,9 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => '데이터 다운로드 중';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ku.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ku.dart
@@ -1710,6 +1710,9 @@ class AppLocalizationsKu extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_kw.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_kw.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsKw extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ky.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ky.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsKy extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_la.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_la.dart
@@ -1710,6 +1710,9 @@ class AppLocalizationsLa extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_lb.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_lb.dart
@@ -1710,6 +1710,9 @@ class AppLocalizationsLb extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_lo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_lo.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsLo extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_lt.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_lt.dart
@@ -1741,6 +1741,9 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Atsisiunčiami duomenys';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_lv.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_lv.dart
@@ -1738,6 +1738,9 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Datu lejupielāde';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_mg.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_mg.dart
@@ -1711,6 +1711,9 @@ class AppLocalizationsMg extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_mi.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_mi.dart
@@ -1711,6 +1711,9 @@ class AppLocalizationsMi extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ml.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ml.dart
@@ -1710,6 +1710,9 @@ class AppLocalizationsMl extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_mn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_mn.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsMn extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_mr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_mr.dart
@@ -1710,6 +1710,9 @@ class AppLocalizationsMr extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ms.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ms.dart
@@ -1712,6 +1712,9 @@ class AppLocalizationsMs extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_mt.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_mt.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsMt extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_my.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_my.dart
@@ -1711,6 +1711,9 @@ class AppLocalizationsMy extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_nb.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_nb.dart
@@ -1718,6 +1718,9 @@ class AppLocalizationsNb extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Laster ned data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ne.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ne.dart
@@ -1708,6 +1708,9 @@ class AppLocalizationsNe extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_nl.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_nl.dart
@@ -1725,6 +1725,9 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Gegevens worden gedownload...';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_nn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_nn.dart
@@ -1710,6 +1710,9 @@ class AppLocalizationsNn extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_no.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_no.dart
@@ -1710,6 +1710,9 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_nr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_nr.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsNr extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_oc.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_oc.dart
@@ -1710,6 +1710,9 @@ class AppLocalizationsOc extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_or.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_or.dart
@@ -1713,6 +1713,9 @@ class AppLocalizationsOr extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_pa.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_pa.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsPa extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_pl.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_pl.dart
@@ -1737,6 +1737,9 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Pobieranie danych';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_pt.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_pt.dart
@@ -1739,6 +1739,9 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'A descarregar os dados';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_qu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_qu.dart
@@ -1710,6 +1710,9 @@ class AppLocalizationsQu extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_rm.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_rm.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsRm extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ro.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ro.dart
@@ -1747,6 +1747,9 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Descărcare date';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ru.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ru.dart
@@ -1747,6 +1747,9 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Загрузка данных';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_sa.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sa.dart
@@ -1710,6 +1710,9 @@ class AppLocalizationsSa extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_sc.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sc.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsSc extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_sd.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sd.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsSd extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_sg.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sg.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsSg extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_si.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_si.dart
@@ -1710,6 +1710,9 @@ class AppLocalizationsSi extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_sk.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sk.dart
@@ -1730,6 +1730,9 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Sťahovanie údajov';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_sl.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sl.dart
@@ -1728,6 +1728,9 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Nalaganje podatkov';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_sn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sn.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsSn extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_so.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_so.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsSo extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_sq.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sq.dart
@@ -1722,6 +1722,9 @@ class AppLocalizationsSq extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_sr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sr.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsSr extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ss.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ss.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsSs extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_st.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_st.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsSt extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_sv.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sv.dart
@@ -1723,6 +1723,9 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Laddar ner data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_sw.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sw.dart
@@ -1708,6 +1708,9 @@ class AppLocalizationsSw extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ta.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ta.dart
@@ -1714,6 +1714,9 @@ class AppLocalizationsTa extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_te.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_te.dart
@@ -1710,6 +1710,9 @@ class AppLocalizationsTe extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_tg.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tg.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsTg extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_th.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_th.dart
@@ -1705,6 +1705,9 @@ class AppLocalizationsTh extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ti.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ti.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsTi extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_tl.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tl.dart
@@ -1710,6 +1710,9 @@ class AppLocalizationsTl extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_tn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tn.dart
@@ -1710,6 +1710,9 @@ class AppLocalizationsTn extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_tr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tr.dart
@@ -1723,6 +1723,9 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Veri indiriliyor';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ts.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ts.dart
@@ -1710,6 +1710,9 @@ class AppLocalizationsTs extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_tt.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tt.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsTt extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_tw.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tw.dart
@@ -1710,6 +1710,9 @@ class AppLocalizationsTw extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ty.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ty.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsTy extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ug.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ug.dart
@@ -1710,6 +1710,9 @@ class AppLocalizationsUg extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_uk.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_uk.dart
@@ -1729,6 +1729,9 @@ class AppLocalizationsUk extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Завантаження даних';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ur.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ur.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsUr extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_uz.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_uz.dart
@@ -1710,6 +1710,9 @@ class AppLocalizationsUz extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ve.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ve.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsVe extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_vi.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_vi.dart
@@ -1722,6 +1722,9 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Đang tải xuống dữ liệu';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_wa.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_wa.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsWa extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_wo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_wo.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsWo extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_xh.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_xh.dart
@@ -1710,6 +1710,9 @@ class AppLocalizationsXh extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_yi.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_yi.dart
@@ -1710,6 +1710,9 @@ class AppLocalizationsYi extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_yo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_yo.dart
@@ -1710,6 +1710,9 @@ class AppLocalizationsYo extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_zh.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_zh.dart
@@ -1631,6 +1631,9 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => '正在下載資料';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_zu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_zu.dart
@@ -1709,6 +1709,9 @@ class AppLocalizationsZu extends AppLocalizations {
   }
 
   @override
+  String get product_list_compare_side_by_side => 'Compare side by side';
+
+  @override
   String get loading_dialog_default_title => 'Downloading data';
 
   @override

--- a/packages/smooth_app/lib/pages/preferences_v2/roots/account_root.dart
+++ b/packages/smooth_app/lib/pages/preferences_v2/roots/account_root.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/user_management_provider.dart';
+import 'package:smooth_app/generic_lib/bottom_sheets/smooth_bottom_sheet.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
-import 'package:smooth_app/generic_lib/dialogs/smooth_alert_dialog.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/l10n/app_localizations.dart';
 import 'package:smooth_app/pages/preferences/account_deletion_webview.dart';
@@ -12,6 +12,8 @@ import 'package:smooth_app/pages/preferences_v2/roots/preferences_root.dart';
 import 'package:smooth_app/pages/preferences_v2/tiles/preference_tile.dart';
 import 'package:smooth_app/pages/preferences_v2/tiles/url_preference_tile.dart';
 import 'package:smooth_app/resources/app_icons.dart' as icons;
+import 'package:smooth_app/themes/smooth_theme.dart';
+import 'package:smooth_app/themes/smooth_theme_colors.dart';
 
 class AccountRoot extends PreferencesRoot {
   const AccountRoot({required super.title});
@@ -115,21 +117,35 @@ class AccountRoot extends PreferencesRoot {
   Future<bool?> _confirmLogout(
     BuildContext context,
     AppLocalizations appLocalizations,
-  ) async => showDialog<bool>(
-    context: context,
-    builder: (BuildContext context) {
-      return SmoothAlertDialog(
-        title: appLocalizations.sign_out,
-        body: Text(appLocalizations.sign_out_confirmation),
-        positiveAction: SmoothActionButton(
-          text: appLocalizations.yes,
-          onPressed: () async => Navigator.of(context).pop(true),
+  ) async {
+    final SmoothColorsThemeExtension theme = context
+        .extension<SmoothColorsThemeExtension>();
+
+    return showSmoothListOfChoicesModalSheet<bool>(
+      context: context,
+      safeArea: true,
+      title: appLocalizations.sign_out,
+      header: Align(
+        alignment: AlignmentDirectional.topStart,
+        child: Padding(
+          padding: const EdgeInsetsDirectional.symmetric(
+            horizontal: LARGE_SPACE,
+            vertical: MEDIUM_SPACE,
+          ),
+          child: Text(
+            appLocalizations.sign_out_confirmation,
+            style: Theme.of(
+              context,
+            ).textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.w500),
+          ),
         ),
-        negativeAction: SmoothActionButton(
-          text: appLocalizations.no,
-          onPressed: () => Navigator.of(context).pop(false),
-        ),
-      );
-    },
-  );
+      ),
+      labels: <String>[appLocalizations.yes, appLocalizations.no],
+      values: <bool>[true, false],
+      prefixIcons: <Widget>[
+        icons.Check.circled(color: theme.success),
+        icons.Close.circled(color: theme.error),
+      ],
+    );
+  }
 }

--- a/packages/smooth_app/lib/pages/product/common/product_list_item_popup_items.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_item_popup_items.dart
@@ -54,7 +54,7 @@ abstract class ProductListItemPopupItem {
 class ProductListItemPopupSideBySide extends ProductListItemPopupItem {
   @override
   String getTitle(final AppLocalizations appLocalizations) =>
-      'Compare side by side';
+      appLocalizations.product_list_compare_side_by_side;
 
   @override
   Widget getIcon() => const icons.Compare.alt();

--- a/packages/smooth_app/lib/pages/product/common/product_list_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_list_page.dart
@@ -223,7 +223,7 @@ class _ProductListPageState extends State<ProductListPage>
       body: products.isEmpty
           ? Center(
               child: Padding(
-                padding: const EdgeInsets.all(SMALL_SPACE),
+                padding: const EdgeInsetsDirectional.all(SMALL_SPACE),
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.spaceAround,
                   children: <Widget>[
@@ -374,7 +374,7 @@ class _ProductListPageState extends State<ProductListPage>
           alignment: AlignmentDirectional.centerEnd,
           color: RED_COLOR,
           padding: const EdgeInsetsDirectional.only(end: 30.0),
-          child: const Icon(Icons.delete, size: 30.0, color: Colors.white),
+          child: const icons.Trash(size: 20.0, color: Colors.white),
         ),
         key: Key(barcode),
         onDismissed: (final DismissDirection direction) async {

--- a/packages/smooth_app/lib/pages/search/search_history_view.dart
+++ b/packages/smooth_app/lib/pages/search/search_history_view.dart
@@ -82,15 +82,11 @@ class _SearchHistoryViewState extends State<SearchHistoryView> {
       ),
       child: Column(
         children: <Widget>[
+          const _SearchHistoryTitle(),
           Expanded(
             child: ListView.builder(
               padding: EdgeInsetsDirectional.zero,
               itemBuilder: (BuildContext context, int i) {
-                if (i == 0) {
-                  return const _SearchHistoryTitle();
-                }
-
-                i--;
                 if (i < widget.preloadedList.length) {
                   final SearchPreloadedItem item = widget.preloadedList[i];
                   return item.getWidget(
@@ -110,6 +106,7 @@ class _SearchHistoryViewState extends State<SearchHistoryView> {
                 final String query = _queries[i];
                 return _SearchHistoryTile(
                   query: query,
+                  bottomBorder: i < _queries.length - 1,
                   onTap: () => widget.onTap.call(query),
                   onEditItem: () => _onEditItem(query),
                   onRemoveItem: () async {
@@ -123,7 +120,7 @@ class _SearchHistoryViewState extends State<SearchHistoryView> {
                   },
                 );
               },
-              itemCount: count + 1,
+              itemCount: count,
             ),
           ),
           Padding(
@@ -173,30 +170,33 @@ class _SearchHistoryTitle extends StatelessWidget {
     final SmoothColorsThemeExtension theme = context
         .extension<SmoothColorsThemeExtension>();
 
-    return Padding(
-      padding: const EdgeInsetsDirectional.only(
-        top: LARGE_SPACE,
-        bottom: VERY_SMALL_SPACE,
-        start: SMALL_SPACE,
-        end: SMALL_SPACE,
-      ),
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          borderRadius: ANGULAR_BORDER_RADIUS,
-          color: theme.primaryMedium,
+    return SizedBox(
+      width: double.infinity,
+      child: Padding(
+        padding: const EdgeInsetsDirectional.only(
+          top: LARGE_SPACE,
+          bottom: VERY_SMALL_SPACE,
+          start: SMALL_SPACE,
+          end: SMALL_SPACE,
         ),
-        child: Padding(
-          padding: const EdgeInsetsDirectional.symmetric(
-            horizontal: SMALL_SPACE,
-            vertical: BALANCED_SPACE,
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            borderRadius: ANGULAR_BORDER_RADIUS,
+            color: theme.primaryMedium,
           ),
-          child: Text(
-            AppLocalizations.of(context).search_history,
-            textAlign: TextAlign.center,
-            style: TextStyle(
-              color: theme.primaryBlack,
-              fontSize: 15.0,
-              fontWeight: FontWeight.bold,
+          child: Padding(
+            padding: const EdgeInsetsDirectional.symmetric(
+              horizontal: SMALL_SPACE,
+              vertical: BALANCED_SPACE,
+            ),
+            child: Text(
+              AppLocalizations.of(context).search_history,
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                color: theme.primaryBlack,
+                fontSize: 15.0,
+                fontWeight: FontWeight.bold,
+              ),
             ),
           ),
         ),
@@ -211,12 +211,14 @@ class _SearchHistoryTile extends StatelessWidget {
     required this.onTap,
     required this.onEditItem,
     required this.onRemoveItem,
+    this.bottomBorder = true,
   });
 
   final String query;
   final VoidCallback onTap;
   final VoidCallback onEditItem;
   final VoidCallback onRemoveItem;
+  final bool bottomBorder;
 
   @override
   Widget build(BuildContext context) {
@@ -224,9 +226,8 @@ class _SearchHistoryTile extends StatelessWidget {
 
     final SmoothColorsThemeExtension theme = context
         .extension<SmoothColorsThemeExtension>();
-    final Color color = context.lightTheme()
-        ? theme.primaryBlack
-        : theme.primaryMedium;
+    final bool lightTheme = context.lightTheme();
+    final Color color = lightTheme ? theme.primaryBlack : theme.primaryMedium;
 
     return InkWell(
       onTap: onTap,
@@ -237,11 +238,13 @@ class _SearchHistoryTile extends StatelessWidget {
         ),
         child: Ink(
           decoration: BoxDecoration(
-            border: DashedBorder(
-              dashLength: 3.0,
-              spaceLength: 3.0,
-              bottom: BorderSide(color: theme.primaryMedium),
-            ),
+            border: bottomBorder
+                ? DashedBorder(
+                    dashLength: 3.0,
+                    spaceLength: 3.0,
+                    bottom: BorderSide(color: theme.primaryMedium),
+                  )
+                : null,
           ),
           child: Padding(
             padding: const EdgeInsetsDirectional.only(top: 2.0, bottom: 2.0),
@@ -261,7 +264,7 @@ class _SearchHistoryTile extends StatelessWidget {
                     child: Text(
                       query,
                       style: TextStyle(
-                        color: color,
+                        color: lightTheme ? color : Colors.white,
                         fontSize: 15.0,
                         fontWeight: FontWeight.w500,
                       ),

--- a/packages/smooth_app/lib/widgets/smooth_app_bar.dart
+++ b/packages/smooth_app/lib/widgets/smooth_app_bar.dart
@@ -3,7 +3,6 @@ import 'package:flutter/services.dart';
 import 'package:smooth_app/generic_lib/duration_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_back_button.dart';
 import 'package:smooth_app/l10n/app_localizations.dart';
-import 'package:smooth_app/resources/app_icons.dart' as icons;
 import 'package:smooth_app/themes/smooth_theme.dart';
 import 'package:smooth_app/themes/smooth_theme_colors.dart';
 import 'package:smooth_app/themes/theme_provider.dart';
@@ -270,10 +269,9 @@ class _ActionModeCloseButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterialLocalizations(context));
-    return IconButton(
-      icon: const icons.Close(),
-      tooltip: tooltip ?? MaterialLocalizations.of(context).closeButtonTooltip,
-      color: PopupMenuTheme.of(context).color,
+    return SmoothBackButton(
+      backButtonType: BackButtonType.close,
+      iconColor: PopupMenuTheme.of(context).color,
       onPressed: () {
         if (onPressed != null) {
           onPressed!();

--- a/packages/smooth_app/lib/widgets/smooth_menu_button.dart
+++ b/packages/smooth_app/lib/widgets/smooth_menu_button.dart
@@ -31,7 +31,7 @@ class _SmoothPopupMenuButtonState<T> extends State<SmoothPopupMenuButton<T>> {
   @override
   Widget build(BuildContext context) {
     return IconButton(
-      icon: widget.buttonIcon ?? Icon(Icons.adaptive.more),
+      icon: widget.buttonIcon ?? const Icon(Icons.more_vert_rounded),
       tooltip:
           widget.buttonLabel ??
           MaterialLocalizations.of(context).showMenuTooltip,


### PR DESCRIPTION
## History view
<img width="720" height="569" alt="Screenshot_1762931606" src="https://github.com/user-attachments/assets/03282c3e-0c3d-4c2c-957a-d73f0887a8bd" />

- 1️⃣ "Search history" is now fixed (won't scroll)
- 2️⃣ In dark mode, a white text is used
- 3️⃣ No dashed line for the last item

## Sign out
A modal sheet instead of a Dialog

<img width="720" height="509" alt="Screenshot_1762932100" src="https://github.com/user-attachments/assets/8e41ea13-1b1b-4447-a90f-e992b76f7cd6" />

## Compare side by side
The sentence was hardcoded.

<img width="660" height="272" alt="IMG_4297" src="https://github.com/user-attachments/assets/882c389c-6ac7-4347-9aa3-da9e15426e76" />

## Lists
<img width="720" height="430" alt="Screenshot_1762932358" src="https://github.com/user-attachments/assets/95a70923-2b22-47fd-af41-b2e9608afec6" />


- 1️⃣ Better icon
- 2️⃣ Vertical dots are better than horizontal ones

<img width="352" height="223" alt="Screenshot 2025-11-12 at 08 31 29" src="https://github.com/user-attachments/assets/754b7eb9-381a-4c1b-b10f-4ea27ff34505" />

- 3️⃣ Fixed icon