### PR TITLE
fix(ci): Correct directory path for pub package-ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,7 +41,7 @@ updates:
       include: "scope"
       
   - package-ecosystem: "pub"
-    directory: "/packages/scanner/mlkit/"
+    directory: "/packages/scanner/ml_kit/"
     schedule:
       interval: "daily"
     commit-message:


### PR DESCRIPTION
Correct typo "mlkit" to "ml_kit"