### PR TITLE
chore: Remove warnings due to `openfoodfacts: 3.29.0`

### DIFF
--- a/packages/smooth_app/lib/cards/data_cards/score_card.dart
+++ b/packages/smooth_app/lib/cards/data_cards/score_card.dart
@@ -50,7 +50,7 @@ class ScoreCard extends StatelessWidget {
     this.margin,
   }) : type = ScoreCardType.title,
        iconUrl = titleElement.iconUrl,
-       description = titleElement.title ?? '',
+       description = titleElement.title,
        cardEvaluation = getCardEvaluationFromKnowledgePanelTitleElement(
          titleElement,
        );

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_page.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_page.dart
@@ -163,7 +163,7 @@ class _KnowledgePanelPageState extends State<KnowledgePanelPage>
       upToDateProduct,
       widget.panelId,
     );
-    if (panel?.titleElement?.title?.isNotEmpty == true) {
+    if (panel?.titleElement?.title.isNotEmpty == true) {
       return (panel?.titleElement?.title)!;
     }
     return '';

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_title_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_title_card.dart
@@ -122,7 +122,7 @@ class KnowledgePanelTitleCard extends StatelessWidget {
                       SizedBox(
                         width: constraints.maxWidth,
                         child: Text(
-                          knowledgePanelTitleElement.title ?? '',
+                          knowledgePanelTitleElement.title,
                           style:
                               textStyleOverride ??
                               TextStyle(

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels_builder.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels_builder.dart
@@ -38,7 +38,7 @@ class KnowledgePanelsBuilder {
     if (rootPanel != null) {
       children.add(
         KnowledgePanelTitle(
-          title: rootPanel.titleElement!.title ?? '',
+          title: rootPanel.titleElement!.title,
           topics: rootPanel.topics,
         ),
       );

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -1156,10 +1156,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mgrs_dart:
     dependency: transitive
     description:
@@ -1791,10 +1791,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   timing:
     dependency: transitive
     description:


### PR DESCRIPTION
The migration to the Dart package 3.29.0 causes some code warnings.