### PR TITLE
fix: Hotfix: Rive animation & search bar

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_loading.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_loading.dart
@@ -49,6 +49,7 @@ class ScanProductCardLoading extends StatelessWidget {
                   artboard: 'Loading',
                   alignment: Alignment.topCenter,
                   fit: Fit.fitHeight,
+                  autoBinding: false,
                 ),
               ),
             ),

--- a/packages/smooth_app/lib/pages/preferences_v2/preferences_page.dart
+++ b/packages/smooth_app/lib/pages/preferences_v2/preferences_page.dart
@@ -96,13 +96,20 @@ class PreferencesPage extends StatelessWidget {
           GithubSearchPreferenceTile(),
           ForumSearchPreferenceTile(),
         ],
-        footer: (_) => Consumer<PreferencesRootSearchController>(
-          builder: (_, PreferencesRootSearchController controller, _) {
-            if (controller.query?.isNotEmpty == true) {
-              return EMPTY_WIDGET;
-            }
-            return const SocialNetworksFooter();
-          },
+        footer: (_) => Consumer2<PreferencesRootSearchController, FocusNode>(
+          builder:
+              (
+                BuildContext context,
+                PreferencesRootSearchController controller,
+                FocusNode focusNode,
+                _,
+              ) {
+                if (controller.query?.isNotEmpty == true ||
+                    focusNode.hasFocus) {
+                  return EMPTY_WIDGET;
+                }
+                return const SocialNetworksFooter();
+              },
         ),
       ),
     );


### PR DESCRIPTION
Hi everyone!

Here's a hotfix for the 3.22 release.

## Loading animation
As discovered by @monsieurtanuki in https://github.com/openfoodfacts/smooth-app/issues/7224, we shoudn't autobind the `Loading` animation in the carousel.

## Search bar in Community
Minor issue visible in this video: if we scroll, the footer is visible

https://github.com/user-attachments/assets/f436d4a8-69b7-4271-a23c-b500a5716458

