### PR TITLE
fix: Price proof picture fixes

### DIFF
--- a/packages/smooth_app/lib/widgets/smooth_interactive_viewer.dart
+++ b/packages/smooth_app/lib/widgets/smooth_interactive_viewer.dart
@@ -70,8 +70,8 @@ class _SmoothInteractiveViewerState extends State<SmoothInteractiveViewer>
       // Zoom x2
       final Offset position = _doubleTapDetails.localPosition;
       matrix = Matrix4.identity()
-        ..translateByDouble(-position.dx, -position.dy, 0.0, 0.0)
-        ..scaleAdjoint(2.0);
+        ..translateByDouble(-position.dx, -position.dy, 0.0, 1.0)
+        ..scaleByDouble(2.0, 2.0, 2.0, 1.0);
       _animationController.duration = SmoothAnimationsDuration.short;
     }
 


### PR DESCRIPTION
Hi everyone!

This PR fixes two issues with the screen showing a price proof.

1) Progress / error
There's now a progress bar during the loading.
In case of an error, there's now the sad Milk bottle.

Weirdly, an image can have this url: https://prices.openfoodfacts.org/img/0064/8dlhbPleHe.csv

Note: The pinch-to-zoom explainer is only visible if an image is full loaded.

2) Double-tap to zoom
I think this is a regression since the migration to Flutter 3.35.