### PR TITLE
fix: 7232 - "back" management

### DIFF
--- a/packages/smooth_app/lib/pages/page_manager.dart
+++ b/packages/smooth_app/lib/pages/page_manager.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/preferences/user_preferences.dart';
 import 'package:smooth_app/l10n/app_localizations.dart';
@@ -133,14 +134,13 @@ class PageManagerState extends State<PageManager> {
         if (isFirstRouteInCurrentTab) {
           if (_currentPage != BottomNavigationTab.Scan) {
             _selectTab(BottomNavigationTab.Scan, 1);
-            return (false, null);
           } else {
             /// Exit the app
-            return (true, null);
+            SystemNavigator.pop();
           }
         }
 
-        // let system handle back button if we're on the first route
+        // let system handle back button
         return (false, null);
       },
       child: Scaffold(

--- a/packages/smooth_app/lib/widgets/will_pop_scope.dart
+++ b/packages/smooth_app/lib/widgets/will_pop_scope.dart
@@ -42,6 +42,9 @@ class WillPopScope2 extends StatelessWidget {
                         // Using regular Navigator as fallback
                         Navigator.of(context).pop(res);
                       } catch (navigatorError) {
+                        // not sure that makes sense anymore, as there's only
+                        // one place where we should have the app killed: a back
+                        // from the root "scan" tab.
                         // Force to kill the app
                         SystemNavigator.pop();
                       }


### PR DESCRIPTION
### What
- When in debug mode, I could start the app, go back and unfortunately see an exception in the logs. That was my main test.
- I tried to roll back all the related code, step by step.
- It looks like the way we kill the app wasn't bold enough:
  - there's only one case where we kill the app - going "back" from the root "scan" tab
  - but the code was like "in that case, just pretend we close the current page - first try to pop the GoRoute, then if it fails try to pop the Navigator, then if it fails try to kill the app"
- Not exactly sure why it crashed, and not even sure it fixes all the similar bugs, but the PR code is more straightforward - if you have to kill the app, just kill the bloody app. As Tuco says: [when you have to shoot, shoot, don't talk!](https://www.youtube.com/watch?v=JrYtD7gSWsI)
- Generally speaking I'm not a big fan of the "pop the GoRoute even if it doesn't mean anything, just in case, we'll try something else if that fails". May be a source of other bugs. Perhaps we should have more specific WillPopScope, one for GoRoute, one for Navigator. But that's another story.
- Anyway, please test, test, test!

### Fixes bug(s)
- Fixes: #7232

### Impacted files
* `page_manager.dart`: explicit call to "kill app" when we go back from the root "scan" tab
* `will_pop_scope.dart`: added comments