### PR TITLE
docs: Update Flutter version from 3.35 to 3.38.5

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,13 +7,13 @@ This is a comprehensive Flutter mobile application for Open Food Facts, supporti
 ## Essential Setup and Environment
 
 ### Flutter Version Management
-- **CRITICAL**: This app requires Flutter version **3.35.1** exactly (as specified in `flutter-version.txt`)
+- **CRITICAL**: This app requires Flutter version **3.38.5** exactly (as specified in `flutter-version.txt`)
 - **ALWAYS** use FVM (Flutter Version Management) for consistent Flutter versions:
   ```bash
   # Install FVM first: https://fvm.app/documentation/getting-started/installation
-  fvm install 3.35.1
-  fvm use 3.35.1
-  fvm flutter --version  # Should show Flutter 3.35.1
+  fvm install 3.38.5
+  fvm use 3.38.5
+  fvm flutter --version  # Should show Flutter 3.38.5
   ```
 - Export Flutter to PATH: `export PATH="$(fvm flutter sdk-path)/bin:$PATH"`
 
@@ -149,7 +149,7 @@ If you encounter build issues:
 - `.github/workflows/` - GitHub Actions CI/CD pipeline
 
 ### Important Files
-- `flutter-version.txt` - Specifies required Flutter version (3.35.1)
+- `flutter-version.txt` - Specifies required Flutter version (3.38.5)
 - `packages/smooth_app/pubspec.yaml` - Main app dependencies
 - `packages/smooth_app/lib/entrypoints/` - Platform-specific entry points
 - `packages/smooth_app/integration_test/` - End-to-end test scenarios

--- a/README.md
+++ b/README.md
@@ -77,14 +77,14 @@ Full list of features on the wiki: https://wiki.openfoodfacts.org/Mobile_App/Fea
 ## 🚀 How to run the project
 - Make sure you have installed Flutter and all the requirements
   - [Official Flutter installation guide](https://docs.flutter.dev/get-started/install)
-- Currently, the app uses the following version of Flutter: **3.35**.
+- Currently, the app uses the following version of Flutter: **3.38.5**.
  - **Setting Up Your Environment with FVM**
    - To manage Flutter versions easily, download and install **FVM (Flutter Version Management)**:
      - Install FVM by following the [official FVM installation guide](https://fvm.app/documentation/getting-started/installation).
-     - Once FVM is installed, run the following commands to set Flutter to version 3.35.1:
+     - Once FVM is installed, run the following commands to set Flutter to version 3.38.5:
        ```bash
-       fvm install 3.35.1
-       fvm use 3.35.1
+       fvm install 3.38.5
+       fvm use 3.38.5
        ```
      - Verify the Flutter version with:
        ```bash


### PR DESCRIPTION
  ### What
  Updates documentation to reflect the correct Flutter version (3.38.5) as specified in `flutter-version.txt`. The previous documentation referenced outdated versions (3.35/3.35.1), causing build failures for new contributors.

  - Updated `README.md` to reference Flutter 3.38.5
  - Updated `.github/copilot-instructions.md` to reference Flutter 3.38.5

  ### Problem
  When following the setup instructions with Flutter 3.35.1, `fvm flutter pub get` fails with:
  The current Dart SDK version is 3.9.0.
  Because smooth_app requires SDK version ^3.10.4, version solving failed.

  **Root cause**: Flutter 3.35.1 includes Dart 3.9.0, but the project requires Dart ^3.10.4 (which comes with Flutter 3.38.5).

  ### Solution
  All documentation now consistently references Flutter 3.38.5 to match `flutter-version.txt`.

  ### Testing
  - Verified by following the updated instructions during local setup on iOS (macOS 15.5)
  - Successfully ran `fvm flutter pub get` with Flutter 3.38.5
  - Build completed successfully

  ### Related Issue
  Fixes #7320