### PR TITLE
fix: Fix Photon request

### DIFF
--- a/packages/smooth_app/lib/data_models/location_list_photon_supplier.dart
+++ b/packages/smooth_app/lib/data_models/location_list_photon_supplier.dart
@@ -55,6 +55,7 @@ class LocationListPhotonSupplier extends LocationListSupplier {
               '&limit=100'
               '${_getAdditionalParameters()}',
         ),
+        headers: <String, String>{'User-Agent': 'OpenFoodFacts/MobileApp'},
       );
       if (response.statusCode != 200) {
         return 'Could not retrieve locations';


### PR DESCRIPTION
Hi everyone!

For some time now, requests to Photon (to obtain locations) have been returning 403 errors.
It seems that Dart’s default User-Agent is to blame.

By providing one, everything works again!

<img width="660" height="1022" alt="Photo from Google Photos" src="https://github.com/user-attachments/assets/a8205d13-7def-4540-b885-401593cd30b8" />
