### PR TITLE
feat: 6846 - Apply Price card glow-up to Top Products and Top Locations

### DIFF
--- a/packages/smooth_app/lib/pages/prices/prices_locations_page.dart
+++ b/packages/smooth_app/lib/pages/prices/prices_locations_page.dart
@@ -4,8 +4,8 @@ import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_back_button.dart';
-import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/helpers/launch_url_helper.dart';
+import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/l10n/app_localizations.dart';
 import 'package:smooth_app/pages/prices/infinite_scroll_list.dart';
 import 'package:smooth_app/pages/prices/infinite_scroll_manager.dart';
@@ -95,45 +95,55 @@ class _InfiniteScrollLocationManager extends InfiniteScrollManager<Location> {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final int priceCount = item.priceCount ?? 0;
 
-    return SmoothCard(
-      child: Wrap(
-        spacing: VERY_SMALL_SPACE,
-        children: <Widget>[
-          PriceLocationWidget(item),
-          PriceCountWidget(
-            count: priceCount,
-            onPressed: () async => PriceLocationWidget.showLocationPrices(
-              locationId: item.locationId,
-              context: context,
+    return buildProductSmoothCard(
+      margin: const EdgeInsetsDirectional.only(
+        start: SMALL_SPACE,
+        end: SMALL_SPACE,
+        top: VERY_LARGE_SPACE,
+      ),
+      body: Padding(
+        padding: const EdgeInsetsDirectional.all(LARGE_SPACE),
+        child: Wrap(
+          spacing: VERY_SMALL_SPACE,
+          children: <Widget>[
+            PriceLocationWidget(item),
+            PriceCountWidget(
+              count: priceCount,
+              onPressed: () async => PriceLocationWidget.showLocationPrices(
+                locationId: item.locationId,
+                context: context,
+              ),
             ),
-          ),
-          PriceButton(
-            onPressed: () {},
-            title: '${item.userCount}',
-            iconData: PriceButton.userIconData,
-            tooltip: item.userCount == null
-                ? null
-                : appLocalizations.prices_button_count_user(item.userCount!),
-          ),
-          PriceButton(
-            onPressed: () {},
-            title: '${item.productCount}',
-            iconData: PriceButton.productIconData,
-            tooltip: item.productCount == null
-                ? null
-                : appLocalizations.prices_button_count_product(
-                    item.productCount!,
-                  ),
-          ),
-          PriceButton(
-            onPressed: () {},
-            title: '${item.proofCount}',
-            iconData: PriceButton.proofIconData,
-            tooltip: item.proofCount == null
-                ? null
-                : appLocalizations.prices_button_count_proof(item.proofCount!),
-          ),
-        ],
+            PriceButton(
+              onPressed: () {},
+              title: '${item.userCount}',
+              iconData: PriceButton.userIconData,
+              tooltip: item.userCount == null
+                  ? null
+                  : appLocalizations.prices_button_count_user(item.userCount!),
+            ),
+            PriceButton(
+              onPressed: () {},
+              title: '${item.productCount}',
+              iconData: PriceButton.productIconData,
+              tooltip: item.productCount == null
+                  ? null
+                  : appLocalizations.prices_button_count_product(
+                      item.productCount!,
+                    ),
+            ),
+            PriceButton(
+              onPressed: () {},
+              title: '${item.proofCount}',
+              iconData: PriceButton.proofIconData,
+              tooltip: item.proofCount == null
+                  ? null
+                  : appLocalizations.prices_button_count_proof(
+                      item.proofCount!,
+                    ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/packages/smooth_app/lib/pages/prices/prices_products_page.dart
+++ b/packages/smooth_app/lib/pages/prices/prices_products_page.dart
@@ -2,9 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_back_button.dart';
-import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/helpers/launch_url_helper.dart';
+import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/l10n/app_localizations.dart';
 import 'package:smooth_app/pages/prices/get_prices_model.dart';
 import 'package:smooth_app/pages/prices/infinite_scroll_list.dart';
@@ -99,19 +100,27 @@ class _InfiniteScrollProductManager
     required BuildContext context,
     required PriceProduct item,
   }) {
-    return SmoothCard(
-      child: InkWell(
-        onTap: () async => Navigator.of(context).push<void>(
-          MaterialPageRoute<void>(
-            builder: (BuildContext context) => PricesPage(
-              GetPricesModel.product(
-                product: PriceMetaProduct.priceProduct(item),
-                context: context,
+    return buildProductSmoothCard(
+      margin: const EdgeInsetsDirectional.only(
+        start: SMALL_SPACE,
+        end: SMALL_SPACE,
+        top: VERY_LARGE_SPACE,
+      ),
+      body: Padding(
+        padding: const EdgeInsetsDirectional.all(LARGE_SPACE),
+        child: InkWell(
+          onTap: () async => Navigator.of(context).push<void>(
+            MaterialPageRoute<void>(
+              builder: (BuildContext context) => PricesPage(
+                GetPricesModel.product(
+                  product: PriceMetaProduct.priceProduct(item),
+                  context: context,
+                ),
               ),
             ),
           ),
+          child: PriceProductWidget(item),
         ),
-        child: PriceProductWidget(item),
       ),
     );
   }


### PR DESCRIPTION

Changes made

Replaced SmoothCard with buildProductSmoothCard for unified card look
Updated card body structure to match the new design guidelines
Maintained existing functionality (click actions, navigation, counters)
Fixed layout spacing and padding to match other price cards
Confirmed with screenshots that the new card visually matches expected design

Screenshot

Before Top Products:
<img src="https://github.com/user-attachments/assets/ee742cad-96e4-4eb7-8048-4a01c6b09be3" height="400px">

After Top Products:
<img src="https://github.com/user-attachments/assets/e6629b16-a4ae-48de-a74e-c83ee475cecd" height="400px">

Before Top Locations:
<img src="https://github.com/user-attachments/assets/586ff1d4-d903-49a4-937b-1ba6cbb901bd" height="400px">

After Top Locations:
<img src="https://github.com/user-attachments/assets/88213d3e-7996-4b06-a264-032c667150f8" height="400px">

Fixes bug(s)
Fixes: #6846
("Apply the Price card glow up to Top Location and Top Products")

Part of: #525 (Price UX Improvements)
