### PR TITLE
feat: Product header improvements (title/brands/qty)

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/product_title_card.dart
+++ b/packages/smooth_app/lib/cards/product_cards/product_title_card.dart
@@ -8,6 +8,10 @@ import 'package:smooth_app/generic_lib/widgets/picture_not_found.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/l10n/app_localizations.dart';
 import 'package:smooth_app/pages/product/gallery_view/product_image_gallery_view.dart';
+import 'package:smooth_app/query/product_query.dart';
+import 'package:smooth_app/themes/smooth_theme.dart';
+import 'package:smooth_app/themes/smooth_theme_colors.dart';
+import 'package:smooth_app/themes/theme_provider.dart';
 
 class ProductTitleCard extends StatelessWidget {
   const ProductTitleCard(
@@ -15,6 +19,7 @@ class ProductTitleCard extends StatelessWidget {
     this.isSelectable, {
     this.heroTag,
     this.isPictureVisible = true,
+    this.expandableBrands = false,
     this.dense = false,
     this.onRemove,
   });
@@ -25,11 +30,10 @@ class ProductTitleCard extends StatelessWidget {
   final String? heroTag;
   final OnRemoveCallback? onRemove;
   final bool isPictureVisible;
+  final bool expandableBrands;
 
   @override
   Widget build(BuildContext context) {
-    final Widget trailing = _ProductTitleCardTrailing(selectable: isSelectable);
-
     final Size imageSize = Size.square(
       MediaQuery.sizeOf(context).width * (dense ? 0.22 : 0.25),
     );
@@ -45,9 +49,9 @@ class ProductTitleCard extends StatelessWidget {
           child: _ProductTitleCardName(selectable: isSelectable, dense: dense),
         ),
         const SizedBox(height: SMALL_SPACE),
-        _ProductTitleCardBrand(selectable: isSelectable, dense: dense),
+        _ProductTitleCardBrands(dense: dense, expandable: expandableBrands),
         const SizedBox(height: 2.0),
-        trailing,
+        _ProductTitleCardQuantity(selectable: isSelectable),
       ],
     );
 
@@ -132,41 +136,104 @@ class _ProductTitleCardName extends StatelessWidget {
 
     final TextStyle? textStyle = Theme.of(context).textTheme.headlineMedium;
 
-    return Text(
-      getProductName(product, appLocalizations),
+    final (OpenFoodFactsLanguage lng, String productName) =
+        getProductNameWithLanguage(product, appLocalizations);
+
+    final Widget child = Text(
+      productName,
       style: dense ? textStyle : textStyle?.copyWith(fontSize: 18.0),
       textAlign: TextAlign.start,
       maxLines: 2,
       overflow: TextOverflow.ellipsis,
     );
+
+    if (lng != ProductQuery.getLanguage()) {
+      return Wrap(
+        spacing: SMALL_SPACE,
+        crossAxisAlignment: WrapCrossAlignment.center,
+        children: <Widget>[
+          child,
+          _ProductTitleChip(label: lng.offTag.toUpperCase()),
+        ],
+      );
+    }
+
+    return child;
   }
 }
 
-class _ProductTitleCardBrand extends StatelessWidget {
-  const _ProductTitleCardBrand({required this.selectable, this.dense = false});
+class _ProductTitleCardBrands extends StatefulWidget {
+  const _ProductTitleCardBrands({required this.expandable, this.dense = false});
 
-  final bool selectable;
   final bool dense;
+  final bool expandable;
+
+  @override
+  State<_ProductTitleCardBrands> createState() =>
+      _ProductTitleCardBrandsState();
+}
+
+class _ProductTitleCardBrandsState extends State<_ProductTitleCardBrands> {
+  bool _expanded = false;
 
   @override
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final Product product = context.watch<Product>();
 
-    final String brands = getProductBrands(product, appLocalizations);
+    final List<String> brands = getProductBrandsList(product, appLocalizations);
 
-    return Text(
-      brands,
-      maxLines: dense ? 1 : 2,
-      overflow: dense ? TextOverflow.ellipsis : null,
-      style: Theme.of(context).textTheme.bodyMedium,
+    TextStyle style = Theme.of(context).textTheme.bodyMedium!;
+    if (brands.isEmpty) {
+      style = style.copyWith(fontStyle: FontStyle.italic);
+    }
+
+    final Widget child = Text(
+      _getBrandsText(brands),
+      maxLines: widget.dense ? 1 : 2,
+      overflow: widget.dense ? TextOverflow.ellipsis : null,
+      style: style,
       textAlign: TextAlign.start,
     );
+
+    if (brands.length <= 1 || !widget.expandable) {
+      return child;
+    }
+
+    return InkWell(
+      onTap: () => setState(() => _expanded = !_expanded),
+      child: Wrap(
+        spacing: SMALL_SPACE,
+        crossAxisAlignment: WrapCrossAlignment.center,
+        children: <Widget>[
+          child,
+          AnimatedSize(
+            duration: const Duration(milliseconds: 200),
+            child: ClipRRect(
+              child: Align(
+                widthFactor: !_expanded ? 1.0 : 0.0,
+                child: _ProductTitleChip(label: '+${brands.length - 1}'),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _getBrandsText(List<String> brands) {
+    if (brands.isEmpty) {
+      return AppLocalizations.of(context).unknownBrand;
+    }
+    if (_expanded || !widget.expandable) {
+      return brands.join(', ');
+    }
+    return brands.first;
   }
 }
 
-class _ProductTitleCardTrailing extends StatelessWidget {
-  const _ProductTitleCardTrailing({required this.selectable});
+class _ProductTitleCardQuantity extends StatelessWidget {
+  const _ProductTitleCardQuantity({required this.selectable});
 
   final bool selectable;
 
@@ -174,10 +241,49 @@ class _ProductTitleCardTrailing extends StatelessWidget {
   Widget build(BuildContext context) {
     final Product product = context.watch<Product>();
 
+    TextStyle style = Theme.of(context).textTheme.bodyMedium!;
+    if (product.quantity == null) {
+      style = style.copyWith(fontStyle: FontStyle.italic);
+    }
+
     return Text(
-      product.quantity ?? '',
-      style: Theme.of(context).textTheme.bodyMedium,
+      product.quantity ?? AppLocalizations.of(context).unknownQuantity,
+      style: style,
       textAlign: TextAlign.end,
+    );
+  }
+}
+
+class _ProductTitleChip extends StatelessWidget {
+  const _ProductTitleChip({required this.label}) : assert(label.length > 0);
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final SmoothColorsThemeExtension extension = context
+        .extension<SmoothColorsThemeExtension>();
+    final bool lightTheme = context.lightTheme();
+
+    return SelectionContainer.disabled(
+      child: Material(
+        shape: RoundedRectangleBorder(
+          borderRadius: ANGULAR_BORDER_RADIUS,
+          side: BorderSide(
+            color: lightTheme
+                ? extension.primaryMedium
+                : extension.primaryNormal,
+          ),
+        ),
+        color: lightTheme ? extension.primaryLight : extension.primarySemiDark,
+        child: Padding(
+          padding: const EdgeInsetsDirectional.symmetric(
+            horizontal: SMALL_SPACE,
+            vertical: VERY_SMALL_SPACE,
+          ),
+          child: Text(label, style: Theme.of(context).textTheme.bodyMedium),
+        ),
+      ),
     );
   }
 }

--- a/packages/smooth_app/lib/cards/product_cards/product_title_card.dart
+++ b/packages/smooth_app/lib/cards/product_cards/product_title_card.dart
@@ -225,7 +225,7 @@ class _ProductTitleCardBrandsState extends State<_ProductTitleCardBrands> {
     if (brands.isEmpty) {
       return AppLocalizations.of(context).unknownBrand;
     }
-    if (_expanded || !widget.expandable) {
+    if (_expanded) {
       return brands.join(', ');
     }
     return brands.first;

--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_card_found.dart
@@ -80,7 +80,11 @@ class SmoothProductCardItemFound extends StatelessWidget {
                       ),
                       const SizedBox(height: VERY_SMALL_SPACE),
                       Text(
-                        getProductBrands(product, appLocalizations),
+                        getProductBrandsList(
+                              product,
+                              appLocalizations,
+                            ).firstOrNull ??
+                            appLocalizations.unknownBrand,
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
                         style: themeData.textTheme.bodyMedium,

--- a/packages/smooth_app/lib/helpers/product_cards_helper.dart
+++ b/packages/smooth_app/lib/helpers/product_cards_helper.dart
@@ -55,15 +55,34 @@ String? _clearString(final String? string) {
 String getProductName(
   final Product product,
   final AppLocalizations appLocalizations,
-) =>
-    _clearString(product.productNameInLanguages?[ProductQuery.getLanguage()]) ??
-    _clearString(product.productName) ??
-    /// Fallback to the first language available
-    _clearString(
-      product.productNameInLanguages?[OpenFoodFactsLanguage.ENGLISH],
-    ) ??
-    _clearString(product.productNameInLanguages?.values.firstOrNull) ??
-    appLocalizations.unknownProductName;
+) => getProductNameWithLanguage(product, appLocalizations).$2;
+
+(OpenFoodFactsLanguage, String) getProductNameWithLanguage(
+  final Product product,
+  final AppLocalizations appLocalizations,
+) {
+  final OpenFoodFactsLanguage currentLanguage = ProductQuery.getLanguage();
+  final String? nameInCurrentLanguage = _clearString(
+    product.productNameInLanguages?[currentLanguage],
+  );
+  if (nameInCurrentLanguage != null) {
+    return (currentLanguage, nameInCurrentLanguage);
+  }
+
+  // Fallback to the first language available
+  final Map<OpenFoodFactsLanguage, String>? namesInLanguages =
+      product.productNameInLanguages;
+  if (namesInLanguages != null && namesInLanguages.isNotEmpty) {
+    final OpenFoodFactsLanguage firstLanguage = namesInLanguages.keys.first;
+    final String firstName = namesInLanguages[firstLanguage]!;
+    return (firstLanguage, firstName);
+  }
+
+  return (
+    OpenFoodFactsLanguage.UNKNOWN_LANGUAGE,
+    appLocalizations.unknownProductName,
+  );
+}
 
 String getProductBrands(
   final Product product,
@@ -76,9 +95,21 @@ String getProductBrands(
   return formatProductBrands(brands);
 }
 
+List<String> getProductBrandsList(
+  final Product product,
+  final AppLocalizations appLocalizations,
+) {
+  final String? brands = _clearString(product.brands);
+  if (brands == null) {
+    return <String>[];
+  }
+
+  const String sep = ',';
+  return formatProductBrands(brands, separator: sep).split(sep);
+}
+
 /// Correctly format word separators between words.
-String formatProductBrands(String brands) {
-  const String separator = ', ';
+String formatProductBrands(String brands, {String separator = ', '}) {
   final String separatorChar = RegExp.escape(',');
   final RegExp regex = RegExp('\\s*$separatorChar\\s*');
   return brands.replaceAll(regex, separator);

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -538,7 +538,7 @@
   "@unknownBrand": {
     "description": "Message when the brand is not available"
   },
-  "unknownQuantity": "Unknown brand",
+  "unknownQuantity": "Unknown quantity",
   "@unknownQuantity": {
     "description": "Message when the quantity is not available"
   },

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -535,9 +535,17 @@
   "product": "Product",
   "@product": {},
   "unknownBrand": "Unknown brand",
-  "@unknownBrand": {},
+  "@unknownBrand": {
+    "description": "Message when the brand is not available"
+  },
+  "unknownQuantity": "Unknown brand",
+  "@unknownQuantity": {
+    "description": "Message when the quantity is not available"
+  },
   "unknownProductName": "Unknown product name",
-  "@unknownProductName": {},
+  "@unknownProductName": {
+    "description": "Message when the product name is not available"
+  },
   "label_refresh": "Refresh",
   "@label_refresh": {
     "description": "Refresh the cached product"

--- a/packages/smooth_app/lib/l10n/app_localizations.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations.dart
@@ -1524,13 +1524,19 @@ abstract class AppLocalizations {
   /// **'Product'**
   String get product;
 
-  /// No description provided for @unknownBrand.
+  /// Message when the brand is not available
   ///
   /// In en, this message translates to:
   /// **'Unknown brand'**
   String get unknownBrand;
 
-  /// No description provided for @unknownProductName.
+  /// Message when the quantity is not available
+  ///
+  /// In en, this message translates to:
+  /// **'Unknown brand'**
+  String get unknownQuantity;
+
+  /// Message when the product name is not available
   ///
   /// In en, this message translates to:
   /// **'Unknown product name'**

--- a/packages/smooth_app/lib/l10n/app_localizations.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations.dart
@@ -1533,7 +1533,7 @@ abstract class AppLocalizations {
   /// Message when the quantity is not available
   ///
   /// In en, this message translates to:
-  /// **'Unknown brand'**
+  /// **'Unknown quantity'**
   String get unknownQuantity;
 
   /// Message when the product name is not available

--- a/packages/smooth_app/lib/l10n/app_localizations_aa.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_aa.dart
@@ -653,6 +653,9 @@ class AppLocalizationsAa extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_aa.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_aa.dart
@@ -653,7 +653,7 @@ class AppLocalizationsAa extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_af.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_af.dart
@@ -653,7 +653,7 @@ class AppLocalizationsAf extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_af.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_af.dart
@@ -653,6 +653,9 @@ class AppLocalizationsAf extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ak.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ak.dart
@@ -653,7 +653,7 @@ class AppLocalizationsAk extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_ak.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ak.dart
@@ -653,6 +653,9 @@ class AppLocalizationsAk extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_am.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_am.dart
@@ -653,6 +653,9 @@ class AppLocalizationsAm extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3515,7 +3518,7 @@ class AppLocalizationsAm extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'በአገር ውስጥ ለተከማቹ የ folksonomy ዝመናዎች የአገልጋይ እርምጃዎችን ማከናወን በመጀመር ላይ';
 
   @override
   String get background_task_title_top_n =>
@@ -6081,7 +6084,7 @@ class AppLocalizationsAm extends AppLocalizations {
 
   @override
   String get preferences_page_open_food_facts_labs_title =>
-      'Open Food Facts ቤተሙከራዎችን ይክፈቱ';
+      'Open Food Facts Labs';
 
   @override
   String get preferences_root_account_title => 'Account';

--- a/packages/smooth_app/lib/l10n/app_localizations_am.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_am.dart
@@ -653,7 +653,7 @@ class AppLocalizationsAm extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_ar.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ar.dart
@@ -212,7 +212,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get help_improve_country =>
-      'Help improve Open Food Facts in your country';
+      'ساعد في تحسين حقائق الأغذية المفتوحة في بلدك';
 
   @override
   String get sign_out => 'تسجيل الخروج';
@@ -593,7 +593,7 @@ class AppLocalizationsAr extends AppLocalizations {
       'تم إعادة تحميلها بتفضيلاتك الجديدة';
 
   @override
-  String get profile_navbar_label => 'Community';
+  String get profile_navbar_label => 'مجتمع';
 
   @override
   String get scan_navbar_label => 'مسح';
@@ -649,6 +649,9 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get unknownBrand => 'علامة تجارية مجهولة';
+
+  @override
+  String get unknownQuantity => 'Unknown brand';
 
   @override
   String get unknownProductName => 'إسم منتج غير معروف';
@@ -857,7 +860,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get categories_added => 'تمت إضافة الفئات';
 
   @override
-  String get new_product_title_nutriscore => 'Compute the Nutri-Score';
+  String get new_product_title_nutriscore => 'حساب النتيجة الغذائية';
 
   @override
   String get new_product_subtitle_nutriscore =>
@@ -889,7 +892,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get new_product_title_pictures_details =>
-      'Please take the following photos and the Open Food Facts engine can work out the rest!';
+      'يرجى التقاط الصور التالية وسيتمكن محرك حقائق الغذاء المفتوحة من معرفة الباقي!';
 
   @override
   String get new_product_title_misc => 'وبعض البيانات الأساسية…';
@@ -1933,7 +1936,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get edit_product_form_item_labels_explanation_good_examples_1 =>
-      'Nutri-Score, NOVA…';
+      'نيوتري سكور، نوفا…';
 
   @override
   String get edit_product_form_item_labels_explanation_good_examples_2 =>
@@ -2538,7 +2541,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get prices_bulk_proof_upload_warning_ai =>
-      'AI will run on your proofs to extract prices.';
+      'سيقوم الذكاء الاصطناعي بتشغيل بياناتك لاستخراج الأسعار.';
 
   @override
   String get prices_bulk_proof_upload_community_switch =>
@@ -2614,7 +2617,7 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
-  String get prices_barcode_search_not_found => 'Product not found';
+  String get prices_barcode_search_not_found => 'لم يُعثر على المنتج';
 
   @override
   String get prices_barcode_search_none_yet => 'لا يوجد منتج حتى الآن';
@@ -2634,7 +2637,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get prices_per_kilogram => 'السعر للكيلوغرام';
 
   @override
-  String get prices_per_unit => 'Price per unit';
+  String get prices_per_unit => 'سعر الوحدة';
 
   @override
   String get prices_per_kilogram_short => ' / كجم';
@@ -2953,7 +2956,7 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
-  String get prices_menu_know_more => 'Know more about Open Prices';
+  String get prices_menu_know_more => 'تعرف على المزيد حول الأسعار المفتوحة';
 
   @override
   String get dev_preferences_import_history_result_success => 'تم';
@@ -3065,10 +3068,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get prices_contribution_assistant => 'مساعد مساهمة الأسعار';
 
   @override
-  String get prices_validation_assistant => 'Price Validation Assistant';
+  String get prices_validation_assistant => 'مساعد التحقق من الأسعار';
 
   @override
-  String get prices_challenges_page => 'Challenges';
+  String get prices_challenges_page => 'التحديات';
 
   @override
   String get prices_multiple_proof_addition_system => 'إضافة أدلة متعددة';
@@ -3502,7 +3505,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'البدء في تنفيذ إجراءات الخادم لتحديثات folksonomy المخزنة محليًا';
 
   @override
   String get background_task_title_top_n => 'بدء تنزيل المنتجات الأكثر شعبية';
@@ -4017,7 +4020,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get nutriscore_b => 'Nutri-Score ب';
 
   @override
-  String get nutriscore_c => 'Nutri-Score C';
+  String get nutriscore_c => 'نيوتري-سكور سي';
 
   @override
   String get nutriscore_d => 'Nutri-Score د';
@@ -4171,8 +4174,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get guide_share_label => 'مشاركة';
 
   @override
-  String get guide_nutriscore_v2_title =>
-      'The Nutri-Score is evolving: explanations!';
+  String get guide_nutriscore_v2_title => 'الدرجة الغذائية في تطور: تفسيرات!';
 
   @override
   String get guide_nutriscore_v2_what_is_nutriscore_title =>
@@ -4180,7 +4182,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get guide_nutriscore_v2_what_is_nutriscore_paragraph1 =>
-      'The Nutri-Score is a logo which aims to inform you about the **nutritional quality of foods**.';
+      'الدرجة الغذائية هو شعار يهدف إلى إعلامك **بالجودة الغذائية للأطعمة**.';
 
   @override
   String get guide_nutriscore_v2_what_is_nutriscore_paragraph2 =>
@@ -4569,7 +4571,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_title =>
-      'What is Open Food Facts?';
+      'ما هي حقائق الغذاء المفتوحة؟';
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_paragraph1 =>
@@ -4650,11 +4652,11 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_title =>
-      'What is Open Pet Food Facts?';
+      'ما هي حقائق طعام الحيوانات الأليفة المفتوحة؟';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_paragraph1 =>
-      'Open Pet Food Facts extends our mission to our furry friends! It\'s a **database of pet food products for cats, dogs, and other companions**.';
+      'حقائق طعام الحيوانات الأليفة المفتوحة تُوسّع نطاق مهمتها لتشمل حيواناتنا الأليفة! إنها **قاعدة بيانات لمنتجات طعام الحيوانات الأليفة للقطط والكلاب وغيرها من الحيوانات الأليفة**.';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_paragraph2 =>
@@ -4662,7 +4664,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get guide_open_pet_food_facts_features_title =>
-      'Features of Open Pet Food Facts';
+      'مميزات حقائق طعام الحيوانات الأليفة المفتوحة';
 
   @override
   String get guide_open_pet_food_facts_features_arg1_title =>
@@ -4729,7 +4731,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_title =>
-      'What is Open Beauty Facts?';
+      'ما هي حقائق الجمال المفتوحة؟';
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_paragraph1 =>
@@ -4811,22 +4813,22 @@ class AppLocalizationsAr extends AppLocalizations {
       'https://world-ar.openbeautyfacts.org/discover';
 
   @override
-  String get guide_open_prices_title => 'Welcome to Open Prices!';
+  String get guide_open_prices_title => 'مرحباً بكم في الأسعار المفتوحة!';
 
   @override
   String get guide_open_prices_what_is_open_prices_title =>
-      'What is Open Prices?';
+      'ما هي الأسعار المفتوحة؟';
 
   @override
   String get guide_open_prices_what_is_open_prices_paragraph1 =>
-      'Open Prices is a project to **collect and share prices of products around the world**. It\'s a publicly available dataset that can be used for research, analysis, and more. Open Prices is developed and maintained by Open Food Facts.';
+      '\"الأسعار المفتوحة\" مشروع لجمع ومشاركة أسعار المنتجات حول العالم. وهي قاعدة بيانات متاحة للعامة، ويمكن استخدامها للبحث والتحليل وغيرها. طُوّرت \"الأسعار المفتوحة\" وصيانتها بواسطة \"حقائق الغذاء المفتوحة\".';
 
   @override
   String get guide_open_prices_what_is_open_prices_paragraph2 =>
-      'There are currently few companies that own large databases of product prices at the barcode level. These prices are not freely available, but sold at a high price to private actors, researchers and other organizations that can afford them.';
+      'يوجد حاليًا عدد قليل من الشركات التي تمتلك قواعد بيانات ضخمة لأسعار المنتجات على مستوى الباركود. هذه الأسعار ليست متاحة مجانًا، بل تُباع بأسعار مرتفعة لجهات خاصة وباحثين ومنظمات أخرى قادرة على تحمل تكلفتها.';
 
   @override
-  String get guide_open_prices_how_title => 'How does Open Prices work?';
+  String get guide_open_prices_how_title => 'كيف تعمل الأسعار المفتوحة؟';
 
   @override
   String get guide_open_prices_how_paragraph1 =>
@@ -4867,7 +4869,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get guide_open_prices_scrapping_paragraph1 =>
-      'For legal and technical reasons, **we don\'t consider scraping prices from retailers\' websites as a valid way to contribute to Open Prices**. We want to make sure that the prices we collect are accurate and up-to-date, and receiving scraped prices from contributors doesn\'t allow us to do that.';
+      'لأسباب قانونية وفنية، **لا نعتبر جمع الأسعار من مواقع تجار التجزئة طريقةً صالحةً للمساهمة في \"الأسعار المفتوحة\". نحرص على دقة الأسعار التي نجمعها وتحديثها، وتلقينا أسعارًا من المساهمين لا يسمح لنا بذلك.';
 
   @override
   String get guide_open_prices_scrapping_paragraph2 =>
@@ -4875,7 +4877,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get guide_open_prices_retailers_title =>
-      'I\'m a retailer and I want to contribute prices. How can I do that?';
+      'أنا بائع تجزئة وأرغب في المساهمة في تحديد الأسعار. كيف يمكنني فعل ذلك؟';
 
   @override
   String get guide_open_prices_retailers_paragraph1 =>
@@ -4891,11 +4893,11 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_title =>
-      'What is Open Products Facts?';
+      'ما هي حقائق المنتجات المفتوحة؟';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_paragraph1 =>
-      'Open Products Facts is a massive, open database for **any product with a barcode, which is not food, cosmetic or pet food**.';
+      'حقائق المنتجات المفتوحة عبارة عن قاعدة بيانات ضخمة مفتوحة لأي منتج يحمل رمزًا شريطيًا، وهو ليس طعامًا أو مستحضر تجميل أو طعامًا للحيوانات الأليفة.';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_paragraph2 =>
@@ -4903,7 +4905,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get guide_open_products_facts_features_title =>
-      'Features of Open Products Facts';
+      'مميزات حقائق المنتجات المفتوحة';
 
   @override
   String get guide_open_products_facts_features_text =>
@@ -5280,7 +5282,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get prices_explanation_card_line1 =>
-      '**Open Prices** is a project to collect and share prices of products around the world 🌍. Open Prices is developed and maintained by Open Food Facts.';
+      '**الأسعار المفتوحة** مشروع لجمع ومشاركة أسعار المنتجات حول العالم 🌍. تم تطوير \"الأسعار المفتوحة\" وصيانتها بواسطة Open Food Facts.';
 
   @override
   String get explanation_card_learn_more_button => 'لمعرفة المزيد';
@@ -5360,7 +5362,7 @@ class AppLocalizationsAr extends AppLocalizations {
       'فشل في استخراج العناصر الغذائية من الصورة';
 
   @override
-  String get prices_discount => 'Discount';
+  String get prices_discount => 'تخفيض';
 
   @override
   String get prices_stats_statistics => 'إحصائيات';
@@ -5375,16 +5377,16 @@ class AppLocalizationsAr extends AppLocalizations {
   String get prices_stats_products_section => 'المنتجات';
 
   @override
-  String get prices_stats_locations_section => 'Locations';
+  String get prices_stats_locations_section => 'المواقع';
 
   @override
-  String get prices_stats_proofs_section => 'Proofs';
+  String get prices_stats_proofs_section => 'البراهين';
 
   @override
   String get prices_stats_contributors_section => 'المساهمون';
 
   @override
-  String get prices_stats_experiments_section => 'Experiments';
+  String get prices_stats_experiments_section => 'التجارب';
 
   @override
   String get prices_stats_misc_section => 'متنوع';
@@ -5393,22 +5395,22 @@ class AppLocalizationsAr extends AppLocalizations {
   String get prices_stats_total => 'Total';
 
   @override
-  String get prices_stats_with_barcode => 'With a barcode';
+  String get prices_stats_with_barcode => 'مع رمز شريطي';
 
   @override
-  String get prices_stats_with_category => 'With a category';
+  String get prices_stats_with_category => 'مع فئة';
 
   @override
-  String get prices_stats_with_discount => 'With a discount';
+  String get prices_stats_with_discount => 'مع خصم';
 
   @override
-  String get prices_stats_community => 'Community';
+  String get prices_stats_community => 'مجتمع';
 
   @override
   String get prices_stats_consumption => 'استهلاك';
 
   @override
-  String get prices_stats_with_price => 'With a price';
+  String get prices_stats_with_price => 'بثمن';
 
   @override
   String get prices_stats_food => 'طعام';
@@ -5426,7 +5428,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get prices_stats_osm => 'خريطة الشارع المفتوحة';
 
   @override
-  String get prices_stats_online => 'Online';
+  String get prices_stats_online => 'متصل';
 
   @override
   String get prices_stats_countries => 'بلدان';
@@ -5438,31 +5440,32 @@ class AppLocalizationsAr extends AppLocalizations {
   String get prices_stats_receipt => 'إيصال';
 
   @override
-  String get prices_stats_gdpr_request => 'GDPR request';
+  String get prices_stats_gdpr_request =>
+      'طلب بموجب اللائحة العامة لحماية البيانات';
 
   @override
-  String get prices_stats_shop_import => 'Shop import';
+  String get prices_stats_shop_import => 'متجر الاستيراد';
 
   @override
-  String get prices_stats_challenges => 'Challenges';
+  String get prices_stats_challenges => 'التحديات';
 
   @override
-  String get prices_stats_linked_to_price_tag => 'Prices linked to a price tag';
+  String get prices_stats_linked_to_price_tag => 'الأسعار مرتبطة ببطاقة السعر';
 
   @override
-  String get prices_stats_currencies => 'Currencies';
+  String get prices_stats_currencies => 'العملات';
 
   @override
-  String get prices_stats_years => 'Years';
+  String get prices_stats_years => 'سنين';
 
   @override
-  String get prices_stats_by_source_title => 'Prices and proofs per source';
+  String get prices_stats_by_source_title => 'الأسعار والإثباتات لكل مصدر';
 
   @override
   String get prices_stats_website => 'موقع إلكتروني';
 
   @override
-  String get prices_stats_mobile_app => 'Mobile app';
+  String get prices_stats_mobile_app => 'تطبيق الهاتف المحمول';
 
   @override
   String get prices_stats_api => 'واجهة برمجة التطبيقات (API)';
@@ -5540,7 +5543,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get preferences_app_bar_products_modified => 'المنتجات المعدلة';
 
   @override
-  String get preferences_app_bar_prices_added => 'Prices added';
+  String get preferences_app_bar_prices_added => 'تمت إضافة الأسعار';
 
   @override
   String get preferences_app_bar_see_all_stats => 'شاهد جميع الإحصائيات';
@@ -5621,7 +5624,7 @@ class AppLocalizationsAr extends AppLocalizations {
       'وابدأ في إحداث تأثير إيجابي على الملايين';
 
   @override
-  String get preferences_add_prices => 'Add prices';
+  String get preferences_add_prices => 'أضف الأسعار';
 
   @override
   String get preferences_complete_products => 'أخبر العالم';
@@ -5747,7 +5750,8 @@ class AppLocalizationsAr extends AppLocalizations {
   String get preferences_faq_faq_title => 'الأسئلة الشائعة';
 
   @override
-  String get preferences_faq_off_ngo_title => 'The Open Food Facts NGO';
+  String get preferences_faq_off_ngo_title =>
+      'منظمة حقائق الغذاء المفتوحة غير الحكومية';
 
   @override
   String get preferences_about_information_title => 'معلومات';
@@ -5769,7 +5773,7 @@ class AppLocalizationsAr extends AppLocalizations {
       'شارك من خلال حضور أحد فعالياتنا الافتراضية';
 
   @override
-  String get preferences_connect_blog_title => 'The Open Food Facts blog';
+  String get preferences_connect_blog_title => 'مدونة حقائق الغذاء المفتوحة';
 
   @override
   String get preferences_connect_blog_subtitle =>
@@ -6045,7 +6049,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String proof_count(int count) {
-    return '$count proofs';
+    return '$count إثباتات';
   }
 
   @override
@@ -6055,7 +6059,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String contributors_count(int count) {
-    return '$count contributors';
+    return '$count المساهمون';
   }
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ar.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ar.dart
@@ -651,7 +651,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get unknownBrand => 'علامة تجارية مجهولة';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'إسم منتج غير معروف';

--- a/packages/smooth_app/lib/l10n/app_localizations_as.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_as.dart
@@ -654,6 +654,9 @@ class AppLocalizationsAs extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3518,7 +3521,7 @@ class AppLocalizationsAs extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'স্থানীয়ভাৱে সংৰক্ষণ কৰা লোকছ\'নমি আপডেইটসমূহৰ বাবে চাৰ্ভাৰ কাৰ্য্যসমূহ সম্পাদন কৰিবলে আৰম্ভ কৰা';
 
   @override
   String get background_task_title_top_n =>
@@ -5659,7 +5662,7 @@ class AppLocalizationsAs extends AppLocalizations {
   String get preferences_tips => 'কিটিপসমূহ';
 
   @override
-  String get tips_discover_nutriscore => 'Discover the new Nutri-Score';
+  String get tips_discover_nutriscore => 'নতুন নিউট্ৰি-স্ক’ৰ আৱিষ্কাৰ কৰক';
 
   @override
   String get preferences_on_off_website_subtitle =>
@@ -5747,7 +5750,7 @@ class AppLocalizationsAs extends AppLocalizations {
 
   @override
   String get preferences_faq_nutriscore_subtitle =>
-      'Discover how the Nutri-Score is computed';
+      'নিউট্ৰি-স্ক’ৰ কেনেকৈ গণনা কৰা হয় আৱিষ্কাৰ কৰক';
 
   @override
   String get preferences_faq_nutriscore_v2_subtitle =>
@@ -6113,14 +6116,14 @@ class AppLocalizationsAs extends AppLocalizations {
 
   @override
   String get preferences_page_open_food_facts_labs_title =>
-      'খোলা Open Food Facts লেব';
+      'Open Food Facts Labs';
 
   @override
   String get preferences_root_account_title => 'Account';
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'আপোনাৰ ভাষালৈ মুকলি খাদ্যৰ তথ্য আনিব';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_as.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_as.dart
@@ -654,7 +654,7 @@ class AppLocalizationsAs extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_az.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_az.dart
@@ -653,7 +653,7 @@ class AppLocalizationsAz extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_az.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_az.dart
@@ -653,6 +653,9 @@ class AppLocalizationsAz extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3520,7 +3523,7 @@ class AppLocalizationsAz extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Yerli olaraq saxlanılan folksonomiya yeniləmələri üçün server hərəkətlərini yerinə yetirməyə başlayır';
 
   @override
   String get background_task_title_top_n =>
@@ -5780,7 +5783,7 @@ class AppLocalizationsAz extends AppLocalizations {
   String get preferences_faq_faq_title => 'FAQ - Tez-tez verilən suallar';
 
   @override
-  String get preferences_faq_off_ngo_title => 'The Open Food Facts NGO';
+  String get preferences_faq_off_ngo_title => 'Açıq Qida Faktları QHT';
 
   @override
   String get preferences_about_information_title => 'Məlumat';
@@ -5802,7 +5805,7 @@ class AppLocalizationsAz extends AppLocalizations {
       'Virtual tədbirlərimizdən birində iştirak etməklə siz də iştirak edin';
 
   @override
-  String get preferences_connect_blog_title => 'The Open Food Facts blog';
+  String get preferences_connect_blog_title => 'Açıq Qida Faktları bloqu';
 
   @override
   String get preferences_connect_blog_subtitle => 'Ən son xəbərləri əldə edin';
@@ -6130,7 +6133,7 @@ class AppLocalizationsAz extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Açıq Qida Faktlarını dilinizə gətirin';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_be.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_be.dart
@@ -662,6 +662,9 @@ class AppLocalizationsBe extends AppLocalizations {
   String get unknownBrand => 'Брэнд невядомы';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Назва прадукту невядома';
 
   @override
@@ -1376,7 +1379,7 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String get product_improvement_add_nutrition_facts =>
-      'Add nutrition facts to calculate the Nutri-Score.';
+      'Дадаць звесткі аб пажыўнасці для разліку Nutri-ацэнкі.';
 
   @override
   String get product_improvement_add_nutrition_facts_and_category =>
@@ -1384,7 +1387,7 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String get product_improvement_categories_but_no_nutriscore =>
-      'The Nutri-Score for this product can\'t be calculated, which may be due to e.g. a non-standard category. If this is considered an error, please contact us.';
+      'Nutri-ацэнка для гэтага прадукта не можа быць разлічана, што можа быць звязана, напрыклад, з нестандартнай катэгорыяй. Калі вы гэта лічыце памылкай, звяжыцеся з намі.';
 
   @override
   String get product_improvement_obsolete_nutrition_image =>
@@ -3544,7 +3547,7 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Пачатак выканання дзеянняў сервера для абнаўленняў folksonomy, якія захоўваюцца лакальна';
 
   @override
   String get background_task_title_top_n =>
@@ -5809,7 +5812,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get preferences_faq_faq_title => 'FAQ - Часта задаваныя пытанні';
 
   @override
-  String get preferences_faq_off_ngo_title => 'The Open Food Facts NGO';
+  String get preferences_faq_off_ngo_title => 'НДА «Адкрытыя факты пра ежу»';
 
   @override
   String get preferences_about_information_title => 'Information';
@@ -5831,7 +5834,7 @@ class AppLocalizationsBe extends AppLocalizations {
       'Далучайцеся, наведаўшы адно з нашых віртуальных мерапрыемстваў';
 
   @override
-  String get preferences_connect_blog_title => 'The Open Food Facts blog';
+  String get preferences_connect_blog_title => 'Блог «Адкрытыя факты пра ежу»';
 
   @override
   String get preferences_connect_blog_subtitle =>
@@ -6159,7 +6162,7 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Перанясіце адкрытыя факты пра ежу на сваю мову';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_be.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_be.dart
@@ -662,7 +662,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get unknownBrand => 'Брэнд невядомы';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Назва прадукту невядома';

--- a/packages/smooth_app/lib/l10n/app_localizations_bg.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_bg.dart
@@ -661,7 +661,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get unknownBrand => 'Неизвестна марка';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Неразпознат продукт';

--- a/packages/smooth_app/lib/l10n/app_localizations_bg.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_bg.dart
@@ -661,6 +661,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get unknownBrand => 'Неизвестна марка';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Неразпознат продукт';
 
   @override
@@ -1982,7 +1985,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get edit_product_form_item_labels_explanation_good_examples_1 =>
-      'Nutri-Score, NOVA…';
+      'Нутри-Скор, NOVA…';
 
   @override
   String get edit_product_form_item_labels_explanation_good_examples_2 =>
@@ -3017,7 +3020,7 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
-  String get prices_menu_know_more => 'Know more about Open Prices';
+  String get prices_menu_know_more => 'Научете повече за отворените цени';
 
   @override
   String get dev_preferences_import_history_result_success => 'Готово';
@@ -3578,7 +3581,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Започване на изпълнението на действията на сървъра за актуализации на folksonomy, съхранявани локално';
 
   @override
   String get background_task_title_top_n =>
@@ -4112,7 +4115,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get nutriscore_new_formula_title => 'Nutri-Score (Ново изчисление)';
 
   @override
-  String get nutriscore_unknown => 'Unknown Nutri-Score';
+  String get nutriscore_unknown => 'Неизвестен хранителен резултат';
 
   @override
   String get nutriscore_unknown_new_formula =>
@@ -4154,16 +4157,16 @@ class AppLocalizationsBg extends AppLocalizations {
   String get nova_group_generic_new => 'Ултрапреработени храни - NOVA groups';
 
   @override
-  String get nova_group_1 => 'NOVA Group 1';
+  String get nova_group_1 => 'NOVA Груп 1';
 
   @override
-  String get nova_group_2 => 'NOVA Group 2';
+  String get nova_group_2 => 'NOVA Груп 2';
 
   @override
-  String get nova_group_3 => 'NOVA Group 3';
+  String get nova_group_3 => 'NOVA Груп 3';
 
   @override
-  String get nova_group_4 => 'NOVA Group 4';
+  String get nova_group_4 => 'NOVA Груп 4';
 
   @override
   String get nova_group_unknown => 'Неизвестна група NOVA';
@@ -4555,7 +4558,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get guide_nova_what_is_nova_paragraph2 =>
-      'Класификацията NOVA позволява категоризирането на храните в **4 групи** въз основа на тяхната **степен на промишлена обработка** (минимално преработени или непреработени храни, кулинарни съставки, преработени храни, ултрапреработени храни).';
+      'Класификацията NOVA позволява категоризирането на храните в **4 групи** въз осNOVA на тяхната **степен на промишлена обработка** (минимално преработени или непреработени храни, кулинарни съставки, преработени храни, ултрапреработени храни).';
 
   @override
   String get guide_nova_logos_caption => 'Логотата на NOVA';
@@ -4739,7 +4742,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_title =>
-      'What is Open Pet Food Facts?';
+      'Какво представляват фактите за храната за домашни любимци в Open Pet Food?';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_paragraph1 =>
@@ -4821,7 +4824,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_title =>
-      'What is Open Beauty Facts?';
+      'Какво представляват откритите факти за красотата?';
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_paragraph1 =>
@@ -4910,7 +4913,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get guide_open_prices_what_is_open_prices_title =>
-      'What is Open Prices?';
+      'Какво представляват отворените цени?';
 
   @override
   String get guide_open_prices_what_is_open_prices_paragraph1 =>
@@ -4921,7 +4924,7 @@ class AppLocalizationsBg extends AppLocalizations {
       'There are currently few companies that own large databases of product prices at the barcode level. These prices are not freely available, but sold at a high price to private actors, researchers and other organizations that can afford them.';
 
   @override
-  String get guide_open_prices_how_title => 'How does Open Prices work?';
+  String get guide_open_prices_how_title => 'Как работят отворените цени?';
 
   @override
   String get guide_open_prices_how_paragraph1 =>
@@ -4987,7 +4990,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_title =>
-      'What is Open Products Facts?';
+      'Какво представляват фактите за отворените продукти?';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_paragraph1 =>
@@ -4999,7 +5002,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get guide_open_products_facts_features_title =>
-      'Features of Open Products Facts';
+      'Характеристики на отворените продукти Факти';
 
   @override
   String get guide_open_products_facts_features_text =>
@@ -6219,7 +6222,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Внесете фактите за отворените храни на вашия език';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_bm.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_bm.dart
@@ -653,7 +653,7 @@ class AppLocalizationsBm extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_bm.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_bm.dart
@@ -653,6 +653,9 @@ class AppLocalizationsBm extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3522,7 +3525,7 @@ class AppLocalizationsBm extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Ka daminɛ ka sèrwɛri walew kɛ folksonomy updates maralenw na sigida la';
 
   @override
   String get background_task_title_top_n =>
@@ -5791,7 +5794,7 @@ class AppLocalizationsBm extends AppLocalizations {
       'FAQ - Ɲininkali minnu bɛ kɛ tuma caman na';
 
   @override
-  String get preferences_faq_off_ngo_title => 'The Open Food Facts NGO';
+  String get preferences_faq_off_ngo_title => 'ONG min bɛ dumuni dafalenw kofɔ';
 
   @override
   String get preferences_about_information_title => 'Information';
@@ -5813,7 +5816,7 @@ class AppLocalizationsBm extends AppLocalizations {
       'Aw ye aw sen don a la ni aw taara an ka ko kɛlen dɔ la min bɛ kɛ virtuel (virtuel) la';
 
   @override
-  String get preferences_connect_blog_title => 'The Open Food Facts blog';
+  String get preferences_connect_blog_title => 'Dumuni dafalenw ka bulɔgu';
 
   @override
   String get preferences_connect_blog_subtitle =>
@@ -6139,7 +6142,7 @@ class AppLocalizationsBm extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Aw ka na ni Dumuni Dabɔlenw Tiɲɛw ye aw ka kan na';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_bn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_bn.dart
@@ -216,7 +216,7 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get help_improve_country =>
-      'Help improve Open Food Facts in your country';
+      'আপনার দেশে ওপেন ফুড ফ্যাক্টস উন্নত করতে সাহায্য করুন';
 
   @override
   String get sign_out => 'সাইন আউট করুন';
@@ -497,7 +497,7 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get contribute_join_skill_pool =>
-      'Contribute your skills to Open Food Facts. Join the skill pool!';
+      'ওপেন ফুড ফ্যাক্টস-এ আপনার দক্ষতা অবদান রাখুন। স্কিল পুলে যোগদান করুন!';
 
   @override
   String get contribute_share_header =>
@@ -663,6 +663,9 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get unknownBrand => 'অজানা ব্র্যান্ড';
+
+  @override
+  String get unknownQuantity => 'Unknown brand';
 
   @override
   String get unknownProductName => 'অজানা পণ্যের নাম';
@@ -905,7 +908,7 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get new_product_title_pictures_details =>
-      'Please take the following photos and the Open Food Facts engine can work out the rest!';
+      'অনুগ্রহ করে নিচের ছবিগুলো তুলুন, ওপেন ফুড ফ্যাক্টস ইঞ্জিন বাকিটা ঠিক করে ফেলবে!';
 
   @override
   String get new_product_title_misc => 'এবং কিছু মৌলিক তথ্য…';
@@ -1972,7 +1975,7 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get edit_product_form_item_labels_explanation_good_examples_1 =>
-      'Nutri-Score, NOVA…';
+      'নিউট্রি-স্কোর, নোভা…';
 
   @override
   String get edit_product_form_item_labels_explanation_good_examples_2 =>
@@ -2956,7 +2959,7 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get prices_privacy_warning_main_message =>
-      'Prices **will be public**, along with the store they refer to.\n\nThat might allow people who know about your Open Food Facts pseudonym to:\n';
+      'দাম **সর্বজনীন** হবে, সেই সাথে তারা যে দোকানটি উল্লেখ করবে।\n\nএটি আপনার ওপেন ফুড ফ্যাক্টস ছদ্মনাম সম্পর্কে যারা জানেন তাদের এটি করতে সাহায্য করতে পারে:\n';
 
   @override
   String get prices_privacy_warning_message_bullet_1 =>
@@ -2968,7 +2971,7 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get prices_privacy_warning_sub_message =>
-      'If you are uneasy with that, please change your pseudonym, or create a new Open Food Facts account and log into the app with it.';
+      'যদি আপনি এতে অস্বস্তিতে থাকেন, তাহলে অনুগ্রহ করে আপনার ছদ্মনাম পরিবর্তন করুন, অথবা একটি নতুন ওপেন ফুড ফ্যাক্টস অ্যাকাউন্ট তৈরি করুন এবং এটি দিয়ে অ্যাপে লগ ইন করুন।';
 
   @override
   String get i_refuse => 'আমি প্রত্যাখ্যান করি।';
@@ -2998,7 +3001,7 @@ class AppLocalizationsBn extends AppLocalizations {
   }
 
   @override
-  String get prices_menu_know_more => 'Know more about Open Prices';
+  String get prices_menu_know_more => 'ওপেন প্রাইস সম্পর্কে আরও জানুন';
 
   @override
   String get dev_preferences_import_history_result_success => 'সম্পন্ন';
@@ -3543,7 +3546,7 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'স্থানীয়ভাবে সংরক্ষিত লোকসাহিত্য আপডেটের জন্য সার্ভারের ক্রিয়া সম্পাদন শুরু করা হচ্ছে';
 
   @override
   String get background_task_title_top_n =>
@@ -4140,26 +4143,26 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get faq_title_vision =>
-      'The Open Food Facts Vision, Mission, Values and Programs';
+      'উন্মুক্ত খাদ্য তথ্য দৃষ্টি, লক্ষ্য, মূল্যবোধ এবং কর্মসূচি';
 
   @override
   String get faq_title_install_beauty =>
-      'Install Open Beauty Facts to create a cosmetic database';
+      'একটি কসমেটিক ডাটাবেস তৈরি করতে ওপেন বিউটি ফ্যাক্টস ইনস্টল করুন';
 
   @override
   String get faq_title_install_pet =>
-      'Install Open Pet Food Facts to create a pet food database';
+      'পোষা প্রাণীর খাদ্যের ডাটাবেস তৈরি করতে ওপেন পেট ফুড ফ্যাক্টস ইনস্টল করুন';
 
   @override
   String get faq_title_install_product =>
-      'Install Open Products Facts to create a products database to extend the life of objects';
+      'বস্তুর আয়ু বাড়ানোর জন্য একটি পণ্য ডাটাবেস তৈরি করতে ওপেন প্রোডাক্টস ফ্যাক্টস ইনস্টল করুন।';
 
   @override
   String get faq_nutriscore_nutriscore => 'Nutri-Scoreের নতুন হিসাব: নতুন কী?';
 
   @override
   String get contact_title_pro_page =>
-      'Pro? Import your products in Open Food Facts';
+      'প্রো? ওপেন ফুড ফ্যাক্টস-এ আপনার পণ্য আমদানি করুন';
 
   @override
   String get contact_title_pro_email => 'প্রযোজক যোগাযোগ';
@@ -4615,11 +4618,11 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_title =>
-      'What is Open Food Facts?';
+      'ওপেন ফুড ফ্যাক্টস কী?';
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_paragraph1 =>
-      'Open Food Facts is a **collaborative**, **free**, and **open** database of food products from around the world.';
+      'ওপেন ফুড ফ্যাক্টস হল বিশ্বজুড়ে খাদ্য পণ্যের একটি **সহযোগী**, **বিনামূল্যে**, এবং **উন্মুক্ত** ডাটাবেস।';
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_paragraph2 =>
@@ -4627,7 +4630,7 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get guide_open_food_facts_features_title =>
-      'Features of Open Food Facts';
+      'ওপেন ফুড ফ্যাক্টসের বৈশিষ্ট্য';
 
   @override
   String get guide_open_food_facts_features_arg1_title =>
@@ -4700,11 +4703,11 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_title =>
-      'What is Open Pet Food Facts?';
+      'ওপেন পোষা প্রাণীর খাদ্যের তথ্য কী?';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_paragraph1 =>
-      'Open Pet Food Facts extends our mission to our furry friends! It\'s a **database of pet food products for cats, dogs, and other companions**.';
+      'ওপেন পেট ফুড ফ্যাক্টস আমাদের লক্ষ্যকে আমাদের পশমী বন্ধুদের কাছে প্রসারিত করে! এটি বিড়াল, কুকুর এবং অন্যান্য সঙ্গীদের জন্য পোষা প্রাণীর খাদ্য পণ্যের **ডাটাবেস**।';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_paragraph2 =>
@@ -4712,7 +4715,7 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get guide_open_pet_food_facts_features_title =>
-      'Features of Open Pet Food Facts';
+      'ওপেন পোষা প্রাণীর খাবারের তথ্যের বৈশিষ্ট্য';
 
   @override
   String get guide_open_pet_food_facts_features_arg1_title =>
@@ -4780,11 +4783,11 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_title =>
-      'What is Open Beauty Facts?';
+      'ওপেন বিউটি ফ্যাক্টস কী?';
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_paragraph1 =>
-      'Open Beauty Facts is a collaborative database of **cosmetic products**.';
+      'ওপেন বিউটি ফ্যাক্টস হল **প্রসাধনী পণ্য** এর একটি সহযোগী ডাটাবেস।';
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_paragraph2 =>
@@ -4792,7 +4795,7 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get guide_open_beauty_facts_features_title =>
-      'Features of Open Beauty Facts';
+      'ওপেন বিউটি ফ্যাক্টসের বৈশিষ্ট্য';
 
   @override
   String get guide_open_beauty_facts_features_arg1_title =>
@@ -4864,26 +4867,25 @@ class AppLocalizationsBn extends AppLocalizations {
       'https://world-bn.openbeautyfacts.org/discover';
 
   @override
-  String get guide_open_prices_title => 'Welcome to Open Prices!';
+  String get guide_open_prices_title => 'ওপেন প্রাইসসে স্বাগতম!';
 
   @override
-  String get guide_open_prices_what_is_open_prices_title =>
-      'What is Open Prices?';
+  String get guide_open_prices_what_is_open_prices_title => 'ওপেন প্রাইস কী?';
 
   @override
   String get guide_open_prices_what_is_open_prices_paragraph1 =>
-      'Open Prices is a project to **collect and share prices of products around the world**. It\'s a publicly available dataset that can be used for research, analysis, and more. Open Prices is developed and maintained by Open Food Facts.';
+      'ওপেন প্রাইস হল **বিশ্বজুড়ে পণ্যের দাম সংগ্রহ এবং ভাগ করে নেওয়ার* একটি প্রকল্প। এটি একটি সর্বজনীনভাবে উপলব্ধ ডেটাসেট যা গবেষণা, বিশ্লেষণ এবং আরও অনেক কিছুর জন্য ব্যবহার করা যেতে পারে। ওপেন প্রাইসগুলি ওপেন ফুড ফ্যাক্টস দ্বারা তৈরি এবং রক্ষণাবেক্ষণ করা হয়।';
 
   @override
   String get guide_open_prices_what_is_open_prices_paragraph2 =>
       'There are currently few companies that own large databases of product prices at the barcode level. These prices are not freely available, but sold at a high price to private actors, researchers and other organizations that can afford them.';
 
   @override
-  String get guide_open_prices_how_title => 'How does Open Prices work?';
+  String get guide_open_prices_how_title => 'ওপেন প্রাইস কিভাবে কাজ করে?';
 
   @override
   String get guide_open_prices_how_paragraph1 =>
-      '**We are crowdsourcing an open-source dataset of prices**. Prices can be added by users via this web app, or via the official Open Food Facts mobile app. Retailers or third-party apps can contribute as well by using our API.';
+      '**আমরা দামের একটি ওপেন-সোর্স ডেটাসেট ক্রাউডসোর্স করছি**। ব্যবহারকারীরা এই ওয়েব অ্যাপের মাধ্যমে অথবা অফিসিয়াল ওপেন ফুড ফ্যাক্টস মোবাইল অ্যাপের মাধ্যমে দাম যোগ করতে পারবেন। খুচরা বিক্রেতারা বা তৃতীয় পক্ষের অ্যাপগুলিও আমাদের API ব্যবহার করে অবদান রাখতে পারে।';
 
   @override
   String get guide_open_prices_how_arg1_title =>
@@ -4893,8 +4895,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get guide_open_prices_how_arg2_title => 'রসিদের ছবি সংগ্রহ করুন';
 
   @override
-  String get guide_open_prices_why_title =>
-      'Why is Open Food Facts doing this ?';
+  String get guide_open_prices_why_title => 'ওপেন ফুড ফ্যাক্টস কেন এটা করছে?';
 
   @override
   String get guide_open_prices_why_paragraph1 =>
@@ -4922,11 +4923,11 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get guide_open_prices_scrapping_paragraph1 =>
-      'For legal and technical reasons, **we don\'t consider scraping prices from retailers\' websites as a valid way to contribute to Open Prices**. We want to make sure that the prices we collect are accurate and up-to-date, and receiving scraped prices from contributors doesn\'t allow us to do that.';
+      'আইনি এবং প্রযুক্তিগত কারণে, **খুচরা বিক্রেতাদের ওয়েবসাইট থেকে মূল্য স্ক্র্যাপ করাকে আমরা ওপেন প্রাইস**-এ অবদান রাখার বৈধ উপায় হিসেবে বিবেচনা করি না। আমরা নিশ্চিত করতে চাই যে আমরা যে মূল্য সংগ্রহ করি তা সঠিক এবং হালনাগাদ, এবং অবদানকারীদের কাছ থেকে মূল্য স্ক্র্যাপ করা আমাদের তা করার অনুমতি দেয় না।';
 
   @override
   String get guide_open_prices_scrapping_paragraph2 =>
-      'Price scraping is a considered option in a future version of Open Prices, but it would be done by Open Prices itself so that we can have a proof of the price based on the HTML page.';
+      'ওপেন প্রাইসের ভবিষ্যতের সংস্করণে মূল্য স্ক্র্যাপিং একটি বিবেচিত বিকল্প, তবে এটি ওপেন প্রাইস নিজেই করবে যাতে আমরা HTML পৃষ্ঠার উপর ভিত্তি করে মূল্যের প্রমাণ পেতে পারি।';
 
   @override
   String get guide_open_prices_retailers_title =>
@@ -4946,11 +4947,11 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_title =>
-      'What is Open Products Facts?';
+      'ওপেন প্রোডাক্টস ফ্যাক্টস কী?';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_paragraph1 =>
-      'Open Products Facts is a massive, open database for **any product with a barcode, which is not food, cosmetic or pet food**.';
+      'ওপেন প্রোডাক্টস ফ্যাক্টস হল **বারকোডযুক্ত যেকোনো পণ্যের জন্য একটি বিশাল, উন্মুক্ত ডাটাবেস, যা খাদ্য, প্রসাধনী বা পোষা প্রাণীর খাবার নয়**।';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_paragraph2 =>
@@ -4958,11 +4959,11 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get guide_open_products_facts_features_title =>
-      'Features of Open Products Facts';
+      'ওপেন প্রোডাক্ট ফ্যাক্টসের বৈশিষ্ট্য';
 
   @override
   String get guide_open_products_facts_features_text =>
-      'Open Products Facts aims to provide consumers to **extend the life of objects** by providing the circular solutions to maintain, **repair**, **recycle** their objects or give them a new owner.';
+      'ওপেন প্রোডাক্টস ফ্যাক্টস-এর লক্ষ্য হল ভোক্তাদের তাদের বস্তুর রক্ষণাবেক্ষণ, **মেরামত**, **পুনর্ব্যবহার** অথবা তাদের একজন নতুন মালিক দেওয়ার জন্য বৃত্তাকার সমাধান প্রদানের মাধ্যমে **বস্তুর আয়ু** বৃদ্ধি করা।';
 
   @override
   String get guide_open_products_facts_features_arg1_title =>
@@ -6154,14 +6155,14 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get preferences_page_open_food_facts_labs_title =>
-      'Open Food Facts ল্যাব খুলুন';
+      'Open Food Facts Labs';
 
   @override
   String get preferences_root_account_title => 'হিসাব';
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'আপনার ভাষায় উন্মুক্ত খাদ্যের তথ্য আনুন';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_bn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_bn.dart
@@ -665,7 +665,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get unknownBrand => 'অজানা ব্র্যান্ড';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'অজানা পণ্যের নাম';

--- a/packages/smooth_app/lib/l10n/app_localizations_bo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_bo.dart
@@ -653,7 +653,7 @@ class AppLocalizationsBo extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_bo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_bo.dart
@@ -653,6 +653,9 @@ class AppLocalizationsBo extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_br.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_br.dart
@@ -654,6 +654,9 @@ class AppLocalizationsBr extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3522,7 +3525,7 @@ class AppLocalizationsBr extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Kregiñ da seveniñ oberoù an dafariad evit an hizivadennoù folksonomy enrollet lec\'hel';
 
   @override
   String get background_task_title_top_n =>
@@ -5953,7 +5956,7 @@ class AppLocalizationsBr extends AppLocalizations {
 
   @override
   String get preferences_contributions_categorize_subtitle =>
-      'Help compute the Nutri-Score & Green-Score in your country';
+      'Sikour da jediñ ar Skor Nutri hag ar Skor Glas en ho bro';
 
   @override
   String get preferences_prices_user_prices_subtitle =>
@@ -6140,7 +6143,7 @@ class AppLocalizationsBr extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Degas fedoù boued digor d\'ho yezh';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_br.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_br.dart
@@ -654,7 +654,7 @@ class AppLocalizationsBr extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_bs.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_bs.dart
@@ -654,6 +654,9 @@ class AppLocalizationsBs extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3522,7 +3525,7 @@ class AppLocalizationsBs extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Početak izvršavanja serverskih akcija za lokalno pohranjena ažuriranja folksonomyja';
 
   @override
   String get background_task_title_top_n =>
@@ -5785,7 +5788,8 @@ class AppLocalizationsBs extends AppLocalizations {
   String get preferences_faq_faq_title => 'ČPP - Često postavljana pitanja';
 
   @override
-  String get preferences_faq_off_ngo_title => 'The Open Food Facts NGO';
+  String get preferences_faq_off_ngo_title =>
+      'Nevladina organizacija Otvorene činjenice o hrani';
 
   @override
   String get preferences_about_information_title => 'Information';
@@ -5807,7 +5811,8 @@ class AppLocalizationsBs extends AppLocalizations {
       'Uključite se posjetom jednom od naših virtualnih događaja';
 
   @override
-  String get preferences_connect_blog_title => 'The Open Food Facts blog';
+  String get preferences_connect_blog_title =>
+      'Blog Otvorene činjenice o hrani';
 
   @override
   String get preferences_connect_blog_subtitle =>
@@ -6133,7 +6138,7 @@ class AppLocalizationsBs extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Prenesite činjenice o otvorenoj hrani na svoj jezik';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_bs.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_bs.dart
@@ -654,7 +654,7 @@ class AppLocalizationsBs extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_ca.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ca.dart
@@ -663,6 +663,9 @@ class AppLocalizationsCa extends AppLocalizations {
   String get unknownBrand => 'Marca desconeguda';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Nom de producte desconegut';
 
   @override
@@ -3561,7 +3564,7 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'S\'estan començant a realitzar les accions del servidor per a les actualitzacions de folksonomy emmagatzemades localment.';
 
   @override
   String get background_task_title_top_n =>

--- a/packages/smooth_app/lib/l10n/app_localizations_ca.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ca.dart
@@ -663,7 +663,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get unknownBrand => 'Marca desconeguda';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Nom de producte desconegut';

--- a/packages/smooth_app/lib/l10n/app_localizations_ce.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ce.dart
@@ -653,6 +653,9 @@ class AppLocalizationsCe extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ce.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ce.dart
@@ -653,7 +653,7 @@ class AppLocalizationsCe extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_co.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_co.dart
@@ -654,7 +654,7 @@ class AppLocalizationsCo extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_co.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_co.dart
@@ -654,6 +654,9 @@ class AppLocalizationsCo extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3522,7 +3525,7 @@ class AppLocalizationsCo extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Principiu di l\'esecuzione di l\'azzioni di u servitore per l\'aghjurnamenti di folksonomy almacenati lucalmente';
 
   @override
   String get background_task_title_top_n =>

--- a/packages/smooth_app/lib/l10n/app_localizations_cs.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_cs.dart
@@ -660,7 +660,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get unknownBrand => 'Neznámá značka';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Neznámý název produktu';

--- a/packages/smooth_app/lib/l10n/app_localizations_cs.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_cs.dart
@@ -660,6 +660,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get unknownBrand => 'Neznámá značka';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Neznámý název produktu';
 
   @override
@@ -3540,7 +3543,7 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Zahájení provádění akcí serveru pro lokálně uložené aktualizace folksonomy';
 
   @override
   String get background_task_title_top_n =>
@@ -4587,7 +4590,7 @@ class AppLocalizationsCs extends AppLocalizations {
       '**The overall purpose of ultra-processing is to create branded**, **convenient** (durable, ready to consume), **attractive** (hyper-palatable) and **highly profitable** (low-cost ingredients) food products designed to displace all other food groups. Ultra-processed food products are usually packaged attractively and marketed intensively.';
 
   @override
-  String get guide_nova_explanations_arg5_title => 'A health hazard';
+  String get guide_nova_explanations_arg5_title => 'Zdravotní riziko';
 
   @override
   String get guide_nova_explanations_arg5_text =>
@@ -4605,83 +4608,83 @@ class AppLocalizationsCs extends AppLocalizations {
   String get guide_nova_share_link => 'https://world-cs.openfoodfacts.org/nova';
 
   @override
-  String get guide_open_food_facts_title => 'Welcome to Open Food Facts!';
+  String get guide_open_food_facts_title => 'Vítejte na Open Food Facts!';
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_title =>
-      'What is Open Food Facts?';
+      'Co je to Open Food Facts?';
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_paragraph1 =>
-      'Open Food Facts is a **collaborative**, **free**, and **open** database of food products from around the world.';
+      'Open Food Facts je **kolaborativní**, **bezplatná** a **otevřená** databáze potravinářských produktů z celého světa.';
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_paragraph2 =>
-      'We believe that everyone should have access to information about what they eat. By collecting data on ingredients, allergens, nutrition facts, and more, **we empower consumers to make informed choices** and drive the food industry **toward greater transparency**.';
+      'Věříme, že každý by měl mít přístup k informacím o tom, co jí. Shromažďováním údajů o složkách, alergenech, nutričních hodnotách a dalších údajích **umožňujeme spotřebitelům činit informovaná rozhodnutí** a posouváme potravinářský průmysl **k větší transparentnosti**.';
 
   @override
   String get guide_open_food_facts_features_title =>
-      'Features of Open Food Facts';
+      'Vlastnosti Open Food Facts';
 
   @override
   String get guide_open_food_facts_features_arg1_title =>
-      'Get alerts for your unwanted ingredients';
+      'Získejte upozornění na nežádoucí přísady';
 
   @override
   String get guide_open_food_facts_tips_title => 'Tips for taking great photos';
 
   @override
-  String get guide_open_food_facts_tips_arg1_title => 'Don’ts';
+  String get guide_open_food_facts_tips_arg1_title => 'Co nedělat';
 
   @override
   String get guide_open_food_facts_tips_arg1_text1 =>
-      'Avoid shadows and glare.';
+      'Vyhněte se stínům a přesvícení.';
 
   @override
   String get guide_open_food_facts_tips_arg1_text2 =>
-      'No blurry or out-of-focus text.';
+      'Žádný rozmazaný nebo nezaostřený text.';
 
   @override
   String get guide_open_food_facts_tips_arg1_text3 =>
-      'Don\'t crop out parts of the text.';
+      'Nevyřezávejte části textu.';
 
   @override
-  String get guide_open_food_facts_tips_arg1_text4 => 'Avoid busy backgrounds.';
+  String get guide_open_food_facts_tips_arg1_text4 =>
+      'Vyhněte se rušivému pozadí.';
 
   @override
-  String get guide_open_food_facts_tips_arg2_title => 'Do’s';
+  String get guide_open_food_facts_tips_arg2_title => 'Co dělat';
 
   @override
   String get guide_open_food_facts_tips_arg2_text1 =>
-      'Use good, even lighting.';
+      'Používejte dobré, rovnoměrné osvětlení.';
 
   @override
   String get guide_open_food_facts_tips_arg2_text2 =>
-      'Ensure text is sharp and readable.';
+      'Ujistěte se, že text je ostrý a čitelný.';
 
   @override
   String get guide_open_food_facts_tips_arg2_text3 =>
-      'Capture the entire ingredients list.';
+      'Zaznamenejte si celý seznam ingrediencí.';
 
   @override
   String get guide_open_food_facts_tips_arg2_text4 =>
-      'Keep the product on a flat surface.';
+      'Dejte výrobek na rovný povrch.';
 
   @override
   String get guide_open_food_facts_scores_title =>
-      'Help us build the \"Wikipedia of Food\"';
+      'Pomozte nám vybudovat \"Wikipedii potravin\"';
 
   @override
   String get guide_open_food_facts_scores_arg1_title =>
-      'A score on the nutritional quality';
+      'Skóre nutriční kvality';
 
   @override
   String get guide_open_food_facts_scores_arg2_title =>
-      'A score to avoid ultra-processed foods';
+      'Skóre, jak se vyhnout ultrazpracovaným potravinám';
 
   @override
-  String get guide_open_food_facts_scores_arg3_title =>
-      'A score for the planet';
+  String get guide_open_food_facts_scores_arg3_title => 'Skóre pro planetu';
 
   @override
   String get guide_open_food_facts_share_link =>
@@ -4689,76 +4692,76 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get guide_open_pet_food_facts_title =>
-      'Welcome to Open Pet Food Facts!';
+      'Vítejte v Open Pet Food Facts!';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_title =>
-      'What is Open Pet Food Facts?';
+      'Co je Open Pet Food Facts?';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_paragraph1 =>
-      'Open Pet Food Facts extends our mission to our furry friends! It\'s a **database of pet food products for cats, dogs, and other companions**.';
+      'Open Pet Food Facts rozšiřuje naši misi na naše chlupaté přátele! Je to **databáze krmiv pro kočky, psy a další domácí mazlíčky**.';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_paragraph2 =>
-      'We gather information on **ingredients**, **nutritional analysis**, and feeding guidelines to help pet owners choose the best food for their animals\' needs.';
+      'Shromažďujeme informace o **složení**, **nutriční analýze** a krmných pokynech, abychom majitelům domácích mazlíčků pomohli vybrat nejlepší krmivo pro jejich zvířata.';
 
   @override
   String get guide_open_pet_food_facts_features_title =>
-      'Features of Open Pet Food Facts';
+      'Vlastnosti Open Pet Food Facts';
 
   @override
   String get guide_open_pet_food_facts_features_arg1_title =>
-      'Get alerts for your unwanted ingredients';
+      'Získejte upozornění na nežádoucí přísady';
 
   @override
   String get guide_open_pet_food_facts_features_arg1_paragraph1 =>
-      'Is your pet allergic to any ingredients? You can set a list of cosmetic ingredients to avoid, right in the app!';
+      'Je váš mazlíček alergický na nějaké složky? Seznam kosmetických složek, kterým se chcete vyhnout, si můžete nastavit přímo v aplikaci!';
 
   @override
   String get guide_open_pet_food_facts_tips_title =>
       'Tips for taking great photos';
 
   @override
-  String get guide_open_pet_food_facts_tips_arg1_title => 'Don’ts';
+  String get guide_open_pet_food_facts_tips_arg1_title => 'Co nedělat';
 
   @override
   String get guide_open_pet_food_facts_tips_arg1_text1 =>
-      'Avoid shadows and glare.';
+      'Vyhněte se stínům a přesvícení.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg1_text2 =>
-      'No blurry or out-of-focus text.';
+      'Žádný rozmazaný nebo nezaostřený text.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg1_text3 =>
-      'Don\'t crop out parts of the text.';
+      'Nevyřezávejte části textu.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg1_text4 =>
-      'Avoid busy backgrounds.';
+      'Vyhněte se rušivému pozadí.';
 
   @override
-  String get guide_open_pet_food_facts_tips_arg2_title => 'Do’s';
+  String get guide_open_pet_food_facts_tips_arg2_title => 'Co dělat';
 
   @override
   String get guide_open_pet_food_facts_tips_arg2_text1 =>
-      'Use good, even lighting.';
+      'Používejte dobré, rovnoměrné osvětlení.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg2_text2 =>
-      'Ensure text is sharp and readable.';
+      'Ujistěte se, že text je ostrý a čitelný.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg2_text3 =>
-      'Capture the entire ingredients list.';
+      'Zaznamenejte si celý seznam ingrediencí.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg2_text4 =>
-      'Keep the product on a flat surface.';
+      'Dejte výrobek na rovný povrch.';
 
   @override
-  String get guide_open_pet_food_facts_scores_title => 'A note on scoring';
+  String get guide_open_pet_food_facts_scores_title => 'Poznámka k bodování';
 
   @override
   String get guide_open_pet_food_facts_scores_paragraph1 =>
@@ -4789,7 +4792,7 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get guide_open_beauty_facts_features_arg1_title =>
-      'Get alerts for your unwanted ingredients';
+      'Získejte upozornění na nežádoucí přísady';
 
   @override
   String get guide_open_beauty_facts_features_arg1_paragraph1 =>
@@ -4800,38 +4803,38 @@ class AppLocalizationsCs extends AppLocalizations {
       'Tips for taking great photos';
 
   @override
-  String get guide_open_beauty_facts_tips_arg1_title => 'Don’ts';
+  String get guide_open_beauty_facts_tips_arg1_title => 'Co nedělat';
 
   @override
   String get guide_open_beauty_facts_tips_arg1_text1 =>
-      'Avoid shadows and glare.';
+      'Vyhněte se stínům a přesvícení.';
 
   @override
   String get guide_open_beauty_facts_tips_arg1_text2 =>
-      'No blurry or out-of-focus text.';
+      'Žádný rozmazaný nebo nezaostřený text.';
 
   @override
   String get guide_open_beauty_facts_tips_arg1_text3 =>
-      'Don\'t crop out parts of the text.';
+      'Nevyřezávejte části textu.';
 
   @override
   String get guide_open_beauty_facts_tips_arg1_text4 =>
-      'Avoid busy backgrounds.';
+      'Vyhněte se rušivému pozadí.';
 
   @override
-  String get guide_open_beauty_facts_tips_arg2_title => 'Do’s';
+  String get guide_open_beauty_facts_tips_arg2_title => 'Co dělat';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text1 =>
-      'Use good, even lighting.';
+      'Používejte dobré, rovnoměrné osvětlení.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text2 =>
-      'Ensure text is sharp and readable.';
+      'Ujistěte se, že text je ostrý a čitelný.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text3 =>
-      'Capture the entire ingredients list.';
+      'Zaznamenejte si celý seznam ingrediencí.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text4 =>
@@ -4843,10 +4846,10 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text6 =>
-      'Keep the product on a flat surface.';
+      'Dejte výrobek na rovný povrch.';
 
   @override
-  String get guide_open_beauty_facts_scores_title => 'A note on scoring';
+  String get guide_open_beauty_facts_scores_title => 'Poznámka k bodování';
 
   @override
   String get guide_open_beauty_facts_scores_paragraph1 =>
@@ -5012,7 +5015,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get guide_open_preferences_button_title => 'Open food preferences';
 
   @override
-  String get guide_coming_soon_button_title => 'Coming soon';
+  String get guide_coming_soon_button_title => 'Již brzy';
 
   @override
   String get guide_learn_more_subtitle => 'Tap to learn more';
@@ -5529,8 +5532,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get prices_stats_last_updated => 'Naposled aktualizováno';
 
   @override
-  String get prices_stats_error =>
-      'An error occurred while loading statistics.';
+  String get prices_stats_error => 'Při načítání statistik došlo k chybě.';
 
   @override
   String get product_edit_robotoff_question_answered => 'Question answered!';
@@ -5794,14 +5796,14 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get preferences_faq_discover_opff_title =>
-      'Discover Open Pet Food Facts';
+      'Objevte Open Pet Food Facts';
 
   @override
-  String get preferences_faq_discover_op_title => 'Discover Open Prices';
+  String get preferences_faq_discover_op_title => 'Objevte Open Prices';
 
   @override
   String get preferences_faq_discover_opf_title =>
-      'Discover Open Products Facts';
+      'Objevte Open Products Facts';
 
   @override
   String get preferences_faq_faq_title =>
@@ -5831,7 +5833,7 @@ class AppLocalizationsCs extends AppLocalizations {
       'Zapojte se účastí na jedné z našich virtuálních akcí';
 
   @override
-  String get preferences_connect_blog_title => 'The Open Food Facts blog';
+  String get preferences_connect_blog_title => 'Blog Otevřená fakta o jídle';
 
   @override
   String get preferences_connect_blog_subtitle =>
@@ -6157,7 +6159,7 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Přineste fakta o otevřeném jídle do svého jazyka';
 
   @override
   String get preferences_contribute_enroll_alpha =>
@@ -6179,26 +6181,26 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
-  String get location_map_details_title => 'Location details';
+  String get location_map_details_title => 'Podrobnosti o poloze';
 
   @override
   String get location_map_details_name => 'Jméno';
 
   @override
-  String get location_map_details_street => 'Street';
+  String get location_map_details_street => 'Ulice';
 
   @override
-  String get location_map_details_city => 'City';
+  String get location_map_details_city => 'Město';
 
   @override
-  String get location_map_details_postcode => 'Postcode';
+  String get location_map_details_postcode => 'PSČ';
 
   @override
   String get location_map_details_country => 'Země';
 
   @override
-  String get location_map_details_coordinates => 'Coordinates';
+  String get location_map_details_coordinates => 'Souřadnice';
 
   @override
-  String get location_map_details_osm_id => 'OSM ID';
+  String get location_map_details_osm_id => 'ID OSM';
 }

--- a/packages/smooth_app/lib/l10n/app_localizations_cv.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_cv.dart
@@ -653,6 +653,9 @@ class AppLocalizationsCv extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3517,7 +3520,7 @@ class AppLocalizationsCv extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Вырӑнта упранакан folksonomy ҫӗнетӗвӗсем валли сервер ӗҫӗсене пурнӑҫлама пуҫласси';
 
   @override
   String get background_task_title_top_n =>
@@ -5663,7 +5666,7 @@ class AppLocalizationsCv extends AppLocalizations {
 
   @override
   String get preferences_on_off_website_subtitle =>
-      'On the Open Food Facts website';
+      'Уҫӑ апат-ҫимӗҫ факчӗсен сайтӗнче';
 
   @override
   String get preferences_manage_account_title => 'Манӑн аккаунта тытса пырӑр';
@@ -5781,7 +5784,7 @@ class AppLocalizationsCv extends AppLocalizations {
   String get preferences_faq_faq_title => 'FAQ - час-часах ыйтакан ыйтусем';
 
   @override
-  String get preferences_faq_off_ngo_title => 'The Open Food Facts NGO';
+  String get preferences_faq_off_ngo_title => '«Уҫӑ апат-ҫимӗҫ факчӗсем» НПО';
 
   @override
   String get preferences_about_information_title => 'Information';
@@ -5803,7 +5806,7 @@ class AppLocalizationsCv extends AppLocalizations {
       'Пирӗн виртуаллӑ мероприятисенчен пӗрне хутшӑнса хутшӑнӑр';
 
   @override
-  String get preferences_connect_blog_title => 'The Open Food Facts blog';
+  String get preferences_connect_blog_title => 'Уҫӑ апат-ҫимӗҫ факчӗсен блогӗ';
 
   @override
   String get preferences_connect_blog_subtitle =>
@@ -6128,7 +6131,7 @@ class AppLocalizationsCv extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Хӑвӑрӑн чӗлхене уҫӑ апат-ҫимӗҫ факчӗсене илсе килӗр';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_cv.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_cv.dart
@@ -653,7 +653,7 @@ class AppLocalizationsCv extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_cy.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_cy.dart
@@ -653,6 +653,9 @@ class AppLocalizationsCy extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3519,7 +3522,7 @@ class AppLocalizationsCy extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Dechrau cyflawni\'r gweithredoedd gweinydd ar gyfer diweddariadau folksonomy sydd wedi\'u storio\'n lleol';
 
   @override
   String get background_task_title_top_n =>
@@ -5586,7 +5589,7 @@ class AppLocalizationsCy extends AppLocalizations {
 
   @override
   String get preferences_app_bar_search_hint =>
-      'Search for a setting (e.g. Nutri-Score)';
+      'Chwiliwch am leoliad (e.e. Sgôr Maeth)';
 
   @override
   String get preferences_accessibility_show_emoji => 'Hygyrchedd: Dangos emoji';
@@ -5663,7 +5666,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get preferences_tips => 'Awgrymiadau';
 
   @override
-  String get tips_discover_nutriscore => 'Discover the new Nutri-Score';
+  String get tips_discover_nutriscore => 'Darganfyddwch y Sgôr Maeth newydd';
 
   @override
   String get preferences_on_off_website_subtitle => 'Ar wefan Open Food Facts';
@@ -6124,7 +6127,7 @@ class AppLocalizationsCy extends AppLocalizations {
 
   @override
   String get preferences_page_open_food_facts_labs_title =>
-      'Labordai Open Food Facts';
+      'Open Food Facts Labs';
 
   @override
   String get preferences_root_account_title => 'Account';

--- a/packages/smooth_app/lib/l10n/app_localizations_cy.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_cy.dart
@@ -653,7 +653,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_da.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_da.dart
@@ -654,6 +654,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get unknownBrand => 'Ukendt brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Ukendt produktnavn';
 
   @override
@@ -2921,7 +2924,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get prices_proof_find => 'Vælg et bevis';
 
   @override
-  String get prices_proof_change => 'Change proof';
+  String get prices_proof_change => 'Skift bevis';
 
   @override
   String get prices_proof_receipt => 'Kvittering';
@@ -2985,7 +2988,7 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
-  String get prices_menu_know_more => 'Know more about Open Prices';
+  String get prices_menu_know_more => 'Læs mere om Open Prices';
 
   @override
   String get dev_preferences_import_history_result_success => 'Færdiggjort';
@@ -3077,7 +3080,7 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String search_proof_title(String user) {
-    return 'Proof from \"$user\"';
+    return 'Bevis fra \"$user\"';
   }
 
   @override
@@ -3536,7 +3539,7 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Begynder at udføre serverhandlinger for folksonomy-opdateringer, der er gemt lokalt';
 
   @override
   String get background_task_title_top_n =>
@@ -4396,14 +4399,14 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get guide_greenscore_bonuses_penalties_intro =>
-      'To reward better products within a category, we then apply **bonuses & penalties based on several criterion**:';
+      'For at belønne bedre produkter inden for en kategori, anvender vi derefter **bonusser og sanktioner baseret på flere kriterier**:';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg1_title => 'Produktionsmåde';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg1_text =>
-      'A **bonus** is awarded to products that have an **official label, a label or a certification that guarantees environmental benefits** (organic, fair trade, HVE, Label Rouge, Bleu Blanc Cœur, MSC/ASC).';
+      'En bonus tildeles produkter, som har et officielt mærke, et mærke eller en certificering, der garanterer miljømæssige fordele (organisk, fairtrade, HVE, Label Rouge, Bleu Blanc Cœur, MSC/ASC).';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg2_title =>
@@ -4411,21 +4414,21 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get guide_greenscore_bonuses_penalties_arg2_text =>
-      'A **bonus** is awarded based on the origin of the ingredients. This bonus takes into account the **impact on transportation** and also the **environmental policy** of each producer\'s country.';
+      'Der tildeles en **bonus** baseret på ingrediensernes oprindelse. Denne bonus tager højde for **påvirkningen på transport** og også den **miljøpolitik**, der gælder i hver producents land.';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg3_title => 'Truede arter';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg3_text =>
-      'A **penalty** is given to products that contain ingredients that have significant **negative impacts on biodiversity and ecosystems**, such as palm oil, the production of which is responsible for massive deforestation.';
+      'Der gives en **straf** til produkter, der indeholder ingredienser, der har betydelig **negativ indvirkning på biodiversiteten og økosystemerne**, såsom palmeolie, hvis produktion er ansvarlig for massiv skovrydning.';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg4_title => 'Emballage';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg4_text =>
-      'A **penalty** is calculated to take into account the **circularity of packaging** (use of recycled raw material and recyclability) and overpacking.';
+      'En **straf** beregnes for at tage højde for emballagens **cirkularitet** (brug af genbrugsråmateriale og genanvendelighed) og overemballage.';
 
   @override
   String get guide_greenscore_transparency_title =>
@@ -4433,11 +4436,11 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get guide_greenscore_transparency_intro1 =>
-      'To accurately calculate the Green-Score, it is necessary to have **information which is not necessarily specified on the packaging** (such as the origin and the exact percentage of each ingredient) or which is rarely available in usable form (such as a list of all the components of the packaging with the precise types of plastics used).';
+      'For at beregne Green-Score præcist er det nødvendigt at have **oplysninger, som ikke nødvendigvis er specificeret på emballagen** (såsom oprindelsen og den nøjagtige procentdel af hver ingrediens), eller som sjældent er tilgængelige i brugbar form (såsom en liste over alle emballagens komponenter med de præcise typer plast, der er anvendt).';
 
   @override
   String get guide_greenscore_transparency_intro2 =>
-      '**Average values are used when this information is not yet available**, but we are now calling on everyone to help us collect this information which will be very useful for the Green-Score but also for many other uses.';
+      '**Gennemsnitsværdier bruges, når disse oplysninger endnu ikke er tilgængelige**, men vi opfordrer nu alle til at hjælpe os med at indsamle disse oplysninger, som vil være meget nyttige for Green-Score, men også til mange andre formål.';
 
   @override
   String get guide_greenscore_transparency_arg1_title =>
@@ -4519,7 +4522,7 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get guide_nova_groups_arg1_text =>
-      'Unprocessed (or natural) foods are the **edible parts of plants** (seeds, fruits, leaves, stems, roots) **or animals** (muscle, offal, eggs, milk), as well as fungi, algae, and water, after being separated from nature.';
+      'Uforarbejdede (eller naturlige) fødevarer er de **spiselige dele af planter** (frø, frugter, blade, stængler, rødder) **eller dyr** (muskler, slagteaffald, æg, mælk), samt svampe, alger og vand, efter at være blevet adskilt fra naturen.';
 
   @override
   String get guide_nova_groups_arg2_title =>
@@ -4553,7 +4556,7 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg1_text =>
-      'Many are **derived from further processing of food constituents**, such as hydrogenated or interesterified oils, hydrolyzed proteins, soy protein isolate, maltodextrin, invert sugar, and high-fructose corn syrup.';
+      'Mange er **udvundet fra yderligere forarbejdning af fødevarebestanddele**, såsom hydrogenerede eller interesterificerede olier, hydrolyserede proteiner, sojaproteinisolat, maltodextrin, invertsukker og majssirup med højt fruktoseindhold.';
 
   @override
   String get guide_nova_explanations_arg2_title =>
@@ -4561,7 +4564,7 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg2_text =>
-      'Additives in ultra-processed foods include some that are also used in processed foods, such as preservatives, antioxidants, and stabilizers. Classes of additives found only in ultra-processed products include those used **to imitate or enhance the sensory qualities of foods or to disguise unpalatable aspects of the final product**. These additives include dyes and other colors, color stabilizers; flavors, flavor enhancers, non-sugar sweeteners; and processing aids such as carbonating, firming, bulking and anti-bulking agents, de-foaming, anti-caking and glazing agents, emulsifiers, sequestrants, and humectants.';
+      'Tilsætningsstoffer i ultraforarbejdede fødevarer omfatter nogle, der også anvendes i forarbejdede fødevarer, såsom konserveringsmidler, antioxidanter og stabilisatorer. Klasser af tilsætningsstoffer, der kun findes i ultraforarbejdede produkter, omfatter dem, der anvendes **til at efterligne eller forbedre fødevarers sensoriske egenskaber eller til at skjule ubehagelige aspekter af det færdige produkt**. Disse tilsætningsstoffer omfatter farvestoffer og andre farver, farvestabilisatorer; smagsstoffer, smagsforstærkere, ikke-sukkerholdige sødestoffer; og proceshjælpemidler såsom kulsyreholdige, fastgørende, fyldegivende og anti-fyldemidler, skumdæmpende, antiklumpningsmidler og glaseringsmidler, emulgatorer, sekvestreringsmidler og fugtighedsbevarende midler.';
 
   @override
   String get guide_nova_explanations_arg3_title =>
@@ -4569,7 +4572,7 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg3_text =>
-      '**A multitude of sequences of processes is used** to combine the usually many ingredients and to create the final product (hence \'ultra-processed\'). The processes include several **with no domestic equivalents**, such as hydrogenation and hydrolysation, extrusion and moulding, and pre-processing for frying.';
+      '**En lang række processekvenser anvendes** til at kombinere de normalt mange ingredienser og skabe det endelige produkt (deraf \'ultraforarbejdet\'). Processerne omfatter adskillige **uden indenlandske ækvivalenter**, såsom hydrogenering og hydrolysering, ekstrudering og støbning samt forbehandling til stegning.';
 
   @override
   String get guide_nova_explanations_arg4_title =>
@@ -4577,22 +4580,22 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg4_text =>
-      '**The overall purpose of ultra-processing is to create branded**, **convenient** (durable, ready to consume), **attractive** (hyper-palatable) and **highly profitable** (low-cost ingredients) food products designed to displace all other food groups. Ultra-processed food products are usually packaged attractively and marketed intensively.';
+      '**Det overordnede formål med ultraforarbejdning er at skabe mærkevareprodukter,** der er **bekvemme** (holdbare, klar til forbrug), **attraktive** (hypervelsmagende) og **yderst rentable** (lavprisingredienser), og som er designet til at erstatte alle andre fødevaregrupper. Ultraforarbejdede fødevarer er normalt pakket attraktivt og markedsføres intensivt.**';
 
   @override
-  String get guide_nova_explanations_arg5_title => 'A health hazard';
+  String get guide_nova_explanations_arg5_title => 'En sundhedsfare';
 
   @override
   String get guide_nova_explanations_arg5_text =>
-      'Since 2018, with NutriNet-Santé, the first links between **the consumption of ultra-processed foods and increased risks of cancer, cardiovascular diseases, and diabetes have been highlighted**. Today, more than 90 studies worldwide confirm these findings.\nThe strongest associations relate to **obesity, cardiovascular mortality, and depressive symptoms**. On children, the effects are primarily observed on weight and lipid imbalances.';
+      'Siden 2018 er de første sammenhænge mellem **forbrug af ultraforarbejdede fødevarer og øget risiko for kræft, hjerte-kar-sygdomme og diabetes blevet fremhævet** med NutriNet-Santé. I dag bekræfter mere end 90 undersøgelser verden over disse fund.\nDe stærkeste sammenhænge relaterer sig til **fedme, hjerte-kar-dødelighed og depressive symptomer**. Hos børn observeres virkningerne primært på vægt og lipidubalancer.';
 
   @override
   String get guide_nova_explanations_arg6_title =>
-      'Countries recommend limiting them';
+      'Lande anbefaler at begrænse dem';
 
   @override
   String get guide_nova_explanations_arg6_text =>
-      'Some countries use the NOVA groups for their dietary guidelines or goals, for instance:\n\n- **🇧🇷 Brazil**\'s dietary guidelines **recommend to limit consumption** of processed food and avoid ultra-processed food.\n\n- **🇫🇷 France**\'s public health nutritional policy goals for 2018-2022 aims to **reduce consumption of group 4 ultra-processed foods by 20%**.';
+      'Nogle lande bruger NOVA-grupperne til deres kostvejledninger eller -mål, for eksempel:\n\n- **🇧🇷 Brasiliens** kostvejledninger **anbefaler at begrænse forbruget** af forarbejdede fødevarer og undgå ultraforarbejdede fødevarer.\n\n- **🇫🇷 Frankrigs** ernæringspolitiske mål for folkesundhed for 2018-2022 sigter mod at **reducere forbruget af ultraforarbejdede fødevarer i gruppe 4 med 20%**.';
 
   @override
   String get guide_nova_share_link => 'https://world-da.openfoodfacts.org/nova';
@@ -4606,75 +4609,76 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_paragraph1 =>
-      'Open Food Facts is a **collaborative**, **free**, and **open** database of food products from around the world.';
+      'Open Food Facts er en **samarbejdsbaseret**, **fri** og **åben** database over fødevarer fra hele verden.';
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_paragraph2 =>
-      'We believe that everyone should have access to information about what they eat. By collecting data on ingredients, allergens, nutrition facts, and more, **we empower consumers to make informed choices** and drive the food industry **toward greater transparency**.';
+      'Vi mener, at alle skal have adgang til information om, hvad de spiser. Ved at indsamle data om ingredienser, allergener, næringsindhold og mere, **giver vi forbrugerne mulighed for at træffe informerede valg** og driver fødevareindustrien **mod større gennemsigtighed**.';
 
   @override
   String get guide_open_food_facts_features_title =>
-      'Features of Open Food Facts';
+      'Funktioner i Open Food Facts';
 
   @override
   String get guide_open_food_facts_features_arg1_title =>
-      'Get alerts for your unwanted ingredients';
+      'Få advarsler om dine uønskede ingredienser';
 
   @override
-  String get guide_open_food_facts_tips_title => 'Tips for taking great photos';
+  String get guide_open_food_facts_tips_title =>
+      'Tips til at tage fantastiske billeder';
 
   @override
-  String get guide_open_food_facts_tips_arg1_title => 'Don’ts';
+  String get guide_open_food_facts_tips_arg1_title => 'Undgå';
 
   @override
   String get guide_open_food_facts_tips_arg1_text1 =>
-      'Avoid shadows and glare.';
+      'Undgå skygger og genskin.';
 
   @override
   String get guide_open_food_facts_tips_arg1_text2 =>
-      'No blurry or out-of-focus text.';
+      'Ingen sløret eller uskarp tekst.';
 
   @override
   String get guide_open_food_facts_tips_arg1_text3 =>
-      'Don\'t crop out parts of the text.';
+      'Beskær ikke dele af teksten væk.';
 
   @override
-  String get guide_open_food_facts_tips_arg1_text4 => 'Avoid busy backgrounds.';
+  String get guide_open_food_facts_tips_arg1_text4 =>
+      'Undgå forstyrrende baggrunde.';
 
   @override
-  String get guide_open_food_facts_tips_arg2_title => 'Do’s';
+  String get guide_open_food_facts_tips_arg2_title => 'Anbefales';
 
   @override
   String get guide_open_food_facts_tips_arg2_text1 =>
-      'Use good, even lighting.';
+      'Brug god, jævn belysning.';
 
   @override
   String get guide_open_food_facts_tips_arg2_text2 =>
-      'Ensure text is sharp and readable.';
+      'Sørg for, at teksten er skarp og læsbar.';
 
   @override
   String get guide_open_food_facts_tips_arg2_text3 =>
-      'Capture the entire ingredients list.';
+      'Optag hele ingredienslisten.';
 
   @override
   String get guide_open_food_facts_tips_arg2_text4 =>
-      'Keep the product on a flat surface.';
+      'Opbevar produktet på en plan overflade.';
 
   @override
   String get guide_open_food_facts_scores_title =>
-      'Help us build the \"Wikipedia of Food\"';
+      'Hjælp os med at opbygge \"Madens Wikipedia\"';
 
   @override
   String get guide_open_food_facts_scores_arg1_title =>
-      'A score on the nutritional quality';
+      'En score på næringskvaliteten';
 
   @override
   String get guide_open_food_facts_scores_arg2_title =>
-      'A score to avoid ultra-processed foods';
+      'En score for at undgå ultraforarbejdede fødevarer';
 
   @override
-  String get guide_open_food_facts_scores_arg3_title =>
-      'A score for the planet';
+  String get guide_open_food_facts_scores_arg3_title => 'En score for planeten';
 
   @override
   String get guide_open_food_facts_share_link =>
@@ -4682,236 +4686,241 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get guide_open_pet_food_facts_title =>
-      'Welcome to Open Pet Food Facts!';
+      'Velkommen til Åbne Fakta om kæledyrsfoder!';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_title =>
-      'What is Open Pet Food Facts?';
+      'Hvad er Open Pet Food Facts?';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_paragraph1 =>
-      'Open Pet Food Facts extends our mission to our furry friends! It\'s a **database of pet food products for cats, dogs, and other companions**.';
+      'Open Pet Food Facts udvider vores mission til også at omfatte vores pelsede venner! Det er en **database med kæledyrsfoderprodukter til katte, hunde og andre kæledyrskammerater**.';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_paragraph2 =>
-      'We gather information on **ingredients**, **nutritional analysis**, and feeding guidelines to help pet owners choose the best food for their animals\' needs.';
+      'Vi indsamler information om **ingredienser**, **ernæringsanalyser** og fodringsretningslinjer for at hjælpe kæledyrsejere med at vælge det bedste foder til deres dyrs behov.';
 
   @override
   String get guide_open_pet_food_facts_features_title =>
-      'Features of Open Pet Food Facts';
+      'Funktioner ved åbne kæledyrsfoderfakta';
 
   @override
   String get guide_open_pet_food_facts_features_arg1_title =>
-      'Get alerts for your unwanted ingredients';
+      'Få advarsler om dine uønskede ingredienser';
 
   @override
   String get guide_open_pet_food_facts_features_arg1_paragraph1 =>
-      'Is your pet allergic to any ingredients? You can set a list of cosmetic ingredients to avoid, right in the app!';
+      'Er dit kæledyr allergisk over for nogen ingredienser? Du kan oprette en liste over kosmetiske ingredienser, du skal undgå, direkte i appen!';
 
   @override
   String get guide_open_pet_food_facts_tips_title =>
-      'Tips for taking great photos';
+      'Tips til at tage fantastiske billeder';
 
   @override
-  String get guide_open_pet_food_facts_tips_arg1_title => 'Don’ts';
+  String get guide_open_pet_food_facts_tips_arg1_title => 'Undgå';
 
   @override
   String get guide_open_pet_food_facts_tips_arg1_text1 =>
-      'Avoid shadows and glare.';
+      'Undgå skygger og genskin.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg1_text2 =>
-      'No blurry or out-of-focus text.';
+      'Ingen sløret eller uskarp tekst.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg1_text3 =>
-      'Don\'t crop out parts of the text.';
+      'Beskær ikke dele af teksten væk.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg1_text4 =>
-      'Avoid busy backgrounds.';
+      'Undgå forstyrrende baggrunde.';
 
   @override
-  String get guide_open_pet_food_facts_tips_arg2_title => 'Do’s';
+  String get guide_open_pet_food_facts_tips_arg2_title => 'Anbefales';
 
   @override
   String get guide_open_pet_food_facts_tips_arg2_text1 =>
-      'Use good, even lighting.';
+      'Brug god, jævn belysning.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg2_text2 =>
-      'Ensure text is sharp and readable.';
+      'Sørg for, at teksten er skarp og læsbar.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg2_text3 =>
-      'Capture the entire ingredients list.';
+      'Optag hele ingredienslisten.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg2_text4 =>
-      'Keep the product on a flat surface.';
+      'Opbevar produktet på en plan overflade.';
 
   @override
-  String get guide_open_pet_food_facts_scores_title => 'A note on scoring';
+  String get guide_open_pet_food_facts_scores_title =>
+      'En bemærkning om pointgivning';
 
   @override
   String get guide_open_pet_food_facts_scores_paragraph1 =>
-      'Developing a scoring system for pet food **is not a priority right now**. The methodology would be complex, as nutritional needs vary greatly by species, age, and health condition. We haven’t found any independant scientific team yet, able to develop such a score.';
+      'Udvikling af et pointsystem til kæledyrsfoder **er ikke en prioritet lige nu**. Metoden ville være kompleks, da ernæringsbehovene varierer meget afhængigt af art, alder og helbredstilstand. Vi har endnu ikke fundet et uafhængigt videnskabeligt team, der er i stand til at udvikle en sådan score.';
 
   @override
   String get guide_open_pet_food_facts_share_link =>
       'https://world-da.openpetfoodfacts.org/discover';
 
   @override
-  String get guide_open_beauty_facts_title => 'Welcome to Open Beauty Facts!';
+  String get guide_open_beauty_facts_title =>
+      'Velkommen til Open Beauty Facts!';
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_title =>
-      'What is Open Beauty Facts?';
+      'Hvad er Open Beauty Facts?';
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_paragraph1 =>
-      'Open Beauty Facts is a collaborative database of **cosmetic products**.';
+      'Open Beauty Facts er en samarbejdsdatabase over **kosmetiske produkter**.';
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_paragraph2 =>
-      'Our goal is to decipher ingredient lists to help you **understand what\'s in your personal care items**. From moisturizers to makeup, we collect data on ingredients, allergens, and packaging to promote transparency in the cosmetics industry.';
+      'Vores mål er at tyde ingredienslister for at hjælpe dig med at **forstå, hvad der er i dine personlige plejeprodukter**. Fra fugtighedscremer til makeup indsamler vi data om ingredienser, allergener og emballage for at fremme gennemsigtighed i kosmetikindustrien.';
 
   @override
   String get guide_open_beauty_facts_features_title =>
-      'Features of Open Beauty Facts';
+      'Funktioner i Open Beauty Facts';
 
   @override
   String get guide_open_beauty_facts_features_arg1_title =>
-      'Get alerts for your unwanted ingredients';
+      'Få advarsler om dine uønskede ingredienser';
 
   @override
   String get guide_open_beauty_facts_features_arg1_paragraph1 =>
-      'Are you allergic to any ingredients? Want to avoid comedogen substances? Want to steer away from controversial components ? You can set a list of cosmetic ingredients to avoid, right in the app!';
+      'Er du allergisk over for nogen af ingredienserne? Vil du undgå komedogene stoffer? Vil du undgå kontroversielle komponenter? Du kan oprette en liste over kosmetiske ingredienser, du skal undgå, direkte i appen!';
 
   @override
   String get guide_open_beauty_facts_tips_title =>
-      'Tips for taking great photos';
+      'Tips til at tage fantastiske billeder';
 
   @override
-  String get guide_open_beauty_facts_tips_arg1_title => 'Don’ts';
+  String get guide_open_beauty_facts_tips_arg1_title => 'Undgå';
 
   @override
   String get guide_open_beauty_facts_tips_arg1_text1 =>
-      'Avoid shadows and glare.';
+      'Undgå skygger og genskin.';
 
   @override
   String get guide_open_beauty_facts_tips_arg1_text2 =>
-      'No blurry or out-of-focus text.';
+      'Ingen sløret eller uskarp tekst.';
 
   @override
   String get guide_open_beauty_facts_tips_arg1_text3 =>
-      'Don\'t crop out parts of the text.';
+      'Beskær ikke dele af teksten væk.';
 
   @override
   String get guide_open_beauty_facts_tips_arg1_text4 =>
-      'Avoid busy backgrounds.';
+      'Undgå forstyrrende baggrunde.';
 
   @override
-  String get guide_open_beauty_facts_tips_arg2_title => 'Do’s';
+  String get guide_open_beauty_facts_tips_arg2_title => 'Anbefales';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text1 =>
-      'Use good, even lighting.';
+      'Brug god, jævn belysning.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text2 =>
-      'Ensure text is sharp and readable.';
+      'Sørg for, at teksten er skarp og læsbar.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text3 =>
-      'Capture the entire ingredients list.';
+      'Optag hele ingredienslisten.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text4 =>
-      'Take as many picture as need if the bottle is curved.';
+      'Tag så mange billeder som nødvendigt, hvis flasken er buet.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text5 =>
-      'You might need to peel the label to see the list of ingredients.';
+      'Du skal muligvis fjerne etiketten for at se ingredienslisten.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text6 =>
-      'Keep the product on a flat surface.';
+      'Opbevar produktet på en plan overflade.';
 
   @override
-  String get guide_open_beauty_facts_scores_title => 'A note on scoring';
+  String get guide_open_beauty_facts_scores_title =>
+      'En bemærkning om pointgivning';
 
   @override
   String get guide_open_beauty_facts_scores_paragraph1 =>
-      'Unlike food products, the world of cosmetics **does not have a universally recognized, government-backed scoring system like the Nutri-Score**. Ingredient effects can be highly personal and depend on skin type, allergies, and individual concerns.';
+      'I modsætning til fødevarer har kosmetikverdenen **ikke et universelt anerkendt, statsstøttet scoringssystem som Nutri-Score**. Ingrediensernes virkninger kan være meget individuelle og afhænge af hudtype, allergier og personlige bekymringer.';
 
   @override
   String get guide_open_beauty_facts_share_link =>
       'https://world-da.openbeautyfacts.org/discover';
 
   @override
-  String get guide_open_prices_title => 'Welcome to Open Prices!';
+  String get guide_open_prices_title => 'Velkommen til Open Prices!';
 
   @override
   String get guide_open_prices_what_is_open_prices_title =>
-      'What is Open Prices?';
+      'Hvad er Open Prices?';
 
   @override
   String get guide_open_prices_what_is_open_prices_paragraph1 =>
-      'Open Prices is a project to **collect and share prices of products around the world**. It\'s a publicly available dataset that can be used for research, analysis, and more. Open Prices is developed and maintained by Open Food Facts.';
+      'Open Prices er et projekt, der har til formål at **indsamle og dele priser på produkter fra hele verden**. Det er et offentligt tilgængeligt datasæt, der kan bruges til forskning, analyse og mere. Open Prices er udviklet og vedligeholdt af Open Food Facts.';
 
   @override
   String get guide_open_prices_what_is_open_prices_paragraph2 =>
       'Der er i øjeblikket få virksomheder, der ejer store databaser over produktpriser på stregkodeniveau. Disse priser er ikke frit tilgængelige, men sælges til en høj pris til private aktører, forskere og andre organisationer, der har råd til dem.';
 
   @override
-  String get guide_open_prices_how_title => 'How does Open Prices work?';
+  String get guide_open_prices_how_title => 'Hvordan fungerer Open Prices?';
 
   @override
   String get guide_open_prices_how_paragraph1 =>
-      '**We are crowdsourcing an open-source dataset of prices**. Prices can be added by users via this web app, or via the official Open Food Facts mobile app. Retailers or third-party apps can contribute as well by using our API.';
+      '**Vi crowdsourcer et open source-datasæt med priser**. Priser kan tilføjes af brugere via denne webapp eller via den officielle Open Food Facts-mobilapp. Detailhandlere eller tredjepartsapps kan også bidrage ved hjælp af vores API.';
 
   @override
   String get guide_open_prices_how_arg1_title =>
-      'Collect photos of price tags in aisles';
+      'Saml billeder af prisskilte i butikken';
 
   @override
-  String get guide_open_prices_how_arg2_title => 'Collect photos of receipts';
+  String get guide_open_prices_how_arg2_title =>
+      'Saml billeder af kvitteringer';
 
   @override
   String get guide_open_prices_why_title =>
-      'Why is Open Food Facts doing this ?';
+      'Hvor indsamler Open Food Facts priser?';
 
   @override
   String get guide_open_prices_why_paragraph1 =>
-      'Price information is of paramount importance to understand food systems. It\'s a key factor in understanding the cost of food and to promote healthier diets. Opening price data is a way to make it easier for researchers, journalists, and citizens to **have a better understanding of how food prices vary geographically and in time**.';
+      'Prisinformation er af afgørende betydning for at forstå fødevaresystemer. Det er en nøglefaktor i at forstå prisen på fødevarer og fremme sundere kostvaner. Åbning af prisdata er en måde at gøre det lettere for forskere, journalister og borgere at **få en bedre forståelse af, hvordan fødevarepriser varierer geografisk og over tid**.';
 
   @override
   String get guide_open_prices_why_arg1_title =>
-      'Track the evolution of prices over time';
+      'Spor prisudviklingen over tid';
 
   @override
   String get guide_open_prices_why_arg1_text =>
-      'See the **evolution of prices**: shrinkflation, cheapflation, we can track them together!';
+      'Se **prisudviklingen**: krympe-inflation, billig-inflation, vi kan spore dem sammen!';
 
   @override
-  String get guide_open_prices_why_arg2_title => 'Compare prices near you';
+  String get guide_open_prices_why_arg2_title =>
+      'Sammenlign priser i nærheden af dig';
 
   @override
   String get guide_open_prices_why_arg2_text =>
-      'As we get more prices, you can spot **the cheapest stores around you**.';
+      'Efterhånden som vi får flere priser, kan du finde **de billigste butikker i nærheden af dig**.';
 
   @override
   String get guide_open_prices_scrapping_title =>
-      'Did you consider scraping prices from retailers\' websites?';
+      'Har du overvejet at scrape priser fra forhandlernes hjemmesider?';
 
   @override
   String get guide_open_prices_scrapping_paragraph1 =>
-      'For legal and technical reasons, **we don\'t consider scraping prices from retailers\' websites as a valid way to contribute to Open Prices**. We want to make sure that the prices we collect are accurate and up-to-date, and receiving scraped prices from contributors doesn\'t allow us to do that.';
+      'Af juridiske og tekniske årsager **anser vi ikke det at indsamle priser fra detailhandleres hjemmesider som en gyldig måde at bidrage til Open Prices**. Vi ønsker at sikre os, at de priser, vi indsamler, er nøjagtige og opdaterede, og det er ikke muligt at modtage indsamlede priser fra bidragydere.';
 
   @override
   String get guide_open_prices_scrapping_paragraph2 =>
-      'Price scraping is a considered option in a future version of Open Prices, but it would be done by Open Prices itself so that we can have a proof of the price based on the HTML page.';
+      'Prisscraping er en overvejet mulighed i en fremtidig version af Open Prices, men det vil blive gjort af Open Prices selv, så vi kan have et bevis på prisen baseret på HTML-siden.';
 
   @override
   String get guide_open_prices_retailers_title =>
@@ -4919,7 +4928,7 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get guide_open_prices_retailers_paragraph1 =>
-      'You can contribute prices by using our API.\nIf you want to contribute prices at scale, please get in touch with us at prices@openfoodfacts.org.';
+      'Du kan bidrage med priser ved hjælp af vores API.\nHvis du ønsker at bidrage med priser i stor skala, bedes du kontakte os på prices@openfoodfacts.org.';
 
   @override
   String get guide_open_prices_share_link =>
@@ -4927,88 +4936,87 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get guide_open_products_facts_title =>
-      'Welcome to Open Products Facts!';
+      'Velkommen til Open Products Facts!';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_title =>
-      'What is Open Products Facts?';
+      'Hvad er Open Products Facts?';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_paragraph1 =>
-      'Open Products Facts is a massive, open database for **any product with a barcode, which is not food, cosmetic or pet food**.';
+      'Open Products Facts er en massiv, åben database for **ethvert produkt med en stregkode, som ikke er fødevarer, kosmetik eller kæledyrsfoder**.';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_paragraph2 =>
-      'From **electronics** to **toys**, and **clothes** to **cleaning supplies**, if it has a barcode, it can be added. This project aims to create an \"Internet of Things\" for everyday objects, making information about them universally accessible.';
+      'Fra **elektronik** til **legetøj** og **tøj** til **rengøringsartikler**, kan det tilføjes, hvis det har en stregkode. Dette projekt har til formål at skabe et \"tingenes internet\" for hverdagsgenstande og gøre information om dem universelt tilgængelig.';
 
   @override
   String get guide_open_products_facts_features_title =>
-      'Features of Open Products Facts';
+      'Funktioner i Open Products Facts';
 
   @override
   String get guide_open_products_facts_features_text =>
-      'Open Products Facts aims to provide consumers to **extend the life of objects** by providing the circular solutions to maintain, **repair**, **recycle** their objects or give them a new owner.';
+      'Open Products Facts har til formål at give forbrugerne mulighed for at **forlænge levetiden på deres genstande** ved at tilbyde cirkulære løsninger til at vedligeholde, **reparere**, **genbruge** deres genstande eller give dem en ny ejer.';
 
   @override
   String get guide_open_products_facts_features_arg1_title =>
-      'Carbon footprints for some products';
+      'CO2-aftryk for nogle produkter';
 
   @override
   String get guide_open_products_facts_features_arg1_text =>
-      '**Impact CO2** by French Environment Authority ADEME provides the **carbon impact** of many categories, make sure to categorize products precisely.';
+      '**CO2-påvirkning** fra den franske miljømyndighed ADEME leverer **CO2-påvirkningen** for mange kategorier. Sørg for at kategorisere produkterne præcist.';
 
   @override
   String get guide_open_products_facts_features_arg2_title =>
-      'Reparability index for many products';
+      'Reparationsindeks for mange produkter';
 
   @override
   String get guide_open_products_facts_features_arg2_text =>
-      'Whenever a French reparability index is available, we’ll display it. Moreover, **you can start collecting the variables using the Folksonomy Engine**; so that we can recompute it ourselves in the future, even in countries where it’s not available.';
+      'Når et fransk reparerbarhedsindeks er tilgængeligt, viser vi det. Derudover **kan du begynde at indsamle variablerne ved hjælp af Folksonomy Engine**, så vi selv kan genberegne det i fremtiden, selv i lande hvor det ikke er tilgængeligt.';
 
   @override
   String get guide_open_products_facts_features_arg3_title =>
-      'Find ways to donate/resell your product';
+      'Find måder at donere/videresælge dit produkt';
 
   @override
   String get guide_open_products_facts_features_arg3_text =>
-      'We provide links to **third party circular friendly services** that help you get the kind of product you’re looking for, as a second hand product, to be more gentle on planetary resources.\nNote that we’re not paid to do that, and that the system only works as an example for two websites in France. You can help expand this system by documenting more sites on the wiki.';
+      'Vi leverer links til **tredjeparts cirkulærvenlige tjenester**, der hjælper dig med at finde den type produkt, du leder efter, som et brugt produkt, for at være mere skånsom mod planetens ressourcer.\nBemærk, at vi ikke bliver betalt for at gøre det, og at systemet kun fungerer som et eksempel for to websteder i Frankrig. Du kan hjælpe med at udvide dette system ved at dokumentere flere websteder på wikien.';
 
   @override
   String get guide_open_products_facts_information_title =>
-      'What information is useful?';
+      'Hvilke oplysninger er nyttige?';
 
   @override
   String get guide_open_products_facts_information_text =>
-      'For such a wide range of items, **the data we collect is flexible**. To do that, **we created the Folksonomy Engine**.';
+      'For så bred en vifte af elementer **er de data, vi indsamler, fleksible**. For at gøre det **har vi skabt Folksonomy Engine**.';
 
   @override
-  String get guide_open_products_facts_folksonomy_title =>
-      'The Folksonomy Engine';
+  String get guide_open_products_facts_folksonomy_title => 'Folksonomy-motoren';
 
   @override
   String get guide_open_products_facts_folksonomy_paragraph1 =>
-      'The Folksonomy Engine is a tool to help you complete products with relevant properties. This helps improve search and discoverability, but also compute and display interesting things in the future.';
+      'Folksonomy Engine er et værktøj, der hjælper dig med at færdiggøre produkter med relevante egenskaber. Dette hjælper med at forbedre søgning og synlighed, men også med at beregne og vise interessante ting i fremtiden.';
 
   @override
   String get guide_open_products_facts_folksonomy_paragraph2 =>
-      'You can add any keys and values like: **compatibility_with_5G_mobile_network: yes**';
+      'Du kan tilføje alle nøgler og værdier som f.eks.: **compatibility_with_5G_mobile_network: yes**';
 
   @override
   String get guide_open_products_facts_folksonomy_paragraph3 =>
-      'You’ll get autosuggestion of possible properties, and you are very welcome to add and document new ones on your favorite kinds of products.';
+      'Du får automatiske forslag til mulige egenskaber, og du er meget velkommen til at tilføje og dokumentere nye på dine yndlingsprodukter.';
 
   @override
   String get guide_open_products_facts_share_link =>
       'https://world-da.openproductsfacts.org/discover';
 
   @override
-  String get guide_open_preferences_button_title => 'Open food preferences';
+  String get guide_open_preferences_button_title => 'Åbn madpræferencer';
 
   @override
-  String get guide_coming_soon_button_title => 'Coming soon';
+  String get guide_coming_soon_button_title => 'Kommer snart';
 
   @override
-  String get guide_learn_more_subtitle => 'Tap to learn more';
+  String get guide_learn_more_subtitle => 'Tryk for at lære mere';
 
   @override
   String get preview_badge => 'Forhåndsvisning';
@@ -5346,11 +5354,11 @@ class AppLocalizationsDa extends AppLocalizations {
       'Disse egenskaber oprettes og arkiveres af bidragydere til enhver form for anvendelse.';
 
   @override
-  String get folksonomy_action_external_link_title => 'Open external link';
+  String get folksonomy_action_external_link_title => 'Åbn eksternt link';
 
   @override
   String get folksonomy_action_external_link_warning =>
-      'External links may be unsafe. Do you really want to visit it?';
+      'Eksterne links kan være usikre. Vil du virkelig besøge dem?';
 
   @override
   String get prices_products_empty_title => 'Ingen pris tilgængelig';
@@ -5783,18 +5791,16 @@ class AppLocalizationsDa extends AppLocalizations {
   String get preferences_faq_discover_off_title => 'Discover Open Food Facts';
 
   @override
-  String get preferences_faq_discover_obf_title => 'Discover Open Beauty Facts';
+  String get preferences_faq_discover_obf_title => 'Opdag Open Beauty Facts';
 
   @override
-  String get preferences_faq_discover_opff_title =>
-      'Discover Open Pet Food Facts';
+  String get preferences_faq_discover_opff_title => 'Opdag Open Pet Food Facts';
 
   @override
-  String get preferences_faq_discover_op_title => 'Discover Open Prices';
+  String get preferences_faq_discover_op_title => 'Opdag Open Prices';
 
   @override
-  String get preferences_faq_discover_opf_title =>
-      'Discover Open Products Facts';
+  String get preferences_faq_discover_opf_title => 'Opdag Open Products Facts';
 
   @override
   String get preferences_faq_faq_title => 'FAQ - Ofte stillede spørgsmål';
@@ -6147,7 +6153,7 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Få åbne fødevarefakta på dit sprog';
 
   @override
   String get preferences_contribute_enroll_alpha =>
@@ -6169,26 +6175,26 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
-  String get location_map_details_title => 'Location details';
+  String get location_map_details_title => 'Placeringsoplysninger';
 
   @override
   String get location_map_details_name => 'Navn';
 
   @override
-  String get location_map_details_street => 'Street';
+  String get location_map_details_street => 'Gade';
 
   @override
-  String get location_map_details_city => 'City';
+  String get location_map_details_city => 'By';
 
   @override
-  String get location_map_details_postcode => 'Postcode';
+  String get location_map_details_postcode => 'Postnummer';
 
   @override
   String get location_map_details_country => 'Land';
 
   @override
-  String get location_map_details_coordinates => 'Coordinates';
+  String get location_map_details_coordinates => 'Koordinater';
 
   @override
-  String get location_map_details_osm_id => 'OSM ID';
+  String get location_map_details_osm_id => 'OSM-ID';
 }

--- a/packages/smooth_app/lib/l10n/app_localizations_da.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_da.dart
@@ -654,7 +654,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get unknownBrand => 'Ukendt brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Ukendt produktnavn';

--- a/packages/smooth_app/lib/l10n/app_localizations_de.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_de.dart
@@ -498,7 +498,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get contribute_join_skill_pool =>
-      'Contribute your skills to Open Food Facts. Join the skill pool!';
+      'Tragen Sie mit Ihren Fähigkeiten zu OpenFoodFacts bei. Treten Sie dem Kompetenzpool bei!';
 
   @override
   String get contribute_share_header =>
@@ -665,6 +665,9 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get unknownBrand => 'Unbekannte Marke';
+
+  @override
+  String get unknownQuantity => 'Unknown brand';
 
   @override
   String get unknownProductName => 'Unbekannter Produktname';
@@ -3028,7 +3031,7 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get prices_menu_know_more => 'Know more about Open Prices';
+  String get prices_menu_know_more => 'Erfahren Sie mehr über Open Prices';
 
   @override
   String get dev_preferences_import_history_result_success => 'Fertig';
@@ -3592,7 +3595,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Die Serveraktionen für lokal gespeicherte Folksonomie-Aktualisierungen werden nun ausgeführt.';
 
   @override
   String get background_task_title_top_n =>
@@ -4686,7 +4689,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get guide_open_food_facts_features_title =>
-      'Features of Open Food Facts';
+      'Merkmale von Open Food Facts';
 
   @override
   String get guide_open_food_facts_features_arg1_title =>
@@ -4772,7 +4775,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get guide_open_pet_food_facts_features_title =>
-      'Features of Open Pet Food Facts';
+      'Merkmale von Open Pet Food Facts';
 
   @override
   String get guide_open_pet_food_facts_features_arg1_title =>
@@ -4854,7 +4857,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get guide_open_beauty_facts_features_title =>
-      'Features of Open Beauty Facts';
+      'Merkmale von Open Beauty Facts';
 
   @override
   String get guide_open_beauty_facts_features_arg1_title =>
@@ -4931,7 +4934,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get guide_open_prices_what_is_open_prices_title =>
-      'What is Open Prices?';
+      'Was sind Open Prices?';
 
   @override
   String get guide_open_prices_what_is_open_prices_paragraph1 =>
@@ -5021,7 +5024,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get guide_open_products_facts_features_title =>
-      'Features of Open Products Facts';
+      'Merkmale von Open Products Facts';
 
   @override
   String get guide_open_products_facts_features_text =>
@@ -5870,18 +5873,18 @@ class AppLocalizationsDe extends AppLocalizations {
       'Entdecken Sie Open Food Facts';
 
   @override
-  String get preferences_faq_discover_obf_title => 'Discover Open Beauty Facts';
+  String get preferences_faq_discover_obf_title => 'Entdecke Open Beauty Facts';
 
   @override
   String get preferences_faq_discover_opff_title =>
-      'Discover Open Pet Food Facts';
+      'Entdecken Sie Open Pet Food Facts';
 
   @override
-  String get preferences_faq_discover_op_title => 'Discover Open Prices';
+  String get preferences_faq_discover_op_title => 'Open Prices entdecken';
 
   @override
   String get preferences_faq_discover_opf_title =>
-      'Discover Open Products Facts';
+      'Entdecken Sie Open Products Facts';
 
   @override
   String get preferences_faq_faq_title => 'FAQ - Häufig gestellte Fragen';

--- a/packages/smooth_app/lib/l10n/app_localizations_de.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_de.dart
@@ -667,7 +667,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get unknownBrand => 'Unbekannte Marke';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unbekannter Produktname';

--- a/packages/smooth_app/lib/l10n/app_localizations_el.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_el.dart
@@ -143,7 +143,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get match_short_unknown => 'Άγνωστη αντιστοιχία';
 
   @override
-  String get licenses => 'Licences';
+  String get licenses =>
+      'Ακρίβεια, πληρότητα και περιεκτικότητα των πληροφοριών και δεδομένων';
 
   @override
   String get looking_for => 'Ψάχνουμε για';
@@ -392,7 +393,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get contributors_label => 'Ποιοι χτίζουν την εφαρμογή';
 
   @override
-  String get contributors_dialog_title => 'Χρηστες';
+  String get contributors_dialog_title => 'Συνεισφέροντες';
 
   @override
   String contributors_dialog_entry_description(Object name) {
@@ -526,7 +527,7 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get contribute_to_get_rewards =>
-      'Become an actor of food transparency';
+      'Γίνετε ένας παράγοντας διαφάνειας στα τρόφιμα';
 
   @override
   String get question_sign_in_text =>
@@ -663,6 +664,9 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get unknownBrand => 'Άγνωστη μάρκα';
+
+  @override
+  String get unknownQuantity => 'Unknown brand';
 
   @override
   String get unknownProductName => 'Άγνωστο όνομα προϊόντος';
@@ -2269,7 +2273,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get edit_product_ingredients_photo_title => 'Φωτογραφία συστατικών';
 
   @override
-  String get edit_product_ingredients_list_title => 'List of ingredients';
+  String get edit_product_ingredients_list_title => 'Λίστα συστατικών';
 
   @override
   String get edit_product_packaging_photo_title => 'Φωτογραφία συσκευασίας';
@@ -2713,7 +2717,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get prices_per_kilogram => 'Τιμή ανά κιλό';
 
   @override
-  String get prices_per_unit => 'Price per unit';
+  String get prices_per_unit => 'Τιμή ανά μονάδα';
 
   @override
   String get prices_per_kilogram_short => ' / κιλό';
@@ -2974,7 +2978,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get prices_proof_find => 'Επιλέξτε μια απόδειξη';
 
   @override
-  String get prices_proof_change => 'Change proof';
+  String get prices_proof_change => 'Απόδειξη αλλαγής';
 
   @override
   String get prices_proof_receipt => 'Απόδειξη';
@@ -3037,7 +3041,8 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get prices_menu_know_more => 'Know more about Open Prices';
+  String get prices_menu_know_more =>
+      'Μάθετε περισσότερα για τις τιμές ανοίγματος';
 
   @override
   String get dev_preferences_import_history_result_success => 'Τέλος';
@@ -3130,7 +3135,7 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String search_proof_title(String user) {
-    return 'Proof from \"$user\"';
+    return 'Απόδειξη από \"$user\"';
   }
 
   @override
@@ -3599,7 +3604,7 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Έναρξη εκτέλεσης ενεργειών διακομιστή για ενημερώσεις folksonomy που είναι αποθηκευμένες τοπικά';
 
   @override
   String get background_task_title_top_n =>
@@ -4271,14 +4276,14 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get guide_title => 'Guide';
+  String get guide_title => 'Οδηγός';
 
   @override
   String get guide_share_label => 'Κοινοποίηση';
 
   @override
   String get guide_nutriscore_v2_title =>
-      'The Nutri-Score is evolving: explanations!';
+      'Το Nutri-Score εξελίσσεται: εξηγήσεις!';
 
   @override
   String get guide_nutriscore_v2_what_is_nutriscore_title =>
@@ -4286,73 +4291,74 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get guide_nutriscore_v2_what_is_nutriscore_paragraph1 =>
-      'The Nutri-Score is a logo which aims to inform you about the **nutritional quality of foods**.';
+      'Το Nutri-Score είναι ένα λογότυπο που στοχεύει να σας ενημερώσει σχετικά με τη **θρεπτική ποιότητα των τροφίμων**.';
 
   @override
   String get guide_nutriscore_v2_what_is_nutriscore_paragraph2 =>
-      'The color code varies from dark green (**A**) for the **healthiest** products to dark red (**E**) for the **less healthy** ones.';
+      'Ο χρωματικός κώδικας ποικίλλει από σκούρο πράσινο (**A**) για τα **πιο υγιεινά** προϊόντα έως σκούρο κόκκινο (**E**) για τα **λιγότερο υγιεινά** προϊόντα.';
 
   @override
   String get guide_nutriscore_v2_nutriscore_a_caption =>
-      'The Nutri-Score A logo';
+      'Το λογότυπο Nutri-Score A';
 
   @override
-  String get guide_nutriscore_v2_why_v2_title => 'Why is Nutri-Score evolving?';
+  String get guide_nutriscore_v2_why_v2_title =>
+      'Γιατί αλλάζει το Nutri-Score;';
 
   @override
   String get guide_nutriscore_v2_why_v2_intro =>
-      'The Nutri-Score formula **is evolving** to provide better recommendations:';
+      'Ο τύπος Nutri-Score **εξελίσσεται** για να παρέχει καλύτερες συστάσεις:';
 
   @override
   String get guide_nutriscore_v2_why_v2_arg1_title =>
-      'Better evaluate all drinks';
+      'Καλύτερη αξιολόγηση όλων των ποτών';
 
   @override
   String get guide_nutriscore_v2_why_v2_arg1_text =>
-      'The comparative notes of **milk**, **dairy drinks** with added sugar and **vegetable** drinks were better differentiated in the new algorithm.';
+      'Οι συγκριτικές σημειώσεις του **γάλακτος**, των **γαλακτοκομικών ποτών** με προσθήκη ζάχαρης και των **λαχανικών** ποτών διαφοροποιήθηκαν καλύτερα στον νέο αλγόριθμο.';
 
   @override
-  String get guide_nutriscore_v2_why_v2_arg2_title =>
-      'Better ranking of drinks';
+  String get guide_nutriscore_v2_why_v2_arg2_title => 'Καλύτερη κατάταξη ποτών';
 
   @override
   String get guide_nutriscore_v2_why_v2_arg2_text =>
-      'The **sugar content** is better taken into account and favors **lowly sweetened** drinks.\\n**Sweeteners will also be penalized**: diet sodas will be downgraded from a B rating to between C and E. Water remains the recommended drink.';
+      'Η **περιεκτικότητα σε ζάχαρη** λαμβάνεται καλύτερα υπόψη και ευνοεί τα **ποτά με χαμηλή περιεκτικότητα σε ζάχαρη**.\\n**Τα γλυκαντικά θα τιμωρούνται επίσης**: τα αναψυκτικά διαίτης θα υποβαθμίζονται από βαθμολογία Β σε μεταξύ C και E. Το νερό παραμένει το συνιστώμενο ποτό.';
 
   @override
   String get guide_nutriscore_v2_why_v2_arg3_title =>
-      'Salt and sugar penalized';
+      'Αλάτι και ζάχαρη τιμωρήθηκαν';
 
   @override
   String get guide_nutriscore_v2_why_v2_arg3_text =>
-      'Products **too sweet** or **too salty** will see their **rating further downgraded**.';
+      'Τα προϊόντα **πολύ γλυκά** ή **πολύ αλμυρά** θα υποβαθμιστούν περαιτέρω.';
 
   @override
   String get guide_nutriscore_v2_why_v2_arg4_title =>
-      'Hierarchy within oils and fishes';
+      'Ιεραρχία εντός των ελαίων και των ψαριών';
 
   @override
   String get guide_nutriscore_v2_why_v2_arg4_text =>
-      'The rating of certain **fatty fish** and **oils rich in good fats** will improve.';
+      'Η βαθμολογία ορισμένων **λιπαρών ψαριών** και **ελαίων πλούσιων σε καλά λιπαρά** θα βελτιωθεί.';
 
   @override
-  String get guide_nutriscore_v2_why_v2_arg5_title => 'Limit red meat';
+  String get guide_nutriscore_v2_why_v2_arg5_title =>
+      'Περιορίστε το κόκκινο κρέας';
 
   @override
   String get guide_nutriscore_v2_why_v2_arg5_text =>
-      'Consumption of **red meat should be limited**. This is why **poultry will be comparatively better ranked**.';
+      'Η κατανάλωση **κόκκινου κρέατος θα πρέπει να είναι περιορισμένη**. Γι\' αυτό το λόγο **τα πουλερικά θα κατατάσσονται συγκριτικά καλύτερα**.';
 
   @override
   String get guide_nutriscore_v2_new_logo_title =>
-      'How to differentiate old Nutri-Score and new calculation?';
+      'Πώς να ξεχωρίσετε το παλιό Nutri-Score και τον νέο υπολογισμό;';
 
   @override
   String get guide_nutriscore_v2_new_logo_text =>
-      'From now on, the logo can display a mention \"**New calculation**\" to clarify that this is indeed the new calculation.';
+      'Από εδώ και στο εξής, το λογότυπο μπορεί να εμφανίζει την ένδειξη «**Νέος υπολογισμός**» για να διευκρινίζει ότι όντως πρόκειται για τον νέο υπολογισμό.';
 
   @override
   String get guide_nutriscore_v2_new_logo_image_caption =>
-      'The logo of the new Nutri-Score';
+      'Το λογότυπο του νέου Nutri-Score';
 
   @override
   String get guide_nutriscore_v2_where_title =>
@@ -4368,18 +4374,18 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get guide_nutriscore_v2_where_paragraph3 =>
-      'Without waiting, you **will already find in the OpenFoodFacts application**, the new calculation, including if the manufacturers have not updated the score.';
+      'Χωρίς να περιμένετε, **θα βρείτε ήδη στην εφαρμογή OpenFoodFacts** τον νέο υπολογισμό, ακόμη και αν οι κατασκευαστές δεν έχουν ενημερώσει τη βαθμολογία.';
 
   @override
-  String get guide_nutriscore_v2_unchanged_title => 'What doesn\'t change';
+  String get guide_nutriscore_v2_unchanged_title => 'Τι δεν αλλάζει';
 
   @override
   String get guide_nutriscore_v2_unchanged_paragraph1 =>
-      'The Nutri-Score is a score designed to **measure nutritional quality**. It is **complementary to the NOVA group** on **ultra-processed foods** (also present in the application).';
+      'Το Nutri-Score είναι μια βαθμολογία που έχει σχεδιαστεί για να **μετράει τη διατροφική ποιότητα**. Είναι **συμπληρωματική της ομάδας NOVA** για τα **υπερ-επεξεργασμένα τρόφιμα** (υπάρχει επίσης στην εφαρμογή).';
 
   @override
   String get guide_nutriscore_v2_unchanged_paragraph2 =>
-      'For manufacturers, the display of the Nutri-Score **remains optional**.';
+      'Για τους κατασκευαστές, η εμφάνιση του Nutri-Score **παραμένει προαιρετική**.';
 
   @override
   String get guide_greenscore_title => 'Green-Score';
@@ -4475,7 +4481,7 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get guide_greenscore_bonuses_penalties_intro =>
-      'To reward better products within a category, we then apply **bonuses & penalties based on several criterion**:';
+      'Για να ανταμείψουμε καλύτερα προϊόντα σε μια κατηγορία, εφαρμόζουμε **μπόνους και κυρώσεις με βάση διάφορα κριτήρια**:';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg1_title =>
@@ -4483,7 +4489,7 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get guide_greenscore_bonuses_penalties_arg1_text =>
-      'A **bonus** is awarded to products that have an **official label, a label or a certification that guarantees environmental benefits** (organic, fair trade, HVE, Label Rouge, Bleu Blanc Cœur, MSC/ASC).';
+      'Ένα **μπόνους** απονέμεται σε προϊόντα που διαθέτουν **επίσημη ετικέτα, ετικέτα ή πιστοποίηση που εγγυάται περιβαλλοντικά οφέλη** (βιολογικά, δίκαιου εμπορίου, HVE, Label Rouge, Bleu Blanc Cœur, MSC/ASC).';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg2_title =>
@@ -4491,7 +4497,7 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get guide_greenscore_bonuses_penalties_arg2_text =>
-      'A **bonus** is awarded based on the origin of the ingredients. This bonus takes into account the **impact on transportation** and also the **environmental policy** of each producer\'s country.';
+      'Απονέμεται ένα **μπόνους** με βάση την προέλευση των συστατικών. Αυτό το μπόνους λαμβάνει υπόψη τον **επιπτώσεις στις μεταφορές** καθώς και την **περιβαλλοντική πολιτική** της χώρας κάθε παραγωγού.';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg3_title =>
@@ -4499,14 +4505,14 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get guide_greenscore_bonuses_penalties_arg3_text =>
-      'A **penalty** is given to products that contain ingredients that have significant **negative impacts on biodiversity and ecosystems**, such as palm oil, the production of which is responsible for massive deforestation.';
+      'Επιβάλλεται **ποινή** σε προϊόντα που περιέχουν συστατικά που έχουν σημαντικές **αρνητικές επιπτώσεις στη βιοποικιλότητα και τα οικοσυστήματα**, όπως το φοινικέλαιο, η παραγωγή του οποίου ευθύνεται για την μαζική αποψίλωση των δασών.';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg4_title => 'Συσκευασία';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg4_text =>
-      'A **penalty** is calculated to take into account the **circularity of packaging** (use of recycled raw material and recyclability) and overpacking.';
+      'Υπολογίζεται **ποινή** λαμβάνοντας υπόψη την **κυκλικότητα της συσκευασίας** (χρήση ανακυκλωμένων πρώτων υλών και ανακυκλωσιμότητα) και την υπερβολική συσκευασία.';
 
   @override
   String get guide_greenscore_transparency_title =>
@@ -4514,19 +4520,19 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get guide_greenscore_transparency_intro1 =>
-      'To accurately calculate the Green-Score, it is necessary to have **information which is not necessarily specified on the packaging** (such as the origin and the exact percentage of each ingredient) or which is rarely available in usable form (such as a list of all the components of the packaging with the precise types of plastics used).';
+      'Για τον ακριβή υπολογισμό του Green-Score, είναι απαραίτητο να υπάρχουν **πληροφορίες που δεν αναφέρονται απαραίτητα στη συσκευασία** (όπως η προέλευση και το ακριβές ποσοστό κάθε συστατικού) ή που σπάνια είναι διαθέσιμες σε χρησιμοποιήσιμη μορφή (όπως μια λίστα με όλα τα συστατικά της συσκευασίας με τους ακριβείς τύπους πλαστικών που χρησιμοποιούνται).';
 
   @override
   String get guide_greenscore_transparency_intro2 =>
-      '**Average values are used when this information is not yet available**, but we are now calling on everyone to help us collect this information which will be very useful for the Green-Score but also for many other uses.';
+      '**Οι μέσες τιμές χρησιμοποιούνται όταν αυτές οι πληροφορίες δεν είναι ακόμη διαθέσιμες**, αλλά τώρα καλούμε όλους να μας βοηθήσουν να συλλέξουμε αυτές τις πληροφορίες, οι οποίες θα είναι πολύ χρήσιμες για το Green-Score αλλά και για πολλές άλλες χρήσεις.';
 
   @override
   String get guide_greenscore_transparency_arg1_title =>
-      'How citizens can help?';
+      'Πώς μπορούν να βοηθήσουν οι πολίτες;';
 
   @override
   String get guide_greenscore_transparency_arg1_text =>
-      'All citizens can help us gather and structure the information that is present on products or that can be deduced from them, such as information on **packaging**: \"Mission Emballages\": a large-scale collaborative inventory of packaging for all food products (in French).';
+      'Όλοι οι πολίτες μπορούν να μας βοηθήσουν να συλλέξουμε και να δομήσουμε τις πληροφορίες που υπάρχουν στα προϊόντα ή που μπορούν να εξαχθούν από αυτά, όπως πληροφορίες σχετικά με τις **συσκευασίες**: \"Mission Emballages\": μια μεγάλης κλίμακας συνεργατική απογραφή συσκευασιών για όλα τα τρόφιμα (στα γαλλικά).';
 
   @override
   String get guide_greenscore_transparency_arg2_title =>
@@ -4601,7 +4607,7 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get guide_nova_groups_arg1_text =>
-      'Unprocessed (or natural) foods are the **edible parts of plants** (seeds, fruits, leaves, stems, roots) **or animals** (muscle, offal, eggs, milk), as well as fungi, algae, and water, after being separated from nature.';
+      'Τα μη επεξεργασμένα (ή φυσικά) τρόφιμα είναι τα **βρώσιμα μέρη των φυτών** (σπόροι, καρποί, φύλλα, μίσχοι, ρίζες) **ή ζώων** (μύες, εντόσθια, αυγά, γάλα), καθώς και μύκητες, φύκια και νερό, αφού διαχωριστούν από τη φύση.';
 
   @override
   String get guide_nova_groups_arg2_title =>
@@ -4635,7 +4641,7 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg1_text =>
-      'Many are **derived from further processing of food constituents**, such as hydrogenated or interesterified oils, hydrolyzed proteins, soy protein isolate, maltodextrin, invert sugar, and high-fructose corn syrup.';
+      'Πολλά προέρχονται **από περαιτέρω επεξεργασία συστατικών τροφίμων**, όπως υδρογονωμένα ή διεστεροποιημένα έλαια, υδρολυμένες πρωτεΐνες, απομονωμένη πρωτεΐνη σόγιας, μαλτοδεξτρίνη, ιμβερτοσάκχαρο και σιρόπι καλαμποκιού υψηλής περιεκτικότητας σε φρουκτόζη.';
 
   @override
   String get guide_nova_explanations_arg2_title =>
@@ -4643,7 +4649,7 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg2_text =>
-      'Additives in ultra-processed foods include some that are also used in processed foods, such as preservatives, antioxidants, and stabilizers. Classes of additives found only in ultra-processed products include those used **to imitate or enhance the sensory qualities of foods or to disguise unpalatable aspects of the final product**. These additives include dyes and other colors, color stabilizers; flavors, flavor enhancers, non-sugar sweeteners; and processing aids such as carbonating, firming, bulking and anti-bulking agents, de-foaming, anti-caking and glazing agents, emulsifiers, sequestrants, and humectants.';
+      'Τα πρόσθετα στα υπερεπεξεργασμένα τρόφιμα περιλαμβάνουν ορισμένα που χρησιμοποιούνται επίσης σε επεξεργασμένα τρόφιμα, όπως συντηρητικά, αντιοξειδωτικά και σταθεροποιητές. Κατηγορίες προσθέτων που βρίσκονται μόνο σε υπερεπεξεργασμένα προϊόντα περιλαμβάνουν εκείνα που χρησιμοποιούνται **για να μιμηθούν ή να ενισχύσουν τις οργανοληπτικές ιδιότητες των τροφίμων ή για να συγκαλύψουν δυσάρεστες πτυχές του τελικού προϊόντος**. Αυτά τα πρόσθετα περιλαμβάνουν χρωστικές και άλλα χρώματα, σταθεροποιητές χρώματος, αρώματα, ενισχυτικά γεύσης, γλυκαντικά χωρίς ζάχαρη, και βοηθητικά επεξεργασίας όπως παράγοντες ενανθράκωσης, σύσφιξης, διόγκωσης και αντιδιογκωτικοί παράγοντες, παράγοντες αποαφρισμού, αντισυσσωματικούς και γλασαρίσματος, γαλακτωματοποιητές, απομονωτικά και υγραντικά.';
 
   @override
   String get guide_nova_explanations_arg3_title =>
@@ -4651,7 +4657,7 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg3_text =>
-      '**A multitude of sequences of processes is used** to combine the usually many ingredients and to create the final product (hence \'ultra-processed\'). The processes include several **with no domestic equivalents**, such as hydrogenation and hydrolysation, extrusion and moulding, and pre-processing for frying.';
+      '**Χρησιμοποιείται πληθώρα αλληλουχιών διεργασιών** για τον συνδυασμό των συνήθως πολλών συστατικών και τη δημιουργία του τελικού προϊόντος (εξ ου και «υπερεπεξεργασμένο»). Οι διεργασίες περιλαμβάνουν αρκετές **χωρίς εγχώρια ισοδύναμα**, όπως υδρογόνωση και υδρόλυση, εξώθηση και χύτευση, και προεπεξεργασία για τηγάνισμα.';
 
   @override
   String get guide_nova_explanations_arg4_title =>
@@ -4659,104 +4665,108 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg4_text =>
-      '**The overall purpose of ultra-processing is to create branded**, **convenient** (durable, ready to consume), **attractive** (hyper-palatable) and **highly profitable** (low-cost ingredients) food products designed to displace all other food groups. Ultra-processed food products are usually packaged attractively and marketed intensively.';
+      'Ο γενικός σκοπός της υπερεπεξεργασίας είναι η δημιουργία επώνυμων**, **βολικών** (ανθεκτικών, έτοιμων προς κατανάλωση), **ελκυστικών** (υπερεύγευστων) και **εξαιρετικά κερδοφόρων** (χαμηλού κόστους συστατικά) τροφίμων, σχεδιασμένων να εκτοπίσουν όλες τις άλλες ομάδες τροφίμων. Τα υπερεπεξεργασμένα τρόφιμα συνήθως συσκευάζονται ελκυστικά και διατίθενται στην αγορά εντατικά.';
 
   @override
-  String get guide_nova_explanations_arg5_title => 'A health hazard';
+  String get guide_nova_explanations_arg5_title =>
+      'Ένας κίνδυνος για την υγεία';
 
   @override
   String get guide_nova_explanations_arg5_text =>
-      'Since 2018, with NutriNet-Santé, the first links between **the consumption of ultra-processed foods and increased risks of cancer, cardiovascular diseases, and diabetes have been highlighted**. Today, more than 90 studies worldwide confirm these findings.\nThe strongest associations relate to **obesity, cardiovascular mortality, and depressive symptoms**. On children, the effects are primarily observed on weight and lipid imbalances.';
+      'Από το 2018, με το NutriNet-Santé, έχουν επισημανθεί οι πρώτες συνδέσεις μεταξύ **της κατανάλωσης υπερεπεξεργασμένων τροφίμων και του αυξημένου κινδύνου καρκίνου, καρδιαγγειακών παθήσεων και διαβήτη**. Σήμερα, περισσότερες από 90 μελέτες παγκοσμίως επιβεβαιώνουν αυτά τα ευρήματα.\nΟι ισχυρότερες συσχετίσεις σχετίζονται με την **παχυσαρκία, την καρδιαγγειακή θνησιμότητα και τα συμπτώματα κατάθλιψης**. Στα παιδιά, οι επιπτώσεις παρατηρούνται κυρίως στο βάρος και στις λιπιδαιμικές ανισορροπίες.';
 
   @override
   String get guide_nova_explanations_arg6_title =>
-      'Countries recommend limiting them';
+      'Οι χώρες συνιστούν τον περιορισμό τους';
 
   @override
   String get guide_nova_explanations_arg6_text =>
-      'Some countries use the NOVA groups for their dietary guidelines or goals, for instance:\n\n- **🇧🇷 Brazil**\'s dietary guidelines **recommend to limit consumption** of processed food and avoid ultra-processed food.\n\n- **🇫🇷 France**\'s public health nutritional policy goals for 2018-2022 aims to **reduce consumption of group 4 ultra-processed foods by 20%**.';
+      'Ορισμένες χώρες χρησιμοποιούν τις ομάδες NOVA για τις διατροφικές τους οδηγίες ή στόχους, για παράδειγμα:\n\n- **🇧🇷 Οι διατροφικές οδηγίες της Βραζιλίας** **συνιστούν τον περιορισμό της κατανάλωσης** επεξεργασμένων τροφίμων και την αποφυγή των υπερεπεξεργασμένων τροφίμων.\n\n- **🇫🇷 Οι στόχοι της διατροφικής πολιτικής δημόσιας υγείας της Γαλλίας** για την περίοδο 2018-2022 αποσκοπούν στη **μείωση της κατανάλωσης υπερεπεξεργασμένων τροφίμων της ομάδας 4 κατά 20%**.';
 
   @override
   String get guide_nova_share_link => 'https://world-el.openfoodfacts.org/nova';
 
   @override
-  String get guide_open_food_facts_title => 'Welcome to Open Food Facts!';
+  String get guide_open_food_facts_title =>
+      'Καλώς ορίσατε στο Open Food Facts!';
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_title =>
-      'What is Open Food Facts?';
+      'Τι είναι το Open Food Facts;';
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_paragraph1 =>
-      'Open Food Facts is a **collaborative**, **free**, and **open** database of food products from around the world.';
+      'Το Open Food Facts είναι μια **συνεργατική**, **δωρεάν** και **ανοιχτή** βάση δεδομένων με προϊόντα διατροφής από όλο τον κόσμο.';
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_paragraph2 =>
-      'We believe that everyone should have access to information about what they eat. By collecting data on ingredients, allergens, nutrition facts, and more, **we empower consumers to make informed choices** and drive the food industry **toward greater transparency**.';
+      'Πιστεύουμε ότι όλοι πρέπει να έχουν πρόσβαση σε πληροφορίες σχετικά με το τι τρώνε. Συλλέγοντας δεδομένα σχετικά με τα συστατικά, τα αλλεργιογόνα, τις διατροφικές πληροφορίες και άλλα, **ενδυναμώνουμε τους καταναλωτές να κάνουν ενημερωμένες επιλογές** και οδηγούμε τη βιομηχανία τροφίμων **προς μεγαλύτερη διαφάνεια**.';
 
   @override
   String get guide_open_food_facts_features_title =>
-      'Features of Open Food Facts';
+      'Χαρακτηριστικά του Open Food Facts';
 
   @override
   String get guide_open_food_facts_features_arg1_title =>
-      'Get alerts for your unwanted ingredients';
+      'Λάβετε ειδοποιήσεις για τα ανεπιθύμητα συστατικά σας';
 
   @override
-  String get guide_open_food_facts_tips_title => 'Tips for taking great photos';
+  String get guide_open_food_facts_tips_title =>
+      'Συμβουλές για να τραβάτε υπέροχες φωτογραφίες';
 
   @override
-  String get guide_open_food_facts_tips_arg1_title => 'Don’ts';
+  String get guide_open_food_facts_tips_arg1_title => 'Τι δεν πρέπει να κάνετε';
 
   @override
   String get guide_open_food_facts_tips_arg1_text1 =>
-      'Avoid shadows and glare.';
+      'Αποφύγετε τις σκιές και την αντανάκλαση.';
 
   @override
   String get guide_open_food_facts_tips_arg1_text2 =>
-      'No blurry or out-of-focus text.';
+      'Δεν υπάρχει θολό ή εκτός εστίασης κείμενο.';
 
   @override
   String get guide_open_food_facts_tips_arg1_text3 =>
-      'Don\'t crop out parts of the text.';
+      'Μην περικόπτετε τμήματα του κειμένου.';
 
   @override
-  String get guide_open_food_facts_tips_arg1_text4 => 'Avoid busy backgrounds.';
+  String get guide_open_food_facts_tips_arg1_text4 =>
+      'Αποφύγετε τα πολυάσχολα φόντα.';
 
   @override
-  String get guide_open_food_facts_tips_arg2_title => 'Do’s';
+  String get guide_open_food_facts_tips_arg2_title => 'Τι πρέπει να κάνετε';
 
   @override
   String get guide_open_food_facts_tips_arg2_text1 =>
-      'Use good, even lighting.';
+      'Χρησιμοποιήστε καλό, ομοιόμορφο φωτισμό.';
 
   @override
   String get guide_open_food_facts_tips_arg2_text2 =>
-      'Ensure text is sharp and readable.';
+      'Βεβαιωθείτε ότι το κείμενο είναι ευκρινές και ευανάγνωστο.';
 
   @override
   String get guide_open_food_facts_tips_arg2_text3 =>
-      'Capture the entire ingredients list.';
+      'Καταγράψτε ολόκληρη τη λίστα συστατικών.';
 
   @override
   String get guide_open_food_facts_tips_arg2_text4 =>
-      'Keep the product on a flat surface.';
+      'Κρατήστε το προϊόν σε επίπεδη επιφάνεια.';
 
   @override
   String get guide_open_food_facts_scores_title =>
-      'Help us build the \"Wikipedia of Food\"';
+      'Βοηθήστε μας να δημιουργήσουμε τη «Βικιπαίδεια του Φαγητού»';
 
   @override
   String get guide_open_food_facts_scores_arg1_title =>
-      'A score on the nutritional quality';
+      'Βαθμολογία για τη διατροφική ποιότητα';
 
   @override
   String get guide_open_food_facts_scores_arg2_title =>
-      'A score to avoid ultra-processed foods';
+      'Μια βαθμολογία για την αποφυγή υπερεπεξεργασμένων τροφίμων';
 
   @override
   String get guide_open_food_facts_scores_arg3_title =>
-      'A score for the planet';
+      'Ένα σκορ για τον πλανήτη';
 
   @override
   String get guide_open_food_facts_share_link =>
@@ -4764,244 +4774,251 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get guide_open_pet_food_facts_title =>
-      'Welcome to Open Pet Food Facts!';
+      'Καλώς ορίσατε στο Open Pet Food Facts!';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_title =>
-      'What is Open Pet Food Facts?';
+      'Τι είναι το Open Pet Food Facts;';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_paragraph1 =>
-      'Open Pet Food Facts extends our mission to our furry friends! It\'s a **database of pet food products for cats, dogs, and other companions**.';
+      'Το Open Pet Food Facts επεκτείνει την αποστολή μας στους τετράποδους φίλους μας! Είναι μια **βάση δεδομένων με προϊόντα τροφής για κατοικίδια για γάτες, σκύλους και άλλους συντροφικούς φίλους**.';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_paragraph2 =>
-      'We gather information on **ingredients**, **nutritional analysis**, and feeding guidelines to help pet owners choose the best food for their animals\' needs.';
+      'Συλλέγουμε πληροφορίες σχετικά με **συστατικά**, **διατροφική ανάλυση** και οδηγίες σίτισης για να βοηθήσουμε τους ιδιοκτήτες κατοικίδιων ζώων να επιλέξουν την καλύτερη τροφή για τις ανάγκες των ζώων τους.';
 
   @override
   String get guide_open_pet_food_facts_features_title =>
-      'Features of Open Pet Food Facts';
+      'Χαρακτηριστικά των πληροφοριών για την ανοιχτή τροφή για κατοικίδια';
 
   @override
   String get guide_open_pet_food_facts_features_arg1_title =>
-      'Get alerts for your unwanted ingredients';
+      'Λάβετε ειδοποιήσεις για τα ανεπιθύμητα συστατικά σας';
 
   @override
   String get guide_open_pet_food_facts_features_arg1_paragraph1 =>
-      'Is your pet allergic to any ingredients? You can set a list of cosmetic ingredients to avoid, right in the app!';
+      'Είναι το κατοικίδιό σας αλλεργικό σε κάποιο συστατικό; Μπορείτε να ορίσετε μια λίστα με τα συστατικά καλλυντικών που πρέπει να αποφεύγετε, απευθείας από την εφαρμογή!';
 
   @override
   String get guide_open_pet_food_facts_tips_title =>
-      'Tips for taking great photos';
+      'Συμβουλές για να τραβάτε υπέροχες φωτογραφίες';
 
   @override
-  String get guide_open_pet_food_facts_tips_arg1_title => 'Don’ts';
+  String get guide_open_pet_food_facts_tips_arg1_title =>
+      'Τι δεν πρέπει να κάνετε';
 
   @override
   String get guide_open_pet_food_facts_tips_arg1_text1 =>
-      'Avoid shadows and glare.';
+      'Αποφύγετε τις σκιές και την αντανάκλαση.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg1_text2 =>
-      'No blurry or out-of-focus text.';
+      'Δεν υπάρχει θολό ή εκτός εστίασης κείμενο.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg1_text3 =>
-      'Don\'t crop out parts of the text.';
+      'Μην περικόπτετε τμήματα του κειμένου.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg1_text4 =>
-      'Avoid busy backgrounds.';
+      'Αποφύγετε τα πολυάσχολα φόντα.';
 
   @override
-  String get guide_open_pet_food_facts_tips_arg2_title => 'Do’s';
+  String get guide_open_pet_food_facts_tips_arg2_title => 'Τι πρέπει να κάνετε';
 
   @override
   String get guide_open_pet_food_facts_tips_arg2_text1 =>
-      'Use good, even lighting.';
+      'Χρησιμοποιήστε καλό, ομοιόμορφο φωτισμό.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg2_text2 =>
-      'Ensure text is sharp and readable.';
+      'Βεβαιωθείτε ότι το κείμενο είναι ευκρινές και ευανάγνωστο.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg2_text3 =>
-      'Capture the entire ingredients list.';
+      'Καταγράψτε ολόκληρη τη λίστα συστατικών.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg2_text4 =>
-      'Keep the product on a flat surface.';
+      'Κρατήστε το προϊόν σε επίπεδη επιφάνεια.';
 
   @override
-  String get guide_open_pet_food_facts_scores_title => 'A note on scoring';
+  String get guide_open_pet_food_facts_scores_title =>
+      'Μια σημείωση για τη βαθμολογία';
 
   @override
   String get guide_open_pet_food_facts_scores_paragraph1 =>
-      'Developing a scoring system for pet food **is not a priority right now**. The methodology would be complex, as nutritional needs vary greatly by species, age, and health condition. We haven’t found any independant scientific team yet, able to develop such a score.';
+      'Η ανάπτυξη ενός συστήματος βαθμολόγησης για τις τροφές για κατοικίδια **δεν αποτελεί προτεραιότητα προς το παρόν**. Η μεθοδολογία θα ήταν πολύπλοκη, καθώς οι διατροφικές ανάγκες ποικίλλουν σημαντικά ανά είδος, ηλικία και κατάσταση υγείας. Δεν έχουμε βρει ακόμη κάποια ανεξάρτητη επιστημονική ομάδα, ικανή να αναπτύξει μια τέτοια βαθμολογία.';
 
   @override
   String get guide_open_pet_food_facts_share_link =>
       'https://world-el.openpetfoodfacts.org/discover';
 
   @override
-  String get guide_open_beauty_facts_title => 'Welcome to Open Beauty Facts!';
+  String get guide_open_beauty_facts_title =>
+      'Καλώς ορίσατε στο Open Beauty Facts!';
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_title =>
-      'What is Open Beauty Facts?';
+      'Τι είναι το Open Beauty Facts;';
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_paragraph1 =>
-      'Open Beauty Facts is a collaborative database of **cosmetic products**.';
+      'Το Open Beauty Facts είναι μια συνεργατική βάση δεδομένων **καλλυντικών προϊόντων**.';
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_paragraph2 =>
-      'Our goal is to decipher ingredient lists to help you **understand what\'s in your personal care items**. From moisturizers to makeup, we collect data on ingredients, allergens, and packaging to promote transparency in the cosmetics industry.';
+      'Στόχος μας είναι να αποκρυπτογραφήσουμε λίστες συστατικών για να σας βοηθήσουμε **να κατανοήσετε τι περιέχουν τα προϊόντα προσωπικής φροντίδας σας**. Από ενυδατικές κρέμες μέχρι μακιγιάζ, συλλέγουμε δεδομένα σχετικά με τα συστατικά, τα αλλεργιογόνα και τις συσκευασίες για να προωθήσουμε τη διαφάνεια στη βιομηχανία καλλυντικών.';
 
   @override
   String get guide_open_beauty_facts_features_title =>
-      'Features of Open Beauty Facts';
+      'Χαρακτηριστικά του Open Beauty Facts';
 
   @override
   String get guide_open_beauty_facts_features_arg1_title =>
-      'Get alerts for your unwanted ingredients';
+      'Λάβετε ειδοποιήσεις για τα ανεπιθύμητα συστατικά σας';
 
   @override
   String get guide_open_beauty_facts_features_arg1_paragraph1 =>
-      'Are you allergic to any ingredients? Want to avoid comedogen substances? Want to steer away from controversial components ? You can set a list of cosmetic ingredients to avoid, right in the app!';
+      'Έχετε αλλεργία σε κάποιο συστατικό; Θέλετε να αποφύγετε τις φαγεσωρογόνες ουσίες; Θέλετε να αποφύγετε αμφιλεγόμενα συστατικά; Μπορείτε να ορίσετε μια λίστα με τα συστατικά καλλυντικών που θέλετε να αποφύγετε, απευθείας από την εφαρμογή!';
 
   @override
   String get guide_open_beauty_facts_tips_title =>
-      'Tips for taking great photos';
+      'Συμβουλές για να τραβάτε υπέροχες φωτογραφίες';
 
   @override
-  String get guide_open_beauty_facts_tips_arg1_title => 'Don’ts';
+  String get guide_open_beauty_facts_tips_arg1_title =>
+      'Τι δεν πρέπει να κάνετε';
 
   @override
   String get guide_open_beauty_facts_tips_arg1_text1 =>
-      'Avoid shadows and glare.';
+      'Αποφύγετε τις σκιές και την αντανάκλαση.';
 
   @override
   String get guide_open_beauty_facts_tips_arg1_text2 =>
-      'No blurry or out-of-focus text.';
+      'Δεν υπάρχει θολό ή εκτός εστίασης κείμενο.';
 
   @override
   String get guide_open_beauty_facts_tips_arg1_text3 =>
-      'Don\'t crop out parts of the text.';
+      'Μην περικόπτετε τμήματα του κειμένου.';
 
   @override
   String get guide_open_beauty_facts_tips_arg1_text4 =>
-      'Avoid busy backgrounds.';
+      'Αποφύγετε τα πολυάσχολα φόντα.';
 
   @override
-  String get guide_open_beauty_facts_tips_arg2_title => 'Do’s';
+  String get guide_open_beauty_facts_tips_arg2_title => 'Τι πρέπει να κάνετε';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text1 =>
-      'Use good, even lighting.';
+      'Χρησιμοποιήστε καλό, ομοιόμορφο φωτισμό.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text2 =>
-      'Ensure text is sharp and readable.';
+      'Βεβαιωθείτε ότι το κείμενο είναι ευκρινές και ευανάγνωστο.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text3 =>
-      'Capture the entire ingredients list.';
+      'Καταγράψτε ολόκληρη τη λίστα συστατικών.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text4 =>
-      'Take as many picture as need if the bottle is curved.';
+      'Τραβήξτε όσες φωτογραφίες χρειάζεστε αν το μπουκάλι είναι κυρτό.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text5 =>
-      'You might need to peel the label to see the list of ingredients.';
+      'Μπορεί να χρειαστεί να ξεκολλήσετε την ετικέτα για να δείτε τη λίστα των συστατικών.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text6 =>
-      'Keep the product on a flat surface.';
+      'Κρατήστε το προϊόν σε επίπεδη επιφάνεια.';
 
   @override
-  String get guide_open_beauty_facts_scores_title => 'A note on scoring';
+  String get guide_open_beauty_facts_scores_title =>
+      'Μια σημείωση για τη βαθμολογία';
 
   @override
   String get guide_open_beauty_facts_scores_paragraph1 =>
-      'Unlike food products, the world of cosmetics **does not have a universally recognized, government-backed scoring system like the Nutri-Score**. Ingredient effects can be highly personal and depend on skin type, allergies, and individual concerns.';
+      'Σε αντίθεση με τα τρόφιμα, ο κόσμος των καλλυντικών **δεν διαθέτει ένα παγκοσμίως αναγνωρισμένο, κυβερνητικά υποστηριζόμενο σύστημα βαθμολόγησης όπως το Nutri-Score**. Οι επιδράσεις των συστατικών μπορεί να είναι ιδιαίτερα προσωπικές και να εξαρτώνται από τον τύπο δέρματος, τις αλλεργίες και τις ατομικές ανησυχίες.';
 
   @override
   String get guide_open_beauty_facts_share_link =>
       'https://world-el.openbeautyfacts.org/discover';
 
   @override
-  String get guide_open_prices_title => 'Welcome to Open Prices!';
+  String get guide_open_prices_title => 'Καλώς ορίσατε στις Ανοιχτές Τιμές!';
 
   @override
   String get guide_open_prices_what_is_open_prices_title =>
-      'What is Open Prices?';
+      'Τι είναι οι τιμές ανοίγματος;';
 
   @override
   String get guide_open_prices_what_is_open_prices_paragraph1 =>
-      'Open Prices is a project to **collect and share prices of products around the world**. It\'s a publicly available dataset that can be used for research, analysis, and more. Open Prices is developed and maintained by Open Food Facts.';
+      'Το Open Prices είναι ένα έργο για τη **συλλογή και κοινοποίηση τιμών προϊόντων σε όλο τον κόσμο**. Είναι ένα δημόσια διαθέσιμο σύνολο δεδομένων που μπορεί να χρησιμοποιηθεί για έρευνα, ανάλυση και πολλά άλλα. Το Open Prices αναπτύσσεται και συντηρείται από το Open Food Facts.';
 
   @override
   String get guide_open_prices_what_is_open_prices_paragraph2 =>
       'Υπάρχουν επί του παρόντος λίγες εταιρείες που διαθέτουν μεγάλες βάσεις δεδομένων τιμών προϊόντων σε επίπεδο γραμμωτού κώδικα. Αυτές οι τιμές δεν είναι ελεύθερα διαθέσιμες, αλλά πωλούνται σε υψηλές τιμές σε ιδιώτες φορείς, ερευνητές και άλλους οργανισμούς που μπορούν να τις αντέξουν οικονομικά.';
 
   @override
-  String get guide_open_prices_how_title => 'How does Open Prices work?';
+  String get guide_open_prices_how_title =>
+      'Πώς λειτουργούν οι Ανοιχτές Τιμές;';
 
   @override
   String get guide_open_prices_how_paragraph1 =>
-      '**We are crowdsourcing an open-source dataset of prices**. Prices can be added by users via this web app, or via the official Open Food Facts mobile app. Retailers or third-party apps can contribute as well by using our API.';
+      '**Αναζητούμε ένα σύνολο δεδομένων τιμών ανοιχτού κώδικα από το crowdsourcing**. Οι χρήστες μπορούν να προσθέσουν τιμές μέσω αυτής της διαδικτυακής εφαρμογής ή μέσω της επίσημης εφαρμογής Open Food Facts για κινητά. Οι λιανοπωλητές ή οι εφαρμογές τρίτων μπορούν επίσης να συνεισφέρουν χρησιμοποιώντας το API μας.';
 
   @override
   String get guide_open_prices_how_arg1_title =>
-      'Collect photos of price tags in aisles';
+      'Συλλέξτε φωτογραφίες από τις ετικέτες τιμών στους διαδρόμους';
 
   @override
-  String get guide_open_prices_how_arg2_title => 'Collect photos of receipts';
+  String get guide_open_prices_how_arg2_title =>
+      'Συλλέξτε φωτογραφίες αποδείξεων';
 
   @override
   String get guide_open_prices_why_title =>
-      'Why is Open Food Facts doing this ?';
+      'Γιατί το κάνει αυτό το Open Food Facts;';
 
   @override
   String get guide_open_prices_why_paragraph1 =>
-      'Price information is of paramount importance to understand food systems. It\'s a key factor in understanding the cost of food and to promote healthier diets. Opening price data is a way to make it easier for researchers, journalists, and citizens to **have a better understanding of how food prices vary geographically and in time**.';
+      'Οι πληροφορίες για τις τιμές είναι ύψιστης σημασίας για την κατανόηση των συστημάτων τροφίμων. Αποτελούν βασικό παράγοντα για την κατανόηση του κόστους των τροφίμων και την προώθηση πιο υγιεινών διατροφών. Τα δεδομένα τιμών είναι ένας τρόπος για να διευκολυνθούν οι ερευνητές, οι δημοσιογράφοι και οι πολίτες να **κατανοήσουν καλύτερα τον τρόπο με τον οποίο οι τιμές των τροφίμων ποικίλλουν γεωγραφικά και χρονικά**.';
 
   @override
   String get guide_open_prices_why_arg1_title =>
-      'Track the evolution of prices over time';
+      'Παρακολουθήστε την εξέλιξη των τιμών με την πάροδο του χρόνου';
 
   @override
   String get guide_open_prices_why_arg1_text =>
-      'See the **evolution of prices**: shrinkflation, cheapflation, we can track them together!';
+      'Δείτε την **εξέλιξη των τιμών**: συρρικνούμενος πληθωρισμός, φθηνός πληθωρισμός, μπορούμε να τα παρακολουθήσουμε μαζί!';
 
   @override
-  String get guide_open_prices_why_arg2_title => 'Compare prices near you';
+  String get guide_open_prices_why_arg2_title => 'Συγκρίνετε τιμές κοντά σας';
 
   @override
   String get guide_open_prices_why_arg2_text =>
-      'As we get more prices, you can spot **the cheapest stores around you**.';
+      'Καθώς θα έχουμε περισσότερες τιμές, μπορείτε να εντοπίσετε **τα φθηνότερα καταστήματα γύρω σας**.';
 
   @override
   String get guide_open_prices_scrapping_title =>
-      'Did you consider scraping prices from retailers\' websites?';
+      'Σκεφτήκατε να αντλήσετε τιμές από τους ιστότοπους των λιανοπωλητών;';
 
   @override
   String get guide_open_prices_scrapping_paragraph1 =>
-      'For legal and technical reasons, **we don\'t consider scraping prices from retailers\' websites as a valid way to contribute to Open Prices**. We want to make sure that the prices we collect are accurate and up-to-date, and receiving scraped prices from contributors doesn\'t allow us to do that.';
+      'Για νομικούς και τεχνικούς λόγους, **δεν θεωρούμε την συλλογή τιμών από τους ιστότοπους των λιανοπωλητών ως έγκυρο τρόπο συμβολής στις Ανοιχτές Τιμές**. Θέλουμε να διασφαλίσουμε ότι οι τιμές που συλλέγουμε είναι ακριβείς και ενημερωμένες και η λήψη συλλεγμένων τιμών από τους συνεισφέροντες δεν μας επιτρέπει να το κάνουμε αυτό.';
 
   @override
   String get guide_open_prices_scrapping_paragraph2 =>
-      'Price scraping is a considered option in a future version of Open Prices, but it would be done by Open Prices itself so that we can have a proof of the price based on the HTML page.';
+      'Η συλλογή τιμών είναι μια επιλογή που εξετάζεται σε μια μελλοντική έκδοση του Open Prices, αλλά θα γίνεται από το ίδιο το Open Prices, ώστε να μπορούμε να έχουμε μια απόδειξη της τιμής με βάση τη σελίδα HTML.';
 
   @override
   String get guide_open_prices_retailers_title =>
-      'I\'m a retailer and I want to contribute prices. How can I do that?';
+      'Είμαι λιανοπωλητής και θέλω να συνεισφέρω στις τιμές. Πώς μπορώ να το κάνω αυτό;';
 
   @override
   String get guide_open_prices_retailers_paragraph1 =>
-      'You can contribute prices by using our API.\nIf you want to contribute prices at scale, please get in touch with us at prices@openfoodfacts.org.';
+      'Μπορείτε να συνεισφέρετε τιμές χρησιμοποιώντας το API μας.\nΕάν θέλετε να συνεισφέρετε τιμές σε κλίμακα, επικοινωνήστε μαζί μας στη διεύθυνση prices@openfoodfacts.org.';
 
   @override
   String get guide_open_prices_share_link =>
@@ -5009,88 +5026,89 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get guide_open_products_facts_title =>
-      'Welcome to Open Products Facts!';
+      'Καλώς ορίσατε στο Open Products Facts!';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_title =>
-      'What is Open Products Facts?';
+      'Τι είναι τα Ανοιχτά Γεγονότα για τα Προϊόντα;';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_paragraph1 =>
-      'Open Products Facts is a massive, open database for **any product with a barcode, which is not food, cosmetic or pet food**.';
+      'Το Open Products Facts είναι μια τεράστια, ανοιχτή βάση δεδομένων για **οποιοδήποτε προϊόν με γραμμωτό κώδικα, το οποίο δεν είναι τρόφιμο, καλλυντικό ή τροφή για κατοικίδια**.';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_paragraph2 =>
-      'From **electronics** to **toys**, and **clothes** to **cleaning supplies**, if it has a barcode, it can be added. This project aims to create an \"Internet of Things\" for everyday objects, making information about them universally accessible.';
+      'Από **ηλεκτρονικά** μέχρι **παιχνίδια** και από **ρούχα** μέχρι **προϊόντα καθαρισμού**, αν υπάρχει γραμμωτός κώδικας, μπορεί να προστεθεί. Αυτό το έργο στοχεύει στη δημιουργία ενός «Διαδικτύου των Πραγμάτων» για καθημερινά αντικείμενα, καθιστώντας τις πληροφορίες σχετικά με αυτά παγκοσμίως προσβάσιμες.';
 
   @override
   String get guide_open_products_facts_features_title =>
-      'Features of Open Products Facts';
+      'Χαρακτηριστικά των Ανοικτών Προϊόντων Γεγονότα';
 
   @override
   String get guide_open_products_facts_features_text =>
-      'Open Products Facts aims to provide consumers to **extend the life of objects** by providing the circular solutions to maintain, **repair**, **recycle** their objects or give them a new owner.';
+      'Το Open Products Facts στοχεύει να παρέχει στους καταναλωτές τη δυνατότητα **να παρατείνουν τη διάρκεια ζωής των αντικειμένων** παρέχοντας κυκλικές λύσεις για τη συντήρηση, την **επισκευή**, την **ανακύκλωση** των αντικειμένων τους ή την παραχώρηση ενός νέου ιδιοκτήτη.';
 
   @override
   String get guide_open_products_facts_features_arg1_title =>
-      'Carbon footprints for some products';
+      'Αποτύπωμα άνθρακα για ορισμένα προϊόντα';
 
   @override
   String get guide_open_products_facts_features_arg1_text =>
-      '**Impact CO2** by French Environment Authority ADEME provides the **carbon impact** of many categories, make sure to categorize products precisely.';
+      'Η **Επιπτώσεις CO2** από την Γαλλική Αρχή Περιβάλλοντος ADEME παρέχει τις **επιπτώσεις άνθρακα** πολλών κατηγοριών, φροντίστε να κατηγοριοποιήσετε τα προϊόντα με ακρίβεια.';
 
   @override
   String get guide_open_products_facts_features_arg2_title =>
-      'Reparability index for many products';
+      'Δείκτης επισκευής για πολλά προϊόντα';
 
   @override
   String get guide_open_products_facts_features_arg2_text =>
-      'Whenever a French reparability index is available, we’ll display it. Moreover, **you can start collecting the variables using the Folksonomy Engine**; so that we can recompute it ourselves in the future, even in countries where it’s not available.';
+      'Όποτε είναι διαθέσιμος ένας δείκτης επανορθωσιμότητας στα γαλλικά, θα τον εμφανίζουμε. Επιπλέον, **μπορείτε να ξεκινήσετε τη συλλογή των μεταβλητών χρησιμοποιώντας τη Μηχανή Folksonomy**, ώστε να μπορούμε να τον υπολογίσουμε ξανά οι ίδιοι στο μέλλον, ακόμα και σε χώρες όπου δεν είναι διαθέσιμος.';
 
   @override
   String get guide_open_products_facts_features_arg3_title =>
-      'Find ways to donate/resell your product';
+      'Βρείτε τρόπους για να δωρίσετε/μεταπωλήσετε το προϊόν σας';
 
   @override
   String get guide_open_products_facts_features_arg3_text =>
-      'We provide links to **third party circular friendly services** that help you get the kind of product you’re looking for, as a second hand product, to be more gentle on planetary resources.\nNote that we’re not paid to do that, and that the system only works as an example for two websites in France. You can help expand this system by documenting more sites on the wiki.';
+      'Παρέχουμε συνδέσμους προς **υπηρεσίες τρίτων μερών φιλικές προς την κυκλική αγορά** που σας βοηθούν να αποκτήσετε το είδος του προϊόντος που αναζητάτε, ως μεταχειρισμένο προϊόν, που να είναι πιο φιλικό προς τους πλανητικούς πόρους.\nΣημειώστε ότι δεν πληρωνόμαστε για να το κάνουμε αυτό και ότι το σύστημα λειτουργεί μόνο ως παράδειγμα για δύο ιστότοπους στη Γαλλία. Μπορείτε να βοηθήσετε στην επέκταση αυτού του συστήματος τεκμηριώνοντας περισσότερους ιστότοπους στο wiki.';
 
   @override
   String get guide_open_products_facts_information_title =>
-      'What information is useful?';
+      'Ποιες πληροφορίες είναι χρήσιμες;';
 
   @override
   String get guide_open_products_facts_information_text =>
-      'For such a wide range of items, **the data we collect is flexible**. To do that, **we created the Folksonomy Engine**.';
+      'Για ένα τόσο ευρύ φάσμα στοιχείων, **τα δεδομένα που συλλέγουμε είναι ευέλικτα**. Για να το πετύχουμε αυτό, **δημιουργήσαμε τη Μηχανή Folksonomy**.';
 
   @override
   String get guide_open_products_facts_folksonomy_title =>
-      'The Folksonomy Engine';
+      'Η Μηχανή Λαϊκής Προσωπικότητας';
 
   @override
   String get guide_open_products_facts_folksonomy_paragraph1 =>
-      'The Folksonomy Engine is a tool to help you complete products with relevant properties. This helps improve search and discoverability, but also compute and display interesting things in the future.';
+      'Η Μηχανή Folksonomy είναι ένα εργαλείο που σας βοηθά να ολοκληρώνετε προϊόντα με σχετικές ιδιότητες. Αυτό βοηθά στη βελτίωση της αναζήτησης και της ανακάλυψης, αλλά και στον υπολογισμό και την εμφάνιση ενδιαφερόντων στοιχείων στο μέλλον.';
 
   @override
   String get guide_open_products_facts_folksonomy_paragraph2 =>
-      'You can add any keys and values like: **compatibility_with_5G_mobile_network: yes**';
+      'Μπορείτε να προσθέσετε οποιαδήποτε κλειδιά και τιμές όπως: **συμβατότητα_με_5G_κινητό_δίκτυο: ναι**';
 
   @override
   String get guide_open_products_facts_folksonomy_paragraph3 =>
-      'You’ll get autosuggestion of possible properties, and you are very welcome to add and document new ones on your favorite kinds of products.';
+      'Θα λάβετε αυτόματη πρόταση πιθανών ιδιοτήτων και είστε ευπρόσδεκτοι να προσθέσετε και να καταγράψετε νέες στα αγαπημένα σας είδη προϊόντων.';
 
   @override
   String get guide_open_products_facts_share_link =>
       'https://world-el.openproductsfacts.org/discover';
 
   @override
-  String get guide_open_preferences_button_title => 'Open food preferences';
+  String get guide_open_preferences_button_title =>
+      'Ανοιχτές προτιμήσεις φαγητού';
 
   @override
-  String get guide_coming_soon_button_title => 'Coming soon';
+  String get guide_coming_soon_button_title => 'Σύντομα διαθέσιμο';
 
   @override
-  String get guide_learn_more_subtitle => 'Tap to learn more';
+  String get guide_learn_more_subtitle => 'Πατήστε για να μάθετε περισσότερα';
 
   @override
   String get preview_badge => 'Προεπισκόπηση';
@@ -5419,7 +5437,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get explanation_card_learn_more_button => 'Μάθετε περισσότερα';
 
   @override
-  String get product_page_tab_folksonomy => 'Folksonomy';
+  String get product_page_tab_folksonomy => 'Λαογραφική';
 
   @override
   String get folksonomy_explanation_card_title =>
@@ -5434,11 +5452,12 @@ class AppLocalizationsEl extends AppLocalizations {
       'Αυτές οι ιδιότητες δημιουργούνται και καταχωρούνται από τους συνεισφέροντες για κάθε είδους χρήση.';
 
   @override
-  String get folksonomy_action_external_link_title => 'Open external link';
+  String get folksonomy_action_external_link_title =>
+      'Άνοιγμα εξωτερικού συνδέσμου';
 
   @override
   String get folksonomy_action_external_link_warning =>
-      'External links may be unsafe. Do you really want to visit it?';
+      'Οι εξωτερικοί σύνδεσμοι ενδέχεται να μην είναι ασφαλείς. Θέλετε πραγματικά να το επισκεφθείτε;';
 
   @override
   String get prices_products_empty_title => 'Δεν υπάρχει διαθέσιμη τιμή';
@@ -5496,7 +5515,7 @@ class AppLocalizationsEl extends AppLocalizations {
       'Αποτυχία εξαγωγής θρεπτικών συστατικών από την εικόνα';
 
   @override
-  String get prices_discount => 'Discount';
+  String get prices_discount => 'Έκπτωση';
 
   @override
   String get prices_stats_statistics => 'Στατιστικά';
@@ -5511,13 +5530,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get prices_stats_products_section => 'Προϊόντα';
 
   @override
-  String get prices_stats_locations_section => 'Locations';
+  String get prices_stats_locations_section => 'Τοποθεσίες';
 
   @override
   String get prices_stats_proofs_section => 'Proofs';
 
   @override
-  String get prices_stats_contributors_section => 'Χρηστες';
+  String get prices_stats_contributors_section => 'Συνεισφέροντες';
 
   @override
   String get prices_stats_experiments_section => 'Experiments';
@@ -5544,7 +5563,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get prices_stats_consumption => 'Κατανάλωση';
 
   @override
-  String get prices_stats_with_price => 'With a price';
+  String get prices_stats_with_price => 'Με τιμή';
 
   @override
   String get prices_stats_food => 'Τροφή';
@@ -6242,7 +6261,7 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Φέρτε τα Ανοιχτά Γεγονότα για τα Τρόφιμα στη γλώσσα σας';
 
   @override
   String get preferences_contribute_enroll_alpha =>
@@ -6265,26 +6284,26 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
-  String get location_map_details_title => 'Location details';
+  String get location_map_details_title => 'Λεπτομέρειες τοποθεσίας';
 
   @override
   String get location_map_details_name => 'Όνομα';
 
   @override
-  String get location_map_details_street => 'Street';
+  String get location_map_details_street => 'Δρόμος';
 
   @override
-  String get location_map_details_city => 'City';
+  String get location_map_details_city => 'Πόλη';
 
   @override
-  String get location_map_details_postcode => 'Postcode';
+  String get location_map_details_postcode => 'Ταχυδρομικός τομέας';
 
   @override
   String get location_map_details_country => 'Χώρα';
 
   @override
-  String get location_map_details_coordinates => 'Coordinates';
+  String get location_map_details_coordinates => 'Συντεταγμένες';
 
   @override
-  String get location_map_details_osm_id => 'OSM ID';
+  String get location_map_details_osm_id => 'Αναγνωριστικό OSM';
 }

--- a/packages/smooth_app/lib/l10n/app_localizations_el.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_el.dart
@@ -666,7 +666,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get unknownBrand => 'Άγνωστη μάρκα';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Άγνωστο όνομα προϊόντος';

--- a/packages/smooth_app/lib/l10n/app_localizations_en.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_en.dart
@@ -653,7 +653,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_en.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_en.dart
@@ -143,7 +143,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get match_short_unknown => 'Unknown match';
 
   @override
-  String get licenses => 'Licences';
+  String get licenses => 'Licenses';
 
   @override
   String get looking_for => 'Looking for';
@@ -292,7 +292,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get sign_up_page_username_description =>
-      'Username cannot contains spaces, caps or special characters.';
+      'Username cannot contain spaces, caps or special characters.';
 
   @override
   String sign_up_page_username_length_invalid(int value) {
@@ -495,7 +495,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get contribute_share_content =>
-      'I wanted to let you know about the app I\'ve been using, Open Food Facts, which allows you to get the health and environmental impacts of your food, in a personalized way. It works by scanning the barcodes on the packaging. Finally it\'s free, does not require registration, and you can even help increase the number of products decyphered. Here\'s the link to get it for your phone: https://openfoodfacts.app';
+      'I wanted to let you know about the app I\'ve been using, Open Food Facts, which allows you to get the health and environmental impacts of your food, in a personalized way. It works by scanning the barcodes on the packaging. Finally it\'s free, does not require registration, and you can even help increase the number of products deciphered. Here\'s the link to get it for your phone: https://openfoodfacts.app';
 
   @override
   String get contribute_prices_gdpr =>
@@ -653,6 +653,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -719,10 +722,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get nutrition_facts_editing_title => 'Edit Nutrition Facts';
 
   @override
-  String get packaging_information => 'Packaging information';
+  String get packaging_information => 'Recycling instructions';
 
   @override
-  String get packaging_information_photo => 'Packaging information photo';
+  String get packaging_information_photo => 'Recycling instructions photo';
 
   @override
   String get missing_product => 'You found a new product!';
@@ -825,7 +828,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get nutritional_facts_photo_title => 'Nutrition Facts Photo';
 
   @override
-  String get recycling_photo_title => 'Recycling Photo';
+  String get recycling_photo_title => 'Recycling instructions Photo';
 
   @override
   String get take_photo_title => 'Take a picture';
@@ -5213,7 +5216,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get photo_field_nutrition => 'Nutrition photo';
 
   @override
-  String get photo_field_packaging => 'Packaging information photo';
+  String get photo_field_packaging => 'Recycling instructions photo';
 
   @override
   String get photo_already_exists => 'This photo already exists';

--- a/packages/smooth_app/lib/l10n/app_localizations_eo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_eo.dart
@@ -653,7 +653,7 @@ class AppLocalizationsEo extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_eo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_eo.dart
@@ -653,6 +653,9 @@ class AppLocalizationsEo extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3519,7 +3522,7 @@ class AppLocalizationsEo extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Komencante plenumi la servilajn agojn por folksonomy-ĝisdatigoj konservitaj loke';
 
   @override
   String get background_task_title_top_n =>
@@ -5616,7 +5619,7 @@ class AppLocalizationsEo extends AppLocalizations {
 
   @override
   String get preferences_legal_header =>
-      'Open Food Facts is a food products database **made by everyone, for everyone**.\nYou can use it to make better food choices, and as it is **open data**, anyone can **re-use it for any purpose**.';
+      'Malfermaj Nutraĵaj Faktoj estas datumbazo pri nutraĵoj **farita de ĉiuj, por ĉiuj**.\nVi povas uzi ĝin por fari pli bonajn elektojn pri nutraĵoj, kaj ĉar ĝi estas **malfermaj datumoj**, ĉiu povas **reuzi ĝin por iu ajn celo**.';
 
   @override
   String get preferences_privacy_policy => 'Privacy policy';
@@ -5753,7 +5756,7 @@ class AppLocalizationsEo extends AppLocalizations {
 
   @override
   String get preferences_faq_nutriscore_subtitle =>
-      'Discover how the Nutri-Score is computed';
+      'Malkovru kiel la Nutri-Poentaro estas kalkulata';
 
   @override
   String get preferences_faq_nutriscore_v2_subtitle =>
@@ -5783,7 +5786,7 @@ class AppLocalizationsEo extends AppLocalizations {
   String get preferences_faq_faq_title => 'Oftaj Demandoj - Oftaj Demandoj';
 
   @override
-  String get preferences_faq_off_ngo_title => 'The Open Food Facts NGO';
+  String get preferences_faq_off_ngo_title => 'La Malferma Manĝaĵa Faktoj NRO';
 
   @override
   String get preferences_about_information_title => 'Information';
@@ -5922,7 +5925,7 @@ class AppLocalizationsEo extends AppLocalizations {
 
   @override
   String get preferences_contributions_new_products_subtitle =>
-      'New products I added to Open Food Facts';
+      'Novaj produktoj, kiujn mi aldonis al Malfermaj Manĝaĵaj Faktoj';
 
   @override
   String get preferences_contributions_to_be_completed_title =>
@@ -6132,7 +6135,7 @@ class AppLocalizationsEo extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Alportu Malfermajn Manĝaĵajn Informojn al via lingvo';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_es.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_es.dart
@@ -673,7 +673,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get unknownBrand => 'Marca desconocida';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Nombre de producto desconocido';

--- a/packages/smooth_app/lib/l10n/app_localizations_es.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_es.dart
@@ -673,6 +673,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get unknownBrand => 'Marca desconocida';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Nombre de producto desconocido';
 
   @override
@@ -1387,11 +1390,11 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get product_improvement_add_category =>
-      'Añade una categoría para calcular la puntuación Nutri-Score.';
+      'Añade una categoría para calcular la Nutri-Score.';
 
   @override
   String get product_improvement_add_nutrition_facts =>
-      'Añade la información nutricional para calcular la puntuación Nutri-Score.';
+      'Añade la información nutricional para calcular la Nutri-Score.';
 
   @override
   String get product_improvement_add_nutrition_facts_and_category =>
@@ -1399,7 +1402,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get product_improvement_categories_but_no_nutriscore =>
-      'No se ha podido calcular la puntuación Nutri-Score para este producto. Esto puede deberse a que, por ejemplo, una categoría no es estándar. Si crees que es un error, por favor, ponte en contacto con nosotros.';
+      'No se ha podido calcular la Nutri-Score para este producto. Esto puede deberse a que, por ejemplo, una categoría no es estándar. Si crees que es un error, por favor, ponte en contacto con nosotros.';
 
   @override
   String get product_improvement_obsolete_nutrition_image =>
@@ -3587,7 +3590,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Iniciando la ejecución de las acciones del servidor para las actualizaciones de folksonomía almacenadas localmente.';
 
   @override
   String get background_task_title_top_n =>
@@ -4125,19 +4128,18 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String nutriscore_new_formula(String letter) {
-    return 'Puntuación Nutri-Score $letter (Nuevo cálculo)';
+    return 'Nutri-Score $letter (Nuevo cálculo)';
   }
 
   @override
-  String get nutriscore_new_formula_title =>
-      'Puntuación Nutri-Score (Nuevo cálculo)';
+  String get nutriscore_new_formula_title => 'Nutri-Score (Nuevo cálculo)';
 
   @override
   String get nutriscore_unknown => 'Nutri-Score desconocido';
 
   @override
   String get nutriscore_unknown_new_formula =>
-      'Puntuación Nutri-Score desconocida (Nuevo cálculo)';
+      'Nutri-Score desconocida (Nuevo cálculo)';
 
   @override
   String get nutriscore_not_applicable =>
@@ -4151,22 +4153,22 @@ class AppLocalizationsEs extends AppLocalizations {
   String get environmental_score_generic_new => 'Green-Score';
 
   @override
-  String get environmental_score_a_new => 'Puntuación verde A';
+  String get environmental_score_a_new => 'Green-Score A';
 
   @override
-  String get environmental_score_b_new => 'Puntuación verde B';
+  String get environmental_score_b_new => 'Green-Score B';
 
   @override
-  String get environmental_score_c_new => 'Puntuación verde C';
+  String get environmental_score_c_new => 'Green-Score C';
 
   @override
-  String get environmental_score_d_new => 'Puntuación verde D';
+  String get environmental_score_d_new => 'Green-Score D';
 
   @override
-  String get environmental_score_e_new => 'Puntuación verde E';
+  String get environmental_score_e_new => 'Green-Score E';
 
   @override
-  String get environmental_score_unknown_new => 'Puntuación verde desconocida';
+  String get environmental_score_unknown_new => 'Green-Score desconocida';
 
   @override
   String get environmental_score_not_applicable_new =>
@@ -5016,7 +5018,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_title =>
-      'What is Open Products Facts?';
+      '¿Qué es Open Products Facts?';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_paragraph1 =>
@@ -5028,7 +5030,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get guide_open_products_facts_features_title =>
-      'Features of Open Products Facts';
+      'Características de Open Products Facts';
 
   @override
   String get guide_open_products_facts_features_text =>
@@ -5872,21 +5874,21 @@ class AppLocalizationsEs extends AppLocalizations {
   String get preferences_faq_discover_project_title => 'Descubre el proyecto';
 
   @override
-  String get preferences_faq_discover_off_title => 'Discover Open Food Facts';
+  String get preferences_faq_discover_off_title => 'Descubra Open Food Facts';
 
   @override
-  String get preferences_faq_discover_obf_title => 'Discover Open Beauty Facts';
+  String get preferences_faq_discover_obf_title => 'Descubre Open Beauty Facts';
 
   @override
   String get preferences_faq_discover_opff_title =>
-      'Discover Open Pet Food Facts';
+      'Descubre Open Pet Food Facts';
 
   @override
   String get preferences_faq_discover_op_title => 'Descubra Open Prices';
 
   @override
   String get preferences_faq_discover_opf_title =>
-      'Discover Open Products Facts';
+      'Descubra Open Products Facts';
 
   @override
   String get preferences_faq_faq_title => 'FAQ - Preguntas frecuentes';
@@ -5914,7 +5916,7 @@ class AppLocalizationsEs extends AppLocalizations {
       'Participe asistiendo a uno de nuestros eventos virtuales';
 
   @override
-  String get preferences_connect_blog_title => 'The Open Food Facts blog';
+  String get preferences_connect_blog_title => 'El blog de Open Food Facts';
 
   @override
   String get preferences_connect_blog_subtitle =>

--- a/packages/smooth_app/lib/l10n/app_localizations_et.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_et.dart
@@ -656,6 +656,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get unknownBrand => 'Tundmatu kaubamärk';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Tundmatu tootenimi';
 
   @override
@@ -2981,7 +2984,7 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
-  String get prices_menu_know_more => 'Know more about Open Prices';
+  String get prices_menu_know_more => 'Lisateave avatud hindade kohta';
 
   @override
   String get dev_preferences_import_history_result_success => 'Valmis';
@@ -3532,7 +3535,7 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Serveri toimingute teostamise alustamine lokaalselt salvestatud folksonomy värskenduste jaoks';
 
   @override
   String get background_task_title_top_n =>
@@ -4042,7 +4045,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get nutriscore_a => 'Nutri-Score A';
 
   @override
-  String get nutriscore_b => 'Nutri-Score B';
+  String get nutriscore_b => 'Nutri-skoor B';
 
   @override
   String get nutriscore_c => 'Nutri-Score C';
@@ -4062,7 +4065,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get nutriscore_new_formula_title => 'Nutri-Score (uus arvutus)';
 
   @override
-  String get nutriscore_unknown => 'Unknown Nutri-Score';
+  String get nutriscore_unknown => 'Tundmatu toiteväärtus';
 
   @override
   String get nutriscore_unknown_new_formula =>
@@ -4126,7 +4129,7 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get faq_title_vision =>
-      'The Open Food Facts Vision, Mission, Values and Programs';
+      'Avatud toidufaktide visioon, missioon, väärtused ja programmid';
 
   @override
   String get faq_title_install_beauty =>
@@ -4603,7 +4606,7 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_title =>
-      'What is Open Food Facts?';
+      'Mis on avatud toidufaktid?';
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_paragraph1 =>
@@ -4615,7 +4618,7 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get guide_open_food_facts_features_title =>
-      'Features of Open Food Facts';
+      'Avatud toidufaktide omadused';
 
   @override
   String get guide_open_food_facts_features_arg1_title =>
@@ -4686,7 +4689,7 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_title =>
-      'What is Open Pet Food Facts?';
+      'Mis on avatud lemmikloomatoidu faktid?';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_paragraph1 =>
@@ -4698,7 +4701,7 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get guide_open_pet_food_facts_features_title =>
-      'Features of Open Pet Food Facts';
+      'Avatud lemmikloomatoidu faktide omadused';
 
   @override
   String get guide_open_pet_food_facts_features_arg1_title =>
@@ -4768,7 +4771,7 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_title =>
-      'What is Open Beauty Facts?';
+      'Mis on avatud ilufaktid?';
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_paragraph1 =>
@@ -4780,7 +4783,7 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get guide_open_beauty_facts_features_title =>
-      'Features of Open Beauty Facts';
+      'Avatud ilufaktide omadused';
 
   @override
   String get guide_open_beauty_facts_features_arg1_title =>
@@ -4852,11 +4855,11 @@ class AppLocalizationsEt extends AppLocalizations {
       'https://world-et.openbeautyfacts.org/discover';
 
   @override
-  String get guide_open_prices_title => 'Welcome to Open Prices!';
+  String get guide_open_prices_title => 'Tere tulemast avatud hindadesse!';
 
   @override
   String get guide_open_prices_what_is_open_prices_title =>
-      'What is Open Prices?';
+      'Mis on avatud hinnad?';
 
   @override
   String get guide_open_prices_what_is_open_prices_paragraph1 =>
@@ -4867,7 +4870,7 @@ class AppLocalizationsEt extends AppLocalizations {
       'There are currently few companies that own large databases of product prices at the barcode level. These prices are not freely available, but sold at a high price to private actors, researchers and other organizations that can afford them.';
 
   @override
-  String get guide_open_prices_how_title => 'How does Open Prices work?';
+  String get guide_open_prices_how_title => 'Kuidas avatud hinnad toimivad?';
 
   @override
   String get guide_open_prices_how_paragraph1 =>
@@ -4907,7 +4910,7 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get guide_open_prices_scrapping_paragraph1 =>
-      'For legal and technical reasons, **we don\'t consider scraping prices from retailers\' websites as a valid way to contribute to Open Prices**. We want to make sure that the prices we collect are accurate and up-to-date, and receiving scraped prices from contributors doesn\'t allow us to do that.';
+      'Juriidilistel ja tehnilistel põhjustel **ei pea me jaemüüjate veebisaitidelt hindade kopeerimist kehtivaks viisiks avatud hindade avaldamiseks**. Soovime veenduda, et meie kogutud hinnad on täpsed ja ajakohased ning kaastööliste käest kopeeritud hindade saamine ei võimalda meil seda teha.';
 
   @override
   String get guide_open_prices_scrapping_paragraph2 =>
@@ -4931,7 +4934,7 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_title =>
-      'What is Open Products Facts?';
+      'Mis on avatud tootefaktid?';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_paragraph1 =>
@@ -4943,7 +4946,7 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get guide_open_products_facts_features_title =>
-      'Features of Open Products Facts';
+      'Avatud toodete faktide omadused';
 
   @override
   String get guide_open_products_facts_features_text =>
@@ -5680,7 +5683,7 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get preferences_on_off_website_subtitle =>
-      'On the Open Food Facts website';
+      'Avatud toidufaktide veebisaidil';
 
   @override
   String get preferences_manage_account_title => 'Halda minu kontot';
@@ -5796,7 +5799,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get preferences_faq_faq_title => 'KKK - Korduma kippuvad küsimused';
 
   @override
-  String get preferences_faq_off_ngo_title => 'The Open Food Facts NGO';
+  String get preferences_faq_off_ngo_title => 'Avatud toidufaktide vabaühendus';
 
   @override
   String get preferences_about_information_title => 'Informatsioon';
@@ -5818,7 +5821,7 @@ class AppLocalizationsEt extends AppLocalizations {
       'Osale ühel meie virtuaalsel üritusel';
 
   @override
-  String get preferences_connect_blog_title => 'The Open Food Facts blog';
+  String get preferences_connect_blog_title => 'Avatud toidufaktide ajaveeb';
 
   @override
   String get preferences_connect_blog_subtitle =>

--- a/packages/smooth_app/lib/l10n/app_localizations_et.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_et.dart
@@ -656,7 +656,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get unknownBrand => 'Tundmatu kaubamärk';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Tundmatu tootenimi';

--- a/packages/smooth_app/lib/l10n/app_localizations_eu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_eu.dart
@@ -656,7 +656,7 @@ class AppLocalizationsEu extends AppLocalizations {
   String get unknownBrand => 'Marka ezezaguna';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Produktu-izen ezezaguna';

--- a/packages/smooth_app/lib/l10n/app_localizations_eu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_eu.dart
@@ -656,6 +656,9 @@ class AppLocalizationsEu extends AppLocalizations {
   String get unknownBrand => 'Marka ezezaguna';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Produktu-izen ezezaguna';
 
   @override
@@ -3528,7 +3531,7 @@ class AppLocalizationsEu extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Tokikoki gordetako folksonomy eguneratzeetarako zerbitzariaren ekintzak egiten hasten da';
 
   @override
   String get background_task_title_top_n =>
@@ -5823,7 +5826,7 @@ class AppLocalizationsEu extends AppLocalizations {
       'Parte hartu gure ekitaldi birtualetako batean parte hartuz';
 
   @override
-  String get preferences_connect_blog_title => 'The Open Food Facts blog';
+  String get preferences_connect_blog_title => 'Elikagaien Datu Irekien bloga';
 
   @override
   String get preferences_connect_blog_subtitle =>
@@ -6152,7 +6155,7 @@ class AppLocalizationsEu extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Ekarri Janari Informazio Irekia zure hizkuntzara';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_fa.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_fa.dart
@@ -653,6 +653,9 @@ class AppLocalizationsFa extends AppLocalizations {
   String get unknownBrand => 'مارک ناشناس';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'نام محصول ناشناخته است';
 
   @override
@@ -3517,7 +3520,7 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'شروع به انجام اقدامات سرور برای به‌روزرسانی‌های folksonomy که به صورت محلی ذخیره شده‌اند، می‌کند.';
 
   @override
   String get background_task_title_top_n =>
@@ -5607,7 +5610,7 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String get preferences_legal_header =>
-      'Open Food Facts is a food products database **made by everyone, for everyone**.\nYou can use it to make better food choices, and as it is **open data**, anyone can **re-use it for any purpose**.';
+      'اطلاعات عمومی غذا یک پایگاه داده محصولات غذایی است **که توسط همه و برای همه ساخته شده است**.\nشما می‌توانید از آن برای انتخاب‌های غذایی بهتر استفاده کنید و از آنجایی که **داده‌های باز** است، هر کسی می‌تواند **از آن برای هر هدفی دوباره استفاده کند**.';
 
   @override
   String get preferences_privacy_policy => 'Privacy policy';
@@ -5654,11 +5657,11 @@ class AppLocalizationsFa extends AppLocalizations {
   String get preferences_tips => 'نکات';
 
   @override
-  String get tips_discover_nutriscore => 'Discover the new Nutri-Score';
+  String get tips_discover_nutriscore => 'با نوتری-اسکور جدید آشنا شوید';
 
   @override
   String get preferences_on_off_website_subtitle =>
-      'On the Open Food Facts website';
+      'در وب‌سایت حقایق غذایی آزاد';
 
   @override
   String get preferences_manage_account_title => 'مدیریت حساب من';
@@ -5771,7 +5774,8 @@ class AppLocalizationsFa extends AppLocalizations {
   String get preferences_faq_faq_title => 'سوالات متداول - سوالات متداول';
 
   @override
-  String get preferences_faq_off_ngo_title => 'The Open Food Facts NGO';
+  String get preferences_faq_off_ngo_title =>
+      'سازمان مردم نهاد حقایق غذایی آزاد';
 
   @override
   String get preferences_about_information_title => 'اطلاعات';
@@ -5793,7 +5797,7 @@ class AppLocalizationsFa extends AppLocalizations {
       'با شرکت در یکی از رویدادهای مجازی ما، مشارکت کنید';
 
   @override
-  String get preferences_connect_blog_title => 'The Open Food Facts blog';
+  String get preferences_connect_blog_title => 'وبلاگ حقایق غذای آزاد';
 
   @override
   String get preferences_connect_blog_subtitle =>
@@ -5934,7 +5938,7 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String get preferences_contributions_categorize_subtitle =>
-      'Help compute the Nutri-Score & Green-Score in your country';
+      'به محاسبه امتیاز تغذیه‌ای و امتیاز سبز در کشور خود کمک کنید';
 
   @override
   String get preferences_prices_user_prices_subtitle =>
@@ -6118,7 +6122,7 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'حقایق غذایی آزاد را به زبان خود بیاورید';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_fa.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_fa.dart
@@ -653,7 +653,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get unknownBrand => 'مارک ناشناس';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'نام محصول ناشناخته است';

--- a/packages/smooth_app/lib/l10n/app_localizations_fi.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_fi.dart
@@ -657,7 +657,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get unknownBrand => 'Tuntematon tuotemerkki';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Tuntematon tuotenimi';

--- a/packages/smooth_app/lib/l10n/app_localizations_fi.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_fi.dart
@@ -657,6 +657,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get unknownBrand => 'Tuntematon tuotemerkki';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Tuntematon tuotenimi';
 
   @override
@@ -1368,7 +1371,7 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get product_improvement_categories_but_no_nutriscore =>
-      'The Nutri-Score for this product can\'t be calculated, which may be due to e.g. a non-standard category. If this is considered an error, please contact us.';
+      'Nutri-pisteytystä ei voi laskea. Syynä voi olla esimerkiksi epätavallinen luokka. Ota yhteyttä, mikäli oletat tämän olevan virhe.';
 
   @override
   String get product_improvement_obsolete_nutrition_image =>
@@ -3516,7 +3519,7 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Paikallisesti tallennetuille folksonomy-päivityksille suoritetaan palvelintoimintoja.';
 
   @override
   String get background_task_title_top_n =>
@@ -6127,7 +6130,7 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Tuo avoimet ruokatiedot omalle kielellesi';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_fo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_fo.dart
@@ -653,7 +653,7 @@ class AppLocalizationsFo extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_fo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_fo.dart
@@ -653,6 +653,9 @@ class AppLocalizationsFo extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_fr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_fr.dart
@@ -218,7 +218,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get help_improve_country =>
-      'Help improve Open Food Facts in your country';
+      'Aidez-nous à améliorer Open Food Facts dans votre pays';
 
   @override
   String get sign_out => 'Se déconnecter';
@@ -670,6 +670,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get unknownBrand => 'Marque inconnue';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Produit inconnu';
 
   @override
@@ -739,11 +742,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Modifier les informations nutritionnelles';
 
   @override
-  String get packaging_information => 'Informations sur l\'emballage';
+  String get packaging_information => 'Consignes de tri / recyclage';
 
   @override
-  String get packaging_information_photo =>
-      'Photo des informations sur l\'emballage';
+  String get packaging_information_photo => 'Consignes de tri ou recyclage';
 
   @override
   String get missing_product => 'Vous avez trouvé un nouveau produit !';
@@ -848,7 +850,7 @@ class AppLocalizationsFr extends AppLocalizations {
       'Photo des valeurs nutritionnelles';
 
   @override
-  String get recycling_photo_title => 'Photo du recyclage';
+  String get recycling_photo_title => 'Photo des consignes de tri ou recyclage';
 
   @override
   String get take_photo_title => 'Prendre une photo';
@@ -3603,7 +3605,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Démarrage des actions serveur pour les mises à jour de folksonomie stockées localement';
 
   @override
   String get background_task_title_top_n =>
@@ -5331,7 +5333,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get photo_field_nutrition => 'Informations nutritionnelles';
 
   @override
-  String get photo_field_packaging => 'Photo des informations sur l\'emballage';
+  String get photo_field_packaging => 'Photo des consignes de tri/recyclage';
 
   @override
   String get photo_already_exists => 'Cette photo existe déjà';
@@ -6141,7 +6143,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get preferences_page_contribute_project_subtitle =>
-      'Simple ways to help Open Food Facts';
+      'Des moyens simples pour aider Open Food Facts';
 
   @override
   String get preferences_page_faq_subtitle =>
@@ -6256,7 +6258,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Traduire Open Food Facts dans votre langue';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_fr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_fr.dart
@@ -670,7 +670,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get unknownBrand => 'Marque inconnue';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Produit inconnu';

--- a/packages/smooth_app/lib/l10n/app_localizations_ga.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ga.dart
@@ -654,6 +654,9 @@ class AppLocalizationsGa extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3524,7 +3527,7 @@ class AppLocalizationsGa extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Ag tosú ag déanamh gníomhartha an fhreastalaí le haghaidh nuashonruithe folksonomy atá stóráilte go háitiúil';
 
   @override
   String get background_task_title_top_n =>
@@ -5667,7 +5670,7 @@ class AppLocalizationsGa extends AppLocalizations {
   String get preferences_tips => 'Leideanna';
 
   @override
-  String get tips_discover_nutriscore => 'Discover the new Nutri-Score';
+  String get tips_discover_nutriscore => 'Faigh amach an Scór Cothaithe nua';
 
   @override
   String get preferences_on_off_website_subtitle =>
@@ -5787,7 +5790,8 @@ class AppLocalizationsGa extends AppLocalizations {
       'Ceisteanna Coitianta - Ceisteanna Coitianta';
 
   @override
-  String get preferences_faq_off_ngo_title => 'The Open Food Facts NGO';
+  String get preferences_faq_off_ngo_title =>
+      'An Eagraíocht Neamhrialtasach Fíricí Bia Oscailte';
 
   @override
   String get preferences_about_information_title => 'Eolas';
@@ -5809,7 +5813,7 @@ class AppLocalizationsGa extends AppLocalizations {
       'Bí páirteach trí fhreastal ar cheann dár n-imeachtaí fíorúla';
 
   @override
-  String get preferences_connect_blog_title => 'The Open Food Facts blog';
+  String get preferences_connect_blog_title => 'Blag Fíricí Bia Oscailte';
 
   @override
   String get preferences_connect_blog_subtitle =>
@@ -6138,7 +6142,7 @@ class AppLocalizationsGa extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Tabhair Fíricí Bia Oscailte chuig do theanga';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_ga.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ga.dart
@@ -654,7 +654,7 @@ class AppLocalizationsGa extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_gd.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_gd.dart
@@ -654,7 +654,7 @@ class AppLocalizationsGd extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_gd.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_gd.dart
@@ -654,6 +654,9 @@ class AppLocalizationsGd extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3523,7 +3526,7 @@ class AppLocalizationsGd extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'A’ tòiseachadh air gnìomhan an fhrithealaiche a dhèanamh airson ùrachaidhean folksonomy a tha air an stòradh gu h-ionadail';
 
   @override
   String get background_task_title_top_n =>
@@ -5798,7 +5801,7 @@ class AppLocalizationsGd extends AppLocalizations {
       'Ceistean Bitheanta - Ceistean Bitheanta';
 
   @override
-  String get preferences_faq_off_ngo_title => 'The Open Food Facts NGO';
+  String get preferences_faq_off_ngo_title => 'NGO Fiosrachadh Biadh Fosgailte';
 
   @override
   String get preferences_about_information_title => 'Information';
@@ -5820,7 +5823,8 @@ class AppLocalizationsGd extends AppLocalizations {
       'Gabh pàirt le bhith an làthair aig aon de na tachartasan brìgheil againn';
 
   @override
-  String get preferences_connect_blog_title => 'The Open Food Facts blog';
+  String get preferences_connect_blog_title =>
+      'Am blog Fiosrachadh Biadh Fosgailte';
 
   @override
   String get preferences_connect_blog_subtitle =>
@@ -6150,7 +6154,7 @@ class AppLocalizationsGd extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Thoir Fiosrachadh Biadh Fosgailte don chànan agad';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_gl.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_gl.dart
@@ -654,7 +654,7 @@ class AppLocalizationsGl extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_gl.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_gl.dart
@@ -654,6 +654,9 @@ class AppLocalizationsGl extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3522,7 +3525,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Comezando a executar as accións do servidor para as actualizacións de folksonomía almacenadas localmente';
 
   @override
   String get background_task_title_top_n =>
@@ -4067,7 +4070,7 @@ class AppLocalizationsGl extends AppLocalizations {
   String get environmental_score_generic_new => 'Green-Score';
 
   @override
-  String get environmental_score_a_new => 'Puntuación verde A';
+  String get environmental_score_a_new => 'Green-Score A';
 
   @override
   String get environmental_score_b_new => 'Green-Score B';
@@ -4082,11 +4085,11 @@ class AppLocalizationsGl extends AppLocalizations {
   String get environmental_score_e_new => 'Green-Score E';
 
   @override
-  String get environmental_score_unknown_new => 'Puntuación verde descoñecida';
+  String get environmental_score_unknown_new => 'Green-Score descoñecida';
 
   @override
   String get environmental_score_not_applicable_new =>
-      'A puntuación verde non é aplicable';
+      'A Green-Score non é aplicable';
 
   @override
   String get nova_group_generic_new =>
@@ -4480,7 +4483,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String get guide_greenscore_better_product_arg4_text =>
-      'A diferenza das etiquetas propietarias, o cálculo da puntuación verde é **completamente aberto** e calquera pode **verificalo**.';
+      'A diferenza das etiquetas propietarias, o cálculo da Green-Score é **completamente aberto** e calquera pode **verificalo**.';
 
   @override
   String get guide_nova_title => 'Ultra-processed foods';
@@ -5957,7 +5960,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String get preferences_contributions_categorize_subtitle =>
-      'Help compute the Nutri-Score & Green-Score in your country';
+      'Axuda a calcular a Nutri-Score e a Green-Score no teu país';
 
   @override
   String get preferences_prices_user_prices_subtitle => 'Prezos que aportei';

--- a/packages/smooth_app/lib/l10n/app_localizations_gu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_gu.dart
@@ -653,6 +653,9 @@ class AppLocalizationsGu extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3519,7 +3522,7 @@ class AppLocalizationsGu extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'સ્થાનિક રીતે સંગ્રહિત ફોલ્કસોનોમી અપડેટ્સ માટે સર્વર ક્રિયાઓ કરવાનું શરૂ કરી રહ્યા છીએ';
 
   @override
   String get background_task_title_top_n =>
@@ -5581,7 +5584,7 @@ class AppLocalizationsGu extends AppLocalizations {
 
   @override
   String get preferences_app_bar_search_hint =>
-      'Search for a setting (e.g. Nutri-Score)';
+      'સેટિંગ શોધો (દા.ત. ન્યુટ્રી-સ્કોર)';
 
   @override
   String get preferences_accessibility_show_emoji =>
@@ -5658,7 +5661,7 @@ class AppLocalizationsGu extends AppLocalizations {
   String get preferences_tips => 'ટિપ્સ';
 
   @override
-  String get tips_discover_nutriscore => 'Discover the new Nutri-Score';
+  String get tips_discover_nutriscore => 'નવા ન્યુટ્રી-સ્કોર શોધો';
 
   @override
   String get preferences_on_off_website_subtitle =>
@@ -5747,7 +5750,7 @@ class AppLocalizationsGu extends AppLocalizations {
 
   @override
   String get preferences_faq_nutriscore_subtitle =>
-      'Discover how the Nutri-Score is computed';
+      'ન્યુટ્રી-સ્કોરની ગણતરી કેવી રીતે થાય છે તે શોધો';
 
   @override
   String get preferences_faq_nutriscore_v2_subtitle =>
@@ -5941,7 +5944,7 @@ class AppLocalizationsGu extends AppLocalizations {
 
   @override
   String get preferences_contributions_categorize_subtitle =>
-      'Help compute the Nutri-Score & Green-Score in your country';
+      'તમારા દેશમાં ન્યુટ્રી-સ્કોર અને ગ્રીન-સ્કોરની ગણતરી કરવામાં મદદ કરો';
 
   @override
   String get preferences_prices_user_prices_subtitle => 'મેં ફાળો આપેલા ભાવો';
@@ -5962,7 +5965,7 @@ class AppLocalizationsGu extends AppLocalizations {
 
   @override
   String get preferences_prices_newest_subtitle =>
-      'Latest prices added by the Open Prices community';
+      'ઓપન પ્રાઈસ સમુદાય દ્વારા ઉમેરવામાં આવેલી નવીનતમ કિંમતો';
 
   @override
   String get preferences_prices_top_contributors_title =>
@@ -6010,7 +6013,7 @@ class AppLocalizationsGu extends AppLocalizations {
 
   @override
   String get preferences_page_contribute_project_subtitle =>
-      'Simple ways to help Open Food Facts';
+      'ખોરાકની હકીકતો ખોલવામાં મદદ કરવાની સરળ રીતો';
 
   @override
   String get preferences_page_faq_subtitle =>
@@ -6124,7 +6127,7 @@ class AppLocalizationsGu extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'તમારી ભાષામાં ખુલ્લા ખોરાકના તથ્યો લાવો';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_gu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_gu.dart
@@ -653,7 +653,7 @@ class AppLocalizationsGu extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_ha.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ha.dart
@@ -653,7 +653,7 @@ class AppLocalizationsHa extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_ha.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ha.dart
@@ -653,6 +653,9 @@ class AppLocalizationsHa extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3520,7 +3523,7 @@ class AppLocalizationsHa extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Fara aiwatar da ayyukan uwar garken don sabuntawar jama\'a da aka adana a gida';
 
   @override
   String get background_task_title_top_n =>
@@ -5308,7 +5311,7 @@ class AppLocalizationsHa extends AppLocalizations {
 
   @override
   String get prices_explanation_card_line1 =>
-      '**Open Prices** is a project to collect and share prices of products around the world 🌍. Open Prices is developed and maintained by Open Food Facts.';
+      '**Open Prices** shiri ne na tarawa da raba farashin kayayyaki a duniya 🌍. Buɗaɗɗen Farashi an haɓaka kuma ana kiyaye shi ta Buɗewar Bayanan Abinci.';
 
   @override
   String get explanation_card_learn_more_button => 'Learn more';
@@ -5614,7 +5617,7 @@ class AppLocalizationsHa extends AppLocalizations {
 
   @override
   String get preferences_legal_header =>
-      'Open Food Facts is a food products database **made by everyone, for everyone**.\nYou can use it to make better food choices, and as it is **open data**, anyone can **re-use it for any purpose**.';
+      'Bude Facts Abinci shine bayanan samfuran abinci ** wanda kowa yayi, ga kowa da kowa**.\nKuna iya amfani da shi don yin zaɓin abinci mafi kyau, kuma kamar yadda yake **buɗaɗɗen bayanai**, kowa zai iya **sake amfani da shi don kowane dalili**.';
 
   @override
   String get preferences_privacy_policy => 'Privacy policy';
@@ -5665,7 +5668,7 @@ class AppLocalizationsHa extends AppLocalizations {
 
   @override
   String get preferences_on_off_website_subtitle =>
-      'On the Open Food Facts website';
+      'A kan Buɗaɗɗen Bayanan Bayanan Abinci';
 
   @override
   String get preferences_manage_account_title => 'Sarrafa asusuna';
@@ -5780,7 +5783,7 @@ class AppLocalizationsHa extends AppLocalizations {
   String get preferences_faq_faq_title => 'FAQ - Tambayoyin da ake yawan yi';
 
   @override
-  String get preferences_faq_off_ngo_title => 'The Open Food Facts NGO';
+  String get preferences_faq_off_ngo_title => 'Budaddiyar Facts Food Facts NGO';
 
   @override
   String get preferences_about_information_title => 'Information';
@@ -5802,7 +5805,7 @@ class AppLocalizationsHa extends AppLocalizations {
       'Shiga ta hanyar halartar ɗaya daga cikin abubuwan da suka faru na kama-da-wane';
 
   @override
-  String get preferences_connect_blog_title => 'The Open Food Facts blog';
+  String get preferences_connect_blog_title => 'Budaddiyar Bayanan Abinci';
 
   @override
   String get preferences_connect_blog_subtitle =>
@@ -5963,7 +5966,7 @@ class AppLocalizationsHa extends AppLocalizations {
 
   @override
   String get preferences_prices_newest_subtitle =>
-      'Latest prices added by the Open Prices community';
+      'Sabbin farashin da jama\'ar Buɗaɗɗen Farashin suka ƙara';
 
   @override
   String get preferences_prices_top_contributors_title =>
@@ -6124,7 +6127,7 @@ class AppLocalizationsHa extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Kawo Budaddiyar Bayanan Abinci zuwa harshenka';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_he.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_he.dart
@@ -641,6 +641,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String get unknownBrand => 'מותג לא ידוע';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'שם המוצר אינו ידוע';
 
   @override
@@ -3507,7 +3510,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'מתחיל לבצע את פעולות השרת עבור עדכוני פולקסונומיה המאוחסנים באופן מקומי';
 
   @override
   String get background_task_title_top_n =>
@@ -5278,7 +5281,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get prices_explanation_card_line1 =>
-      '**Open Prices** is a project to collect and share prices of products around the world 🌍. Open Prices is developed and maintained by Open Food Facts.';
+      '**Prices פתוחים** הוא פרויקט לאיסוף ושיתוף מחירים של מוצרים ברחבי העולם 🌍. Prices פתוחים פותח ומתוחזק על ידי Open Food Facts.';
 
   @override
   String get explanation_card_learn_more_button => 'מידע נוסף';
@@ -5738,7 +5741,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get preferences_faq_faq_title => 'שאלות נפוצות - שאלות נפוצות';
 
   @override
-  String get preferences_faq_off_ngo_title => 'The Open Food Facts NGO';
+  String get preferences_faq_off_ngo_title => 'עמותת \"עובדות על אוכל פתוח\"';
 
   @override
   String get preferences_about_information_title => 'פרטים';
@@ -5759,7 +5762,7 @@ class AppLocalizationsHe extends AppLocalizations {
       'הצטרפו אלינו באחד מהאירועים הווירטואליים שלנו';
 
   @override
-  String get preferences_connect_blog_title => 'The Open Food Facts blog';
+  String get preferences_connect_blog_title => 'הבלוג של עובדות המזון הפתוחות';
 
   @override
   String get preferences_connect_blog_subtitle =>
@@ -6068,14 +6071,14 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get preferences_page_open_food_facts_labs_title =>
-      'מעבדות Open Food Facts';
+      'Open Food Facts Labs';
 
   @override
   String get preferences_root_account_title => 'חשבון';
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'הביאו עובדות פתוחות על מזון לשפה שלכם';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_he.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_he.dart
@@ -641,7 +641,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get unknownBrand => 'מותג לא ידוע';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'שם המוצר אינו ידוע';

--- a/packages/smooth_app/lib/l10n/app_localizations_hi.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_hi.dart
@@ -216,7 +216,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get help_improve_country =>
-      'Help improve Open Food Facts in your country';
+      'अपने देश में ओपन फ़ूड फैक्ट्स को बेहतर बनाने में मदद करें';
 
   @override
   String get sign_out => 'साइन आउट';
@@ -492,7 +492,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get contribute_join_skill_pool =>
-      'Contribute your skills to Open Food Facts. Join the skill pool!';
+      'ओपन फ़ूड फ़ैक्ट्स में अपने कौशल का योगदान दें। कौशल पूल में शामिल हों!';
 
   @override
   String get contribute_share_header =>
@@ -658,6 +658,9 @@ class AppLocalizationsHi extends AppLocalizations {
   String get unknownBrand => 'अज्ञात ब्रांड';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'अज्ञात उत्पाद का नाम';
 
   @override
@@ -769,7 +772,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get new_product_dialog_illustration_description =>
-      'An illustration with unknown Nutri-Score and Green Score';
+      'अज्ञात न्यूट्री-स्कोर और ग्रीन स्कोर के साथ एक चित्रण';
 
   @override
   String get front_packaging_photo_button_label =>
@@ -865,7 +868,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get categories_added => 'श्रेणियाँ जोड़ी गईं';
 
   @override
-  String get new_product_title_nutriscore => 'Compute the Nutri-Score';
+  String get new_product_title_nutriscore => 'न्यूट्री-स्कोर की गणना करें';
 
   @override
   String get new_product_subtitle_nutriscore =>
@@ -899,7 +902,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get new_product_title_pictures_details =>
-      'Please take the following photos and the Open Food Facts engine can work out the rest!';
+      'कृपया निम्नलिखित तस्वीरें लें और ओपन फूड फैक्ट्स इंजन बाकी का पता लगा लेगा!';
 
   @override
   String get new_product_title_misc => 'और कुछ बुनियादी डेटा…';
@@ -917,7 +920,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get hey_incomplete_product_message =>
-      'Tap to answer 3 questions NOW to compute Nutri-Score, Green Score & Ultra-processing (NOVA)!';
+      'न्यूट्री-स्कोर, ग्रीन स्कोर और अल्ट्रा-प्रोसेसिंग (नोवा) की गणना करने के लिए अभी 3 प्रश्नों के उत्तर देने के लिए टैप करें!';
 
   @override
   String get hey_incomplete_product_message_beauty =>
@@ -1358,19 +1361,19 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get product_improvement_add_category =>
-      'Add a category to calculate the Nutri-Score.';
+      'न्यूट्री-स्कोर की गणना करने के लिए एक श्रेणी जोड़ें।';
 
   @override
   String get product_improvement_add_nutrition_facts =>
-      'Add nutrition facts to calculate the Nutri-Score.';
+      'न्यूट्री-स्कोर की गणना करने के लिए पोषण संबंधी तथ्य जोड़ें।';
 
   @override
   String get product_improvement_add_nutrition_facts_and_category =>
-      'Add nutrition facts and a category to calculate the Nutri-Score.';
+      'न्यूट्री-स्कोर की गणना करने के लिए पोषण संबंधी तथ्य और एक श्रेणी जोड़ें।';
 
   @override
   String get product_improvement_categories_but_no_nutriscore =>
-      'The Nutri-Score for this product can\'t be calculated, which may be due to e.g. a non-standard category. If this is considered an error, please contact us.';
+      'इस उत्पाद के लिए न्यूट्री-स्कोर की गणना नहीं की जा सकती, जो कि गैर-मानक श्रेणी के कारण हो सकता है। अगर इसे त्रुटि माना जाता है, तो कृपया हमसे संपर्क करें।';
 
   @override
   String get product_improvement_obsolete_nutrition_image =>
@@ -1953,7 +1956,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get edit_product_form_item_labels_explanation_good_examples_1 =>
-      'Nutri-Score, NOVA…';
+      'न्यूट्री-स्कोर, नोवा…';
 
   @override
   String get edit_product_form_item_labels_explanation_good_examples_2 =>
@@ -2937,7 +2940,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get prices_privacy_warning_main_message =>
-      'Prices **will be public**, along with the store they refer to.\n\nThat might allow people who know about your Open Food Facts pseudonym to:\n';
+      'कीमतें **सार्वजनिक होंगी**, साथ ही वे जिस स्टोर का उल्लेख करती हैं उसकी जानकारी भी।\n\nइससे आपके ओपन फ़ूड फैक्ट्स छद्म नाम के बारे में जानने वाले लोगों को यह करने में मदद मिल सकती है:\n';
 
   @override
   String get prices_privacy_warning_message_bullet_1 =>
@@ -2949,7 +2952,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get prices_privacy_warning_sub_message =>
-      'If you are uneasy with that, please change your pseudonym, or create a new Open Food Facts account and log into the app with it.';
+      'यदि आप इससे असहज हैं, तो कृपया अपना छद्म नाम बदलें, या एक नया ओपन फूड फैक्ट्स अकाउंट बनाएं और उसके साथ ऐप में लॉग इन करें।';
 
   @override
   String get i_refuse => 'मैंने मना कर दिया';
@@ -2979,7 +2982,7 @@ class AppLocalizationsHi extends AppLocalizations {
   }
 
   @override
-  String get prices_menu_know_more => 'Know more about Open Prices';
+  String get prices_menu_know_more => 'खुली कीमतों के बारे में अधिक जानें';
 
   @override
   String get dev_preferences_import_history_result_success => 'हो गया';
@@ -3532,7 +3535,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'स्थानीय रूप से संग्रहीत फोल्क्सोनॉमी अपडेट के लिए सर्वर क्रियाएँ निष्पादित करना प्रारंभ करना';
 
   @override
   String get background_task_title_top_n =>
@@ -4060,18 +4063,18 @@ class AppLocalizationsHi extends AppLocalizations {
   String get nutriscore_new_formula_title => 'Nutri-Score (नई गणना)';
 
   @override
-  String get nutriscore_unknown => 'Unknown Nutri-Score';
+  String get nutriscore_unknown => 'अज्ञात न्यूट्री-स्कोर';
 
   @override
   String get nutriscore_unknown_new_formula =>
-      'Unknown Nutri-Score (New calculation)';
+      'अज्ञात न्यूट्री-स्कोर (नई गणना)';
 
   @override
-  String get nutriscore_not_applicable => 'Nutri-Score is not applicable';
+  String get nutriscore_not_applicable => 'न्यूट्री-स्कोर लागू नहीं है';
 
   @override
   String get nutriscore_not_applicable_new_formula =>
-      'Nutri-Score is not applicable (New calculation)';
+      'न्यूट्री-स्कोर लागू नहीं है (नई गणना)';
 
   @override
   String get environmental_score_generic_new => 'Green-Score';
@@ -4125,27 +4128,27 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get faq_title_vision =>
-      'The Open Food Facts Vision, Mission, Values and Programs';
+      'ओपन फ़ूड फैक्ट्स विजन, मिशन, मूल्य और कार्यक्रम';
 
   @override
   String get faq_title_install_beauty =>
-      'Install Open Beauty Facts to create a cosmetic database';
+      'कॉस्मेटिक डेटाबेस बनाने के लिए ओपन ब्यूटी फैक्ट्स इंस्टॉल करें';
 
   @override
   String get faq_title_install_pet =>
-      'Install Open Pet Food Facts to create a pet food database';
+      'पालतू पशुओं के भोजन का डेटाबेस बनाने के लिए ओपन पेट फ़ूड फैक्ट्स इंस्टॉल करें';
 
   @override
   String get faq_title_install_product =>
-      'Install Open Products Facts to create a products database to extend the life of objects';
+      'वस्तुओं का जीवन बढ़ाने के लिए उत्पाद डेटाबेस बनाने हेतु ओपन प्रोडक्ट्स फैक्ट्स स्थापित करें';
 
   @override
   String get faq_nutriscore_nutriscore =>
-      'New calculation of the Nutri-Score: what\'s new?';
+      'न्यूट्री-स्कोर की नई गणना: क्या नया है?';
 
   @override
   String get contact_title_pro_page =>
-      'Pro? Import your products in Open Food Facts';
+      'प्रो? अपने उत्पादों को ओपन फ़ूड फैक्ट्स में आयात करें';
 
   @override
   String get contact_title_pro_email => 'निर्माता संपर्क';
@@ -4278,11 +4281,11 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get guide_nutriscore_v2_where_title =>
-      'Where to find the new Nutri-Score calculation?';
+      'नया न्यूट्री-स्कोर गणना कहां मिलेगी?';
 
   @override
   String get guide_nutriscore_v2_where_paragraph1 =>
-      'The Nutri-Score is applied in 7 countries: France, Germany, Belgium, Spain, Luxembourg, the Netherlands and Switzerland.';
+      'न्यूट्री-स्कोर 7 देशों में लागू किया जाता है: फ्रांस, जर्मनी, बेल्जियम, स्पेन, लक्जमबर्ग, नीदरलैंड और स्विट्जरलैंड।';
 
   @override
   String get guide_nutriscore_v2_where_paragraph2 =>
@@ -4602,19 +4605,18 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_title =>
-      'What is Open Food Facts?';
+      'ओपन फूड फैक्ट्स क्या है?';
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_paragraph1 =>
-      'Open Food Facts is a **collaborative**, **free**, and **open** database of food products from around the world.';
+      'ओपन फूड फैक्ट्स दुनिया भर के खाद्य उत्पादों का एक सहयोगात्मक, निःशुल्क और खुला डेटाबेस है।';
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_paragraph2 =>
       'हमारा मानना है कि हर किसी को अपने खाने की जानकारी होनी चाहिए। सामग्री, एलर्जी, पोषण संबंधी तथ्यों और अन्य चीज़ों पर डेटा इकट्ठा करके, **हम उपभोक्ताओं को सूचित विकल्प चुनने में सक्षम बनाते हैं** और खाद्य उद्योग को **अधिक पारदर्शिता** की ओर ले जाते हैं।';
 
   @override
-  String get guide_open_food_facts_features_title =>
-      'Features of Open Food Facts';
+  String get guide_open_food_facts_features_title => 'खुले भोजन की विशेषताएं';
 
   @override
   String get guide_open_food_facts_features_arg1_title =>
@@ -4687,11 +4689,11 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_title =>
-      'What is Open Pet Food Facts?';
+      'ओपन पेट फ़ूड तथ्य क्या है?';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_paragraph1 =>
-      'Open Pet Food Facts extends our mission to our furry friends! It\'s a **database of pet food products for cats, dogs, and other companions**.';
+      'ओपन पेट फ़ूड फैक्ट्स हमारे मिशन को हमारे प्यारे दोस्तों तक बढ़ाता है! यह बिल्लियों, कुत्तों और अन्य पालतू जानवरों के लिए पालतू भोजन उत्पादों का एक डेटाबेस है।';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_paragraph2 =>
@@ -4699,7 +4701,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get guide_open_pet_food_facts_features_title =>
-      'Features of Open Pet Food Facts';
+      'खुले पालतू भोजन के तथ्य की विशेषताएं';
 
   @override
   String get guide_open_pet_food_facts_features_arg1_title =>
@@ -4768,11 +4770,11 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_title =>
-      'What is Open Beauty Facts?';
+      'ओपन ब्यूटी फैक्ट्स क्या है?';
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_paragraph1 =>
-      'Open Beauty Facts is a collaborative database of **cosmetic products**.';
+      'ओपन ब्यूटी फैक्ट्स कॉस्मेटिक उत्पादों का एक सहयोगी डेटाबेस है।';
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_paragraph2 =>
@@ -4780,7 +4782,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get guide_open_beauty_facts_features_title =>
-      'Features of Open Beauty Facts';
+      'ओपन ब्यूटी फैक्ट्स की विशेषताएं';
 
   @override
   String get guide_open_beauty_facts_features_arg1_title =>
@@ -4845,14 +4847,14 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get guide_open_beauty_facts_scores_paragraph1 =>
-      'Unlike food products, the world of cosmetics **does not have a universally recognized, government-backed scoring system like the Nutri-Score**. Ingredient effects can be highly personal and depend on skin type, allergies, and individual concerns.';
+      'खाद्य उत्पादों के विपरीत, सौंदर्य प्रसाधनों की दुनिया में **न्यूट्री-स्कोर** जैसी कोई सार्वभौमिक रूप से मान्यता प्राप्त, सरकार समर्थित स्कोरिंग प्रणाली नहीं है। अवयवों का प्रभाव अत्यधिक व्यक्तिगत हो सकता है और त्वचा के प्रकार, एलर्जी और व्यक्तिगत चिंताओं पर निर्भर करता है।';
 
   @override
   String get guide_open_beauty_facts_share_link =>
       'https://world-hi.openbeautyfacts.org/discover';
 
   @override
-  String get guide_open_prices_title => 'Welcome to Open Prices!';
+  String get guide_open_prices_title => 'ओपन प्राइसेस में आपका स्वागत है!';
 
   @override
   String get guide_open_prices_what_is_open_prices_title =>
@@ -4860,18 +4862,18 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get guide_open_prices_what_is_open_prices_paragraph1 =>
-      'Open Prices is a project to **collect and share prices of products around the world**. It\'s a publicly available dataset that can be used for research, analysis, and more. Open Prices is developed and maintained by Open Food Facts.';
+      'ओपन प्राइसेज़ दुनिया भर के उत्पादों की कीमतें एकत्रित करने और साझा करने की एक परियोजना है। यह एक सार्वजनिक रूप से उपलब्ध डेटासेट है जिसका उपयोग शोध, विश्लेषण आदि के लिए किया जा सकता है। ओपन प्राइसेज़ का विकास और रखरखाव ओपन फ़ूड फ़ैक्ट्स द्वारा किया जाता है।';
 
   @override
   String get guide_open_prices_what_is_open_prices_paragraph2 =>
       'There are currently few companies that own large databases of product prices at the barcode level. These prices are not freely available, but sold at a high price to private actors, researchers and other organizations that can afford them.';
 
   @override
-  String get guide_open_prices_how_title => 'How does Open Prices work?';
+  String get guide_open_prices_how_title => 'ओपन प्राइस कैसे काम करता है?';
 
   @override
   String get guide_open_prices_how_paragraph1 =>
-      '**We are crowdsourcing an open-source dataset of prices**. Prices can be added by users via this web app, or via the official Open Food Facts mobile app. Retailers or third-party apps can contribute as well by using our API.';
+      '**हम कीमतों का एक ओपन-सोर्स डेटासेट क्राउडसोर्स कर रहे हैं**। उपयोगकर्ता इस वेब ऐप या आधिकारिक ओपन फ़ूड फ़ैक्ट्स मोबाइल ऐप के ज़रिए कीमतें जोड़ सकते हैं। खुदरा विक्रेता या तृतीय-पक्ष ऐप भी हमारे एपीआई का उपयोग करके योगदान दे सकते हैं।';
 
   @override
   String get guide_open_prices_how_arg1_title =>
@@ -4883,7 +4885,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get guide_open_prices_why_title =>
-      'Why is Open Food Facts doing this ?';
+      'ओपन फ़ूड फैक्ट्स ऐसा क्यों कर रहा है?';
 
   @override
   String get guide_open_prices_why_paragraph1 =>
@@ -4911,11 +4913,11 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get guide_open_prices_scrapping_paragraph1 =>
-      'For legal and technical reasons, **we don\'t consider scraping prices from retailers\' websites as a valid way to contribute to Open Prices**. We want to make sure that the prices we collect are accurate and up-to-date, and receiving scraped prices from contributors doesn\'t allow us to do that.';
+      'कानूनी और तकनीकी कारणों से, **हम खुदरा विक्रेताओं की वेबसाइटों से कीमतें स्क्रैप करना ओपन प्राइसेज़ में योगदान करने का एक वैध तरीका नहीं मानते**। हम यह सुनिश्चित करना चाहते हैं कि हमारे द्वारा एकत्रित की गई कीमतें सटीक और अद्यतित हों, और योगदानकर्ताओं से स्क्रैप की गई कीमतें प्राप्त करने से हमें ऐसा करने की अनुमति नहीं मिलती।';
 
   @override
   String get guide_open_prices_scrapping_paragraph2 =>
-      'Price scraping is a considered option in a future version of Open Prices, but it would be done by Open Prices itself so that we can have a proof of the price based on the HTML page.';
+      'ओपन प्राइस के भावी संस्करण में मूल्य स्क्रैपिंग एक विचारणीय विकल्प है, लेकिन यह ओपन प्राइस द्वारा ही किया जाएगा, ताकि हमें HTML पृष्ठ के आधार पर मूल्य का प्रमाण मिल सके।';
 
   @override
   String get guide_open_prices_retailers_title =>
@@ -4935,11 +4937,11 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_title =>
-      'What is Open Products Facts?';
+      'ओपन प्रोडक्ट्स तथ्य क्या है?';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_paragraph1 =>
-      'Open Products Facts is a massive, open database for **any product with a barcode, which is not food, cosmetic or pet food**.';
+      'ओपन प्रोडक्ट्स फैक्ट्स **बारकोड वाले किसी भी उत्पाद के लिए एक विशाल, खुला डेटाबेस है, जो खाद्य, कॉस्मेटिक या पालतू भोजन नहीं है**।';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_paragraph2 =>
@@ -4947,11 +4949,11 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get guide_open_products_facts_features_title =>
-      'Features of Open Products Facts';
+      'खुले उत्पादों की विशेषताएं और तथ्य';
 
   @override
   String get guide_open_products_facts_features_text =>
-      'Open Products Facts aims to provide consumers to **extend the life of objects** by providing the circular solutions to maintain, **repair**, **recycle** their objects or give them a new owner.';
+      'ओपन प्रोडक्ट्स फैक्ट्स का उद्देश्य उपभोक्ताओं को उनकी वस्तुओं के रखरखाव, मरम्मत, पुनर्चक्रण या उन्हें नया मालिक देने के लिए परिपत्र समाधान प्रदान करके वस्तुओं का जीवन बढ़ाना है।';
 
   @override
   String get guide_open_products_facts_features_arg1_title =>
@@ -5271,11 +5273,11 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get knowledge_panel_nutriscore_banner_incorrect_score_title =>
-      'Why is this Nutri-Score different from the one on the package?';
+      'यह न्यूट्री-स्कोर पैकेज पर दिए गए न्यूट्री-स्कोर से अलग क्यों है?';
 
   @override
   String get knowledge_panel_nutriscore_banner_incorrect_score_message =>
-      'There are two possible explanations:\nThe list of ingredients and/or nutrition facts are not up-to-date.\n\nWe provide the \"New calculation\" of the Nutri-Score (or V2). Please check that you have the banner \"New calculation\" on the package.';
+      'इसके दो संभावित कारण हैं:\nसामग्री की सूची और/या पोषण संबंधी तथ्य अद्यतित नहीं हैं।\n\nहम न्यूट्री-स्कोर (या V2) की \"नई गणना\" प्रदान करते हैं। कृपया जाँच लें कि पैकेज पर \"नई गणना\" का बैनर लगा है।';
 
   @override
   String get knowledge_panel_nutriscore_banner_incorrect_score_button1 =>
@@ -5329,7 +5331,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get prices_explanation_card_line1 =>
-      '**Open Prices** is a project to collect and share prices of products around the world 🌍. Open Prices is developed and maintained by Open Food Facts.';
+      '**Open Prices** दुनिया भर के उत्पादों की कीमतें एकत्रित करने और उन्हें साझा करने का एक प्रोजेक्ट है। Open Prices का विकास और रखरखाव ओपन फ़ूड फ़ैक्ट्स द्वारा किया जाता है।';
 
   @override
   String get explanation_card_learn_more_button => 'और अधिक जानें';
@@ -5606,7 +5608,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get preferences_app_bar_search_hint =>
-      'Search for a setting (e.g. Nutri-Score)';
+      'किसी सेटिंग की खोज करें (जैसे न्यूट्री-स्कोर)';
 
   @override
   String get preferences_accessibility_show_emoji => 'पहुँच: इमोजी दिखाएँ';
@@ -5682,11 +5684,11 @@ class AppLocalizationsHi extends AppLocalizations {
   String get preferences_tips => 'सुझावों';
 
   @override
-  String get tips_discover_nutriscore => 'Discover the new Nutri-Score';
+  String get tips_discover_nutriscore => 'नए न्यूट्री-स्कोर की खोज करें';
 
   @override
   String get preferences_on_off_website_subtitle =>
-      'On the Open Food Facts website';
+      'ओपन फ़ूड फैक्ट्स वेबसाइट पर';
 
   @override
   String get preferences_manage_account_title => 'मेरा खाता प्रबंधित करें';
@@ -5770,7 +5772,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get preferences_faq_nutriscore_subtitle =>
-      'Discover how the Nutri-Score is computed';
+      'जानें कि न्यूट्री-स्कोर की गणना कैसे की जाती है';
 
   @override
   String get preferences_faq_nutriscore_v2_subtitle =>
@@ -5801,7 +5803,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get preferences_faq_faq_title => 'FAQ - अक्सर पूछे जाने वाले प्रश्न';
 
   @override
-  String get preferences_faq_off_ngo_title => 'The Open Food Facts NGO';
+  String get preferences_faq_off_ngo_title => 'ओपन फ़ूड फैक्ट्स एनजीओ';
 
   @override
   String get preferences_about_information_title => 'जानकारी';
@@ -5823,7 +5825,7 @@ class AppLocalizationsHi extends AppLocalizations {
       'हमारे किसी वर्चुअल कार्यक्रम में शामिल होकर इसमें शामिल हों';
 
   @override
-  String get preferences_connect_blog_title => 'The Open Food Facts blog';
+  String get preferences_connect_blog_title => 'ओपन फ़ूड फैक्ट्स ब्लॉग';
 
   @override
   String get preferences_connect_blog_subtitle =>
@@ -5938,7 +5940,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get preferences_contributions_new_products_subtitle =>
-      'New products I added to Open Food Facts';
+      'ओपन फ़ूड फैक्ट्स में मेरे द्वारा जोड़े गए नए उत्पाद';
 
   @override
   String get preferences_contributions_to_be_completed_title =>
@@ -5964,7 +5966,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get preferences_contributions_categorize_subtitle =>
-      'Help compute the Nutri-Score & Green-Score in your country';
+      'अपने देश में न्यूट्री-स्कोर और ग्रीन-स्कोर की गणना में सहायता करें';
 
   @override
   String get preferences_prices_user_prices_subtitle =>
@@ -6148,7 +6150,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'खुले भोजन के तथ्यों को अपनी भाषा में लाएँ';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_hi.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_hi.dart
@@ -658,7 +658,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get unknownBrand => 'अज्ञात ब्रांड';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'अज्ञात उत्पाद का नाम';

--- a/packages/smooth_app/lib/l10n/app_localizations_hr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_hr.dart
@@ -654,7 +654,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_hr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_hr.dart
@@ -49,7 +49,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get exit_label => 'Exit';
 
   @override
-  String get previous_label => 'Previous';
+  String get previous_label => 'Prethodno';
 
   @override
   String get go_back_to_top => 'Go back to top';
@@ -652,6 +652,9 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get unknownBrand => 'Unknown brand';
+
+  @override
+  String get unknownQuantity => 'Unknown brand';
 
   @override
   String get unknownProductName => 'Unknown product name';
@@ -2083,7 +2086,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get edit_product_form_item_traces_title => 'Traces';
 
   @override
-  String get edit_product_form_item_traces_hint => 'trace';
+  String get edit_product_form_item_traces_hint => 'trag';
 
   @override
   String get edit_product_form_item_traces_type =>
@@ -2518,7 +2521,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get product_type_label_pet_food => 'Pet food';
 
   @override
-  String get product_type_label_product => 'Other';
+  String get product_type_label_product => 'Ostalo';
 
   @override
   String get product_type_selection_title => 'Product type';
@@ -2632,7 +2635,7 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
-  String get prices_barcode_search_not_found => 'Product not found';
+  String get prices_barcode_search_not_found => 'Proizvod nije pronađen';
 
   @override
   String get prices_barcode_search_none_yet => 'No product yet';
@@ -2661,7 +2664,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get prices_per_unit_short => ' / jedinica';
 
   @override
-  String get prices_category_mandatory => 'Mandatory';
+  String get prices_category_mandatory => 'Obavezno';
 
   @override
   String get prices_category_optional => 'Izborno';
@@ -3522,7 +3525,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Početak izvršavanja radnji poslužitelja za lokalno pohranjena ažuriranja folksonomyja';
 
   @override
   String get background_task_title_top_n =>
@@ -4064,7 +4067,7 @@ class AppLocalizationsHr extends AppLocalizations {
       'Nutri-Score is not applicable (New calculation)';
 
   @override
-  String get environmental_score_generic_new => 'Green-Score';
+  String get environmental_score_generic_new => 'Zeleni rezultat';
 
   @override
   String get environmental_score_a_new => 'Zelena ocjena A';
@@ -4146,7 +4149,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get contact_title_press_email => 'Press Contact';
 
   @override
-  String get contact_title_newsletter => 'Subscribe to our newsletter';
+  String get contact_title_newsletter => 'Pretplatite se na naš newsletter';
 
   @override
   String get contact_title_calendar => 'Subscribe to our community calendar';
@@ -4193,7 +4196,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get guide_nutriscore_v2_what_is_nutriscore_title =>
-      'What is the Nutri-Score?';
+      'Što je Nutri-Score?';
 
   @override
   String get guide_nutriscore_v2_what_is_nutriscore_paragraph1 =>
@@ -4293,7 +4296,7 @@ class AppLocalizationsHr extends AppLocalizations {
       'For manufacturers, the display of the Nutri-Score **remains optional**.';
 
   @override
-  String get guide_greenscore_title => 'Green-Score';
+  String get guide_greenscore_title => 'Zeleni rezultat';
 
   @override
   String get guide_greenscore_what_is_greenscore_title =>
@@ -4333,22 +4336,22 @@ class AppLocalizationsHr extends AppLocalizations {
   String get guide_greenscore_lca_arg2_title => '6 koraka proizvodnje';
 
   @override
-  String get guide_greenscore_lca_arg2_agriculture => 'Agriculture';
+  String get guide_greenscore_lca_arg2_agriculture => 'Poljoprivreda';
 
   @override
-  String get guide_greenscore_lca_arg2_processing => 'Processing';
+  String get guide_greenscore_lca_arg2_processing => 'Obrada';
 
   @override
   String get guide_greenscore_lca_arg2_packaging => 'Packaging';
 
   @override
-  String get guide_greenscore_lca_arg2_transportation => 'Transportation';
+  String get guide_greenscore_lca_arg2_transportation => 'Prijevoz';
 
   @override
-  String get guide_greenscore_lca_arg2_distribution => 'Distribution';
+  String get guide_greenscore_lca_arg2_distribution => 'Distribucija';
 
   @override
-  String get guide_greenscore_lca_arg2_consumption => 'Consumption';
+  String get guide_greenscore_lca_arg2_consumption => 'Potrošnja';
 
   @override
   String get guide_greenscore_lca_arg3_title =>
@@ -5227,10 +5230,10 @@ class AppLocalizationsHr extends AppLocalizations {
   String get date => 'Date';
 
   @override
-  String get photo_rotate_left => 'Rotate left';
+  String get photo_rotate_left => 'Zakreni lijevo';
 
   @override
-  String get photo_rotate_right => 'Rotate right';
+  String get photo_rotate_right => 'Zakreni desno';
 
   @override
   String get photo_undo_action => 'Undo the previous action';
@@ -5422,7 +5425,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get prices_stats_misc_section => 'Miscellaneous';
 
   @override
-  String get prices_stats_total => 'Total';
+  String get prices_stats_total => 'Ukupno';
 
   @override
   String get prices_stats_with_barcode => 'With a barcode';
@@ -5437,7 +5440,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get prices_stats_community => 'Community';
 
   @override
-  String get prices_stats_consumption => 'Consumption';
+  String get prices_stats_consumption => 'Potrošnja';
 
   @override
   String get prices_stats_with_price => 'With a price';
@@ -5446,7 +5449,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get prices_stats_food => 'Food';
 
   @override
-  String get prices_stats_beauty => 'Beauty';
+  String get prices_stats_beauty => 'Ljepota';
 
   @override
   String get prices_stats_products => 'Products';
@@ -5500,7 +5503,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get prices_stats_api => 'API';
 
   @override
-  String get prices_stats_other => 'Other';
+  String get prices_stats_other => 'Ostalo';
 
   @override
   String get prices_stats_last_updated => 'Last updated on';
@@ -5572,7 +5575,7 @@ class AppLocalizationsHr extends AppLocalizations {
       'Hvala vam što ste jedan od naših članova!';
 
   @override
-  String get preferences_app_bar_products_modified => 'Products modified';
+  String get preferences_app_bar_products_modified => 'Proizvodi modificirani';
 
   @override
   String get preferences_app_bar_prices_added => 'Prices added';
@@ -5808,7 +5811,8 @@ class AppLocalizationsHr extends AppLocalizations {
       'Uključite se posjetom jednom od naših virtualnih događaja';
 
   @override
-  String get preferences_connect_blog_title => 'The Open Food Facts blog';
+  String get preferences_connect_blog_title =>
+      'Blog Otvorene činjenice o hrani';
 
   @override
   String get preferences_connect_blog_subtitle =>
@@ -6135,7 +6139,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Prenesite činjenice o otvorenoj hrani na svoj jezik';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_ht.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ht.dart
@@ -654,7 +654,7 @@ class AppLocalizationsHt extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_ht.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ht.dart
@@ -654,6 +654,9 @@ class AppLocalizationsHt extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3519,7 +3522,7 @@ class AppLocalizationsHt extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Ap kòmanse fè aksyon sèvè a pou mizajou folksonomy ki estoke lokalman.';
 
   @override
   String get background_task_title_top_n =>
@@ -5798,7 +5801,8 @@ class AppLocalizationsHt extends AppLocalizations {
       'Patisipe nan youn nan evènman vityèl nou yo';
 
   @override
-  String get preferences_connect_blog_title => 'The Open Food Facts blog';
+  String get preferences_connect_blog_title =>
+      'Blog Enfòmasyon Ouvè sou Manje a';
 
   @override
   String get preferences_connect_blog_subtitle =>
@@ -6124,7 +6128,7 @@ class AppLocalizationsHt extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Pote Enfòmasyon Ouvè sou Manje nan lang ou';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_hu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_hu.dart
@@ -664,6 +664,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get unknownBrand => 'Ismeretlen márka';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Ismeretlen terméknév';
 
   @override
@@ -907,7 +910,7 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get new_product_title_pictures_details =>
-      'Please take the following photos and the Open Food Facts engine can work out the rest!';
+      'Készítse el az alábbi fotókat, és az OpenFoodFacts motorja elvégzi a többi munkát!';
 
   @override
   String get new_product_title_misc => 'És pár alapvető adat…';
@@ -3556,7 +3559,7 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'A helyileg tárolt folksonomy-frissítésekhez kapcsolódó kiszolgálói műveletek végrehajtásának megkezdése';
 
   @override
   String get background_task_title_top_n =>
@@ -6183,7 +6186,7 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Hozd el a Nyílt Élelmiszerinformációkat a saját nyelvedre';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_hu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_hu.dart
@@ -664,7 +664,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get unknownBrand => 'Ismeretlen márka';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Ismeretlen terméknév';

--- a/packages/smooth_app/lib/l10n/app_localizations_hy.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_hy.dart
@@ -653,6 +653,9 @@ class AppLocalizationsHy extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3517,7 +3520,7 @@ class AppLocalizationsHy extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Սկսվում է սերվերի գործողությունների կատարումը տեղականորեն պահված folksonomy թարմացումների համար';
 
   @override
   String get background_task_title_top_n =>
@@ -5618,7 +5621,7 @@ class AppLocalizationsHy extends AppLocalizations {
 
   @override
   String get preferences_legal_header =>
-      'Open Food Facts is a food products database **made by everyone, for everyone**.\nYou can use it to make better food choices, and as it is **open data**, anyone can **re-use it for any purpose**.';
+      'Բաց սննդի փաստերը սննդամթերքի տվյալների շտեմարան է, **ստեղծված բոլորի կողմից, բոլորի համար**:\nԴուք կարող եք օգտագործել այն՝ սննդի ավելի լավ ընտրություն կատարելու համար, և քանի որ դա **բաց տվյալ** է, յուրաքանչյուրը կարող է **վերաօգտագործել այն ցանկացած նպատակով**:';
 
   @override
   String get preferences_privacy_policy => 'Privacy policy';
@@ -5668,8 +5671,7 @@ class AppLocalizationsHy extends AppLocalizations {
   String get tips_discover_nutriscore => 'Բացահայտեք նոր Nutri-Score-ը';
 
   @override
-  String get preferences_on_off_website_subtitle =>
-      'On the Open Food Facts website';
+  String get preferences_on_off_website_subtitle => 'Բաց սննդի փաստերի կայքում';
 
   @override
   String get preferences_manage_account_title => 'Կառավարել իմ հաշիվը';
@@ -5787,7 +5789,7 @@ class AppLocalizationsHy extends AppLocalizations {
       'Հաճախակի տրվող հարցեր - Հաճախակի տրվող հարցեր';
 
   @override
-  String get preferences_faq_off_ngo_title => 'The Open Food Facts NGO';
+  String get preferences_faq_off_ngo_title => '«Բաց սննդի փաստեր» ՀԿ';
 
   @override
   String get preferences_about_information_title => 'Տեղեկատվություն';
@@ -5809,7 +5811,7 @@ class AppLocalizationsHy extends AppLocalizations {
       'Մասնակցեք մեր վիրտուալ միջոցառումներից մեկին';
 
   @override
-  String get preferences_connect_blog_title => 'The Open Food Facts blog';
+  String get preferences_connect_blog_title => 'Բաց սննդի փաստերի բլոգ';
 
   @override
   String get preferences_connect_blog_subtitle =>
@@ -5925,7 +5927,7 @@ class AppLocalizationsHy extends AppLocalizations {
 
   @override
   String get preferences_contributions_new_products_subtitle =>
-      'New products I added to Open Food Facts';
+      'Բաց սննդի փաստերին ավելացված նոր ապրանքներ';
 
   @override
   String get preferences_contributions_to_be_completed_title =>
@@ -6133,7 +6135,7 @@ class AppLocalizationsHy extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Բաց սննդի փաստերը բերեք ձեր լեզվով';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_hy.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_hy.dart
@@ -653,7 +653,7 @@ class AppLocalizationsHy extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_id.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_id.dart
@@ -658,7 +658,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get unknownBrand => 'Merek tidak dikenal';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Nama produk tidak dikenal';

--- a/packages/smooth_app/lib/l10n/app_localizations_id.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_id.dart
@@ -658,6 +658,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get unknownBrand => 'Merek tidak dikenal';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Nama produk tidak dikenal';
 
   @override
@@ -2041,7 +2044,7 @@ class AppLocalizationsId extends AppLocalizations {
       'Kedelai tidak berasal dari Uni Eropa';
 
   @override
-  String get edit_product_form_item_countries_title => 'Country';
+  String get edit_product_form_item_countries_title => 'Negara';
 
   @override
   String get edit_product_form_item_countries_hint =>
@@ -3548,7 +3551,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Mulai melakukan tindakan server untuk pembaruan folksonomi yang disimpan secara lokal';
 
   @override
   String get background_task_title_top_n =>
@@ -6165,7 +6168,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get preferences_page_open_food_facts_labs_title =>
-      'Laboratorium Open Food Facts';
+      'Open Food Facts Labs';
 
   @override
   String get preferences_root_account_title => 'Akun';
@@ -6209,7 +6212,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get location_map_details_postcode => 'Postcode';
 
   @override
-  String get location_map_details_country => 'Country';
+  String get location_map_details_country => 'Negara';
 
   @override
   String get location_map_details_coordinates => 'Coordinates';

--- a/packages/smooth_app/lib/l10n/app_localizations_ii.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ii.dart
@@ -653,6 +653,9 @@ class AppLocalizationsIi extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ii.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ii.dart
@@ -653,7 +653,7 @@ class AppLocalizationsIi extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_is.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_is.dart
@@ -653,6 +653,9 @@ class AppLocalizationsIs extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3518,7 +3521,7 @@ class AppLocalizationsIs extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Byrja að framkvæma aðgerðir á netþjóni fyrir uppfærslur á fólksonomíunni sem eru geymdar á staðnum';
 
   @override
   String get background_task_title_top_n =>
@@ -5580,7 +5583,7 @@ class AppLocalizationsIs extends AppLocalizations {
 
   @override
   String get preferences_app_bar_search_hint =>
-      'Search for a setting (e.g. Nutri-Score)';
+      'Leita að stillingu (t.d. næringarstig)';
 
   @override
   String get preferences_accessibility_show_emoji => 'Aðgengi: Sýna emoji';
@@ -5941,7 +5944,7 @@ class AppLocalizationsIs extends AppLocalizations {
 
   @override
   String get preferences_contributions_categorize_subtitle =>
-      'Help compute the Nutri-Score & Green-Score in your country';
+      'Hjálpaðu til við að reikna út næringargildið og græna gildið í þínu landi';
 
   @override
   String get preferences_prices_user_prices_subtitle => 'Verð sem ég lagði til';

--- a/packages/smooth_app/lib/l10n/app_localizations_is.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_is.dart
@@ -653,7 +653,7 @@ class AppLocalizationsIs extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_it.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_it.dart
@@ -601,7 +601,7 @@ class AppLocalizationsIt extends AppLocalizations {
       'Ricaricato con le nuove preferenze';
 
   @override
-  String get profile_navbar_label => 'Community';
+  String get profile_navbar_label => 'Comunità';
 
   @override
   String get scan_navbar_label => 'Analizza';
@@ -657,6 +657,9 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get unknownBrand => 'Marca sconosciuta';
+
+  @override
+  String get unknownQuantity => 'Unknown brand';
 
   @override
   String get unknownProductName => 'Nome del prodotto sconosciuto';
@@ -1981,7 +1984,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get edit_product_form_item_labels_explanation_good_examples_1 =>
-      'Nutri-Score, NOVA…';
+      'Punteggio Nutrizionale, NOVA…';
 
   @override
   String get edit_product_form_item_labels_explanation_good_examples_2 =>
@@ -2055,7 +2058,7 @@ class AppLocalizationsIt extends AppLocalizations {
       'La soia non proviene dall\'Unione Europea';
 
   @override
-  String get edit_product_form_item_countries_title => 'Country';
+  String get edit_product_form_item_countries_title => 'Paese';
 
   @override
   String get edit_product_form_item_countries_hint =>
@@ -2599,7 +2602,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get prices_bulk_proof_upload_warning_ai =>
-      'AI will run on your proofs to extract prices.';
+      'L\'intelligenza artificiale utilizzerà le tue prove per estrarre i prezzi.';
 
   @override
   String get prices_bulk_proof_upload_community_switch =>
@@ -3020,7 +3023,7 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get prices_menu_know_more => 'Know more about Open Prices';
+  String get prices_menu_know_more => 'Scopri di più sui Open Prices';
 
   @override
   String get dev_preferences_import_history_result_success => 'Fatto';
@@ -3137,10 +3140,11 @@ class AppLocalizationsIt extends AppLocalizations {
       'Assistente al contributo dei prezzi';
 
   @override
-  String get prices_validation_assistant => 'Price Validation Assistant';
+  String get prices_validation_assistant =>
+      'Assistente per la convalida dei prezzi';
 
   @override
-  String get prices_challenges_page => 'Challenges';
+  String get prices_challenges_page => 'Sfide';
 
   @override
   String get prices_multiple_proof_addition_system => 'Aggiungi più prove';
@@ -3579,7 +3583,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Inizio dell\'esecuzione delle azioni del server per gli aggiornamenti folksonomia archiviati localmente';
 
   @override
   String get background_task_title_top_n =>
@@ -4751,7 +4755,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_title =>
-      'What is Open Pet Food Facts?';
+      'Che cosa è Open Pet Food Facts?';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_paragraph1 =>
@@ -4763,7 +4767,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get guide_open_pet_food_facts_features_title =>
-      'Features of Open Pet Food Facts';
+      'Caratteristiche di Open Pet Food Facts';
 
   @override
   String get guide_open_pet_food_facts_features_arg1_title =>
@@ -4919,7 +4923,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get guide_open_prices_what_is_open_prices_title =>
-      'What is Open Prices?';
+      'Cosa sono i Open Prices?';
 
   @override
   String get guide_open_prices_what_is_open_prices_paragraph1 =>
@@ -4997,7 +5001,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_title =>
-      'What is Open Products Facts?';
+      'Che cosa è Open Products Facts?';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_paragraph1 =>
@@ -5009,7 +5013,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get guide_open_products_facts_features_title =>
-      'Features of Open Products Facts';
+      'Caratteristiche di Open Products Facts';
 
   @override
   String get guide_open_products_facts_features_text =>
@@ -5500,7 +5504,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get prices_stats_contributors_section => 'Contributori';
 
   @override
-  String get prices_stats_experiments_section => 'Experiments';
+  String get prices_stats_experiments_section => 'Esperimenti';
 
   @override
   String get prices_stats_misc_section => 'Varie';
@@ -5515,10 +5519,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get prices_stats_with_category => 'Con una categoria';
 
   @override
-  String get prices_stats_with_discount => 'With a discount';
+  String get prices_stats_with_discount => 'Con uno sconto';
 
   @override
-  String get prices_stats_community => 'Community';
+  String get prices_stats_community => 'Comunità';
 
   @override
   String get prices_stats_consumption => 'Consumo';
@@ -5560,25 +5564,26 @@ class AppLocalizationsIt extends AppLocalizations {
   String get prices_stats_shop_import => 'Shop import';
 
   @override
-  String get prices_stats_challenges => 'Challenges';
+  String get prices_stats_challenges => 'Sfide';
 
   @override
-  String get prices_stats_linked_to_price_tag => 'Prices linked to a price tag';
+  String get prices_stats_linked_to_price_tag =>
+      'Prezzi collegati a un cartellino del prezzo';
 
   @override
-  String get prices_stats_currencies => 'Currencies';
+  String get prices_stats_currencies => 'Valute';
 
   @override
   String get prices_stats_years => 'Years';
 
   @override
-  String get prices_stats_by_source_title => 'Prices and proofs per source';
+  String get prices_stats_by_source_title => 'Prezzi e prove per fonte';
 
   @override
   String get prices_stats_website => 'Sito web';
 
   @override
-  String get prices_stats_mobile_app => 'Mobile app';
+  String get prices_stats_mobile_app => 'App mobile';
 
   @override
   String get prices_stats_api => 'API';
@@ -5659,7 +5664,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get preferences_app_bar_products_modified => 'Prodotti modificati';
 
   @override
-  String get preferences_app_bar_prices_added => 'Prices added';
+  String get preferences_app_bar_prices_added => 'Prezzi aggiunti';
 
   @override
   String get preferences_app_bar_see_all_stats => 'Vedi tutte le statistiche';
@@ -5740,7 +5745,7 @@ class AppLocalizationsIt extends AppLocalizations {
       'E inizia ad avere un impatto per milioni di persone';
 
   @override
-  String get preferences_add_prices => 'Add prices';
+  String get preferences_add_prices => 'Aggiungi prezzi';
 
   @override
   String get preferences_complete_products => 'Completa i prodotti';
@@ -5849,21 +5854,20 @@ class AppLocalizationsIt extends AppLocalizations {
   String get preferences_faq_discover_project_title => 'Scopri il progetto';
 
   @override
-  String get preferences_faq_discover_off_title => 'Discover Open Food Facts';
+  String get preferences_faq_discover_off_title => 'Scopri Open Food Facts';
 
   @override
-  String get preferences_faq_discover_obf_title => 'Discover Open Beauty Facts';
+  String get preferences_faq_discover_obf_title => 'Scopri Open Beauty Facts';
 
   @override
   String get preferences_faq_discover_opff_title =>
-      'Discover Open Pet Food Facts';
+      'Scopri Open Pet Food Facts';
 
   @override
-  String get preferences_faq_discover_op_title => 'Discover Open Prices';
+  String get preferences_faq_discover_op_title => 'Scopri i Open Prices';
 
   @override
-  String get preferences_faq_discover_opf_title =>
-      'Discover Open Products Facts';
+  String get preferences_faq_discover_opf_title => 'Scopri Open Products Facts';
 
   @override
   String get preferences_faq_faq_title => 'FAQ - Domande frequenti';
@@ -5941,7 +5945,7 @@ class AppLocalizationsIt extends AppLocalizations {
       'Contattaci per iniziare';
 
   @override
-  String get preferences_connect_press_title => 'Stampa';
+  String get preferences_connect_press_title => 'Stampa se';
 
   @override
   String get preferences_connect_press_page_subtitle =>
@@ -6258,7 +6262,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get location_map_details_postcode => 'Codice postale';
 
   @override
-  String get location_map_details_country => 'Country';
+  String get location_map_details_country => 'Paese';
 
   @override
   String get location_map_details_coordinates => 'Coordinate';

--- a/packages/smooth_app/lib/l10n/app_localizations_it.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_it.dart
@@ -659,7 +659,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get unknownBrand => 'Marca sconosciuta';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Nome del prodotto sconosciuto';

--- a/packages/smooth_app/lib/l10n/app_localizations_iu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_iu.dart
@@ -653,7 +653,7 @@ class AppLocalizationsIu extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_iu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_iu.dart
@@ -653,6 +653,9 @@ class AppLocalizationsIu extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ja.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ja.dart
@@ -631,7 +631,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get unknownBrand => '不明なブランド';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => '不明な製品名';

--- a/packages/smooth_app/lib/l10n/app_localizations_ja.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ja.dart
@@ -631,6 +631,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get unknownBrand => '不明なブランド';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => '不明な製品名';
 
   @override
@@ -3382,7 +3385,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'ローカルに保存されたフォークソノミーの更新に対するサーバーアクションの実行を開始します';
 
   @override
   String get background_task_title_top_n => '最も人気のある製品のダウンロードを開始します';
@@ -3891,11 +3894,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get nutriscore_new_formula_title => 'Nutri-Score (新しい計算)';
 
   @override
-  String get nutriscore_unknown => 'Unknown Nutri-Score';
+  String get nutriscore_unknown => '不明な栄養スコア';
 
   @override
-  String get nutriscore_unknown_new_formula =>
-      'Unknown Nutri-Score (New calculation)';
+  String get nutriscore_unknown_new_formula => '未知の栄養スコア（新しい計算）';
 
   @override
   String get nutriscore_not_applicable => 'Nutri-Scoreは適用されません';
@@ -4490,8 +4492,7 @@ class AppLocalizationsJa extends AppLocalizations {
       '私たちは、ペットの飼い主が動物のニーズに最適な食べ物を選択できるように、**原材料**、**栄養分析**、給餌ガイドラインに関する情報を収集しています。';
 
   @override
-  String get guide_open_pet_food_facts_features_title =>
-      'Features of Open Pet Food Facts';
+  String get guide_open_pet_food_facts_features_title => 'オープンペットフードファクトの特徴';
 
   @override
   String get guide_open_pet_food_facts_features_arg1_title =>
@@ -4564,8 +4565,7 @@ class AppLocalizationsJa extends AppLocalizations {
       '私たちの目標は、**パーソナルケア製品に何が含まれているのか**を理解していただくために、成分リストを解読することです。保湿剤から化粧品まで、化粧品業界の透明性を高めるために、成分、アレルゲン、パッケージに関するデータを収集しています。';
 
   @override
-  String get guide_open_beauty_facts_features_title =>
-      'Features of Open Beauty Facts';
+  String get guide_open_beauty_facts_features_title => 'オープンビューティーファクトの特徴';
 
   @override
   String get guide_open_beauty_facts_features_arg1_title =>
@@ -4719,8 +4719,7 @@ class AppLocalizationsJa extends AppLocalizations {
       '**電化製品**から**おもちゃ**、**衣類**から**掃除用品**まで、バーコードがあれば追加できます。このプロジェクトは、日常のあらゆるモノに「モノのインターネット」を構築し、それらに関する情報を誰もがアクセスできるようにすることを目的としています。';
 
   @override
-  String get guide_open_products_facts_features_title =>
-      'Features of Open Products Facts';
+  String get guide_open_products_facts_features_title => 'オープンプロダクトの特徴';
 
   @override
   String get guide_open_products_facts_features_text =>
@@ -5840,7 +5839,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get preferences_about_app_development_title => 'Development';
 
   @override
-  String get preferences_page_open_food_facts_labs_title => 'Open Food Factsラボ';
+  String get preferences_page_open_food_facts_labs_title =>
+      'Open Food Facts Labs';
 
   @override
   String get preferences_root_account_title => 'アカウント';

--- a/packages/smooth_app/lib/l10n/app_localizations_jv.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_jv.dart
@@ -653,6 +653,9 @@ class AppLocalizationsJv extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3518,7 +3521,7 @@ class AppLocalizationsJv extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Miwiti nindakake tumindak server kanggo nganyari folksonomy sing disimpen sacara lokal';
 
   @override
   String get background_task_title_top_n =>

--- a/packages/smooth_app/lib/l10n/app_localizations_jv.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_jv.dart
@@ -653,7 +653,7 @@ class AppLocalizationsJv extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_ka.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ka.dart
@@ -653,6 +653,9 @@ class AppLocalizationsKa extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3518,7 +3521,7 @@ class AppLocalizationsKa extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'ლოკალურად შენახული folksonomy-ის განახლებებისთვის სერვერის მოქმედებების შესრულება იწყება';
 
   @override
   String get background_task_title_top_n =>
@@ -5808,7 +5811,7 @@ class AppLocalizationsKa extends AppLocalizations {
       'ჩაერთეთ ჩვენს ერთ-ერთ ვირტუალურ ღონისძიებაში';
 
   @override
-  String get preferences_connect_blog_title => 'The Open Food Facts blog';
+  String get preferences_connect_blog_title => 'ღია კვების ფაქტების ბლოგი';
 
   @override
   String get preferences_connect_blog_subtitle =>
@@ -6131,7 +6134,7 @@ class AppLocalizationsKa extends AppLocalizations {
 
   @override
   String get preferences_page_open_food_facts_labs_title =>
-      'Open Food Factsს ლაბორატორიები';
+      'Open Food Facts Labs';
 
   @override
   String get preferences_root_account_title => 'Account';

--- a/packages/smooth_app/lib/l10n/app_localizations_ka.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ka.dart
@@ -653,7 +653,7 @@ class AppLocalizationsKa extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_kk.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_kk.dart
@@ -654,6 +654,9 @@ class AppLocalizationsKk extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3520,7 +3523,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Жергілікті сақталған фольксономиялық жаңартулар үшін сервер әрекеттерін орындауды бастау';
 
   @override
   String get background_task_title_top_n =>
@@ -5787,7 +5790,8 @@ class AppLocalizationsKk extends AppLocalizations {
       'Жиі қойылатын сұрақтар - Жиі қойылатын сұрақтар';
 
   @override
-  String get preferences_faq_off_ngo_title => 'The Open Food Facts NGO';
+  String get preferences_faq_off_ngo_title =>
+      '«Ашық азық-түлік фактілері» үкіметтік емес ұйымы';
 
   @override
   String get preferences_about_information_title => 'Ақпарат';
@@ -6134,7 +6138,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Ашық тағам фактілерін тіліңізге жеткізіңіз';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_kk.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_kk.dart
@@ -654,7 +654,7 @@ class AppLocalizationsKk extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_km.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_km.dart
@@ -653,7 +653,7 @@ class AppLocalizationsKm extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_km.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_km.dart
@@ -653,6 +653,9 @@ class AppLocalizationsKm extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3010,7 +3013,7 @@ class AppLocalizationsKm extends AppLocalizations {
 
   @override
   String get dev_mode_openprices_switch_env_title =>
-      'Switch between prices.openfoodfacts.org (PROD) and test env';
+      'ប្តូររវាង price.openfoodfacts.org (PROD) និង test env';
 
   @override
   String get search_history_item_edit_tooltip => 'Reuse and edit this search';
@@ -3517,7 +3520,7 @@ class AppLocalizationsKm extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'ចាប់ផ្តើមអនុវត្តសកម្មភាពម៉ាស៊ីនមេសម្រាប់ការអាប់ដេត folksonomy ដែលរក្សាទុកក្នុងមូលដ្ឋាន';
 
   @override
   String get background_task_title_top_n =>
@@ -5747,7 +5750,7 @@ class AppLocalizationsKm extends AppLocalizations {
 
   @override
   String get preferences_faq_nutriscore_subtitle =>
-      'Discover how the Nutri-Score is computed';
+      'ស្វែងយល់ពីរបៀបដែលពិន្ទុ Nutri ត្រូវបានគណនា';
 
   @override
   String get preferences_faq_nutriscore_v2_subtitle =>
@@ -6008,7 +6011,7 @@ class AppLocalizationsKm extends AppLocalizations {
 
   @override
   String get preferences_page_contribute_project_subtitle =>
-      'Simple ways to help Open Food Facts';
+      'វិធីសាមញ្ញដើម្បីជួយបើកការពិតអំពីអាហារ';
 
   @override
   String get preferences_page_faq_subtitle =>
@@ -6123,7 +6126,7 @@ class AppLocalizationsKm extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'នាំយកការពិតអាហារបើកចំហទៅកាន់ភាសារបស់អ្នក។';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_kn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_kn.dart
@@ -654,6 +654,9 @@ class AppLocalizationsKn extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3523,7 +3526,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'ಸ್ಥಳೀಯವಾಗಿ ಸಂಗ್ರಹವಾಗಿರುವ ಫೋಲ್ಕ್‌ಸೊನಮಿ ನವೀಕರಣಗಳಿಗಾಗಿ ಸರ್ವರ್ ಕ್ರಿಯೆಗಳನ್ನು ನಿರ್ವಹಿಸಲು ಪ್ರಾರಂಭಿಸಲಾಗುತ್ತಿದೆ.';
 
   @override
   String get background_task_title_top_n =>
@@ -5310,7 +5313,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String get prices_explanation_card_line1 =>
-      '**Open Prices** is a project to collect and share prices of products around the world 🌍. Open Prices is developed and maintained by Open Food Facts.';
+      '**ಓಪನ್ ಪ್ರೈಸಸ್** ಎಂಬುದು ಪ್ರಪಂಚದಾದ್ಯಂತದ ಉತ್ಪನ್ನಗಳ ಬೆಲೆಗಳನ್ನು ಸಂಗ್ರಹಿಸಿ ಹಂಚಿಕೊಳ್ಳುವ ಯೋಜನೆಯಾಗಿದೆ 🌍. ಓಪನ್ ಪ್ರೈಸಸ್ ಅನ್ನು Open Food Facts ಅಭಿವೃದ್ಧಿಪಡಿಸಿದೆ ಮತ್ತು ನಿರ್ವಹಿಸುತ್ತದೆ.';
 
   @override
   String get explanation_card_learn_more_button => 'Learn more';
@@ -5590,7 +5593,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String get preferences_app_bar_search_hint =>
-      'Search for a setting (e.g. Nutri-Score)';
+      'ಸೆಟ್ಟಿಂಗ್‌ಗಾಗಿ ಹುಡುಕಿ (ಉದಾ. ನ್ಯೂಟ್ರಿ-ಸ್ಕೋರ್)';
 
   @override
   String get preferences_accessibility_show_emoji =>
@@ -5668,7 +5671,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get preferences_tips => 'ಸಲಹೆಗಳು';
 
   @override
-  String get tips_discover_nutriscore => 'Discover the new Nutri-Score';
+  String get tips_discover_nutriscore => 'ಹೊಸ ನ್ಯೂಟ್ರಿ-ಸ್ಕೋರ್ ಅನ್ವೇಷಿಸಿ';
 
   @override
   String get preferences_on_off_website_subtitle =>
@@ -5758,7 +5761,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String get preferences_faq_nutriscore_subtitle =>
-      'Discover how the Nutri-Score is computed';
+      'ನ್ಯೂಟ್ರಿ-ಸ್ಕೋರ್ ಅನ್ನು ಹೇಗೆ ಲೆಕ್ಕ ಹಾಕಲಾಗುತ್ತದೆ ಎಂಬುದನ್ನು ಕಂಡುಕೊಳ್ಳಿ';
 
   @override
   String get preferences_faq_nutriscore_v2_subtitle =>
@@ -5926,7 +5929,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String get preferences_contributions_new_products_subtitle =>
-      'New products I added to Open Food Facts';
+      'ಓಪನ್ ಫುಡ್ ಫ್ಯಾಕ್ಟ್‌ಗಳಿಗೆ ನಾನು ಸೇರಿಸಿದ ಹೊಸ ಉತ್ಪನ್ನಗಳು';
 
   @override
   String get preferences_contributions_to_be_completed_title =>
@@ -5952,7 +5955,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String get preferences_contributions_categorize_subtitle =>
-      'Help compute the Nutri-Score & Green-Score in your country';
+      'ನಿಮ್ಮ ದೇಶದಲ್ಲಿ ನ್ಯೂಟ್ರಿ-ಸ್ಕೋರ್ ಮತ್ತು ಗ್ರೀನ್-ಸ್ಕೋರ್ ಅನ್ನು ಲೆಕ್ಕಾಚಾರ ಮಾಡಲು ಸಹಾಯ ಮಾಡಿ';
 
   @override
   String get preferences_prices_user_prices_subtitle =>
@@ -5975,7 +5978,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String get preferences_prices_newest_subtitle =>
-      'Latest prices added by the Open Prices community';
+      'ಮುಕ್ತ ಬೆಲೆಗಳ ಸಮುದಾಯದಿಂದ ಸೇರಿಸಲಾದ ಇತ್ತೀಚಿನ ಬೆಲೆಗಳು';
 
   @override
   String get preferences_prices_top_contributors_title =>
@@ -6024,7 +6027,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String get preferences_page_contribute_project_subtitle =>
-      'Simple ways to help Open Food Facts';
+      'ಆಹಾರ ಸಂಗತಿಗಳನ್ನು ತೆರೆಯಲು ಸಹಾಯ ಮಾಡುವ ಸರಳ ಮಾರ್ಗಗಳು';
 
   @override
   String get preferences_page_faq_subtitle =>
@@ -6132,14 +6135,14 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String get preferences_page_open_food_facts_labs_title =>
-      'Open Food Facts ಲ್ಯಾಬ್ಸ್';
+      'Open Food Facts Labs';
 
   @override
   String get preferences_root_account_title => 'Account';
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'ಮುಕ್ತ ಆಹಾರ ಸಂಗತಿಗಳನ್ನು ನಿಮ್ಮ ಭಾಷೆಗೆ ತನ್ನಿ';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_kn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_kn.dart
@@ -654,7 +654,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_ko.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ko.dart
@@ -630,7 +630,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get unknownBrand => '알 수 없는 상표';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => '알 수 없는 상품명';

--- a/packages/smooth_app/lib/l10n/app_localizations_ko.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ko.dart
@@ -630,6 +630,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get unknownBrand => '알 수 없는 상표';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => '알 수 없는 상품명';
 
   @override
@@ -1304,12 +1307,11 @@ class AppLocalizationsKo extends AppLocalizations {
       'Nutri-Score를 계산할 카테고리를 추가하세요.';
 
   @override
-  String get product_improvement_add_nutrition_facts =>
-      'Add nutrition facts to calculate the Nutri-Score.';
+  String get product_improvement_add_nutrition_facts => '영양 성분을 추가하여 영양 점수 계산';
 
   @override
   String get product_improvement_add_nutrition_facts_and_category =>
-      'Add nutrition facts and a category to calculate the Nutri-Score.';
+      '영양 성분을 추가하여 영양 점수 계산';
 
   @override
   String get product_improvement_categories_but_no_nutriscore =>
@@ -1875,7 +1877,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get edit_product_form_item_labels_explanation_good_examples_1 =>
-      'Nutri-Score, NOVA…';
+      '뉴트리스코어, NOVA…';
 
   @override
   String get edit_product_form_item_labels_explanation_good_examples_2 =>
@@ -3382,7 +3384,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      '로컬에 저장된 folksonomy 업데이트에 대한 서버 작업을 시작합니다.';
 
   @override
   String get background_task_title_top_n => '가장 인기 있는 상품 다운로드 시작';
@@ -3868,19 +3870,19 @@ class AppLocalizationsKo extends AppLocalizations {
   String get nutriscore_generic => 'Nutri-Score';
 
   @override
-  String get nutriscore_a => 'Nutri-Score A';
+  String get nutriscore_a => '뉴트리스코어 A';
 
   @override
-  String get nutriscore_b => 'Nutri-Score B';
+  String get nutriscore_b => '뉴트리스코어 B';
 
   @override
-  String get nutriscore_c => 'Nutri-Score C';
+  String get nutriscore_c => '뉴트리스코어 C';
 
   @override
-  String get nutriscore_d => 'Nutri-Score D';
+  String get nutriscore_d => '뉴트리스코어 D';
 
   @override
-  String get nutriscore_e => 'Nutri-Score E';
+  String get nutriscore_e => '뉴트리스코어 E';
 
   @override
   String nutriscore_new_formula(String letter) {
@@ -3891,7 +3893,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get nutriscore_new_formula_title => 'Nutri-Score(새로운 계산)';
 
   @override
-  String get nutriscore_unknown => 'Unknown Nutri-Score';
+  String get nutriscore_unknown => '알 수 없는 영양 점수';
 
   @override
   String get nutriscore_unknown_new_formula => '알 수 없는 Nutri-Score(새로운 계산)';
@@ -4410,19 +4412,18 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_title =>
-      'What is Open Food Facts?';
+      '오픈푸드팩트란 무엇인가요?';
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_paragraph1 =>
-      'Open Food Facts is a **collaborative**, **free**, and **open** database of food products from around the world.';
+      '오픈 푸드 팩츠는 전 세계 식품 제품에 대한 **협업적**, **무료**, **개방형** 데이터베이스입니다.';
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_paragraph2 =>
       '저희는 모든 사람이 자신이 먹는 음식에 대한 정보에 접근할 수 있어야 한다고 믿습니다. 재료, 알레르기 유발 물질, 영양 정보 등에 대한 데이터를 수집함으로써 **소비자가 정보에 기반한 선택을 할 수 있도록 지원**하고 식품 산업의 **투명성을 더욱 강화**합니다.';
 
   @override
-  String get guide_open_food_facts_features_title =>
-      'Features of Open Food Facts';
+  String get guide_open_food_facts_features_title => '오픈푸드팩트의 특징';
 
   @override
   String get guide_open_food_facts_features_arg1_title =>
@@ -4484,7 +4485,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_title =>
-      'What is Open Pet Food Facts?';
+      '오픈 펫 푸드 팩트란 무엇인가요?';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_paragraph1 =>
@@ -4495,8 +4496,7 @@ class AppLocalizationsKo extends AppLocalizations {
       '우리는 애완동물 주인이 자신의 애완동물에게 가장 적합한 사료를 선택할 수 있도록 돕기 위해 **성분**, **영양 분석** 및 급여 지침에 대한 정보를 수집합니다.';
 
   @override
-  String get guide_open_pet_food_facts_features_title =>
-      'Features of Open Pet Food Facts';
+  String get guide_open_pet_food_facts_features_title => '오픈 펫푸드 팩트의 특징';
 
   @override
   String get guide_open_pet_food_facts_features_arg1_title =>
@@ -4557,19 +4557,18 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_title =>
-      'What is Open Beauty Facts?';
+      '오픈 뷰티 팩트란 무엇인가요?';
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_paragraph1 =>
-      'Open Beauty Facts is a collaborative database of **cosmetic products**.';
+      '오픈 뷰티 팩츠는 **화장품**에 대한 협업 데이터베이스입니다.';
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_paragraph2 =>
       '저희의 목표는 **개인 관리 용품에 무엇이 들어 있는지** 이해하기 쉽도록 성분 목록을 분석하는 것입니다. 보습제부터 화장품까지, 저희는 화장품 업계의 투명성을 높이기 위해 성분, 알레르기 유발 물질, 포장에 대한 데이터를 수집합니다.';
 
   @override
-  String get guide_open_beauty_facts_features_title =>
-      'Features of Open Beauty Facts';
+  String get guide_open_beauty_facts_features_title => '오픈 뷰티 팩트의 특징';
 
   @override
   String get guide_open_beauty_facts_features_arg1_title =>
@@ -4712,23 +4711,22 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_title =>
-      'What is Open Products Facts?';
+      '오픈 프로덕츠 팩트란 무엇인가요?';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_paragraph1 =>
-      'Open Products Facts is a massive, open database for **any product with a barcode, which is not food, cosmetic or pet food**.';
+      '오픈 프로덕츠 팩츠는 **식품, 화장품, 애완동물 사료가 아닌 바코드가 있는 모든 제품**을 위한 대규모 오픈 데이터베이스입니다.';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_paragraph2 =>
       '**전자제품**부터 **장난감**, **옷**부터 **청소용품**까지, 바코드가 있으면 추가할 수 있습니다. 이 프로젝트는 일상 사물에 대한 \"사물 인터넷\"을 구축하여 누구나 해당 사물에 대한 정보를 접근할 수 있도록 하는 것을 목표로 합니다.';
 
   @override
-  String get guide_open_products_facts_features_title =>
-      'Features of Open Products Facts';
+  String get guide_open_products_facts_features_title => '오픈 제품 정보의 특징';
 
   @override
   String get guide_open_products_facts_features_text =>
-      'Open Products Facts aims to provide consumers to **extend the life of objects** by providing the circular solutions to maintain, **repair**, **recycle** their objects or give them a new owner.';
+      '오픈 프로덕츠 팩츠는 소비자에게 물건을 유지 관리, **수리**, **재활용**하거나 새로운 소유자에게 돌려주는 순환 솔루션을 제공함으로써 **사물의 수명을 연장**하는 것을 목표로 합니다.';
 
   @override
   String get guide_open_products_facts_features_arg1_title => '일부 제품의 탄소 발자국';
@@ -5091,7 +5089,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get prices_explanation_card_line1 =>
-      '**Open Prices** is a project to collect and share prices of products around the world 🌍. Open Prices is developed and maintained by Open Food Facts.';
+      '**Open Prices**는 전 세계 제품 가격을 수집하고 공유하는 프로젝트입니다. 🌍 Open Prices는 오픈 푸드 팩츠에서 개발 및 관리합니다.';
 
   @override
   String get explanation_card_learn_more_button => '더보기';
@@ -5386,7 +5384,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get preferences_legal_header =>
-      'Open Food Facts is a food products database **made by everyone, for everyone**.\nYou can use it to make better food choices, and as it is **open data**, anyone can **re-use it for any purpose**.';
+      '오픈 푸드 팩츠는 **모든 사람이 만들고, 모든 사람을 위해** 만든 식품 데이터베이스입니다.\n더 나은 식품 선택을 하는 데 활용할 수 있으며, **오픈 데이터**이므로 누구나 **어떤 목적으로든 재사용**할 수 있습니다.';
 
   @override
   String get preferences_privacy_policy => '개인정보 보호정책';
@@ -5539,7 +5537,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get preferences_faq_faq_title => 'FAQ - 자주 묻는 질문';
 
   @override
-  String get preferences_faq_off_ngo_title => 'The Open Food Facts NGO';
+  String get preferences_faq_off_ngo_title => '오픈 푸드 팩츠 NGO';
 
   @override
   String get preferences_about_information_title => '정보';
@@ -5559,7 +5557,7 @@ class AppLocalizationsKo extends AppLocalizations {
       '당사의 가상 이벤트 중 하나에 참석하여 참여하세요.';
 
   @override
-  String get preferences_connect_blog_title => 'The Open Food Facts blog';
+  String get preferences_connect_blog_title => '오픈 푸드 팩츠 블로그';
 
   @override
   String get preferences_connect_blog_subtitle => '최신 뉴스를 실시간으로 받아보세요';
@@ -5705,7 +5703,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get preferences_prices_newest_subtitle =>
-      'Latest prices added by the Open Prices community';
+      'Open Price 커뮤니티에서 추가한 최신 가격';
 
   @override
   String get preferences_prices_top_contributors_title => '가장 많은 가격을 제시한 기여자';
@@ -5858,7 +5856,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      '공개 식품 정보를 귀하의 언어로 제공하세요';
 
   @override
   String get preferences_contribute_enroll_alpha => '앱의 알파 버전에 등록하세요';

--- a/packages/smooth_app/lib/l10n/app_localizations_ku.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ku.dart
@@ -654,7 +654,7 @@ class AppLocalizationsKu extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_ku.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ku.dart
@@ -654,6 +654,9 @@ class AppLocalizationsKu extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3523,7 +3526,7 @@ class AppLocalizationsKu extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Dest bi pêkanîna çalakiyên serverê ji bo nûvekirinên folksonomy yên ku li herêmê hatine hilanîn dike';
 
   @override
   String get background_task_title_top_n =>
@@ -5786,7 +5789,8 @@ class AppLocalizationsKu extends AppLocalizations {
       'Pirsên Pir tên Pirsîn - Pirsên Pir tên Pirsîn';
 
   @override
-  String get preferences_faq_off_ngo_title => 'The Open Food Facts NGO';
+  String get preferences_faq_off_ngo_title =>
+      'Rêxistina Nehikûmî ya Rastiyên Xwarinê ya Vekirî';
 
   @override
   String get preferences_about_information_title => 'Agahî';
@@ -5973,7 +5977,7 @@ class AppLocalizationsKu extends AppLocalizations {
 
   @override
   String get preferences_prices_newest_subtitle =>
-      'Latest prices added by the Open Prices community';
+      'Bihayên herî dawî yên ji hêla civaka Buhayên Vekirî ve hatine zêdekirin';
 
   @override
   String get preferences_prices_top_contributors_title =>

--- a/packages/smooth_app/lib/l10n/app_localizations_kw.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_kw.dart
@@ -653,6 +653,9 @@ class AppLocalizationsKw extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_kw.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_kw.dart
@@ -653,7 +653,7 @@ class AppLocalizationsKw extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_ky.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ky.dart
@@ -653,7 +653,7 @@ class AppLocalizationsKy extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_ky.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ky.dart
@@ -653,6 +653,9 @@ class AppLocalizationsKy extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3520,7 +3523,7 @@ class AppLocalizationsKy extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Жергиликтүү сакталган фольксономия жаңыртуулары үчүн сервер аракеттерин аткарууну баштоо';
 
   @override
   String get background_task_title_top_n =>
@@ -6137,7 +6140,7 @@ class AppLocalizationsKy extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Ачык тамак-аш фактыларын өз тилиңизге алып келиңиз';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_la.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_la.dart
@@ -654,7 +654,7 @@ class AppLocalizationsLa extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_la.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_la.dart
@@ -654,6 +654,9 @@ class AppLocalizationsLa extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3519,7 +3522,7 @@ class AppLocalizationsLa extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Incipio actiones servitoris exsequi pro renovationibus folksonomy localiter servatis.';
 
   @override
   String get background_task_title_top_n =>
@@ -5787,7 +5790,8 @@ class AppLocalizationsLa extends AppLocalizations {
       'Quaestiones Frequentes - Quaestiones Frequentes';
 
   @override
-  String get preferences_faq_off_ngo_title => 'The Open Food Facts NGO';
+  String get preferences_faq_off_ngo_title =>
+      'Consociatio Non-Governativa de Cibis Apertis Factis (vel Notitiae Ciborum Apertae)';
 
   @override
   String get preferences_about_information_title => 'Information';
@@ -5809,7 +5813,8 @@ class AppLocalizationsLa extends AppLocalizations {
       'Participa participando unum ex eventibus nostris virtualibus';
 
   @override
-  String get preferences_connect_blog_title => 'The Open Food Facts blog';
+  String get preferences_connect_blog_title =>
+      'Diarium de rebus cibariis apertis';
 
   @override
   String get preferences_connect_blog_subtitle =>
@@ -5974,7 +5979,7 @@ class AppLocalizationsLa extends AppLocalizations {
 
   @override
   String get preferences_prices_newest_subtitle =>
-      'Latest prices added by the Open Prices community';
+      'Pretia recentissima a communitate Pretiorum Apertorum addita';
 
   @override
   String get preferences_prices_top_contributors_title =>
@@ -6136,7 +6141,7 @@ class AppLocalizationsLa extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Affer Facta Cibaria Aperta in Linguam Tuam';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_lb.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_lb.dart
@@ -654,6 +654,9 @@ class AppLocalizationsLb extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3522,7 +3525,7 @@ class AppLocalizationsLb extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Ufänken vun den Serveraktiounen fir lokal gespäichert Folksonomy-Updates';
 
   @override
   String get background_task_title_top_n =>

--- a/packages/smooth_app/lib/l10n/app_localizations_lb.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_lb.dart
@@ -654,7 +654,7 @@ class AppLocalizationsLb extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_lo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_lo.dart
@@ -653,7 +653,7 @@ class AppLocalizationsLo extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_lo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_lo.dart
@@ -653,6 +653,9 @@ class AppLocalizationsLo extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3515,7 +3518,7 @@ class AppLocalizationsLo extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'ເລີ່ມຕົ້ນປະຕິບັດການປະຕິບັດຂອງເຄື່ອງແມ່ຂ່າຍສໍາລັບການອັບເດດ folksonomy ເກັບຮັກສາໄວ້ຢູ່ໃນທ້ອງຖິ່ນ';
 
   @override
   String get background_task_title_top_n =>
@@ -5777,7 +5780,8 @@ class AppLocalizationsLo extends AppLocalizations {
   String get preferences_faq_faq_title => 'FAQ - ຄໍາຖາມທີ່ຖາມເລື້ອຍໆ';
 
   @override
-  String get preferences_faq_off_ngo_title => 'The Open Food Facts NGO';
+  String get preferences_faq_off_ngo_title =>
+      'ອົງການ NGO ເປີດເຜີຍຄວາມຈິງກ່ຽວກັບອາຫານ';
 
   @override
   String get preferences_about_information_title => 'Information';
@@ -6120,7 +6124,7 @@ class AppLocalizationsLo extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'ເອົາຄວາມຈິງກ່ຽວກັບອາຫານທີ່ເປີດເຜີຍໃຫ້ກັບພາສາຂອງເຈົ້າ';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_lt.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_lt.dart
@@ -526,8 +526,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get saving_answer => 'Išsaugomas jūsų atsakymas';
 
   @override
-  String get contribute_to_get_rewards =>
-      'Become an actor of food transparency';
+  String get contribute_to_get_rewards => 'Tapkite maisto skaidrumo veikėju';
 
   @override
   String get question_sign_in_text =>
@@ -664,6 +663,9 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get unknownBrand => 'Nežinomas prekės ženklas';
+
+  @override
+  String get unknownQuantity => 'Unknown brand';
 
   @override
   String get unknownProductName => 'Nežinomas produkto pavadinimas';
@@ -3016,7 +3018,7 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
-  String get prices_menu_know_more => 'Know more about Open Prices';
+  String get prices_menu_know_more => 'Sužinokite daugiau apie atviras kainas';
 
   @override
   String get dev_preferences_import_history_result_success => 'Atlikta';
@@ -3576,7 +3578,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Pradedami vykdyti serverio veiksmai su lokaliai saugomais „folksonomy“ atnaujinimais';
 
   @override
   String get background_task_title_top_n =>
@@ -4112,7 +4114,7 @@ class AppLocalizationsLt extends AppLocalizations {
       '„Nutri-Score“ (naujas skaičiavimas)';
 
   @override
-  String get nutriscore_unknown => 'Unknown Nutri-Score';
+  String get nutriscore_unknown => 'Nežinomas maistingumo balas';
 
   @override
   String get nutriscore_unknown_new_formula =>
@@ -4656,7 +4658,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_title =>
-      'What is Open Food Facts?';
+      'Kas yra atviri faktai apie maistą?';
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_paragraph1 =>
@@ -4668,7 +4670,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get guide_open_food_facts_features_title =>
-      'Features of Open Food Facts';
+      'Atvirų maisto faktų ypatybės';
 
   @override
   String get guide_open_food_facts_features_arg1_title =>
@@ -4740,7 +4742,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_title =>
-      'What is Open Pet Food Facts?';
+      'Kas yra atviri naminių gyvūnėlių ėdalo faktai?';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_paragraph1 =>
@@ -4752,7 +4754,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get guide_open_pet_food_facts_features_title =>
-      'Features of Open Pet Food Facts';
+      'Atviro naminių gyvūnėlių ėdalo faktų ypatybės';
 
   @override
   String get guide_open_pet_food_facts_features_arg1_title =>
@@ -4822,7 +4824,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_title =>
-      'What is Open Beauty Facts?';
+      'Kas yra atviri grožio faktai?';
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_paragraph1 =>
@@ -4834,7 +4836,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get guide_open_beauty_facts_features_title =>
-      'Features of Open Beauty Facts';
+      'Atvirų grožio faktų ypatybės';
 
   @override
   String get guide_open_beauty_facts_features_arg1_title =>
@@ -4906,11 +4908,12 @@ class AppLocalizationsLt extends AppLocalizations {
       'https://world-lt.openbeautyfacts.org/discover';
 
   @override
-  String get guide_open_prices_title => 'Welcome to Open Prices!';
+  String get guide_open_prices_title =>
+      'Sveiki atvykę į atvirų kainų atidarymo programą!';
 
   @override
   String get guide_open_prices_what_is_open_prices_title =>
-      'What is Open Prices?';
+      'Kas yra atviros kainos?';
 
   @override
   String get guide_open_prices_what_is_open_prices_paragraph1 =>
@@ -4921,7 +4924,7 @@ class AppLocalizationsLt extends AppLocalizations {
       'There are currently few companies that own large databases of product prices at the barcode level. These prices are not freely available, but sold at a high price to private actors, researchers and other organizations that can afford them.';
 
   @override
-  String get guide_open_prices_how_title => 'How does Open Prices work?';
+  String get guide_open_prices_how_title => 'Kaip veikia atviros kainos?';
 
   @override
   String get guide_open_prices_how_paragraph1 =>
@@ -4963,7 +4966,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get guide_open_prices_scrapping_paragraph1 =>
-      'For legal and technical reasons, **we don\'t consider scraping prices from retailers\' websites as a valid way to contribute to Open Prices**. We want to make sure that the prices we collect are accurate and up-to-date, and receiving scraped prices from contributors doesn\'t allow us to do that.';
+      'Dėl teisinių ir techninių priežasčių **nelaikome kainų nuskaitymo iš mažmenininkų svetainių tinkamu būdu prisidėti prie atvirų kainų**. Norime įsitikinti, kad mūsų renkamos kainos yra tikslios ir atnaujintos, o nuskaitytų kainų gavimas iš bendraautorių neleidžia mums to daryti.';
 
   @override
   String get guide_open_prices_scrapping_paragraph2 =>
@@ -4987,7 +4990,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_title =>
-      'What is Open Products Facts?';
+      'Kas yra atviri produktų faktai?';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_paragraph1 =>
@@ -4999,7 +5002,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get guide_open_products_facts_features_title =>
-      'Features of Open Products Facts';
+      'Atvirų produktų faktų ypatybės';
 
   @override
   String get guide_open_products_facts_features_text =>
@@ -5748,7 +5751,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get preferences_on_off_website_subtitle =>
-      'On the Open Food Facts website';
+      'Atvirų maisto faktų svetainėje';
 
   @override
   String get preferences_manage_account_title => 'Tvarkyti mano paskyrą';
@@ -5865,7 +5868,8 @@ class AppLocalizationsLt extends AppLocalizations {
   String get preferences_faq_faq_title => 'DUK – Dažnai užduodami klausimai';
 
   @override
-  String get preferences_faq_off_ngo_title => 'The Open Food Facts NGO';
+  String get preferences_faq_off_ngo_title =>
+      'Atvirų maisto faktų nevyriausybinė organizacija';
 
   @override
   String get preferences_about_information_title => 'Information';
@@ -6214,7 +6218,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Atviri maisto faktai jūsų kalba';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_lt.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_lt.dart
@@ -665,7 +665,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get unknownBrand => 'Nežinomas prekės ženklas';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Nežinomas produkto pavadinimas';

--- a/packages/smooth_app/lib/l10n/app_localizations_lv.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_lv.dart
@@ -662,7 +662,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get unknownBrand => 'Nezināms zīmols';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Nezināms produkta nosaukums';

--- a/packages/smooth_app/lib/l10n/app_localizations_lv.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_lv.dart
@@ -110,7 +110,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get match_very_good => 'Ļoti laba spēle';
 
   @override
-  String get match_good => 'Laba spēle';
+  String get match_good => 'Laba atbilstība';
 
   @override
   String get match_poor => 'Slikta atbilstība';
@@ -128,7 +128,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get match_short_very_good => 'Ļoti laba spēle';
 
   @override
-  String get match_short_good => 'Laba spēle';
+  String get match_short_good => 'Laba atbilstība';
 
   @override
   String get match_short_poor => 'Slikta atbilstība';
@@ -660,6 +660,9 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get unknownBrand => 'Nezināms zīmols';
+
+  @override
+  String get unknownQuantity => 'Unknown brand';
 
   @override
   String get unknownProductName => 'Nezināms produkta nosaukums';
@@ -3014,7 +3017,7 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
-  String get prices_menu_know_more => 'Know more about Open Prices';
+  String get prices_menu_know_more => 'Uzziniet vairāk par atvērtajām cenām';
 
   @override
   String get dev_preferences_import_history_result_success => 'Pabeigts';
@@ -3572,7 +3575,7 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Servera darbību veikšanas sākšana lokāli saglabātajiem folksonomy atjauninājumiem';
 
   @override
   String get background_task_title_top_n =>
@@ -4169,7 +4172,7 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get faq_title_vision =>
-      'The Open Food Facts Vision, Mission, Values and Programs';
+      'Atvērto pārtikas faktu vīzija, misija, vērtības un programmas';
 
   @override
   String get faq_title_install_beauty =>
@@ -4647,7 +4650,7 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_title =>
-      'What is Open Food Facts?';
+      'Kas ir Atklātie pārtikas fakti?';
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_paragraph1 =>
@@ -4659,7 +4662,7 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get guide_open_food_facts_features_title =>
-      'Features of Open Food Facts';
+      'Atvērto pārtikas faktu iezīmes';
 
   @override
   String get guide_open_food_facts_features_arg1_title =>
@@ -4732,7 +4735,7 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_title =>
-      'What is Open Pet Food Facts?';
+      'Kas ir atklātie mājdzīvnieku barības fakti?';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_paragraph1 =>
@@ -4744,7 +4747,7 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get guide_open_pet_food_facts_features_title =>
-      'Features of Open Pet Food Facts';
+      'Atvērtā mājdzīvnieku barības faktu sadaļas iezīmes';
 
   @override
   String get guide_open_pet_food_facts_features_arg1_title =>
@@ -4814,7 +4817,7 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_title =>
-      'What is Open Beauty Facts?';
+      'Kas ir Atklātie skaistumkopšanas fakti?';
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_paragraph1 =>
@@ -4826,7 +4829,7 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get guide_open_beauty_facts_features_title =>
-      'Features of Open Beauty Facts';
+      'Atvērto skaistumkopšanas faktu iezīmes';
 
   @override
   String get guide_open_beauty_facts_features_arg1_title =>
@@ -4899,11 +4902,11 @@ class AppLocalizationsLv extends AppLocalizations {
       'https://world-lv.openbeautyfacts.org/discover';
 
   @override
-  String get guide_open_prices_title => 'Welcome to Open Prices!';
+  String get guide_open_prices_title => 'Laipni lūdzam Atvērtajās cenās!';
 
   @override
   String get guide_open_prices_what_is_open_prices_title =>
-      'What is Open Prices?';
+      'Kas ir atvērtās cenas?';
 
   @override
   String get guide_open_prices_what_is_open_prices_paragraph1 =>
@@ -4914,7 +4917,7 @@ class AppLocalizationsLv extends AppLocalizations {
       'There are currently few companies that own large databases of product prices at the barcode level. These prices are not freely available, but sold at a high price to private actors, researchers and other organizations that can afford them.';
 
   @override
-  String get guide_open_prices_how_title => 'How does Open Prices work?';
+  String get guide_open_prices_how_title => 'Kā darbojas Atvērtās cenas?';
 
   @override
   String get guide_open_prices_how_paragraph1 =>
@@ -4956,7 +4959,7 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get guide_open_prices_scrapping_paragraph1 =>
-      'For legal and technical reasons, **we don\'t consider scraping prices from retailers\' websites as a valid way to contribute to Open Prices**. We want to make sure that the prices we collect are accurate and up-to-date, and receiving scraped prices from contributors doesn\'t allow us to do that.';
+      'Juridisku un tehnisku iemeslu dēļ **cenu iegūšanu no mazumtirgotāju tīmekļa vietnēm mēs neuzskatām par derīgu veidu, kā piedalīties atvērto cenu apkopošanā**. Mēs vēlamies pārliecināties, ka mūsu apkopotās cenas ir precīzas un aktuālas, un iegūto cenu saņemšana no līdzstrādniekiem mums to neļauj.';
 
   @override
   String get guide_open_prices_scrapping_paragraph2 =>
@@ -4980,7 +4983,7 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_title =>
-      'What is Open Products Facts?';
+      'Kas ir atklātie produktu fakti?';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_paragraph1 =>
@@ -4992,7 +4995,7 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get guide_open_products_facts_features_title =>
-      'Features of Open Products Facts';
+      'Atvērto produktu faktu iezīmes';
 
   @override
   String get guide_open_products_facts_features_text =>
@@ -5732,7 +5735,7 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get preferences_on_off_website_subtitle =>
-      'On the Open Food Facts website';
+      'Atvērto pārtikas faktu tīmekļa vietnē';
 
   @override
   String get preferences_manage_account_title => 'Pārvaldīt manu kontu';
@@ -5870,7 +5873,7 @@ class AppLocalizationsLv extends AppLocalizations {
       'Iesaistieties, apmeklējot kādu no mūsu virtuālajiem pasākumiem';
 
   @override
-  String get preferences_connect_blog_title => 'The Open Food Facts blog';
+  String get preferences_connect_blog_title => 'Atvērto pārtikas faktu emuārs';
 
   @override
   String get preferences_connect_blog_subtitle =>
@@ -6197,7 +6200,7 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Atvērtie pārtikas fakti jūsu valodā';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_mg.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_mg.dart
@@ -655,7 +655,7 @@ class AppLocalizationsMg extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_mg.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_mg.dart
@@ -655,6 +655,9 @@ class AppLocalizationsMg extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3525,7 +3528,7 @@ class AppLocalizationsMg extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Manomboka manao ny hetsika mpizara ho an\'ny fanavaozana folksonomy voatahiry eo an-toerana';
 
   @override
   String get background_task_title_top_n =>

--- a/packages/smooth_app/lib/l10n/app_localizations_mi.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_mi.dart
@@ -655,7 +655,7 @@ class AppLocalizationsMi extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_mi.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_mi.dart
@@ -655,6 +655,9 @@ class AppLocalizationsMi extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3525,7 +3528,7 @@ class AppLocalizationsMi extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Ka timata ki te mahi i nga mahi a te kaimau mo nga whakahōutanga folksonomy kua rongoa i te rohe';
 
   @override
   String get background_task_title_top_n =>
@@ -6028,7 +6031,7 @@ class AppLocalizationsMi extends AppLocalizations {
 
   @override
   String get preferences_page_contribute_project_subtitle =>
-      'Simple ways to help Open Food Facts';
+      'Nga huarahi ngawari hei awhina i nga Meka Kai Tuwhera';
 
   @override
   String get preferences_page_faq_subtitle =>
@@ -6143,7 +6146,7 @@ class AppLocalizationsMi extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Kawea mai nga Meka Kai Tuwhera ki to reo';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_ml.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ml.dart
@@ -654,7 +654,7 @@ class AppLocalizationsMl extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_ml.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ml.dart
@@ -654,6 +654,9 @@ class AppLocalizationsMl extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3520,7 +3523,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'പ്രാദേശികമായി സംഭരിച്ചിരിക്കുന്ന ഫോക്ക്‌സോണമി അപ്‌ഡേറ്റുകൾക്കായി സെർവർ പ്രവർത്തനങ്ങൾ നടത്താൻ ആരംഭിക്കുന്നു.';
 
   @override
   String get background_task_title_top_n =>
@@ -5925,7 +5928,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String get preferences_contributions_new_products_subtitle =>
-      'New products I added to Open Food Facts';
+      'ഓപ്പൺ ഫുഡ് ഫാക്റ്റുകളിൽ ഞാൻ ചേർത്ത പുതിയ ഉൽപ്പന്നങ്ങൾ';
 
   @override
   String get preferences_contributions_to_be_completed_title =>
@@ -5973,7 +5976,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String get preferences_prices_newest_subtitle =>
-      'Latest prices added by the Open Prices community';
+      'ഓപ്പൺ പ്രൈസ് കമ്മ്യൂണിറ്റി ചേർത്ത ഏറ്റവും പുതിയ വിലകൾ';
 
   @override
   String get preferences_prices_top_contributors_title =>
@@ -6022,7 +6025,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String get preferences_page_contribute_project_subtitle =>
-      'Simple ways to help Open Food Facts';
+      'സഹായിക്കാനുള്ള ലളിതമായ വഴികൾ ഭക്ഷണ വസ്തുതകൾ തുറക്കുക';
 
   @override
   String get preferences_page_faq_subtitle =>
@@ -6131,7 +6134,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String get preferences_page_open_food_facts_labs_title =>
-      'Open Food Facts ലാബുകൾ';
+      'Open Food Facts Labs';
 
   @override
   String get preferences_root_account_title => 'Account';

--- a/packages/smooth_app/lib/l10n/app_localizations_mn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_mn.dart
@@ -653,6 +653,9 @@ class AppLocalizationsMn extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3520,7 +3523,7 @@ class AppLocalizationsMn extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Орон нутагт хадгалагдсан фолксономи шинэчлэлтийн серверийн үйлдлийг хийж эхэлж байна';
 
   @override
   String get background_task_title_top_n =>
@@ -5786,7 +5789,7 @@ class AppLocalizationsMn extends AppLocalizations {
       'Түгээмэл асуултууд - Түгээмэл асуултууд';
 
   @override
-  String get preferences_faq_off_ngo_title => 'The Open Food Facts NGO';
+  String get preferences_faq_off_ngo_title => 'Нээлттэй хүнсний баримт ТББ';
 
   @override
   String get preferences_about_information_title => 'Information';
@@ -5808,7 +5811,7 @@ class AppLocalizationsMn extends AppLocalizations {
       'Манай виртуал арга хэмжээнүүдийн аль нэгэнд оролцож, оролцоорой';
 
   @override
-  String get preferences_connect_blog_title => 'The Open Food Facts blog';
+  String get preferences_connect_blog_title => 'Нээлттэй хүнсний баримт блог';
 
   @override
   String get preferences_connect_blog_subtitle =>
@@ -5972,7 +5975,7 @@ class AppLocalizationsMn extends AppLocalizations {
 
   @override
   String get preferences_prices_newest_subtitle =>
-      'Latest prices added by the Open Prices community';
+      'Нээлттэй үнийн нийгэмлэгийн нэмсэн хамгийн сүүлийн үнэ';
 
   @override
   String get preferences_prices_top_contributors_title =>
@@ -6022,7 +6025,7 @@ class AppLocalizationsMn extends AppLocalizations {
 
   @override
   String get preferences_page_contribute_project_subtitle =>
-      'Simple ways to help Open Food Facts';
+      'Нээлттэй хүнсний баримтуудад туслах энгийн аргууд';
 
   @override
   String get preferences_page_faq_subtitle =>
@@ -6137,7 +6140,7 @@ class AppLocalizationsMn extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Нээлттэй хүнсний баримтуудыг хэл дээрээ авчир';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_mn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_mn.dart
@@ -653,7 +653,7 @@ class AppLocalizationsMn extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_mr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_mr.dart
@@ -654,7 +654,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_mr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_mr.dart
@@ -654,6 +654,9 @@ class AppLocalizationsMr extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3517,7 +3520,7 @@ class AppLocalizationsMr extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'स्थानिक पातळीवर संग्रहित केलेल्या लोकसाहित्य अद्यतनांसाठी सर्व्हर क्रिया करण्यास सुरुवात करत आहे';
 
   @override
   String get background_task_title_top_n =>
@@ -4084,7 +4087,8 @@ class AppLocalizationsMr extends AppLocalizations {
       'ग्रीन-स्कोअर लागू नाही.';
 
   @override
-  String get nova_group_generic_new => 'Ultra-processed foods - NOVA groups';
+  String get nova_group_generic_new =>
+      'अल्ट्रा-प्रक्रिया केलेले अन्न - नोव्हा गट';
 
   @override
   String get nova_group_1 => 'NOVA Group 1';
@@ -4491,7 +4495,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get guide_nova_logos_caption => 'NOVA लोगो';
 
   @override
-  String get guide_nova_groups_title => 'The 4 NOVA groups';
+  String get guide_nova_groups_title => '४ नोव्हा गट';
 
   @override
   String get guide_nova_groups_intro =>
@@ -5581,7 +5585,7 @@ class AppLocalizationsMr extends AppLocalizations {
 
   @override
   String get preferences_app_bar_search_hint =>
-      'Search for a setting (e.g. Nutri-Score)';
+      'सेटिंग शोधा (उदा. न्यूट्री-स्कोअर)';
 
   @override
   String get preferences_accessibility_show_emoji =>
@@ -5659,7 +5663,7 @@ class AppLocalizationsMr extends AppLocalizations {
   String get preferences_tips => 'टिपा';
 
   @override
-  String get tips_discover_nutriscore => 'Discover the new Nutri-Score';
+  String get tips_discover_nutriscore => 'नवीन न्यूट्री-स्कोअर शोधा';
 
   @override
   String get preferences_on_off_website_subtitle => 'Open Food Facts वेबसाइटवर';
@@ -5745,7 +5749,7 @@ class AppLocalizationsMr extends AppLocalizations {
 
   @override
   String get preferences_faq_nutriscore_subtitle =>
-      'Discover how the Nutri-Score is computed';
+      'न्यूट्री-स्कोअर कसा मोजला जातो ते शोधा';
 
   @override
   String get preferences_faq_nutriscore_v2_subtitle =>
@@ -5940,7 +5944,7 @@ class AppLocalizationsMr extends AppLocalizations {
 
   @override
   String get preferences_contributions_categorize_subtitle =>
-      'Help compute the Nutri-Score & Green-Score in your country';
+      'तुमच्या देशातील न्यूट्री-स्कोअर आणि ग्रीन-स्कोअरची गणना करण्यात मदत करा.';
 
   @override
   String get preferences_prices_user_prices_subtitle => 'मी दिलेल्या किमती';
@@ -6010,7 +6014,7 @@ class AppLocalizationsMr extends AppLocalizations {
 
   @override
   String get preferences_page_contribute_project_subtitle =>
-      'Simple ways to help Open Food Facts';
+      'अन्न तथ्ये उघडण्यास मदत करण्याचे सोपे मार्ग';
 
   @override
   String get preferences_page_faq_subtitle =>
@@ -6125,7 +6129,7 @@ class AppLocalizationsMr extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'तुमच्या भाषेत खुल्या अन्नाचे तथ्य आणा';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_ms.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ms.dart
@@ -653,7 +653,7 @@ class AppLocalizationsMs extends AppLocalizations {
   String get unknownBrand => 'Jenama tidak diketahui';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Nama produk yang tidak diketahui';

--- a/packages/smooth_app/lib/l10n/app_localizations_ms.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ms.dart
@@ -653,6 +653,9 @@ class AppLocalizationsMs extends AppLocalizations {
   String get unknownBrand => 'Jenama tidak diketahui';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Nama produk yang tidak diketahui';
 
   @override
@@ -3522,7 +3525,7 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Mula melakukan tindakan pelayan untuk kemas kini folksonomy yang disimpan secara setempat';
 
   @override
   String get background_task_title_top_n =>
@@ -6125,7 +6128,7 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get preferences_page_open_food_facts_labs_title =>
-      'Makmal Open Food Facts';
+      'Open Food Facts Labs';
 
   @override
   String get preferences_root_account_title => 'Account';

--- a/packages/smooth_app/lib/l10n/app_localizations_mt.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_mt.dart
@@ -653,7 +653,7 @@ class AppLocalizationsMt extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_mt.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_mt.dart
@@ -653,6 +653,9 @@ class AppLocalizationsMt extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3518,7 +3521,7 @@ class AppLocalizationsMt extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Nibdew inwettqu l-azzjonijiet tas-server għall-aġġornamenti tal-folksonomija maħżuna lokalment';
 
   @override
   String get background_task_title_top_n =>
@@ -5806,7 +5809,8 @@ class AppLocalizationsMt extends AppLocalizations {
       'Involvi ruħek billi tattendi wieħed mill-avvenimenti virtwali tagħna';
 
   @override
-  String get preferences_connect_blog_title => 'The Open Food Facts blog';
+  String get preferences_connect_blog_title =>
+      'Il-blogg tal-Fatti dwar l-Ikel Miftuħ';
 
   @override
   String get preferences_connect_blog_subtitle =>
@@ -6134,7 +6138,7 @@ class AppLocalizationsMt extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Ġib il-Fatti Miftuħa dwar l-Ikel fil-lingwa tiegħek';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_my.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_my.dart
@@ -655,7 +655,7 @@ class AppLocalizationsMy extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_my.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_my.dart
@@ -655,6 +655,9 @@ class AppLocalizationsMy extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3020,7 +3023,7 @@ class AppLocalizationsMy extends AppLocalizations {
 
   @override
   String get dev_mode_openprices_switch_env_title =>
-      'Switch between prices.openfoodfacts.org (PROD) and test env';
+      'price.openfoodfacts.org (PROD) နှင့် test env အကြား ပြောင်းပါ။';
 
   @override
   String get search_history_item_edit_tooltip => 'Reuse and edit this search';
@@ -3527,7 +3530,7 @@ class AppLocalizationsMy extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'စက်တွင်းသိမ်းဆည်းထားသော folksonomy အပ်ဒိတ်များအတွက် ဆာဗာလုပ်ဆောင်ချက်များကို စတင်လုပ်ဆောင်နေပါသည်။';
 
   @override
   String get background_task_title_top_n =>
@@ -6037,7 +6040,7 @@ class AppLocalizationsMy extends AppLocalizations {
 
   @override
   String get preferences_page_contribute_project_subtitle =>
-      'Simple ways to help Open Food Facts';
+      'Food Facts ကိုဖွင့်ရန် ရိုးရှင်းသောနည်းလမ်းများ';
 
   @override
   String get preferences_page_faq_subtitle =>

--- a/packages/smooth_app/lib/l10n/app_localizations_nb.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_nb.dart
@@ -43,7 +43,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get next_label => 'Neste';
 
   @override
-  String get continue_label => 'Continue';
+  String get continue_label => 'Fortsette';
 
   @override
   String get exit_label => 'Avslutt';
@@ -167,11 +167,11 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get server_error_open_new_issue =>
-      'No server response! You may open an issue with the following link.';
+      'Ingen serverrespons! Du kan åpne et problem med følgende lenke.';
 
   @override
   String get sign_in_text =>
-      'Sign in to your Open Food Facts account to save your contributions';
+      'Logg inn på Open Food Facts-kontoen din for å lagre bidragene dine';
 
   @override
   String get incorrect_credentials => 'Feil brukernavn eller passord.';
@@ -182,7 +182,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get password_lost_server_unavailable =>
-      'We are currently experiencing slowdowns on our servers and we apologise for it. Please try again later.';
+      'Vi opplever for tiden nedgang på serverne våre, og vi beklager dette. Prøv igjen senere.';
 
   @override
   String get login => 'Logg inn';
@@ -213,7 +213,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get help_improve_country =>
-      'Help improve Open Food Facts in your country';
+      'Hjelp med å forbedre Open Food Facts i landet ditt';
 
   @override
   String get sign_out => 'Logg ut';
@@ -323,7 +323,7 @@ class AppLocalizationsNb extends AppLocalizations {
       'Passordene er ikke like';
 
   @override
-  String get sign_up_page_agree_text => 'I agree to the Open Food Facts';
+  String get sign_up_page_agree_text => 'Jeg godtar de åpne matfaktaene';
 
   @override
   String get sign_up_page_terms_text => 'vilkår for bruk og bidrag';
@@ -333,7 +333,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get sign_up_page_agree_error_invalid =>
-      'When creating an account, agreeing to the Terms of Use is mandatory, however, anonymous contributions can still be made through the app';
+      'Når du oppretter en konto, er det obligatorisk å godta bruksvilkårene, men anonyme bidrag kan fortsatt gis gjennom appen.';
 
   @override
   String get sign_up_page_producer_checkbox => 'Jeg er en matprodusent';
@@ -347,7 +347,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get sign_up_page_subscribe_checkbox =>
-      'I\'d like to subscribe to the Open Food Facts newsletter (You can unsubscribe from it at any time)';
+      'Jeg vil gjerne abonnere på nyhetsbrevet fra Open Food Facts (du kan når som helst melde deg av)';
 
   @override
   String get sign_up_page_user_name_already_used =>
@@ -363,7 +363,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get sign_up_page_server_busy =>
-      'We are deeply sorry, we have some technical difficulties to create your account. Please try again later.';
+      'Vi beklager på det sterkeste, men vi har hatt noen tekniske problemer med å opprette kontoen din. Prøv igjen senere.';
 
   @override
   String get settingsTitle => 'Innstillinger';
@@ -384,7 +384,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get thanks_for_contributing => 'Takk for at du bidrar!';
 
   @override
-  String get contributors_label => 'They are building the app';
+  String get contributors_label => 'De bygger appen';
 
   @override
   String get contributors_dialog_title => 'Bidragsytere';
@@ -425,7 +425,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get legalNotices => 'Juridisk informasjon';
 
   @override
-  String get privacy_policy => 'Privacy policy';
+  String get privacy_policy => 'Personvernerklæring';
 
   @override
   String get about_this_app => 'Om denne appen';
@@ -445,10 +445,10 @@ class AppLocalizationsNb extends AppLocalizations {
       'Du kan bli med i Slack-chatterommet til Open Food Facts, som er den foretrukne måten å stille spørsmål på.';
 
   @override
-  String get contribute_develop_dev_mode_title => 'DEV Mode?';
+  String get contribute_develop_dev_mode_title => 'DEV-modus?';
 
   @override
-  String get contribute_develop_dev_mode_subtitle => 'Activate the DEV Mode';
+  String get contribute_develop_dev_mode_subtitle => 'Aktiver DEV-modus';
 
   @override
   String get contribute_donate_title => 'Doner';
@@ -458,7 +458,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get contribute_enroll_alpha_warning =>
-      'Please acknowledge that with the internal alpha version, complete loss of data is possible, and the app may become unusable at any time !';
+      'Vær oppmerksom på at med den interne alfaversjonen er fullstendig tap av data mulig, og appen kan bli ubrukelig når som helst!';
 
   @override
   String get contribute_improve_ProductsToBeCompleted =>
@@ -497,25 +497,25 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get contribute_share_content =>
-      'I wanted to let you know about the app I\'ve been using, Open Food Facts, which allows you to get the health and environmental impacts of your food, in a personalized way. It works by scanning the barcodes on the packaging. Finally it\'s free, does not require registration, and you can even help increase the number of products decyphered. Here\'s the link to get it for your phone: https://openfoodfacts.app';
+      'Jeg ville fortelle deg om appen jeg har brukt, Open Food Facts, som lar deg få informasjon om helse- og miljøpåvirkningen av maten din på en personlig måte. Den fungerer ved å skanne strekkodene på emballasjen. Den er gratis, krever ikke registrering, og du kan til og med bidra til å øke antallet produkter som dekrypteres. Her er lenken for å laste den ned til telefonen din: https://openfoodfacts.app';
 
   @override
   String get contribute_prices_gdpr =>
-      'Contribute prices by requesting a GDPR export of your loyalty cards data';
+      'Bidra til priser ved å be om GDPR-eksport av lojalitetskortdataene dine';
 
   @override
-  String get tap_to_answer => 'Tap here to answer questions';
+  String get tap_to_answer => 'Trykk her for å svare på spørsmål';
 
   @override
   String get tap_to_answer_hint =>
-      'Tap here to answer questions about this product';
+      'Trykk her for å svare på spørsmål om dette produktet';
 
   @override
   String get robotoff_questions_loading_hint =>
-      'Please wait while questions about this product are loaded';
+      'Vent mens spørsmål om dette produktet lastes inn';
 
   @override
-  String get saving_answer => 'Saving your answer';
+  String get saving_answer => 'Lagrer svaret ditt';
 
   @override
   String get contribute_to_get_rewards =>
@@ -523,7 +523,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get question_sign_in_text =>
-      'Sign in to your Open Food Facts account to get credit for your contributions';
+      'Logg inn på Open Food Facts-kontoen din for å få kreditt for bidragene dine';
 
   @override
   String get question_yes_button_accessibility_value => 'Svar med ja';
@@ -559,7 +559,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get myPreferences_settings_title => 'Appinnstillinger';
 
   @override
-  String get myPreferences_settings_subtitle => 'Dark mode, Languages…';
+  String get myPreferences_settings_subtitle => 'Mørk modus, Språk…';
 
   @override
   String get myPreferences_food_title => 'Matpreferanser';
@@ -570,7 +570,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get myPreferences_food_comment =>
-      'Choose what information about food matters most to you, in order to rank food according to your preferences, see the information you care about first, and get a compatibility summary. Those food preferences stay on your device, and are not associated with your Open Food Facts contributor account if you have one.';
+      'Velg hvilken informasjon om mat som er viktigst for deg, for å rangere mat i henhold til dine preferanser, se informasjonen du bryr deg om først, og få et kompatibilitetssammendrag. Disse matpreferansene forblir på enheten din, og er ikke knyttet til din Open Food Facts-bidragsyterkonto hvis du har en.';
 
   @override
   String get confirmResetPreferences => 'Tilbakestill matpreferansene dine?';
@@ -592,11 +592,11 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get refresh_with_new_preferences =>
-      'Refresh the list with your new preferences';
+      'Oppdater listen med de nye innstillingene dine';
 
   @override
   String get reloaded_with_new_preferences =>
-      'Reloaded with your new preferences';
+      'Lastet inn på nytt med dine nye preferanser';
 
   @override
   String get profile_navbar_label => 'Community';
@@ -642,141 +642,145 @@ class AppLocalizationsNb extends AppLocalizations {
   String get search_history => 'Søk historikk';
 
   @override
-  String get search_store => 'Search for a store';
+  String get search_store => 'Søk etter en butikk';
 
   @override
   String get search_store_help => 'Tips: legg til byen eller landet';
 
   @override
-  String get tap_for_more => 'Tap to see more info…';
+  String get tap_for_more => 'Trykk for å se mer informasjon…';
 
   @override
   String get product => 'Produkt';
 
   @override
-  String get unknownBrand => 'Unknown brand';
+  String get unknownBrand => 'Ukjent merke';
 
   @override
-  String get unknownProductName => 'Unknown product name';
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
+  String get unknownProductName => 'Ukjent produktnavn';
 
   @override
   String get label_refresh => 'Oppdater';
 
   @override
-  String get label_reload => 'Reload';
+  String get label_reload => 'Last inn på nytt';
 
   @override
-  String get image => 'Image';
+  String get image => 'Bilde';
 
   @override
-  String get front_photo => 'Front photo';
+  String get front_photo => 'Forsidebilde';
 
   @override
   String outdated_image_accessibility_label(Object imageType) {
-    return '$imageType (this image may be outdated)';
+    return '$imageType (dette bildet kan være utdatert)';
   }
 
   @override
-  String get outdated_image_short_label => 'may be outdated';
+  String get outdated_image_short_label => 'kan være utdatert';
 
   @override
   String get ingredients => 'Ingredienser';
 
   @override
   String get ingredients_editing_instructions =>
-      'Keep the original order. Indicate the percentage when specified. Separate with a comma or hyphen and use parentheses for ingredients of an ingredient.';
+      'Behold den opprinnelige rekkefølgen. Angi prosentandelen når den er spesifisert. Skill med komma eller bindestrek, og bruk parenteser for ingrediensene til en ingrediens.';
 
   @override
-  String get ingredients_editing_error => 'Failed to save the ingredients.';
+  String get ingredients_editing_error => 'Kunne ikke lagre ingrediensene.';
 
   @override
   String get ingredients_editing_image_error =>
-      'Failed to get a new ingredients image.';
+      'Klarte ikke å hente et nytt ingrediensbilde.';
 
   @override
-  String get ingredients_editing_title => 'Edit Ingredients';
+  String get ingredients_editing_title => 'Rediger ingredienser';
 
   @override
-  String get ingredients_photo => 'Ingredients photo';
+  String get ingredients_photo => 'Ingredienser bilde';
 
   @override
   String get packaging_editing_instructions =>
-      'List all packaging parts separated by a comma or line feed, with their amount (e.g. 1 or 6) type (e.g. bottle, box, can), material (e.g. plastic, metal, aluminium) and if available their size (e.g. 33cl) and recycling instructions.\nExample: 1 glass bottle to recycle, 1 plastic cork to throw away';
+      'List opp alle emballasjedeler atskilt med komma eller linjeskift, med mengde (f.eks. 1 eller 6), type (f.eks. flaske, eske, boks), materiale (f.eks. plast, metall, aluminium) og hvis tilgjengelig størrelse (f.eks. 33 cl) og resirkuleringsinstruksjoner.\nEksempel: 1 glassflaske til resirkulering, 1 plastkork til kasting';
 
   @override
-  String get packaging_editing_error => 'Failed to save the packaging.';
+  String get packaging_editing_error => 'Klarte ikke å lagre emballasjen.';
 
   @override
   String get packaging_editing_image_error =>
-      'Failed to get a new packaging image.';
+      'Klarte ikke å hente et nytt emballasjebilde.';
 
   @override
-  String get packaging_editing_title => 'Edit Packaging';
+  String get packaging_editing_title => 'Rediger emballasje';
 
   @override
   String get nutrition => 'Ernæring';
 
   @override
-  String get nutrition_facts_photo => 'Nutrition facts photo';
+  String get nutrition_facts_photo => 'Næringsinnholdsinformasjonsbilde';
 
   @override
-  String get nutrition_facts_editing_title => 'Edit Nutrition Facts';
+  String get nutrition_facts_editing_title => 'Rediger næringsinnhold';
 
   @override
-  String get packaging_information => 'Packaging information';
+  String get packaging_information => 'Emballasjeinformasjon';
 
   @override
-  String get packaging_information_photo => 'Packaging information photo';
+  String get packaging_information_photo => 'Emballasjeinformasjonsbilde';
 
   @override
-  String get missing_product => 'You found a new product!';
+  String get missing_product => 'Du har funnet et nytt produkt!';
 
   @override
   String get add_product_take_photos =>
-      'Take photos of the packaging to add this product to Open Food Facts';
+      'Ta bilder av emballasjen for å legge til dette produktet i Open Food Facts';
 
   @override
   String get add_product_take_photos_descriptive =>
-      'Please take some photos first. You may always complete the product at a later time.';
+      'Ta noen bilder først. Du kan alltids fullføre produktet senere.';
 
   @override
   String get add_product_information_button_label =>
       'Legg til produktinformasjon';
 
   @override
-  String get new_product => 'New Product';
+  String get new_product => 'Nytt produkt';
 
   @override
-  String get new_product_found_title => 'New product found!';
+  String get new_product_found_title => 'Nytt produkt funnet!';
 
   @override
   String get new_product_found_text =>
-      'Our collaborative database contains more than **3 million products**, but this barcode doesn\'t exist: ';
+      'Vår samarbeidsdatabase inneholder mer enn **3 millioner produkter**, men denne strekkoden finnes ikke: ';
 
   @override
   String get new_product_found_button => 'Legg til dette produktet';
 
   @override
-  String get new_product_leave_title => 'Leave this page?';
+  String get new_product_leave_title => 'Forlate denne siden?';
 
   @override
   String get new_product_leave_message =>
-      'It looks like you didn\'t input anything. Do you really want to leave this page?';
+      'Det ser ut som du ikke har skrevet inn noe. Vil du virkelig forlate denne siden?';
 
   @override
   String get new_product_dialog_description =>
-      'Please take photos of the packaging to add this product to our common database';
+      'Vennligst ta bilder av emballasjen for å legge dette produktet til i vår felles database.';
 
   @override
   String get new_product_dialog_illustration_description =>
-      'An illustration with unknown Nutri-Score and Green Score';
+      'En illustrasjon med ukjent Nutri-Score og Green Score';
 
   @override
-  String get front_packaging_photo_button_label => 'Front packaging photo';
+  String get front_packaging_photo_button_label =>
+      'Foto av forsiden av emballasjen';
 
   @override
   String get confirm_front_packaging_photo_button_label =>
-      'Confirm upload of Front packaging photo';
+      'Bekreft opplasting av bilde av frontemballasjen';
 
   @override
   String get confirm_button_label => 'Bekreft';
@@ -802,7 +806,7 @@ class AppLocalizationsNb extends AppLocalizations {
       'Vi klarer ikke å behandle bildet lokalt før vi sender det til serveren vår. Vennligst prøv igjen senere eller kontakt oss om problemet vedvarer.';
 
   @override
-  String get crop_page_action_retake => 'Retake a photo';
+  String get crop_page_action_retake => 'Ta et bilde på nytt';
 
   @override
   String get crop_page_too_small_image_title => 'Bildet er for lite!';
@@ -818,7 +822,7 @@ class AppLocalizationsNb extends AppLocalizations {
   }
 
   @override
-  String get crop_page_action_server => 'Preparing a call to the server…';
+  String get crop_page_action_server => 'Forbereder et kall til serveren…';
 
   @override
   String get front_packaging_photo_title => 'Bilde av framsiden på emballasjen';
@@ -842,20 +846,21 @@ class AppLocalizationsNb extends AppLocalizations {
   String get front_photo_uploaded => 'Framsidebilde lastet opp';
 
   @override
-  String get ingredients_photo_button_label => 'Ingredients photo';
+  String get ingredients_photo_button_label => 'Ingredienser bilde';
 
   @override
   String get ingredients_photo_uploaded => 'Bilde av ingredienser lastet opp';
 
   @override
   String get nutrition_cache_loading_error =>
-      'Unable to load nutrients from cache';
+      'Kan ikke laste inn næringsstoffer fra hurtigbufferen';
 
   @override
-  String get nutritional_facts_photo_button_label => 'Nutrition facts photo';
+  String get nutritional_facts_photo_button_label =>
+      'Næringsinnholdsinformasjonsbilde';
 
   @override
-  String get nutritional_facts_input_button_label => 'Fill nutrition facts';
+  String get nutritional_facts_input_button_label => 'Fyll inn næringsinnhold';
 
   @override
   String get nutritional_facts_added => 'Ernæringsfakta lagt til';
@@ -864,30 +869,30 @@ class AppLocalizationsNb extends AppLocalizations {
   String get categories_added => 'Kategorier lagt til';
 
   @override
-  String get new_product_title_nutriscore => 'Compute the Nutri-Score';
+  String get new_product_title_nutriscore => 'Beregn ernæringspoengsummen';
 
   @override
   String get new_product_subtitle_nutriscore =>
-      'Help us by filling at least a category and nutritional values';
+      'Hjelp oss ved å fylle ut minst én kategori og næringsverdier';
 
   @override
-  String get new_product_title_environmental_score => 'Compute the Green Score';
+  String get new_product_title_environmental_score =>
+      'Beregn den grønne poengsummen';
 
   @override
   String get new_product_subtitle_environmental_score =>
-      'Get it by filling at least a category';
+      'Få det ved å fylle ut minst én kategori';
 
   @override
   String get new_product_additional_environmental_score =>
-      'Make Green Score computation more precise with origins, packaging & more';
+      'Gjør beregningen av Green Score mer presis med opprinnelse, emballasje og mer';
 
   @override
-  String get new_product_title_nova =>
-      'Compute the food processing level (NOVA)';
+  String get new_product_title_nova => 'Beregn matforedlingsnivået (NOVA)';
 
   @override
   String get new_product_subtitle_nova =>
-      'Get it by filling the food category and ingredients';
+      'Få det ved å fylle ut matkategorien og ingrediensene';
 
   @override
   String get new_product_desc_nova_unknown => 'Matbearbeidingsnivå ukjent';
@@ -915,19 +920,19 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get hey_incomplete_product_message =>
-      'Tap to answer 3 questions NOW to compute Nutri-Score, Green Score & Ultra-processing (NOVA)!';
+      'Trykk for å svare på 3 spørsmål NÅ for å beregne Nutri-Score, Green Score og Ultra-processing (NOVA)!';
 
   @override
   String get hey_incomplete_product_message_beauty =>
-      'Tap now to answer 2 questions to help analyze this cosmetic!';
+      'Trykk nå for å svare på to spørsmål som kan hjelpe deg med å analysere dette produktet!';
 
   @override
   String get hey_incomplete_product_message_pet_food =>
-      'Tap now to answer 3 questions to help analyze this pet food product!';
+      'Trykk nå for å svare på tre spørsmål som kan hjelpe deg med å analysere dette dyrefôrproduktet!';
 
   @override
   String get hey_incomplete_product_message_product =>
-      'Tap now to help complete this product!';
+      'Trykk nå for å fullføre dette produktet!';
 
   @override
   String get nutritional_facts_photo_uploaded =>
@@ -945,7 +950,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get take_more_photo_button_label => 'Ta flere bilder';
 
   @override
-  String get other_photo_uploaded => 'Miscellaneous photo uploaded';
+  String get other_photo_uploaded => 'Diverse bilder lastet opp';
 
   @override
   String get retake_photo_button_label => 'Ta på nytt';
@@ -974,7 +979,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get uploading_image_type_other =>
-      'Uploading other image to Open Food Facts';
+      'Laster opp et annet bilde til Open Food Facts';
 
   @override
   String get uploading_image_type_generic =>
@@ -988,13 +993,15 @@ class AppLocalizationsNb extends AppLocalizations {
       'Legg til manglende emballasjebilde';
 
   @override
-  String get score_add_missing_nutrition_facts => 'Add missing nutrition facts';
+  String get score_add_missing_nutrition_facts =>
+      'Legg til manglende næringsinnhold';
 
   @override
-  String get score_add_missing_product_traces => 'Add missing product traces';
+  String get score_add_missing_product_traces =>
+      'Legg til manglende produktspor';
 
   @override
-  String get score_add_missing_product_category => 'Select a category';
+  String get score_add_missing_product_category => 'Velg en kategori';
 
   @override
   String get score_add_missing_precise_product_category =>
@@ -1002,36 +1009,40 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get score_add_missing_product_countries =>
-      'Add missing product countries';
+      'Legg til manglende produktland';
 
   @override
   String get score_add_missing_product_emb =>
-      'Add missing product traceability codes';
+      'Legg til manglende sporbarhetskoder for produkter';
 
   @override
-  String get score_add_missing_product_labels => 'Add missing product labels';
+  String get score_add_missing_product_labels =>
+      'Legg til manglende produktetiketter';
 
   @override
-  String get score_add_missing_product_origins => 'Add missing product origins';
+  String get score_add_missing_product_origins =>
+      'Legg til manglende produktopprinnelser';
 
   @override
-  String get score_add_missing_product_stores => 'Add missing product stores';
+  String get score_add_missing_product_stores =>
+      'Legg til manglende produktbutikker';
 
   @override
-  String get score_add_missing_product_brands => 'Add missing product brands';
+  String get score_add_missing_product_brands =>
+      'Legg til manglende produktmerker';
 
   @override
-  String get score_update_nutrition_facts => 'Update nutrition facts';
+  String get score_update_nutrition_facts => 'Oppdater næringsinnhold';
 
   @override
   String get nutrition_page_title => 'Ernæringsinnhold';
 
   @override
-  String get nutrition_page_nutritional_info_title => 'Nutritional information';
+  String get nutrition_page_nutritional_info_title => 'Næringsinnhold';
 
   @override
   String get nutrition_page_nutritional_info_label =>
-      'Values specified on the product:';
+      'Verdier spesifisert på produktet:';
 
   @override
   String get nutrition_page_nutritional_info_value_positive => 'Ja';
@@ -1040,24 +1051,24 @@ class AppLocalizationsNb extends AppLocalizations {
   String get nutrition_page_nutritional_info_value_negative => 'Nei';
 
   @override
-  String get nutrition_page_nutritional_info_open_photo => 'Open photo';
+  String get nutrition_page_nutritional_info_open_photo => 'Åpne bildet';
 
   @override
   String get nutrition_page_nutritional_info_explanation_title =>
-      'Good practices: Nutritional information';
+      'God praksis: Næringsinnhold';
 
   @override
   String get nutrition_page_nutritional_info_explanation_info1 =>
-      'Sometimes nutrition facts are **not specified on the packaging** or on a document given with the product. In this case, and only in this case, you can set the value to **NO**.';
+      'Noen ganger er næringsinnholdet **ikke spesifisert på emballasjen** eller på et dokument som følger med produktet. I dette tilfellet, og bare i dette tilfellet, kan du sette verdien til **NEI**.';
 
   @override
-  String get nutrition_page_serving_type_label => 'Nutritional values:';
+  String get nutrition_page_serving_type_label => 'Næringsinnhold:';
 
   @override
-  String get nutrition_page_per_100g => 'per 100g';
+  String get nutrition_page_per_100g => 'per 100 g';
 
   @override
-  String get nutrition_page_per_100g_100ml => 'per 100g/ml';
+  String get nutrition_page_per_100g_100ml => 'per 100 g/ml';
 
   @override
   String get nutrition_page_per_serving => 'per porsjon';
@@ -1070,31 +1081,31 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get nutrition_page_serving_size_hint =>
-      'Input a serving size (eg: 100g)';
+      'Skriv inn en porsjonsstørrelse (f.eks. 100 g)';
 
   @override
   String get nutrition_page_serving_size_explanation_title =>
-      'Good practices: Serving size';
+      'God praksis: Serveringsstørrelse';
 
   @override
   String get nutrition_page_serving_size_explanation_info1 =>
-      'This value helps to **make a proportional calculation of each nutrient per serving size**.';
+      'Denne verdien bidrar til å **lage en proporsjonal beregning av hvert næringsstoff per porsjonsstørrelse**.';
 
   @override
   String get nutrition_page_serving_size_explanation_info2 =>
-      '**Allowed units** are: kg, g, mg, µg, oz, l, dl, cl, ml, fl.oz, fl oz, г, мг, кг, л, дл, кл, мл, 毫克, 公斤, 毫升, 公升, 吨.';
+      '**Tillatte enheter** er: kg, g, mg, µg, oz, l, dl, cl, ml, fl.oz, fl oz, г, мг, кг, л, дл, кл, мл, 毫克, 公斤, 毫升, 公卨.';
 
   @override
   String get nutrition_page_serving_size_explanation_good_example1 =>
-      '**60 g**, **60g** or **60 G** (prefer the first one)';
+      '**60 g**, **60 g** eller **60 G** (foretrekk den første)';
 
   @override
   String get nutrition_page_serving_size_explanation_good_example2 =>
-      '**1000 ml** or **1L**';
+      '**1000 ml** eller **1 l**';
 
   @override
   String get nutrition_page_serving_size_explanation_bad_example1_explanation =>
-      'Invalid unit';
+      'Ugyldig enhet';
 
   @override
   String get nutrition_page_serving_size_explanation_bad_example1_example =>
@@ -1102,88 +1113,88 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get nutrition_page_serving_size_explanation_bad_example2_explanation =>
-      'Invalid units';
+      'Ugyldige enheter';
 
   @override
   String get nutrition_page_serving_size_explanation_bad_example2_example =>
-      '9 **candies** and 2 **biscuits**';
+      '9 **godteri** og 2 **kjeks**';
 
   @override
   String get nutrition_page_serving_size_explanation_bad_example3_explanation =>
-      'Missing unit';
+      'Manglende enhet';
 
   @override
   String get nutrition_page_serving_size_explanation_bad_example3_example =>
       '**30**';
 
   @override
-  String get nutrition_page_invalid_number => 'Invalid number';
+  String get nutrition_page_invalid_number => 'Ugyldig nummer';
 
   @override
   String get nutrition_page_update_running =>
-      'Updating the product on the server…';
+      'Oppdaterer produktet på serveren…';
 
   @override
-  String get nutrition_page_update_done => 'Product updated!';
+  String get nutrition_page_update_done => 'Produkt oppdatert!';
 
   @override
   String get nutrition_page_take_serving_size_from_product_quantity =>
-      'Use the product quantity as serving size';
+      'Bruk produktmengden som porsjonsstørrelse';
 
   @override
-  String get nutrition_page_photo_error => 'Unable to load the photo';
+  String get nutrition_page_photo_error => 'Kan ikke laste inn bildet';
 
   @override
-  String get more_photos => 'More interesting photos';
+  String get more_photos => 'Flere interessante bilder';
 
   @override
   String get view_more_photo_button =>
-      'View all existing photos for this product';
+      'Se alle eksisterende bilder for dette produktet';
 
   @override
-  String get no_product_found => 'No product found';
+  String get no_product_found => 'Ingen produkt funnet';
 
   @override
-  String get no_location_found => 'No location found';
+  String get no_location_found => 'Ingen plassering funnet';
 
   @override
-  String get not_found => 'not found:';
+  String get not_found => 'ikke funnet:';
 
   @override
-  String get refreshing_product => 'Refreshing product';
+  String get refreshing_product => 'Forfriskende produkt';
 
   @override
-  String get product_refreshed => 'Product refreshed';
+  String get product_refreshed => 'Produktet er oppdatert';
 
   @override
   String product_image_accessibility_label(String date) {
-    return 'Image taken on $date';
+    return 'Bilde tatt $date';
   }
 
   @override
   String product_image_outdated_accessibility_label(String date) {
-    return 'Image taken on $date. This image may be outdated';
+    return 'Bildet er tatt $date. Dette bildet kan være utdatert';
   }
 
   @override
-  String get product_image_outdated => 'This image may be outdated';
+  String get product_image_outdated => 'Dette bildet kan være utdatert';
 
   @override
   String get product_image_outdated_explanations_title =>
-      'This image may be outdated';
+      'Dette bildet kan være utdatert';
 
   @override
   String get product_image_outdated_explanations_content =>
-      'This image was taken more than a year ago.\n**Please check that\'s it\'s still up-to-date**.\n\nThis is **just a warning**. If the content is still the same, you can ignore this message.';
+      'Dette bildet ble tatt for over et år siden.\n**Sjekk at det fortsatt er oppdatert**.\n\nDette er **bare en advarsel**. Hvis innholdet fortsatt er det samme, kan du ignorere denne meldingen.';
 
   @override
   String product_image_action_replace_photo(String type) {
-    return 'Replace photo ($type)';
+    return 'Erstatt bilde ($type)';
   }
 
   @override
   String product_image_action_add_photo(String type) {
-    return 'Add a photo ($type)';
+    return 'Legg til et bilde ($type)';
   }
 
   @override
@@ -1193,92 +1204,91 @@ class AppLocalizationsNb extends AppLocalizations {
   String get product_image_action_take_picture => 'Ta et bilde';
 
   @override
-  String get product_image_action_from_gallery =>
-      'Select from your phone\'s gallery';
+  String get product_image_action_from_gallery => 'Velg fra telefonens galleri';
 
   @override
   String get product_image_action_choose_existing_photo =>
-      'Select from the product photos';
+      'Velg fra produktbildene';
 
   @override
-  String get product_image_details_label => 'Information about the photo';
+  String get product_image_details_label => 'Informasjon om bildet';
 
   @override
-  String get product_image_details_from_producer => 'From the producer';
+  String get product_image_details_from_producer => 'Fra produsenten';
 
   @override
   String get product_image_details_contributor => 'Bidrager';
 
   @override
   String get product_image_details_contributor_producer =>
-      'Contributor (producer)';
+      'Bidragsyter (produsent)';
 
   @override
-  String get product_image_details_date => 'Date';
+  String get product_image_details_date => 'Dato';
 
   @override
   String get product_image_details_date_unknown => 'Ukjent';
 
   @override
   String get homepage_main_card_logo_description =>
-      'Welcome to Open Food Facts';
+      'Velkommen til Åpne matfakta';
 
   @override
   String get homepage_main_card_subheading =>
-      '**Scan** a barcode or\n**search** for a product';
+      '**Skann** en strekkode eller\n**søk** etter et produkt';
 
   @override
   String get homepage_main_card_search_field_hint => 'Søk etter et produkt';
 
   @override
-  String get homepage_main_card_search_field_tooltip => 'Start search';
+  String get homepage_main_card_search_field_tooltip => 'Start søk';
 
   @override
   String scan_tagline_news_item_accessibility(String news_title) {
-    return 'Latest news: $news_title';
+    return 'Siste nytt: $news_title';
   }
 
   @override
-  String get tagline_app_review => 'Do you like the app?';
+  String get tagline_app_review => 'Liker du appen?';
 
   @override
-  String get tagline_app_review_button_positive => 'I love it! 😍';
+  String get tagline_app_review_button_positive => 'Jeg elsker det! 😍';
 
   @override
-  String get tagline_app_review_button_negative => 'Not really…';
+  String get tagline_app_review_button_negative => 'Ikke egentlig…';
 
   @override
-  String get tagline_app_review_button_later => 'Ask me later';
+  String get tagline_app_review_button_later => 'Spør meg senere';
 
   @override
-  String get tagline_feed_news_button => 'Know more';
+  String get tagline_feed_news_button => 'Lær mer';
 
   @override
-  String get app_review_negative_modal_title => 'You don\'t like our app?';
+  String get app_review_negative_modal_title => 'Liker du ikke appen vår?';
 
   @override
   String get app_review_negative_modal_text =>
-      'Could you take a few seconds to tell us why?';
+      'Kan du bruke noen sekunder på å fortelle oss hvorfor?';
 
   @override
-  String get app_review_negative_modal_positive_button => 'Yes, absolutely!';
+  String get app_review_negative_modal_positive_button => 'Ja, absolutt!';
 
   @override
   String get app_review_negative_modal_negative_button => 'Nei';
 
   @override
-  String get could_not_refresh => 'Could not refresh product';
+  String get could_not_refresh => 'Kunne ikke oppdatere produktet';
 
   @override
-  String get product_internet_error_modal_title => 'An error has occurred!';
+  String get product_internet_error_modal_title => 'Det har oppstått en feil!';
 
   @override
   String product_internet_error_modal_message(String error) {
-    return 'We are unable to fetch information about this product due to a network error. Please check your internet connection and try again.\n\nInternal error:\n$error';
+    return 'Vi kan ikke hente informasjon om dette produktet på grunn av en nettverksfeil. Sjekk internettforbindelsen din og prøv på nytt.\n\nIntern feil:\n$error';
   }
 
   @override
-  String get product_tags_title => 'Product properties';
+  String get product_tags_title => 'Produktegenskaper';
 
   @override
   String get no_product_tags_found_message =>
@@ -1295,28 +1305,28 @@ class AppLocalizationsNb extends AppLocalizations {
   String get add_tag => 'Add property';
 
   @override
-  String get add_tags => 'Add properties';
+  String get add_tags => 'Legg til egenskaper';
 
   @override
-  String get add_edit_tags => 'Add or edit properties';
+  String get add_edit_tags => 'Legg til eller rediger egenskaper';
 
   @override
-  String get edit_tag => 'Edit property';
+  String get edit_tag => 'Rediger egenskap';
 
   @override
-  String get remove_tag => 'Remove property';
+  String get remove_tag => 'Fjern egenskap';
 
   @override
-  String get tag_key => 'Property';
+  String get tag_key => 'Eiendom';
 
   @override
   String get tag_keys => 'Egenskaper';
 
   @override
-  String get tag_key_uneditable => 'Property (uneditable)';
+  String get tag_key_uneditable => 'Egenskap (kan ikke redigeres)';
 
   @override
-  String get tag_key_input_hint => 'Input a property';
+  String get tag_key_input_hint => 'Skriv inn en egenskap';
 
   @override
   String get tag_value => 'Verdi';
@@ -1325,29 +1335,29 @@ class AppLocalizationsNb extends AppLocalizations {
   String get tag_values => 'Values';
 
   @override
-  String get tag_value_input_hint => 'Input a value';
+  String get tag_value_input_hint => 'Skriv inn en verdi';
 
   @override
-  String get tag_key_item => 'Property:';
+  String get tag_key_item => 'Eiendom:';
 
   @override
-  String get tag_value_item => 'Value:';
+  String get tag_value_item => 'Verdi:';
 
   @override
   String get tag_key_explanations =>
-      'A key must be lowercase and without any spaces.';
+      'En nøkkel må være liten og uten mellomrom.';
 
   @override
   String tag_key_already_exists(String property) {
-    return 'A tag with a property $property already exists!';
+    return 'En tagg med en egenskap $property finnes allerede!';
   }
 
   @override
   String get product_internet_error =>
-      'Impossible to fetch information about this product due to a network error.';
+      'Umulig å hente informasjon om dette produktet på grunn av en nettverksfeil.';
 
   @override
-  String get cached_results_from => 'Show results from:';
+  String get cached_results_from => 'Vis resultater fra:';
 
   @override
   String get product_search_same_category => 'Finn alternativer';
@@ -1357,31 +1367,31 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get product_search_same_category_error =>
-      'This feature can only be used for products with a category.\n\nPlease edit the product to add a category.';
+      'Denne funksjonen kan bare brukes for produkter med en kategori.\n\nVennligst rediger produktet for å legge til en kategori.';
 
   @override
   String get product_improvement_add_category =>
-      'Add a category to calculate the Nutri-Score.';
+      'Legg til en kategori for å beregne Nutri-Score.';
 
   @override
   String get product_improvement_add_nutrition_facts =>
-      'Add nutrition facts to calculate the Nutri-Score.';
+      'Legg til næringsinnhold for å beregne Nutri-Score.';
 
   @override
   String get product_improvement_add_nutrition_facts_and_category =>
-      'Add nutrition facts and a category to calculate the Nutri-Score.';
+      'Legg til næringsinnhold og en kategori for å beregne Nutri-Score.';
 
   @override
   String get product_improvement_categories_but_no_nutriscore =>
-      'The Nutri-Score for this product can\'t be calculated, which may be due to e.g. a non-standard category. If this is considered an error, please contact us.';
+      'Næringspoengsummen for dette produktet kan ikke beregnes, noe som for eksempel kan skyldes en ikke-standard kategori. Hvis dette anses som en feil, vennligst kontakt oss.';
 
   @override
   String get product_improvement_obsolete_nutrition_image =>
-      'The nutrition image is obsolete: please refresh it.';
+      'Ernæringsbildet er utdatert: vennligst oppdater det.';
 
   @override
   String get product_improvement_origins_to_be_completed =>
-      'The Green Score takes into account the origins of the ingredients. Please take a photo of the ingredient list and/or any geographic claim or edit the product, so they can be taken into account.';
+      'Den grønne poengsummen tar hensyn til ingrediensenes opprinnelse. Vennligst ta et bilde av ingredienslisten og/eller eventuelle geografiske påstander, eller rediger produktet, slik at de kan tas i betraktning.';
 
   @override
   String get country_chooser_label => 'Velg et land';
@@ -1390,7 +1400,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get currency_chooser_label => 'Velg en valuta';
 
   @override
-  String get country_change_message => 'You have just changed countries.';
+  String get country_change_message => 'Du har nettopp byttet land.';
 
   @override
   String currency_auto_change_message(
@@ -1401,10 +1411,10 @@ class AppLocalizationsNb extends AppLocalizations {
   }
 
   @override
-  String get onboarding_country_chooser_label => 'Please choose a country:';
+  String get onboarding_country_chooser_label => 'Vennligst velg et land:';
 
   @override
-  String get country_chooser_label_from_settings => 'Your country';
+  String get country_chooser_label_from_settings => 'Landet ditt';
 
   @override
   String get country_selection_explanation =>
@@ -1526,24 +1536,24 @@ class AppLocalizationsNb extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count selected products',
-      one: 'One selected product',
-      zero: 'No selected product',
+      other: '$count valgte produkter',
+      one: 'Ett valgt produkt',
+      zero: 'Ingen valgte produkter',
     );
     return '$_temp0';
   }
 
   @override
-  String get compare_products_mode => 'Compare selected products';
+  String get compare_products_mode => 'Sammenlign utvalgte produkter';
 
   @override
-  String get delete_products_mode => 'Delete selected products';
+  String get delete_products_mode => 'Slett valgte produkter';
 
   @override
-  String get select_all_products_mode => 'Select all products';
+  String get select_all_products_mode => 'Velg alle produkter';
 
   @override
-  String get select_none_products_mode => 'Select none';
+  String get select_none_products_mode => 'Velg ingen';
 
   @override
   String get compare_products_appbar_title => 'Sammenlign produkter';
@@ -1558,7 +1568,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get connect_with_us => 'Kontakt oss';
 
   @override
-  String get tiktok => 'Follow us on TikTok';
+  String get tiktok => 'Følg oss på TikTok';
 
   @override
   String get tiktok_link => 'https://www.tiktok.com/@openfoodfacts';
@@ -1576,13 +1586,13 @@ class AppLocalizationsNb extends AppLocalizations {
   String get twitter_link => 'https://www.twitter.com/openfoodfacts';
 
   @override
-  String get mastodon => 'Follow us on Mastodon';
+  String get mastodon => 'Følg oss på Mastodon';
 
   @override
   String get mastodon_link => 'https://mastodon.social/@openfoodfacts';
 
   @override
-  String get bsky => 'Follow us on BlueSky';
+  String get bsky => 'Følg oss på BlueSky';
 
   @override
   String get bsky_link => 'https://bsky.app/profile/openfoodfacts.bsky.social';
@@ -1601,7 +1611,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get hint_knowledge_panel_message =>
-      'Your can tap on any part of the card to get more details about what you see. Try it now!';
+      'Du kan trykke på hvilken som helst del av kortet for å få mer informasjon om hva du ser. Prøv det nå!';
 
   @override
   String get permissions_page_title => 'Kameratilgang';
@@ -1663,18 +1673,18 @@ class AppLocalizationsNb extends AppLocalizations {
   }
 
   @override
-  String get onboarding_home_welcome_text1 => 'Welcome !';
+  String get onboarding_home_welcome_text1 => 'Velkommen!';
 
   @override
   String get onboarding_home_welcome_text2 =>
-      'The app that helps you choose food that is good for **you** and the **planet**!';
+      'Appen som hjelper deg med å velge mat som er bra for **deg** og **planeten**!';
 
   @override
-  String get onboarding_continue_button => 'Continue';
+  String get onboarding_continue_button => 'Fortsette';
 
   @override
   String get onboarding_welcome_loading_dialog_title =>
-      'Loading your first example product';
+      'Laster inn ditt første eksempelprodukt';
 
   @override
   String get onboarding_welcome_warning =>
@@ -1687,22 +1697,22 @@ class AppLocalizationsNb extends AppLocalizations {
   String get product_list_empty_icon_desc => 'Historikk utilgjengelig';
 
   @override
-  String get product_list_empty_title => 'Start scanning';
+  String get product_list_empty_title => 'Start skanning';
 
   @override
   String get product_list_empty_message =>
-      'Scanned products will appear here and you can check detailed information about them';
+      'Skannede produkter vil vises her, og du kan sjekke detaljert informasjon om dem';
 
   @override
   String product_list_reloading_in_progress_multiple(num count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'products',
-      one: 'product',
-      zero: 'product',
+      other: 'produkter',
+      one: 'produkt',
+      zero: 'produkt',
     );
-    return 'Refreshing $_temp0 in your history';
+    return 'Oppdaterer $_temp0 i historikken din';
   }
 
   @override
@@ -1710,11 +1720,11 @@ class AppLocalizationsNb extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'Products',
-      one: 'Product',
-      zero: 'Product',
+      other: 'Produkter',
+      one: 'Produkt',
+      zero: 'Produkt',
     );
-    return '$_temp0 refresh complete';
+    return '$_temp0 oppdatering fullført';
   }
 
   @override
@@ -1741,11 +1751,11 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get user_profile_subtitle_guest =>
-      'Sign-in or sign-up to join the Open Food Facts community';
+      'Logg inn eller registrer deg for å bli med i Open Food Facts-fellesskapet';
 
   @override
   String user_profile_title_id_email(String email) {
-    return 'Open Food Facts login: $email';
+    return 'Åpne Matfakta-innlogging: $email';
   }
 
   @override
@@ -1758,7 +1768,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String email_body_account_deletion(String userId) {
-    return 'Hi there, please delete my Open Food Facts account: $userId';
+    return 'Hei, vennligst slett Open Food Facts-kontoen min: $userId';
   }
 
   @override
@@ -1774,7 +1784,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get settings_app_products => 'Produkter';
 
   @override
-  String get settings_app_miscellaneous => 'Miscellaneous';
+  String get settings_app_miscellaneous => 'Diverse';
 
   @override
   String get camera_play_sound_title => 'Spill av en lyd ved skanning';
@@ -1785,21 +1795,21 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get camera_window_accessibility_label =>
-      'Scan a barcode with your camera';
+      'Skann en strekkode med kameraet ditt';
 
   @override
-  String get app_haptic_feedback_title => 'Vibration & Haptics';
+  String get app_haptic_feedback_title => 'Vibrasjon og haptikk';
 
   @override
   String get app_haptic_feedback_subtitle =>
-      'Vibrations after executing some actions (barcode decoded, product removed…).';
+      'Vibrasjoner etter utførelse av enkelte handlinger (strekkode dekodet, produkt fjernet…).';
 
   @override
   String get crash_reporting_toggle_title => 'Feilrapportering';
 
   @override
   String get crash_reporting_toggle_subtitle =>
-      'When enabled, crash reports are automatically submitted to Open Food Facts\' error tracking system, so that bugs can be fixed and thus improve the app.';
+      'Når det er aktivert, sendes krasjrapporter automatisk til Open Food Facts\' feilsporingssystem, slik at feil kan rettes og dermed forbedre appen.';
 
   @override
   String get send_anonymous_data_toggle_title => 'Del anonyme data';
@@ -1816,23 +1826,23 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get permission_photo_denied_title =>
-      'Allow camera use to scan barcodes';
+      'Tillat kamerabruk for å skanne strekkoder';
 
   @override
   String permission_photo_denied_message(String appName) {
-    return 'For an enhanced experience, please allow $appName to access your camera. You will be able to directly scan barcodes.';
+    return 'For en forbedret opplevelse, vennligst gi $appName tilgang til kameraet ditt. Du vil kunne skanne strekkoder direkte.';
   }
 
   @override
-  String get permission_photo_denied_button => 'Allow';
+  String get permission_photo_denied_button => 'Tillate';
 
   @override
   String get permission_photo_denied_dialog_settings_title =>
-      'Permission denied';
+      'Tillatelse nektet';
 
   @override
   String get permission_photo_denied_dialog_settings_message =>
-      'As you\'ve previously denied the camera permission, you must allow it manually from the Settings.';
+      'Siden du tidligere har nektet kameratillatelse, må du tillate det manuelt fra Innstillingene.';
 
   @override
   String get permission_photo_denied_dialog_settings_button_open =>
@@ -1842,116 +1852,124 @@ class AppLocalizationsNb extends AppLocalizations {
   String get permission_photo_denied_dialog_settings_button_cancel => 'Avbryt';
 
   @override
-  String get permission_photo_none_found => 'No camera detected';
+  String get permission_photo_none_found => 'Ingen kamera oppdaget';
 
   @override
-  String get permission_photo_denied => 'No camera access granted';
+  String get permission_photo_denied => 'Ingen kameratilgang gitt';
 
   @override
-  String get show_product_pictures => 'Show product pictures';
+  String get show_product_pictures => 'Vis produktbilder';
 
   @override
   String get edit_product_label => 'Rediger produkt';
 
   @override
   String get edit_product_pending_operations_banner_title =>
-      'Uploading your edits…';
+      'Laster opp redigeringene dine…';
 
   @override
   String get edit_product_pending_operations_banner_message =>
-      'Your edits are being **sent in the background** (or later in case of error).\nYou can continue editing other product fields.';
+      'Redigeringene dine sendes i bakgrunnen (eller senere ved feil).\nDu kan fortsette å redigere andre produktfelt.';
 
   @override
   String get edit_product_pending_operations_banner_short_message =>
-      'Your edits are being **sent in the background** (or later in case of error).';
+      'Redigerelsene dine sendes i bakgrunnen (eller senere ved feil).';
 
   @override
   String get edit_product_label_short => 'Rediger ';
 
   @override
   String edit_product_form_item_help(String value) {
-    return 'How to enter \"$value\"?';
+    return 'Hvordan skriver man inn «$value»?';
   }
 
   @override
   String get edit_product_form_item_error_empty =>
-      'Please enter a non-empty value!';
+      'Vennligst skriv inn en verdi som ikke er tom!';
 
   @override
   String get edit_product_form_item_error_existing =>
-      'This value is already there!';
+      'Denne verdien er allerede der!';
 
   @override
-  String get edit_product_form_item_add_action_brand => 'Add a new brand';
+  String get edit_product_form_item_add_action_brand =>
+      'Legg til et nytt merke';
 
   @override
-  String get edit_product_form_item_add_action_label => 'Add a new label';
+  String get edit_product_form_item_add_action_label =>
+      'Legg til en ny etikett';
 
   @override
-  String get edit_product_form_item_add_action_store => 'Add a new store';
+  String get edit_product_form_item_add_action_store => 'Legg til en ny butikk';
 
   @override
-  String get edit_product_form_item_add_action_origin => 'Add a new origin';
+  String get edit_product_form_item_add_action_origin =>
+      'Legg til en ny opprinnelse';
 
   @override
   String get edit_product_form_item_add_action_emb_code =>
-      'Add a new traceability code';
+      'Legg til en ny sporbarhetskode';
 
   @override
-  String get edit_product_form_item_add_action_country => 'Add a new country';
+  String get edit_product_form_item_add_action_country =>
+      'Legg til et nytt land';
 
   @override
-  String get edit_product_form_item_add_action_category => 'Add a new category';
+  String get edit_product_form_item_add_action_category =>
+      'Legg til en ny kategori';
 
   @override
-  String get edit_product_form_item_add_action_trace => 'Add a new trace';
+  String get edit_product_form_item_add_action_trace => 'Legg til et nytt spor';
 
   @override
-  String get edit_product_form_item_add_suggestion => 'Add suggestion';
+  String get edit_product_form_item_add_suggestion => 'Legg til forslag';
 
   @override
   String get edit_product_form_item_deny_suggestion => 'Nekt forslag';
 
   @override
-  String get edit_product_form_item_details_title => 'Basic details';
+  String get edit_product_form_item_details_title => 'Grunnleggende detaljer';
 
   @override
   String get edit_product_form_item_details_subtitle =>
-      'Product name, brand, quantity';
+      'Produktnavn, merke, antall';
 
   @override
-  String get edit_product_form_item_other_details_title => 'Additional details';
+  String get edit_product_form_item_other_details_title =>
+      'Ytterligere detaljer';
 
   @override
-  String get edit_product_form_item_other_details_subtitle => 'Website…';
+  String get edit_product_form_item_other_details_subtitle => 'Nettsted…';
 
   @override
   String get edit_product_form_item_photos_title => 'Bilder';
 
   @override
-  String get edit_product_form_item_photos_subtitle => 'Add or refresh photos';
+  String get edit_product_form_item_photos_subtitle =>
+      'Legg til eller oppdater bilder';
 
   @override
-  String get edit_product_form_item_labels_title => 'Labels & Certifications';
+  String get edit_product_form_item_labels_title =>
+      'Etiketter og sertifiseringer';
 
   @override
   String get edit_product_form_item_labels_subtitle =>
-      'Environmental, Quality labels…';
+      'Miljø, kvalitetsmerker…';
 
   @override
   String get edit_product_form_item_labels_hint =>
-      'Input a label (eg: NutriScore)';
+      'Skriv inn en etikett (f.eks.: NutriScore)';
 
   @override
   String get edit_product_form_item_labels_type => 'stempel';
 
   @override
   String get edit_product_form_item_labels_explanation_title =>
-      'Good practices: Labels';
+      'God praksis: Etiketter';
 
   @override
   String get edit_product_form_item_labels_explanation_info1 =>
-      'Any characteristic of the product **which is factual** and different from the other fields.';
+      'Enhver egenskap ved produktet **som er faktisk** og forskjellig fra de andre feltene.';
 
   @override
   String get edit_product_form_item_labels_explanation_good_examples_1 =>
@@ -1959,7 +1977,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get edit_product_form_item_labels_explanation_good_examples_2 =>
-      'Made in Belgium, produced in Brittany…';
+      'Laget i Belgia, produsert i Bretagne…';
 
   @override
   String get edit_product_form_item_labels_explanation_good_examples_3 =>
@@ -1967,28 +1985,28 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get edit_product_form_item_labels_explanation_good_examples_4 =>
-      'Rich in fiber, source of iron…';
+      'Rik på fiber, kilde til jern…';
 
   @override
   String get edit_product_form_item_labels_explanation_good_examples_5 =>
-      'Fair trade, Max Havelaar…';
+      'Rettferdig handel, Max Havelaar…';
 
   @override
   String get edit_product_form_item_stores_title => 'Butikker';
 
   @override
-  String get edit_product_form_item_stores_hint => 'Input a store';
+  String get edit_product_form_item_stores_hint => 'Legg inn en butikk';
 
   @override
   String get edit_product_form_item_stores_type => 'butikk';
 
   @override
   String get edit_product_form_item_stores_explanation_title =>
-      'Good practices: Stores';
+      'God praksis: Butikker';
 
   @override
   String get edit_product_form_item_stores_explanation_info1 =>
-      'Input the store where you bought the product.';
+      'Skriv inn butikken der du kjøpte produktet.';
 
   @override
   String get edit_product_form_item_stores_explanation_good_examples_1 =>
@@ -2003,74 +2021,74 @@ class AppLocalizationsNb extends AppLocalizations {
       'Lidl';
 
   @override
-  String get edit_product_form_item_origins_title => 'Origins';
+  String get edit_product_form_item_origins_title => 'Opprinnelse';
 
   @override
   String get edit_product_form_item_origins_hint =>
-      'Input an origin (eg: Germany)';
+      'Skriv inn en opprinnelse (f.eks. Tyskland)';
 
   @override
   String get edit_product_form_item_origins_type => 'land';
 
   @override
   String get edit_product_form_item_origins_explanation_title =>
-      'Good practices: Origins';
+      'God praksis: Opprinnelse';
 
   @override
   String get edit_product_form_item_origins_explanation_info1 =>
-      'Add **any indications of origins you can find on the packaging**.\nYou need not worry about origins indicated directly in the ingredient list.';
+      'Legg til **eventuelle opprinnelsesangivelser du finner på emballasjen**.\nDu trenger ikke å bekymre deg for opprinnelsesangivelser som er angitt direkte i ingredienslisten.';
 
   @override
   String get edit_product_form_item_origins_explanation_good_examples_1 =>
-      'Beef from Argentina';
+      'Storfekjøtt fra Argentina';
 
   @override
   String get edit_product_form_item_origins_explanation_good_examples_2 =>
-      'The soy does not come from the European Union';
+      'Soyaen kommer ikke fra EU';
 
   @override
   String get edit_product_form_item_countries_title => 'Country';
 
   @override
   String get edit_product_form_item_countries_hint =>
-      'Input a country (eg: Germany)';
+      'Skriv inn et land (f.eks. Tyskland)';
 
   @override
   String get edit_product_form_item_countries_type => 'land';
 
   @override
   String get edit_product_form_item_countries_explanations_title =>
-      'Good practices: Countries';
+      'God praksis: Land';
 
   @override
   String get edit_product_form_item_countries_explanations_info1 =>
-      '**Countries where the product is widely available** (not including stores specialising in foreign products).';
+      '**Land der produktet er allment tilgjengelig** (ikke inkludert butikker som spesialiserer seg på utenlandske produkter).';
 
   @override
   String get edit_product_form_item_emb_codes_title => 'Sporbarhetskode';
 
   @override
   String get edit_product_form_item_emb_codes_hint =>
-      'Input a code (eg: EMB 53062, FR 62.448.034 CE, 84 R 20, 33 RECOLTANT 522…)';
+      'Skriv inn en kode (f.eks.: EMB 53062, FR 62.448.034 CE, 84 R 20, 33 RECOLTANT 522…)';
 
   @override
   String get edit_product_form_item_emb_codes_type => 'sporbarhetskode';
 
   @override
   String get edit_product_form_item_emb_help_title =>
-      'Good practices: Traceability codes';
+      'God praksis: Sporbarhetskoder';
 
   @override
   String get edit_product_form_item_emb_help_info1 =>
-      'In this section, you can input codes related to **packaging marks**, **identification marks** or **health marks**.';
+      'I denne delen kan du legge inn koder relatert til **emballasjemerker**, **identifikasjonsmerker** eller **helsemerker**.';
 
   @override
   String get edit_product_form_item_emb_help_info2_title =>
-      'Examples of traceability codes';
+      'Eksempler på sporbarhetskoder';
 
   @override
   String get edit_product_form_item_emb_help_info2_item1_text =>
-      '**EC codes** used in the European Community to identify food producers or packagers:';
+      '**EF-koder** brukt i Det europeiske fellesskap for å identifisere matprodusenter eller -pakkere:';
 
   @override
   String get edit_product_form_item_emb_help_info2_item1_example =>
@@ -2078,11 +2096,11 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get edit_product_form_item_emb_help_info2_item1_explanation =>
-      '**FR**: country code of **France**\n**72.264.002**: geographic data\n**CE**: European Community';
+      '**FR**: landskode for **Frankrike**\n**72.264.002**: geografiske data\n**CE**: Det europeiske fellesskap';
 
   @override
   String get edit_product_form_item_emb_help_info2_item2_text =>
-      '**EMB codes** used in France:';
+      '**EMB-koder** brukt i Frankrike:';
 
   @override
   String get edit_product_form_item_emb_help_info2_item2_explanation =>
@@ -2096,7 +2114,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get edit_product_form_item_traces_type =>
-      'Input a trace (eg: Soy beans)';
+      'Skriv inn et spor (f.eks. soyabønner)';
 
   @override
   String get edit_product_form_item_categories_title => 'Kategorier';
@@ -2106,82 +2124,83 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get edit_product_form_item_categories_type =>
-      'Input a category (eg: Orange juice)';
+      'Skriv inn en kategori (f.eks.: Appelsinjuice)';
 
   @override
   String get edit_product_form_item_categories_explanation_title =>
-      'Good practices: Categories';
+      'God praksis: Kategorier';
 
   @override
   String get edit_product_form_item_categories_explanation_info1 =>
-      'Indicate **only the most specific category**.\nParent categories will be automatically added.';
+      'Angi **kun den mest spesifikke kategorien**.\nOverordnede kategorier vil bli lagt til automatisk.';
 
   @override
   String get edit_product_form_item_categories_explanation_info2_title =>
-      'Missing category?';
+      'Mangler kategori?';
 
   @override
   String get edit_product_form_item_categories_explanation_info2_content =>
-      'In case a category is **not available in autocomplete**, feel free to add it anyway.\nThis will help us improve Open Food Facts in your country.';
+      'Hvis en kategori **ikke er tilgjengelig i autofullføring**, kan du gjerne legge den til likevel.\nDette vil hjelpe oss med å forbedre Open Food Facts i landet ditt.';
 
   @override
   String get edit_product_form_item_categories_explanation_good_examples_1 =>
-      'Sardines in olive oil';
+      'Sardiner i olivenolje';
 
   @override
   String get edit_product_form_item_categories_explanation_good_examples_2 =>
-      'Orange juice from concentrate';
+      'Appelsinjuice fra konsentrat';
 
   @override
-  String get edit_product_form_item_exit_title => 'Quit without saving?';
+  String get edit_product_form_item_exit_title => 'Avslutte uten å lagre?';
 
   @override
   String get edit_product_form_item_exit_confirmation =>
-      'Do you want to save your changes before leaving this page?';
+      'Vil du lagre endringene dine før du forlater denne siden?';
 
   @override
   String get edit_product_form_item_exit_confirmation_positive_button =>
-      'Save changes';
+      'Lagre endringer';
 
   @override
   String get edit_product_form_item_exit_confirmation_negative_button =>
-      'Discard changes';
+      'Forkast endringer';
 
   @override
   String get edit_product_form_item_ingredients_title => 'Ingredienser';
 
   @override
   String get edit_product_form_item_ingredients_pinch_to_zoom_tooltip =>
-      'Zoom in and out by pinching the screen';
+      'Zoom inn og ut ved å klype skjermen';
 
   @override
   String get edit_product_form_item_ingredients_pinch_to_zoom_title =>
-      'Zoom in and out the photo';
+      'Zoom inn og ut av bildet';
 
   @override
   String get edit_product_form_item_ingredients_pinch_to_zoom_message =>
-      'Using the **Pinch-to-zoom gesture**, you can zoom in or out the photo:';
+      'Ved å bruke **Klyp-for-å-zoome-bevegelsen** kan du zoome inn eller ut av bildet:';
 
   @override
   String get edit_product_form_item_add_valid_item_tooltip => 'Legg til';
 
   @override
   String get edit_product_form_item_add_invalid_item_tooltip =>
-      'Please enter a text first';
+      'Vennligst skriv inn en tekst først';
 
   @override
-  String get edit_product_form_item_remove_item_tooltip => 'Remove';
+  String get edit_product_form_item_remove_item_tooltip => 'Fjerne';
 
   @override
-  String get edit_product_form_item_save_edit_item_tooltip => 'Save your edit';
+  String get edit_product_form_item_save_edit_item_tooltip =>
+      'Lagre redigeringen din';
 
   @override
   String get edit_product_form_item_cancel_edit_item_tooltip =>
-      'Cancel your edit';
+      'Avbryt redigeringen din';
 
   @override
   String get edit_product_form_item_packaging_title =>
-      'Recycling instructions photo';
+      'Instruksjoner for resirkulering, bilde';
 
   @override
   String get edit_product_form_item_nutrition_facts_title => 'Ernæringsinnhold';
@@ -2192,15 +2211,15 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get edit_product_form_item_nutrition_facts_explanation_title =>
-      'Good practices: Nutrition facts';
+      'God praksis: Næringsinnhold';
 
   @override
   String get edit_product_form_item_nutrition_facts_explanation_info1_title =>
-      'Nutritional values';
+      'Næringsverdier';
 
   @override
   String get edit_product_form_item_nutrition_facts_explanation_info1_content =>
-      'First, select if the **values are provided**:';
+      'Først velger du om **verdiene er oppgitt**:';
 
   @override
   String get edit_product_form_item_nutrition_facts_explanation_info2_title =>
@@ -2208,30 +2227,30 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get edit_product_form_item_nutrition_facts_explanation_info2_content =>
-      'Then, input the nutritional values **as indicated on the packaging**. If there is no value, you can click on the \"Eye\" icon.';
+      'Deretter skriver du inn næringsverdiene **som angitt på emballasjen**. Hvis det ikke finnes noen verdi, kan du klikke på «Øye»-ikonet.';
 
   @override
   String get edit_product_form_item_nutrition_facts_explanation_info3_title =>
-      'Missing field?';
+      'Mangler et felt?';
 
   @override
   String get edit_product_form_item_nutrition_facts_explanation_info3_content =>
-      'If an entry is missing, you can **click on the \"Plus\" icon** to add it (eg: vitamin D, magnesium…).';
+      'Hvis en oppføring mangler, kan du **klikke på «Pluss»-ikonet** for å legge den til (f.eks.: vitamin D, magnesium…).';
 
   @override
   String get edit_product_form_save => 'Rediger ';
 
   @override
-  String get edit_product_ingredients_photo_title => 'Ingredients photo';
+  String get edit_product_ingredients_photo_title => 'Ingredienser bilde';
 
   @override
   String get edit_product_ingredients_list_title => 'Ingrediensliste';
 
   @override
-  String get edit_product_packaging_photo_title => 'Packaging photo';
+  String get edit_product_packaging_photo_title => 'Emballasjebilde';
 
   @override
-  String get edit_product_packaging_list_title => 'Packaging list';
+  String get edit_product_packaging_list_title => 'Pakkeliste';
 
   @override
   String get no_data_available => 'Ingen data tilgjengelig';
@@ -2240,21 +2259,21 @@ class AppLocalizationsNb extends AppLocalizations {
   String get product_field_website_title => 'Nettsted';
 
   @override
-  String get origins_editing_title => 'Edit Origins';
+  String get origins_editing_title => 'Rediger opprinnelse';
 
   @override
   String get completed_basic_details_btn_text =>
       'Fullfør grunnleggende detaljer';
 
   @override
-  String get not_implemented_snackbar_text => 'Not implemented yet';
+  String get not_implemented_snackbar_text => 'Ikke implementert ennå';
 
   @override
   String get category_picker_page_appbar_text => 'Kategorier';
 
   @override
   String get edit_ingredients_extract_ingredients_btn_text =>
-      'Extract ingredients from the photo';
+      'Hent ut ingredienser fra bildet';
 
   @override
   String get edit_ingredients_extract_ingredients_btn_text_short =>
@@ -2262,43 +2281,43 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get edit_ingredients_extracting_ingredients_btn_text =>
-      'Extracting ingredients\nfrom the photo';
+      'Uttrekk av ingredienser\nfra bildet';
 
   @override
-  String get edit_ingredients_loading_photo_btn_text => 'Loading photo…';
+  String get edit_ingredients_loading_photo_btn_text => 'Laster inn bilde…';
 
   @override
   String get edit_ingredients_loading_photo_help_dialog_title =>
-      'Why do I see this message?';
+      'Hvorfor ser jeg denne meldingen?';
 
   @override
   String get edit_ingredients_loading_photo_help_dialog_body =>
-      'To use the \"Extract ingredients\" feature, the photo needs to be uploaded first.\n\nPlease wait a few seconds or enter them manually.';
+      'For å bruke funksjonen «Trekke ut ingredienser», må bildet lastes opp først.\n\nVent noen sekunder eller skriv dem inn manuelt.';
 
   @override
   String get edit_ingredients_refresh_photo_btn_text => 'Oppdater bildet';
 
   @override
   String get edit_packaging_extract_btn_text =>
-      'Extract packaging\nfrom the photo';
+      'Hent ut emballasje\nfra bildet';
 
   @override
-  String get edit_packaging_extract_btn_text_short => 'Extract packaging';
+  String get edit_packaging_extract_btn_text_short => 'Ekstraktemballasje';
 
   @override
   String get edit_packaging_extracting_btn_text =>
-      'Extracting packaging from the photo';
+      'Utpakking av emballasje fra bildet';
 
   @override
-  String get edit_packaging_loading_photo_btn_text => 'Loading photo…';
+  String get edit_packaging_loading_photo_btn_text => 'Laster inn bilde…';
 
   @override
   String get edit_packaging_loading_photo_help_dialog_title =>
-      'Why do I see this message?';
+      'Hvorfor ser jeg denne meldingen?';
 
   @override
   String get edit_packaging_loading_photo_help_dialog_body =>
-      'To use the \"Extract packaging\" feature, the photo needs to be uploaded first.\n\nPlease wait a few seconds or enter them manually.';
+      'For å bruke funksjonen «Pakk ut emballasje» må bildet lastes opp først.\n\nVent noen sekunder eller skriv dem inn manuelt.';
 
   @override
   String get edit_packaging_refresh_photo_btn_text => 'Oppdater bildet';
@@ -2308,11 +2327,11 @@ class AppLocalizationsNb extends AppLocalizations {
       'Kunne ikke gjenkjenne tekst på bildet.';
 
   @override
-  String get edit_ocr_extract_disabled_title => 'No picture!';
+  String get edit_ocr_extract_disabled_title => 'Ikke noe bilde!';
 
   @override
   String get edit_ocr_extract_disabled_message =>
-      'In order to use the text extraction feature, you must first take a photo.';
+      'For å bruke tekstuttrekkingsfunksjonen må du først ta et bilde.';
 
   @override
   String get user_list_dialog_new_title => 'Ny liste med produkter';
@@ -2361,7 +2380,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get user_list_name_error_same => 'Det er det samme navnet';
 
   @override
-  String get user_list_name_input_hint => 'Name of the list';
+  String get user_list_name_input_hint => 'Navnet på listen';
 
   @override
   String get try_again => 'Prøv igjen';
@@ -2401,14 +2420,15 @@ class AppLocalizationsNb extends AppLocalizations {
       'Klikk for å åpne i nettleseren din eller i appen (hvis den er installert)';
 
   @override
-  String get dev_preferences_screen_title => 'DEV Mode';
+  String get dev_preferences_screen_title => 'DEV-modus';
 
   @override
   String get dev_preferences_screen_subtitle =>
       'Få tilgang til eksperimentelle funksjoner og utviklingsverktøy';
 
   @override
-  String get dev_preferences_reset_onboarding_title => 'Restart onboarding';
+  String get dev_preferences_reset_onboarding_title =>
+      'Start omstart av onboarding';
 
   @override
   String get dev_preferences_reset_onboarding_subtitle =>
@@ -2416,35 +2436,34 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get dev_preferences_environment_switch_title =>
-      'Switch between openfoodfacts.org (PROD) and test env';
+      'Bytt mellom openfoodfacts.org (PROD) og testmiljø';
 
   @override
   String get dev_preferences_test_environment_title =>
-      'Test environment parameters';
+      'Parametere for testmiljø';
 
   @override
   String dev_preferences_test_environment_subtitle(String url) {
-    return 'Base URL for current test env: $url';
+    return 'Basis-URL for gjeldende testmiljø: $url';
   }
 
   @override
-  String get dev_preferences_test_environment_dialog_title =>
-      'Test environment host';
+  String get dev_preferences_test_environment_dialog_title => 'Testmiljøvert';
 
   @override
-  String get dev_preferences_ml_kit_title => 'Use ML Kit';
+  String get dev_preferences_ml_kit_title => 'Bruk ML-settet';
 
   @override
   String get dev_preferences_ml_kit_subtitle =>
-      'then you have to restart this app';
+      'så må du starte denne appen på nytt';
 
   @override
   String get dev_preferences_product_additional_features_title =>
-      'Additional button on product page';
+      'Ekstra knapp på produktsiden';
 
   @override
   String get dev_preferences_edit_ingredients_title =>
-      'Edit ingredients via a knowledge panel button';
+      'Rediger ingredienser via en kunnskapspanelknapp';
 
   @override
   String get dev_preferences_export_history_title => 'Eksporthistorikk';
@@ -2478,91 +2497,91 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get dev_preferences_migration_status_already_done =>
-      'success or fresh install';
+      'suksess eller ny installasjon';
 
   @override
-  String get dev_preferences_migration_status_success => 'success';
+  String get dev_preferences_migration_status_success => 'suksess';
 
   @override
-  String get dev_preferences_migration_status_error => 'error';
+  String get dev_preferences_migration_status_error => 'feil';
 
   @override
-  String get dev_preferences_migration_status_in_progress => 'in progress';
+  String get dev_preferences_migration_status_in_progress => 'pågår';
 
   @override
   String get dev_preferences_migration_status_required =>
-      'required (click to start)';
+      'obligatorisk (klikk for å starte)';
 
   @override
-  String get dev_preferences_migration_status_not_started => 'unknown';
+  String get dev_preferences_migration_status_not_started => 'ukjent';
 
   @override
   String get dev_preferences_import_history_subtitle =>
-      'Will clear history and put 3 products in there';
+      'Vil slette historikken og legge inn 3 produkter der';
 
   @override
-  String get dev_preferences_news_custom_url_title => 'Custom URL for news';
+  String get dev_preferences_news_custom_url_title =>
+      'Tilpasset URL for nyheter';
 
   @override
   String get dev_preferences_news_custom_url_subtitle =>
-      'URL of the JSON file:';
+      'URL-adressen til JSON-filen:';
 
   @override
-  String get dev_preferences_news_custom_url_empty_value => 'Not set';
+  String get dev_preferences_news_custom_url_empty_value => 'Ikke angitt';
 
   @override
   String get dev_preferences_news_provider_status_title => 'Status';
 
   @override
   String dev_preferences_news_provider_status_subtitle(String date) {
-    return 'Last refresh: $date';
+    return 'Siste oppdatering: $date';
   }
 
   @override
-  String get product_type_label_food => 'Food';
+  String get product_type_label_food => 'Mat';
 
   @override
-  String get product_type_label_beauty => 'Personal care';
+  String get product_type_label_beauty => 'Personlig pleie';
 
   @override
-  String get product_type_label_pet_food => 'Pet food';
+  String get product_type_label_pet_food => 'Kjæledyrfôr';
 
   @override
   String get product_type_label_product => 'Andre';
 
   @override
-  String get product_type_selection_title => 'Product type';
+  String get product_type_selection_title => 'Produkttype';
 
   @override
-  String get product_type_selection_subtitle =>
-      'Select the type of this product';
+  String get product_type_selection_subtitle => 'Velg typen av dette produktet';
 
   @override
   String get product_type_selection_empty =>
-      'You need to select a product type first!';
+      'Du må velge en produkttype først!';
 
   @override
   String product_type_selection_already(String productType) {
-    return 'You cannot change the product type ($productType)!';
+    return 'Du kan ikke endre produkttypen ($productType)!';
   }
 
   @override
   String get prices_app_dev_mode_flag =>
-      'Shortcut to Prices app on product page';
+      'Snarvei til Priser-appen på produktsiden';
 
   @override
-  String get prices_app_button => 'Go to Prices app';
+  String get prices_app_button => 'Gå til Priser-appen';
 
   @override
   String get prices_website_button => 'Åpne på Open Prices website';
 
   @override
   String get prices_bulk_proof_upload_select =>
-      'Add price tags directly from gallery';
+      'Legg til prislapper direkte fra galleriet';
 
   @override
   String get prices_bulk_proof_upload_warning =>
-      'Once you\'ve selected images, you won\'t be able to edit them!';
+      'Når du har valgt bilder, kan du ikke redigere dem!';
 
   @override
   String get prices_bulk_proof_upload_warning_ai =>
@@ -2573,10 +2592,10 @@ class AppLocalizationsNb extends AppLocalizations {
       'La fellesskapet validere prisene utvunnet av AI.';
 
   @override
-  String get prices_bulk_proof_upload_subtitle => 'Multiple Price Tags';
+  String get prices_bulk_proof_upload_subtitle => 'Flere prislapper';
 
   @override
-  String get prices_bulk_proof_upload_title => 'Bulk Proof Upload';
+  String get prices_bulk_proof_upload_title => 'Masseopplasting av bevis';
 
   @override
   String get prices_bulk_proof_upload_step_selecting => 'Velger filer';
@@ -2600,15 +2619,15 @@ class AppLocalizationsNb extends AppLocalizations {
   }
 
   @override
-  String get prices_generic_title => 'Prices';
+  String get prices_generic_title => 'Priser';
 
   @override
   String prices_add_n_prices(num count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'Add $count prices',
-      one: 'Add a price',
+      other: 'Legg til $count priser',
+      one: 'Legg til en pris',
     );
     return '$_temp0';
   }
@@ -2618,42 +2637,42 @@ class AppLocalizationsNb extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'Send $count prices',
-      one: 'Send the price',
+      other: 'Send $count priser',
+      one: 'Send prisen',
     );
     return '$_temp0';
   }
 
   @override
-  String get prices_add_an_item => 'Add an item';
+  String get prices_add_an_item => 'Legg til et element';
 
   @override
-  String get prices_add_a_price => 'Add a price';
+  String get prices_add_a_price => 'Legg til en pris';
 
   @override
-  String get prices_add_a_receipt => 'Add a receipt';
+  String get prices_add_a_receipt => 'Legg til en kvittering';
 
   @override
-  String get prices_add_price_tags => 'Add price tags';
+  String get prices_add_price_tags => 'Legg til prislapper';
 
   @override
   String prices_barcode_already(String barcode) {
-    return 'This barcode ($barcode) is already in the list!';
+    return 'Denne strekkoden ($barcode) er allerede i listen!';
   }
 
   @override
   String get prices_barcode_search_not_found => 'Fant ikke produktet';
 
   @override
-  String get prices_barcode_search_none_yet => 'No product yet';
+  String get prices_barcode_search_none_yet => 'Ingen produkt ennå';
 
   @override
   String prices_barcode_search_running(String barcode) {
-    return 'Looking for $barcode';
+    return 'Leter etter $barcode';
   }
 
   @override
-  String get prices_barcode_enter => 'Enter the Barcode';
+  String get prices_barcode_enter => 'Skriv inn strekkoden';
 
   @override
   String get prices_category_enter => 'Element uten strekkode';
@@ -2680,10 +2699,10 @@ class AppLocalizationsNb extends AppLocalizations {
   String get prices_category_error_mandatory => 'Kategorien er obligatorisk';
 
   @override
-  String get prices_barcode_reader_action => 'Barcode reader';
+  String get prices_barcode_reader_action => 'Strekkodeleser';
 
   @override
-  String get prices_view_prices => 'View the prices';
+  String get prices_view_prices => 'Se prisene';
 
   @override
   String get prices_list_title => 'Prisliste';
@@ -2731,8 +2750,8 @@ class AppLocalizationsNb extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count prices',
-      one: '1 price',
+      other: '$count priser',
+      one: '1 pris',
     );
     return '$_temp0 for $product';
   }
@@ -2742,16 +2761,16 @@ class AppLocalizationsNb extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'All $count prices',
-      one: 'Only one price',
-      zero: 'No price yet',
+      other: 'Alle $count priser',
+      one: 'Kun én pris',
+      zero: 'Ingen pris ennå',
     );
     return '$_temp0';
   }
 
   @override
   String prices_list_length_many_pages(int pageSize, int total) {
-    return 'Latest $pageSize prices (total: $total)';
+    return 'Siste $pageSize priser (totalt: $total)';
   }
 
   @override
@@ -2761,32 +2780,32 @@ class AppLocalizationsNb extends AppLocalizations {
     String date,
     String user,
   ) {
-    return 'Price: $price / Store: \"$location\" / Published on $date by \"$user\"';
+    return 'Pris: $price / Butikk: \"$location\" / Publisert $date av \"$user\"';
   }
 
   @override
   String prices_open_user_proofs(String user) {
-    return 'Open proofs of \"$user\"';
+    return 'Åpne bevis for «$user»';
   }
 
   @override
-  String get prices_open_proof => 'Open price proof';
+  String get prices_open_proof => 'Åpen prisbevis';
 
   @override
   String prices_proofs_list_length_one_page(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'All $count proofs',
-      one: 'Only one proof',
-      zero: 'No proof yet',
+      other: 'Alle $count bevis',
+      one: 'Bare ett bevis',
+      zero: 'Ingen bevis ennå',
     );
     return '$_temp0';
   }
 
   @override
   String prices_proofs_list_length_many_pages(int pageSize, int total) {
-    return 'Latest $pageSize proofs (total: $total)';
+    return 'Siste $pageSize bevis (totalt: $total)';
   }
 
   @override
@@ -2798,7 +2817,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String prices_users_list_length_many_pages(int pageSize, int total) {
-    return 'Top $pageSize contributors (total: $total)';
+    return 'Topp $pageSize bidragsytere (totalt: $total)';
   }
 
   @override
@@ -2810,7 +2829,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String prices_locations_list_length_many_pages(int pageSize, int total) {
-    return 'Top $pageSize locations (total: $total)';
+    return 'Topp $pageSize steder (totalt: $total)';
   }
 
   @override
@@ -2818,9 +2837,9 @@ class AppLocalizationsNb extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count proofs',
-      one: 'One proof',
-      zero: 'No proof',
+      other: '$count bevis',
+      one: 'Ett bevis',
+      zero: 'Ingen bevis',
     );
     return '$_temp0';
   }
@@ -2830,9 +2849,9 @@ class AppLocalizationsNb extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count products',
-      one: 'One product',
-      zero: 'No product',
+      other: '$count produkter',
+      one: 'Ett produkt',
+      zero: 'Ingen produkter',
     );
     return '$_temp0';
   }
@@ -2842,9 +2861,9 @@ class AppLocalizationsNb extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count users',
-      one: 'One user',
-      zero: 'No user',
+      other: '$count brukere',
+      one: 'Én bruker',
+      zero: 'Ingen bruker',
     );
     return '$_temp0';
   }
@@ -2854,9 +2873,9 @@ class AppLocalizationsNb extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count prices',
-      one: 'One price',
-      zero: 'No price',
+      other: '$count priser',
+      one: 'Én pris',
+      zero: 'Ingen pris',
     );
     return '$_temp0';
   }
@@ -2865,50 +2884,50 @@ class AppLocalizationsNb extends AppLocalizations {
   String get prices_amount_existing_subtitle => 'Pris tidligere lagt til';
 
   @override
-  String get prices_amount_subtitle => 'Amount';
+  String get prices_amount_subtitle => 'Beløp';
 
   @override
-  String get prices_amount_is_discounted => 'Is discounted?';
+  String get prices_amount_is_discounted => 'Er det rabattert?';
 
   @override
-  String get prices_amount_price_normal => 'Price';
+  String get prices_amount_price_normal => 'Pris';
 
   @override
-  String get prices_amount_price_discounted => 'Discounted price';
+  String get prices_amount_price_discounted => 'Rabattert pris';
 
   @override
-  String get prices_amount_price_not_discounted => 'Original price';
+  String get prices_amount_price_not_discounted => 'Opprinnelig pris';
 
   @override
-  String get prices_amount_no_product => 'One product is missing!';
+  String get prices_amount_no_product => 'Ett produkt mangler!';
 
   @override
-  String get prices_amount_price_incorrect => 'Incorrect value';
+  String get prices_amount_price_incorrect => 'Feil verdi';
 
   @override
-  String get prices_amount_price_mandatory => 'Mandatory value';
+  String get prices_amount_price_mandatory => 'Obligatorisk verdi';
 
   @override
   String get prices_currency_subtitle => 'Valuta';
 
   @override
-  String get prices_date_subtitle => 'Date';
+  String get prices_date_subtitle => 'Dato';
 
   @override
-  String get prices_location_subtitle => 'Shop';
+  String get prices_location_subtitle => 'Butikk';
 
   @override
-  String get prices_location_find => 'Find a shop';
+  String get prices_location_find => 'Finn en butikk';
 
   @override
-  String get prices_location_mandatory => 'You need to select a shop!';
+  String get prices_location_mandatory => 'Du må velge en butikk!';
 
   @override
   String get prices_location_search_broader =>
-      'Couldn\'t find what you were looking for? Let\'s try a broader search!';
+      'Fant du ikke det du lette etter? La oss prøve et bredere søk!';
 
   @override
-  String get prices_proof_subtitle => 'Proof';
+  String get prices_proof_subtitle => 'Bevis';
 
   @override
   String get prices_proof_empty_title => 'Ingen bevis ennå!';
@@ -2918,103 +2937,104 @@ class AppLocalizationsNb extends AppLocalizations {
       'Start ved å legge til et bilde av en **kvittering** eller en **pristagg**!';
 
   @override
-  String get prices_proof_find => 'Select a proof';
+  String get prices_proof_find => 'Velg et bevis';
 
   @override
-  String get prices_proof_change => 'Change proof';
+  String get prices_proof_change => 'Endringsbevis';
 
   @override
-  String get prices_proof_receipt => 'Receipt';
+  String get prices_proof_receipt => 'Kvittering';
 
   @override
-  String get prices_proof_price_tag => 'Price tag';
+  String get prices_proof_price_tag => 'Prislapp';
 
   @override
-  String get prices_proof_mandatory => 'You need to select a proof!';
+  String get prices_proof_mandatory => 'Du må velge et bevis!';
 
   @override
-  String get prices_add_validation_error => 'Validation error';
+  String get prices_add_validation_error => 'Valideringsfeil';
 
   @override
-  String get prices_privacy_warning_title => 'Privacy warning';
+  String get prices_privacy_warning_title => 'Personvernadvarsel';
 
   @override
-  String get prices_unknown_product => 'Unknown product';
+  String get prices_unknown_product => 'Ukjent produkt';
 
   @override
   String get prices_privacy_warning_main_message =>
-      'Prices **will be public**, along with the store they refer to.\n\nThat might allow people who know about your Open Food Facts pseudonym to:\n';
+      'Prisene **vil være offentlige**, sammen med butikken de refererer til.\n\nDet kan gjøre det mulig for folk som kjenner til pseudonymet ditt fra Open Food Facts å:\n';
 
   @override
   String get prices_privacy_warning_message_bullet_1 =>
-      'Infer in which area you live';
+      'Gjenkjenn hvilket område du bor i';
 
   @override
-  String get prices_privacy_warning_message_bullet_2 =>
-      'Know what you are buying';
+  String get prices_privacy_warning_message_bullet_2 => 'Vit hva du kjøper';
 
   @override
   String get prices_privacy_warning_sub_message =>
-      'If you are uneasy with that, please change your pseudonym, or create a new Open Food Facts account and log into the app with it.';
+      'Hvis du er usikker på det, kan du endre pseudonymet ditt, eller opprette en ny Open Food Facts-konto og logge inn på appen med den.';
 
   @override
-  String get i_refuse => 'I refuse';
+  String get i_refuse => 'Jeg nekter';
 
   @override
-  String get i_accept => 'I accept';
+  String get i_accept => 'Jeg aksepterer';
 
   @override
-  String get prices_currency_change_proposal_title => 'Change the currency?';
+  String get prices_currency_change_proposal_title => 'Endre valutaen?';
 
   @override
   String prices_currency_change_proposal_message(
     String currency,
     String newCurrency,
   ) {
-    return 'Your current currency is **$currency**. Would you like to change it to **$newCurrency**?';
+    return 'Din nåværende valuta er **$currency**. Vil du endre den til **$newCurrency**?';
   }
 
   @override
   String prices_currency_change_proposal_action_approve(String newCurrency) {
-    return 'Yes, use $newCurrency';
+    return 'Ja, bruk $newCurrency';
   }
 
   @override
   String prices_currency_change_proposal_action_cancel(String currency) {
-    return 'No, keep $currency';
+    return 'Nei, behold $currency';
   }
 
   @override
-  String get prices_menu_know_more => 'Know more about Open Prices';
+  String get prices_menu_know_more => 'Lær mer om åpne priser';
 
   @override
   String get dev_preferences_import_history_result_success => 'Ferdig';
 
   @override
-  String get dev_mode_section_server => 'Server configuration';
+  String get dev_mode_section_server => 'Serverkonfigurasjon';
 
   @override
-  String get dev_mode_section_news => 'News provider configuration';
+  String get dev_mode_section_news => 'Konfigurasjon av nyhetsleverandør';
 
   @override
-  String get dev_mode_section_product_page => 'Product page';
+  String get dev_mode_section_product_page => 'Produktside';
 
   @override
-  String get dev_mode_section_ui => 'User Interface';
+  String get dev_mode_section_ui => 'Brukergrensesnitt';
 
   @override
-  String get dev_mode_section_experimental_features => 'Experimental features';
+  String get dev_mode_section_experimental_features =>
+      'Eksperimentelle funksjoner';
 
   @override
-  String get dev_mode_hide_environmental_score_title => 'Exclude Green Score';
+  String get dev_mode_hide_environmental_score_title =>
+      'Ekskluder grønn poengsum';
 
   @override
   String get dev_mode_spellchecker_for_ocr_title =>
-      'Use a spellchecker for OCR screens';
+      'Bruk en stavekontroll for OCR-skjermer';
 
   @override
   String get dev_mode_spellchecker_for_ocr_subtitle =>
-      '(Ingredients and packaging)';
+      '(Ingredienser og emballasje)';
 
   @override
   String get dev_mode_reset_app_language_title => 'Tilbakestill appspråk';
@@ -3027,10 +3047,11 @@ class AppLocalizationsNb extends AppLocalizations {
       'Bytt mellom prices.openfoodfacts.org (PROD) og test env';
 
   @override
-  String get search_history_item_edit_tooltip => 'Reuse and edit this search';
+  String get search_history_item_edit_tooltip =>
+      'Bruk og rediger dette søket på nytt';
 
   @override
-  String get search_history_item_remove_tooltip => 'Remove';
+  String get search_history_item_remove_tooltip => 'Fjerne';
 
   @override
   String product_search_no_more_results(int totalSize) {
@@ -3043,12 +3064,12 @@ class AppLocalizationsNb extends AppLocalizations {
     int downloaded,
     int totalSize,
   ) {
-    return 'Download $count more products\nAlready downloaded $downloaded out of $totalSize.';
+    return 'Last ned $count flere produkter\nAllerede lastet ned $downloaded av $totalSize.';
   }
 
   @override
   String product_search_loading_message(Object search) {
-    return 'Your search of $search is in progress.\n\nPlease wait a few seconds…';
+    return 'Søket ditt etter $search pågår.\n\nVent noen sekunder…';
   }
 
   @override
@@ -3061,20 +3082,21 @@ class AppLocalizationsNb extends AppLocalizations {
   String get user_search_photographer_title => 'Produkter jeg har fotografert';
 
   @override
-  String get user_search_to_be_completed_title => 'My to-be-completed products';
+  String get user_search_to_be_completed_title =>
+      'Mine produkter som skal fullføres';
 
   @override
-  String get user_search_prices_title => 'My prices';
+  String get user_search_prices_title => 'Mine priser';
 
   @override
-  String get user_search_proofs_title => 'My proofs';
+  String get user_search_proofs_title => 'Mine bevis';
 
   @override
-  String get user_search_proof_title => 'My proof';
+  String get user_search_proof_title => 'Mitt bevis';
 
   @override
   String search_proof_title(String user) {
-    return 'Proof from \"$user\"';
+    return 'Bevis fra «$user»';
   }
 
   @override
@@ -3083,17 +3105,17 @@ class AppLocalizationsNb extends AppLocalizations {
   }
 
   @override
-  String get all_search_prices_latest_title => 'Latest Prices added';
+  String get all_search_prices_latest_title => 'Siste priser lagt til';
 
   @override
-  String get all_search_prices_top_user_title => 'Top price contributors';
+  String get all_search_prices_top_user_title => 'De største prisbidragsyterne';
 
   @override
   String get all_search_prices_top_location_title =>
-      'Stores with the most prices';
+      'Butikkene med de høyeste prisene';
 
   @override
-  String get prices_contribution_assistant => 'Price Contribution Assistant';
+  String get prices_contribution_assistant => 'Assistent for prisbidrag';
 
   @override
   String get prices_validation_assistant => 'Price Validation Assistant';
@@ -3102,14 +3124,15 @@ class AppLocalizationsNb extends AppLocalizations {
   String get prices_challenges_page => 'Challenges';
 
   @override
-  String get prices_multiple_proof_addition_system => 'Add Multiple Proofs';
+  String get prices_multiple_proof_addition_system => 'Legg til flere bevis';
 
   @override
-  String get all_search_prices_top_location_single_title => 'Prices in a store';
+  String get all_search_prices_top_location_single_title =>
+      'Priser i en butikk';
 
   @override
   String get all_search_prices_top_product_title =>
-      'Products with the most prices';
+      'Produktene med høyest pris';
 
   @override
   String get all_search_to_be_completed_title =>
@@ -3117,35 +3140,35 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get categorize_products_country_title =>
-      'Help categorize products in your country';
+      'Hjelp med å kategorisere produkter i landet ditt';
 
   @override
-  String get edit_product_action_retake_picture => 'Retake photo';
+  String get edit_product_action_retake_picture => 'Ta bildet på nytt';
 
   @override
-  String get edit_product_action_take_picture => 'Take photo';
+  String get edit_product_action_take_picture => 'Ta bilde';
 
   @override
   String get edit_product_action_confirm => 'Bekreft';
 
   @override
   String get signup_page_terms_of_use_line1 =>
-      'I agree to the Open Food Facts ';
+      'Jeg godtar de åpne matfaktaene ';
 
   @override
   String get signup_page_terms_of_use_line2 => 'vilkår for bruk og bidrag';
 
   @override
-  String get analytics_consent_image_semantic_label => 'Analytics icon';
+  String get analytics_consent_image_semantic_label => 'Analytics-ikon';
 
   @override
   String knowledge_panel_page_loading_error(Object? error) {
-    return 'Fatal Error: $error';
+    return 'Fatal feil: $error';
   }
 
   @override
   String preferences_page_loading_error(Object? error) {
-    return 'Fatal Error: $error';
+    return 'Fatal feil: $error';
   }
 
   @override
@@ -3156,11 +3179,11 @@ class AppLocalizationsNb extends AppLocalizations {
   String get edit_photo_button_label => 'Rediger ';
 
   @override
-  String get edit_photo_unselect_button_label => 'Unselect photo';
+  String get edit_photo_unselect_button_label => 'Fjern valg av bilde';
 
   @override
   String get edit_photo_select_existing_button_label =>
-      'Select an existing image';
+      'Velg et eksisterende bilde';
 
   @override
   String get edit_photo_select_existing_all_label =>
@@ -3168,52 +3191,52 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get edit_photo_select_existing_all_subtitle =>
-      'Select an image by clicking on it';
+      'Velg et bilde ved å klikke på det';
 
   @override
   String get edit_photo_select_existing_download_label =>
-      'Retrieving existing images…';
+      'Henter eksisterende bilder…';
 
   @override
   String get edit_photo_select_existing_downloaded_none =>
-      'There are no images previously uploaded related to this product.';
+      'Det er ingen bilder lastet opp tidligere relatert til dette produktet.';
 
   @override
   String get edit_photo_language_not_this_one =>
-      'No image in that language yet';
+      'Ingen bilder på det språket ennå';
 
   @override
-  String get edit_photo_language_none => 'No image yet';
+  String get edit_photo_language_none => 'Ikke noe bilde ennå';
 
   @override
   String get category_picker_screen_title => 'Kategorier';
 
   @override
-  String get basic_details => 'Basic Details';
+  String get basic_details => 'Grunnleggende detaljer';
 
   @override
-  String get product_name => 'Product Name';
+  String get product_name => 'Produktnavn';
 
   @override
-  String get product_names => 'Product Names';
+  String get product_names => 'Produktnavn';
 
   @override
   String get add_basic_details_product_name_add_translation =>
-      'Add a new translation';
+      'Legg til en ny oversettelse';
 
   @override
   String get add_basic_details_product_name_warning_translations =>
-      'Before validating, please ensure you only add a translation **if the language is present on the packaging**';
+      'Før du validerer, må du bare legge til en oversettelse **hvis språket står på emballasjen**';
 
   @override
-  String get add_basic_details_product_name_open_photo => 'View front photo';
+  String get add_basic_details_product_name_open_photo => 'Se forsidebilde';
 
   @override
-  String get add_basic_details_product_name_take_photo => 'Take front photo';
+  String get add_basic_details_product_name_take_photo => 'Ta et bilde foran';
 
   @override
   String get add_basic_details_product_name_hint =>
-      'Input the name of the product (eg: Nutella)';
+      'Skriv inn navnet på produktet (f.eks. Nutella)';
 
   @override
   String get add_basic_details_product_name_change_main_language_title =>
@@ -3227,41 +3250,41 @@ class AppLocalizationsNb extends AppLocalizations {
   }
 
   @override
-  String get explanation_section_good_examples => 'Good examples';
+  String get explanation_section_good_examples => 'Gode eksempler';
 
   @override
-  String get explanation_section_bad_examples => 'Bad examples';
+  String get explanation_section_bad_examples => 'Dårlige eksempler';
 
   @override
   String get add_basic_details_product_name_help_title =>
-      'Good practices: Product name';
+      'God praksis: Produktnavn';
 
   @override
   String get add_basic_details_product_name_help_info1 =>
-      'The product name is the **main name printed on the packaging**. It can be a registered trademark.';
+      'Produktnavnet er **hovednavnet som er trykt på emballasjen**. Det kan være et registrert varemerke.';
 
   @override
   String get add_basic_details_product_name_help_info2 =>
-      '**Note:** Please don\'t add a translation **if the language is not present on the packaging**.';
+      '**Merk:** Vennligst ikke legg til en oversettelse **hvis språket ikke finnes på emballasjen**.';
 
   @override
   String get add_basic_details_product_name_help_good_examples_1 => 'Nesquik';
 
   @override
   String get add_basic_details_product_name_help_good_examples_2 =>
-      'Tomato Ketchup';
+      'Tomatketchup';
 
   @override
   String get add_basic_details_product_name_help_bad_examples_1_explanation =>
-      'Don\'t include the brand in the name';
+      'Ikke ta med merkevaren i navnet';
 
   @override
   String get add_basic_details_product_name_help_bad_examples_1_example =>
-      'Tomato Ketchup **by Heinz**';
+      'Tomatketchup **fra Heinz**';
 
   @override
   String get add_basic_details_product_name_help_bad_examples_2_explanation =>
-      'Don\'t use symbols ®, ™, © or similar';
+      'Ikke bruk symbolene ®, ™, © eller lignende';
 
   @override
   String get add_basic_details_product_name_help_bad_examples_2_example =>
@@ -3272,58 +3295,59 @@ class AppLocalizationsNb extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count other translations',
-      one: '$count other translation',
+      other: '$count andre oversettelser',
+      one: '$count annen oversettelse',
     );
     return '$_temp0';
   }
 
   @override
-  String get brand_name => 'Brand name';
+  String get brand_name => 'Merkenavn';
 
   @override
-  String get brand_names => 'Brand names';
+  String get brand_names => 'Merkenavn';
 
   @override
   String get add_basic_details_brand_name_error =>
-      'Please enter the brand name';
+      'Vennligst skriv inn merkenavnet';
 
   @override
-  String get add_basic_details_brand_names_hint => 'Input brands (eg: Ferrero)';
+  String get add_basic_details_brand_names_hint =>
+      'Merker av innsatsfaktorer (f.eks. Ferrero)';
 
   @override
   String get add_basic_details_product_brand_help_title =>
-      'Good practices: Brands';
+      'God praksis: Merker';
 
   @override
   String get add_basic_details_product_brand_help_info1 =>
-      'Input **all the brands of the product**.';
+      'Skriv inn **alle merkene til produktet**.';
 
   @override
-  String get add_basic_details_product_brand_help_info2_title => 'Main brand';
+  String get add_basic_details_product_brand_help_info2_title => 'Hovedmerke';
 
   @override
   String get add_basic_details_product_brand_help_info2_content =>
-      'The **main brand**, generally clearly displayed on the front pack, should be **entered first**.';
+      '**Hovedmerket**, som vanligvis vises tydelig på forsiden av pakken, skal **oppgis først**.';
 
   @override
-  String get add_basic_details_product_brand_help_info3_title => 'Other brands';
+  String get add_basic_details_product_brand_help_info3_title => 'Andre merker';
 
   @override
   String get add_basic_details_product_brand_help_info3_item1_text =>
-      'When sold **by a big company**:';
+      'Når det selges **av et stort selskap**:';
 
   @override
   String get add_basic_details_product_brand_help_info3_item1_explanation =>
-      '**Actimel** is sold by **Danone**';
+      '**Actimel** selges av **Danone**';
 
   @override
   String get add_basic_details_product_brand_help_info3_item2_text =>
-      'When sold with its brand **translated in multiple languages**:';
+      'Når det selges med sitt merke **oversatt til flere språk**:';
 
   @override
   String get add_basic_details_product_brand_help_info3_item2_explanation =>
-      '**Nature Valley** is sometimes written **Val Nature**';
+      '**Nature Valley** skrives noen ganger som **Val Nature**';
 
   @override
   String get add_basic_details_product_brand_help_good_examples_1 => 'Nutella';
@@ -3333,42 +3357,42 @@ class AppLocalizationsNb extends AppLocalizations {
       'Oreo, Mondelez';
 
   @override
-  String get quantity => 'Quantity and weight';
+  String get quantity => 'Mengde og vekt';
 
   @override
   String get add_basic_details_quantity_hint =>
-      'Input the weight and if needed the quantity (eg : 4x100g)';
+      'Skriv inn vekten og om nødvendig mengden (f.eks.: 4 x 100 g)';
 
   @override
   String get add_basic_details_product_quantity_help_title =>
-      'Good practices: Quantity';
+      'God praksis: Mengde';
 
   @override
   String get add_basic_details_product_quantity_help_info1 =>
-      'Copy the value indicated on the product and **don\'t forget the units**.';
+      'Kopier verdien som er angitt på produktet, og **ikke glem enhetene**.';
 
   @override
   String get add_basic_details_product_quantity_help_good_examples_1 =>
-      '**230g** or **230 g**';
+      '**230 g** eller **230 g**';
 
   @override
   String get add_basic_details_product_quantity_help_good_examples_2 =>
-      '**6** (for 6 eggs)';
+      '**6** (for 6 egg)';
 
   @override
   String get add_basic_details_product_quantity_help_good_examples_3 =>
-      '**3 x 150g**\n(for a product with 3 boxes, each of 150g)';
+      '**3 x 150 g**\n(for et produkt med 3 esker, hver på 150 g)';
 
   @override
   String get barcode => 'Strekkode';
 
   @override
   String barcode_barcode(String barcode) {
-    return 'Barcode: $barcode';
+    return 'Strekkode: $barcode';
   }
 
   @override
-  String get barcode_invalid_error => 'Invalid barcode';
+  String get barcode_invalid_error => 'Ugyldig strekkode';
 
   @override
   String get basic_details_add_success => 'Grunnleggende detaljer lagt til';
@@ -3394,11 +3418,11 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get alert_select_items_to_clear =>
-      'Please select one or more items to clear';
+      'Vennligst velg ett eller flere elementer som skal fjernes';
 
   @override
   String confirm_clear_user_list(String name) {
-    return 'You\'re about to clear this list ($name): are you sure you want to continue?';
+    return 'Du er i ferd med å tømme denne listen ($name): er du sikker på at du vil fortsette?';
   }
 
   @override
@@ -3457,7 +3481,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get add_emb_photo_button_label =>
-      'Take photos of any traceability code information';
+      'Ta bilder av all sporbarhetskodeinformasjon';
 
   @override
   String get add_label_photo_button_label =>
@@ -3473,11 +3497,11 @@ class AppLocalizationsNb extends AppLocalizations {
   String get gallery_source_label => 'Galleri';
 
   @override
-  String get gallery_source_access_denied_dialog_title => 'Access denied';
+  String get gallery_source_access_denied_dialog_title => 'Tilgang nektet';
 
   @override
   String get gallery_source_access_denied_dialog_message_ios =>
-      'Unfortunately, the application can\'t access your gallery, as you have previously denied the permission.\n\nPlease go to the app settings in your phone Settings -> Photos';
+      'Dessverre har ikke appen tilgang til galleriet ditt, siden du tidligere har nektet tillatelsen.\n\nGå til appinnstillingene i telefonen din Innstillinger -> Bilder';
 
   @override
   String get gallery_source_access_denied_dialog_button =>
@@ -3493,17 +3517,17 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String share_product_text_beauty(String url) {
-    return 'Have a look at this product on Open Beauty Facts: $url';
+    return 'Ta en titt på dette produktet på Open Beauty Facts: $url';
   }
 
   @override
   String share_product_text_pet_food(String url) {
-    return 'Have a look at this product on Open PetFood Facts: $url';
+    return 'Ta en titt på dette produktet på Open PetFood Facts: $url';
   }
 
   @override
   String share_product_text_product(String url) {
-    return 'Have a look at this product on Open Products Facts: $url';
+    return 'Ta en titt på dette produktet på Åpne produktfakta: $url';
   }
 
   @override
@@ -3526,7 +3550,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get add_price_queued =>
-      'The price will be sent to the server as soon as possible.';
+      'Prisen vil bli sendt til serveren så snart som mulig.';
 
   @override
   String get background_task_title_full_refresh =>
@@ -3534,7 +3558,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Starter å utføre server-handlinger for folksonomi-oppdateringer lagret lokalt';
 
   @override
   String get background_task_title_top_n =>
@@ -3566,11 +3590,11 @@ class AppLocalizationsNb extends AppLocalizations {
   String get copy_to_clipboard => 'Kopier';
 
   @override
-  String get paste_from_clipboard => 'Paste from clipboard';
+  String get paste_from_clipboard => 'Lim inn fra utklippstavlen';
 
   @override
   String get no_data_available_in_clipboard =>
-      'No data available in your clipboard';
+      'Ingen data tilgjengelig på utklippstavlen';
 
   @override
   String get clipboard_barcode_copy => 'Kopier strekkoden til utklippstavlen';
@@ -3581,16 +3605,16 @@ class AppLocalizationsNb extends AppLocalizations {
   }
 
   @override
-  String get open_product_website => 'Open this product on the website';
+  String get open_product_website => 'Åpne dette produktet på nettsiden';
 
   @override
   String get language_picker_label => 'Språket ditt';
 
   @override
-  String get country_picker_label => 'Your country';
+  String get country_picker_label => 'Landet ditt';
 
   @override
-  String get currency_picker_label => 'Your currency';
+  String get currency_picker_label => 'Din valuta';
 
   @override
   String get help_with_openfoodfacts => 'Hjelp med OpenFoodFacts';
@@ -3600,90 +3624,90 @@ class AppLocalizationsNb extends AppLocalizations {
       'Produktet vil bli oppdatert i bakgrunnen så fort som mulig.';
 
   @override
-  String get no_email_client_available_dialog_title => 'No email apps!';
+  String get no_email_client_available_dialog_title => 'Ingen e-postapper!';
 
   @override
   String get no_email_client_available_dialog_content =>
-      'Please send us manually an email to mobile@openfoodfacts.org';
+      'Send oss en e-post manuelt til mobile@openfoodfacts.org';
 
   @override
-  String get all_images => 'All Images';
+  String get all_images => 'Alle bilder';
 
   @override
-  String get selected_images => 'Selected Images';
+  String get selected_images => 'Utvalgte bilder';
 
   @override
-  String get product_card_remove_product_tooltip => 'Remove product';
+  String get product_card_remove_product_tooltip => 'Fjern produktet';
 
   @override
   String scan_announce_new_barcode(String barcode) {
-    return 'New barcode scanned: $barcode';
+    return 'Ny strekkode skannet: $barcode';
   }
 
   @override
   String get scan_header_clear_button_tooltip =>
-      'Remove all products from the carousel';
+      'Fjern alle produkter fra karusellen';
 
   @override
   String get scan_header_compare_button_invalid_state_tooltip =>
-      'Please scan at least two products to compare them';
+      'Vennligst skann minst to produkter for å sammenligne dem';
 
   @override
   String get scan_header_compare_button_valid_state_tooltip =>
-      'Click to compare the products you have scanned';
+      'Klikk for å sammenligne produktene du har skannet';
 
   @override
-  String get scan_product_loading => 'You have scanned\nthe barcode:';
+  String get scan_product_loading => 'Du har skannet\nstrekkoden:';
 
   @override
   String get scan_product_loading_initial =>
-      'We\'re looking for this product!\nPlease wait a few seconds…';
+      'Vi ser etter dette produktet!\nVent noen sekunder…';
 
   @override
   String get scan_product_loading_long_request =>
-      'We\'re still looking for this product!\nDo you find it takes a long time to load? So are we…';
+      'Vi leter fortsatt etter dette produktet!\nSynes du det tar lang tid å laste? Det gjør vi også…';
 
   @override
   String get scan_product_loading_unresponsive =>
-      'We\'re still looking for this product.\nWould you like to restart the search?';
+      'Vi leter fortsatt etter dette produktet.\nVil du starte søket på nytt?';
 
   @override
-  String get scan_product_loading_restart_button => 'Restart search';
+  String get scan_product_loading_restart_button => 'Start søket på nytt';
 
   @override
   String get portion_calculator_description =>
-      'Calculate nutrition facts for a specific quantity';
+      'Beregn næringsinnhold for en bestemt mengde';
 
   @override
-  String get portion_calculator_hint => 'Quantity in';
+  String get portion_calculator_hint => 'Antall i';
 
   @override
   String get portion_calculator_accessibility =>
-      'Input a quantity to calculate nutrition facts';
+      'Skriv inn en mengde for å beregne næringsinnhold';
 
   @override
   String portion_calculator_error(int min, int max) {
-    return 'Please enter a quantity between $min and $max g';
+    return 'Vennligst skriv inn en mengde mellom $min og $max g';
   }
 
   @override
   String get portion_calculator_computation_error =>
-      'Missing data. Calculation could not be performed.';
+      'Manglende data. Beregningen kunne ikke utføres.';
 
   @override
   String portion_calculator_result_title(int grams) {
-    return 'Nutrition facts for $grams g (or ml)';
+    return 'Næringsinnhold for $grams g (eller ml)';
   }
 
   @override
-  String get offline_data => 'Offline Data';
+  String get offline_data => 'Frakoblede data';
 
   @override
   String get ocr_image_upload_instruction =>
-      'Upload an image to automatically extract the information it contains.';
+      'Last opp et bilde for å automatisk hente ut informasjonen det inneholder.';
 
   @override
-  String get upload_image => 'Upload Photo';
+  String get upload_image => 'Last opp bilde';
 
   @override
   String get word_separator_char => ',';
@@ -3692,342 +3716,343 @@ class AppLocalizationsNb extends AppLocalizations {
   String get word_separator => ', ';
 
   @override
-  String get image_download_error => 'Failed to download image';
+  String get image_download_error => 'Kunne ikke laste ned bildet';
 
   @override
   String get image_edit_url_error =>
-      'Failed to edit image because the image URL was not set.';
+      'Kunne ikke redigere bildet fordi bilde-URL-en ikke ble angitt.';
 
   @override
-  String get user_picture_source_remember => 'Remember my choice';
+  String get user_picture_source_remember => 'Husk valget mitt';
 
   @override
-  String get user_picture_source_ask => 'Ask each time';
+  String get user_picture_source_ask => 'Spør hver gang';
 
   @override
-  String get robotoff_continue => 'Continue';
+  String get robotoff_continue => 'Fortsette';
 
   @override
   String robotoff_next_n_questions(num count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count questions',
-      one: 'question',
+      other: '$count spørsmål',
+      one: 'spørsmål',
     );
-    return 'Next $_temp0';
+    return 'Neste $_temp0';
   }
 
   @override
-  String get show_password => 'Show Password';
+  String get show_password => 'Vis passord';
 
   @override
-  String get owner_field_info_title => 'Producer provided values';
+  String get owner_field_info_title => 'Produsentens oppgitte verdier';
 
   @override
   String get owner_field_info_message =>
-      'With that logo we highlight data provided by the producer, and that may not be editable.';
+      'Med den logoen fremhever vi data levert av produsenten, og som kanskje ikke kan redigeres.';
 
   @override
-  String get owner_field_info_close_button => 'Close this info';
+  String get owner_field_info_close_button => 'Lukk denne informasjonen';
 
   @override
   String get owner_field_image =>
-      'This image is provided by the producer. It may not be editable.';
+      'Dette bildet er levert av produsenten. Det kan hende det ikke kan redigeres.';
 
   @override
-  String get edit_packagings_title => 'Packaging components';
+  String get edit_packagings_title => 'Emballasjekomponenter';
 
   @override
-  String get edit_packagings_element_add => 'Add a packaging component';
+  String get edit_packagings_element_add => 'Legg til en emballasjekomponent';
 
   @override
-  String get edit_packagings_completed => 'The packaging is complete';
+  String get edit_packagings_completed => 'Emballasjen er komplett';
 
   @override
   String edit_packagings_element_title(int index) {
-    return 'Packaging component #$index';
+    return 'Emballasjekomponent #$index';
   }
 
   @override
-  String get edit_packagings_element_field_units => 'Number of units';
+  String get edit_packagings_element_field_units => 'Antall enheter';
 
   @override
   String get edit_packagings_element_hint_units =>
-      'Enter the number of packaging units of the same shape and material contained in the product.';
+      'Angi antall emballasjeenheter av samme form og materiale som produktet inneholder.';
 
   @override
   String get edit_packagings_element_field_shape => 'Form';
 
   @override
   String get edit_packagings_element_hint_shape =>
-      'Enter the shape name listed in the recycling instructions if they are available, or select a shape.';
+      'Skriv inn formnavnet som er oppført i resirkuleringsinstruksjonene hvis de er tilgjengelige, eller velg en form.';
 
   @override
-  String get edit_packagings_element_example_shape => 'Bottle';
+  String get edit_packagings_element_example_shape => 'Flaske';
 
   @override
-  String get edit_packagings_element_field_material => 'Material';
+  String get edit_packagings_element_field_material => 'Materiale';
 
   @override
   String get edit_packagings_element_hint_material =>
-      'Enter the specific material if it can be determined (a material code inside a triangle can often be found on packaging parts), or a generic material (for instance plastic or metal) if you are unsure.';
+      'Oppgi det spesifikke materialet hvis det kan bestemmes (en materialkode inni en trekant finnes ofte på emballasjedelene), eller et generisk materiale (for eksempel plast eller metall) hvis du er usikker.';
 
   @override
   String get edit_packagings_element_example_material => 'Glass';
 
   @override
-  String get edit_packagings_element_field_recycling => 'Recycling instruction';
+  String get edit_packagings_element_field_recycling =>
+      'Instruksjoner for resirkulering';
 
   @override
   String get edit_packagings_element_hint_recycling =>
-      'Enter recycling instructions only if they are listed on the product.';
+      'Skriv bare inn resirkuleringsinstruksjoner hvis de er oppført på produktet.';
 
   @override
-  String get edit_packagings_element_example_recycling => 'Recycle';
+  String get edit_packagings_element_example_recycling => 'Resirkulere';
 
   @override
   String get edit_packagings_element_field_quantity =>
-      'Net quantity of product per unit';
+      'Netto mengde produkt per enhet';
 
   @override
   String get edit_packagings_element_hint_quantity =>
-      'Enter the net weight or net volume and indicate the unit (for example g or ml).';
+      'Skriv inn nettovekten eller nettovolumet og angi enheten (for eksempel g eller ml).';
 
   @override
-  String get edit_packagings_element_field_weight =>
-      'Weight of one empty unit (g)';
+  String get edit_packagings_element_field_weight => 'Vekt av én tom enhet (g)';
 
   @override
   String get edit_packagings_element_hint_weight =>
-      'Remove any remaining food and wash and dry the packaging part before weighing. If possible, use a scale with 0.1g or 0.01g precision.';
+      'Fjern eventuelle matrester og vask og tørk emballasjen før veiing. Bruk om mulig en vekt med 0,1 g eller 0,01 g presisjon.';
 
   @override
-  String get background_task_title => 'Pending contributions';
+  String get background_task_title => 'Ventende bidrag';
 
   @override
   String get background_task_subtitle =>
-      'Your contributions are automatically saved to our server, but not always in real-time.';
+      'Bidragene dine lagres automatisk på serveren vår, men ikke alltid i sanntid.';
 
   @override
-  String get background_task_list_empty => 'No Pending Background Tasks';
+  String get background_task_list_empty => 'Ingen ventende bakgrunnsoppgaver';
 
   @override
-  String get background_task_error_server_time_out => 'Server timeout';
+  String get background_task_error_server_time_out => 'Servertidsavbrudd';
 
   @override
   String get background_task_error_no_internet =>
-      'Internet connection error. Try later.';
+      'Internett-tilkoblingsfeil. Prøv senere.';
 
   @override
-  String get background_task_operation_unknown => 'unknown operation type';
+  String get background_task_operation_unknown => 'ukjent operasjonstype';
 
   @override
-  String get background_task_operation_details => 'detailed changes';
+  String get background_task_operation_details => 'detaljerte endringer';
 
   @override
-  String get background_task_operation_image => 'photo upload';
+  String get background_task_operation_image => 'bildeopplasting';
 
   @override
   String get background_task_operation_refresh =>
-      'refresh delayed after photo upload';
+      'oppdatering forsinket etter bildeopplasting';
 
   @override
-  String get background_task_run_started => 'started';
+  String get background_task_run_started => 'startet';
 
   @override
-  String get background_task_run_not_started => 'not started yet';
+  String get background_task_run_not_started => 'ikke startet ennå';
 
   @override
-  String get background_task_run_to_be_deleted => 'to be deleted';
+  String get background_task_run_to_be_deleted => 'skal slettes';
 
   @override
   String get background_task_question_stop =>
-      'Do you want to stop that task ASAP?';
+      'Vil du stoppe den oppgaven så fort som mulig?';
 
   @override
-  String get feed_back => 'Feedback';
+  String get feed_back => 'Tilbakemelding';
 
   @override
-  String get undo => 'Undo';
+  String get undo => 'Angre';
 
   @override
-  String get copy_email_to_clip_board => 'Copy email to clipboard';
+  String get copy_email_to_clip_board => 'Kopier e-post til utklippstavlen';
 
   @override
-  String get please_send_us_an_email_to =>
-      'Please send us manually an email to';
+  String get please_send_us_an_email_to => 'Send oss en e-post manuelt til';
 
   @override
-  String get email_copied_to_clip_board => 'Email copied to clipboard!';
+  String get email_copied_to_clip_board => 'E-post kopiert til utklippstavlen!';
 
   @override
-  String get select_accent_color => 'Select Accent Color';
+  String get select_accent_color => 'Velg aksentfarge';
 
   @override
   String get theme_amoled => 'AMOLED';
 
   @override
-  String get color_blue => 'Blue';
+  String get color_blue => 'Blå';
 
   @override
   String get color_cyan => 'Cyan';
 
   @override
-  String get color_green => 'Green';
+  String get color_green => 'Grønn';
 
   @override
-  String get color_light_brown => 'Default';
+  String get color_light_brown => 'Misligholde';
 
   @override
   String get color_magenta => 'Magenta';
 
   @override
-  String get color_orange => 'Orange';
+  String get color_orange => 'Oransje';
 
   @override
-  String get color_pink => 'Pink';
+  String get color_pink => 'Rosa';
 
   @override
-  String get color_red => 'Red';
+  String get color_red => 'Rød';
 
   @override
   String get color_rust => 'Rust';
 
   @override
-  String get color_teal => 'Teal';
+  String get color_teal => 'Blågrønn';
 
   @override
-  String get text_contrast_mode => 'Text Contrast';
+  String get text_contrast_mode => 'Tekstkontrast';
 
   @override
-  String get contrast_high => 'High';
+  String get contrast_high => 'Høy';
 
   @override
   String get contrast_medium => 'Medium';
 
   @override
-  String get contrast_low => 'Low';
+  String get contrast_low => 'Lav';
 
   @override
-  String get product_refresher_internet_not_found => 'Product not found!';
+  String get product_refresher_internet_not_found =>
+      'Produktet ble ikke funnet!';
 
   @override
   String get product_refresher_internet_not_connected =>
-      'You are not connected to internet!';
+      'Du er ikke koblet til internett!';
 
   @override
   String product_refresher_internet_no_ping(String? host) {
-    return 'Server down ($host)';
+    return 'Server nede ($host)';
   }
 
   @override
   String product_refresher_internet_error(String? exception) {
-    return 'Server error ($exception)';
+    return 'Serverfeil ($exception)';
   }
 
   @override
-  String get product_loader_not_found_title => 'Product not found!';
+  String get product_loader_not_found_title => 'Produktet ble ikke funnet!';
 
   @override
   String product_loader_not_found_message(String barcode) {
-    return 'A product with the following barcode doesn\'t exist in our database: $barcode';
+    return 'Et produkt med følgende strekkode finnes ikke i databasen vår: $barcode';
   }
 
   @override
-  String get product_loader_network_error_title => 'No internet connection!';
+  String get product_loader_network_error_title =>
+      'Ingen internettforbindelse!';
 
   @override
   String get product_loader_network_error_message =>
-      'Please check that your smartphone is on a WiFi network or has mobile data enabled';
+      'Sjekk at smarttelefonen din er på et WiFi-nettverk eller at mobildata er aktivert';
 
   @override
-  String get page_not_found_title => 'Page not found!';
+  String get page_not_found_title => 'Siden ble ikke funnet!';
 
   @override
-  String get page_not_found_button => 'Go back to the homepage';
+  String get page_not_found_button => 'Gå tilbake til hjemmesiden';
 
   @override
-  String get download_data => 'Download data';
+  String get download_data => 'Last ned data';
 
   @override
   String get download_top_products =>
-      'Download the top 1000 products in your country for instant scanning';
+      'Last ned de 1000 beste produktene i landet ditt for umiddelbar skanning';
 
   @override
   String download_top_n_products(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count products',
+      other: '$count produktene',
     );
-    return 'Download the top $_temp0 in your country for instant scanning';
+    return 'Last ned de beste $_temp0 i ditt land for umiddelbar skanning';
   }
 
   @override
-  String get download_in_progress => 'Downloading data\nThis may take a while';
+  String get download_in_progress => 'Laster ned data\nDette kan ta en stund';
 
   @override
   String downloaded_products(int num) {
-    return '$num products added';
+    return '$num produkter lagt til';
   }
 
   @override
-  String get update_offline_data => 'Update offline product data';
+  String get update_offline_data => 'Oppdater produktdata frakoblet';
 
   @override
   String get update_local_database_sub =>
-      'Update the local product database with the latest data from Open Food Facts';
+      'Oppdater den lokale produktdatabasen med de nyeste dataene fra Open Food Facts';
 
   @override
-  String get clear_local_database => 'Clear offline product data';
+  String get clear_local_database => 'Fjern produktdata frakoblet';
 
   @override
   String get clear_local_database_sub =>
-      'Clear all local product data from your app to free up space';
+      'Fjern all lokal produktdata fra appen din for å frigjøre plass';
 
   @override
   String deleted_products(int num) {
-    return '$num products deleted';
+    return '$num produkter slettet';
   }
 
   @override
   String get loading => 'Laster…';
 
   @override
-  String get know_more => 'Know More';
+  String get know_more => 'Lær mer';
 
   @override
-  String get offline_data_desc => 'Click to know more about offline data';
+  String get offline_data_desc => 'Klikk for å finne ut mer om frakoblet data';
 
   @override
-  String get offline_product_data_title => 'Offline product data';
+  String get offline_product_data_title => 'Produktdata frakoblet';
 
   @override
   String available_for_download(int num) {
-    return '$num products available for immediate scaning';
+    return '$num produkter tilgjengelig for umiddelbar skanning';
   }
 
   @override
-  String get country_selector_title => 'Select your country:';
+  String get country_selector_title => 'Velg ditt land:';
 
   @override
   String get currency_selector_title => 'Velg valuta:';
 
   @override
-  String get language_selector_title => 'Select your language:';
+  String get language_selector_title => 'Velg språk:';
 
   @override
-  String get language_selector_section_selected => 'Selected languages';
+  String get language_selector_section_selected => 'Valgte språk';
 
   @override
-  String get language_selector_section_frequently_used => 'Frequently used';
+  String get language_selector_section_frequently_used => 'Ofte brukt';
 
   @override
   String get action_delete_list => 'Slett';
 
   @override
-  String get action_change_list => 'Change the current list';
+  String get action_change_list => 'Endre gjeldende liste';
 
   @override
   String get product_list_create => 'Opprett';
@@ -4039,41 +4064,41 @@ class AppLocalizationsNb extends AppLocalizations {
   String get nutriscore_generic => 'Nutri-Score';
 
   @override
-  String get nutriscore_a => 'Nutri-Score A';
+  String get nutriscore_a => 'Næringsscore A';
 
   @override
-  String get nutriscore_b => 'Nutri-Score B';
+  String get nutriscore_b => 'Næringsscore B';
 
   @override
-  String get nutriscore_c => 'Nutri-Score C';
+  String get nutriscore_c => 'Næringsscore C';
 
   @override
-  String get nutriscore_d => 'Nutri-Score D';
+  String get nutriscore_d => 'Næringsscore D';
 
   @override
-  String get nutriscore_e => 'Nutri-Score E';
+  String get nutriscore_e => 'Næringsscore E';
 
   @override
   String nutriscore_new_formula(String letter) {
-    return 'Nutri-Score $letter (New calculation)';
+    return 'Nutri-Score $letter (Ny beregning)';
   }
 
   @override
-  String get nutriscore_new_formula_title => 'Nutri-Score (New calculation)';
+  String get nutriscore_new_formula_title => 'Nutri-Score (Ny beregning)';
 
   @override
-  String get nutriscore_unknown => 'Unknown Nutri-Score';
+  String get nutriscore_unknown => 'Ukjent ernæringspoengsum';
 
   @override
   String get nutriscore_unknown_new_formula =>
-      'Unknown Nutri-Score (New calculation)';
+      'Ukjent ernæringspoengsum (ny beregning)';
 
   @override
-  String get nutriscore_not_applicable => 'Nutri-Score is not applicable';
+  String get nutriscore_not_applicable => 'Nutri-Score er ikke aktuelt';
 
   @override
   String get nutriscore_not_applicable_new_formula =>
-      'Nutri-Score is not applicable (New calculation)';
+      'Nutri-Score er ikke aktuelt (ny beregning)';
 
   @override
   String get environmental_score_generic_new => 'Green-Score';
@@ -4104,93 +4129,93 @@ class AppLocalizationsNb extends AppLocalizations {
   String get nova_group_generic_new => 'Ultra-behandlet mat – NOVA-grupper';
 
   @override
-  String get nova_group_1 => 'NOVA Group 1';
+  String get nova_group_1 => 'NOVA Gruppe 1';
 
   @override
-  String get nova_group_2 => 'NOVA Group 2';
+  String get nova_group_2 => 'NOVA Gruppe 2';
 
   @override
-  String get nova_group_3 => 'NOVA Group 3';
+  String get nova_group_3 => 'NOVA Gruppe 3';
 
   @override
-  String get nova_group_4 => 'NOVA Group 4';
+  String get nova_group_4 => 'NOVA Gruppe 4';
 
   @override
-  String get nova_group_unknown => 'Unknown NOVA Group';
+  String get nova_group_unknown => 'Ukjent NOVA-gruppe';
 
   @override
-  String get nutrition_facts => 'Nutrient Levels';
+  String get nutrition_facts => 'Næringsnivåer';
 
   @override
-  String get faq_title_partners => 'Partners & Patrons of the NGO';
+  String get faq_title_partners => 'Partnere og beskyttere av NGO-en';
 
   @override
   String get faq_title_vision =>
-      'The Open Food Facts Vision, Mission, Values and Programs';
+      'Open Food Facts visjon, oppdrag, verdier og programmer';
 
   @override
   String get faq_title_install_beauty =>
-      'Install Open Beauty Facts to create a cosmetic database';
+      'Installer Open Beauty Facts for å opprette en kosmetisk database';
 
   @override
   String get faq_title_install_pet =>
-      'Install Open Pet Food Facts to create a pet food database';
+      'Installer Open Pet Food Facts for å opprette en database med kjæledyrfôr';
 
   @override
   String get faq_title_install_product =>
-      'Install Open Products Facts to create a products database to extend the life of objects';
+      'Installer Open Products Facts for å opprette en produktdatabase for å forlenge levetiden til objekter.';
 
   @override
   String get faq_nutriscore_nutriscore =>
-      'New calculation of the Nutri-Score: what\'s new?';
+      'Ny beregning av Nutri-Score: hva er nytt?';
 
   @override
   String get contact_title_pro_page =>
-      'Pro? Import your products in Open Food Facts';
+      'Pro? Importer produktene dine i Open Food Facts';
 
   @override
-  String get contact_title_pro_email => 'Producer Contact';
+  String get contact_title_pro_email => 'Produsentkontakt';
 
   @override
-  String get contact_title_press_page => 'Press Page';
+  String get contact_title_press_page => 'Presseside';
 
   @override
-  String get contact_title_press_email => 'Press Contact';
+  String get contact_title_press_email => 'Pressekontakt';
 
   @override
   String get contact_title_newsletter => 'Abonnér på vårt nyhetsbrev';
 
   @override
-  String get contact_title_calendar => 'Subscribe to our community calendar';
+  String get contact_title_calendar => 'Abonner på vår fellesskapskalender';
 
   @override
-  String get hunger_games_loading_line1 => 'Please give us a few seconds…';
+  String get hunger_games_loading_line1 => 'Vennligst gi oss noen sekunder…';
 
   @override
-  String get hunger_games_loading_line2 => 'We\'re downloading the questions!';
+  String get hunger_games_loading_line2 => 'Vi laster ned spørsmålene!';
 
   @override
   String get hunger_games_error_label =>
-      'Argh! Something went wrong… and we couldn\'t load the questions.';
+      'Æsj! Noe gikk galt… , og vi kunne ikke laste inn spørsmålene.';
 
   @override
-  String get hunger_games_error_retry_button => 'Let\'s retry!';
+  String get hunger_games_error_retry_button => 'La oss prøve på nytt!';
 
   @override
-  String get reorder_attribute_action => 'Reorder the attributes';
+  String get reorder_attribute_action => 'Endre rekkefølgen på attributtene';
 
   @override
   String get link_cant_be_opened =>
-      'This link can\'t be opened on your device. Please check that you have a browser installed.';
+      'Denne lenken kan ikke åpnes på enheten din. Sjekk at du har en nettleser installert.';
 
   @override
   String knowledge_panel_page_title_no_title(String productName) {
-    return 'Details for $productName';
+    return 'Detaljer for $productName';
   }
 
   @override
   String knowledge_panel_page_title(String pageName, String productName) {
-    return 'Details for $pageName with $productName';
+    return 'Detaljer for $pageName med $productName';
   }
 
   @override
@@ -4279,15 +4304,15 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get guide_nutriscore_v2_where_title =>
-      'Where to find the new Nutri-Score calculation?';
+      'Hvor finner jeg den nye Nutri-Score-beregningen?';
 
   @override
   String get guide_nutriscore_v2_where_paragraph1 =>
-      'The Nutri-Score is applied in 7 countries: France, Germany, Belgium, Spain, Luxembourg, the Netherlands and Switzerland.';
+      'Nutri-Score brukes i 7 land: Frankrike, Tyskland, Belgia, Spania, Luxembourg, Nederland og Sveits.';
 
   @override
   String get guide_nutriscore_v2_where_paragraph2 =>
-      'Manufacturers have at most **2 years** at the latest after the signature of the decree **to replace** the old calculation with the new one.';
+      'Produsentene har maksimalt **2 år** etter at dekretet er undertegnet **til å erstatte** den gamle beregningen med den nye.';
 
   @override
   String get guide_nutriscore_v2_where_paragraph3 =>
@@ -4396,7 +4421,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get guide_greenscore_bonuses_penalties_intro =>
-      'To reward better products within a category, we then apply **bonuses & penalties based on several criterion**:';
+      'For å belønne bedre produkter innenfor en kategori, bruker vi deretter **bonuser og straffer basert på flere kriterier**:';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg1_title =>
@@ -4404,7 +4429,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get guide_greenscore_bonuses_penalties_arg1_text =>
-      'A **bonus** is awarded to products that have an **official label, a label or a certification that guarantees environmental benefits** (organic, fair trade, HVE, Label Rouge, Bleu Blanc Cœur, MSC/ASC).';
+      'En **bonus** gis til produkter som har en **offisiell etikett, en etikett eller en sertifisering som garanterer miljøfordeler** (økologisk, rettferdig handel, HVE, Label Rouge, Bleu Blanc Cœur, MSC/ASC).';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg2_title =>
@@ -4412,7 +4437,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get guide_greenscore_bonuses_penalties_arg2_text =>
-      'A **bonus** is awarded based on the origin of the ingredients. This bonus takes into account the **impact on transportation** and also the **environmental policy** of each producer\'s country.';
+      'En **bonus** tildeles basert på ingrediensenes opprinnelse. Denne bonusen tar hensyn til **påvirkningen på transport** og også **miljøpolitikken** i hver produsents land.';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg3_title =>
@@ -4420,14 +4445,14 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get guide_greenscore_bonuses_penalties_arg3_text =>
-      'A **penalty** is given to products that contain ingredients that have significant **negative impacts on biodiversity and ecosystems**, such as palm oil, the production of which is responsible for massive deforestation.';
+      'Det gis en **straff** til produkter som inneholder ingredienser som har betydelig **negativ innvirkning på biologisk mangfold og økosystemer**, som for eksempel palmeolje, hvis produksjon er ansvarlig for massiv avskoging.';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg4_title => 'Emballasje';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg4_text =>
-      'A **penalty** is calculated to take into account the **circularity of packaging** (use of recycled raw material and recyclability) and overpacking.';
+      'En **straff** beregnes for å ta hensyn til **emballasjens sirkularitet** (bruk av resirkulert råmateriale og resirkulerbarhet) og overpakking.';
 
   @override
   String get guide_greenscore_transparency_title =>
@@ -4435,19 +4460,19 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get guide_greenscore_transparency_intro1 =>
-      'To accurately calculate the Green-Score, it is necessary to have **information which is not necessarily specified on the packaging** (such as the origin and the exact percentage of each ingredient) or which is rarely available in usable form (such as a list of all the components of the packaging with the precise types of plastics used).';
+      'For å beregne Green-Score nøyaktig er det nødvendig med **informasjon som ikke nødvendigvis er spesifisert på emballasjen** (som opprinnelse og den nøyaktige prosentandelen av hver ingrediens) eller som sjelden er tilgjengelig i brukbar form (som en liste over alle komponentene i emballasjen med de nøyaktige plasttypene som brukes).';
 
   @override
   String get guide_greenscore_transparency_intro2 =>
-      '**Average values are used when this information is not yet available**, but we are now calling on everyone to help us collect this information which will be very useful for the Green-Score but also for many other uses.';
+      '**Gjennomsnittsverdier brukes når denne informasjonen ikke er tilgjengelig ennå**, men vi ber nå alle om å hjelpe oss med å samle inn denne informasjonen, som vil være svært nyttig for Green-Score, men også for mange andre bruksområder.';
 
   @override
   String get guide_greenscore_transparency_arg1_title =>
-      'How citizens can help?';
+      'Hvordan kan innbyggere hjelpe?';
 
   @override
   String get guide_greenscore_transparency_arg1_text =>
-      'All citizens can help us gather and structure the information that is present on products or that can be deduced from them, such as information on **packaging**: \"Mission Emballages\": a large-scale collaborative inventory of packaging for all food products (in French).';
+      'Alle borgere kan hjelpe oss med å samle og strukturere informasjonen som finnes på produkter eller som kan utledes fra dem, for eksempel informasjon om **emballasje**: «Mission Emballages»: en storstilt samarbeidende inventarisering av emballasje for alle matvarer (på fransk).';
 
   @override
   String get guide_greenscore_transparency_arg2_title =>
@@ -4521,7 +4546,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get guide_nova_groups_arg1_text =>
-      'Unprocessed (or natural) foods are the **edible parts of plants** (seeds, fruits, leaves, stems, roots) **or animals** (muscle, offal, eggs, milk), as well as fungi, algae, and water, after being separated from nature.';
+      'Ubearbeidet (eller naturlig) mat er de **spiselige delene av planter** (frø, frukt, blader, stilker, røtter) **eller dyr** (muskler, innmat, egg, melk), samt sopp, alger og vann, etter å ha blitt separert fra naturen.';
 
   @override
   String get guide_nova_groups_arg2_title =>
@@ -4555,7 +4580,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg1_text =>
-      'Many are **derived from further processing of food constituents**, such as hydrogenated or interesterified oils, hydrolyzed proteins, soy protein isolate, maltodextrin, invert sugar, and high-fructose corn syrup.';
+      'Mange er **utvunnet fra videre bearbeiding av matbestanddeler**, som hydrogenerte eller interesterifiserte oljer, hydrolyserte proteiner, soyaproteinisolat, maltodekstrin, invertsukker og maissirup med høyt fruktoseinnhold.';
 
   @override
   String get guide_nova_explanations_arg2_title =>
@@ -4563,7 +4588,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg2_text =>
-      'Additives in ultra-processed foods include some that are also used in processed foods, such as preservatives, antioxidants, and stabilizers. Classes of additives found only in ultra-processed products include those used **to imitate or enhance the sensory qualities of foods or to disguise unpalatable aspects of the final product**. These additives include dyes and other colors, color stabilizers; flavors, flavor enhancers, non-sugar sweeteners; and processing aids such as carbonating, firming, bulking and anti-bulking agents, de-foaming, anti-caking and glazing agents, emulsifiers, sequestrants, and humectants.';
+      'Tilsetningsstoffer i ultrabearbeidet mat inkluderer noen som også brukes i bearbeidet mat, for eksempel konserveringsmidler, antioksidanter og stabilisatorer. Klasser av tilsetningsstoffer som bare finnes i ultrabearbeidede produkter inkluderer de som brukes **for å imitere eller forbedre de sensoriske egenskapene til matvarer eller for å skjule usmakelige aspekter ved sluttproduktet**. Disse tilsetningsstoffene inkluderer fargestoffer og andre farger, fargestabilisatorer; smakstilsetninger, smaksforsterkere, ikke-sukkerholdige søtningsmidler; og prosesseringshjelpemidler som kullsyre-, fasthets-, fyllings- og antifylningsmidler, skumdempende, antiklumpe- og glaseringsmidler, emulgatorer, sekvestreringsmidler og fuktighetsbevarende midler.';
 
   @override
   String get guide_nova_explanations_arg3_title =>
@@ -4571,7 +4596,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg3_text =>
-      '**A multitude of sequences of processes is used** to combine the usually many ingredients and to create the final product (hence \'ultra-processed\'). The processes include several **with no domestic equivalents**, such as hydrogenation and hydrolysation, extrusion and moulding, and pre-processing for frying.';
+      '**En rekke prosesssekvenser brukes** for å kombinere de vanligvis mange ingrediensene og for å lage sluttproduktet (derav «ultraprosessert»). Prosessene inkluderer flere **uten innenlandske ekvivalenter**, som hydrogenering og hydrolysering, ekstrudering og støping, og forbehandling for steking.';
 
   @override
   String get guide_nova_explanations_arg4_title =>
@@ -4579,104 +4604,105 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg4_text =>
-      '**The overall purpose of ultra-processing is to create branded**, **convenient** (durable, ready to consume), **attractive** (hyper-palatable) and **highly profitable** (low-cost ingredients) food products designed to displace all other food groups. Ultra-processed food products are usually packaged attractively and marketed intensively.';
+      '**Det overordnede formålet med ultraprosessering er å skape merkevareprodukter som er **praktiske** (holdbare, klare til konsum), **attraktive** (hypervelsmakende) og **svært lønnsomme** (lavkostingredienser) og er utformet for å fortrenge alle andre matvaregrupper. Ultraprosesserte matvarer pakkes vanligvis attraktivt og markedsføres intensivt.**';
 
   @override
-  String get guide_nova_explanations_arg5_title => 'A health hazard';
+  String get guide_nova_explanations_arg5_title => 'En helsefare';
 
   @override
   String get guide_nova_explanations_arg5_text =>
-      'Since 2018, with NutriNet-Santé, the first links between **the consumption of ultra-processed foods and increased risks of cancer, cardiovascular diseases, and diabetes have been highlighted**. Today, more than 90 studies worldwide confirm these findings.\nThe strongest associations relate to **obesity, cardiovascular mortality, and depressive symptoms**. On children, the effects are primarily observed on weight and lipid imbalances.';
+      'Siden 2018 har de første koblingene mellom **forbruk av ultraprosessert mat og økt risiko for kreft, hjerte- og karsykdommer og diabetes blitt fremhevet** med NutriNet-Santé. I dag bekrefter mer enn 90 studier over hele verden disse funnene.\nDe sterkeste assosiasjonene er knyttet til **fedme, hjerte- og kardødelighet og depressive symptomer**. Hos barn observeres effektene primært på vekt og lipidubalanser.';
 
   @override
   String get guide_nova_explanations_arg6_title =>
-      'Countries recommend limiting them';
+      'Land anbefaler å begrense dem';
 
   @override
   String get guide_nova_explanations_arg6_text =>
-      'Some countries use the NOVA groups for their dietary guidelines or goals, for instance:\n\n- **🇧🇷 Brazil**\'s dietary guidelines **recommend to limit consumption** of processed food and avoid ultra-processed food.\n\n- **🇫🇷 France**\'s public health nutritional policy goals for 2018-2022 aims to **reduce consumption of group 4 ultra-processed foods by 20%**.';
+      'Noen land bruker NOVA-gruppene for sine kostholdsretningslinjer eller -mål, for eksempel:\n\n- **🇧🇷 Brasils** kostholdsretningslinjer **anbefaler å begrense forbruket** av bearbeidet mat og unngå ultrabearbeidet mat.\n\n- **🇫🇷 Frankrikes** ernæringspolitiske mål for folkehelse for 2018–2022 har som mål å **redusere forbruket av ultrabearbeidet mat i gruppe 4 med 20 %**.';
 
   @override
   String get guide_nova_share_link => 'https://world.openfoodfacts.org/nova';
 
   @override
-  String get guide_open_food_facts_title => 'Welcome to Open Food Facts!';
+  String get guide_open_food_facts_title => 'Velkommen til Åpne matfakta!';
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_title =>
-      'What is Open Food Facts?';
+      'Hva er åpne matfakta?';
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_paragraph1 =>
-      'Open Food Facts is a **collaborative**, **free**, and **open** database of food products from around the world.';
+      'Open Food Facts er en **samarbeidsbasert**, **gratis** og **åpen** database med matvarer fra hele verden.';
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_paragraph2 =>
-      'We believe that everyone should have access to information about what they eat. By collecting data on ingredients, allergens, nutrition facts, and more, **we empower consumers to make informed choices** and drive the food industry **toward greater transparency**.';
+      'Vi mener at alle bør ha tilgang til informasjon om hva de spiser. Ved å samle inn data om ingredienser, allergener, næringsinnhold og mer, **gir vi forbrukerne mulighet til å ta informerte valg** og driver matindustrien **mot større åpenhet**.';
 
   @override
   String get guide_open_food_facts_features_title =>
-      'Features of Open Food Facts';
+      'Funksjoner ved åpne matfakta';
 
   @override
   String get guide_open_food_facts_features_arg1_title =>
-      'Get alerts for your unwanted ingredients';
+      'Få varsler om uønskede ingredienser';
 
   @override
-  String get guide_open_food_facts_tips_title => 'Tips for taking great photos';
+  String get guide_open_food_facts_tips_title => 'Tips for å ta flotte bilder';
 
   @override
-  String get guide_open_food_facts_tips_arg1_title => 'Don’ts';
+  String get guide_open_food_facts_tips_arg1_title => 'Ikke gjør';
 
   @override
   String get guide_open_food_facts_tips_arg1_text1 =>
-      'Avoid shadows and glare.';
+      'Unngå skygger og gjenskinn.';
 
   @override
   String get guide_open_food_facts_tips_arg1_text2 =>
-      'No blurry or out-of-focus text.';
+      'Ingen uskarp eller uskarp tekst.';
 
   @override
   String get guide_open_food_facts_tips_arg1_text3 =>
-      'Don\'t crop out parts of the text.';
+      'Ikke beskjær ut deler av teksten.';
 
   @override
-  String get guide_open_food_facts_tips_arg1_text4 => 'Avoid busy backgrounds.';
+  String get guide_open_food_facts_tips_arg1_text4 =>
+      'Unngå travle bakgrunner.';
 
   @override
-  String get guide_open_food_facts_tips_arg2_title => 'Do’s';
+  String get guide_open_food_facts_tips_arg2_title => 'Gjør-det-selv';
 
   @override
   String get guide_open_food_facts_tips_arg2_text1 =>
-      'Use good, even lighting.';
+      'Bruk god, jevn belysning.';
 
   @override
   String get guide_open_food_facts_tips_arg2_text2 =>
-      'Ensure text is sharp and readable.';
+      'Sørg for at teksten er skarp og lesbar.';
 
   @override
   String get guide_open_food_facts_tips_arg2_text3 =>
-      'Capture the entire ingredients list.';
+      'Ta opp hele ingredienslisten.';
 
   @override
   String get guide_open_food_facts_tips_arg2_text4 =>
-      'Keep the product on a flat surface.';
+      'Oppbevar produktet på en flat overflate.';
 
   @override
   String get guide_open_food_facts_scores_title =>
-      'Help us build the \"Wikipedia of Food\"';
+      'Hjelp oss å bygge «Matens Wikipedia»';
 
   @override
   String get guide_open_food_facts_scores_arg1_title =>
-      'A score on the nutritional quality';
+      'En poengsum på næringskvaliteten';
 
   @override
   String get guide_open_food_facts_scores_arg2_title =>
-      'A score to avoid ultra-processed foods';
+      'En poengsum for å unngå ultraprosessert mat';
 
   @override
   String get guide_open_food_facts_scores_arg3_title =>
-      'A score for the planet';
+      'En poengsum for planeten';
 
   @override
   String get guide_open_food_facts_share_link =>
@@ -4684,236 +4710,240 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get guide_open_pet_food_facts_title =>
-      'Welcome to Open Pet Food Facts!';
+      'Velkommen til Åpne fakta om kjæledyrmat!';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_title =>
-      'What is Open Pet Food Facts?';
+      'Hva er åpne fakta om kjæledyrfôr?';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_paragraph1 =>
-      'Open Pet Food Facts extends our mission to our furry friends! It\'s a **database of pet food products for cats, dogs, and other companions**.';
+      'Open Pet Food Facts utvider vårt oppdrag til våre pelskledde venner! Det er en **database med kjæledyrfôrprodukter for katter, hunder og andre følgesvenner**.';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_paragraph2 =>
-      'We gather information on **ingredients**, **nutritional analysis**, and feeding guidelines to help pet owners choose the best food for their animals\' needs.';
+      'Vi samler informasjon om **ingredienser**, **ernæringsanalyse** og fôringsretningslinjer for å hjelpe dyreeiere med å velge det beste fôret for dyrenes behov.';
 
   @override
   String get guide_open_pet_food_facts_features_title =>
-      'Features of Open Pet Food Facts';
+      'Funksjoner ved åpne kjæledyrfôrfakta';
 
   @override
   String get guide_open_pet_food_facts_features_arg1_title =>
-      'Get alerts for your unwanted ingredients';
+      'Få varsler om uønskede ingredienser';
 
   @override
   String get guide_open_pet_food_facts_features_arg1_paragraph1 =>
-      'Is your pet allergic to any ingredients? You can set a list of cosmetic ingredients to avoid, right in the app!';
+      'Er kjæledyret ditt allergisk mot noen ingredienser? Du kan sette opp en liste over kosmetiske ingredienser du bør unngå, rett i appen!';
 
   @override
   String get guide_open_pet_food_facts_tips_title =>
-      'Tips for taking great photos';
+      'Tips for å ta flotte bilder';
 
   @override
-  String get guide_open_pet_food_facts_tips_arg1_title => 'Don’ts';
+  String get guide_open_pet_food_facts_tips_arg1_title => 'Ikke gjør';
 
   @override
   String get guide_open_pet_food_facts_tips_arg1_text1 =>
-      'Avoid shadows and glare.';
+      'Unngå skygger og gjenskinn.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg1_text2 =>
-      'No blurry or out-of-focus text.';
+      'Ingen uskarp eller uskarp tekst.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg1_text3 =>
-      'Don\'t crop out parts of the text.';
+      'Ikke beskjær ut deler av teksten.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg1_text4 =>
-      'Avoid busy backgrounds.';
+      'Unngå travle bakgrunner.';
 
   @override
-  String get guide_open_pet_food_facts_tips_arg2_title => 'Do’s';
+  String get guide_open_pet_food_facts_tips_arg2_title => 'Gjør-det-selv';
 
   @override
   String get guide_open_pet_food_facts_tips_arg2_text1 =>
-      'Use good, even lighting.';
+      'Bruk god, jevn belysning.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg2_text2 =>
-      'Ensure text is sharp and readable.';
+      'Sørg for at teksten er skarp og lesbar.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg2_text3 =>
-      'Capture the entire ingredients list.';
+      'Ta opp hele ingredienslisten.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg2_text4 =>
-      'Keep the product on a flat surface.';
+      'Oppbevar produktet på en flat overflate.';
 
   @override
-  String get guide_open_pet_food_facts_scores_title => 'A note on scoring';
+  String get guide_open_pet_food_facts_scores_title =>
+      'En merknad om poengberegning';
 
   @override
   String get guide_open_pet_food_facts_scores_paragraph1 =>
-      'Developing a scoring system for pet food **is not a priority right now**. The methodology would be complex, as nutritional needs vary greatly by species, age, and health condition. We haven’t found any independant scientific team yet, able to develop such a score.';
+      'Å utvikle et poengsystem for kjæledyrfôr **er ikke en prioritet akkurat nå**. Metodikken ville være kompleks, ettersom ernæringsbehovene varierer sterkt etter art, alder og helsetilstand. Vi har ennå ikke funnet noe uavhengig vitenskapelig team som er i stand til å utvikle en slik poengsum.';
 
   @override
   String get guide_open_pet_food_facts_share_link =>
       'https://world-nb.openpetfoodfacts.org/discover';
 
   @override
-  String get guide_open_beauty_facts_title => 'Welcome to Open Beauty Facts!';
+  String get guide_open_beauty_facts_title =>
+      'Velkommen til Åpne skjønnhetsfakta!';
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_title =>
-      'What is Open Beauty Facts?';
+      'Hva er åpne skjønnhetsfakta?';
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_paragraph1 =>
-      'Open Beauty Facts is a collaborative database of **cosmetic products**.';
+      'Open Beauty Facts er en samarbeidende database med **kosmetikkprodukter**.';
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_paragraph2 =>
-      'Our goal is to decipher ingredient lists to help you **understand what\'s in your personal care items**. From moisturizers to makeup, we collect data on ingredients, allergens, and packaging to promote transparency in the cosmetics industry.';
+      'Målet vårt er å tyde ingredienslister for å hjelpe deg med å **forstå hva som finnes i dine personlige pleieprodukter**. Fra fuktighetskremer til sminke samler vi inn data om ingredienser, allergener og emballasje for å fremme åpenhet i kosmetikkindustrien.';
 
   @override
   String get guide_open_beauty_facts_features_title =>
-      'Features of Open Beauty Facts';
+      'Funksjoner ved åpne skjønnhetsfakta';
 
   @override
   String get guide_open_beauty_facts_features_arg1_title =>
-      'Get alerts for your unwanted ingredients';
+      'Få varsler om uønskede ingredienser';
 
   @override
   String get guide_open_beauty_facts_features_arg1_paragraph1 =>
-      'Are you allergic to any ingredients? Want to avoid comedogen substances? Want to steer away from controversial components ? You can set a list of cosmetic ingredients to avoid, right in the app!';
+      'Er du allergisk mot noen ingredienser? Vil du unngå komedogene stoffer? Vil du unngå kontroversielle komponenter? Du kan angi en liste over kosmetiske ingredienser du vil unngå, rett i appen!';
 
   @override
   String get guide_open_beauty_facts_tips_title =>
-      'Tips for taking great photos';
+      'Tips for å ta flotte bilder';
 
   @override
-  String get guide_open_beauty_facts_tips_arg1_title => 'Don’ts';
+  String get guide_open_beauty_facts_tips_arg1_title => 'Ikke gjør';
 
   @override
   String get guide_open_beauty_facts_tips_arg1_text1 =>
-      'Avoid shadows and glare.';
+      'Unngå skygger og gjenskinn.';
 
   @override
   String get guide_open_beauty_facts_tips_arg1_text2 =>
-      'No blurry or out-of-focus text.';
+      'Ingen uskarp eller uskarp tekst.';
 
   @override
   String get guide_open_beauty_facts_tips_arg1_text3 =>
-      'Don\'t crop out parts of the text.';
+      'Ikke beskjær ut deler av teksten.';
 
   @override
   String get guide_open_beauty_facts_tips_arg1_text4 =>
-      'Avoid busy backgrounds.';
+      'Unngå travle bakgrunner.';
 
   @override
-  String get guide_open_beauty_facts_tips_arg2_title => 'Do’s';
+  String get guide_open_beauty_facts_tips_arg2_title => 'Gjør-det-selv';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text1 =>
-      'Use good, even lighting.';
+      'Bruk god, jevn belysning.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text2 =>
-      'Ensure text is sharp and readable.';
+      'Sørg for at teksten er skarp og lesbar.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text3 =>
-      'Capture the entire ingredients list.';
+      'Ta opp hele ingredienslisten.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text4 =>
-      'Take as many picture as need if the bottle is curved.';
+      'Ta så mange bilder som nødvendig hvis flasken er buet.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text5 =>
-      'You might need to peel the label to see the list of ingredients.';
+      'Du må kanskje rive av etiketten for å se ingredienslisten.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text6 =>
-      'Keep the product on a flat surface.';
+      'Oppbevar produktet på en flat overflate.';
 
   @override
-  String get guide_open_beauty_facts_scores_title => 'A note on scoring';
+  String get guide_open_beauty_facts_scores_title =>
+      'En merknad om poengberegning';
 
   @override
   String get guide_open_beauty_facts_scores_paragraph1 =>
-      'Unlike food products, the world of cosmetics **does not have a universally recognized, government-backed scoring system like the Nutri-Score**. Ingredient effects can be highly personal and depend on skin type, allergies, and individual concerns.';
+      'I motsetning til matvarer har ikke kosmetikkverdenen et universelt anerkjent, myndighetsstøttet poengsystem som Nutri-Score. Ingrediensenes effekt kan være svært personlig og avhenge av hudtype, allergier og individuelle bekymringer.';
 
   @override
   String get guide_open_beauty_facts_share_link =>
       'https://world-nb.openbeautyfacts.org/discover';
 
   @override
-  String get guide_open_prices_title => 'Welcome to Open Prices!';
+  String get guide_open_prices_title => 'Velkommen til Åpne priser!';
 
   @override
   String get guide_open_prices_what_is_open_prices_title =>
-      'What is Open Prices?';
+      'Hva er åpningspriser?';
 
   @override
   String get guide_open_prices_what_is_open_prices_paragraph1 =>
-      'Open Prices is a project to **collect and share prices of products around the world**. It\'s a publicly available dataset that can be used for research, analysis, and more. Open Prices is developed and maintained by Open Food Facts.';
+      'Open Prices er et prosjekt for å **samle inn og dele priser på produkter over hele verden**. Det er et offentlig tilgjengelig datasett som kan brukes til forskning, analyse og mer. Open Prices er utviklet og vedlikeholdt av Open Food Facts.';
 
   @override
   String get guide_open_prices_what_is_open_prices_paragraph2 =>
       'There are currently few companies that own large databases of product prices at the barcode level. These prices are not freely available, but sold at a high price to private actors, researchers and other organizations that can afford them.';
 
   @override
-  String get guide_open_prices_how_title => 'How does Open Prices work?';
+  String get guide_open_prices_how_title => 'Hvordan fungerer åpne priser?';
 
   @override
   String get guide_open_prices_how_paragraph1 =>
-      '**We are crowdsourcing an open-source dataset of prices**. Prices can be added by users via this web app, or via the official Open Food Facts mobile app. Retailers or third-party apps can contribute as well by using our API.';
+      '**Vi bruker crowdsourcing til å finne et åpen kildekode-datasett med priser.** Priser kan legges til av brukere via denne nettappen eller via den offisielle Open Food Facts-mobilappen. Forhandlere eller tredjepartsapper kan også bidra ved å bruke API-et vårt.';
 
   @override
   String get guide_open_prices_how_arg1_title =>
-      'Collect photos of price tags in aisles';
+      'Samle bilder av prislapper i gangene';
 
   @override
-  String get guide_open_prices_how_arg2_title => 'Collect photos of receipts';
+  String get guide_open_prices_how_arg2_title => 'Samle bilder av kvitteringer';
 
   @override
   String get guide_open_prices_why_title =>
-      'Why is Open Food Facts doing this ?';
+      'Hvorfor gjør Open Food Facts dette?';
 
   @override
   String get guide_open_prices_why_paragraph1 =>
-      'Price information is of paramount importance to understand food systems. It\'s a key factor in understanding the cost of food and to promote healthier diets. Opening price data is a way to make it easier for researchers, journalists, and citizens to **have a better understanding of how food prices vary geographically and in time**.';
+      'Prisinformasjon er av største betydning for å forstå matsystemer. Det er en nøkkelfaktor for å forstå kostnadene ved mat og for å fremme sunnere kosthold. Å åpne prisdata er en måte å gjøre det enklere for forskere, journalister og innbyggere å **få en bedre forståelse av hvordan matprisene varierer geografisk og over tid**.';
 
   @override
   String get guide_open_prices_why_arg1_title =>
-      'Track the evolution of prices over time';
+      'Spor prisutviklingen over tid';
 
   @override
   String get guide_open_prices_why_arg1_text =>
-      'See the **evolution of prices**: shrinkflation, cheapflation, we can track them together!';
+      'Se **prisutviklingen**: krympeinflasjon, billiginflasjon, vi kan spore dem sammen!';
 
   @override
-  String get guide_open_prices_why_arg2_title => 'Compare prices near you';
+  String get guide_open_prices_why_arg2_title =>
+      'Sammenlign priser i nærheten av deg';
 
   @override
   String get guide_open_prices_why_arg2_text =>
-      'As we get more prices, you can spot **the cheapest stores around you**.';
+      'Etter hvert som vi får flere priser, kan du finne **de billigste butikkene i nærheten**.';
 
   @override
   String get guide_open_prices_scrapping_title =>
-      'Did you consider scraping prices from retailers\' websites?';
+      'Har du vurdert å hente priser fra forhandlernes nettsider?';
 
   @override
   String get guide_open_prices_scrapping_paragraph1 =>
-      'For legal and technical reasons, **we don\'t consider scraping prices from retailers\' websites as a valid way to contribute to Open Prices**. We want to make sure that the prices we collect are accurate and up-to-date, and receiving scraped prices from contributors doesn\'t allow us to do that.';
+      'Av juridiske og tekniske årsaker **anser vi ikke det å hente priser fra forhandlernes nettsteder som en gyldig måte å bidra til åpne priser**. Vi ønsker å sørge for at prisene vi samler inn er nøyaktige og oppdaterte, og det å motta hentede priser fra bidragsytere tillater oss ikke å gjøre det.';
 
   @override
   String get guide_open_prices_scrapping_paragraph2 =>
-      'Price scraping is a considered option in a future version of Open Prices, but it would be done by Open Prices itself so that we can have a proof of the price based on the HTML page.';
+      'Prisskraping er et vurdert alternativ i en fremtidig versjon av Open Prices, men det vil bli gjort av Open Prices selv, slik at vi kan ha et bevis på prisen basert på HTML-siden.';
 
   @override
   String get guide_open_prices_retailers_title =>
@@ -4921,7 +4951,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get guide_open_prices_retailers_paragraph1 =>
-      'You can contribute prices by using our API.\nIf you want to contribute prices at scale, please get in touch with us at prices@openfoodfacts.org.';
+      'Du kan bidra med priser ved å bruke API-et vårt.\nHvis du ønsker å bidra med priser i stor skala, kan du ta kontakt med oss på prices@openfoodfacts.org.';
 
   @override
   String get guide_open_prices_share_link =>
@@ -4929,149 +4959,148 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get guide_open_products_facts_title =>
-      'Welcome to Open Products Facts!';
+      'Velkommen til fakta om åpne produkter!';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_title =>
-      'What is Open Products Facts?';
+      'Hva er fakta om åpne produkter?';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_paragraph1 =>
-      'Open Products Facts is a massive, open database for **any product with a barcode, which is not food, cosmetic or pet food**.';
+      'Open Products Facts er en massiv, åpen database for **alle produkter med strekkode, som ikke er mat, kosmetikk eller dyrefôr**.';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_paragraph2 =>
-      'From **electronics** to **toys**, and **clothes** to **cleaning supplies**, if it has a barcode, it can be added. This project aims to create an \"Internet of Things\" for everyday objects, making information about them universally accessible.';
+      'Fra **elektronikk** til **leker**, og **klær** til **rengjøringsartikler**, hvis det har en strekkode, kan det legges til. Dette prosjektet har som mål å skape et «tingenes internett» for hverdagsgjenstander, og gjøre informasjon om dem universelt tilgjengelig.';
 
   @override
   String get guide_open_products_facts_features_title =>
-      'Features of Open Products Facts';
+      'Funksjoner i åpne produktfakta';
 
   @override
   String get guide_open_products_facts_features_text =>
-      'Open Products Facts aims to provide consumers to **extend the life of objects** by providing the circular solutions to maintain, **repair**, **recycle** their objects or give them a new owner.';
+      'Open Products Facts har som mål å gi forbrukere muligheten til å **forlenge levetiden til gjenstander** ved å tilby sirkulære løsninger for å vedlikeholde, **reparere**, **resirkulere** gjenstandene sine eller gi dem en ny eier.';
 
   @override
   String get guide_open_products_facts_features_arg1_title =>
-      'Carbon footprints for some products';
+      'Karbonavtrykk for noen produkter';
 
   @override
   String get guide_open_products_facts_features_arg1_text =>
-      '**Impact CO2** by French Environment Authority ADEME provides the **carbon impact** of many categories, make sure to categorize products precisely.';
+      '**CO2-påvirkning** fra den franske miljømyndigheten ADEME gir **karbonpåvirkningen** for mange kategorier. Sørg for å kategorisere produktene nøyaktig.';
 
   @override
   String get guide_open_products_facts_features_arg2_title =>
-      'Reparability index for many products';
+      'Reparasjonsindeks for mange produkter';
 
   @override
   String get guide_open_products_facts_features_arg2_text =>
-      'Whenever a French reparability index is available, we’ll display it. Moreover, **you can start collecting the variables using the Folksonomy Engine**; so that we can recompute it ourselves in the future, even in countries where it’s not available.';
+      'Når en fransk reparerbarhetsindeks er tilgjengelig, viser vi den. Dessuten **kan du begynne å samle inn variablene ved hjelp av Folksonomy Engine**, slik at vi kan beregne den på nytt selv i fremtiden, selv i land der den ikke er tilgjengelig.';
 
   @override
   String get guide_open_products_facts_features_arg3_title =>
-      'Find ways to donate/resell your product';
+      'Finn måter å donere/videreselge produktet ditt på';
 
   @override
   String get guide_open_products_facts_features_arg3_text =>
-      'We provide links to **third party circular friendly services** that help you get the kind of product you’re looking for, as a second hand product, to be more gentle on planetary resources.\nNote that we’re not paid to do that, and that the system only works as an example for two websites in France. You can help expand this system by documenting more sites on the wiki.';
+      'Vi tilbyr lenker til **tredjeparts sirkulærvennlige tjenester** som hjelper deg med å få den typen produkt du leter etter, som et bruktprodukt, for å være mer skånsom mot planetens ressurser.\nMerk at vi ikke får betalt for å gjøre det, og at systemet bare fungerer som et eksempel for to nettsteder i Frankrike. Du kan bidra til å utvide dette systemet ved å dokumentere flere nettsteder på wikien.';
 
   @override
   String get guide_open_products_facts_information_title =>
-      'What information is useful?';
+      'Hvilken informasjon er nyttig?';
 
   @override
   String get guide_open_products_facts_information_text =>
-      'For such a wide range of items, **the data we collect is flexible**. To do that, **we created the Folksonomy Engine**.';
+      'For et så bredt spekter av elementer er **dataene vi samler inn fleksible**. For å gjøre det har **vi laget Folksonomy Engine**.';
 
   @override
-  String get guide_open_products_facts_folksonomy_title =>
-      'The Folksonomy Engine';
+  String get guide_open_products_facts_folksonomy_title => 'Folksonomi-motoren';
 
   @override
   String get guide_open_products_facts_folksonomy_paragraph1 =>
-      'The Folksonomy Engine is a tool to help you complete products with relevant properties. This helps improve search and discoverability, but also compute and display interesting things in the future.';
+      'Folksonomy-motoren er et verktøy som hjelper deg med å fullføre produkter med relevante egenskaper. Dette bidrar til å forbedre søk og synlighet, men også beregne og vise interessante ting i fremtiden.';
 
   @override
   String get guide_open_products_facts_folksonomy_paragraph2 =>
-      'You can add any keys and values like: **compatibility_with_5G_mobile_network: yes**';
+      'Du kan legge til hvilke som helst nøkler og verdier som: **kompatibilitet_med_5G_mobilnettverk: ja**';
 
   @override
   String get guide_open_products_facts_folksonomy_paragraph3 =>
-      'You’ll get autosuggestion of possible properties, and you are very welcome to add and document new ones on your favorite kinds of products.';
+      'Du får automatiske forslag til mulige egenskaper, og du er hjertelig velkommen til å legge til og dokumentere nye på dine favorittprodukter.';
 
   @override
   String get guide_open_products_facts_share_link =>
       'https://world-nb.openproductsfacts.org/discover';
 
   @override
-  String get guide_open_preferences_button_title => 'Open food preferences';
+  String get guide_open_preferences_button_title => 'Åpne matpreferanser';
 
   @override
-  String get guide_coming_soon_button_title => 'Coming soon';
+  String get guide_coming_soon_button_title => 'Kommer snart';
 
   @override
-  String get guide_learn_more_subtitle => 'Tap to learn more';
+  String get guide_learn_more_subtitle => 'Trykk for å finne ut mer';
 
   @override
-  String get preview_badge => 'Preview';
+  String get preview_badge => 'Forhåndsvisning';
 
   @override
   String get prices_feedback_form =>
-      'Click here to send us your feedback about this new feature!';
+      'Klikk her for å sende oss din tilbakemelding om denne nye funksjonen!';
 
   @override
-  String get menu_button_list_actions => 'Select an action';
+  String get menu_button_list_actions => 'Velg en handling';
 
   @override
-  String get error_loading_photo => 'Error loading photo';
+  String get error_loading_photo => 'Feil ved lasting av bilde';
 
   @override
-  String get photo_viewer_action_use_picture_as => 'Use as…';
+  String get photo_viewer_action_use_picture_as => 'Bruk som…';
 
   @override
-  String get photo_viewer_use_picture_as_tooltip => 'Use this picture as…';
+  String get photo_viewer_use_picture_as_tooltip => 'Bruk dette bildet som…';
 
   @override
   String photo_viewer_use_picture_as_title(String language) {
-    return 'Use this picture as… ($language)';
+    return 'Bruk dette bildet som… ($language)';
   }
 
   @override
-  String get photo_viewer_details_button => 'Details';
+  String get photo_viewer_details_button => 'Detaljer';
 
   @override
   String get photo_viewer_details_button_accessibility_label =>
-      'Details of this photo';
+      'Detaljer om dette bildet';
 
   @override
-  String get photo_viewer_details_title => 'Details of the photo';
+  String get photo_viewer_details_title => 'Detaljer om bildet';
 
   @override
   String get photo_viewer_details_contributor_title => 'Bidrager';
 
   @override
-  String get photo_viewer_details_size_title => 'Size';
+  String get photo_viewer_details_size_title => 'Størrelse';
 
   @override
   String photo_viewer_details_size_value(int width, int height) {
-    return '$width x $height pixels';
+    return '$width x $height piksler';
   }
 
   @override
-  String get photo_viewer_details_date_title => 'Date';
+  String get photo_viewer_details_date_title => 'Dato';
 
   @override
-  String get photo_viewer_details_url_title => 'URL';
+  String get photo_viewer_details_url_title => 'URL-adresse';
 
   @override
-  String get product_page_compatibility_score => 'Compatible';
+  String get product_page_compatibility_score => 'Kompatibel';
 
   @override
-  String get user_lists_action_multi_select => 'Multi-select';
+  String get user_lists_action_multi_select => 'Flervalg';
 
   @override
   String product_page_compatibility_score_tooltip(String score) {
-    return 'Your compatibility score: $score%';
+    return 'Din kompatibilitetspoengsum: $score%';
   }
 
   @override
@@ -5082,164 +5111,165 @@ class AppLocalizationsNb extends AppLocalizations {
       'Bilde av ingredienser';
 
   @override
-  String get product_image_nutrition_accessibility_label => 'Nutrition picture';
+  String get product_image_nutrition_accessibility_label => 'Ernæringsbilde';
 
   @override
-  String get product_image_packaging_accessibility_label => 'Packaging picture';
+  String get product_image_packaging_accessibility_label => 'Emballasjebilde';
 
   @override
-  String get product_image_other_accessibility_label => 'Other picture';
+  String get product_image_other_accessibility_label => 'Annet bilde';
 
   @override
-  String get product_image_outdated_message => 'This picture may be outdated';
+  String get product_image_outdated_message => 'Dette bildet kan være utdatert';
 
   @override
   String product_image_outdated_message_accessibility_label(String type) {
-    return '$type (this image may be outdated)';
+    return '$type (dette bildet kan være utdatert)';
   }
 
   @override
   String product_image_locked_message_accessibility_label(String type) {
-    return '$type (this image may be locked by the producer)';
+    return '$type (dette bildet kan være låst av produsenten)';
   }
 
   @override
-  String get product_image_error => 'Unable to load the image!';
+  String get product_image_error => 'Klarte ikke å laste inn bildet!';
 
   @override
   String product_image_error_accessibility_label(String type) {
-    return 'Unable to load the $type (network error?)';
+    return 'Kan ikke laste inn $type (nettverksfeil?)';
   }
 
   @override
-  String get product_page_image_no_image_available => 'No\nimage!';
+  String get product_page_image_no_image_available => 'Ikke noe\nbilde!';
 
   @override
   String get product_page_image_no_image_available_accessibility_label =>
-      'No picture available for this product';
+      'Ingen bilder tilgjengelig for dette produktet';
 
   @override
   String get product_page_action_bar_settings_accessibility_label =>
-      'Reorder or hide actions';
+      'Endre rekkefølgen på eller skjul handlinger';
 
   @override
-  String get product_page_action_bar_setting_modal_title => 'Edit actions';
+  String get product_page_action_bar_setting_modal_title =>
+      'Rediger handlinger';
 
   @override
-  String get product_page_action_bar_item_move_up => 'Move up';
+  String get product_page_action_bar_item_move_up => 'Flytt opp';
 
   @override
-  String get product_page_action_bar_item_move_down => 'Move down';
+  String get product_page_action_bar_item_move_down => 'Flytt ned';
 
   @override
-  String get product_page_action_bar_item_enable => 'Enable action';
+  String get product_page_action_bar_item_enable => 'Aktiver handling';
 
   @override
-  String get product_page_action_bar_item_disable => 'Disable action';
+  String get product_page_action_bar_item_disable => 'Deaktiver handling';
 
   @override
   String get product_page_pending_operations_banner_title =>
-      'Uploading your edits…';
+      'Laster opp redigeringene dine…';
 
   @override
   String get product_page_pending_operations_banner_message =>
-      'The data displayed on this page **does not yet reflect your modifications**.\nPlease wait a few seconds…';
+      'Dataene som vises på denne siden **gjenspeiler ikke endringene dine ennå**.\nVent noen sekunder…';
 
   @override
-  String get product_add_a_language => 'Add a language';
+  String get product_add_a_language => 'Legg til et språk';
 
   @override
   String barcode_accessibility_label(String barcode) {
-    return 'Barcode $barcode';
+    return 'Strekkode $barcode';
   }
 
   @override
-  String get carousel_close_tooltip => 'Remove this product from the carousel';
+  String get carousel_close_tooltip => 'Fjern dette produktet fra karusellen';
 
   @override
-  String get carousel_unsupported_header => 'Unsupported barcode!';
+  String get carousel_unsupported_header => 'Ustøttet strekkode!';
 
   @override
-  String get carousel_unsupported_title => 'Ooops!';
+  String get carousel_unsupported_title => 'Ups!';
 
   @override
   String get carousel_unsupported_text =>
-      'The barcode scanned is not supported by Open Food Facts!';
+      'Strekkoden som skannes støttes ikke av Open Food Facts!';
 
   @override
-  String get carousel_error_header => 'Error!';
+  String get carousel_error_header => 'Feil!';
 
   @override
-  String get carousel_error_title => 'It\'s a bummer!';
+  String get carousel_error_title => 'Det er kjipt!';
 
   @override
   String get carousel_error_text_1 =>
-      'We couldn\'t download information on this barcode:';
+      'Vi kunne ikke laste ned informasjon om denne strekkoden:';
 
   @override
   String get carousel_error_text_2 =>
-      'Please check your Internet connection or click this button:';
+      'Sjekk internettforbindelsen din, eller klikk på denne knappen:';
 
   @override
   String get carousel_error_button => 'Prøv på nytt';
 
   @override
-  String get carousel_unknown_product_header => 'Unknown product';
+  String get carousel_unknown_product_header => 'Ukjent produkt';
 
   @override
   String get carousel_unknown_product_title =>
-      'Congratulations!\nYou\'ve found __the rare gem!__';
+      'Gratulerer!\nDu har funnet __den sjeldne juvelen!__';
 
   @override
   String get carousel_unknown_product_text =>
-      'Our collaborative database contains more than **3 million products**, but this barcode doesn\'t exist: ';
+      'Vår samarbeidsdatabase inneholder mer enn **3 millioner produkter**, men denne strekkoden finnes ikke: ';
 
   @override
   String get carousel_unknown_product_button => 'Legg til dette produktet';
 
   @override
-  String get carousel_loading_header => 'Loading information...';
+  String get carousel_loading_header => 'Laster inn informasjon ...';
 
   @override
   String get carousel_loading_title =>
-      'You\'ve just scanned a product with the following barcode:';
+      'Du har nettopp skannet et produkt med følgende strekkode:';
 
   @override
   String get carousel_loading_text =>
-      'We are searching for it in our database of more than **3 million products!**';
+      'Vi søker etter det i databasen vår med mer enn **3 millioner produkter!**';
 
   @override
-  String get product_type_subtitle_food => 'Vegetables, fruits, frozen food…';
+  String get product_type_subtitle_food => 'Grønnsaker, frukt, frossenmat…';
 
   @override
-  String get product_type_subtitle_beauty => 'Makeup, soaps, toothpastes…';
+  String get product_type_subtitle_beauty => 'Sminke, såper, tannkremer…';
 
   @override
-  String get product_type_subtitle_pet_food => 'Food for dogs, cats…';
+  String get product_type_subtitle_pet_food => 'Mat til hunder og katter…';
 
   @override
-  String get product_type_subtitle_product => 'Smartphones, furniture…';
+  String get product_type_subtitle_product => 'Smarttelefoner, møbler…';
 
   @override
-  String get photo_field_front => 'Product photo';
+  String get photo_field_front => 'Produktbilde';
 
   @override
-  String get photo_field_ingredients => 'Ingredients photo';
+  String get photo_field_ingredients => 'Ingredienser bilde';
 
   @override
-  String get photo_field_nutrition => 'Nutrition photo';
+  String get photo_field_nutrition => 'Næringsinnholdsbilde';
 
   @override
-  String get photo_field_packaging => 'Packaging information photo';
+  String get photo_field_packaging => 'Emballasjeinformasjonsbilde';
 
   @override
-  String get photo_already_exists => 'This photo already exists';
+  String get photo_already_exists => 'Dette bildet finnes allerede';
 
   @override
-  String get photo_missing => 'This photo is missing';
+  String get photo_missing => 'Dette bildet mangler';
 
   @override
-  String get date => 'Date';
+  String get date => 'Dato';
 
   @override
   String get photo_rotate_left => 'Roter mot venstre';
@@ -5248,67 +5278,67 @@ class AppLocalizationsNb extends AppLocalizations {
   String get photo_rotate_right => 'Roter mot høyre';
 
   @override
-  String get photo_undo_action => 'Undo the previous action';
+  String get photo_undo_action => 'Angre forrige handling';
 
   @override
   String knowledge_panel_world_map_accessibility_label(String location) {
-    return 'A world map of $location';
+    return 'Et verdenskart over $location';
   }
 
   @override
   String get open_street_map_contributor_attribution =>
-      'OpenStreetMap contributors';
+      'OpenStreetMap-bidragsytere';
 
   @override
-  String get not_applicable_short => 'N/A';
+  String get not_applicable_short => 'Ikke aktuelt';
 
   @override
   String get knowledge_panel_warning_text => 'Advarsel';
 
   @override
   String get knowledge_panel_nutriscore_banner_incorrect_score_title =>
-      'Why is this Nutri-Score different from the one on the package?';
+      'Hvorfor er denne næringsverdien forskjellig fra den på pakken?';
 
   @override
   String get knowledge_panel_nutriscore_banner_incorrect_score_message =>
-      'There are two possible explanations:\nThe list of ingredients and/or nutrition facts are not up-to-date.\n\nWe provide the \"New calculation\" of the Nutri-Score (or V2). Please check that you have the banner \"New calculation\" on the package.';
+      'Det er to mulige forklaringer:\nListen over ingredienser og/eller næringsinnholdet er ikke oppdatert.\n\nVi tilbyr den «nye beregningen» av Nutri-Score (eller V2). Sjekk at du har banneret «Ny beregning» på pakken.';
 
   @override
   String get knowledge_panel_nutriscore_banner_incorrect_score_button1 =>
-      'Check ingredients';
+      'Sjekk ingrediensene';
 
   @override
   String get knowledge_panel_nutriscore_banner_incorrect_score_button2 =>
-      'Check nutrition facts';
+      'Sjekk næringsinnholdet';
 
   @override
   String url_not_supported(String url) {
-    return 'Unfortunately, we can\'t open the URL:\n$url';
+    return 'Dessverre kan vi ikke åpne URL-en:\n$url';
   }
 
   @override
-  String get product_list_export => 'Export';
+  String get product_list_export => 'Eksport';
 
   @override
   String get product_list_import => 'Import';
 
   @override
-  String get product_footer_action_barcode => 'View barcode';
+  String get product_footer_action_barcode => 'Vis strekkode';
 
   @override
   String get product_footer_action_barcode_short => 'Strekkode';
 
   @override
-  String get product_footer_action_open_website => 'Open website';
+  String get product_footer_action_open_website => 'Åpne nettsiden';
 
   @override
-  String get product_footer_action_report => 'Report';
+  String get product_footer_action_report => 'Rapportere';
 
   @override
-  String get product_footer_action_contributor_guide => 'Help';
+  String get product_footer_action_contributor_guide => 'Hjelp';
 
   @override
-  String get product_footer_action_data_quality_tags => 'Data quality';
+  String get product_footer_action_data_quality_tags => 'Datakvalitet';
 
   @override
   String get product_page_tab_for_me => 'For meg';
@@ -5317,7 +5347,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get product_page_tab_website => 'Nettsted';
 
   @override
-  String get product_page_tab_prices => 'Prices';
+  String get product_page_tab_prices => 'Priser';
 
   @override
   String get prices_explanation_card_title => 'Hvorfor priser?';
@@ -5330,7 +5360,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get explanation_card_learn_more_button => 'Lær mer';
 
   @override
-  String get product_page_tab_folksonomy => 'Folksonomy';
+  String get product_page_tab_folksonomy => 'Folkesonomi';
 
   @override
   String get folksonomy_explanation_card_title =>
@@ -5345,11 +5375,11 @@ class AppLocalizationsNb extends AppLocalizations {
       'Eiendommene lages og deles av bidragsytere for alle typer bruk.';
 
   @override
-  String get folksonomy_action_external_link_title => 'Open external link';
+  String get folksonomy_action_external_link_title => 'Åpne ekstern lenke';
 
   @override
   String get folksonomy_action_external_link_warning =>
-      'External links may be unsafe. Do you really want to visit it?';
+      'Eksterne lenker kan være utrygge. Vil du virkelig besøke dem?';
 
   @override
   String get prices_products_empty_title => 'Ingen pris tilgjengelig';
@@ -5359,41 +5389,41 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String prices_products_list_length_many_pages(int pageSize, int total) {
-    return 'Top $pageSize products (total: $total)';
+    return 'Topp $pageSize produkter (totalt: $total)';
   }
 
   @override
-  String get app_review_title => 'Are you enjoying this app?';
+  String get app_review_title => 'Liker du denne appen?';
 
   @override
-  String get app_review_low => 'Could do better';
+  String get app_review_low => 'Kunne gjort det bedre';
 
   @override
-  String get app_review_medium => 'Not bad';
+  String get app_review_medium => 'Ikke dårlig';
 
   @override
-  String get app_review_high => 'I love it!';
+  String get app_review_high => 'Jeg elsker det!';
 
   @override
   String get app_review_feedback_modal_title =>
-      'Help us improve our application';
+      'Hjelp oss med å forbedre applikasjonen vår';
 
   @override
   String get app_review_feedback_modal_content =>
-      'If you have a few minutes, could you answer this form so that **we can improve in future updates**:';
+      'Hvis du har noen minutter, kan du svare på dette skjemaet slik at **vi kan forbedre oss i fremtidige oppdateringer**:';
 
   @override
-  String get app_review_feedback_modal_open_form => 'Answer the form';
+  String get app_review_feedback_modal_open_form => 'Svar på skjemaet';
 
   @override
-  String get app_review_feedback_modal_later => 'Ask me later';
+  String get app_review_feedback_modal_later => 'Spør meg senere';
 
   @override
   String get nutrition_facts_extract_new =>
-      'NEW: You can automatically extract the nutrients from the picture!';
+      'NYTT: Du kan automatisk trekke ut næringsstoffene fra bildet!';
 
   @override
-  String get nutrition_facts_extract_button_text => 'Extract now';
+  String get nutrition_facts_extract_button_text => 'Uttrekk nå';
 
   @override
   String get nutrition_facts_extract_in_progress => 'Uttrekking pågår…';
@@ -5403,19 +5433,19 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get nutrition_facts_extract_failed =>
-      'Failed to extract nutrients from picture';
+      'Klarte ikke å hente ut næringsstoffer fra bildet';
 
   @override
   String get prices_discount => 'Discount';
 
   @override
-  String get prices_stats_statistics => 'Statistics';
+  String get prices_stats_statistics => 'Statistikk';
 
   @override
-  String get prices_stats_title => 'Prices Statistics';
+  String get prices_stats_title => 'Prisstatistikk';
 
   @override
-  String get prices_stats_prices_section => 'Prices';
+  String get prices_stats_prices_section => 'Priser';
 
   @override
   String get prices_stats_products_section => 'Produkter';
@@ -5433,7 +5463,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get prices_stats_experiments_section => 'Experiments';
 
   @override
-  String get prices_stats_misc_section => 'Miscellaneous';
+  String get prices_stats_misc_section => 'Diverse';
 
   @override
   String get prices_stats_total => 'Total';
@@ -5457,7 +5487,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get prices_stats_with_price => 'With a price';
 
   @override
-  String get prices_stats_food => 'Food';
+  String get prices_stats_food => 'Mat';
 
   @override
   String get prices_stats_beauty => 'Beauty';
@@ -5466,7 +5496,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get prices_stats_products => 'Produkter';
 
   @override
-  String get prices_stats_pet_food => 'Pet food';
+  String get prices_stats_pet_food => 'Kjæledyrfôr';
 
   @override
   String get prices_stats_osm => 'OpenStreetMap';
@@ -5478,10 +5508,10 @@ class AppLocalizationsNb extends AppLocalizations {
   String get prices_stats_countries => 'Land';
 
   @override
-  String get prices_stats_price_tag => 'Price tag';
+  String get prices_stats_price_tag => 'Prislapp';
 
   @override
-  String get prices_stats_receipt => 'Receipt';
+  String get prices_stats_receipt => 'Kvittering';
 
   @override
   String get prices_stats_gdpr_request => 'GDPR request';
@@ -5511,29 +5541,30 @@ class AppLocalizationsNb extends AppLocalizations {
   String get prices_stats_mobile_app => 'Mobile app';
 
   @override
-  String get prices_stats_api => 'API';
+  String get prices_stats_api => 'API-en';
 
   @override
   String get prices_stats_other => 'Andre';
 
   @override
-  String get prices_stats_last_updated => 'Last updated on';
+  String get prices_stats_last_updated => 'Sist oppdatert';
 
   @override
   String get prices_stats_error =>
-      'An error occurred while loading statistics.';
+      'Det oppsto en feil under lasting av statistikk.';
 
   @override
-  String get product_edit_robotoff_question_answered => 'Question answered!';
+  String get product_edit_robotoff_question_answered =>
+      'Spørsmålet er besvart!';
 
   @override
-  String get product_edit_robotoff_proof => 'Proof';
+  String get product_edit_robotoff_proof => 'Bevis';
 
   @override
   String get preferences_card_general => 'Generelt';
 
   @override
-  String get preferences_prices_title => 'Prices';
+  String get preferences_prices_title => 'Priser';
 
   @override
   String get preferences_prices_subtitle =>
@@ -5601,7 +5632,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get preferences_app_bar_search_hint =>
-      'Search for a setting (e.g. Nutri-Score)';
+      'Søk etter innstillinger (f.eks. nøtt-resultat)';
 
   @override
   String get preferences_accessibility_show_emoji =>
@@ -5635,7 +5666,7 @@ class AppLocalizationsNb extends AppLocalizations {
       'Open Food Facts er en matprodukter database **laget av alle, for alle**.\ndu kan bruke det til å bedre matfatninger og fordi det er **åpne data**, alle kan **bruke det til andre formål**.';
 
   @override
-  String get preferences_privacy_policy => 'Privacy policy';
+  String get preferences_privacy_policy => 'Personvernerklæring';
 
   @override
   String get preferences_licenses => 'Lisenser';
@@ -5813,7 +5844,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get preferences_connect_community_calendar_title =>
-      'Subscribe to our community calendar';
+      'Abonner på vår fellesskapskalender';
 
   @override
   String get preferences_connect_community_calendar_subtitle =>
@@ -5920,7 +5951,7 @@ class AppLocalizationsNb extends AppLocalizations {
       'Enkle skritt for å øke åpenhet om mat i landet ditt';
 
   @override
-  String get preferences_contribute_data_quality_title => 'Data quality';
+  String get preferences_contribute_data_quality_title => 'Datakvalitet';
 
   @override
   String get preferences_contribute_data_quality_team_title =>
@@ -5947,10 +5978,10 @@ class AppLocalizationsNb extends AppLocalizations {
       'Alle ufullstendige produkter';
 
   @override
-  String get preferences_my_contributions_prices_title => 'Prices';
+  String get preferences_my_contributions_prices_title => 'Priser';
 
   @override
-  String get preferences_my_contributions_my_prices_title => 'My prices';
+  String get preferences_my_contributions_my_prices_title => 'Mine priser';
 
   @override
   String get preferences_my_contributions_my_prices_subtitle =>
@@ -6168,26 +6199,26 @@ class AppLocalizationsNb extends AppLocalizations {
   }
 
   @override
-  String get location_map_details_title => 'Location details';
+  String get location_map_details_title => 'Stedsdetaljer';
 
   @override
   String get location_map_details_name => 'Navn';
 
   @override
-  String get location_map_details_street => 'Street';
+  String get location_map_details_street => 'Gate';
 
   @override
-  String get location_map_details_city => 'City';
+  String get location_map_details_city => 'By';
 
   @override
-  String get location_map_details_postcode => 'Postcode';
+  String get location_map_details_postcode => 'Postnummer';
 
   @override
   String get location_map_details_country => 'Country';
 
   @override
-  String get location_map_details_coordinates => 'Coordinates';
+  String get location_map_details_coordinates => 'Koordinater';
 
   @override
-  String get location_map_details_osm_id => 'OSM ID';
+  String get location_map_details_osm_id => 'OSM-ID';
 }

--- a/packages/smooth_app/lib/l10n/app_localizations_nb.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_nb.dart
@@ -657,7 +657,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get unknownBrand => 'Ukjent merke';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Ukjent produktnavn';

--- a/packages/smooth_app/lib/l10n/app_localizations_ne.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ne.dart
@@ -653,6 +653,9 @@ class AppLocalizationsNe extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3518,7 +3521,7 @@ class AppLocalizationsNe extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'स्थानीय रूपमा भण्डारण गरिएका लोकगीत अद्यावधिकहरूको लागि सर्भर कार्यहरू गर्न सुरु गर्दै';
 
   @override
   String get background_task_title_top_n =>
@@ -5304,7 +5307,7 @@ class AppLocalizationsNe extends AppLocalizations {
 
   @override
   String get prices_explanation_card_line1 =>
-      '**Open Prices** is a project to collect and share prices of products around the world 🌍. Open Prices is developed and maintained by Open Food Facts.';
+      '**ओपन प्राइस** विश्वभरका उत्पादनहरूको मूल्य सङ्कलन र साझेदारी गर्ने परियोजना हो 🌍। ओपन प्राइस ओपन फूड फ्याक्ट्सद्वारा विकसित र मर्मत गरिएको हो।';
 
   @override
   String get explanation_card_learn_more_button => 'Learn more';
@@ -5581,7 +5584,7 @@ class AppLocalizationsNe extends AppLocalizations {
 
   @override
   String get preferences_app_bar_search_hint =>
-      'Search for a setting (e.g. Nutri-Score)';
+      'सेटिङ खोज्नुहोस् (जस्तै न्यूट्री-स्कोर)';
 
   @override
   String get preferences_accessibility_show_emoji =>
@@ -5612,7 +5615,7 @@ class AppLocalizationsNe extends AppLocalizations {
 
   @override
   String get preferences_legal_header =>
-      'Open Food Facts is a food products database **made by everyone, for everyone**.\nYou can use it to make better food choices, and as it is **open data**, anyone can **re-use it for any purpose**.';
+      'ओपन फूड फ्याक्ट्स भनेको **सबैले बनाएको, सबैका लागि** खाद्य उत्पादनहरूको डाटाबेस हो।\nतपाईं यसलाई राम्रो खाना छनौट गर्न प्रयोग गर्न सक्नुहुन्छ, र यो **खुला डाटा** भएकोले, जो कोहीले पनि **कुनै पनि उद्देश्यका लागि पुन: प्रयोग गर्न सक्छन्**।';
 
   @override
   String get preferences_privacy_policy => 'Privacy policy';
@@ -5663,7 +5666,7 @@ class AppLocalizationsNe extends AppLocalizations {
 
   @override
   String get preferences_on_off_website_subtitle =>
-      'On the Open Food Facts website';
+      'ओपन फूड फ्याक्ट्स वेबसाइटमा';
 
   @override
   String get preferences_manage_account_title =>
@@ -5750,7 +5753,7 @@ class AppLocalizationsNe extends AppLocalizations {
 
   @override
   String get preferences_faq_nutriscore_subtitle =>
-      'Discover how the Nutri-Score is computed';
+      'न्यूट्री-स्कोर कसरी गणना गरिन्छ पत्ता लगाउनुहोस्';
 
   @override
   String get preferences_faq_nutriscore_v2_subtitle =>
@@ -5780,7 +5783,7 @@ class AppLocalizationsNe extends AppLocalizations {
   String get preferences_faq_faq_title => 'FAQ - बारम्बार सोधिने प्रश्नहरू';
 
   @override
-  String get preferences_faq_off_ngo_title => 'The Open Food Facts NGO';
+  String get preferences_faq_off_ngo_title => 'द ओपन फूड फ्याक्ट्स एनजीओ';
 
   @override
   String get preferences_about_information_title => 'Information';
@@ -5917,7 +5920,7 @@ class AppLocalizationsNe extends AppLocalizations {
 
   @override
   String get preferences_contributions_new_products_subtitle =>
-      'New products I added to Open Food Facts';
+      'ओपन फूड फ्याक्ट्समा मैले थपेका नयाँ उत्पादनहरू';
 
   @override
   String get preferences_contributions_to_be_completed_title =>
@@ -5943,7 +5946,7 @@ class AppLocalizationsNe extends AppLocalizations {
 
   @override
   String get preferences_contributions_categorize_subtitle =>
-      'Help compute the Nutri-Score & Green-Score in your country';
+      'तपाईंको देशमा न्यूट्री-स्कोर र ग्रीन-स्कोर गणना गर्न मद्दत गर्नुहोस्';
 
   @override
   String get preferences_prices_user_prices_subtitle =>
@@ -5965,7 +5968,7 @@ class AppLocalizationsNe extends AppLocalizations {
 
   @override
   String get preferences_prices_newest_subtitle =>
-      'Latest prices added by the Open Prices community';
+      'खुला मूल्य समुदायद्वारा थपिएका नवीनतम मूल्यहरू';
 
   @override
   String get preferences_prices_top_contributors_title =>
@@ -6014,7 +6017,7 @@ class AppLocalizationsNe extends AppLocalizations {
 
   @override
   String get preferences_page_contribute_project_subtitle =>
-      'Simple ways to help Open Food Facts';
+      'खानाको तथ्यहरू खोल्न मद्दत गर्ने सरल तरिकाहरू';
 
   @override
   String get preferences_page_faq_subtitle =>
@@ -6130,7 +6133,7 @@ class AppLocalizationsNe extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'आफ्नो भाषामा खुला खानाका तथ्यहरू ल्याउनुहोस्';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_ne.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ne.dart
@@ -653,7 +653,7 @@ class AppLocalizationsNe extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_nl.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_nl.dart
@@ -46,7 +46,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get continue_label => 'Doorgaan';
 
   @override
-  String get exit_label => 'Afsluiten';
+  String get exit_label => 'Verlaten';
 
   @override
   String get previous_label => 'Vorige';
@@ -79,7 +79,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get stop => 'Stop';
 
   @override
-  String get finish => 'Voltooien';
+  String get finish => 'Beëindigen';
 
   @override
   String get calculate => 'Berekenen';
@@ -97,7 +97,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get featureInProgress => 'We werken nog aan deze functie, wacht af';
 
   @override
-  String get label_web => 'Bekijk in een browser';
+  String get label_web => 'Bekijk op het web';
 
   @override
   String get learnMore => 'Meer informatie';
@@ -156,10 +156,11 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get productDataUtility =>
-      'Zie de voedselgegevens die relevant zijn voor uw voorkeuren.';
+      'Bekijk de voedselgegevens die relevant zijn voor uw voorkeuren.';
 
   @override
-  String get healthCardUtility => 'Kies de producten die goed voor je zijn.';
+  String get healthCardUtility =>
+      'Kies voedingsmiddelen die goed voor je zijn.';
 
   @override
   String get ecoCardUtility => 'Kies voedsel dat goed is voor de planeet.';
@@ -184,7 +185,7 @@ class AppLocalizationsNl extends AppLocalizations {
       'We ondervinden momenteel vertragingen op onze servers en bieden hiervoor onze excuses aan. Probeer het later opnieuw.';
 
   @override
-  String get login => 'Inloggen';
+  String get login => 'Log in';
 
   @override
   String get login_result_type_server_unreachable => 'Netwerk niet bereikbaar';
@@ -195,7 +196,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get login_page_username_or_email =>
-      'Voer gebruikersnaam of e-mailadres in';
+      'Voer je gebruikersnaam of e-mailadres in';
 
   @override
   String get login_page_password_error_empty =>
@@ -233,7 +234,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get view_profile => 'Profiel bekijken';
 
   @override
-  String get reset_password => 'Wachtwoord resetten';
+  String get reset_password => 'Paswoord resetten';
 
   @override
   String get reset_password_explanation_text =>
@@ -244,7 +245,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get reset_password_done =>
-      'Een e-mail met een link om je wachtwoord te resetten is verstuurd naar het e-mailadres dat gekoppeld is aan je account. Controleer ook je spammap.';
+      'Een e-mail met een link om je wachtwoord te resetten is verstuurd naar het e-mailadres dat gekoppeld is aan je account. Controleer ook je spammap';
 
   @override
   String get send_reset_password_mail => 'Wachtwoord wijzigen';
@@ -276,7 +277,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get sign_up_page_email_hint => 'E-mail';
 
   @override
-  String get sign_up_page_email_error_empty => 'E-mail is verplicht';
+  String get sign_up_page_email_error_empty => 'E-mail is vereist';
 
   @override
   String get sign_up_page_email_error_invalid => 'Ongeldig e-mailadres';
@@ -285,11 +286,12 @@ class AppLocalizationsNl extends AppLocalizations {
   String get sign_up_page_username_hint => 'Gebruikersnaam: Openbaar zichtbaar';
 
   @override
-  String get sign_up_page_username_error_empty => 'Voer een gebruikersnaam in';
+  String get sign_up_page_username_error_empty =>
+      'Voer aub. een gebruikersnaam in';
 
   @override
   String get sign_up_page_username_error_invalid =>
-      'Vul a.u.b. een geldige gebruikersnaam in';
+      'Vul a. u. b. een geldige gebruikersnaam in';
 
   @override
   String get sign_up_page_username_description =>
@@ -297,7 +299,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String sign_up_page_username_length_invalid(int value) {
-    return 'Gebruikersnaam mag niet langer zijn dan $value tekens';
+    return 'De gebruikersnaam mag niet langer zijn dan $value tekens';
   }
 
   @override
@@ -312,11 +314,11 @@ class AppLocalizationsNl extends AppLocalizations {
       'Voer een geldig wachtwoord in (minimaal 6 tekens)';
 
   @override
-  String get sign_up_page_confirm_password_hint => 'Bevestig wachtwoord';
+  String get sign_up_page_confirm_password_hint => 'Wachtwoord bevestigen';
 
   @override
   String get sign_up_page_confirm_password_error_empty =>
-      'Bevestig a.u.b. het nieuwe wachtwoord';
+      'Bevestig uw wachtwoord';
 
   @override
   String get sign_up_page_confirm_password_error_invalid =>
@@ -363,7 +365,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get sign_up_page_server_busy =>
-      'Het spijt ons heel erg, we hebben wat technische problemen bij het aanmaken van uw account. Probeer het later opnieuw.';
+      'Het spijt ons zeer erg, we hebben wat technische problemen bij het aanmaken van uw account. Probeer het later opnieuw.';
 
   @override
   String get settingsTitle => 'Instellingen';
@@ -387,7 +389,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get contributors_label => 'Ze bouwen de app';
 
   @override
-  String get contributors_dialog_title => 'Medewerkers';
+  String get contributors_dialog_title => 'Bijdragers';
 
   @override
   String contributors_dialog_entry_description(Object name) {
@@ -416,7 +418,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get support_via_email_include_logs_dialog_body =>
-      'Wilt u toepassingslogboeken als bijlage bij uw e-mail voegen?';
+      'Wilt u toepassingslogboeken toevoegen aan uw e-mail?';
 
   @override
   String get termsOfUse => 'Gebruiksvoorwaarden';
@@ -472,7 +474,7 @@ class AppLocalizationsNl extends AppLocalizations {
       'De database is het hart van het project. Je kan ons makkelijk en heel snel helpen: door de app voor je telefoon te downloaden en te beginnen met het toevoegen of verbeteren van producten.\n\nDe Open Food Facts-website biedt vele andere manieren om bij te dragen: ';
 
   @override
-  String get contribute_translate_header => 'Vertalen';
+  String get contribute_translate_header => 'Vertaal';
 
   @override
   String get contribute_data_quality => 'Gegevenskwaliteit';
@@ -519,7 +521,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get contribute_to_get_rewards =>
-      'Word een deelnemer aan voedseltransparantie';
+      'Word een speler voor voedseltransparantie';
 
   @override
   String get question_sign_in_text =>
@@ -548,11 +550,11 @@ class AppLocalizationsNl extends AppLocalizations {
   String get join_us => 'Doe mee';
 
   @override
-  String get myPreferences_profile_title => 'Uw profiel';
+  String get myPreferences_profile_title => 'Jouw profiel';
 
   @override
   String get myPreferences_profile_subtitle =>
-      'Beheer uw Open Food Facts-bijdragersaccount.';
+      'Beheer je Open Food Facts-bijdragersaccount.';
 
   @override
   String get myPreferences_settings_title => 'App-instellingen';
@@ -569,7 +571,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get myPreferences_food_comment =>
-      'Kies welke informatie over voedsel voor u het belangrijkst is, om voedsel te rangschikken volgens uw voorkeuren, bekijk eerst de informatie die u belangrijk vindt en ontvang een compatibiliteitsoverzicht. Die voedselvoorkeuren blijven op uw apparaat staan en zijn niet gekoppeld aan uw Open Food Facts-bijdragersaccount, als je er een hebt.';
+      'Kies welke informatie over voedsel voor u het belangrijkst is, om voedsel te rangschikken volgens uw voorkeuren, bekijk eerst de informatie die u belangrijk vindt en ontvang een compatibiliteitsoverzicht. Die voedselvoorkeuren blijven op uw apparaat staan en zijn niet gekoppeld aan uw Open Food Facts-bijdragersaccount, als u er een heeft.';
 
   @override
   String get confirmResetPreferences => 'Voedselvoorkeuren resetten?';
@@ -578,7 +580,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get myPersonalizedRanking => 'Mijn persoonlijke ranglijst';
 
   @override
-  String get ranking_tab_all => 'Alles';
+  String get ranking_tab_all => 'Alle';
 
   @override
   String get ranking_subtitle_match_yes => 'Een geweldige overeenkomst voor u';
@@ -591,7 +593,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get refresh_with_new_preferences =>
-      'Ververs de lijst met je nieuwe voorkeuren';
+      'Vernieuw de lijst met uw nieuwe voorkeuren';
 
   @override
   String get reloaded_with_new_preferences =>
@@ -613,7 +615,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get category => 'Filter op categorie';
 
   @override
-  String get category_all => 'Alles';
+  String get category_all => 'Alle';
 
   @override
   String get category_search => '(categorie zoeken)';
@@ -656,10 +658,13 @@ class AppLocalizationsNl extends AppLocalizations {
   String get unknownBrand => 'Onbekend merk';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Onbekende productnaam';
 
   @override
-  String get label_refresh => 'Vernieuw';
+  String get label_refresh => 'Herladen';
 
   @override
   String get label_reload => 'Herladen';
@@ -690,13 +695,13 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get ingredients_editing_image_error =>
-      'Kan geen afbeelding voor nieuwe ingrediënten ophalen.';
+      'Kan geen afbeelding voor de nieuwe ingrediënten ophalen.';
 
   @override
   String get ingredients_editing_title => 'Ingrediënten bewerken';
 
   @override
-  String get ingredients_photo => 'Ingrediënten foto';
+  String get ingredients_photo => 'Foto van de ingrediëntenlijst';
 
   @override
   String get packaging_editing_instructions =>
@@ -828,13 +833,13 @@ class AppLocalizationsNl extends AppLocalizations {
   String get ingredients_photo_title => 'Foto van de ingrediëntenlijst';
 
   @override
-  String get nutritional_facts_photo_title => 'Foto van de voedingswaardetabel';
+  String get nutritional_facts_photo_title => 'Foto van voedingswaarden';
 
   @override
-  String get recycling_photo_title => 'Foto recycleren';
+  String get recycling_photo_title => 'Recycling afbeelding';
 
   @override
-  String get take_photo_title => 'Neem een foto';
+  String get take_photo_title => 'Maak een foto';
 
   @override
   String get take_more_photo_title => 'Maak meer foto\'s';
@@ -843,7 +848,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get front_photo_uploaded => 'Foto voorkant geüpload';
 
   @override
-  String get ingredients_photo_button_label => 'Ingrediënten foto';
+  String get ingredients_photo_button_label => 'Foto van de ingrediëntenlijst';
 
   @override
   String get ingredients_photo_uploaded => 'Foto van ingrediënten geüpload';
@@ -856,7 +861,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get nutritional_facts_photo_button_label => 'Foto van voedingswaarden';
 
   @override
-  String get nutritional_facts_input_button_label => 'Vul voedingswaarden in';
+  String get nutritional_facts_input_button_label => 'Voer voedingswaarden in';
 
   @override
   String get nutritional_facts_added => 'Voedingswaarden toegevoegd';
@@ -958,7 +963,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get uploading_image_type_front =>
-      'Afbeelding van de voorkant uploaden naar Open Food Facts';
+      'Voorste afbeelding uploaden naar Open Food Facts';
 
   @override
   String get uploading_image_type_ingredients =>
@@ -966,7 +971,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get uploading_image_type_nutrition =>
-      'Voedingswaardenafbeelding uploaden naar Open Food Facts';
+      'Uploaden van afbeelding van voedingswaarden naar Open Food Facts';
 
   @override
   String get uploading_image_type_packaging =>
@@ -1077,7 +1082,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get nutrition_page_serving_size_hint =>
-      'Voer een portiegrootte in (bijv. 100 g)';
+      'Voer een portiegrootte in (bijv. 100g)';
 
   @override
   String get nutrition_page_serving_size_explanation_title =>
@@ -1157,7 +1162,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get not_found => 'niet gevonden:';
 
   @override
-  String get refreshing_product => 'Herladen product';
+  String get refreshing_product => 'Product herladen';
 
   @override
   String get product_refreshed => 'Product herladen';
@@ -1197,7 +1202,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get product_image_action_take_new_picture => 'Maak een nieuwe foto';
 
   @override
-  String get product_image_action_take_picture => 'Neem een foto';
+  String get product_image_action_take_picture => 'Maak een foto';
 
   @override
   String get product_image_action_from_gallery =>
@@ -1255,7 +1260,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get tagline_app_review_button_negative => 'Niet echt…';
 
   @override
-  String get tagline_app_review_button_later => 'Vraag het me later nog eens';
+  String get tagline_app_review_button_later => 'Vraag me later nog eens';
 
   @override
   String get tagline_feed_news_button => 'Meer weten';
@@ -1289,7 +1294,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get no_product_tags_found_message =>
-      'Geen producteigenschappen gevonden. Eigenschappen kunnen worden gebruikt om producten op een flexibele manier gedetailleerder te beschrijven.';
+      'Geen producteigenschappen gevonden. Eigenschappen kunnen worden gebruikt om producten op een flexibele manier gedetailleerder te beschrijven. Tik om toe te voegen.';
 
   @override
   String get product_tags_empty => 'Geen eigenschappen';
@@ -1299,7 +1304,7 @@ class AppLocalizationsNl extends AppLocalizations {
       'Door eigenschappen (sleutel/waarde) aan een product toe te voegen, draagt u bij aan de verrijking ervan.';
 
   @override
-  String get add_tag => 'Voeg een eigenschap toe';
+  String get add_tag => 'Eigenschap toevoegen';
 
   @override
   String get add_tags => 'Eigenschappen toevoegen';
@@ -1360,7 +1365,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get product_search_same_category => 'Vind alternatieven';
 
   @override
-  String get product_search_same_category_short => 'Vergelijk';
+  String get product_search_same_category_short => 'Vergelijken';
 
   @override
   String get product_search_same_category_error =>
@@ -1384,14 +1389,14 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get product_improvement_obsolete_nutrition_image =>
-      'De voedingsafbeelding is verouderd: ververs deze alstublieft.';
+      'De voedingsafbeelding is verouderd: vernieuw deze alstublieft.';
 
   @override
   String get product_improvement_origins_to_be_completed =>
       'De Green Score houdt rekening met de herkomst van de ingrediënten. Maak een foto van de ingrediëntenlijst en/of een geografische claim of bewerk het product, zodat er rekening mee kan worden gehouden.';
 
   @override
-  String get country_chooser_label => 'Kies een land a.u.b';
+  String get country_chooser_label => 'Kies een land a.u.b.';
 
   @override
   String get currency_chooser_label => 'Kies een valuta';
@@ -1415,14 +1420,14 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get country_selection_explanation =>
-      'Sommige milieukenmerken zijn locatie-specifiek';
+      'Sommige omgevingskenmerken zijn locatiespecifiek';
 
   @override
   String get product_removed_comparison =>
       'Product verwijderd uit vergelijking';
 
   @override
-  String get native_app_settings => 'Instellingen voor native applicaties';
+  String get native_app_settings => 'Native app-instellingen';
 
   @override
   String get native_app_description =>
@@ -1522,7 +1527,7 @@ class AppLocalizationsNl extends AppLocalizations {
       count,
       locale: localeName,
       other: 'Vergelijk $count producten',
-      one: 'Vergelijk één product',
+      one: 'Compare one Product',
     );
     return '$_temp0';
   }
@@ -1552,7 +1557,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get select_none_products_mode => 'Niets selecteren';
 
   @override
-  String get compare_products_appbar_title => 'Vergelijk Producten';
+  String get compare_products_appbar_title => 'Producten vergelijken';
 
   @override
   String get compare_products_appbar_subtitle =>
@@ -1615,11 +1620,11 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get permissions_page_body1 =>
-      'Om barcodes te scannen met de camera van uw telefoon, moet u toestemming verlenen.';
+      'Om barcodes te scannen met de camera van uw telefoon, moet u de toegang autoriseren.';
 
   @override
   String get permissions_page_body2 =>
-      'Als u van gedachten verandert, kan deze optie op elk moment in de instellingen worden in- en uitgeschakeld.';
+      'Als u van gedachten verandert, kan deze optie op elk moment in de instellingen worden aan- en uitgeschakeld.';
 
   @override
   String contact_form_body_android(
@@ -1649,7 +1654,7 @@ class AppLocalizationsNl extends AppLocalizations {
     String appBuildNumber,
     String appPackageName,
   ) {
-    return '$osContent\nApp versie:$appVersion\nApp build nummer:$appBuildNumber\nApp package naam:$appPackageName';
+    return '$osContent\nApp-versie:$appVersion\nApp-buildnummer:$appBuildNumber\nApp-pakketnaam:$appPackageName';
   }
 
   @override
@@ -1705,7 +1710,7 @@ class AppLocalizationsNl extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'producten',
+      other: 'products',
       one: 'product',
       zero: 'product',
     );
@@ -1721,14 +1726,14 @@ class AppLocalizationsNl extends AppLocalizations {
       one: 'Product',
       zero: 'Product',
     );
-    return '$_temp0 vernieuwing voltooid';
+    return '$_temp0 verversen voltooid';
   }
 
   @override
   String get product_list_compare_side_by_side => 'Vergelijk naast elkaar';
 
   @override
-  String get loading_dialog_default_title => 'Gegevens worden gedownload...';
+  String get loading_dialog_default_title => 'Gegevens downloaden';
 
   @override
   String get loading_dialog_default_error_message =>
@@ -1784,7 +1789,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get settings_app_miscellaneous => 'Diversen';
 
   @override
-  String get camera_play_sound_title => 'Een geluid afspelen bij scannen';
+  String get camera_play_sound_title => 'Een geluid afspelen bij het scannen';
 
   @override
   String get camera_play_sound_subtitle => 'Piept bij elke geslaagde scan';
@@ -1816,7 +1821,7 @@ class AppLocalizationsNl extends AppLocalizations {
       'Wanneer ingeschakeld, wordt strikt anonieme informatie over het gebruik van functies naar de Open Food Facts-servers verzonden, zodat we kunnen begrijpen hoe functies worden gebruikt om ze te verbeteren. Anders wordt een 0-id verzonden.';
 
   @override
-  String get product_edit_photo_title => 'Foto bewerken';
+  String get product_edit_photo_title => 'Foto Bewerken';
 
   @override
   String get permission_photo_error => 'Foutmelding';
@@ -1843,7 +1848,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get permission_photo_denied_dialog_settings_button_open =>
-      'Open instellingen';
+      'Instellingen openen';
 
   @override
   String get permission_photo_denied_dialog_settings_button_cancel =>
@@ -1948,7 +1953,7 @@ class AppLocalizationsNl extends AppLocalizations {
       'Foto\'s toevoegen of vernieuwen';
 
   @override
-  String get edit_product_form_item_labels_title => 'Labels en certificeringen';
+  String get edit_product_form_item_labels_title => 'Etiketten & certificaten';
 
   @override
   String get edit_product_form_item_labels_subtitle =>
@@ -2045,7 +2050,7 @@ class AppLocalizationsNl extends AppLocalizations {
       'De soja komt niet uit de Europese Unie';
 
   @override
-  String get edit_product_form_item_countries_title => 'Country';
+  String get edit_product_form_item_countries_title => 'Land';
 
   @override
   String get edit_product_form_item_countries_hint =>
@@ -2153,7 +2158,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get edit_product_form_item_exit_confirmation =>
-      'Wilt u de wijzigingen opslaan voor het verlaten van deze pagina?';
+      'Wilt u uw wijzigingen opslaan voordat u deze pagina verlaat?';
 
   @override
   String get edit_product_form_item_exit_confirmation_positive_button =>
@@ -2239,7 +2244,8 @@ class AppLocalizationsNl extends AppLocalizations {
   String get edit_product_form_save => 'Bewerken';
 
   @override
-  String get edit_product_ingredients_photo_title => 'Ingrediënten foto';
+  String get edit_product_ingredients_photo_title =>
+      'Foto van de ingrediëntenlijst';
 
   @override
   String get edit_product_ingredients_list_title => 'Lijst van ingrediënten';
@@ -2274,7 +2280,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get edit_ingredients_extract_ingredients_btn_text_short =>
-      'Ingrediënten extraheren';
+      'Extract ingrediënten';
 
   @override
   String get edit_ingredients_extracting_ingredients_btn_text =>
@@ -2332,10 +2338,10 @@ class AppLocalizationsNl extends AppLocalizations {
       'Om de tekstextractiefunctie te kunnen gebruiken, moet u eerst een foto maken.';
 
   @override
-  String get user_list_dialog_new_title => 'Nieuwe lijst van producten';
+  String get user_list_dialog_new_title => 'Nieuwe lijst met producten';
 
   @override
-  String get user_list_dialog_rename_title => 'Lijst hernoemen';
+  String get user_list_dialog_rename_title => 'Lijstnaam wijzigen';
 
   @override
   String get user_list_subtitle_product => 'Lijsten';
@@ -2347,7 +2353,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get user_list_add_product => 'Voeg het product toe aan je lijsten';
 
   @override
-  String get user_list_button_new => 'Een nieuwe lijst maken';
+  String get user_list_button_new => 'Maak een nieuwe lijst aan';
 
   @override
   String get user_list_empty_label =>
@@ -2369,10 +2375,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get user_list_name_hint => 'Mijn lijst';
 
   @override
-  String get user_list_name_error_empty => 'Naam is verplicht!';
+  String get user_list_name_error_empty => 'Naam is verplicht';
 
   @override
-  String get user_list_name_error_already => 'Deze naam is al in gebruik!';
+  String get user_list_name_error_already => 'Deze naam is al in gebruik';
 
   @override
   String get user_list_name_error_same => 'Dat is dezelfde naam';
@@ -2381,10 +2387,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get user_list_name_input_hint => 'Naam van de lijst';
 
   @override
-  String get try_again => 'Probeer opnieuw';
+  String get try_again => 'Probeer het opnieuw';
 
   @override
-  String get there_was_an_error => 'Er is een fout opgetreden!';
+  String get there_was_an_error => 'Er is een fout opgetreden';
 
   @override
   String category_picker_no_category_found_message(String items) {
@@ -2399,17 +2405,17 @@ class AppLocalizationsNl extends AppLocalizations {
   String get camera_toggle_flash => 'Zet de flitser van de camera AAN of UIT';
 
   @override
-  String get camera_enable_flash => 'Schakel flitser in';
+  String get camera_enable_flash => 'Flits inschakelen';
 
   @override
-  String get camera_disable_flash => 'Flitser uitschakelen';
+  String get camera_disable_flash => 'Flits uitschakelen';
 
   @override
   String get camera_flash_error_dialog_title => 'Er is een fout opgetreden!';
 
   @override
   String get camera_flash_error_dialog_message =>
-      'Er is een fout opgetreden bij het wijzigen van de status van uw flitser. Zorg ervoor dat op uw smartphone de zaklamp nog niet is ingeschakeld.';
+      'Er is een fout opgetreden tijdens het wijzigen van de status van uw flitser. Zorg ervoor dat de zaklamp niet reeds is ingeschakeld op uw smartphone.';
 
   @override
   String get category_picker_no_category_found_button => 'Terug';
@@ -2469,7 +2475,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get dev_preferences_export_history_title => 'Geschiedenis exporteren';
 
   @override
-  String get dev_preferences_export_history_progress_error => 'Uitzondering';
+  String get dev_preferences_export_history_progress_error => 'uitzondering';
 
   @override
   String get dev_preferences_export_history_progress_found =>
@@ -2533,7 +2539,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get dev_preferences_news_custom_url_empty_value => 'Niet ingesteld';
 
   @override
-  String get dev_preferences_news_provider_status_title => 'Status';
+  String get dev_preferences_news_provider_status_title => 'Toestand';
 
   @override
   String dev_preferences_news_provider_status_subtitle(String date) {
@@ -2664,7 +2670,7 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
-  String get prices_barcode_search_not_found => 'Product niet gevonden';
+  String get prices_barcode_search_not_found => 'Geen product gevonden';
 
   @override
   String get prices_barcode_search_none_yet => 'Nog geen product';
@@ -2813,7 +2819,7 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
-  String get prices_users_empty_title => 'No contributor yet!';
+  String get prices_users_empty_title => 'Nog geen bijdrage!';
 
   @override
   String get prices_users_empty_explanation =>
@@ -2825,7 +2831,7 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
-  String get prices_locations_empty_title => 'No shop yet!';
+  String get prices_locations_empty_title => 'Nog geen winkel!';
 
   @override
   String get prices_locations_empty_explanation =>
@@ -3007,7 +3013,7 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
-  String get prices_menu_know_more => 'Know more about Open Prices';
+  String get prices_menu_know_more => 'Lees meer over Open Prices';
 
   @override
   String get dev_preferences_import_history_result_success => 'Voltooid';
@@ -3028,7 +3034,8 @@ class AppLocalizationsNl extends AppLocalizations {
   String get dev_mode_section_experimental_features => 'Experimentele functies';
 
   @override
-  String get dev_mode_hide_environmental_score_title => 'Greenscore uitsluiten';
+  String get dev_mode_hide_environmental_score_title =>
+      'Green-score uitsluiten';
 
   @override
   String get dev_mode_spellchecker_for_ocr_title =>
@@ -3107,7 +3114,7 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
-  String get all_search_prices_latest_title => 'Laatste toegevoegde prijzen';
+  String get all_search_prices_latest_title => 'Laatst toegevoegde prijzen';
 
   @override
   String get all_search_prices_top_user_title => 'Beste prijsbijdragers';
@@ -3207,13 +3214,13 @@ class AppLocalizationsNl extends AppLocalizations {
       'Nog geen afbeelding in die taal';
 
   @override
-  String get edit_photo_language_none => 'Nog geen afbeeldingen';
+  String get edit_photo_language_none => 'Nog geen afbeelding';
 
   @override
   String get category_picker_screen_title => 'Categorieën';
 
   @override
-  String get basic_details => 'Basisgegevens';
+  String get basic_details => 'Basisdetails';
 
   @override
   String get product_name => 'Productnaam';
@@ -3308,10 +3315,11 @@ class AppLocalizationsNl extends AppLocalizations {
   String get brand_name => 'Merknaam';
 
   @override
-  String get brand_names => 'Merknaam';
+  String get brand_names => 'Merknamen';
 
   @override
-  String get add_basic_details_brand_name_error => 'Vul a.u.b. de merknaam in';
+  String get add_basic_details_brand_name_error =>
+      'Vul a. u. b. de merknaam in';
 
   @override
   String get add_basic_details_brand_names_hint =>
@@ -3402,7 +3410,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get basic_details_add_error =>
-      'Kan basisgegevens niet toevoegen. Probeer het later opnieuw';
+      'Kan de basisgegevens niet toevoegen. Probeer het later opnieuw';
 
   @override
   String get clear_search => 'Wis je zoekopdracht';
@@ -3425,7 +3433,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String confirm_clear_user_list(String name) {
-    return 'Je staat op het punt deze lijst ($name) te wissen: weet je zeker dat je wilt doorgaan?';
+    return 'Je staat op het punt deze lijst te wissen ($name): weet je zeker dat je door wilt gaan?';
   }
 
   @override
@@ -3459,7 +3467,7 @@ class AppLocalizationsNl extends AppLocalizations {
       count,
       locale: localeName,
       other: '$count producten',
-      one: 'Eén product',
+      one: 'Een product',
       zero: 'Lege lijst',
     );
     return '$_temp0';
@@ -3491,7 +3499,7 @@ class AppLocalizationsNl extends AppLocalizations {
       'Maak foto\'s van alle labels en certificeringsinformatie';
 
   @override
-  String get choose_image_source_title => 'Kies afbeeldingsbron';
+  String get choose_image_source_title => 'Kies een afbeeldingsbron';
 
   @override
   String get choose_image_source_body => 'Kies een afbeeldingsbron';
@@ -3542,7 +3550,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get capture => 'Maak een nieuwe foto';
 
   @override
-  String get capture_new_picture => 'Neem een foto';
+  String get capture_new_picture => 'Maak een foto';
 
   @override
   String get choose_from_gallery => 'Kies uit gallerij';
@@ -3561,7 +3569,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Beginnen met het uitvoeren van de serveracties voor folksonomie-updates die lokaal zijn opgeslagen';
 
   @override
   String get background_task_title_top_n =>
@@ -3601,11 +3609,11 @@ class AppLocalizationsNl extends AppLocalizations {
       'Er zijn geen gegevens beschikbaar op uw klembord';
 
   @override
-  String get clipboard_barcode_copy => 'Kopieer streepjescode naar klembord';
+  String get clipboard_barcode_copy => 'Kopieer de barcode naar het klembord';
 
   @override
   String clipboard_barcode_copied(Object barcode) {
-    return 'Streepjescode $barcode gekopieerd naar het klembord!';
+    return 'Barcode $barcode gekopieerd naar het klembord!';
   }
 
   @override
@@ -3628,7 +3636,7 @@ class AppLocalizationsNl extends AppLocalizations {
       'Het product zal zo snel mogelijk op de achtergrond worden bijgewerkt.';
 
   @override
-  String get no_email_client_available_dialog_title => 'Geen e-mail-apps!';
+  String get no_email_client_available_dialog_title => 'Geen e-mail apps!';
 
   @override
   String get no_email_client_available_dialog_content =>
@@ -3708,7 +3716,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get ocr_image_upload_instruction =>
-      'Upload een afbeelding om de verstrekte informatie automatisch te extraheren.';
+      'Upload een afbeelding om automatisch de informatie die erop staat te extraheren.';
 
   @override
   String get upload_image => 'Foto uploaden';
@@ -3747,7 +3755,7 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
-  String get show_password => 'Toon wachtwoord';
+  String get show_password => 'Laat wachtwoord zien';
 
   @override
   String get owner_field_info_title => 'Door de producent verstrekte waarden';
@@ -3809,10 +3817,10 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get edit_packagings_element_hint_recycling =>
-      'Voer alleen recyclinginstructies in als deze op het product staan vermeld.';
+      'Voer recyclinginstructies alleen in als ze op het product vermeld staan.';
 
   @override
-  String get edit_packagings_element_example_recycling => 'Hergebruik';
+  String get edit_packagings_element_example_recycling => 'Recyclen';
 
   @override
   String get edit_packagings_element_field_quantity =>
@@ -3820,7 +3828,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get edit_packagings_element_hint_quantity =>
-      'Vul het nettogewicht of het nettovolume in en geef de eenheid aan (bijvoorbeeld g of ml).';
+      'Vul het netto gewicht of netto volume in en geef de eenheid aan (bijvoorbeeld g of ml).';
 
   @override
   String get edit_packagings_element_field_weight =>
@@ -3867,7 +3875,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get background_task_run_not_started => 'nog niet gestart';
 
   @override
-  String get background_task_run_to_be_deleted => 'om te worden verwijderd';
+  String get background_task_run_to_be_deleted => 'wordt verwijderd';
 
   @override
   String get background_task_question_stop => 'Wil je die taak ASAP stoppen?';
@@ -3975,7 +3983,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get page_not_found_button => 'Ga terug naar de startpagina';
 
   @override
-  String get download_data => 'Download gegevens';
+  String get download_data => 'Gegevens downloaden';
 
   @override
   String get download_top_products =>
@@ -4004,10 +4012,10 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get update_local_database_sub =>
-      'Update de lokale productdatabase met de nieuwste gegevens van Open Food Facts';
+      'Werk de lokale productdatabase bij met de nieuwste gegevens van Open Food Facts';
 
   @override
-  String get clear_local_database => 'Offline productgegevens wissen';
+  String get clear_local_database => 'Wis offline productgegevens';
 
   @override
   String get clear_local_database_sub =>
@@ -4055,13 +4063,13 @@ class AppLocalizationsNl extends AppLocalizations {
   String get action_delete_list => 'Verwijder';
 
   @override
-  String get action_change_list => 'De huidige lijst wijzigen';
+  String get action_change_list => 'Wijzig de huidige lijst';
 
   @override
   String get product_list_create => 'Aanmaken';
 
   @override
-  String get product_list_create_tooltip => 'Een nieuwe lijst maken';
+  String get product_list_create_tooltip => 'Maak een nieuwe lijst aan';
 
   @override
   String get nutriscore_generic => 'Nutri-Score';
@@ -4175,7 +4183,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get contact_title_pro_page =>
-      'Pro? Importeer uw producten in Open Food Facts';
+      'Pro? Importeer je producten in Open Food Facts';
 
   @override
   String get contact_title_pro_email => 'Producentcontact';
@@ -4187,7 +4195,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get contact_title_press_email => 'Perscontact';
 
   @override
-  String get contact_title_newsletter => 'Abonneer u op onze nieuwsbrief';
+  String get contact_title_newsletter => 'Abonneer op onze nieuwsbrief';
 
   @override
   String get contact_title_calendar => 'Abonneer je op onze communitykalender';
@@ -4426,14 +4434,14 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get guide_greenscore_bonuses_penalties_intro =>
-      'To reward better products within a category, we then apply **bonuses & penalties based on several criterion**:';
+      'Om betere producten binnen een categorie te belonen, passen we vervolgens **bonussen en sancties toe op basis van verschillende criteria**:';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg1_title => 'Productiewijze';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg1_text =>
-      'A **bonus** is awarded to products that have an **official label, a label or a certification that guarantees environmental benefits** (organic, fair trade, HVE, Label Rouge, Bleu Blanc Cœur, MSC/ASC).';
+      'Er wordt een **bonus** toegekend aan producten die een **officieel label, een keurmerk of een certificering hebben die milieuvoordelen garandeert** (biologisch, fair trade, HVE, Label Rouge, Bleu Blanc Cœur, MSC/ASC).';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg2_title =>
@@ -4441,7 +4449,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get guide_greenscore_bonuses_penalties_arg2_text =>
-      'A **bonus** is awarded based on the origin of the ingredients. This bonus takes into account the **impact on transportation** and also the **environmental policy** of each producer\'s country.';
+      'Er wordt een **bonus** toegekend op basis van de herkomst van de ingrediënten. Deze bonus houdt rekening met de **impact op het transport** en ook met het **milieubeleid** van het land van elke producent.';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg3_title =>
@@ -4449,14 +4457,14 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get guide_greenscore_bonuses_penalties_arg3_text =>
-      'A **penalty** is given to products that contain ingredients that have significant **negative impacts on biodiversity and ecosystems**, such as palm oil, the production of which is responsible for massive deforestation.';
+      'Er wordt een **strafpunt** toegekend aan producten die ingrediënten bevatten die een aanzienlijke **negatieve impact hebben op de biodiversiteit en ecosystemen**, zoals palmolie, waarvan de productie verantwoordelijk is voor grootschalige ontbossing.';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg4_title => 'Verpakking';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg4_text =>
-      'A **penalty** is calculated to take into account the **circularity of packaging** (use of recycled raw material and recyclability) and overpacking.';
+      'Er wordt een **boete** berekend om rekening te houden met de **circulariteit van verpakkingen** (gebruik van gerecycleerde grondstoffen en recycleerbaarheid) en oververpakking.';
 
   @override
   String get guide_greenscore_transparency_title =>
@@ -4464,11 +4472,11 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get guide_greenscore_transparency_intro1 =>
-      'To accurately calculate the Green-Score, it is necessary to have **information which is not necessarily specified on the packaging** (such as the origin and the exact percentage of each ingredient) or which is rarely available in usable form (such as a list of all the components of the packaging with the precise types of plastics used).';
+      'Om de Green-Score nauwkeurig te kunnen berekenen, is het noodzakelijk om te beschikken over **informatie die niet noodzakelijkerwijs op de verpakking staat vermeld** (zoals de herkomst en het exacte percentage van elk ingrediënt) of die zelden in bruikbare vorm beschikbaar is (zoals een lijst van alle componenten van de verpakking met de precieze soorten kunststoffen die zijn gebruikt).';
 
   @override
   String get guide_greenscore_transparency_intro2 =>
-      '**Average values are used when this information is not yet available**, but we are now calling on everyone to help us collect this information which will be very useful for the Green-Score but also for many other uses.';
+      '**Er worden gemiddelde waarden gebruikt wanneer deze informatie nog niet beschikbaar is**, maar we roepen nu iedereen op om ons te helpen deze informatie te verzamelen, die zeer nuttig zal zijn voor de Green-Score, maar ook voor vele andere doeleinden.';
 
   @override
   String get guide_greenscore_transparency_arg1_title =>
@@ -4476,7 +4484,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get guide_greenscore_transparency_arg1_text =>
-      'All citizens can help us gather and structure the information that is present on products or that can be deduced from them, such as information on **packaging**: \"Mission Emballages\": a large-scale collaborative inventory of packaging for all food products (in French).';
+      'Alle burgers kunnen ons helpen bij het verzamelen en structureren van informatie die op producten staat of daaruit kan worden afgeleid, zoals informatie over **verpakkingen**: \"Mission Emballages\": een grootschalige gezamenlijke inventarisatie van verpakkingen voor alle voedingsmiddelen (in het Frans).';
 
   @override
   String get guide_greenscore_transparency_arg2_title =>
@@ -4550,28 +4558,28 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get guide_nova_groups_arg1_text =>
-      'Unprocessed (or natural) foods are the **edible parts of plants** (seeds, fruits, leaves, stems, roots) **or animals** (muscle, offal, eggs, milk), as well as fungi, algae, and water, after being separated from nature.';
+      'Onbewerkte (of natuurlijke) voedingsmiddelen zijn de **eetbare delen van planten** (zaden, vruchten, bladeren, stengels, wortels) **of dieren** (spiervlees, slachtafval, eieren, melk), evenals schimmels, algen en water, nadat ze uit de natuur zijn gehaald.';
 
   @override
-  String get guide_nova_groups_arg2_title => 'Bewerkte ingrediënten';
+  String get guide_nova_groups_arg2_title => 'Berwerkte ingrediënten';
 
   @override
   String get guide_nova_groups_arg2_text =>
-      'Processed culinary ingredients, such as **oils, butter, sugar, and salt**, are substances derived from Group 1 foods or from nature through processes that include pressing, refining, grinding, milling, and drying.';
+      'Processed culinary ingredients, such as **oils, butter, sugar, and salt**, are substances derived from group 1 foods or from nature through processes that include pressing, refining, grinding, milling, and drying.';
 
   @override
-  String get guide_nova_groups_arg3_title => 'Bewerkte levensmiddelen';
+  String get guide_nova_groups_arg3_title => 'Bewerkte voedingsmiddelen';
 
   @override
   String get guide_nova_groups_arg3_text =>
-      'Processed foods, such as bottled vegetables, canned fish, fruits in syrup, cheeses, and freshly made breads, are **primarily made by adding salt, oil, sugar, or other substances from Group 2 to Group 1** foods. Processes include various preservation or cooking methods, and in the case of breads and cheese, non-alcoholic fermentation. Most processed foods have two or three ingredients and are recognizable as modified versions of Group 1 foods. They can be eaten on their own or, more commonly, in combination with other foods.';
+      'Processed foods, such as bottled vegetables, canned fish, fruits in syrup, cheeses, and freshly made breads, are **primarily made by adding salt, oil, sugar, or other substances from Group 2 to group 1** foods. processes include various Preservation or cooking methods, and in the case of breads and cheese, non-alcoholic fermentation. most processed Foods have two or three ingredients and are recognizable as modified versions of group 1 foods. they can be eaten on Their own or, more commonly, in combination with other foods.';
 
   @override
   String get guide_nova_groups_arg4_title => 'Ultra-verwerkte voedingsmiddelen';
 
   @override
   String get guide_nova_groups_arg4_text =>
-      'Ultra-processed foods, such as soft drinks, sweet or savory packaged snacks, reconstituted meat products, and pre-prepared frozen dishes, **are not merely modified foods but formulations made mostly or entirely from substances derived from foods and additives**, with little to no intact Group 1 food. Ingredients in these formulations usually include those also found in processed foods, such as sugars, oils, fats, or salt. However, ultra-processed products also contain other sources of energy and nutrients not typically used in culinary preparations. Some of these are directly extracted from foods, such as casein, lactose, whey, and gluten.';
+      'Ultra-processed foods, such as soft drinks, sweet or savory packaged snacks, reconstituted meat products, and pre-prepared frozen dishes, **are not merely modified foods but formulations made mostly or entirely from substances derived from foods and additives**, with little to no intact group 1 food. ingredients in these formulations usually include those also found in processed foods, such as sugars, oils, fats, or Salt. however, ultra-processed products also contain other sources of energy and nutrients not typically used in Culinary preparations. some of these are directly extracted from foods, such as casein, lactose, whey, and gluten.';
 
   @override
   String get guide_nova_explanations_title =>
@@ -4583,7 +4591,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg1_text =>
-      'Many are **derived from further processing of food constituents**, such as hydrogenated or interesterified oils, hydrolyzed proteins, soy protein isolate, maltodextrin, invert sugar, and high-fructose corn syrup.';
+      'Veel daarvan zijn **afgeleid van verdere verwerking van voedingsbestanddelen**, zoals gehydrogeneerde of geïnteresterificeerde oliën, gehydrolyseerde eiwitten, soja-eiwitisolaat, maltodextrine, invertsuiker en fructoserijke glucosestroop.';
 
   @override
   String get guide_nova_explanations_arg2_title =>
@@ -4591,7 +4599,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg2_text =>
-      'Additives in ultra-processed foods include some that are also used in processed foods, such as preservatives, antioxidants, and stabilizers. Classes of additives found only in ultra-processed products include those used **to imitate or enhance the sensory qualities of foods or to disguise unpalatable aspects of the final product**. These additives include dyes and other colors, color stabilizers; flavors, flavor enhancers, non-sugar sweeteners; and processing aids such as carbonating, firming, bulking and anti-bulking agents, de-foaming, anti-caking and glazing agents, emulsifiers, sequestrants, and humectants.';
+      'Additieven in ultraverwerkte voedingsmiddelen omvatten sommige die ook in verwerkte voedingsmiddelen worden gebruikt, zoals conserveermiddelen, antioxidanten en stabilisatoren. Additieven die alleen in ultraverwerkte producten voorkomen, zijn onder meer additieven die worden gebruikt **om de sensorische eigenschappen van voedingsmiddelen na te bootsen of te verbeteren of om onaangename aspecten van het eindproduct te maskeren**. Deze additieven omvatten kleurstoffen en andere kleurmiddelen, kleurstabilisatoren, smaakstoffen, smaakversterkers, niet-suikerhoudende zoetstoffen en technische hulpstoffen zoals koolzuur, verstevigingsmiddelen, vulstoffen en antiklontermiddelen, ontschuimers, antiklontermiddelen en glansmiddelen, emulgatoren, sekwestranten en bevochtigingsmiddelen.';
 
   @override
   String get guide_nova_explanations_arg3_title =>
@@ -4599,7 +4607,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg3_text =>
-      '**A multitude of sequences of processes is used** to combine the usually many ingredients and to create the final product (hence \'ultra-processed\'). The processes include several **with no domestic equivalents**, such as hydrogenation and hydrolysation, extrusion and moulding, and pre-processing for frying.';
+      '**Er wordt een veelheid aan processtappen gebruikt** om de doorgaans vele ingrediënten te combineren en het eindproduct te creëren (vandaar \'ultraverwerkt\'). De processen omvatten verschillende **stappen die geen huishoudelijke equivalenten hebben**, zoals hydrogenering en hydrolyse, extrusie en vormgeving, en voorbewerking voor frituren.';
 
   @override
   String get guide_nova_explanations_arg4_title =>
@@ -4607,25 +4615,25 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg4_text =>
-      '**The overall purpose of ultra-processing is to create branded**, **convenient** (durable, ready to consume), **attractive** (hyper-palatable) and **highly profitable** (low-cost ingredients) food products designed to displace all other food groups. Ultra-processed food products are usually packaged attractively and marketed intensively.';
+      '**Het algemene doel van ultraverwerking is het creëren van merkproducten**, **gemakkelijke** (houdbaar, klaar voor consumptie), **aantrekkelijke** (zeer smakelijk) en **zeer winstgevende** (goedkope ingrediënten) voedingsmiddelen die zijn ontworpen om alle andere voedingsmiddelen te verdringen. Ultraverwerkte voedingsmiddelen worden meestal aantrekkelijk verpakt en intensief op de markt gebracht.';
 
   @override
   String get guide_nova_explanations_arg5_title => 'Een gezondheidsrisico';
 
   @override
   String get guide_nova_explanations_arg5_text =>
-      'Since 2018, with NutriNet-Santé, the first links between **the consumption of ultra-processed foods and increased risks of cancer, cardiovascular diseases, and diabetes have been highlighted**. Today, more than 90 studies worldwide confirm these findings.\nThe strongest associations relate to **obesity, cardiovascular mortality, and depressive symptoms**. On children, the effects are primarily observed on weight and lipid imbalances.';
+      'Sinds 2018 zijn met NutriNet-Santé de eerste verbanden tussen **de consumptie van ultraverwerkte voedingsmiddelen en een verhoogd risico op kanker, hart- en vaatziekten en diabetes** aan het licht gekomen. Vandaag de dag bevestigen meer dan 90 studies wereldwijd deze bevindingen. De sterkste verbanden hebben betrekking op **obesitas, cardiovasculaire mortaliteit en depressieve symptomen**. Bij kinderen worden de effecten vooral waargenomen op het gewicht en de vetbalans.';
 
   @override
   String get guide_nova_explanations_arg6_title =>
-      'Countries recommend limiting them';
+      'Landen raden aan om ze te beperken';
 
   @override
   String get guide_nova_explanations_arg6_text =>
-      'Some countries use the NOVA groups for their dietary guidelines or goals, for instance:\n\n- **🇧🇷 Brazil**\'s dietary guidelines **recommend to limit consumption** of processed food and avoid ultra-processed food.\n\n- **🇫🇷 France**\'s public health nutritional policy goals for 2018-2022 aims to **reduce consumption of group 4 ultra-processed foods by 20%**.';
+      'Sommige landen gebruiken de NOVA-groepen voor hun voedingsrichtlijnen of -doelstellingen, bijvoorbeeld: - **🇧🇷 Brazilië**\'s voedingsrichtlijnen **bevelen aan om de consumptie** van bewerkte voedingsmiddelen te beperken en ultraverwerkte voedingsmiddelen te vermijden.\n\n- **🇫🇷 Frankrijk** heeft in zijn volksgezondheidsbeleid voor 2018-2022 als doel gesteld **de consumptie van ultraverwerkte voedingsmiddelen uit groep 4 met 20% te verminderen**.';
 
   @override
-  String get guide_nova_share_link => 'https://world.openfoodfacts.org/nova';
+  String get guide_nova_share_link => 'https://world-nl.openfoodfacts.org/nova';
 
   @override
   String get guide_open_food_facts_title => 'Welkom bij Open Food Facts!';
@@ -4636,11 +4644,11 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_paragraph1 =>
-      'Open Food Facts is a **collaborative**, **free**, and **open** database of food products from around the world.';
+      'Open Food Facts is een **collaboratieve**, **gratis** en **open** database met voedingsmiddelen uit de hele wereld.';
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_paragraph2 =>
-      'We believe that everyone should have access to information about what they eat. By collecting data on ingredients, allergens, nutrition facts, and more, **we empower consumers to make informed choices** and drive the food industry **toward greater transparency**.';
+      'Wij vinden dat iedereen toegang moet hebben tot informatie over wat hij of zij eet. Door gegevens te verzamelen over ingrediënten, allergenen, voedingsfeiten en meer, **stellen we consumenten in staat om weloverwogen keuzes te maken** en stimuleren we de voedingsindustrie **tot meer transparantie**.';
 
   @override
   String get guide_open_food_facts_features_title =>
@@ -4674,7 +4682,7 @@ class AppLocalizationsNl extends AppLocalizations {
       'Vermijd drukke achtergronden.';
 
   @override
-  String get guide_open_food_facts_tips_arg2_title => 'Do’s';
+  String get guide_open_food_facts_tips_arg2_title => 'Wat je wel moet doen';
 
   @override
   String get guide_open_food_facts_tips_arg2_text1 =>
@@ -4698,7 +4706,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get guide_open_food_facts_scores_arg1_title =>
-      'A score on the nutritional quality';
+      'Een score voor de voedingskwaliteit';
 
   @override
   String get guide_open_food_facts_scores_arg2_title =>
@@ -4722,11 +4730,11 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_paragraph1 =>
-      'Open Pet Food Facts extends our mission to our furry friends! It\'s a **database of pet food products for cats, dogs, and other companions**.';
+      'Open Pet Food Facts breidt onze missie uit naar onze harige vrienden! Het is een **database met voeding voor katten, honden en andere huisdieren**.';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_paragraph2 =>
-      'We gather information on **ingredients**, **nutritional analysis**, and feeding guidelines to help pet owners choose the best food for their animals\' needs.';
+      'We verzamelen informatie over **ingrediënten**, **voedingsanalyses** en voedingsrichtlijnen om eigenaren van huisdieren te helpen bij het kiezen van het beste voer voor de behoeften van hun dieren.';
 
   @override
   String get guide_open_pet_food_facts_features_title =>
@@ -4765,7 +4773,8 @@ class AppLocalizationsNl extends AppLocalizations {
       'Vermijd drukke achtergronden.';
 
   @override
-  String get guide_open_pet_food_facts_tips_arg2_title => 'Do’s';
+  String get guide_open_pet_food_facts_tips_arg2_title =>
+      'Wat je wel moet doen';
 
   @override
   String get guide_open_pet_food_facts_tips_arg2_text1 =>
@@ -4789,7 +4798,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get guide_open_pet_food_facts_scores_paragraph1 =>
-      'Developing a scoring system for pet food **is not a priority right now**. The methodology would be complex, as nutritional needs vary greatly by species, age, and health condition. We haven’t found any independant scientific team yet, able to develop such a score.';
+      'Het ontwikkelen van een scoresysteem voor dierenvoeding **is op dit moment geen prioriteit**. De methodologie zou complex zijn, aangezien de voedingsbehoeften sterk variëren naargelang de diersoort, leeftijd en gezondheidstoestand. We hebben nog geen onafhankelijk wetenschappelijk team gevonden dat in staat is om een dergelijke score te ontwikkelen.';
 
   @override
   String get guide_open_pet_food_facts_share_link =>
@@ -4804,11 +4813,11 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_paragraph1 =>
-      'Open Beauty Facts is a collaborative database of **cosmetic products**.';
+      'Open Beauty Facts is een gezamenlijke database van **cosmetische producten**.';
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_paragraph2 =>
-      'Our goal is to decipher ingredient lists to help you **understand what\'s in your personal care items**. From moisturizers to makeup, we collect data on ingredients, allergens, and packaging to promote transparency in the cosmetics industry.';
+      'Ons doel is om ingrediëntenlijsten te ontcijferen, zodat u **beter begrijpt wat er in uw persoonlijke verzorgingsproducten zit**. Van moisturizers tot make-up: we verzamelen gegevens over ingrediënten, allergenen en verpakkingen om de transparantie in de cosmetica-industrie te bevorderen.';
 
   @override
   String get guide_open_beauty_facts_features_title =>
@@ -4820,7 +4829,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get guide_open_beauty_facts_features_arg1_paragraph1 =>
-      'Are you allergic to any ingredients? Want to avoid comedogen substances? Want to steer away from controversial components ? You can set a list of cosmetic ingredients to avoid, right in the app!';
+      'Ben je allergisch voor bepaalde ingrediënten? Wil je comedogene stoffen vermijden? Wil je controversiële ingrediënten vermijden? Je kunt een lijst met cosmetische ingrediënten die je wilt vermijden rechtstreeks in de app instellen!';
 
   @override
   String get guide_open_beauty_facts_tips_title =>
@@ -4846,7 +4855,7 @@ class AppLocalizationsNl extends AppLocalizations {
       'Vermijd drukke achtergronden.';
 
   @override
-  String get guide_open_beauty_facts_tips_arg2_title => 'Do’s';
+  String get guide_open_beauty_facts_tips_arg2_title => 'Wat je wel moet doen';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text1 =>
@@ -4862,11 +4871,11 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text4 =>
-      'Take as many picture as need if the bottle is curved.';
+      'Maak zoveel foto\'s als nodig is als de fles gebogen is.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text5 =>
-      'You might need to peel the label to see the list of ingredients.';
+      'Het kan zijn dat u het etiket moet verwijderen om de lijst met ingrediënten te kunnen zien.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text6 =>
@@ -4893,7 +4902,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get guide_open_prices_what_is_open_prices_paragraph1 =>
-      'Open Prices is a project to **collect and share prices of products around the world**. It\'s a publicly available dataset that can be used for research, analysis, and more. Open Prices is developed and maintained by Open Food Facts.';
+      'Open Prices is een project om **prijzen van producten over de hele wereld te verzamelen en te delen**. Het is een openbaar beschikbare dataset die kan worden gebruikt voor onderzoek, analyse en meer. Open Prices wordt ontwikkeld en onderhouden door Open Food Facts.';
 
   @override
   String get guide_open_prices_what_is_open_prices_paragraph2 =>
@@ -4904,11 +4913,11 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get guide_open_prices_how_paragraph1 =>
-      '**We are crowdsourcing an open-source dataset of prices**. Prices can be added by users via this web app, or via the official Open Food Facts mobile app. Retailers or third-party apps can contribute as well by using our API.';
+      '**We zijn bezig met het crowdsourcen van een open-source dataset met prijzen**. Prijzen kunnen door gebruikers worden toegevoegd via deze webapp of via de officiële mobiele app van Open Food Facts. Detailhandelaren of apps van derden kunnen ook bijdragen door gebruik te maken van onze API.';
 
   @override
   String get guide_open_prices_how_arg1_title =>
-      'Collect photos of price tags in aisles';
+      'Verzamel foto\'s van prijskaartjes in gangpaden';
 
   @override
   String get guide_open_prices_how_arg2_title =>
@@ -4919,15 +4928,15 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get guide_open_prices_why_paragraph1 =>
-      'Price information is of paramount importance to understand food systems. It\'s a key factor in understanding the cost of food and to promote healthier diets. Opening price data is a way to make it easier for researchers, journalists, and citizens to **have a better understanding of how food prices vary geographically and in time**.';
+      'Prijsinformatie is van cruciaal belang om voedselsystemen te begrijpen. Het is een belangrijke factor om inzicht te krijgen in de kosten van voedsel en om gezondere voedingspatronen te bevorderen. Het openbaar maken van prijsgegevens is een manier om het voor onderzoekers, journalisten en burgers gemakkelijker te maken om **een beter inzicht te krijgen in hoe voedselprijzen geografisch en in de tijd variëren**.';
 
   @override
   String get guide_open_prices_why_arg1_title =>
-      'Track the evolution of prices over time';
+      'Volg de evolutie van de prijzen in de loop van de tijd';
 
   @override
   String get guide_open_prices_why_arg1_text =>
-      'See the **evolution of prices**: shrinkflation, cheapflation, we can track them together!';
+      'Bekijk de **evolutie van de prijzen**: krimpende inflatie, goedkope inflatie, we kunnen ze samen volgen!';
 
   @override
   String get guide_open_prices_why_arg2_title =>
@@ -4935,31 +4944,31 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get guide_open_prices_why_arg2_text =>
-      'As we get more prices, you can spot **the cheapest stores around you**.';
+      'Naarmate we meer prijzen verzamelen, kun je **de goedkoopste winkels in je omgeving** vinden.';
 
   @override
   String get guide_open_prices_scrapping_title =>
-      'Did you consider scraping prices from retailers\' websites?';
+      'Heb je overwogen om prijzen van websites van retailers te scrapen?';
 
   @override
   String get guide_open_prices_scrapping_paragraph1 =>
-      'For legal and technical reasons, **we don\'t consider scraping prices from retailers\' websites as a valid way to contribute to Open Prices**. We want to make sure that the prices we collect are accurate and up-to-date, and receiving scraped prices from contributors doesn\'t allow us to do that.';
+      'Om juridische en technische redenen **beschouwen we het scrapen van prijzen van websites van retailers niet als een geldige manier om bij te dragen aan Open Prices**. We willen ervoor zorgen dat de prijzen die we verzamelen nauwkeurig en actueel zijn, en dat is niet mogelijk als we gescrapete prijzen van bijdragers ontvangen.';
 
   @override
   String get guide_open_prices_scrapping_paragraph2 =>
-      'Price scraping is a considered option in a future version of Open Prices, but it would be done by Open Prices itself so that we can have a proof of the price based on the HTML page.';
+      'Prijsscraping is een optie die wordt overwogen voor een toekomstige versie van Open Prices, maar dit zou door Open Prices zelf worden gedaan, zodat we een bewijs van de prijs op basis van de HTML-pagina kunnen hebben.';
 
   @override
   String get guide_open_prices_retailers_title =>
-      'Ik ben een detailhandelaar en ik wil prijzen bijdragen. Hoe kan ik dat doen?';
+      'Ik ben een retailer en ik wil prijzen bijdragen. Hoe kan ik dat doen?';
 
   @override
   String get guide_open_prices_retailers_paragraph1 =>
-      'You can contribute prices by using our API.\nIf you want to contribute prices at scale, please get in touch with us at prices@openfoodfacts.org.';
+      'U kunt prijzen aanleveren via onze API. Als u op grote schaal prijzen wilt aanleveren, neem dan contact met ons op via prices@openfoodfacts.org.';
 
   @override
   String get guide_open_prices_share_link =>
-      'https://prices.openfoodfacts.org/about';
+      'https://prijzen.openfoodfacts.org/over';
 
   @override
   String get guide_open_products_facts_title =>
@@ -4971,11 +4980,11 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_paragraph1 =>
-      'Open Products Facts is a massive, open database for **any product with a barcode, which is not food, cosmetic or pet food**.';
+      'Open Products Facts is een enorme, open database voor **elk product met een barcode, dat geen voedingsmiddel, cosmetica of dierenvoeding is**.';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_paragraph2 =>
-      'From **electronics** to **toys**, and **clothes** to **cleaning supplies**, if it has a barcode, it can be added. This project aims to create an \"Internet of Things\" for everyday objects, making information about them universally accessible.';
+      'Van **elektronica** tot **speelgoed** en van **kleding** tot **schoonmaakmiddelen**: als het een streepjescode heeft, kan het worden toegevoegd. Dit project heeft tot doel een \'internet der dingen\' voor alledaagse voorwerpen te creëren, waardoor informatie over deze voorwerpen universeel toegankelijk wordt.';
 
   @override
   String get guide_open_products_facts_features_title =>
@@ -4983,31 +4992,31 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get guide_open_products_facts_features_text =>
-      'Open Products Facts aims to provide consumers to **extend the life of objects** by providing the circular solutions to maintain, **repair**, **recycle** their objects or give them a new owner.';
+      'Open Products Facts wil consumenten helpen **de levensduur van voorwerpen te verlengen** door circulaire oplossingen aan te bieden voor het onderhoud, **de reparatie** en **de recycling** van hun voorwerpen, of door ze aan een nieuwe eigenaar te geven.';
 
   @override
   String get guide_open_products_facts_features_arg1_title =>
-      'Carbon footprints for some products';
+      'Koolstofvoetafdrukken voor sommige producten';
 
   @override
   String get guide_open_products_facts_features_arg1_text =>
-      '**Impact CO2** by French Environment Authority ADEME provides the **carbon impact** of many categories, make sure to categorize products precisely.';
+      '**Impact CO2** van de Franse milieuautoriteit ADEME geeft de **koolstofimpact** van vele categorieën weer. Zorg ervoor dat u producten nauwkeurig categoriseert.';
 
   @override
   String get guide_open_products_facts_features_arg2_title =>
-      'Reparability index for many products';
+      'Reparatie-index voor veel producten';
 
   @override
   String get guide_open_products_facts_features_arg2_text =>
-      'Whenever a French reparability index is available, we’ll display it. Moreover, **you can start collecting the variables using the Folksonomy Engine**; so that we can recompute it ourselves in the future, even in countries where it’s not available.';
+      'Wanneer er een Franse reparatie-index beschikbaar is, zullen we deze weergeven. Bovendien **kunt u beginnen met het verzamelen van de variabelen met behulp van de Folksonomy Engine**, zodat we deze in de toekomst zelf kunnen herberekenen, zelfs in landen waar deze niet beschikbaar is.';
 
   @override
   String get guide_open_products_facts_features_arg3_title =>
-      'Find ways to donate/resell your product';
+      'Zoek manieren om uw product te doneren/door te verkopen';
 
   @override
   String get guide_open_products_facts_features_arg3_text =>
-      'We provide links to **third party circular friendly services** that help you get the kind of product you’re looking for, as a second hand product, to be more gentle on planetary resources.\nNote that we’re not paid to do that, and that the system only works as an example for two websites in France. You can help expand this system by documenting more sites on the wiki.';
+      'We bieden links naar **milieuvriendelijke diensten van derden** die u helpen het product te vinden dat u zoekt, als tweedehands product, om zuiniger om te gaan met de hulpbronnen van onze planeet. Houd er rekening mee dat we hiervoor niet worden betaald en dat het systeem alleen werkt als voorbeeld voor twee websites in Frankrijk. U kunt helpen dit systeem uit te breiden door meer sites op de wiki te documenteren.';
 
   @override
   String get guide_open_products_facts_information_title =>
@@ -5015,23 +5024,23 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get guide_open_products_facts_information_text =>
-      'For such a wide range of items, **the data we collect is flexible**. To do that, **we created the Folksonomy Engine**.';
+      'Voor zo\'n breed scala aan items **zijn de gegevens die we verzamelen flexibel**. Om dat te doen, **hebben we de Folksonomy Engine ontwikkeld**.';
 
   @override
   String get guide_open_products_facts_folksonomy_title =>
-      'The Folksonomy Engine';
+      'De folksonomie-engine';
 
   @override
   String get guide_open_products_facts_folksonomy_paragraph1 =>
-      'The Folksonomy Engine is a tool to help you complete products with relevant properties. This helps improve search and discoverability, but also compute and display interesting things in the future.';
+      'De Folksonomy Engine is een tool die u helpt producten te voorzien van relevante eigenschappen. Dit helpt bij het verbeteren van zoekresultaten en vindbaarheid, maar ook bij het berekenen en weergeven van interessante zaken in de toekomst.';
 
   @override
   String get guide_open_products_facts_folksonomy_paragraph2 =>
-      'You can add any keys and values like: **compatibility_with_5G_mobile_network: yes**';
+      'U kunt alle gewenste sleutels en waarden toevoegen, zoals: **compatibility_with_5G_mobile_network: yes**';
 
   @override
   String get guide_open_products_facts_folksonomy_paragraph3 =>
-      'You’ll get autosuggestion of possible properties, and you are very welcome to add and document new ones on your favorite kinds of products.';
+      'U krijgt automatische suggesties voor mogelijke eigenschappen en u bent van harte welkom om nieuwe eigenschappen toe te voegen en te documenteren voor uw favoriete soorten producten.';
 
   @override
   String get guide_open_products_facts_share_link =>
@@ -5102,7 +5111,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get product_page_compatibility_score => 'Compatibel';
 
   @override
-  String get user_lists_action_multi_select => 'Meerdere selecteren';
+  String get user_lists_action_multi_select => 'Meervoudige selectie';
 
   @override
   String product_page_compatibility_score_tooltip(String score) {
@@ -5111,7 +5120,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get product_image_front_accessibility_label =>
-      'Foto van het product (voorkant)';
+      'Foto van het product (voorzijde)';
 
   @override
   String get product_image_ingredients_accessibility_label =>
@@ -5164,7 +5173,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get product_page_action_bar_setting_modal_title => 'Acties bewerken';
 
   @override
-  String get product_page_action_bar_item_move_up => 'Verplaats naar boven';
+  String get product_page_action_bar_item_move_up => 'Verplaats naar omhoog';
 
   @override
   String get product_page_action_bar_item_move_down => 'Verplaats naar beneden';
@@ -5263,7 +5272,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get photo_field_front => 'Productfoto';
 
   @override
-  String get photo_field_ingredients => 'Ingrediënten foto';
+  String get photo_field_ingredients => 'Foto van de ingrediëntenlijst';
 
   @override
   String get photo_field_nutrition => 'Voedingswaarde foto';
@@ -5281,10 +5290,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get date => 'Datum';
 
   @override
-  String get photo_rotate_left => 'Draai naar links';
+  String get photo_rotate_left => 'Naar links draaien';
 
   @override
-  String get photo_rotate_right => 'Draai naar rechts';
+  String get photo_rotate_right => 'Naar rechts draaien';
 
   @override
   String get photo_undo_action => 'Vorige actie ongedaan maken';
@@ -5426,7 +5435,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get app_review_feedback_modal_open_form => 'Beantwoord de vragenlijst';
 
   @override
-  String get app_review_feedback_modal_later => 'Vraag het me later nog eens';
+  String get app_review_feedback_modal_later => 'Vraag me later nog eens';
 
   @override
   String get nutrition_facts_extract_new =>
@@ -5467,7 +5476,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get prices_stats_proofs_section => 'Bewijzen';
 
   @override
-  String get prices_stats_contributors_section => 'Medewerkers';
+  String get prices_stats_contributors_section => 'Bijdragers';
 
   @override
   String get prices_stats_experiments_section => 'Experimenten';
@@ -5667,7 +5676,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get preferences_terms_of_use => 'Gebruiksvoorwaarden';
 
   @override
-  String get preferences_legal_mentions => 'Wettelijke vermeldingen';
+  String get preferences_legal_mentions => 'Juridische vermeldingen';
 
   @override
   String get preferences_legal_header =>
@@ -5712,7 +5721,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get preferences_add_prices => 'Prijzen toevoegen';
 
   @override
-  String get preferences_complete_products => 'Voltooi producten';
+  String get preferences_complete_products => 'Producten voltooien';
 
   @override
   String get preferences_tips => 'Tips';
@@ -6224,11 +6233,11 @@ class AppLocalizationsNl extends AppLocalizations {
   String get location_map_details_postcode => 'Postcode';
 
   @override
-  String get location_map_details_country => 'Country';
+  String get location_map_details_country => 'Land';
 
   @override
   String get location_map_details_coordinates => 'Coördinaten';
 
   @override
-  String get location_map_details_osm_id => 'OSM ID';
+  String get location_map_details_osm_id => 'OSM-ID';
 }

--- a/packages/smooth_app/lib/l10n/app_localizations_nl.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_nl.dart
@@ -658,7 +658,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get unknownBrand => 'Onbekend merk';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Onbekende productnaam';

--- a/packages/smooth_app/lib/l10n/app_localizations_nn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_nn.dart
@@ -659,7 +659,7 @@ class AppLocalizationsNn extends AppLocalizations {
   String get unknownBrand => 'Ukjent merke';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Ukjent produktnavn';

--- a/packages/smooth_app/lib/l10n/app_localizations_nn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_nn.dart
@@ -22,19 +22,19 @@ class AppLocalizationsNn extends AppLocalizations {
 
   @override
   String get account_delete_message =>
-      'Are you sure you want to delete your account?\nIf there is a specific reason, please share below';
+      'Er du sikker på at du vil slette kontoen din?\nHvis det er en spesifikk grunn, vennligst del den nedenfor.';
 
   @override
-  String get reason => 'Reason';
+  String get reason => 'Grunn';
 
   @override
-  String get okay => 'Okay';
+  String get okay => 'Greit';
 
   @override
   String get validate => 'Validate';
 
   @override
-  String get create => 'Create';
+  String get create => 'Skape';
 
   @override
   String get applyButtonText => 'Apply';
@@ -43,7 +43,7 @@ class AppLocalizationsNn extends AppLocalizations {
   String get next_label => 'Neste';
 
   @override
-  String get continue_label => 'Continue';
+  String get continue_label => 'Fortsette';
 
   @override
   String get exit_label => 'Exit';
@@ -52,13 +52,13 @@ class AppLocalizationsNn extends AppLocalizations {
   String get previous_label => 'Previous';
 
   @override
-  String get go_back_to_top => 'Go back to top';
+  String get go_back_to_top => 'Gå tilbake til toppen';
 
   @override
   String get save => 'Lagr';
 
   @override
-  String get save_confirmation => 'Are you sure you want to save?';
+  String get save_confirmation => 'Er du sikker på at du vil lagre?';
 
   @override
   String get skip => 'Skip';
@@ -67,7 +67,7 @@ class AppLocalizationsNn extends AppLocalizations {
   String get cancel => 'Cancel';
 
   @override
-  String get ignore => 'Ignore';
+  String get ignore => 'Overse';
 
   @override
   String get close => 'Close';
@@ -76,292 +76,297 @@ class AppLocalizationsNn extends AppLocalizations {
   String get no => 'Nei';
 
   @override
-  String get stop => 'Stop';
+  String get stop => 'Stoppe';
 
   @override
-  String get finish => 'Finish';
+  String get finish => 'Fullfør';
 
   @override
-  String get calculate => 'Calculate';
+  String get calculate => 'Kalkulere';
 
   @override
-  String get reset_food_prefs => 'Reset food preferences';
+  String get reset_food_prefs => 'Tilbakestill matpreferanser';
 
   @override
-  String get error => 'Something went wrong';
+  String get error => 'Noe gikk galt';
 
   @override
-  String get error_occurred => 'An error occurred';
+  String get error_occurred => 'Det oppsto en feil';
 
   @override
   String get featureInProgress =>
-      'We\'re still working on this feature, stay tuned';
+      'Vi jobber fortsatt med denne funksjonen, følg med';
 
   @override
-  String get label_web => 'View on the web';
+  String get label_web => 'Vis på nettet';
 
   @override
-  String get learnMore => 'Learn more';
+  String get learnMore => 'Lær mer';
 
   @override
-  String get unknown => 'Unknown';
+  String get unknown => 'Ukjent';
 
   @override
-  String get match_very_good => 'Very good match';
+  String get match_very_good => 'Veldig god kamp';
 
   @override
-  String get match_good => 'Good match';
+  String get match_good => 'God match';
 
   @override
-  String get match_poor => 'Poor match';
+  String get match_poor => 'Dårlig kamp';
 
   @override
   String get match_may_not => 'May not match';
 
   @override
-  String get match_does_not => 'Does not match';
+  String get match_does_not => 'Stemmer ikke overens';
 
   @override
-  String get match_unknown => 'Unknown match';
+  String get match_unknown => 'Ukjent treff';
 
   @override
-  String get match_short_very_good => 'Very good match';
+  String get match_short_very_good => 'Veldig god kamp';
 
   @override
-  String get match_short_good => 'Good match';
+  String get match_short_good => 'God match';
 
   @override
-  String get match_short_poor => 'Poor match';
+  String get match_short_poor => 'Dårlig kamp';
 
   @override
   String get match_short_may_not => 'May not match';
 
   @override
-  String get match_short_does_not => 'Does not match';
+  String get match_short_does_not => 'Stemmer ikke overens';
 
   @override
-  String get match_short_unknown => 'Unknown match';
+  String get match_short_unknown => 'Ukjent treff';
 
   @override
   String get licenses => 'Licences';
 
   @override
-  String get looking_for => 'Looking for';
+  String get looking_for => 'Leter etter';
 
   @override
-  String get welcomeToOpenFoodFacts => 'Welcome to Open Food Facts';
+  String get welcomeToOpenFoodFacts => 'Velkommen til Åpne matfakta';
 
   @override
   String get whatIsOff =>
-      'Open Food Facts is a global non-profit powered by local communities.';
+      'Open Food Facts er en global ideell organisasjon drevet av lokalsamfunn.';
 
   @override
   String get productDataUtility =>
-      'See the food data relevant to your preferences.';
+      'Se matdataene som er relevante for dine preferanser.';
 
   @override
-  String get healthCardUtility => 'Choose foods that are good for you.';
+  String get healthCardUtility => 'Velg matvarer som er bra for deg.';
 
   @override
-  String get ecoCardUtility => 'Choose foods that are good for the planet.';
+  String get ecoCardUtility => 'Velg matvarer som er bra for planeten.';
 
   @override
   String get server_error_open_new_issue =>
-      'No server response! You may open an issue with the following link.';
+      'Ingen serverrespons! Du kan åpne et problem med følgende lenke.';
 
   @override
   String get sign_in_text =>
-      'Sign in to your Open Food Facts account to save your contributions';
+      'Logg inn på Open Food Facts-kontoen din for å lagre bidragene dine';
 
   @override
-  String get incorrect_credentials => 'Incorrect username or password.';
+  String get incorrect_credentials => 'Feil brukernavn eller passord.';
 
   @override
   String get password_lost_incorrect_credentials =>
-      'This email or username doesn\'t exist. Please check your credentials.';
+      'Denne e-postadressen eller brukernavnet finnes ikke. Vennligst sjekk påloggingsinformasjonen din.';
 
   @override
   String get password_lost_server_unavailable =>
-      'We are currently experiencing slowdowns on our servers and we apologise for it. Please try again later.';
+      'Vi opplever for tiden nedgang på serverne våre, og vi beklager dette. Prøv igjen senere.';
 
   @override
   String get login => 'Username';
 
   @override
-  String get login_result_type_server_unreachable => 'Network is unreachable';
+  String get login_result_type_server_unreachable =>
+      'Nettverket er utilgjengelig';
 
   @override
   String get login_result_type_server_issue =>
-      'Problem on the server. Please try later.';
+      'Problem på serveren. Prøv senere.';
 
   @override
-  String get login_page_username_or_email => 'Please enter username or e-mail';
+  String get login_page_username_or_email =>
+      'Vennligst skriv inn brukernavn eller e-post';
 
   @override
-  String get login_page_password_error_empty => 'Please enter a password';
+  String get login_page_password_error_empty =>
+      'Vennligst skriv inn et passord';
 
   @override
-  String get create_account => 'Create account';
+  String get create_account => 'Opprett konto';
 
   @override
   String get sign_in => 'Logg inn';
 
   @override
-  String get sign_in_mandatory => 'For that feature we need you to sign in.';
+  String get sign_in_mandatory => 'For den funksjonen må du logge inn.';
 
   @override
   String get help_improve_country =>
-      'Help improve Open Food Facts in your country';
+      'Hjelp med å forbedre Open Food Facts i landet ditt';
 
   @override
-  String get sign_out => 'Sign out';
+  String get sign_out => 'Logg ut';
 
   @override
-  String get sign_out_confirmation => 'Are you sure you want to sign out?';
+  String get sign_out_confirmation => 'Er du sikker på at du vil logge ut?';
 
   @override
   String get password => 'Passord';
 
   @override
-  String get forgot_password => 'Forgot password';
+  String get forgot_password => 'Glemt passord';
 
   @override
   String get forgot_password_question => 'Glemt passord?';
 
   @override
-  String get view_profile => 'View profile';
+  String get view_profile => 'Vis profil';
 
   @override
-  String get reset_password => 'Reset password';
+  String get reset_password => 'Tilbakestill passord';
 
   @override
   String get reset_password_explanation_text =>
-      'In case of a forgotten password, enter your username or e-mail address to receive instructions for a password reset. Also, remember to check the Spam folder.';
+      'Hvis du har glemt passordet, skriv inn brukernavnet eller e-postadressen din for å motta instruksjoner for tilbakestilling av passord. Husk også å sjekke spam-mappen.';
 
   @override
-  String get username_or_email => 'Username or e-mail';
+  String get username_or_email => 'Brukernavn eller e-post';
 
   @override
   String get reset_password_done =>
-      'An e-mail with a link to reset your password has been sent to the e-mail address associated with your account. Also check your spam';
+      'En e-post med en lenke for å tilbakestille passordet ditt er sendt til e-postadressen som er knyttet til kontoen din. Sjekk også spam-mappen din.';
 
   @override
-  String get send_reset_password_mail => 'Change password';
+  String get send_reset_password_mail => 'Endre passord';
 
   @override
-  String get enter_some_text => 'Please enter some text';
+  String get enter_some_text => 'Vennligst skriv inn litt tekst';
 
   @override
-  String get sign_up_page_title => 'Sign Up';
+  String get sign_up_page_title => 'Registrer deg';
 
   @override
-  String get sign_up_page_action_button => 'Sign Up';
+  String get sign_up_page_action_button => 'Registrer deg';
 
   @override
-  String get sign_up_page_action_doing_it => 'Signing up…';
+  String get sign_up_page_action_doing_it => 'Registrering…';
 
   @override
   String get sign_up_page_action_ok =>
-      'Congratulations! Your account has just been created.';
+      'Gratulerer! Kontoen din er nettopp opprettet.';
 
   @override
   String get sign_up_page_display_name_hint => 'Navn';
 
   @override
   String get sign_up_page_display_name_error_empty =>
-      'Please enter the display name you want to use';
+      'Vennligst skriv inn visningsnavnet du vil bruke';
 
   @override
-  String get sign_up_page_email_hint => 'E-mail';
+  String get sign_up_page_email_hint => 'E-post';
 
   @override
-  String get sign_up_page_email_error_empty => 'E-mail is required';
+  String get sign_up_page_email_error_empty => 'E-post er påkrevd';
 
   @override
-  String get sign_up_page_email_error_invalid => 'Invalid e-mail';
+  String get sign_up_page_email_error_invalid => 'Ugyldig e-post';
 
   @override
-  String get sign_up_page_username_hint => 'Username: Publicly visible';
+  String get sign_up_page_username_hint => 'Brukernavn: Offentlig synlig';
 
   @override
-  String get sign_up_page_username_error_empty => 'Please enter a username';
+  String get sign_up_page_username_error_empty =>
+      'Vennligst skriv inn et brukernavn';
 
   @override
   String get sign_up_page_username_error_invalid =>
-      'Please enter a valid username';
+      'Vennligst skriv inn et gyldig brukernavn';
 
   @override
   String get sign_up_page_username_description =>
-      'Username cannot contains spaces, caps or special characters.';
+      'Brukernavnet kan ikke inneholde mellomrom, store bokstaver eller spesialtegn.';
 
   @override
   String sign_up_page_username_length_invalid(int value) {
-    return 'Username cannot exceed $value characters';
+    return 'Brukernavnet kan ikke overskride $value tegn';
   }
 
   @override
   String get sign_up_page_password_hint => 'Passord';
 
   @override
-  String get sign_up_page_password_error_empty => 'Please enter a password';
+  String get sign_up_page_password_error_empty =>
+      'Vennligst skriv inn et passord';
 
   @override
   String get sign_up_page_password_error_invalid =>
-      'Please enter a valid password (at least 6 characters)';
+      'Vennligst skriv inn et gyldig passord (minst 6 tegn)';
 
   @override
-  String get sign_up_page_confirm_password_hint => 'Confirm Password';
+  String get sign_up_page_confirm_password_hint => 'Bekreft passord';
 
   @override
   String get sign_up_page_confirm_password_error_empty =>
-      'Please confirm the password';
+      'Vennligst bekreft passordet';
 
   @override
   String get sign_up_page_confirm_password_error_invalid =>
-      'Passwords don\'t match';
+      'Passordene samsvarer ikke';
 
   @override
-  String get sign_up_page_agree_text => 'I agree to the Open Food Facts';
+  String get sign_up_page_agree_text => 'Jeg godtar de åpne matfaktaene';
 
   @override
-  String get sign_up_page_terms_text => 'terms of use and contribution';
+  String get sign_up_page_terms_text => 'bruksvilkår og bidrag';
 
   @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
   String get sign_up_page_agree_error_invalid =>
-      'When creating an account, agreeing to the Terms of Use is mandatory, however, anonymous contributions can still be made through the app';
+      'Når du oppretter en konto, er det obligatorisk å godta bruksvilkårene, men anonyme bidrag kan fortsatt gis gjennom appen.';
 
   @override
-  String get sign_up_page_producer_checkbox => 'I am a food producer';
+  String get sign_up_page_producer_checkbox => 'Jeg er en matprodusent';
 
   @override
-  String get sign_up_page_producer_hint => 'Producer/brand';
+  String get sign_up_page_producer_hint => 'Produsent/merke';
 
   @override
   String get sign_up_page_producer_error_empty =>
-      'Please enter a producer or a brand name';
+      'Vennligst skriv inn en produsent eller et merkenavn';
 
   @override
   String get sign_up_page_subscribe_checkbox =>
-      'I\'d like to subscribe to the Open Food Facts newsletter (You can unsubscribe from it at any time)';
+      'Jeg vil gjerne abonnere på nyhetsbrevet fra Open Food Facts (du kan når som helst melde deg av)';
 
   @override
   String get sign_up_page_user_name_already_used =>
-      'The user name already exists, please choose another username.';
+      'Brukernavnet finnes allerede, vennligst velg et annet brukernavn.';
 
   @override
   String get sign_up_page_email_already_exists =>
-      'already exists, login to the account or try with another email.';
+      'finnes allerede, logg inn på kontoen eller prøv med en annen e-postadresse.';
 
   @override
   String get sign_up_page_provide_valid_email =>
-      'Please provide a valid email address.';
+      'Vennligst oppgi en gyldig e-postadresse.';
 
   @override
   String get sign_up_page_server_busy =>
-      'We are deeply sorry, we have some technical difficulties to create your account. Please try again later.';
+      'Vi beklager på det sterkeste, men vi har hatt noen tekniske problemer med å opprette kontoen din. Prøv igjen senere.';
 
   @override
   String get settingsTitle => 'Innstillinger';
@@ -379,141 +384,140 @@ class AppLocalizationsNn extends AppLocalizations {
   String get darkmode_system_default => 'Systemstandard';
 
   @override
-  String get thanks_for_contributing => 'Thanks for contributing!';
+  String get thanks_for_contributing => 'Takk for bidraget!';
 
   @override
-  String get contributors_label => 'They are building the app';
+  String get contributors_label => 'De bygger appen';
 
   @override
   String get contributors_dialog_title => 'Bidragere';
 
   @override
   String contributors_dialog_entry_description(Object name) {
-    return 'Contributor: $name';
+    return 'Bidragsyter: $name';
   }
 
   @override
   String get contributors_description =>
-      'A list of all contributors of this app';
+      'En liste over alle bidragsytere til denne appen';
 
   @override
-  String get support => 'Support';
+  String get support => 'Støtte';
 
   @override
-  String get support_join_slack => 'Ask for help in our Slack channel';
+  String get support_join_slack => 'Be om hjelp i Slack-kanalen vår';
 
   @override
-  String get support_via_forum => 'Ask for help on our forum';
+  String get support_via_forum => 'Be om hjelp på forumet vårt';
 
   @override
-  String get support_via_email => 'Send us an e-mail';
+  String get support_via_email => 'Send oss en e-post';
 
   @override
-  String get support_via_email_include_logs_dialog_title => 'Send app logs?';
+  String get support_via_email_include_logs_dialog_title => 'Send applogger?';
 
   @override
   String get support_via_email_include_logs_dialog_body =>
-      'Do you wish to include application logs in attachment to your email?';
+      'Ønsker du å legge ved applikasjonslogger som vedlegg i e-posten din?';
 
   @override
-  String get termsOfUse => 'Terms of use';
+  String get termsOfUse => 'Bruksvilkår';
 
   @override
-  String get legalNotices => 'Legal notices';
+  String get legalNotices => 'Juridiske merknader';
 
   @override
-  String get privacy_policy => 'Privacy policy';
+  String get privacy_policy => 'Personvernerklæring';
 
   @override
-  String get about_this_app => 'About this app';
+  String get about_this_app => 'Om denne appen';
 
   @override
   String get contribute => 'Contribute';
 
   @override
-  String get contribute_sw_development => 'Software development';
+  String get contribute_sw_development => 'Programvareutvikling';
 
   @override
   String get contribute_develop_text =>
-      'The code for every Open Food Facts product is available on GitHub. You are welcome to reuse the code (it\'s open source) and help us improve it, for everyone, on all the planet.';
+      'Koden for alle Open Food Facts-produkter er tilgjengelig på GitHub. Du er velkommen til å gjenbruke koden (den er åpen kildekode) og hjelpe oss med å forbedre den, for alle, på hele planeten.';
 
   @override
   String get contribute_develop_text_2 =>
-      'You can join the Open Food Facts Slack chatroom which is the preferred way to ask questions.';
+      'Du kan bli med i Open Food Facts Slack-chatten, som er den foretrukne måten å stille spørsmål på.';
 
   @override
-  String get contribute_develop_dev_mode_title => 'DEV Mode?';
+  String get contribute_develop_dev_mode_title => 'DEV-modus?';
 
   @override
-  String get contribute_develop_dev_mode_subtitle => 'Activate the DEV Mode';
+  String get contribute_develop_dev_mode_subtitle => 'Aktiver DEV-modus';
 
   @override
   String get contribute_donate_title => 'Donate';
 
   @override
-  String get contribute_donate_header => 'Donate to Open Food Facts';
+  String get contribute_donate_header => 'Doner til Open Food Facts';
 
   @override
   String get contribute_enroll_alpha_warning =>
-      'Please acknowledge that with the internal alpha version, complete loss of data is possible, and the app may become unusable at any time !';
+      'Vær oppmerksom på at med den interne alfaversjonen er fullstendig tap av data mulig, og appen kan bli ubrukelig når som helst!';
 
   @override
   String get contribute_improve_ProductsToBeCompleted =>
-      'Products to be completed';
+      'Produkter som skal fullføres';
 
   @override
-  String get contribute_improve_header => 'Improving';
+  String get contribute_improve_header => 'Forbedring';
 
   @override
   String get contribute_improve_text =>
-      'The database is the core of the project. It\'s easy and very quick to help. You can download the mobile app for your phone, and start adding or improving products.\n\nOn the other hand, Open Food Facts website offers many ways to contribute: ';
+      'Databasen er kjernen i prosjektet. Det er enkelt og raskt å hjelpe. Du kan laste ned mobilappen til telefonen din og begynne å legge til eller forbedre produkter.\n\nPå den annen side tilbyr nettstedet Open Food Facts mange måter å bidra på: ';
 
   @override
-  String get contribute_translate_header => 'Translate';
+  String get contribute_translate_header => 'Oversett';
 
   @override
   String get contribute_data_quality => 'Data Quality';
 
   @override
-  String get contribute_translate_link_text => 'Start Translating';
+  String get contribute_translate_link_text => 'Begynn å oversette';
 
   @override
   String get contribute_translate_text =>
-      'Open Food Facts is a global project, containing products from more than 160 countries. Open Food Facts is translated into dozens of languages, with constantly evolving content.';
+      'Open Food Facts er et globalt prosjekt som inneholder produkter fra mer enn 160 land. Open Food Facts er oversatt til en rekke språk, med innhold i stadig utvikling.';
 
   @override
   String get contribute_translate_text_2 =>
-      'Translations is one of the key tasks of the project';
+      'Oversettelser er en av prosjektets hovedoppgaver';
 
   @override
   String get contribute_join_skill_pool =>
-      'Contribute your skills to Open Food Facts. Join the skill pool!';
+      'Bidra med ferdighetene dine til Open Food Facts. Bli med i ferdighetspoolen!';
 
   @override
-  String get contribute_share_header =>
-      'Share Open Food Facts with your friends';
+  String get contribute_share_header => 'Del Åpne matfakta med vennene dine';
 
   @override
   String get contribute_share_content =>
-      'I wanted to let you know about the app I\'ve been using, Open Food Facts, which allows you to get the health and environmental impacts of your food, in a personalized way. It works by scanning the barcodes on the packaging. Finally it\'s free, does not require registration, and you can even help increase the number of products decyphered. Here\'s the link to get it for your phone: https://openfoodfacts.app';
+      'Jeg ville fortelle deg om appen jeg har brukt, Open Food Facts, som lar deg få informasjon om helse- og miljøpåvirkningen av maten din på en personlig måte. Den fungerer ved å skanne strekkodene på emballasjen. Den er gratis, krever ikke registrering, og du kan til og med bidra til å øke antallet produkter som dekrypteres. Her er lenken for å laste den ned til telefonen din: https://openfoodfacts.app';
 
   @override
   String get contribute_prices_gdpr =>
-      'Contribute prices by requesting a GDPR export of your loyalty cards data';
+      'Bidra til priser ved å be om GDPR-eksport av lojalitetskortdataene dine';
 
   @override
-  String get tap_to_answer => 'Tap here to answer questions';
+  String get tap_to_answer => 'Trykk her for å svare på spørsmål';
 
   @override
   String get tap_to_answer_hint =>
-      'Tap here to answer questions about this product';
+      'Trykk her for å svare på spørsmål om dette produktet';
 
   @override
   String get robotoff_questions_loading_hint =>
-      'Please wait while questions about this product are loaded';
+      'Vent mens spørsmål om dette produktet lastes inn';
 
   @override
-  String get saving_answer => 'Saving your answer';
+  String get saving_answer => 'Lagrer svaret ditt';
 
   @override
   String get contribute_to_get_rewards =>
@@ -521,109 +525,110 @@ class AppLocalizationsNn extends AppLocalizations {
 
   @override
   String get question_sign_in_text =>
-      'Sign in to your Open Food Facts account to get credit for your contributions';
+      'Logg inn på Open Food Facts-kontoen din for å få kreditt for bidragene dine';
 
   @override
-  String get question_yes_button_accessibility_value => 'Answer with yes';
+  String get question_yes_button_accessibility_value => 'Svar med ja';
 
   @override
-  String get question_no_button_accessibility_value => 'Answer with no';
+  String get question_no_button_accessibility_value => 'Svar med nei';
 
   @override
-  String get question_skip_button_accessibility_value => 'Skip this question';
+  String get question_skip_button_accessibility_value =>
+      'Hopp over dette spørsmålet';
 
   @override
-  String get tap_to_edit_search => 'Tap to edit search';
+  String get tap_to_edit_search => 'Trykk for å redigere søket';
 
   @override
-  String get myPreferences => 'My preferences';
+  String get myPreferences => 'Mine preferanser';
 
   @override
   String get account_create_message =>
-      'Create your account and join the Open Food Facts community to help build food knowledge all over the world!';
+      'Opprett din konto og bli med i Open Food Facts-fellesskapet for å bidra til å bygge matkunnskap over hele verden!';
 
   @override
-  String get join_us => 'Join us';
+  String get join_us => 'Bli med oss';
 
   @override
-  String get myPreferences_profile_title => 'Your Profile';
+  String get myPreferences_profile_title => 'Din profil';
 
   @override
   String get myPreferences_profile_subtitle =>
-      'Manage your Open Food Facts contributor account.';
+      'Administrer din Open Food Facts-bidragsyterkonto.';
 
   @override
-  String get myPreferences_settings_title => 'App Settings';
+  String get myPreferences_settings_title => 'Appinnstillinger';
 
   @override
-  String get myPreferences_settings_subtitle => 'Dark mode, Languages…';
+  String get myPreferences_settings_subtitle => 'Mørk modus, Språk…';
 
   @override
-  String get myPreferences_food_title => 'Food Preferences';
+  String get myPreferences_food_title => 'Matpreferanser';
 
   @override
   String get myPreferences_food_subtitle =>
-      'Choose what information about food matters most to you.';
+      'Velg hvilken informasjon om mat som er viktigst for deg.';
 
   @override
   String get myPreferences_food_comment =>
-      'Choose what information about food matters most to you, in order to rank food according to your preferences, see the information you care about first, and get a compatibility summary. Those food preferences stay on your device, and are not associated with your Open Food Facts contributor account if you have one.';
+      'Velg hvilken informasjon om mat som er viktigst for deg, for å rangere mat i henhold til dine preferanser, se informasjonen du bryr deg om først, og få et kompatibilitetssammendrag. Disse matpreferansene forblir på enheten din, og er ikke knyttet til din Open Food Facts-bidragsyterkonto hvis du har en.';
 
   @override
-  String get confirmResetPreferences => 'Reset your food preferences?';
+  String get confirmResetPreferences => 'Tilbakestille matpreferansene dine?';
 
   @override
-  String get myPersonalizedRanking => 'My personalized ranking';
+  String get myPersonalizedRanking => 'Min personlige rangering';
 
   @override
   String get ranking_tab_all => 'All';
 
   @override
-  String get ranking_subtitle_match_yes => 'A great match for you';
+  String get ranking_subtitle_match_yes => 'En flott match for deg';
 
   @override
-  String get ranking_subtitle_match_no => 'Very poor match';
+  String get ranking_subtitle_match_no => 'Veldig dårlig kamp';
 
   @override
-  String get ranking_subtitle_match_maybe => 'Unknown match';
+  String get ranking_subtitle_match_maybe => 'Ukjent treff';
 
   @override
   String get refresh_with_new_preferences =>
-      'Refresh the list with your new preferences';
+      'Oppdater listen med de nye innstillingene dine';
 
   @override
   String get reloaded_with_new_preferences =>
-      'Reloaded with your new preferences';
+      'Lastet inn på nytt med dine nye preferanser';
 
   @override
   String get profile_navbar_label => 'Community';
 
   @override
-  String get scan_navbar_label => 'Scan';
+  String get scan_navbar_label => 'Skann';
 
   @override
   String get history_navbar_label => 'Logg';
 
   @override
-  String get list_navbar_label => 'Lists';
+  String get list_navbar_label => 'Lister';
 
   @override
-  String get category => 'Filter by category';
+  String get category => 'Filtrer etter kategori';
 
   @override
   String get category_all => 'All';
 
   @override
-  String get category_search => '(category search)';
+  String get category_search => '(kategorisøk)';
 
   @override
   String get filter => 'Filter';
 
   @override
-  String get scan => 'Products from the Scan screen';
+  String get scan => 'Produkter fra skanneskjermen';
 
   @override
-  String get scan_history => 'Scan history';
+  String get scan_history => 'Skanningshistorikk';
 
   @override
   String get search => 'Søk';
@@ -639,169 +644,173 @@ class AppLocalizationsNn extends AppLocalizations {
   String get search_history => 'Søkelogg';
 
   @override
-  String get search_store => 'Search for a store';
+  String get search_store => 'Søk etter en butikk';
 
   @override
   String get search_store_help => 'Hint: legg til byen eller landet';
 
   @override
-  String get tap_for_more => 'Tap to see more info…';
+  String get tap_for_more => 'Trykk for å se mer informasjon…';
 
   @override
   String get product => 'Produkt';
 
   @override
-  String get unknownBrand => 'Unknown brand';
+  String get unknownBrand => 'Ukjent merke';
 
   @override
-  String get unknownProductName => 'Unknown product name';
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
+  String get unknownProductName => 'Ukjent produktnavn';
 
   @override
   String get label_refresh => 'Refresh';
 
   @override
-  String get label_reload => 'Reload';
+  String get label_reload => 'Last inn på nytt';
 
   @override
-  String get image => 'Image';
+  String get image => 'Bilde';
 
   @override
-  String get front_photo => 'Front photo';
+  String get front_photo => 'Forsidebilde';
 
   @override
   String outdated_image_accessibility_label(Object imageType) {
-    return '$imageType (this image may be outdated)';
+    return '$imageType (dette bildet kan være utdatert)';
   }
 
   @override
-  String get outdated_image_short_label => 'may be outdated';
+  String get outdated_image_short_label => 'kan være utdatert';
 
   @override
   String get ingredients => 'Ingredienser';
 
   @override
   String get ingredients_editing_instructions =>
-      'Keep the original order. Indicate the percentage when specified. Separate with a comma or hyphen and use parentheses for ingredients of an ingredient.';
+      'Behold den opprinnelige rekkefølgen. Angi prosentandelen når den er spesifisert. Skill med komma eller bindestrek, og bruk parenteser for ingrediensene til en ingrediens.';
 
   @override
-  String get ingredients_editing_error => 'Failed to save the ingredients.';
+  String get ingredients_editing_error => 'Kunne ikke lagre ingrediensene.';
 
   @override
   String get ingredients_editing_image_error =>
-      'Failed to get a new ingredients image.';
+      'Klarte ikke å hente et nytt ingrediensbilde.';
 
   @override
-  String get ingredients_editing_title => 'Edit Ingredients';
+  String get ingredients_editing_title => 'Rediger ingredienser';
 
   @override
-  String get ingredients_photo => 'Ingredients photo';
+  String get ingredients_photo => 'Ingredienser bilde';
 
   @override
   String get packaging_editing_instructions =>
-      'List all packaging parts separated by a comma or line feed, with their amount (e.g. 1 or 6) type (e.g. bottle, box, can), material (e.g. plastic, metal, aluminium) and if available their size (e.g. 33cl) and recycling instructions.\nExample: 1 glass bottle to recycle, 1 plastic cork to throw away';
+      'List opp alle emballasjedeler atskilt med komma eller linjeskift, med mengde (f.eks. 1 eller 6), type (f.eks. flaske, eske, boks), materiale (f.eks. plast, metall, aluminium) og hvis tilgjengelig størrelse (f.eks. 33 cl) og resirkuleringsinstruksjoner.\nEksempel: 1 glassflaske til resirkulering, 1 plastkork til kasting';
 
   @override
-  String get packaging_editing_error => 'Failed to save the packaging.';
+  String get packaging_editing_error => 'Klarte ikke å lagre emballasjen.';
 
   @override
   String get packaging_editing_image_error =>
-      'Failed to get a new packaging image.';
+      'Klarte ikke å hente et nytt emballasjebilde.';
 
   @override
-  String get packaging_editing_title => 'Edit Packaging';
+  String get packaging_editing_title => 'Rediger emballasje';
 
   @override
   String get nutrition => 'Næring';
 
   @override
-  String get nutrition_facts_photo => 'Nutrition facts photo';
+  String get nutrition_facts_photo => 'Næringsinnholdsinformasjonsbilde';
 
   @override
-  String get nutrition_facts_editing_title => 'Edit Nutrition Facts';
+  String get nutrition_facts_editing_title => 'Rediger næringsinnhold';
 
   @override
-  String get packaging_information => 'Packaging information';
+  String get packaging_information => 'Emballasjeinformasjon';
 
   @override
-  String get packaging_information_photo => 'Packaging information photo';
+  String get packaging_information_photo => 'Emballasjeinformasjonsbilde';
 
   @override
-  String get missing_product => 'You found a new product!';
+  String get missing_product => 'Du har funnet et nytt produkt!';
 
   @override
   String get add_product_take_photos =>
-      'Take photos of the packaging to add this product to Open Food Facts';
+      'Ta bilder av emballasjen for å legge til dette produktet i Open Food Facts';
 
   @override
   String get add_product_take_photos_descriptive =>
-      'Please take some photos first. You may always complete the product at a later time.';
+      'Ta noen bilder først. Du kan alltids fullføre produktet senere.';
 
   @override
   String get add_product_information_button_label => 'Add product information';
 
   @override
-  String get new_product => 'New Product';
+  String get new_product => 'Nytt produkt';
 
   @override
-  String get new_product_found_title => 'New product found!';
+  String get new_product_found_title => 'Nytt produkt funnet!';
 
   @override
   String get new_product_found_text =>
-      'Our collaborative database contains more than **3 million products**, but this barcode doesn\'t exist: ';
+      'Vår samarbeidsdatabase inneholder mer enn **3 millioner produkter**, men denne strekkoden finnes ikke: ';
 
   @override
   String get new_product_found_button => 'Add this product';
 
   @override
-  String get new_product_leave_title => 'Leave this page?';
+  String get new_product_leave_title => 'Forlate denne siden?';
 
   @override
   String get new_product_leave_message =>
-      'It looks like you didn\'t input anything. Do you really want to leave this page?';
+      'Det ser ut som du ikke har skrevet inn noe. Vil du virkelig forlate denne siden?';
 
   @override
   String get new_product_dialog_description =>
-      'Please take photos of the packaging to add this product to our common database';
+      'Vennligst ta bilder av emballasjen for å legge dette produktet til i vår felles database.';
 
   @override
   String get new_product_dialog_illustration_description =>
-      'An illustration with unknown Nutri-Score and Green Score';
+      'En illustrasjon med ukjent Nutri-Score og Green Score';
 
   @override
-  String get front_packaging_photo_button_label => 'Front packaging photo';
+  String get front_packaging_photo_button_label =>
+      'Foto av forsiden av emballasjen';
 
   @override
   String get confirm_front_packaging_photo_button_label =>
-      'Confirm upload of Front packaging photo';
+      'Bekreft opplasting av bilde av frontemballasjen';
 
   @override
-  String get confirm_button_label => 'Confirm';
+  String get confirm_button_label => 'Bekrefte';
 
   @override
-  String get send_image_button_label => 'Send image';
+  String get send_image_button_label => 'Send bilde';
 
   @override
-  String get crop_page_action_saving => 'Saving the image…';
+  String get crop_page_action_saving => 'Lagrer bildet…';
 
   @override
-  String get crop_page_action_cropping => 'Cropping the image…';
+  String get crop_page_action_cropping => 'Beskjæring av bildet…';
 
   @override
-  String get crop_page_action_local => 'Saving a local version…';
+  String get crop_page_action_local => 'Lagre en lokal versjon…';
 
   @override
   String get crop_page_action_local_failed_title =>
-      'Oops… there\'s something with your photo!';
+      'Ups… det er noe galt med bildet ditt!';
 
   @override
   String get crop_page_action_local_failed_message =>
-      'We are unable to process the image locally, before sending it to our server. Please try again later or contact-us if the issue persists.';
+      'Vi kan ikke behandle bildet lokalt før vi sender det til serveren vår. Prøv igjen senere, eller kontakt oss hvis problemet vedvarer.';
 
   @override
-  String get crop_page_action_retake => 'Retake a photo';
+  String get crop_page_action_retake => 'Ta et bilde på nytt';
 
   @override
-  String get crop_page_too_small_image_title => 'The image is too small!';
+  String get crop_page_too_small_image_title => 'Bildet er for lite!';
 
   @override
   String crop_page_too_small_image_message(
@@ -810,23 +819,23 @@ class AppLocalizationsNn extends AppLocalizations {
     int actualWidth,
     int actualHeight,
   ) {
-    return 'The minimum size in pixels for picture upload is ${expectedMinWidth}x$expectedMinHeight. The current picture is ${actualWidth}x$actualHeight.';
+    return 'Minimumsstørrelsen i piksler for bildeopplasting er ${expectedMinWidth}x$expectedMinHeight. Det nåværende bildet er ${actualWidth}x$actualHeight.';
   }
 
   @override
-  String get crop_page_action_server => 'Preparing a call to the server…';
+  String get crop_page_action_server => 'Forbereder et kall til serveren…';
 
   @override
-  String get front_packaging_photo_title => 'Front Packaging Photo';
+  String get front_packaging_photo_title => 'Foto av forsiden av emballasjen';
 
   @override
-  String get ingredients_photo_title => 'Ingredients Photo';
+  String get ingredients_photo_title => 'Ingredienser Foto';
 
   @override
-  String get nutritional_facts_photo_title => 'Nutrition Facts Photo';
+  String get nutritional_facts_photo_title => 'Næringsinnhold Foto';
 
   @override
-  String get recycling_photo_title => 'Recycling Photo';
+  String get recycling_photo_title => 'Resirkuleringsfoto';
 
   @override
   String get take_photo_title => 'Ta et bilde';
@@ -835,159 +844,163 @@ class AppLocalizationsNn extends AppLocalizations {
   String get take_more_photo_title => 'Ta flere bilder';
 
   @override
-  String get front_photo_uploaded => 'Front photo uploaded';
+  String get front_photo_uploaded => 'Frontbilde lastet opp';
 
   @override
-  String get ingredients_photo_button_label => 'Ingredients photo';
+  String get ingredients_photo_button_label => 'Ingredienser bilde';
 
   @override
-  String get ingredients_photo_uploaded => 'Ingredients photo uploaded';
+  String get ingredients_photo_uploaded => 'Ingrediensbilde lastet opp';
 
   @override
   String get nutrition_cache_loading_error =>
-      'Unable to load nutrients from cache';
+      'Kan ikke laste inn næringsstoffer fra hurtigbufferen';
 
   @override
-  String get nutritional_facts_photo_button_label => 'Nutrition facts photo';
+  String get nutritional_facts_photo_button_label =>
+      'Næringsinnholdsinformasjonsbilde';
 
   @override
-  String get nutritional_facts_input_button_label => 'Fill nutrition facts';
+  String get nutritional_facts_input_button_label => 'Fyll inn næringsinnhold';
 
   @override
-  String get nutritional_facts_added => 'Nutrition facts added';
+  String get nutritional_facts_added => 'Næringsinnhold lagt til';
 
   @override
-  String get categories_added => 'Categories added';
+  String get categories_added => 'Kategorier lagt til';
 
   @override
-  String get new_product_title_nutriscore => 'Compute the Nutri-Score';
+  String get new_product_title_nutriscore => 'Beregn ernæringspoengsummen';
 
   @override
   String get new_product_subtitle_nutriscore =>
-      'Help us by filling at least a category and nutritional values';
+      'Hjelp oss ved å fylle ut minst én kategori og næringsverdier';
 
   @override
-  String get new_product_title_environmental_score => 'Compute the Green Score';
+  String get new_product_title_environmental_score =>
+      'Beregn den grønne poengsummen';
 
   @override
   String get new_product_subtitle_environmental_score =>
-      'Get it by filling at least a category';
+      'Få det ved å fylle ut minst én kategori';
 
   @override
   String get new_product_additional_environmental_score =>
-      'Make Green Score computation more precise with origins, packaging & more';
+      'Gjør beregningen av Green Score mer presis med opprinnelse, emballasje og mer';
 
   @override
-  String get new_product_title_nova =>
-      'Compute the food processing level (NOVA)';
+  String get new_product_title_nova => 'Beregn matforedlingsnivået (NOVA)';
 
   @override
   String get new_product_subtitle_nova =>
-      'Get it by filling the food category and ingredients';
+      'Få det ved å fylle ut matkategorien og ingrediensene';
 
   @override
-  String get new_product_desc_nova_unknown => 'Food processing level unknown';
+  String get new_product_desc_nova_unknown => 'Matforedlingsnivå ukjent';
 
   @override
-  String get new_product_title_pictures => 'New product';
+  String get new_product_title_pictures => 'Nytt produkt';
 
   @override
   String get new_product_title_pictures_details =>
-      'Please take the following photos and the Open Food Facts engine can work out the rest!';
+      'Ta følgende bilder, så kan Open Food Facts-motoren finne ut av resten!';
 
   @override
-  String get new_product_title_misc => 'And some basic data…';
+  String get new_product_title_misc => 'Og noen grunnleggende data…';
 
   @override
   String new_product_done_msg(String username) {
-    return 'Thanks for your contribution “$username”!';
+    return 'Takk for bidraget ditt «$username»!';
   }
 
   @override
-  String get new_product_done_msg_no_user => 'Thanks for your contribution!';
+  String get new_product_done_msg_no_user => 'Takk for bidraget ditt!';
 
   @override
-  String get new_product_done_button_label => 'Discover the completed product';
+  String get new_product_done_button_label => 'Oppdag det ferdige produktet';
 
   @override
   String get hey_incomplete_product_message =>
-      'Tap to answer 3 questions NOW to compute Nutri-Score, Green Score & Ultra-processing (NOVA)!';
+      'Trykk for å svare på 3 spørsmål NÅ for å beregne Nutri-Score, Green Score og Ultra-processing (NOVA)!';
 
   @override
   String get hey_incomplete_product_message_beauty =>
-      'Tap now to answer 2 questions to help analyze this cosmetic!';
+      'Trykk nå for å svare på to spørsmål som kan hjelpe deg med å analysere dette produktet!';
 
   @override
   String get hey_incomplete_product_message_pet_food =>
-      'Tap now to answer 3 questions to help analyze this pet food product!';
+      'Trykk nå for å svare på tre spørsmål som kan hjelpe deg med å analysere dette dyrefôrproduktet!';
 
   @override
   String get hey_incomplete_product_message_product =>
-      'Tap now to help complete this product!';
+      'Trykk nå for å fullføre dette produktet!';
 
   @override
   String get nutritional_facts_photo_uploaded =>
-      'Nutrition facts photo uploaded';
+      'Bilde av næringsinnhold lastet opp';
 
   @override
-  String get recycling_photo_button_label => 'Recycling photo';
+  String get recycling_photo_button_label => 'Resirkuleringsbilde';
 
   @override
-  String get recycling_photo_uploaded => 'Recycling photo uploaded';
+  String get recycling_photo_uploaded => 'Resirkuleringsbilde lastet opp';
 
   @override
   String get take_more_photo_button_label => 'Ta flere bilder';
 
   @override
-  String get other_photo_uploaded => 'Miscellaneous photo uploaded';
+  String get other_photo_uploaded => 'Diverse bilder lastet opp';
 
   @override
-  String get retake_photo_button_label => 'Retake';
+  String get retake_photo_button_label => 'Ta på nytt';
 
   @override
-  String get selecting_photo => 'Selecting photo';
+  String get selecting_photo => 'Velger bilde';
 
   @override
-  String get uploading_image => 'Uploading photo to the server';
+  String get uploading_image => 'Laster opp bilde til serveren';
 
   @override
   String get uploading_image_type_front =>
-      'Uploading front image to Open Food Facts';
+      'Laster opp frontbilde til Open Food Facts';
 
   @override
   String get uploading_image_type_ingredients =>
-      'Uploading ingredients image to Open Food Facts';
+      'Laster opp ingrediensbilde til Open Food Facts';
 
   @override
   String get uploading_image_type_nutrition =>
-      'Uploading nutrition image to Open Food Facts';
+      'Laster opp ernæringsbilde til Open Food Facts';
 
   @override
   String get uploading_image_type_packaging =>
-      'Uploading packaging image to Open Food Facts';
+      'Laster opp emballasjebilde til Open Food Facts';
 
   @override
   String get uploading_image_type_other =>
-      'Uploading other image to Open Food Facts';
+      'Laster opp et annet bilde til Open Food Facts';
 
   @override
   String get uploading_image_type_generic =>
-      'Uploading image to Open Food Facts';
+      'Laster opp bilde til Open Food Facts';
 
   @override
-  String get score_add_missing_ingredients => 'Add missing ingredients';
+  String get score_add_missing_ingredients => 'Legg til manglende ingredienser';
 
   @override
-  String get score_add_missing_packaging_image => 'Add missing packaging image';
+  String get score_add_missing_packaging_image =>
+      'Legg til manglende emballasjebilde';
 
   @override
-  String get score_add_missing_nutrition_facts => 'Add missing nutrition facts';
+  String get score_add_missing_nutrition_facts =>
+      'Legg til manglende næringsinnhold';
 
   @override
-  String get score_add_missing_product_traces => 'Add missing product traces';
+  String get score_add_missing_product_traces =>
+      'Legg til manglende produktspor';
 
   @override
-  String get score_add_missing_product_category => 'Select a category';
+  String get score_add_missing_product_category => 'Velg en kategori';
 
   @override
   String get score_add_missing_precise_product_category =>
@@ -995,36 +1008,40 @@ class AppLocalizationsNn extends AppLocalizations {
 
   @override
   String get score_add_missing_product_countries =>
-      'Add missing product countries';
+      'Legg til manglende produktland';
 
   @override
   String get score_add_missing_product_emb =>
-      'Add missing product traceability codes';
+      'Legg til manglende sporbarhetskoder for produkter';
 
   @override
-  String get score_add_missing_product_labels => 'Add missing product labels';
+  String get score_add_missing_product_labels =>
+      'Legg til manglende produktetiketter';
 
   @override
-  String get score_add_missing_product_origins => 'Add missing product origins';
+  String get score_add_missing_product_origins =>
+      'Legg til manglende produktopprinnelser';
 
   @override
-  String get score_add_missing_product_stores => 'Add missing product stores';
+  String get score_add_missing_product_stores =>
+      'Legg til manglende produktbutikker';
 
   @override
-  String get score_add_missing_product_brands => 'Add missing product brands';
+  String get score_add_missing_product_brands =>
+      'Legg til manglende produktmerker';
 
   @override
-  String get score_update_nutrition_facts => 'Update nutrition facts';
+  String get score_update_nutrition_facts => 'Oppdater næringsinnhold';
 
   @override
-  String get nutrition_page_title => 'Nutrition Facts';
+  String get nutrition_page_title => 'Næringsinnhold';
 
   @override
-  String get nutrition_page_nutritional_info_title => 'Nutritional information';
+  String get nutrition_page_nutritional_info_title => 'Næringsinnhold';
 
   @override
   String get nutrition_page_nutritional_info_label =>
-      'Values specified on the product:';
+      'Verdier spesifisert på produktet:';
 
   @override
   String get nutrition_page_nutritional_info_value_positive => 'Ja';
@@ -1033,61 +1050,61 @@ class AppLocalizationsNn extends AppLocalizations {
   String get nutrition_page_nutritional_info_value_negative => 'Nei';
 
   @override
-  String get nutrition_page_nutritional_info_open_photo => 'Open photo';
+  String get nutrition_page_nutritional_info_open_photo => 'Åpne bildet';
 
   @override
   String get nutrition_page_nutritional_info_explanation_title =>
-      'Good practices: Nutritional information';
+      'God praksis: Næringsinnhold';
 
   @override
   String get nutrition_page_nutritional_info_explanation_info1 =>
-      'Sometimes nutrition facts are **not specified on the packaging** or on a document given with the product. In this case, and only in this case, you can set the value to **NO**.';
+      'Noen ganger er næringsinnholdet **ikke spesifisert på emballasjen** eller på et dokument som følger med produktet. I dette tilfellet, og bare i dette tilfellet, kan du sette verdien til **NEI**.';
 
   @override
-  String get nutrition_page_serving_type_label => 'Nutritional values:';
+  String get nutrition_page_serving_type_label => 'Næringsinnhold:';
 
   @override
-  String get nutrition_page_per_100g => 'per 100g';
+  String get nutrition_page_per_100g => 'per 100 g';
 
   @override
-  String get nutrition_page_per_100g_100ml => 'per 100g/ml';
+  String get nutrition_page_per_100g_100ml => 'per 100 g/ml';
 
   @override
   String get nutrition_page_per_serving => 'per porsjon';
 
   @override
-  String get nutrition_page_add_nutrient => 'Add a nutrient';
+  String get nutrition_page_add_nutrient => 'Tilsett et næringsstoff';
 
   @override
   String get nutrition_page_serving_size => 'Porsjonstørrelse';
 
   @override
   String get nutrition_page_serving_size_hint =>
-      'Input a serving size (eg: 100g)';
+      'Skriv inn en porsjonsstørrelse (f.eks. 100 g)';
 
   @override
   String get nutrition_page_serving_size_explanation_title =>
-      'Good practices: Serving size';
+      'God praksis: Serveringsstørrelse';
 
   @override
   String get nutrition_page_serving_size_explanation_info1 =>
-      'This value helps to **make a proportional calculation of each nutrient per serving size**.';
+      'Denne verdien bidrar til å **lage en proporsjonal beregning av hvert næringsstoff per porsjonsstørrelse**.';
 
   @override
   String get nutrition_page_serving_size_explanation_info2 =>
-      '**Allowed units** are: kg, g, mg, µg, oz, l, dl, cl, ml, fl.oz, fl oz, г, мг, кг, л, дл, кл, мл, 毫克, 公斤, 毫升, 公升, 吨.';
+      '**Tillatte enheter** er: kg, g, mg, µg, oz, l, dl, cl, ml, fl.oz, fl oz, г, мг, кг, л, дл, кл, мл, 毫克, 公斤, 毫升, 公卨.';
 
   @override
   String get nutrition_page_serving_size_explanation_good_example1 =>
-      '**60 g**, **60g** or **60 G** (prefer the first one)';
+      '**60 g**, **60 g** eller **60 G** (foretrekk den første)';
 
   @override
   String get nutrition_page_serving_size_explanation_good_example2 =>
-      '**1000 ml** or **1L**';
+      '**1000 ml** eller **1 l**';
 
   @override
   String get nutrition_page_serving_size_explanation_bad_example1_explanation =>
-      'Invalid unit';
+      'Ugyldig enhet';
 
   @override
   String get nutrition_page_serving_size_explanation_bad_example1_example =>
@@ -1095,88 +1112,88 @@ class AppLocalizationsNn extends AppLocalizations {
 
   @override
   String get nutrition_page_serving_size_explanation_bad_example2_explanation =>
-      'Invalid units';
+      'Ugyldige enheter';
 
   @override
   String get nutrition_page_serving_size_explanation_bad_example2_example =>
-      '9 **candies** and 2 **biscuits**';
+      '9 **godteri** og 2 **kjeks**';
 
   @override
   String get nutrition_page_serving_size_explanation_bad_example3_explanation =>
-      'Missing unit';
+      'Manglende enhet';
 
   @override
   String get nutrition_page_serving_size_explanation_bad_example3_example =>
       '**30**';
 
   @override
-  String get nutrition_page_invalid_number => 'Invalid number';
+  String get nutrition_page_invalid_number => 'Ugyldig nummer';
 
   @override
   String get nutrition_page_update_running =>
-      'Updating the product on the server…';
+      'Oppdaterer produktet på serveren…';
 
   @override
-  String get nutrition_page_update_done => 'Product updated!';
+  String get nutrition_page_update_done => 'Produkt oppdatert!';
 
   @override
   String get nutrition_page_take_serving_size_from_product_quantity =>
-      'Use the product quantity as serving size';
+      'Bruk produktmengden som porsjonsstørrelse';
 
   @override
-  String get nutrition_page_photo_error => 'Unable to load the photo';
+  String get nutrition_page_photo_error => 'Kan ikke laste inn bildet';
 
   @override
-  String get more_photos => 'More interesting photos';
+  String get more_photos => 'Flere interessante bilder';
 
   @override
   String get view_more_photo_button =>
-      'View all existing photos for this product';
+      'Se alle eksisterende bilder for dette produktet';
 
   @override
-  String get no_product_found => 'No product found';
+  String get no_product_found => 'Ingen produkt funnet';
 
   @override
-  String get no_location_found => 'No location found';
+  String get no_location_found => 'Ingen plassering funnet';
 
   @override
-  String get not_found => 'not found:';
+  String get not_found => 'ikke funnet:';
 
   @override
-  String get refreshing_product => 'Refreshing product';
+  String get refreshing_product => 'Forfriskende produkt';
 
   @override
-  String get product_refreshed => 'Product refreshed';
+  String get product_refreshed => 'Produktet er oppdatert';
 
   @override
   String product_image_accessibility_label(String date) {
-    return 'Image taken on $date';
+    return 'Bilde tatt $date';
   }
 
   @override
   String product_image_outdated_accessibility_label(String date) {
-    return 'Image taken on $date. This image may be outdated';
+    return 'Bildet er tatt $date. Dette bildet kan være utdatert';
   }
 
   @override
-  String get product_image_outdated => 'This image may be outdated';
+  String get product_image_outdated => 'Dette bildet kan være utdatert';
 
   @override
   String get product_image_outdated_explanations_title =>
-      'This image may be outdated';
+      'Dette bildet kan være utdatert';
 
   @override
   String get product_image_outdated_explanations_content =>
-      'This image was taken more than a year ago.\n**Please check that\'s it\'s still up-to-date**.\n\nThis is **just a warning**. If the content is still the same, you can ignore this message.';
+      'Dette bildet ble tatt for over et år siden.\n**Sjekk at det fortsatt er oppdatert**.\n\nDette er **bare en advarsel**. Hvis innholdet fortsatt er det samme, kan du ignorere denne meldingen.';
 
   @override
   String product_image_action_replace_photo(String type) {
-    return 'Replace photo ($type)';
+    return 'Erstatt bilde ($type)';
   }
 
   @override
   String product_image_action_add_photo(String type) {
-    return 'Add a photo ($type)';
+    return 'Legg til et bilde ($type)';
   }
 
   @override
@@ -1186,92 +1203,91 @@ class AppLocalizationsNn extends AppLocalizations {
   String get product_image_action_take_picture => 'Ta et bilde';
 
   @override
-  String get product_image_action_from_gallery =>
-      'Select from your phone\'s gallery';
+  String get product_image_action_from_gallery => 'Velg fra telefonens galleri';
 
   @override
   String get product_image_action_choose_existing_photo =>
-      'Select from the product photos';
+      'Velg fra produktbildene';
 
   @override
-  String get product_image_details_label => 'Information about the photo';
+  String get product_image_details_label => 'Informasjon om bildet';
 
   @override
-  String get product_image_details_from_producer => 'From the producer';
+  String get product_image_details_from_producer => 'Fra produsenten';
 
   @override
   String get product_image_details_contributor => 'Bidrager';
 
   @override
   String get product_image_details_contributor_producer =>
-      'Contributor (producer)';
+      'Bidragsyter (produsent)';
 
   @override
-  String get product_image_details_date => 'Date';
+  String get product_image_details_date => 'Dato';
 
   @override
-  String get product_image_details_date_unknown => 'Unknown';
+  String get product_image_details_date_unknown => 'Ukjent';
 
   @override
   String get homepage_main_card_logo_description =>
-      'Welcome to Open Food Facts';
+      'Velkommen til Åpne matfakta';
 
   @override
   String get homepage_main_card_subheading =>
-      '**Scan** a barcode or\n**search** for a product';
+      '**Skann** en strekkode eller\n**søk** etter et produkt';
 
   @override
   String get homepage_main_card_search_field_hint => 'Søk etter et produkt';
 
   @override
-  String get homepage_main_card_search_field_tooltip => 'Start search';
+  String get homepage_main_card_search_field_tooltip => 'Start søk';
 
   @override
   String scan_tagline_news_item_accessibility(String news_title) {
-    return 'Latest news: $news_title';
+    return 'Siste nytt: $news_title';
   }
 
   @override
-  String get tagline_app_review => 'Do you like the app?';
+  String get tagline_app_review => 'Liker du appen?';
 
   @override
-  String get tagline_app_review_button_positive => 'I love it! 😍';
+  String get tagline_app_review_button_positive => 'Jeg elsker det! 😍';
 
   @override
-  String get tagline_app_review_button_negative => 'Not really…';
+  String get tagline_app_review_button_negative => 'Ikke egentlig…';
 
   @override
-  String get tagline_app_review_button_later => 'Ask me later';
+  String get tagline_app_review_button_later => 'Spør meg senere';
 
   @override
-  String get tagline_feed_news_button => 'Know more';
+  String get tagline_feed_news_button => 'Lær mer';
 
   @override
-  String get app_review_negative_modal_title => 'You don\'t like our app?';
+  String get app_review_negative_modal_title => 'Liker du ikke appen vår?';
 
   @override
   String get app_review_negative_modal_text =>
-      'Could you take a few seconds to tell us why?';
+      'Kan du bruke noen sekunder på å fortelle oss hvorfor?';
 
   @override
-  String get app_review_negative_modal_positive_button => 'Yes, absolutely!';
+  String get app_review_negative_modal_positive_button => 'Ja, absolutt!';
 
   @override
   String get app_review_negative_modal_negative_button => 'Nei';
 
   @override
-  String get could_not_refresh => 'Could not refresh product';
+  String get could_not_refresh => 'Kunne ikke oppdatere produktet';
 
   @override
-  String get product_internet_error_modal_title => 'An error has occurred!';
+  String get product_internet_error_modal_title => 'Det har oppstått en feil!';
 
   @override
   String product_internet_error_modal_message(String error) {
-    return 'We are unable to fetch information about this product due to a network error. Please check your internet connection and try again.\n\nInternal error:\n$error';
+    return 'Vi kan ikke hente informasjon om dette produktet på grunn av en nettverksfeil. Sjekk internettforbindelsen din og prøv på nytt.\n\nIntern feil:\n$error';
   }
 
   @override
-  String get product_tags_title => 'Product properties';
+  String get product_tags_title => 'Produktegenskaper';
 
   @override
   String get no_product_tags_found_message =>
@@ -1288,28 +1304,28 @@ class AppLocalizationsNn extends AppLocalizations {
   String get add_tag => 'Add property';
 
   @override
-  String get add_tags => 'Add properties';
+  String get add_tags => 'Legg til egenskaper';
 
   @override
-  String get add_edit_tags => 'Add or edit properties';
+  String get add_edit_tags => 'Legg til eller rediger egenskaper';
 
   @override
-  String get edit_tag => 'Edit property';
+  String get edit_tag => 'Rediger egenskap';
 
   @override
-  String get remove_tag => 'Remove property';
+  String get remove_tag => 'Fjern egenskap';
 
   @override
-  String get tag_key => 'Property';
+  String get tag_key => 'Eiendom';
 
   @override
   String get tag_keys => 'Eiendommer';
 
   @override
-  String get tag_key_uneditable => 'Property (uneditable)';
+  String get tag_key_uneditable => 'Egenskap (kan ikke redigeres)';
 
   @override
-  String get tag_key_input_hint => 'Input a property';
+  String get tag_key_input_hint => 'Skriv inn en egenskap';
 
   @override
   String get tag_value => 'Value';
@@ -1318,29 +1334,29 @@ class AppLocalizationsNn extends AppLocalizations {
   String get tag_values => 'Values';
 
   @override
-  String get tag_value_input_hint => 'Input a value';
+  String get tag_value_input_hint => 'Skriv inn en verdi';
 
   @override
-  String get tag_key_item => 'Property:';
+  String get tag_key_item => 'Eiendom:';
 
   @override
-  String get tag_value_item => 'Value:';
+  String get tag_value_item => 'Verdi:';
 
   @override
   String get tag_key_explanations =>
-      'A key must be lowercase and without any spaces.';
+      'En nøkkel må være liten og uten mellomrom.';
 
   @override
   String tag_key_already_exists(String property) {
-    return 'A tag with a property $property already exists!';
+    return 'En tagg med en egenskap $property finnes allerede!';
   }
 
   @override
   String get product_internet_error =>
-      'Impossible to fetch information about this product due to a network error.';
+      'Umulig å hente informasjon om dette produktet på grunn av en nettverksfeil.';
 
   @override
-  String get cached_results_from => 'Show results from:';
+  String get cached_results_from => 'Vis resultater fra:';
 
   @override
   String get product_search_same_category => 'Finn alternativer';
@@ -1350,40 +1366,40 @@ class AppLocalizationsNn extends AppLocalizations {
 
   @override
   String get product_search_same_category_error =>
-      'This feature can only be used for products with a category.\n\nPlease edit the product to add a category.';
+      'Denne funksjonen kan bare brukes for produkter med en kategori.\n\nVennligst rediger produktet for å legge til en kategori.';
 
   @override
   String get product_improvement_add_category =>
-      'Add a category to calculate the Nutri-Score.';
+      'Legg til en kategori for å beregne Nutri-Score.';
 
   @override
   String get product_improvement_add_nutrition_facts =>
-      'Add nutrition facts to calculate the Nutri-Score.';
+      'Legg til næringsinnhold for å beregne Nutri-Score.';
 
   @override
   String get product_improvement_add_nutrition_facts_and_category =>
-      'Add nutrition facts and a category to calculate the Nutri-Score.';
+      'Legg til næringsinnhold og en kategori for å beregne Nutri-Score.';
 
   @override
   String get product_improvement_categories_but_no_nutriscore =>
-      'The Nutri-Score for this product can\'t be calculated, which may be due to e.g. a non-standard category. If this is considered an error, please contact us.';
+      'Næringspoengsummen for dette produktet kan ikke beregnes, noe som for eksempel kan skyldes en ikke-standard kategori. Hvis dette anses som en feil, vennligst kontakt oss.';
 
   @override
   String get product_improvement_obsolete_nutrition_image =>
-      'The nutrition image is obsolete: please refresh it.';
+      'Ernæringsbildet er utdatert: vennligst oppdater det.';
 
   @override
   String get product_improvement_origins_to_be_completed =>
-      'The Green Score takes into account the origins of the ingredients. Please take a photo of the ingredient list and/or any geographic claim or edit the product, so they can be taken into account.';
+      'Den grønne poengsummen tar hensyn til ingrediensenes opprinnelse. Vennligst ta et bilde av ingredienslisten og/eller eventuelle geografiske påstander, eller rediger produktet, slik at de kan tas i betraktning.';
 
   @override
-  String get country_chooser_label => 'Please choose a country';
+  String get country_chooser_label => 'Vennligst velg et land';
 
   @override
   String get currency_chooser_label => 'Velg en valuta';
 
   @override
-  String get country_change_message => 'You have just changed countries.';
+  String get country_change_message => 'Du har nettopp byttet land.';
 
   @override
   String currency_auto_change_message(
@@ -1394,55 +1410,57 @@ class AppLocalizationsNn extends AppLocalizations {
   }
 
   @override
-  String get onboarding_country_chooser_label => 'Please choose a country:';
+  String get onboarding_country_chooser_label => 'Vennligst velg et land:';
 
   @override
-  String get country_chooser_label_from_settings => 'Your country';
+  String get country_chooser_label_from_settings => 'Landet ditt';
 
   @override
   String get country_selection_explanation =>
-      'Some environmental features are location-specific';
+      'Noen miljøtrekk er stedsspesifikke';
 
   @override
-  String get product_removed_comparison => 'Product removed from comparison';
+  String get product_removed_comparison =>
+      'Produkt fjernet fra sammenligningen';
 
   @override
-  String get native_app_settings => 'Native App Settings';
+  String get native_app_settings => 'Innstillinger for integrerte apper';
 
   @override
   String get native_app_description =>
-      'Open systems settings for Open Food Facts';
+      'Åpne systeminnstillinger for Åpne matfakta';
 
   @override
-  String get product_removed_history => 'Product removed from history';
+  String get product_removed_history => 'Produkt fjernet fra historikken';
 
   @override
-  String get product_removed_list => 'Product removed from list';
+  String get product_removed_list => 'Produkt fjernet fra listen';
 
   @override
-  String get product_could_not_remove => 'Could not remove product';
+  String get product_could_not_remove => 'Kunne ikke fjerne produktet';
 
   @override
-  String get no_prodcut_in_list => 'There is no product in this list';
+  String get no_prodcut_in_list => 'Det finnes ikke noe produkt i denne listen';
 
   @override
-  String get no_product_in_section => 'There is no product in this section';
+  String get no_product_in_section =>
+      'Det finnes ikke noe produkt i denne seksjonen';
 
   @override
-  String get recently_seen_products => 'All viewed products';
+  String get recently_seen_products => 'Alle viste produkter';
 
   @override
   String get clear => 'Tøm';
 
   @override
-  String get clear_long => 'Empty the list';
+  String get clear_long => 'Tøm listen';
 
   @override
-  String get really_clear => 'Do you really want to delete this list?';
+  String get really_clear => 'Vil du virkelig slette denne listen?';
 
   @override
   String pct_match(Object percent) {
-    return '$percent% match';
+    return '$percent% samsvar';
   }
 
   @override
@@ -1450,8 +1468,8 @@ class AppLocalizationsNn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count days ago',
-      one: 'one day ago',
+      other: '$count for dager siden',
+      one: 'for én dag siden',
     );
     return '$_temp0';
   }
@@ -1461,8 +1479,8 @@ class AppLocalizationsNn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count hours ago',
-      one: 'one hour ago',
+      other: '$count for timer siden',
+      one: 'for én time siden',
     );
     return '$_temp0';
   }
@@ -1472,9 +1490,9 @@ class AppLocalizationsNn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count minutes ago',
-      one: 'one minute ago',
-      zero: 'less than a minute ago',
+      other: '$count for minutter siden',
+      one: 'for ett minutt siden',
+      zero: 'for mindre enn ett minutt siden',
     );
     return '$_temp0';
   }
@@ -1484,8 +1502,8 @@ class AppLocalizationsNn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count months ago',
-      one: 'one month ago',
+      other: '$count for måneder siden',
+      one: 'for én måned siden',
     );
     return '$_temp0';
   }
@@ -1495,8 +1513,8 @@ class AppLocalizationsNn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count weeks ago',
-      one: 'one week ago',
+      other: '$count for uker siden',
+      one: 'for én uke siden',
     );
     return '$_temp0';
   }
@@ -1506,8 +1524,8 @@ class AppLocalizationsNn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'Compare $count Products',
-      one: 'Compare one Product',
+      other: 'Sammenlign $count Produkter',
+      one: 'Sammenlign ett produkt',
     );
     return '$_temp0';
   }
@@ -1517,86 +1535,86 @@ class AppLocalizationsNn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count selected products',
-      one: 'One selected product',
-      zero: 'No selected product',
+      other: '$count valgte produkter',
+      one: 'Ett valgt produkt',
+      zero: 'Ingen valgte produkter',
     );
     return '$_temp0';
   }
 
   @override
-  String get compare_products_mode => 'Compare selected products';
+  String get compare_products_mode => 'Sammenlign utvalgte produkter';
 
   @override
-  String get delete_products_mode => 'Delete selected products';
+  String get delete_products_mode => 'Slett valgte produkter';
 
   @override
-  String get select_all_products_mode => 'Select all products';
+  String get select_all_products_mode => 'Velg alle produkter';
 
   @override
-  String get select_none_products_mode => 'Select none';
+  String get select_none_products_mode => 'Velg ingen';
 
   @override
   String get compare_products_appbar_title => 'Compare products';
 
   @override
   String get compare_products_appbar_subtitle =>
-      'Please select at least two products';
+      'Vennligst velg minst to produkter';
 
   @override
-  String get retry_button_label => 'Retry';
+  String get retry_button_label => 'Prøv på nytt';
 
   @override
-  String get connect_with_us => 'Connect with us';
+  String get connect_with_us => 'Ta kontakt med oss';
 
   @override
-  String get tiktok => 'Follow us on TikTok';
+  String get tiktok => 'Følg oss på TikTok';
 
   @override
   String get tiktok_link => 'https://www.tiktok.com/@openfoodfacts';
 
   @override
-  String get instagram => 'Follow us on Instagram';
+  String get instagram => 'Følg oss på Instagram';
 
   @override
   String get instagram_link => 'https://instagram.com/open.food.facts';
 
   @override
-  String get twitter => 'Follow us on X (formerly Twitter)';
+  String get twitter => 'Følg oss på X (tidligere Twitter)';
 
   @override
   String get twitter_link => 'https://www.twitter.com/openfoodfacts';
 
   @override
-  String get mastodon => 'Follow us on Mastodon';
+  String get mastodon => 'Følg oss på Mastodon';
 
   @override
   String get mastodon_link => 'https://mastodon.social/@openfoodfacts';
 
   @override
-  String get bsky => 'Follow us on BlueSky';
+  String get bsky => 'Følg oss på BlueSky';
 
   @override
   String get bsky_link => 'https://bsky.app/profile/openfoodfacts.bsky.social';
 
   @override
-  String get blog => 'Blog';
+  String get blog => 'Blogg';
 
   @override
-  String get faq => 'FAQ';
+  String get faq => 'Vanlige spørsmål';
 
   @override
   String get discover => 'Utforsk';
 
   @override
-  String get how_to_contribute => 'How to Contribute';
+  String get how_to_contribute => 'Hvordan bidra';
 
   @override
   String get hint_knowledge_panel_message =>
-      'Your can tap on any part of the card to get more details about what you see. Try it now!';
+      'Du kan trykke på hvilken som helst del av kortet for å få mer informasjon om hva du ser. Prøv det nå!';
 
   @override
-  String get permissions_page_title => 'Camera access';
+  String get permissions_page_title => 'Kameratilgang';
 
   @override
   String get permissions_page_body1 =>
@@ -1604,7 +1622,7 @@ class AppLocalizationsNn extends AppLocalizations {
 
   @override
   String get permissions_page_body2 =>
-      'If you change your mind, this option can be enabled and disabled at any time from the settings.';
+      'Hvis du ombestemmer deg, kan dette alternativet aktiveres og deaktiveres når som helst fra innstillingene.';
 
   @override
   String contact_form_body_android(
@@ -1615,7 +1633,7 @@ class AppLocalizationsNn extends AppLocalizations {
     String? device,
     String? brand,
   ) {
-    return 'OS: Android (SDK Int: $sdkInt / Release: $release)\nModel: $model\nProduct: $product\nDevice: $device\nBrand:$brand';
+    return 'OS: Android (SDK Int: $sdkInt / Utgivelse: $release)\nModell: $model\nProdukt: $product\nEnhet: $device\nMerke:$brand';
   }
 
   @override
@@ -1624,7 +1642,7 @@ class AppLocalizationsNn extends AppLocalizations {
     String? model,
     String? localizedModel,
   ) {
-    return 'OS: iOS ($version)\nModel: $model\nLocalized model: $localizedModel';
+    return 'OS: iOS ($version)\nModell: $model\nLokalisert modell: $localizedModel';
   }
 
   @override
@@ -1634,67 +1652,67 @@ class AppLocalizationsNn extends AppLocalizations {
     String appBuildNumber,
     String appPackageName,
   ) {
-    return '$osContent\nApp version:$appVersion\nApp build number:$appBuildNumber\nApp package name:$appPackageName';
+    return '$osContent\nAppversjon:$appVersion\nAppens byggenummer:$appBuildNumber\nAppens pakkenavn:$appPackageName';
   }
 
   @override
   String get authorize_button_label => 'Authorise';
 
   @override
-  String get refuse_button_label => 'Refuse';
+  String get refuse_button_label => 'Avslå';
 
   @override
-  String get ask_me_later_button_label => 'Later';
+  String get ask_me_later_button_label => 'Seinere';
 
   @override
-  String get are_you_sure => 'Are you sure?';
+  String get are_you_sure => 'Er du sikker?';
 
   @override
   String knowledge_panel_text_source(String sourceName) {
-    return 'Go further on $sourceName';
+    return 'Gå videre på $sourceName';
   }
 
   @override
-  String get onboarding_home_welcome_text1 => 'Welcome !';
+  String get onboarding_home_welcome_text1 => 'Velkommen!';
 
   @override
   String get onboarding_home_welcome_text2 =>
-      'The app that helps you choose food that is good for **you** and the **planet**!';
+      'Appen som hjelper deg med å velge mat som er bra for **deg** og **planeten**!';
 
   @override
-  String get onboarding_continue_button => 'Continue';
+  String get onboarding_continue_button => 'Fortsette';
 
   @override
   String get onboarding_welcome_loading_dialog_title =>
-      'Loading your first example product';
+      'Laster inn ditt første eksempelprodukt';
 
   @override
   String get onboarding_welcome_warning =>
       'Beklager, dette er vårt eksempelprodukt, du kan ikke redigere det :)';
 
   @override
-  String get product_list_your_ranking => 'Your ranking';
+  String get product_list_your_ranking => 'Din rangering';
 
   @override
-  String get product_list_empty_icon_desc => 'History not available';
+  String get product_list_empty_icon_desc => 'Historikk ikke tilgjengelig';
 
   @override
-  String get product_list_empty_title => 'Start scanning';
+  String get product_list_empty_title => 'Start skanning';
 
   @override
   String get product_list_empty_message =>
-      'Scanned products will appear here and you can check detailed information about them';
+      'Skannede produkter vil vises her, og du kan sjekke detaljert informasjon om dem';
 
   @override
   String product_list_reloading_in_progress_multiple(num count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'products',
-      one: 'product',
-      zero: 'product',
+      other: 'produkter',
+      one: 'produkt',
+      zero: 'produkt',
     );
-    return 'Refreshing $_temp0 in your history';
+    return 'Oppdaterer $_temp0 i historikken din';
   }
 
   @override
@@ -1702,94 +1720,96 @@ class AppLocalizationsNn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'Products',
-      one: 'Product',
-      zero: 'Product',
+      other: 'Produkter',
+      one: 'Produkt',
+      zero: 'Produkt',
     );
-    return '$_temp0 refresh complete';
+    return '$_temp0 oppdatering fullført';
   }
 
   @override
   String get product_list_compare_side_by_side => 'Sammenlign side om side';
 
   @override
-  String get loading_dialog_default_title => 'Downloading data';
+  String get loading_dialog_default_title => 'Laster ned data';
 
   @override
-  String get loading_dialog_default_error_message => 'Could not download data';
+  String get loading_dialog_default_error_message =>
+      'Kunne ikke laste ned data';
 
   @override
-  String get account_delete => 'Delete account';
+  String get account_delete => 'Slett konto';
 
   @override
   String get account_delete_title => 'Slett kontoen min';
 
   @override
-  String get user_profile => 'Account';
+  String get user_profile => 'Konto';
 
   @override
-  String get user_profile_title_guest => 'Welcome!';
+  String get user_profile_title_guest => 'Velkomst!';
 
   @override
   String get user_profile_subtitle_guest =>
-      'Sign-in or sign-up to join the Open Food Facts community';
+      'Logg inn eller registrer deg for å bli med i Open Food Facts-fellesskapet';
 
   @override
   String user_profile_title_id_email(String email) {
-    return 'Open Food Facts login: $email';
+    return 'Åpne Matfakta-innlogging: $email';
   }
 
   @override
   String user_profile_title_id_default(String id) {
-    return 'Welcome $id!';
+    return 'Velkommen $id!';
   }
 
   @override
-  String get email_subject_account_deletion => 'Delete account';
+  String get email_subject_account_deletion => 'Slett konto';
 
   @override
   String email_body_account_deletion(String userId) {
-    return 'Hi there, please delete my Open Food Facts account: $userId';
+    return 'Hei, vennligst slett Open Food Facts-kontoen min: $userId';
   }
 
   @override
-  String get settings_app_app => 'Application';
+  String get settings_app_app => 'Søknad';
 
   @override
   String get settings_app_data => 'Privacy & monitoring';
 
   @override
-  String get settings_app_camera => 'Camera';
+  String get settings_app_camera => 'Kamera';
 
   @override
   String get settings_app_products => 'Produkter';
 
   @override
-  String get settings_app_miscellaneous => 'Miscellaneous';
+  String get settings_app_miscellaneous => 'Diverse';
 
   @override
-  String get camera_play_sound_title => 'Play a sound on scan';
+  String get camera_play_sound_title => 'Spill av en lyd ved skanning';
 
   @override
-  String get camera_play_sound_subtitle => 'Will beep on each successful scan';
+  String get camera_play_sound_subtitle =>
+      'Vil pipe ved hver vellykket skanning';
 
   @override
   String get camera_window_accessibility_label =>
-      'Scan a barcode with your camera';
+      'Skann en strekkode med kameraet ditt';
 
   @override
-  String get app_haptic_feedback_title => 'Vibration & Haptics';
+  String get app_haptic_feedback_title => 'Vibrasjon og haptikk';
 
   @override
   String get app_haptic_feedback_subtitle =>
-      'Vibrations after executing some actions (barcode decoded, product removed…).';
+      'Vibrasjoner etter utførelse av enkelte handlinger (strekkode dekodet, produkt fjernet…).';
 
   @override
   String get crash_reporting_toggle_title => 'Crash reporting';
 
   @override
   String get crash_reporting_toggle_subtitle =>
-      'When enabled, crash reports are automatically submitted to Open Food Facts\' error tracking system, so that bugs can be fixed and thus improve the app.';
+      'Når det er aktivert, sendes krasjrapporter automatisk til Open Food Facts\' feilsporingssystem, slik at feil kan rettes og dermed forbedre appen.';
 
   @override
   String get send_anonymous_data_toggle_title => 'Send anonymous data';
@@ -1799,149 +1819,157 @@ class AppLocalizationsNn extends AppLocalizations {
       'When enabled, some anonymous information regarding app usage will be sent to the Open Food Facts servers, so that we can understand how and how much features are used in order to improve them.';
 
   @override
-  String get product_edit_photo_title => 'Edit Photo';
+  String get product_edit_photo_title => 'Rediger bilde';
 
   @override
-  String get permission_photo_error => 'Error';
+  String get permission_photo_error => 'Feil';
 
   @override
   String get permission_photo_denied_title =>
-      'Allow camera use to scan barcodes';
+      'Tillat kamerabruk for å skanne strekkoder';
 
   @override
   String permission_photo_denied_message(String appName) {
-    return 'For an enhanced experience, please allow $appName to access your camera. You will be able to directly scan barcodes.';
+    return 'For en forbedret opplevelse, vennligst gi $appName tilgang til kameraet ditt. Du vil kunne skanne strekkoder direkte.';
   }
 
   @override
-  String get permission_photo_denied_button => 'Allow';
+  String get permission_photo_denied_button => 'Tillate';
 
   @override
   String get permission_photo_denied_dialog_settings_title =>
-      'Permission denied';
+      'Tillatelse nektet';
 
   @override
   String get permission_photo_denied_dialog_settings_message =>
-      'As you\'ve previously denied the camera permission, you must allow it manually from the Settings.';
+      'Siden du tidligere har nektet kameratillatelse, må du tillate det manuelt fra Innstillingene.';
 
   @override
   String get permission_photo_denied_dialog_settings_button_open =>
-      'Open settings';
+      'Åpne innstillinger';
 
   @override
   String get permission_photo_denied_dialog_settings_button_cancel => 'Cancel';
 
   @override
-  String get permission_photo_none_found => 'No camera detected';
+  String get permission_photo_none_found => 'Ingen kamera oppdaget';
 
   @override
-  String get permission_photo_denied => 'No camera access granted';
+  String get permission_photo_denied => 'Ingen kameratilgang gitt';
 
   @override
-  String get show_product_pictures => 'Show product pictures';
+  String get show_product_pictures => 'Vis produktbilder';
 
   @override
   String get edit_product_label => 'Redigér produkt';
 
   @override
   String get edit_product_pending_operations_banner_title =>
-      'Uploading your edits…';
+      'Laster opp redigeringene dine…';
 
   @override
   String get edit_product_pending_operations_banner_message =>
-      'Your edits are being **sent in the background** (or later in case of error).\nYou can continue editing other product fields.';
+      'Redigeringene dine sendes i bakgrunnen (eller senere ved feil).\nDu kan fortsette å redigere andre produktfelt.';
 
   @override
   String get edit_product_pending_operations_banner_short_message =>
-      'Your edits are being **sent in the background** (or later in case of error).';
+      'Redigerelsene dine sendes i bakgrunnen (eller senere ved feil).';
 
   @override
   String get edit_product_label_short => 'Edit';
 
   @override
   String edit_product_form_item_help(String value) {
-    return 'How to enter \"$value\"?';
+    return 'Hvordan skriver man inn «$value»?';
   }
 
   @override
   String get edit_product_form_item_error_empty =>
-      'Please enter a non-empty value!';
+      'Vennligst skriv inn en verdi som ikke er tom!';
 
   @override
   String get edit_product_form_item_error_existing =>
-      'This value is already there!';
+      'Denne verdien er allerede der!';
 
   @override
-  String get edit_product_form_item_add_action_brand => 'Add a new brand';
+  String get edit_product_form_item_add_action_brand =>
+      'Legg til et nytt merke';
 
   @override
-  String get edit_product_form_item_add_action_label => 'Add a new label';
+  String get edit_product_form_item_add_action_label =>
+      'Legg til en ny etikett';
 
   @override
-  String get edit_product_form_item_add_action_store => 'Add a new store';
+  String get edit_product_form_item_add_action_store => 'Legg til en ny butikk';
 
   @override
-  String get edit_product_form_item_add_action_origin => 'Add a new origin';
+  String get edit_product_form_item_add_action_origin =>
+      'Legg til en ny opprinnelse';
 
   @override
   String get edit_product_form_item_add_action_emb_code =>
-      'Add a new traceability code';
+      'Legg til en ny sporbarhetskode';
 
   @override
-  String get edit_product_form_item_add_action_country => 'Add a new country';
+  String get edit_product_form_item_add_action_country =>
+      'Legg til et nytt land';
 
   @override
-  String get edit_product_form_item_add_action_category => 'Add a new category';
+  String get edit_product_form_item_add_action_category =>
+      'Legg til en ny kategori';
 
   @override
-  String get edit_product_form_item_add_action_trace => 'Add a new trace';
+  String get edit_product_form_item_add_action_trace => 'Legg til et nytt spor';
 
   @override
-  String get edit_product_form_item_add_suggestion => 'Add suggestion';
+  String get edit_product_form_item_add_suggestion => 'Legg til forslag';
 
   @override
   String get edit_product_form_item_deny_suggestion => 'Avvis forslaget';
 
   @override
-  String get edit_product_form_item_details_title => 'Basic details';
+  String get edit_product_form_item_details_title => 'Grunnleggende detaljer';
 
   @override
   String get edit_product_form_item_details_subtitle =>
-      'Product name, brand, quantity';
+      'Produktnavn, merke, antall';
 
   @override
-  String get edit_product_form_item_other_details_title => 'Additional details';
+  String get edit_product_form_item_other_details_title =>
+      'Ytterligere detaljer';
 
   @override
-  String get edit_product_form_item_other_details_subtitle => 'Website…';
+  String get edit_product_form_item_other_details_subtitle => 'Nettsted…';
 
   @override
-  String get edit_product_form_item_photos_title => 'Photos';
+  String get edit_product_form_item_photos_title => 'Bilder';
 
   @override
-  String get edit_product_form_item_photos_subtitle => 'Add or refresh photos';
+  String get edit_product_form_item_photos_subtitle =>
+      'Legg til eller oppdater bilder';
 
   @override
-  String get edit_product_form_item_labels_title => 'Labels & Certifications';
+  String get edit_product_form_item_labels_title =>
+      'Etiketter og sertifiseringer';
 
   @override
   String get edit_product_form_item_labels_subtitle =>
-      'Environmental, Quality labels…';
+      'Miljø, kvalitetsmerker…';
 
   @override
   String get edit_product_form_item_labels_hint =>
-      'Input a label (eg: NutriScore)';
+      'Skriv inn en etikett (f.eks.: NutriScore)';
 
   @override
   String get edit_product_form_item_labels_type => 'etikett';
 
   @override
   String get edit_product_form_item_labels_explanation_title =>
-      'Good practices: Labels';
+      'God praksis: Etiketter';
 
   @override
   String get edit_product_form_item_labels_explanation_info1 =>
-      'Any characteristic of the product **which is factual** and different from the other fields.';
+      'Enhver egenskap ved produktet **som er faktisk** og forskjellig fra de andre feltene.';
 
   @override
   String get edit_product_form_item_labels_explanation_good_examples_1 =>
@@ -1949,7 +1977,7 @@ class AppLocalizationsNn extends AppLocalizations {
 
   @override
   String get edit_product_form_item_labels_explanation_good_examples_2 =>
-      'Made in Belgium, produced in Brittany…';
+      'Laget i Belgia, produsert i Bretagne…';
 
   @override
   String get edit_product_form_item_labels_explanation_good_examples_3 =>
@@ -1957,28 +1985,28 @@ class AppLocalizationsNn extends AppLocalizations {
 
   @override
   String get edit_product_form_item_labels_explanation_good_examples_4 =>
-      'Rich in fiber, source of iron…';
+      'Rik på fiber, kilde til jern…';
 
   @override
   String get edit_product_form_item_labels_explanation_good_examples_5 =>
-      'Fair trade, Max Havelaar…';
+      'Rettferdig handel, Max Havelaar…';
 
   @override
   String get edit_product_form_item_stores_title => 'Butikker';
 
   @override
-  String get edit_product_form_item_stores_hint => 'Input a store';
+  String get edit_product_form_item_stores_hint => 'Legg inn en butikk';
 
   @override
   String get edit_product_form_item_stores_type => 'butikk';
 
   @override
   String get edit_product_form_item_stores_explanation_title =>
-      'Good practices: Stores';
+      'God praksis: Butikker';
 
   @override
   String get edit_product_form_item_stores_explanation_info1 =>
-      'Input the store where you bought the product.';
+      'Skriv inn butikken der du kjøpte produktet.';
 
   @override
   String get edit_product_form_item_stores_explanation_good_examples_1 =>
@@ -1993,74 +2021,74 @@ class AppLocalizationsNn extends AppLocalizations {
       'Lidl';
 
   @override
-  String get edit_product_form_item_origins_title => 'Origins';
+  String get edit_product_form_item_origins_title => 'Opprinnelse';
 
   @override
   String get edit_product_form_item_origins_hint =>
-      'Input an origin (eg: Germany)';
+      'Skriv inn en opprinnelse (f.eks. Tyskland)';
 
   @override
   String get edit_product_form_item_origins_type => 'land';
 
   @override
   String get edit_product_form_item_origins_explanation_title =>
-      'Good practices: Origins';
+      'God praksis: Opprinnelse';
 
   @override
   String get edit_product_form_item_origins_explanation_info1 =>
-      'Add **any indications of origins you can find on the packaging**.\nYou need not worry about origins indicated directly in the ingredient list.';
+      'Legg til **eventuelle opprinnelsesangivelser du finner på emballasjen**.\nDu trenger ikke å bekymre deg for opprinnelsesangivelser som er angitt direkte i ingredienslisten.';
 
   @override
   String get edit_product_form_item_origins_explanation_good_examples_1 =>
-      'Beef from Argentina';
+      'Storfekjøtt fra Argentina';
 
   @override
   String get edit_product_form_item_origins_explanation_good_examples_2 =>
-      'The soy does not come from the European Union';
+      'Soyaen kommer ikke fra EU';
 
   @override
   String get edit_product_form_item_countries_title => 'Country';
 
   @override
   String get edit_product_form_item_countries_hint =>
-      'Input a country (eg: Germany)';
+      'Skriv inn et land (f.eks. Tyskland)';
 
   @override
   String get edit_product_form_item_countries_type => 'land';
 
   @override
   String get edit_product_form_item_countries_explanations_title =>
-      'Good practices: Countries';
+      'God praksis: Land';
 
   @override
   String get edit_product_form_item_countries_explanations_info1 =>
-      '**Countries where the product is widely available** (not including stores specialising in foreign products).';
+      '**Land der produktet er allment tilgjengelig** (ikke inkludert butikker som spesialiserer seg på utenlandske produkter).';
 
   @override
-  String get edit_product_form_item_emb_codes_title => 'Traceability codes';
+  String get edit_product_form_item_emb_codes_title => 'Sporbarhetskoder';
 
   @override
   String get edit_product_form_item_emb_codes_hint =>
-      'Input a code (eg: EMB 53062, FR 62.448.034 CE, 84 R 20, 33 RECOLTANT 522…)';
+      'Skriv inn en kode (f.eks.: EMB 53062, FR 62.448.034 CE, 84 R 20, 33 RECOLTANT 522…)';
 
   @override
-  String get edit_product_form_item_emb_codes_type => 'traceability code';
+  String get edit_product_form_item_emb_codes_type => 'sporbarhetskode';
 
   @override
   String get edit_product_form_item_emb_help_title =>
-      'Good practices: Traceability codes';
+      'God praksis: Sporbarhetskoder';
 
   @override
   String get edit_product_form_item_emb_help_info1 =>
-      'In this section, you can input codes related to **packaging marks**, **identification marks** or **health marks**.';
+      'I denne delen kan du legge inn koder relatert til **emballasjemerker**, **identifikasjonsmerker** eller **helsemerker**.';
 
   @override
   String get edit_product_form_item_emb_help_info2_title =>
-      'Examples of traceability codes';
+      'Eksempler på sporbarhetskoder';
 
   @override
   String get edit_product_form_item_emb_help_info2_item1_text =>
-      '**EC codes** used in the European Community to identify food producers or packagers:';
+      '**EF-koder** brukt i Det europeiske fellesskap for å identifisere matprodusenter eller -pakkere:';
 
   @override
   String get edit_product_form_item_emb_help_info2_item1_example =>
@@ -2068,11 +2096,11 @@ class AppLocalizationsNn extends AppLocalizations {
 
   @override
   String get edit_product_form_item_emb_help_info2_item1_explanation =>
-      '**FR**: country code of **France**\n**72.264.002**: geographic data\n**CE**: European Community';
+      '**FR**: landskode for **Frankrike**\n**72.264.002**: geografiske data\n**CE**: Det europeiske fellesskap';
 
   @override
   String get edit_product_form_item_emb_help_info2_item2_text =>
-      '**EMB codes** used in France:';
+      '**EMB-koder** brukt i Frankrike:';
 
   @override
   String get edit_product_form_item_emb_help_info2_item2_explanation =>
@@ -2086,7 +2114,7 @@ class AppLocalizationsNn extends AppLocalizations {
 
   @override
   String get edit_product_form_item_traces_type =>
-      'Input a trace (eg: Soy beans)';
+      'Skriv inn et spor (f.eks. soyabønner)';
 
   @override
   String get edit_product_form_item_categories_title => 'Kategorier';
@@ -2096,101 +2124,102 @@ class AppLocalizationsNn extends AppLocalizations {
 
   @override
   String get edit_product_form_item_categories_type =>
-      'Input a category (eg: Orange juice)';
+      'Skriv inn en kategori (f.eks.: Appelsinjuice)';
 
   @override
   String get edit_product_form_item_categories_explanation_title =>
-      'Good practices: Categories';
+      'God praksis: Kategorier';
 
   @override
   String get edit_product_form_item_categories_explanation_info1 =>
-      'Indicate **only the most specific category**.\nParent categories will be automatically added.';
+      'Angi **kun den mest spesifikke kategorien**.\nOverordnede kategorier vil bli lagt til automatisk.';
 
   @override
   String get edit_product_form_item_categories_explanation_info2_title =>
-      'Missing category?';
+      'Mangler kategori?';
 
   @override
   String get edit_product_form_item_categories_explanation_info2_content =>
-      'In case a category is **not available in autocomplete**, feel free to add it anyway.\nThis will help us improve Open Food Facts in your country.';
+      'Hvis en kategori **ikke er tilgjengelig i autofullføring**, kan du gjerne legge den til likevel.\nDette vil hjelpe oss med å forbedre Open Food Facts i landet ditt.';
 
   @override
   String get edit_product_form_item_categories_explanation_good_examples_1 =>
-      'Sardines in olive oil';
+      'Sardiner i olivenolje';
 
   @override
   String get edit_product_form_item_categories_explanation_good_examples_2 =>
-      'Orange juice from concentrate';
+      'Appelsinjuice fra konsentrat';
 
   @override
-  String get edit_product_form_item_exit_title => 'Quit without saving?';
+  String get edit_product_form_item_exit_title => 'Avslutte uten å lagre?';
 
   @override
   String get edit_product_form_item_exit_confirmation =>
-      'Do you want to save your changes before leaving this page?';
+      'Vil du lagre endringene dine før du forlater denne siden?';
 
   @override
   String get edit_product_form_item_exit_confirmation_positive_button =>
-      'Save changes';
+      'Lagre endringer';
 
   @override
   String get edit_product_form_item_exit_confirmation_negative_button =>
-      'Discard changes';
+      'Forkast endringer';
 
   @override
   String get edit_product_form_item_ingredients_title => 'Ingredienser';
 
   @override
   String get edit_product_form_item_ingredients_pinch_to_zoom_tooltip =>
-      'Zoom in and out by pinching the screen';
+      'Zoom inn og ut ved å klype skjermen';
 
   @override
   String get edit_product_form_item_ingredients_pinch_to_zoom_title =>
-      'Zoom in and out the photo';
+      'Zoom inn og ut av bildet';
 
   @override
   String get edit_product_form_item_ingredients_pinch_to_zoom_message =>
-      'Using the **Pinch-to-zoom gesture**, you can zoom in or out the photo:';
+      'Ved å bruke **Klyp-for-å-zoome-bevegelsen** kan du zoome inn eller ut av bildet:';
 
   @override
   String get edit_product_form_item_add_valid_item_tooltip => 'Legg til';
 
   @override
   String get edit_product_form_item_add_invalid_item_tooltip =>
-      'Please enter a text first';
+      'Vennligst skriv inn en tekst først';
 
   @override
-  String get edit_product_form_item_remove_item_tooltip => 'Remove';
+  String get edit_product_form_item_remove_item_tooltip => 'Fjerne';
 
   @override
-  String get edit_product_form_item_save_edit_item_tooltip => 'Save your edit';
+  String get edit_product_form_item_save_edit_item_tooltip =>
+      'Lagre redigeringen din';
 
   @override
   String get edit_product_form_item_cancel_edit_item_tooltip =>
-      'Cancel your edit';
+      'Avbryt redigeringen din';
 
   @override
   String get edit_product_form_item_packaging_title =>
-      'Recycling instructions photo';
+      'Instruksjoner for resirkulering, bilde';
 
   @override
   String get edit_product_form_item_nutrition_facts_title => 'Næringsfakta';
 
   @override
   String get edit_product_form_item_nutrition_facts_subtitle =>
-      'Nutrition, alcohol content…';
+      'Næringsinnhold, alkoholinnhold…';
 
   @override
   String get edit_product_form_item_nutrition_facts_explanation_title =>
-      'Good practices: Nutrition facts';
+      'God praksis: Næringsinnhold';
 
   @override
   String get edit_product_form_item_nutrition_facts_explanation_info1_title =>
-      'Nutritional values';
+      'Næringsverdier';
 
   @override
   String get edit_product_form_item_nutrition_facts_explanation_info1_content =>
-      'First, select if the **values are provided**:';
+      'Først velger du om **verdiene er oppgitt**:';
 
   @override
   String get edit_product_form_item_nutrition_facts_explanation_info2_title =>
@@ -2198,52 +2227,53 @@ class AppLocalizationsNn extends AppLocalizations {
 
   @override
   String get edit_product_form_item_nutrition_facts_explanation_info2_content =>
-      'Then, input the nutritional values **as indicated on the packaging**. If there is no value, you can click on the \"Eye\" icon.';
+      'Deretter skriver du inn næringsverdiene **som angitt på emballasjen**. Hvis det ikke finnes noen verdi, kan du klikke på «Øye»-ikonet.';
 
   @override
   String get edit_product_form_item_nutrition_facts_explanation_info3_title =>
-      'Missing field?';
+      'Mangler et felt?';
 
   @override
   String get edit_product_form_item_nutrition_facts_explanation_info3_content =>
-      'If an entry is missing, you can **click on the \"Plus\" icon** to add it (eg: vitamin D, magnesium…).';
+      'Hvis en oppføring mangler, kan du **klikke på «Pluss»-ikonet** for å legge den til (f.eks.: vitamin D, magnesium…).';
 
   @override
   String get edit_product_form_save => 'Edit';
 
   @override
-  String get edit_product_ingredients_photo_title => 'Ingredients photo';
+  String get edit_product_ingredients_photo_title => 'Ingredienser bilde';
 
   @override
   String get edit_product_ingredients_list_title => 'Ingrediensliste';
 
   @override
-  String get edit_product_packaging_photo_title => 'Packaging photo';
+  String get edit_product_packaging_photo_title => 'Emballasjebilde';
 
   @override
-  String get edit_product_packaging_list_title => 'Packaging list';
+  String get edit_product_packaging_list_title => 'Pakkeliste';
 
   @override
-  String get no_data_available => 'No data available';
+  String get no_data_available => 'Ingen data tilgjengelig';
 
   @override
-  String get product_field_website_title => 'Website';
+  String get product_field_website_title => 'Nettsted';
 
   @override
-  String get origins_editing_title => 'Edit Origins';
+  String get origins_editing_title => 'Rediger opprinnelse';
 
   @override
-  String get completed_basic_details_btn_text => 'Complete basic details';
+  String get completed_basic_details_btn_text =>
+      'Fullfør grunnleggende detaljer';
 
   @override
-  String get not_implemented_snackbar_text => 'Not implemented yet';
+  String get not_implemented_snackbar_text => 'Ikke implementert ennå';
 
   @override
   String get category_picker_page_appbar_text => 'Kategorier';
 
   @override
   String get edit_ingredients_extract_ingredients_btn_text =>
-      'Extract ingredients from the photo';
+      'Hent ut ingredienser fra bildet';
 
   @override
   String get edit_ingredients_extract_ingredients_btn_text_short =>
@@ -2251,204 +2281,204 @@ class AppLocalizationsNn extends AppLocalizations {
 
   @override
   String get edit_ingredients_extracting_ingredients_btn_text =>
-      'Extracting ingredients\nfrom the photo';
+      'Uttrekk av ingredienser\nfra bildet';
 
   @override
-  String get edit_ingredients_loading_photo_btn_text => 'Loading photo…';
+  String get edit_ingredients_loading_photo_btn_text => 'Laster inn bilde…';
 
   @override
   String get edit_ingredients_loading_photo_help_dialog_title =>
-      'Why do I see this message?';
+      'Hvorfor ser jeg denne meldingen?';
 
   @override
   String get edit_ingredients_loading_photo_help_dialog_body =>
-      'To use the \"Extract ingredients\" feature, the photo needs to be uploaded first.\n\nPlease wait a few seconds or enter them manually.';
+      'For å bruke funksjonen «Trekke ut ingredienser», må bildet lastes opp først.\n\nVent noen sekunder eller skriv dem inn manuelt.';
 
   @override
-  String get edit_ingredients_refresh_photo_btn_text => 'Refresh photo';
+  String get edit_ingredients_refresh_photo_btn_text => 'Oppdater bildet';
 
   @override
   String get edit_packaging_extract_btn_text =>
-      'Extract packaging\nfrom the photo';
+      'Hent ut emballasje\nfra bildet';
 
   @override
-  String get edit_packaging_extract_btn_text_short => 'Extract packaging';
+  String get edit_packaging_extract_btn_text_short => 'Ekstraktemballasje';
 
   @override
   String get edit_packaging_extracting_btn_text =>
-      'Extracting packaging from the photo';
+      'Utpakking av emballasje fra bildet';
 
   @override
-  String get edit_packaging_loading_photo_btn_text => 'Loading photo…';
+  String get edit_packaging_loading_photo_btn_text => 'Laster inn bilde…';
 
   @override
   String get edit_packaging_loading_photo_help_dialog_title =>
-      'Why do I see this message?';
+      'Hvorfor ser jeg denne meldingen?';
 
   @override
   String get edit_packaging_loading_photo_help_dialog_body =>
-      'To use the \"Extract packaging\" feature, the photo needs to be uploaded first.\n\nPlease wait a few seconds or enter them manually.';
+      'For å bruke funksjonen «Pakk ut emballasje» må bildet lastes opp først.\n\nVent noen sekunder eller skriv dem inn manuelt.';
 
   @override
-  String get edit_packaging_refresh_photo_btn_text => 'Refresh photo';
+  String get edit_packaging_refresh_photo_btn_text => 'Oppdater bildet';
 
   @override
-  String get edit_ocr_extract_failed => 'Failed to detect text in image.';
+  String get edit_ocr_extract_failed => 'Klarte ikke å oppdage tekst i bildet.';
 
   @override
-  String get edit_ocr_extract_disabled_title => 'No picture!';
+  String get edit_ocr_extract_disabled_title => 'Ikke noe bilde!';
 
   @override
   String get edit_ocr_extract_disabled_message =>
-      'In order to use the text extraction feature, you must first take a photo.';
+      'For å bruke tekstuttrekkingsfunksjonen må du først ta et bilde.';
 
   @override
-  String get user_list_dialog_new_title => 'New list of products';
+  String get user_list_dialog_new_title => 'Ny produktliste';
 
   @override
-  String get user_list_dialog_rename_title => 'Rename list';
+  String get user_list_dialog_rename_title => 'Gi nytt navn til listen';
 
   @override
-  String get user_list_subtitle_product => 'Lists';
+  String get user_list_subtitle_product => 'Lister';
 
   @override
   String get user_list_title => 'Your lists';
 
   @override
-  String get user_list_add_product => 'Add the product to your lists';
+  String get user_list_add_product => 'Legg produktet til i listene dine';
 
   @override
-  String get user_list_button_new => 'Create a new list';
+  String get user_list_button_new => 'Opprett en ny liste';
 
   @override
   String get user_list_empty_label =>
       'No list available yet, please start by creating one';
 
   @override
-  String get user_list_button_add_product => 'Add to list';
+  String get user_list_button_add_product => 'Legg til i listen';
 
   @override
-  String get added_to_list_msg => 'Added to list';
+  String get added_to_list_msg => 'Lagt til i listen';
 
   @override
-  String get user_list_popup_clear => 'Clear your history';
+  String get user_list_popup_clear => 'Tøm historikken din';
 
   @override
-  String get user_list_popup_rename => 'Rename';
+  String get user_list_popup_rename => 'Gi nytt navn';
 
   @override
-  String get user_list_name_hint => 'My list';
+  String get user_list_name_hint => 'Min liste';
 
   @override
-  String get user_list_name_error_empty => 'Name is mandatory';
+  String get user_list_name_error_empty => 'Navn er obligatorisk';
 
   @override
-  String get user_list_name_error_already => 'That name is already used';
+  String get user_list_name_error_already => 'Det navnet er allerede brukt';
 
   @override
-  String get user_list_name_error_same => 'That is the same name';
+  String get user_list_name_error_same => 'Det er det samme navnet';
 
   @override
-  String get user_list_name_input_hint => 'Name of the list';
+  String get user_list_name_input_hint => 'Navnet på listen';
 
   @override
-  String get try_again => 'Try Again';
+  String get try_again => 'Prøv igjen';
 
   @override
-  String get there_was_an_error => 'There was an error';
+  String get there_was_an_error => 'Det oppsto en feil';
 
   @override
   String category_picker_no_category_found_message(String items) {
-    return 'No category found for $items';
+    return 'Ingen kategori funnet for $items';
   }
 
   @override
-  String get camera_toggle_camera => 'Switch between back and front camera';
+  String get camera_toggle_camera => 'Bytt mellom bak- og frontkamera';
 
   @override
-  String get camera_toggle_flash => 'Turn ON or OFF the flash of the camera';
+  String get camera_toggle_flash => 'Slå PÅ eller AV blitsen på kameraet';
 
   @override
-  String get camera_enable_flash => 'Enable flash';
+  String get camera_enable_flash => 'Aktiver blits';
 
   @override
-  String get camera_disable_flash => 'Disable flash';
+  String get camera_disable_flash => 'Deaktiver blits';
 
   @override
-  String get camera_flash_error_dialog_title => 'An error occurred!';
+  String get camera_flash_error_dialog_title => 'Det oppsto en feil!';
 
   @override
   String get camera_flash_error_dialog_message =>
-      'An error occurred while changing the state of your flash. Please ensure your smartphone has not the torch already enabled.';
+      'Det oppsto en feil under endring av blitstilstanden. Sørg for at lommelykten ikke allerede er aktivert på smarttelefonen din.';
 
   @override
-  String get category_picker_no_category_found_button => 'Back';
+  String get category_picker_no_category_found_button => 'Tilbake';
 
   @override
   String get user_preferences_item_accessibility_hint =>
-      'Click to open in your browser or in the application (if installed)';
+      'Klikk for å åpne i nettleseren din eller i applikasjonen (hvis installert)';
 
   @override
-  String get dev_preferences_screen_title => 'DEV Mode';
+  String get dev_preferences_screen_title => 'DEV-modus';
 
   @override
   String get dev_preferences_screen_subtitle =>
       'Få tilgang til eksperimentelle funksjoner og utviklingsverktøy';
 
   @override
-  String get dev_preferences_reset_onboarding_title => 'Restart onboarding';
+  String get dev_preferences_reset_onboarding_title =>
+      'Start omstart av onboarding';
 
   @override
   String get dev_preferences_reset_onboarding_subtitle =>
-      'You then have to restart the App to see it again.';
+      'Deretter må du starte appen på nytt for å se den igjen.';
 
   @override
   String get dev_preferences_environment_switch_title =>
-      'Switch between openfoodfacts.org (PROD) and test env';
+      'Bytt mellom openfoodfacts.org (PROD) og testmiljø';
 
   @override
   String get dev_preferences_test_environment_title =>
-      'Test environment parameters';
+      'Parametere for testmiljø';
 
   @override
   String dev_preferences_test_environment_subtitle(String url) {
-    return 'Base URL for current test env: $url';
+    return 'Basis-URL for gjeldende testmiljø: $url';
   }
 
   @override
-  String get dev_preferences_test_environment_dialog_title =>
-      'Test environment host';
+  String get dev_preferences_test_environment_dialog_title => 'Testmiljøvert';
 
   @override
-  String get dev_preferences_ml_kit_title => 'Use ML Kit';
+  String get dev_preferences_ml_kit_title => 'Bruk ML-settet';
 
   @override
   String get dev_preferences_ml_kit_subtitle =>
-      'then you have to restart this app';
+      'så må du starte denne appen på nytt';
 
   @override
   String get dev_preferences_product_additional_features_title =>
-      'Additional button on product page';
+      'Ekstra knapp på produktsiden';
 
   @override
   String get dev_preferences_edit_ingredients_title =>
-      'Edit ingredients via a knowledge panel button';
+      'Rediger ingredienser via en kunnskapspanelknapp';
 
   @override
-  String get dev_preferences_export_history_title => 'Export History';
+  String get dev_preferences_export_history_title => 'Eksportlogg';
 
   @override
-  String get dev_preferences_export_history_progress_error => 'exception';
+  String get dev_preferences_export_history_progress_error => 'unntak';
 
   @override
-  String get dev_preferences_export_history_progress_found => 'product found';
+  String get dev_preferences_export_history_progress_found => 'produkt funnet';
 
   @override
   String get dev_preferences_export_history_progress_not_found =>
-      'product NOT found';
+      'produktet IKKE funnet';
 
   @override
-  String get dev_preferences_export_history_dialog_title => 'Export history';
+  String get dev_preferences_export_history_dialog_title => 'Eksportlogg';
 
   @override
   String get dev_preferences_button_positive => 'OK';
@@ -2457,7 +2487,7 @@ class AppLocalizationsNn extends AppLocalizations {
   String get dev_preferences_button_negative => 'Cancel';
 
   @override
-  String get dev_preferences_migration_title => 'Data migration from V1';
+  String get dev_preferences_migration_title => 'Datamigrering fra V1';
 
   @override
   String dev_preferences_migration_subtitle(String status) {
@@ -2466,91 +2496,91 @@ class AppLocalizationsNn extends AppLocalizations {
 
   @override
   String get dev_preferences_migration_status_already_done =>
-      'success or fresh install';
+      'suksess eller ny installasjon';
 
   @override
-  String get dev_preferences_migration_status_success => 'success';
+  String get dev_preferences_migration_status_success => 'suksess';
 
   @override
-  String get dev_preferences_migration_status_error => 'error';
+  String get dev_preferences_migration_status_error => 'feil';
 
   @override
-  String get dev_preferences_migration_status_in_progress => 'in progress';
+  String get dev_preferences_migration_status_in_progress => 'pågår';
 
   @override
   String get dev_preferences_migration_status_required =>
-      'required (click to start)';
+      'obligatorisk (klikk for å starte)';
 
   @override
-  String get dev_preferences_migration_status_not_started => 'unknown';
+  String get dev_preferences_migration_status_not_started => 'ukjent';
 
   @override
   String get dev_preferences_import_history_subtitle =>
-      'Will clear history and put 3 products in there';
+      'Vil slette historikken og legge inn 3 produkter der';
 
   @override
-  String get dev_preferences_news_custom_url_title => 'Custom URL for news';
+  String get dev_preferences_news_custom_url_title =>
+      'Tilpasset URL for nyheter';
 
   @override
   String get dev_preferences_news_custom_url_subtitle =>
-      'URL of the JSON file:';
+      'URL-adressen til JSON-filen:';
 
   @override
-  String get dev_preferences_news_custom_url_empty_value => 'Not set';
+  String get dev_preferences_news_custom_url_empty_value => 'Ikke angitt';
 
   @override
   String get dev_preferences_news_provider_status_title => 'Status';
 
   @override
   String dev_preferences_news_provider_status_subtitle(String date) {
-    return 'Last refresh: $date';
+    return 'Siste oppdatering: $date';
   }
 
   @override
-  String get product_type_label_food => 'Food';
+  String get product_type_label_food => 'Mat';
 
   @override
-  String get product_type_label_beauty => 'Personal care';
+  String get product_type_label_beauty => 'Personlig pleie';
 
   @override
-  String get product_type_label_pet_food => 'Pet food';
+  String get product_type_label_pet_food => 'Kjæledyrfôr';
 
   @override
   String get product_type_label_product => 'Other';
 
   @override
-  String get product_type_selection_title => 'Product type';
+  String get product_type_selection_title => 'Produkttype';
 
   @override
-  String get product_type_selection_subtitle =>
-      'Select the type of this product';
+  String get product_type_selection_subtitle => 'Velg typen av dette produktet';
 
   @override
   String get product_type_selection_empty =>
-      'You need to select a product type first!';
+      'Du må velge en produkttype først!';
 
   @override
   String product_type_selection_already(String productType) {
-    return 'You cannot change the product type ($productType)!';
+    return 'Du kan ikke endre produkttypen ($productType)!';
   }
 
   @override
   String get prices_app_dev_mode_flag =>
-      'Shortcut to Prices app on product page';
+      'Snarvei til Priser-appen på produktsiden';
 
   @override
-  String get prices_app_button => 'Go to Prices app';
+  String get prices_app_button => 'Gå til Priser-appen';
 
   @override
   String get prices_website_button => 'Åpne på nettsiden for åpne priser';
 
   @override
   String get prices_bulk_proof_upload_select =>
-      'Add price tags directly from gallery';
+      'Legg til prislapper direkte fra galleriet';
 
   @override
   String get prices_bulk_proof_upload_warning =>
-      'Once you\'ve selected images, you won\'t be able to edit them!';
+      'Når du har valgt bilder, kan du ikke redigere dem!';
 
   @override
   String get prices_bulk_proof_upload_warning_ai =>
@@ -2561,10 +2591,10 @@ class AppLocalizationsNn extends AppLocalizations {
       'La fellesskapet validere priser hentet ut av AI.';
 
   @override
-  String get prices_bulk_proof_upload_subtitle => 'Multiple Price Tags';
+  String get prices_bulk_proof_upload_subtitle => 'Flere prislapper';
 
   @override
-  String get prices_bulk_proof_upload_title => 'Bulk Proof Upload';
+  String get prices_bulk_proof_upload_title => 'Masseopplasting av bevis';
 
   @override
   String get prices_bulk_proof_upload_step_selecting => 'Velge filer';
@@ -2588,15 +2618,15 @@ class AppLocalizationsNn extends AppLocalizations {
   }
 
   @override
-  String get prices_generic_title => 'Prices';
+  String get prices_generic_title => 'Priser';
 
   @override
   String prices_add_n_prices(num count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'Add $count prices',
-      one: 'Add a price',
+      other: 'Legg til $count priser',
+      one: 'Legg til en pris',
     );
     return '$_temp0';
   }
@@ -2606,42 +2636,42 @@ class AppLocalizationsNn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'Send $count prices',
-      one: 'Send the price',
+      other: 'Send $count priser',
+      one: 'Send prisen',
     );
     return '$_temp0';
   }
 
   @override
-  String get prices_add_an_item => 'Add an item';
+  String get prices_add_an_item => 'Legg til et element';
 
   @override
-  String get prices_add_a_price => 'Add a price';
+  String get prices_add_a_price => 'Legg til en pris';
 
   @override
-  String get prices_add_a_receipt => 'Add a receipt';
+  String get prices_add_a_receipt => 'Legg til en kvittering';
 
   @override
-  String get prices_add_price_tags => 'Add price tags';
+  String get prices_add_price_tags => 'Legg til prislapper';
 
   @override
   String prices_barcode_already(String barcode) {
-    return 'This barcode ($barcode) is already in the list!';
+    return 'Denne strekkoden ($barcode) er allerede i listen!';
   }
 
   @override
   String get prices_barcode_search_not_found => 'Product not found';
 
   @override
-  String get prices_barcode_search_none_yet => 'No product yet';
+  String get prices_barcode_search_none_yet => 'Ingen produkt ennå';
 
   @override
   String prices_barcode_search_running(String barcode) {
-    return 'Looking for $barcode';
+    return 'Leter etter $barcode';
   }
 
   @override
-  String get prices_barcode_enter => 'Enter the Barcode';
+  String get prices_barcode_enter => 'Skriv inn strekkoden';
 
   @override
   String get prices_category_enter => 'Vare uten strekkode';
@@ -2668,10 +2698,10 @@ class AppLocalizationsNn extends AppLocalizations {
   String get prices_category_error_mandatory => 'Kategorien er obligatorisk';
 
   @override
-  String get prices_barcode_reader_action => 'Barcode reader';
+  String get prices_barcode_reader_action => 'Strekkodeleser';
 
   @override
-  String get prices_view_prices => 'View the prices';
+  String get prices_view_prices => 'Se prisene';
 
   @override
   String get prices_list_title => 'Prisliste';
@@ -2719,8 +2749,8 @@ class AppLocalizationsNn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count prices',
-      one: '1 price',
+      other: '$count priser',
+      one: '1 pris',
     );
     return '$_temp0 for $product';
   }
@@ -2730,16 +2760,16 @@ class AppLocalizationsNn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'All $count prices',
-      one: 'Only one price',
-      zero: 'No price yet',
+      other: 'Alle $count priser',
+      one: 'Kun én pris',
+      zero: 'Ingen pris ennå',
     );
     return '$_temp0';
   }
 
   @override
   String prices_list_length_many_pages(int pageSize, int total) {
-    return 'Latest $pageSize prices (total: $total)';
+    return 'Siste $pageSize priser (totalt: $total)';
   }
 
   @override
@@ -2749,32 +2779,32 @@ class AppLocalizationsNn extends AppLocalizations {
     String date,
     String user,
   ) {
-    return 'Price: $price / Store: \"$location\" / Published on $date by \"$user\"';
+    return 'Pris: $price / Butikk: \"$location\" / Publisert $date av \"$user\"';
   }
 
   @override
   String prices_open_user_proofs(String user) {
-    return 'Open proofs of \"$user\"';
+    return 'Åpne bevis for «$user»';
   }
 
   @override
-  String get prices_open_proof => 'Open price proof';
+  String get prices_open_proof => 'Åpen prisbevis';
 
   @override
   String prices_proofs_list_length_one_page(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'All $count proofs',
-      one: 'Only one proof',
-      zero: 'No proof yet',
+      other: 'Alle $count bevis',
+      one: 'Bare ett bevis',
+      zero: 'Ingen bevis ennå',
     );
     return '$_temp0';
   }
 
   @override
   String prices_proofs_list_length_many_pages(int pageSize, int total) {
-    return 'Latest $pageSize proofs (total: $total)';
+    return 'Siste $pageSize bevis (totalt: $total)';
   }
 
   @override
@@ -2786,7 +2816,7 @@ class AppLocalizationsNn extends AppLocalizations {
 
   @override
   String prices_users_list_length_many_pages(int pageSize, int total) {
-    return 'Top $pageSize contributors (total: $total)';
+    return 'Topp $pageSize bidragsytere (totalt: $total)';
   }
 
   @override
@@ -2798,7 +2828,7 @@ class AppLocalizationsNn extends AppLocalizations {
 
   @override
   String prices_locations_list_length_many_pages(int pageSize, int total) {
-    return 'Top $pageSize locations (total: $total)';
+    return 'Topp $pageSize steder (totalt: $total)';
   }
 
   @override
@@ -2806,9 +2836,9 @@ class AppLocalizationsNn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count proofs',
-      one: 'One proof',
-      zero: 'No proof',
+      other: '$count bevis',
+      one: 'Ett bevis',
+      zero: 'Ingen bevis',
     );
     return '$_temp0';
   }
@@ -2818,9 +2848,9 @@ class AppLocalizationsNn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count products',
-      one: 'One product',
-      zero: 'No product',
+      other: '$count produkter',
+      one: 'Ett produkt',
+      zero: 'Ingen produkter',
     );
     return '$_temp0';
   }
@@ -2830,9 +2860,9 @@ class AppLocalizationsNn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count users',
-      one: 'One user',
-      zero: 'No user',
+      other: '$count brukere',
+      one: 'Én bruker',
+      zero: 'Ingen bruker',
     );
     return '$_temp0';
   }
@@ -2842,9 +2872,9 @@ class AppLocalizationsNn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count prices',
-      one: 'One price',
-      zero: 'No price',
+      other: '$count priser',
+      one: 'Én pris',
+      zero: 'Ingen pris',
     );
     return '$_temp0';
   }
@@ -2853,50 +2883,50 @@ class AppLocalizationsNn extends AppLocalizations {
   String get prices_amount_existing_subtitle => 'Pris lagt til tidligere';
 
   @override
-  String get prices_amount_subtitle => 'Amount';
+  String get prices_amount_subtitle => 'Beløp';
 
   @override
-  String get prices_amount_is_discounted => 'Is discounted?';
+  String get prices_amount_is_discounted => 'Er det rabattert?';
 
   @override
-  String get prices_amount_price_normal => 'Price';
+  String get prices_amount_price_normal => 'Pris';
 
   @override
-  String get prices_amount_price_discounted => 'Discounted price';
+  String get prices_amount_price_discounted => 'Rabattert pris';
 
   @override
-  String get prices_amount_price_not_discounted => 'Original price';
+  String get prices_amount_price_not_discounted => 'Opprinnelig pris';
 
   @override
-  String get prices_amount_no_product => 'One product is missing!';
+  String get prices_amount_no_product => 'Ett produkt mangler!';
 
   @override
-  String get prices_amount_price_incorrect => 'Incorrect value';
+  String get prices_amount_price_incorrect => 'Feil verdi';
 
   @override
-  String get prices_amount_price_mandatory => 'Mandatory value';
+  String get prices_amount_price_mandatory => 'Obligatorisk verdi';
 
   @override
   String get prices_currency_subtitle => 'Valuta';
 
   @override
-  String get prices_date_subtitle => 'Date';
+  String get prices_date_subtitle => 'Dato';
 
   @override
-  String get prices_location_subtitle => 'Shop';
+  String get prices_location_subtitle => 'Butikk';
 
   @override
-  String get prices_location_find => 'Find a shop';
+  String get prices_location_find => 'Finn en butikk';
 
   @override
-  String get prices_location_mandatory => 'You need to select a shop!';
+  String get prices_location_mandatory => 'Du må velge en butikk!';
 
   @override
   String get prices_location_search_broader =>
-      'Couldn\'t find what you were looking for? Let\'s try a broader search!';
+      'Fant du ikke det du lette etter? La oss prøve et bredere søk!';
 
   @override
-  String get prices_proof_subtitle => 'Proof';
+  String get prices_proof_subtitle => 'Bevis';
 
   @override
   String get prices_proof_empty_title => 'Ingen bevis ennå!';
@@ -2906,103 +2936,104 @@ class AppLocalizationsNn extends AppLocalizations {
       'Start med å legge til et bilde av en **kvittering** eller en **prislapp**!';
 
   @override
-  String get prices_proof_find => 'Select a proof';
+  String get prices_proof_find => 'Velg et bevis';
 
   @override
-  String get prices_proof_change => 'Change proof';
+  String get prices_proof_change => 'Endringsbevis';
 
   @override
-  String get prices_proof_receipt => 'Receipt';
+  String get prices_proof_receipt => 'Kvittering';
 
   @override
-  String get prices_proof_price_tag => 'Price tag';
+  String get prices_proof_price_tag => 'Prislapp';
 
   @override
-  String get prices_proof_mandatory => 'You need to select a proof!';
+  String get prices_proof_mandatory => 'Du må velge et bevis!';
 
   @override
-  String get prices_add_validation_error => 'Validation error';
+  String get prices_add_validation_error => 'Valideringsfeil';
 
   @override
-  String get prices_privacy_warning_title => 'Privacy warning';
+  String get prices_privacy_warning_title => 'Personvernadvarsel';
 
   @override
-  String get prices_unknown_product => 'Unknown product';
+  String get prices_unknown_product => 'Ukjent produkt';
 
   @override
   String get prices_privacy_warning_main_message =>
-      'Prices **will be public**, along with the store they refer to.\n\nThat might allow people who know about your Open Food Facts pseudonym to:\n';
+      'Prisene **vil være offentlige**, sammen med butikken de refererer til.\n\nDet kan gjøre det mulig for folk som kjenner til pseudonymet ditt fra Open Food Facts å:\n';
 
   @override
   String get prices_privacy_warning_message_bullet_1 =>
-      'Infer in which area you live';
+      'Gjenkjenn hvilket område du bor i';
 
   @override
-  String get prices_privacy_warning_message_bullet_2 =>
-      'Know what you are buying';
+  String get prices_privacy_warning_message_bullet_2 => 'Vit hva du kjøper';
 
   @override
   String get prices_privacy_warning_sub_message =>
-      'If you are uneasy with that, please change your pseudonym, or create a new Open Food Facts account and log into the app with it.';
+      'Hvis du er usikker på det, kan du endre pseudonymet ditt, eller opprette en ny Open Food Facts-konto og logge inn på appen med den.';
 
   @override
-  String get i_refuse => 'I refuse';
+  String get i_refuse => 'Jeg nekter';
 
   @override
-  String get i_accept => 'I accept';
+  String get i_accept => 'Jeg aksepterer';
 
   @override
-  String get prices_currency_change_proposal_title => 'Change the currency?';
+  String get prices_currency_change_proposal_title => 'Endre valutaen?';
 
   @override
   String prices_currency_change_proposal_message(
     String currency,
     String newCurrency,
   ) {
-    return 'Your current currency is **$currency**. Would you like to change it to **$newCurrency**?';
+    return 'Din nåværende valuta er **$currency**. Vil du endre den til **$newCurrency**?';
   }
 
   @override
   String prices_currency_change_proposal_action_approve(String newCurrency) {
-    return 'Yes, use $newCurrency';
+    return 'Ja, bruk $newCurrency';
   }
 
   @override
   String prices_currency_change_proposal_action_cancel(String currency) {
-    return 'No, keep $currency';
+    return 'Nei, behold $currency';
   }
 
   @override
-  String get prices_menu_know_more => 'Know more about Open Prices';
+  String get prices_menu_know_more => 'Lær mer om åpne priser';
 
   @override
-  String get dev_preferences_import_history_result_success => 'Done';
+  String get dev_preferences_import_history_result_success => 'Ferdig';
 
   @override
-  String get dev_mode_section_server => 'Server configuration';
+  String get dev_mode_section_server => 'Serverkonfigurasjon';
 
   @override
-  String get dev_mode_section_news => 'News provider configuration';
+  String get dev_mode_section_news => 'Konfigurasjon av nyhetsleverandør';
 
   @override
-  String get dev_mode_section_product_page => 'Product page';
+  String get dev_mode_section_product_page => 'Produktside';
 
   @override
-  String get dev_mode_section_ui => 'User Interface';
+  String get dev_mode_section_ui => 'Brukergrensesnitt';
 
   @override
-  String get dev_mode_section_experimental_features => 'Experimental features';
+  String get dev_mode_section_experimental_features =>
+      'Eksperimentelle funksjoner';
 
   @override
-  String get dev_mode_hide_environmental_score_title => 'Exclude Green Score';
+  String get dev_mode_hide_environmental_score_title =>
+      'Ekskluder grønn poengsum';
 
   @override
   String get dev_mode_spellchecker_for_ocr_title =>
-      'Use a spellchecker for OCR screens';
+      'Bruk en stavekontroll for OCR-skjermer';
 
   @override
   String get dev_mode_spellchecker_for_ocr_subtitle =>
-      '(Ingredients and packaging)';
+      '(Ingredienser og emballasje)';
 
   @override
   String get dev_mode_reset_app_language_title => 'Tilbakestill appspråk';
@@ -3015,14 +3046,15 @@ class AppLocalizationsNn extends AppLocalizations {
       'Bytt mellom prices.openfoodfacts.org (PROD) og testmiljø';
 
   @override
-  String get search_history_item_edit_tooltip => 'Reuse and edit this search';
+  String get search_history_item_edit_tooltip =>
+      'Bruk og rediger dette søket på nytt';
 
   @override
-  String get search_history_item_remove_tooltip => 'Remove';
+  String get search_history_item_remove_tooltip => 'Fjerne';
 
   @override
   String product_search_no_more_results(int totalSize) {
-    return 'You\'ve downloaded all the $totalSize products.';
+    return 'Du har lastet ned alle $totalSize -produktene.';
   }
 
   @override
@@ -3031,38 +3063,39 @@ class AppLocalizationsNn extends AppLocalizations {
     int downloaded,
     int totalSize,
   ) {
-    return 'Download $count more products\nAlready downloaded $downloaded out of $totalSize.';
+    return 'Last ned $count flere produkter\nAllerede lastet ned $downloaded av $totalSize.';
   }
 
   @override
   String product_search_loading_message(Object search) {
-    return 'Your search of $search is in progress.\n\nPlease wait a few seconds…';
+    return 'Søket ditt etter $search pågår.\n\nVent noen sekunder…';
   }
 
   @override
-  String get user_search_contributor_title => 'Products I added';
+  String get user_search_contributor_title => 'Produkter jeg har lagt til';
 
   @override
-  String get user_search_informer_title => 'Products I edited';
+  String get user_search_informer_title => 'Produkter jeg redigerte';
 
   @override
-  String get user_search_photographer_title => 'Products I photographed';
+  String get user_search_photographer_title => 'Produkter jeg fotograferte';
 
   @override
-  String get user_search_to_be_completed_title => 'My to-be-completed products';
+  String get user_search_to_be_completed_title =>
+      'Mine produkter som skal fullføres';
 
   @override
-  String get user_search_prices_title => 'My prices';
+  String get user_search_prices_title => 'Mine priser';
 
   @override
-  String get user_search_proofs_title => 'My proofs';
+  String get user_search_proofs_title => 'Mine bevis';
 
   @override
-  String get user_search_proof_title => 'My proof';
+  String get user_search_proof_title => 'Mitt bevis';
 
   @override
   String search_proof_title(String user) {
-    return 'Proof from \"$user\"';
+    return 'Bevis fra «$user»';
   }
 
   @override
@@ -3071,17 +3104,17 @@ class AppLocalizationsNn extends AppLocalizations {
   }
 
   @override
-  String get all_search_prices_latest_title => 'Latest Prices added';
+  String get all_search_prices_latest_title => 'Siste priser lagt til';
 
   @override
-  String get all_search_prices_top_user_title => 'Top price contributors';
+  String get all_search_prices_top_user_title => 'De største prisbidragsyterne';
 
   @override
   String get all_search_prices_top_location_title =>
-      'Stores with the most prices';
+      'Butikkene med de høyeste prisene';
 
   @override
-  String get prices_contribution_assistant => 'Price Contribution Assistant';
+  String get prices_contribution_assistant => 'Assistent for prisbidrag';
 
   @override
   String get prices_validation_assistant => 'Price Validation Assistant';
@@ -3090,63 +3123,66 @@ class AppLocalizationsNn extends AppLocalizations {
   String get prices_challenges_page => 'Challenges';
 
   @override
-  String get prices_multiple_proof_addition_system => 'Add Multiple Proofs';
+  String get prices_multiple_proof_addition_system => 'Legg til flere bevis';
 
   @override
-  String get all_search_prices_top_location_single_title => 'Prices in a store';
+  String get all_search_prices_top_location_single_title =>
+      'Priser i en butikk';
 
   @override
   String get all_search_prices_top_product_title =>
-      'Products with the most prices';
+      'Produktene med høyest pris';
 
   @override
-  String get all_search_to_be_completed_title => 'All to-be-completed products';
+  String get all_search_to_be_completed_title =>
+      'Alle produkter som skal ferdigstilles';
 
   @override
   String get categorize_products_country_title =>
-      'Help categorize products in your country';
+      'Hjelp med å kategorisere produkter i landet ditt';
 
   @override
-  String get edit_product_action_retake_picture => 'Retake photo';
+  String get edit_product_action_retake_picture => 'Ta bildet på nytt';
 
   @override
-  String get edit_product_action_take_picture => 'Take photo';
+  String get edit_product_action_take_picture => 'Ta bilde';
 
   @override
-  String get edit_product_action_confirm => 'Confirm';
+  String get edit_product_action_confirm => 'Bekrefte';
 
   @override
   String get signup_page_terms_of_use_line1 =>
-      'I agree to the Open Food Facts ';
+      'Jeg godtar de åpne matfaktaene ';
 
   @override
-  String get signup_page_terms_of_use_line2 => 'terms of use and contribution';
+  String get signup_page_terms_of_use_line2 => 'bruksvilkår og bidrag';
 
   @override
-  String get analytics_consent_image_semantic_label => 'Analytics icon';
+  String get analytics_consent_image_semantic_label => 'Analytics-ikon';
 
   @override
   String knowledge_panel_page_loading_error(Object? error) {
-    return 'Fatal Error: $error';
+    return 'Fatal feil: $error';
   }
 
   @override
   String preferences_page_loading_error(Object? error) {
-    return 'Fatal Error: $error';
+    return 'Fatal feil: $error';
   }
 
   @override
-  String get summary_card_button_add_basic_details => 'Complete basic details';
+  String get summary_card_button_add_basic_details =>
+      'Fullfør grunnleggende detaljer';
 
   @override
   String get edit_photo_button_label => 'Edit';
 
   @override
-  String get edit_photo_unselect_button_label => 'Unselect photo';
+  String get edit_photo_unselect_button_label => 'Fjern valg av bilde';
 
   @override
   String get edit_photo_select_existing_button_label =>
-      'Select an existing image';
+      'Velg et eksisterende bilde';
 
   @override
   String get edit_photo_select_existing_all_label =>
@@ -3154,52 +3190,52 @@ class AppLocalizationsNn extends AppLocalizations {
 
   @override
   String get edit_photo_select_existing_all_subtitle =>
-      'Select an image by clicking on it';
+      'Velg et bilde ved å klikke på det';
 
   @override
   String get edit_photo_select_existing_download_label =>
-      'Retrieving existing images…';
+      'Henter eksisterende bilder…';
 
   @override
   String get edit_photo_select_existing_downloaded_none =>
-      'There are no images previously uploaded related to this product.';
+      'Det er ingen bilder lastet opp tidligere relatert til dette produktet.';
 
   @override
   String get edit_photo_language_not_this_one =>
-      'No image in that language yet';
+      'Ingen bilder på det språket ennå';
 
   @override
-  String get edit_photo_language_none => 'No image yet';
+  String get edit_photo_language_none => 'Ikke noe bilde ennå';
 
   @override
   String get category_picker_screen_title => 'Kategorier';
 
   @override
-  String get basic_details => 'Basic Details';
+  String get basic_details => 'Grunnleggende detaljer';
 
   @override
-  String get product_name => 'Product Name';
+  String get product_name => 'Produktnavn';
 
   @override
-  String get product_names => 'Product Names';
+  String get product_names => 'Produktnavn';
 
   @override
   String get add_basic_details_product_name_add_translation =>
-      'Add a new translation';
+      'Legg til en ny oversettelse';
 
   @override
   String get add_basic_details_product_name_warning_translations =>
-      'Before validating, please ensure you only add a translation **if the language is present on the packaging**';
+      'Før du validerer, må du bare legge til en oversettelse **hvis språket står på emballasjen**';
 
   @override
-  String get add_basic_details_product_name_open_photo => 'View front photo';
+  String get add_basic_details_product_name_open_photo => 'Se forsidebilde';
 
   @override
-  String get add_basic_details_product_name_take_photo => 'Take front photo';
+  String get add_basic_details_product_name_take_photo => 'Ta et bilde foran';
 
   @override
   String get add_basic_details_product_name_hint =>
-      'Input the name of the product (eg: Nutella)';
+      'Skriv inn navnet på produktet (f.eks. Nutella)';
 
   @override
   String get add_basic_details_product_name_change_main_language_title =>
@@ -3213,41 +3249,41 @@ class AppLocalizationsNn extends AppLocalizations {
   }
 
   @override
-  String get explanation_section_good_examples => 'Good examples';
+  String get explanation_section_good_examples => 'Gode eksempler';
 
   @override
-  String get explanation_section_bad_examples => 'Bad examples';
+  String get explanation_section_bad_examples => 'Dårlige eksempler';
 
   @override
   String get add_basic_details_product_name_help_title =>
-      'Good practices: Product name';
+      'God praksis: Produktnavn';
 
   @override
   String get add_basic_details_product_name_help_info1 =>
-      'The product name is the **main name printed on the packaging**. It can be a registered trademark.';
+      'Produktnavnet er **hovednavnet som er trykt på emballasjen**. Det kan være et registrert varemerke.';
 
   @override
   String get add_basic_details_product_name_help_info2 =>
-      '**Note:** Please don\'t add a translation **if the language is not present on the packaging**.';
+      '**Merk:** Vennligst ikke legg til en oversettelse **hvis språket ikke finnes på emballasjen**.';
 
   @override
   String get add_basic_details_product_name_help_good_examples_1 => 'Nesquik';
 
   @override
   String get add_basic_details_product_name_help_good_examples_2 =>
-      'Tomato Ketchup';
+      'Tomatketchup';
 
   @override
   String get add_basic_details_product_name_help_bad_examples_1_explanation =>
-      'Don\'t include the brand in the name';
+      'Ikke ta med merkevaren i navnet';
 
   @override
   String get add_basic_details_product_name_help_bad_examples_1_example =>
-      'Tomato Ketchup **by Heinz**';
+      'Tomatketchup **fra Heinz**';
 
   @override
   String get add_basic_details_product_name_help_bad_examples_2_explanation =>
-      'Don\'t use symbols ®, ™, © or similar';
+      'Ikke bruk symbolene ®, ™, © eller lignende';
 
   @override
   String get add_basic_details_product_name_help_bad_examples_2_example =>
@@ -3258,58 +3294,59 @@ class AppLocalizationsNn extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count other translations',
-      one: '$count other translation',
+      other: '$count andre oversettelser',
+      one: '$count annen oversettelse',
     );
     return '$_temp0';
   }
 
   @override
-  String get brand_name => 'Brand name';
+  String get brand_name => 'Merkenavn';
 
   @override
-  String get brand_names => 'Brand names';
+  String get brand_names => 'Merkenavn';
 
   @override
   String get add_basic_details_brand_name_error =>
-      'Please enter the brand name';
+      'Vennligst skriv inn merkenavnet';
 
   @override
-  String get add_basic_details_brand_names_hint => 'Input brands (eg: Ferrero)';
+  String get add_basic_details_brand_names_hint =>
+      'Merker av innsatsfaktorer (f.eks. Ferrero)';
 
   @override
   String get add_basic_details_product_brand_help_title =>
-      'Good practices: Brands';
+      'God praksis: Merker';
 
   @override
   String get add_basic_details_product_brand_help_info1 =>
-      'Input **all the brands of the product**.';
+      'Skriv inn **alle merkene til produktet**.';
 
   @override
-  String get add_basic_details_product_brand_help_info2_title => 'Main brand';
+  String get add_basic_details_product_brand_help_info2_title => 'Hovedmerke';
 
   @override
   String get add_basic_details_product_brand_help_info2_content =>
-      'The **main brand**, generally clearly displayed on the front pack, should be **entered first**.';
+      '**Hovedmerket**, som vanligvis vises tydelig på forsiden av pakken, skal **oppgis først**.';
 
   @override
-  String get add_basic_details_product_brand_help_info3_title => 'Other brands';
+  String get add_basic_details_product_brand_help_info3_title => 'Andre merker';
 
   @override
   String get add_basic_details_product_brand_help_info3_item1_text =>
-      'When sold **by a big company**:';
+      'Når det selges **av et stort selskap**:';
 
   @override
   String get add_basic_details_product_brand_help_info3_item1_explanation =>
-      '**Actimel** is sold by **Danone**';
+      '**Actimel** selges av **Danone**';
 
   @override
   String get add_basic_details_product_brand_help_info3_item2_text =>
-      'When sold with its brand **translated in multiple languages**:';
+      'Når det selges med sitt merke **oversatt til flere språk**:';
 
   @override
   String get add_basic_details_product_brand_help_info3_item2_explanation =>
-      '**Nature Valley** is sometimes written **Val Nature**';
+      '**Nature Valley** skrives noen ganger som **Val Nature**';
 
   @override
   String get add_basic_details_product_brand_help_good_examples_1 => 'Nutella';
@@ -3319,181 +3356,182 @@ class AppLocalizationsNn extends AppLocalizations {
       'Oreo, Mondelez';
 
   @override
-  String get quantity => 'Quantity and weight';
+  String get quantity => 'Mengde og vekt';
 
   @override
   String get add_basic_details_quantity_hint =>
-      'Input the weight and if needed the quantity (eg : 4x100g)';
+      'Skriv inn vekten og om nødvendig mengden (f.eks.: 4 x 100 g)';
 
   @override
   String get add_basic_details_product_quantity_help_title =>
-      'Good practices: Quantity';
+      'God praksis: Mengde';
 
   @override
   String get add_basic_details_product_quantity_help_info1 =>
-      'Copy the value indicated on the product and **don\'t forget the units**.';
+      'Kopier verdien som er angitt på produktet, og **ikke glem enhetene**.';
 
   @override
   String get add_basic_details_product_quantity_help_good_examples_1 =>
-      '**230g** or **230 g**';
+      '**230 g** eller **230 g**';
 
   @override
   String get add_basic_details_product_quantity_help_good_examples_2 =>
-      '**6** (for 6 eggs)';
+      '**6** (for 6 egg)';
 
   @override
   String get add_basic_details_product_quantity_help_good_examples_3 =>
-      '**3 x 150g**\n(for a product with 3 boxes, each of 150g)';
+      '**3 x 150 g**\n(for et produkt med 3 esker, hver på 150 g)';
 
   @override
   String get barcode => 'Strekkode';
 
   @override
   String barcode_barcode(String barcode) {
-    return 'Barcode: $barcode';
+    return 'Strekkode: $barcode';
   }
 
   @override
-  String get barcode_invalid_error => 'Invalid barcode';
+  String get barcode_invalid_error => 'Ugyldig strekkode';
 
   @override
-  String get basic_details_add_success => 'Basic details added successfully';
+  String get basic_details_add_success => 'Grunnleggende detaljer er lagt til';
 
   @override
   String get basic_details_add_error =>
-      'Unable to add basic details. Please try again after some time';
+      'Kan ikke legge til grunnleggende detaljer. Prøv igjen om en stund.';
 
   @override
-  String get clear_search => 'Clear your search';
+  String get clear_search => 'Fjern søket ditt';
 
   @override
   String get confirm_clear =>
-      'You\'re about to clear your entire history: are you sure you want to continue?';
+      'Du er i ferd med å slette hele historikken din: er du sikker på at du vil fortsette?';
 
   @override
   String get alert_clear_selected_user_list =>
-      'You\'re about to clear selected items in your history';
+      'Du er i ferd med å slette valgte elementer i historikken din';
 
   @override
   String get confirm_clear_selected_user_list =>
-      'Are you sure you want to continue?';
+      'Er du sikker på at du vil fortsette?';
 
   @override
   String get alert_select_items_to_clear =>
-      'Please select one or more items to clear';
+      'Vennligst velg ett eller flere elementer som skal fjernes';
 
   @override
   String confirm_clear_user_list(String name) {
-    return 'You\'re about to clear this list ($name): are you sure you want to continue?';
+    return 'Du er i ferd med å tømme denne listen ($name): er du sikker på at du vil fortsette?';
   }
 
   @override
-  String get confirm_delete_user_list_title => 'Delete the list?';
+  String get confirm_delete_user_list_title => 'Slette listen?';
 
   @override
   String confirm_delete_user_list_message(String name) {
-    return 'You\'re about to delete the list \"$name\".\nAre you sure you want to continue?';
+    return 'Du er i ferd med å slette listen «$name».\nEr du sikker på at du vil fortsette?';
   }
 
   @override
-  String get confirm_delete_user_list_button => 'Yes, I confirm';
+  String get confirm_delete_user_list_button => 'Ja, jeg bekrefter';
 
   @override
   String importance_label(String name, String id) {
-    return '$name importance: $id';
+    return '$name viktighet: $id';
   }
 
   @override
-  String get user_list_all_title => 'Lists';
+  String get user_list_all_title => 'Lister';
 
   @override
-  String get user_list_all_empty => 'Create your first list';
+  String get user_list_all_empty => 'Lag din første liste';
 
   @override
-  String get product_list_select => 'Select a list';
+  String get product_list_select => 'Velg en liste';
 
   @override
   String user_list_length(num count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count products',
-      one: 'One product',
-      zero: 'Empty list',
+      other: '$count produkter',
+      one: 'Ett produkt',
+      zero: 'Tom liste',
     );
     return '$_temp0';
   }
 
   @override
-  String get add_list_label => 'Add list';
+  String get add_list_label => 'Legg til liste';
 
   @override
-  String get open_food_preferences_tooltip => 'Edit your food preferences';
+  String get open_food_preferences_tooltip => 'Rediger matpreferansene dine';
 
   @override
-  String get add_photo_button_label => 'Add photo';
+  String get add_photo_button_label => 'Legg til bilde';
 
   @override
   String get add_packaging_photo_button_label =>
-      'Take photos of any packaging/recycling information';
+      'Ta bilder av all emballasje-/resirkuleringsinformasjon';
 
   @override
   String get add_origin_photo_button_label =>
-      'Take photos of any origin information';
+      'Ta bilder av all opprinnelsesinformasjon';
 
   @override
   String get add_emb_photo_button_label =>
-      'Take photos of any traceability code information';
+      'Ta bilder av all sporbarhetskodeinformasjon';
 
   @override
   String get add_label_photo_button_label =>
-      'Take photos of any labels & certifications information';
+      'Ta bilder av all informasjon om etiketter og sertifiseringer';
 
   @override
-  String get choose_image_source_title => 'Choose image source';
+  String get choose_image_source_title => 'Velg bildekilde';
 
   @override
-  String get choose_image_source_body => 'Please choose a image source';
+  String get choose_image_source_body => 'Vennligst velg en bildekilde';
 
   @override
-  String get gallery_source_label => 'Gallery';
+  String get gallery_source_label => 'Galleri';
 
   @override
-  String get gallery_source_access_denied_dialog_title => 'Access denied';
+  String get gallery_source_access_denied_dialog_title => 'Tilgang nektet';
 
   @override
   String get gallery_source_access_denied_dialog_message_ios =>
-      'Unfortunately, the application can\'t access your gallery, as you have previously denied the permission.\n\nPlease go to the app settings in your phone Settings -> Photos';
+      'Dessverre har ikke appen tilgang til galleriet ditt, siden du tidligere har nektet tillatelsen.\n\nGå til appinnstillingene i telefonen din Innstillinger -> Bilder';
 
   @override
-  String get gallery_source_access_denied_dialog_button => 'Open the Settings';
+  String get gallery_source_access_denied_dialog_button =>
+      'Åpne innstillingene';
 
   @override
   String get share => 'Del';
 
   @override
   String share_product_text(String url) {
-    return 'Have a look at this product on Open Food Facts: $url';
+    return 'Ta en titt på dette produktet på Open Food Facts: $url';
   }
 
   @override
   String share_product_text_beauty(String url) {
-    return 'Have a look at this product on Open Beauty Facts: $url';
+    return 'Ta en titt på dette produktet på Open Beauty Facts: $url';
   }
 
   @override
   String share_product_text_pet_food(String url) {
-    return 'Have a look at this product on Open PetFood Facts: $url';
+    return 'Ta en titt på dette produktet på Open PetFood Facts: $url';
   }
 
   @override
   String share_product_text_product(String url) {
-    return 'Have a look at this product on Open Products Facts: $url';
+    return 'Ta en titt på dette produktet på Åpne produktfakta: $url';
   }
 
   @override
   String share_product_list_text(String url) {
-    return 'Have a look at my list of products on Open Food Facts: $url';
+    return 'Ta en titt på produktlisten min på Open Food Facts: $url';
   }
 
   @override
@@ -3503,172 +3541,172 @@ class AppLocalizationsNn extends AppLocalizations {
   String get capture_new_picture => 'Ta et bilde';
 
   @override
-  String get choose_from_gallery => 'Choose from gallery';
+  String get choose_from_gallery => 'Velg fra galleriet';
 
   @override
   String get image_upload_queued =>
-      'The image will be uploaded in the background as soon as possible.';
+      'Bildet lastes opp i bakgrunnen så snart som mulig.';
 
   @override
   String get add_price_queued =>
-      'The price will be sent to the server as soon as possible.';
+      'Prisen vil bli sendt til serveren så snart som mulig.';
 
   @override
   String get background_task_title_full_refresh =>
-      'Starting the refresh of all the products locally stored';
+      'Starter oppdateringen av alle produktene som er lagret lokalt';
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Begynner å utføre serverhandlingene for folksonomi-oppdateringer som er lagret lokalt';
 
   @override
   String get background_task_title_top_n =>
-      'Starting the download of the most popular products';
+      'Starter nedlastingen av de mest populære produktene';
 
   @override
-  String get expand_nutrition_facts => 'Expand nutrition facts table';
+  String get expand_nutrition_facts => 'Utvid tabellen over næringsinnhold';
 
   @override
   String get expand_nutrition_facts_body =>
-      'Keep the nutrition facts table expanded';
+      'Hold næringsinnholdstabellen utvidet';
 
   @override
-  String get expand_ingredients => 'Expand ingredients';
+  String get expand_ingredients => 'Utvid ingredienser';
 
   @override
-  String get expand_ingredients_body => 'Keep the ingredients panel expanded';
+  String get expand_ingredients_body => 'Hold ingredienspanelet utvidet';
 
   @override
-  String get no_internet_connection => 'No internet connection';
+  String get no_internet_connection => 'Ingen internettforbindelse';
 
   @override
-  String get world_results_label => 'Entire world';
+  String get world_results_label => 'Hele verden';
 
   @override
-  String get world_results_action => 'Extend your search to the world';
+  String get world_results_action => 'Utvid søket ditt til verden';
 
   @override
-  String get copy_to_clipboard => 'Copy';
+  String get copy_to_clipboard => 'Kopiere';
 
   @override
-  String get paste_from_clipboard => 'Paste from clipboard';
+  String get paste_from_clipboard => 'Lim inn fra utklippstavlen';
 
   @override
   String get no_data_available_in_clipboard =>
-      'No data available in your clipboard';
+      'Ingen data tilgjengelig på utklippstavlen';
 
   @override
-  String get clipboard_barcode_copy => 'Copy barcode to clipboard';
+  String get clipboard_barcode_copy => 'Kopier strekkoden til utklippstavlen';
 
   @override
   String clipboard_barcode_copied(Object barcode) {
-    return 'Barcode $barcode copied to the clipboard!';
+    return 'Strekkode $barcode kopiert til utklippstavlen!';
   }
 
   @override
-  String get open_product_website => 'Open this product on the website';
+  String get open_product_website => 'Åpne dette produktet på nettsiden';
 
   @override
-  String get language_picker_label => 'Your language';
+  String get language_picker_label => 'Språket ditt';
 
   @override
-  String get country_picker_label => 'Your country';
+  String get country_picker_label => 'Landet ditt';
 
   @override
-  String get currency_picker_label => 'Your currency';
+  String get currency_picker_label => 'Din valuta';
 
   @override
-  String get help_with_openfoodfacts => 'Help with OpenFoodFacts';
+  String get help_with_openfoodfacts => 'Hjelp med OpenFoodFacts';
 
   @override
   String get product_task_background_schedule =>
-      'The product will be updated in the background as soon as possible.';
+      'Produktet vil bli oppdatert i bakgrunnen så snart som mulig.';
 
   @override
-  String get no_email_client_available_dialog_title => 'No email apps!';
+  String get no_email_client_available_dialog_title => 'Ingen e-postapper!';
 
   @override
   String get no_email_client_available_dialog_content =>
-      'Please send us manually an email to mobile@openfoodfacts.org';
+      'Send oss en e-post manuelt til mobile@openfoodfacts.org';
 
   @override
-  String get all_images => 'All Images';
+  String get all_images => 'Alle bilder';
 
   @override
-  String get selected_images => 'Selected Images';
+  String get selected_images => 'Utvalgte bilder';
 
   @override
-  String get product_card_remove_product_tooltip => 'Remove product';
+  String get product_card_remove_product_tooltip => 'Fjern produktet';
 
   @override
   String scan_announce_new_barcode(String barcode) {
-    return 'New barcode scanned: $barcode';
+    return 'Ny strekkode skannet: $barcode';
   }
 
   @override
   String get scan_header_clear_button_tooltip =>
-      'Remove all products from the carousel';
+      'Fjern alle produkter fra karusellen';
 
   @override
   String get scan_header_compare_button_invalid_state_tooltip =>
-      'Please scan at least two products to compare them';
+      'Vennligst skann minst to produkter for å sammenligne dem';
 
   @override
   String get scan_header_compare_button_valid_state_tooltip =>
-      'Click to compare the products you have scanned';
+      'Klikk for å sammenligne produktene du har skannet';
 
   @override
-  String get scan_product_loading => 'You have scanned\nthe barcode:';
+  String get scan_product_loading => 'Du har skannet\nstrekkoden:';
 
   @override
   String get scan_product_loading_initial =>
-      'We\'re looking for this product!\nPlease wait a few seconds…';
+      'Vi ser etter dette produktet!\nVent noen sekunder…';
 
   @override
   String get scan_product_loading_long_request =>
-      'We\'re still looking for this product!\nDo you find it takes a long time to load? So are we…';
+      'Vi leter fortsatt etter dette produktet!\nSynes du det tar lang tid å laste? Det gjør vi også…';
 
   @override
   String get scan_product_loading_unresponsive =>
-      'We\'re still looking for this product.\nWould you like to restart the search?';
+      'Vi leter fortsatt etter dette produktet.\nVil du starte søket på nytt?';
 
   @override
-  String get scan_product_loading_restart_button => 'Restart search';
+  String get scan_product_loading_restart_button => 'Start søket på nytt';
 
   @override
   String get portion_calculator_description =>
-      'Calculate nutrition facts for a specific quantity';
+      'Beregn næringsinnhold for en bestemt mengde';
 
   @override
-  String get portion_calculator_hint => 'Quantity in';
+  String get portion_calculator_hint => 'Antall i';
 
   @override
   String get portion_calculator_accessibility =>
-      'Input a quantity to calculate nutrition facts';
+      'Skriv inn en mengde for å beregne næringsinnhold';
 
   @override
   String portion_calculator_error(int min, int max) {
-    return 'Please enter a quantity between $min and $max g';
+    return 'Vennligst skriv inn en mengde mellom $min og $max g';
   }
 
   @override
   String get portion_calculator_computation_error =>
-      'Missing data. Calculation could not be performed.';
+      'Manglende data. Beregningen kunne ikke utføres.';
 
   @override
   String portion_calculator_result_title(int grams) {
-    return 'Nutrition facts for $grams g (or ml)';
+    return 'Næringsinnhold for $grams g (eller ml)';
   }
 
   @override
-  String get offline_data => 'Offline Data';
+  String get offline_data => 'Frakoblede data';
 
   @override
   String get ocr_image_upload_instruction =>
-      'Upload an image to automatically extract the information it contains.';
+      'Last opp et bilde for å automatisk hente ut informasjonen det inneholder.';
 
   @override
-  String get upload_image => 'Upload Photo';
+  String get upload_image => 'Last opp bilde';
 
   @override
   String get word_separator_char => ',';
@@ -3677,388 +3715,389 @@ class AppLocalizationsNn extends AppLocalizations {
   String get word_separator => ', ';
 
   @override
-  String get image_download_error => 'Failed to download image';
+  String get image_download_error => 'Kunne ikke laste ned bildet';
 
   @override
   String get image_edit_url_error =>
-      'Failed to edit image because the image URL was not set.';
+      'Kunne ikke redigere bildet fordi bilde-URL-en ikke ble angitt.';
 
   @override
-  String get user_picture_source_remember => 'Remember my choice';
+  String get user_picture_source_remember => 'Husk valget mitt';
 
   @override
-  String get user_picture_source_ask => 'Ask each time';
+  String get user_picture_source_ask => 'Spør hver gang';
 
   @override
-  String get robotoff_continue => 'Continue';
+  String get robotoff_continue => 'Fortsette';
 
   @override
   String robotoff_next_n_questions(num count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count questions',
-      one: 'question',
+      other: '$count spørsmål',
+      one: 'spørsmål',
     );
-    return 'Next $_temp0';
+    return 'Neste $_temp0';
   }
 
   @override
-  String get show_password => 'Show Password';
+  String get show_password => 'Vis passord';
 
   @override
-  String get owner_field_info_title => 'Producer provided values';
+  String get owner_field_info_title => 'Produsentens oppgitte verdier';
 
   @override
   String get owner_field_info_message =>
-      'With that logo we highlight data provided by the producer, and that may not be editable.';
+      'Med den logoen fremhever vi data levert av produsenten, og som kanskje ikke kan redigeres.';
 
   @override
-  String get owner_field_info_close_button => 'Close this info';
+  String get owner_field_info_close_button => 'Lukk denne informasjonen';
 
   @override
   String get owner_field_image =>
-      'This image is provided by the producer. It may not be editable.';
+      'Dette bildet er levert av produsenten. Det kan hende det ikke kan redigeres.';
 
   @override
-  String get edit_packagings_title => 'Packaging components';
+  String get edit_packagings_title => 'Emballasjekomponenter';
 
   @override
-  String get edit_packagings_element_add => 'Add a packaging component';
+  String get edit_packagings_element_add => 'Legg til en emballasjekomponent';
 
   @override
-  String get edit_packagings_completed => 'The packaging is complete';
+  String get edit_packagings_completed => 'Emballasjen er komplett';
 
   @override
   String edit_packagings_element_title(int index) {
-    return 'Packaging component #$index';
+    return 'Emballasjekomponent #$index';
   }
 
   @override
-  String get edit_packagings_element_field_units => 'Number of units';
+  String get edit_packagings_element_field_units => 'Antall enheter';
 
   @override
   String get edit_packagings_element_hint_units =>
-      'Enter the number of packaging units of the same shape and material contained in the product.';
+      'Angi antall emballasjeenheter av samme form og materiale som produktet inneholder.';
 
   @override
-  String get edit_packagings_element_field_shape => 'Shape';
+  String get edit_packagings_element_field_shape => 'Form';
 
   @override
   String get edit_packagings_element_hint_shape =>
-      'Enter the shape name listed in the recycling instructions if they are available, or select a shape.';
+      'Skriv inn formnavnet som er oppført i resirkuleringsinstruksjonene hvis de er tilgjengelige, eller velg en form.';
 
   @override
-  String get edit_packagings_element_example_shape => 'Bottle';
+  String get edit_packagings_element_example_shape => 'Flaske';
 
   @override
-  String get edit_packagings_element_field_material => 'Material';
+  String get edit_packagings_element_field_material => 'Materiale';
 
   @override
   String get edit_packagings_element_hint_material =>
-      'Enter the specific material if it can be determined (a material code inside a triangle can often be found on packaging parts), or a generic material (for instance plastic or metal) if you are unsure.';
+      'Oppgi det spesifikke materialet hvis det kan bestemmes (en materialkode inni en trekant finnes ofte på emballasjedelene), eller et generisk materiale (for eksempel plast eller metall) hvis du er usikker.';
 
   @override
   String get edit_packagings_element_example_material => 'Glass';
 
   @override
-  String get edit_packagings_element_field_recycling => 'Recycling instruction';
+  String get edit_packagings_element_field_recycling =>
+      'Instruksjoner for resirkulering';
 
   @override
   String get edit_packagings_element_hint_recycling =>
-      'Enter recycling instructions only if they are listed on the product.';
+      'Skriv bare inn resirkuleringsinstruksjoner hvis de er oppført på produktet.';
 
   @override
-  String get edit_packagings_element_example_recycling => 'Recycle';
+  String get edit_packagings_element_example_recycling => 'Resirkulere';
 
   @override
   String get edit_packagings_element_field_quantity =>
-      'Net quantity of product per unit';
+      'Netto mengde produkt per enhet';
 
   @override
   String get edit_packagings_element_hint_quantity =>
-      'Enter the net weight or net volume and indicate the unit (for example g or ml).';
+      'Skriv inn nettovekten eller nettovolumet og angi enheten (for eksempel g eller ml).';
 
   @override
-  String get edit_packagings_element_field_weight =>
-      'Weight of one empty unit (g)';
+  String get edit_packagings_element_field_weight => 'Vekt av én tom enhet (g)';
 
   @override
   String get edit_packagings_element_hint_weight =>
-      'Remove any remaining food and wash and dry the packaging part before weighing. If possible, use a scale with 0.1g or 0.01g precision.';
+      'Fjern eventuelle matrester og vask og tørk emballasjen før veiing. Bruk om mulig en vekt med 0,1 g eller 0,01 g presisjon.';
 
   @override
-  String get background_task_title => 'Pending contributions';
+  String get background_task_title => 'Ventende bidrag';
 
   @override
   String get background_task_subtitle =>
-      'Your contributions are automatically saved to our server, but not always in real-time.';
+      'Bidragene dine lagres automatisk på serveren vår, men ikke alltid i sanntid.';
 
   @override
-  String get background_task_list_empty => 'No Pending Background Tasks';
+  String get background_task_list_empty => 'Ingen ventende bakgrunnsoppgaver';
 
   @override
-  String get background_task_error_server_time_out => 'Server timeout';
+  String get background_task_error_server_time_out => 'Servertidsavbrudd';
 
   @override
   String get background_task_error_no_internet =>
-      'Internet connection error. Try later.';
+      'Internett-tilkoblingsfeil. Prøv senere.';
 
   @override
-  String get background_task_operation_unknown => 'unknown operation type';
+  String get background_task_operation_unknown => 'ukjent operasjonstype';
 
   @override
-  String get background_task_operation_details => 'detailed changes';
+  String get background_task_operation_details => 'detaljerte endringer';
 
   @override
-  String get background_task_operation_image => 'photo upload';
+  String get background_task_operation_image => 'bildeopplasting';
 
   @override
   String get background_task_operation_refresh =>
-      'refresh delayed after photo upload';
+      'oppdatering forsinket etter bildeopplasting';
 
   @override
-  String get background_task_run_started => 'started';
+  String get background_task_run_started => 'startet';
 
   @override
-  String get background_task_run_not_started => 'not started yet';
+  String get background_task_run_not_started => 'ikke startet ennå';
 
   @override
-  String get background_task_run_to_be_deleted => 'to be deleted';
+  String get background_task_run_to_be_deleted => 'skal slettes';
 
   @override
   String get background_task_question_stop =>
-      'Do you want to stop that task ASAP?';
+      'Vil du stoppe den oppgaven så fort som mulig?';
 
   @override
-  String get feed_back => 'Feedback';
+  String get feed_back => 'Tilbakemelding';
 
   @override
-  String get undo => 'Undo';
+  String get undo => 'Angre';
 
   @override
-  String get copy_email_to_clip_board => 'Copy email to clipboard';
+  String get copy_email_to_clip_board => 'Kopier e-post til utklippstavlen';
 
   @override
-  String get please_send_us_an_email_to =>
-      'Please send us manually an email to';
+  String get please_send_us_an_email_to => 'Send oss en e-post manuelt til';
 
   @override
-  String get email_copied_to_clip_board => 'Email copied to clipboard!';
+  String get email_copied_to_clip_board => 'E-post kopiert til utklippstavlen!';
 
   @override
-  String get select_accent_color => 'Select Accent Color';
+  String get select_accent_color => 'Velg aksentfarge';
 
   @override
   String get theme_amoled => 'AMOLED';
 
   @override
-  String get color_blue => 'Blue';
+  String get color_blue => 'Blå';
 
   @override
   String get color_cyan => 'Cyan';
 
   @override
-  String get color_green => 'Green';
+  String get color_green => 'Grønn';
 
   @override
-  String get color_light_brown => 'Default';
+  String get color_light_brown => 'Misligholde';
 
   @override
   String get color_magenta => 'Magenta';
 
   @override
-  String get color_orange => 'Orange';
+  String get color_orange => 'Oransje';
 
   @override
-  String get color_pink => 'Pink';
+  String get color_pink => 'Rosa';
 
   @override
-  String get color_red => 'Red';
+  String get color_red => 'Rød';
 
   @override
   String get color_rust => 'Rust';
 
   @override
-  String get color_teal => 'Teal';
+  String get color_teal => 'Blågrønn';
 
   @override
-  String get text_contrast_mode => 'Text Contrast';
+  String get text_contrast_mode => 'Tekstkontrast';
 
   @override
-  String get contrast_high => 'High';
+  String get contrast_high => 'Høy';
 
   @override
   String get contrast_medium => 'Medium';
 
   @override
-  String get contrast_low => 'Low';
+  String get contrast_low => 'Lav';
 
   @override
-  String get product_refresher_internet_not_found => 'Product not found!';
+  String get product_refresher_internet_not_found =>
+      'Produktet ble ikke funnet!';
 
   @override
   String get product_refresher_internet_not_connected =>
-      'You are not connected to internet!';
+      'Du er ikke koblet til internett!';
 
   @override
   String product_refresher_internet_no_ping(String? host) {
-    return 'Server down ($host)';
+    return 'Server nede ($host)';
   }
 
   @override
   String product_refresher_internet_error(String? exception) {
-    return 'Server error ($exception)';
+    return 'Serverfeil ($exception)';
   }
 
   @override
-  String get product_loader_not_found_title => 'Product not found!';
+  String get product_loader_not_found_title => 'Produktet ble ikke funnet!';
 
   @override
   String product_loader_not_found_message(String barcode) {
-    return 'A product with the following barcode doesn\'t exist in our database: $barcode';
+    return 'Et produkt med følgende strekkode finnes ikke i databasen vår: $barcode';
   }
 
   @override
-  String get product_loader_network_error_title => 'No internet connection!';
+  String get product_loader_network_error_title =>
+      'Ingen internettforbindelse!';
 
   @override
   String get product_loader_network_error_message =>
-      'Please check that your smartphone is on a WiFi network or has mobile data enabled';
+      'Sjekk at smarttelefonen din er på et WiFi-nettverk eller at mobildata er aktivert';
 
   @override
-  String get page_not_found_title => 'Page not found!';
+  String get page_not_found_title => 'Siden ble ikke funnet!';
 
   @override
-  String get page_not_found_button => 'Go back to the homepage';
+  String get page_not_found_button => 'Gå tilbake til hjemmesiden';
 
   @override
-  String get download_data => 'Download data';
+  String get download_data => 'Last ned data';
 
   @override
   String get download_top_products =>
-      'Download the top 1000 products in your country for instant scanning';
+      'Last ned de 1000 beste produktene i landet ditt for umiddelbar skanning';
 
   @override
   String download_top_n_products(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count products',
+      other: '$count produktene',
     );
-    return 'Download the top $_temp0 in your country for instant scanning';
+    return 'Last ned de beste $_temp0 i ditt land for umiddelbar skanning';
   }
 
   @override
-  String get download_in_progress => 'Downloading data\nThis may take a while';
+  String get download_in_progress => 'Laster ned data\nDette kan ta en stund';
 
   @override
   String downloaded_products(int num) {
-    return '$num products added';
+    return '$num produkter lagt til';
   }
 
   @override
-  String get update_offline_data => 'Update offline product data';
+  String get update_offline_data => 'Oppdater produktdata frakoblet';
 
   @override
   String get update_local_database_sub =>
-      'Update the local product database with the latest data from Open Food Facts';
+      'Oppdater den lokale produktdatabasen med de nyeste dataene fra Open Food Facts';
 
   @override
-  String get clear_local_database => 'Clear offline product data';
+  String get clear_local_database => 'Fjern produktdata frakoblet';
 
   @override
   String get clear_local_database_sub =>
-      'Clear all local product data from your app to free up space';
+      'Fjern all lokal produktdata fra appen din for å frigjøre plass';
 
   @override
   String deleted_products(int num) {
-    return '$num products deleted';
+    return '$num produkter slettet';
   }
 
   @override
   String get loading => 'Laster inn…';
 
   @override
-  String get know_more => 'Know More';
+  String get know_more => 'Lær mer';
 
   @override
-  String get offline_data_desc => 'Click to know more about offline data';
+  String get offline_data_desc => 'Klikk for å finne ut mer om frakoblet data';
 
   @override
-  String get offline_product_data_title => 'Offline product data';
+  String get offline_product_data_title => 'Produktdata frakoblet';
 
   @override
   String available_for_download(int num) {
-    return '$num products available for immediate scaning';
+    return '$num produkter tilgjengelig for umiddelbar skanning';
   }
 
   @override
-  String get country_selector_title => 'Select your country:';
+  String get country_selector_title => 'Velg ditt land:';
 
   @override
   String get currency_selector_title => 'Velg valuta:';
 
   @override
-  String get language_selector_title => 'Select your language:';
+  String get language_selector_title => 'Velg språk:';
 
   @override
-  String get language_selector_section_selected => 'Selected languages';
+  String get language_selector_section_selected => 'Valgte språk';
 
   @override
-  String get language_selector_section_frequently_used => 'Frequently used';
+  String get language_selector_section_frequently_used => 'Ofte brukt';
 
   @override
   String get action_delete_list => 'Slett';
 
   @override
-  String get action_change_list => 'Change the current list';
+  String get action_change_list => 'Endre gjeldende liste';
 
   @override
-  String get product_list_create => 'Create';
+  String get product_list_create => 'Skape';
 
   @override
-  String get product_list_create_tooltip => 'Create a new list';
+  String get product_list_create_tooltip => 'Opprett en ny liste';
 
   @override
   String get nutriscore_generic => 'Nutri-Score';
 
   @override
-  String get nutriscore_a => 'Nutri-Score A';
+  String get nutriscore_a => 'Næringsscore A';
 
   @override
-  String get nutriscore_b => 'Nutri-Score B';
+  String get nutriscore_b => 'Næringsscore B';
 
   @override
-  String get nutriscore_c => 'Nutri-Score C';
+  String get nutriscore_c => 'Næringsscore C';
 
   @override
-  String get nutriscore_d => 'Nutri-Score D';
+  String get nutriscore_d => 'Næringsscore D';
 
   @override
-  String get nutriscore_e => 'Nutri-Score E';
+  String get nutriscore_e => 'Næringsscore E';
 
   @override
   String nutriscore_new_formula(String letter) {
-    return 'Nutri-Score $letter (New calculation)';
+    return 'Nutri-Score $letter (Ny beregning)';
   }
 
   @override
-  String get nutriscore_new_formula_title => 'Nutri-Score (New calculation)';
+  String get nutriscore_new_formula_title => 'Nutri-Score (Ny beregning)';
 
   @override
-  String get nutriscore_unknown => 'Unknown Nutri-Score';
+  String get nutriscore_unknown => 'Ukjent ernæringspoengsum';
 
   @override
   String get nutriscore_unknown_new_formula =>
-      'Unknown Nutri-Score (New calculation)';
+      'Ukjent ernæringspoengsum (ny beregning)';
 
   @override
-  String get nutriscore_not_applicable => 'Nutri-Score is not applicable';
+  String get nutriscore_not_applicable => 'Nutri-Score er ikke aktuelt';
 
   @override
   String get nutriscore_not_applicable_new_formula =>
-      'Nutri-Score is not applicable (New calculation)';
+      'Nutri-Score er ikke aktuelt (ny beregning)';
 
   @override
   String get environmental_score_generic_new => 'Green-Score';
@@ -4089,93 +4128,93 @@ class AppLocalizationsNn extends AppLocalizations {
   String get nova_group_generic_new => 'Ultrabearbeidet mat - NOVA-grupper';
 
   @override
-  String get nova_group_1 => 'NOVA Group 1';
+  String get nova_group_1 => 'NOVA Gruppe 1';
 
   @override
-  String get nova_group_2 => 'NOVA Group 2';
+  String get nova_group_2 => 'NOVA Gruppe 2';
 
   @override
-  String get nova_group_3 => 'NOVA Group 3';
+  String get nova_group_3 => 'NOVA Gruppe 3';
 
   @override
-  String get nova_group_4 => 'NOVA Group 4';
+  String get nova_group_4 => 'NOVA Gruppe 4';
 
   @override
-  String get nova_group_unknown => 'Unknown NOVA Group';
+  String get nova_group_unknown => 'Ukjent NOVA-gruppe';
 
   @override
-  String get nutrition_facts => 'Nutrient Levels';
+  String get nutrition_facts => 'Næringsnivåer';
 
   @override
-  String get faq_title_partners => 'Partners & Patrons of the NGO';
+  String get faq_title_partners => 'Partnere og beskyttere av NGO-en';
 
   @override
   String get faq_title_vision =>
-      'The Open Food Facts Vision, Mission, Values and Programs';
+      'Open Food Facts visjon, oppdrag, verdier og programmer';
 
   @override
   String get faq_title_install_beauty =>
-      'Install Open Beauty Facts to create a cosmetic database';
+      'Installer Open Beauty Facts for å opprette en kosmetisk database';
 
   @override
   String get faq_title_install_pet =>
-      'Install Open Pet Food Facts to create a pet food database';
+      'Installer Open Pet Food Facts for å opprette en database med kjæledyrfôr';
 
   @override
   String get faq_title_install_product =>
-      'Install Open Products Facts to create a products database to extend the life of objects';
+      'Installer Open Products Facts for å opprette en produktdatabase for å forlenge levetiden til objekter.';
 
   @override
   String get faq_nutriscore_nutriscore =>
-      'New calculation of the Nutri-Score: what\'s new?';
+      'Ny beregning av Nutri-Score: hva er nytt?';
 
   @override
   String get contact_title_pro_page =>
-      'Pro? Import your products in Open Food Facts';
+      'Pro? Importer produktene dine i Open Food Facts';
 
   @override
-  String get contact_title_pro_email => 'Producer Contact';
+  String get contact_title_pro_email => 'Produsentkontakt';
 
   @override
-  String get contact_title_press_page => 'Press Page';
+  String get contact_title_press_page => 'Presseside';
 
   @override
-  String get contact_title_press_email => 'Press Contact';
+  String get contact_title_press_email => 'Pressekontakt';
 
   @override
   String get contact_title_newsletter => 'Subscribe to our newsletter';
 
   @override
-  String get contact_title_calendar => 'Subscribe to our community calendar';
+  String get contact_title_calendar => 'Abonner på vår fellesskapskalender';
 
   @override
-  String get hunger_games_loading_line1 => 'Please give us a few seconds…';
+  String get hunger_games_loading_line1 => 'Vennligst gi oss noen sekunder…';
 
   @override
-  String get hunger_games_loading_line2 => 'We\'re downloading the questions!';
+  String get hunger_games_loading_line2 => 'Vi laster ned spørsmålene!';
 
   @override
   String get hunger_games_error_label =>
-      'Argh! Something went wrong… and we couldn\'t load the questions.';
+      'Æsj! Noe gikk galt… , og vi kunne ikke laste inn spørsmålene.';
 
   @override
-  String get hunger_games_error_retry_button => 'Let\'s retry!';
+  String get hunger_games_error_retry_button => 'La oss prøve på nytt!';
 
   @override
-  String get reorder_attribute_action => 'Reorder the attributes';
+  String get reorder_attribute_action => 'Endre rekkefølgen på attributtene';
 
   @override
   String get link_cant_be_opened =>
-      'This link can\'t be opened on your device. Please check that you have a browser installed.';
+      'Denne lenken kan ikke åpnes på enheten din. Sjekk at du har en nettleser installert.';
 
   @override
   String knowledge_panel_page_title_no_title(String productName) {
-    return 'Details for $productName';
+    return 'Detaljer for $productName';
   }
 
   @override
   String knowledge_panel_page_title(String pageName, String productName) {
-    return 'Details for $pageName with $productName';
+    return 'Detaljer for $pageName med $productName';
   }
 
   @override
@@ -4264,15 +4303,15 @@ class AppLocalizationsNn extends AppLocalizations {
 
   @override
   String get guide_nutriscore_v2_where_title =>
-      'Where to find the new Nutri-Score calculation?';
+      'Hvor finner jeg den nye Nutri-Score-beregningen?';
 
   @override
   String get guide_nutriscore_v2_where_paragraph1 =>
-      'The Nutri-Score is applied in 7 countries: France, Germany, Belgium, Spain, Luxembourg, the Netherlands and Switzerland.';
+      'Nutri-Score brukes i 7 land: Frankrike, Tyskland, Belgia, Spania, Luxembourg, Nederland og Sveits.';
 
   @override
   String get guide_nutriscore_v2_where_paragraph2 =>
-      'Manufacturers have at most **2 years** at the latest after the signature of the decree **to replace** the old calculation with the new one.';
+      'Produsentene har maksimalt **2 år** etter at dekretet er undertegnet **til å erstatte** den gamle beregningen med den nye.';
 
   @override
   String get guide_nutriscore_v2_where_paragraph3 =>
@@ -4380,7 +4419,7 @@ class AppLocalizationsNn extends AppLocalizations {
 
   @override
   String get guide_greenscore_bonuses_penalties_intro =>
-      'To reward better products within a category, we then apply **bonuses & penalties based on several criterion**:';
+      'For å belønne bedre produkter innenfor en kategori, bruker vi deretter **bonuser og straffer basert på flere kriterier**:';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg1_title =>
@@ -4388,7 +4427,7 @@ class AppLocalizationsNn extends AppLocalizations {
 
   @override
   String get guide_greenscore_bonuses_penalties_arg1_text =>
-      'A **bonus** is awarded to products that have an **official label, a label or a certification that guarantees environmental benefits** (organic, fair trade, HVE, Label Rouge, Bleu Blanc Cœur, MSC/ASC).';
+      'En **bonus** gis til produkter som har en **offisiell etikett, en etikett eller en sertifisering som garanterer miljøfordeler** (økologisk, rettferdig handel, HVE, Label Rouge, Bleu Blanc Cœur, MSC/ASC).';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg2_title =>
@@ -4396,7 +4435,7 @@ class AppLocalizationsNn extends AppLocalizations {
 
   @override
   String get guide_greenscore_bonuses_penalties_arg2_text =>
-      'A **bonus** is awarded based on the origin of the ingredients. This bonus takes into account the **impact on transportation** and also the **environmental policy** of each producer\'s country.';
+      'En **bonus** tildeles basert på ingrediensenes opprinnelse. Denne bonusen tar hensyn til **påvirkningen på transport** og også **miljøpolitikken** i hver produsents land.';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg3_title =>
@@ -4404,14 +4443,14 @@ class AppLocalizationsNn extends AppLocalizations {
 
   @override
   String get guide_greenscore_bonuses_penalties_arg3_text =>
-      'A **penalty** is given to products that contain ingredients that have significant **negative impacts on biodiversity and ecosystems**, such as palm oil, the production of which is responsible for massive deforestation.';
+      'Det gis en **straff** til produkter som inneholder ingredienser som har betydelig **negativ innvirkning på biologisk mangfold og økosystemer**, som for eksempel palmeolje, hvis produksjon er ansvarlig for massiv avskoging.';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg4_title => 'Emballasje';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg4_text =>
-      'A **penalty** is calculated to take into account the **circularity of packaging** (use of recycled raw material and recyclability) and overpacking.';
+      'En **straff** beregnes for å ta hensyn til **emballasjens sirkularitet** (bruk av resirkulert råmateriale og resirkulerbarhet) og overpakking.';
 
   @override
   String get guide_greenscore_transparency_title =>
@@ -4419,19 +4458,19 @@ class AppLocalizationsNn extends AppLocalizations {
 
   @override
   String get guide_greenscore_transparency_intro1 =>
-      'To accurately calculate the Green-Score, it is necessary to have **information which is not necessarily specified on the packaging** (such as the origin and the exact percentage of each ingredient) or which is rarely available in usable form (such as a list of all the components of the packaging with the precise types of plastics used).';
+      'For å beregne Green-Score nøyaktig er det nødvendig med **informasjon som ikke nødvendigvis er spesifisert på emballasjen** (som opprinnelse og den nøyaktige prosentandelen av hver ingrediens) eller som sjelden er tilgjengelig i brukbar form (som en liste over alle komponentene i emballasjen med de nøyaktige plasttypene som brukes).';
 
   @override
   String get guide_greenscore_transparency_intro2 =>
-      '**Average values are used when this information is not yet available**, but we are now calling on everyone to help us collect this information which will be very useful for the Green-Score but also for many other uses.';
+      '**Gjennomsnittsverdier brukes når denne informasjonen ikke er tilgjengelig ennå**, men vi ber nå alle om å hjelpe oss med å samle inn denne informasjonen, som vil være svært nyttig for Green-Score, men også for mange andre bruksområder.';
 
   @override
   String get guide_greenscore_transparency_arg1_title =>
-      'How citizens can help?';
+      'Hvordan kan innbyggere hjelpe?';
 
   @override
   String get guide_greenscore_transparency_arg1_text =>
-      'All citizens can help us gather and structure the information that is present on products or that can be deduced from them, such as information on **packaging**: \"Mission Emballages\": a large-scale collaborative inventory of packaging for all food products (in French).';
+      'Alle borgere kan hjelpe oss med å samle og strukturere informasjonen som finnes på produkter eller som kan utledes fra dem, for eksempel informasjon om **emballasje**: «Mission Emballages»: en storstilt samarbeidende inventarisering av emballasje for alle matvarer (på fransk).';
 
   @override
   String get guide_greenscore_transparency_arg2_title =>
@@ -4505,7 +4544,7 @@ class AppLocalizationsNn extends AppLocalizations {
 
   @override
   String get guide_nova_groups_arg1_text =>
-      'Unprocessed (or natural) foods are the **edible parts of plants** (seeds, fruits, leaves, stems, roots) **or animals** (muscle, offal, eggs, milk), as well as fungi, algae, and water, after being separated from nature.';
+      'Ubearbeidet (eller naturlig) mat er de **spiselige delene av planter** (frø, frukt, blader, stilker, røtter) **eller dyr** (muskler, innmat, egg, melk), samt sopp, alger og vann, etter å ha blitt separert fra naturen.';
 
   @override
   String get guide_nova_groups_arg2_title => 'Processed culinary ingredients';
@@ -4538,7 +4577,7 @@ class AppLocalizationsNn extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg1_text =>
-      'Many are **derived from further processing of food constituents**, such as hydrogenated or interesterified oils, hydrolyzed proteins, soy protein isolate, maltodextrin, invert sugar, and high-fructose corn syrup.';
+      'Mange er **utvunnet fra videre bearbeiding av matbestanddeler**, som hydrogenerte eller interesterifiserte oljer, hydrolyserte proteiner, soyaproteinisolat, maltodekstrin, invertsukker og maissirup med høyt fruktoseinnhold.';
 
   @override
   String get guide_nova_explanations_arg2_title =>
@@ -4546,7 +4585,7 @@ class AppLocalizationsNn extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg2_text =>
-      'Additives in ultra-processed foods include some that are also used in processed foods, such as preservatives, antioxidants, and stabilizers. Classes of additives found only in ultra-processed products include those used **to imitate or enhance the sensory qualities of foods or to disguise unpalatable aspects of the final product**. These additives include dyes and other colors, color stabilizers; flavors, flavor enhancers, non-sugar sweeteners; and processing aids such as carbonating, firming, bulking and anti-bulking agents, de-foaming, anti-caking and glazing agents, emulsifiers, sequestrants, and humectants.';
+      'Tilsetningsstoffer i ultrabearbeidet mat inkluderer noen som også brukes i bearbeidet mat, for eksempel konserveringsmidler, antioksidanter og stabilisatorer. Klasser av tilsetningsstoffer som bare finnes i ultrabearbeidede produkter inkluderer de som brukes **for å imitere eller forbedre de sensoriske egenskapene til matvarer eller for å skjule usmakelige aspekter ved sluttproduktet**. Disse tilsetningsstoffene inkluderer fargestoffer og andre farger, fargestabilisatorer; smakstilsetninger, smaksforsterkere, ikke-sukkerholdige søtningsmidler; og prosesseringshjelpemidler som kullsyre-, fasthets-, fyllings- og antifylningsmidler, skumdempende, antiklumpe- og glaseringsmidler, emulgatorer, sekvestreringsmidler og fuktighetsbevarende midler.';
 
   @override
   String get guide_nova_explanations_arg3_title =>
@@ -4554,7 +4593,7 @@ class AppLocalizationsNn extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg3_text =>
-      '**A multitude of sequences of processes is used** to combine the usually many ingredients and to create the final product (hence \'ultra-processed\'). The processes include several **with no domestic equivalents**, such as hydrogenation and hydrolysation, extrusion and moulding, and pre-processing for frying.';
+      '**En rekke prosesssekvenser brukes** for å kombinere de vanligvis mange ingrediensene og for å lage sluttproduktet (derav «ultraprosessert»). Prosessene inkluderer flere **uten innenlandske ekvivalenter**, som hydrogenering og hydrolysering, ekstrudering og støping, og forbehandling for steking.';
 
   @override
   String get guide_nova_explanations_arg4_title =>
@@ -4562,104 +4601,105 @@ class AppLocalizationsNn extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg4_text =>
-      '**The overall purpose of ultra-processing is to create branded**, **convenient** (durable, ready to consume), **attractive** (hyper-palatable) and **highly profitable** (low-cost ingredients) food products designed to displace all other food groups. Ultra-processed food products are usually packaged attractively and marketed intensively.';
+      '**Det overordnede formålet med ultraprosessering er å skape merkevareprodukter som er **praktiske** (holdbare, klare til konsum), **attraktive** (hypervelsmakende) og **svært lønnsomme** (lavkostingredienser) og er utformet for å fortrenge alle andre matvaregrupper. Ultraprosesserte matvarer pakkes vanligvis attraktivt og markedsføres intensivt.**';
 
   @override
-  String get guide_nova_explanations_arg5_title => 'A health hazard';
+  String get guide_nova_explanations_arg5_title => 'En helsefare';
 
   @override
   String get guide_nova_explanations_arg5_text =>
-      'Since 2018, with NutriNet-Santé, the first links between **the consumption of ultra-processed foods and increased risks of cancer, cardiovascular diseases, and diabetes have been highlighted**. Today, more than 90 studies worldwide confirm these findings.\nThe strongest associations relate to **obesity, cardiovascular mortality, and depressive symptoms**. On children, the effects are primarily observed on weight and lipid imbalances.';
+      'Siden 2018 har de første koblingene mellom **forbruk av ultraprosessert mat og økt risiko for kreft, hjerte- og karsykdommer og diabetes blitt fremhevet** med NutriNet-Santé. I dag bekrefter mer enn 90 studier over hele verden disse funnene.\nDe sterkeste assosiasjonene er knyttet til **fedme, hjerte- og kardødelighet og depressive symptomer**. Hos barn observeres effektene primært på vekt og lipidubalanser.';
 
   @override
   String get guide_nova_explanations_arg6_title =>
-      'Countries recommend limiting them';
+      'Land anbefaler å begrense dem';
 
   @override
   String get guide_nova_explanations_arg6_text =>
-      'Some countries use the NOVA groups for their dietary guidelines or goals, for instance:\n\n- **🇧🇷 Brazil**\'s dietary guidelines **recommend to limit consumption** of processed food and avoid ultra-processed food.\n\n- **🇫🇷 France**\'s public health nutritional policy goals for 2018-2022 aims to **reduce consumption of group 4 ultra-processed foods by 20%**.';
+      'Noen land bruker NOVA-gruppene for sine kostholdsretningslinjer eller -mål, for eksempel:\n\n- **🇧🇷 Brasils** kostholdsretningslinjer **anbefaler å begrense forbruket** av bearbeidet mat og unngå ultrabearbeidet mat.\n\n- **🇫🇷 Frankrikes** ernæringspolitiske mål for folkehelse for 2018–2022 har som mål å **redusere forbruket av ultrabearbeidet mat i gruppe 4 med 20 %**.';
 
   @override
   String get guide_nova_share_link => 'https://world-nn.openfoodfacts.org/nova';
 
   @override
-  String get guide_open_food_facts_title => 'Welcome to Open Food Facts!';
+  String get guide_open_food_facts_title => 'Velkommen til Åpne matfakta!';
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_title =>
-      'What is Open Food Facts?';
+      'Hva er åpne matfakta?';
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_paragraph1 =>
-      'Open Food Facts is a **collaborative**, **free**, and **open** database of food products from around the world.';
+      'Open Food Facts er en **samarbeidsbasert**, **gratis** og **åpen** database med matvarer fra hele verden.';
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_paragraph2 =>
-      'We believe that everyone should have access to information about what they eat. By collecting data on ingredients, allergens, nutrition facts, and more, **we empower consumers to make informed choices** and drive the food industry **toward greater transparency**.';
+      'Vi mener at alle bør ha tilgang til informasjon om hva de spiser. Ved å samle inn data om ingredienser, allergener, næringsinnhold og mer, **gir vi forbrukerne mulighet til å ta informerte valg** og driver matindustrien **mot større åpenhet**.';
 
   @override
   String get guide_open_food_facts_features_title =>
-      'Features of Open Food Facts';
+      'Funksjoner ved åpne matfakta';
 
   @override
   String get guide_open_food_facts_features_arg1_title =>
-      'Get alerts for your unwanted ingredients';
+      'Få varsler om uønskede ingredienser';
 
   @override
-  String get guide_open_food_facts_tips_title => 'Tips for taking great photos';
+  String get guide_open_food_facts_tips_title => 'Tips for å ta flotte bilder';
 
   @override
-  String get guide_open_food_facts_tips_arg1_title => 'Don’ts';
+  String get guide_open_food_facts_tips_arg1_title => 'Ikke gjør';
 
   @override
   String get guide_open_food_facts_tips_arg1_text1 =>
-      'Avoid shadows and glare.';
+      'Unngå skygger og gjenskinn.';
 
   @override
   String get guide_open_food_facts_tips_arg1_text2 =>
-      'No blurry or out-of-focus text.';
+      'Ingen uskarp eller uskarp tekst.';
 
   @override
   String get guide_open_food_facts_tips_arg1_text3 =>
-      'Don\'t crop out parts of the text.';
+      'Ikke beskjær ut deler av teksten.';
 
   @override
-  String get guide_open_food_facts_tips_arg1_text4 => 'Avoid busy backgrounds.';
+  String get guide_open_food_facts_tips_arg1_text4 =>
+      'Unngå travle bakgrunner.';
 
   @override
-  String get guide_open_food_facts_tips_arg2_title => 'Do’s';
+  String get guide_open_food_facts_tips_arg2_title => 'Gjør-det-selv';
 
   @override
   String get guide_open_food_facts_tips_arg2_text1 =>
-      'Use good, even lighting.';
+      'Bruk god, jevn belysning.';
 
   @override
   String get guide_open_food_facts_tips_arg2_text2 =>
-      'Ensure text is sharp and readable.';
+      'Sørg for at teksten er skarp og lesbar.';
 
   @override
   String get guide_open_food_facts_tips_arg2_text3 =>
-      'Capture the entire ingredients list.';
+      'Ta opp hele ingredienslisten.';
 
   @override
   String get guide_open_food_facts_tips_arg2_text4 =>
-      'Keep the product on a flat surface.';
+      'Oppbevar produktet på en flat overflate.';
 
   @override
   String get guide_open_food_facts_scores_title =>
-      'Help us build the \"Wikipedia of Food\"';
+      'Hjelp oss å bygge «Matens Wikipedia»';
 
   @override
   String get guide_open_food_facts_scores_arg1_title =>
-      'A score on the nutritional quality';
+      'En poengsum på næringskvaliteten';
 
   @override
   String get guide_open_food_facts_scores_arg2_title =>
-      'A score to avoid ultra-processed foods';
+      'En poengsum for å unngå ultraprosessert mat';
 
   @override
   String get guide_open_food_facts_scores_arg3_title =>
-      'A score for the planet';
+      'En poengsum for planeten';
 
   @override
   String get guide_open_food_facts_share_link =>
@@ -4667,236 +4707,240 @@ class AppLocalizationsNn extends AppLocalizations {
 
   @override
   String get guide_open_pet_food_facts_title =>
-      'Welcome to Open Pet Food Facts!';
+      'Velkommen til Åpne fakta om kjæledyrmat!';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_title =>
-      'What is Open Pet Food Facts?';
+      'Hva er åpne fakta om kjæledyrfôr?';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_paragraph1 =>
-      'Open Pet Food Facts extends our mission to our furry friends! It\'s a **database of pet food products for cats, dogs, and other companions**.';
+      'Open Pet Food Facts utvider vårt oppdrag til våre pelskledde venner! Det er en **database med kjæledyrfôrprodukter for katter, hunder og andre følgesvenner**.';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_paragraph2 =>
-      'We gather information on **ingredients**, **nutritional analysis**, and feeding guidelines to help pet owners choose the best food for their animals\' needs.';
+      'Vi samler informasjon om **ingredienser**, **ernæringsanalyse** og fôringsretningslinjer for å hjelpe dyreeiere med å velge det beste fôret for dyrenes behov.';
 
   @override
   String get guide_open_pet_food_facts_features_title =>
-      'Features of Open Pet Food Facts';
+      'Funksjoner ved åpne kjæledyrfôrfakta';
 
   @override
   String get guide_open_pet_food_facts_features_arg1_title =>
-      'Get alerts for your unwanted ingredients';
+      'Få varsler om uønskede ingredienser';
 
   @override
   String get guide_open_pet_food_facts_features_arg1_paragraph1 =>
-      'Is your pet allergic to any ingredients? You can set a list of cosmetic ingredients to avoid, right in the app!';
+      'Er kjæledyret ditt allergisk mot noen ingredienser? Du kan sette opp en liste over kosmetiske ingredienser du bør unngå, rett i appen!';
 
   @override
   String get guide_open_pet_food_facts_tips_title =>
-      'Tips for taking great photos';
+      'Tips for å ta flotte bilder';
 
   @override
-  String get guide_open_pet_food_facts_tips_arg1_title => 'Don’ts';
+  String get guide_open_pet_food_facts_tips_arg1_title => 'Ikke gjør';
 
   @override
   String get guide_open_pet_food_facts_tips_arg1_text1 =>
-      'Avoid shadows and glare.';
+      'Unngå skygger og gjenskinn.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg1_text2 =>
-      'No blurry or out-of-focus text.';
+      'Ingen uskarp eller uskarp tekst.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg1_text3 =>
-      'Don\'t crop out parts of the text.';
+      'Ikke beskjær ut deler av teksten.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg1_text4 =>
-      'Avoid busy backgrounds.';
+      'Unngå travle bakgrunner.';
 
   @override
-  String get guide_open_pet_food_facts_tips_arg2_title => 'Do’s';
+  String get guide_open_pet_food_facts_tips_arg2_title => 'Gjør-det-selv';
 
   @override
   String get guide_open_pet_food_facts_tips_arg2_text1 =>
-      'Use good, even lighting.';
+      'Bruk god, jevn belysning.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg2_text2 =>
-      'Ensure text is sharp and readable.';
+      'Sørg for at teksten er skarp og lesbar.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg2_text3 =>
-      'Capture the entire ingredients list.';
+      'Ta opp hele ingredienslisten.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg2_text4 =>
-      'Keep the product on a flat surface.';
+      'Oppbevar produktet på en flat overflate.';
 
   @override
-  String get guide_open_pet_food_facts_scores_title => 'A note on scoring';
+  String get guide_open_pet_food_facts_scores_title =>
+      'En merknad om poengberegning';
 
   @override
   String get guide_open_pet_food_facts_scores_paragraph1 =>
-      'Developing a scoring system for pet food **is not a priority right now**. The methodology would be complex, as nutritional needs vary greatly by species, age, and health condition. We haven’t found any independant scientific team yet, able to develop such a score.';
+      'Å utvikle et poengsystem for kjæledyrfôr **er ikke en prioritet akkurat nå**. Metodikken ville være kompleks, ettersom ernæringsbehovene varierer sterkt etter art, alder og helsetilstand. Vi har ennå ikke funnet noe uavhengig vitenskapelig team som er i stand til å utvikle en slik poengsum.';
 
   @override
   String get guide_open_pet_food_facts_share_link =>
       'https://world-nn.openpetfoodfacts.org/discover';
 
   @override
-  String get guide_open_beauty_facts_title => 'Welcome to Open Beauty Facts!';
+  String get guide_open_beauty_facts_title =>
+      'Velkommen til Åpne skjønnhetsfakta!';
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_title =>
-      'What is Open Beauty Facts?';
+      'Hva er åpne skjønnhetsfakta?';
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_paragraph1 =>
-      'Open Beauty Facts is a collaborative database of **cosmetic products**.';
+      'Open Beauty Facts er en samarbeidende database med **kosmetikkprodukter**.';
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_paragraph2 =>
-      'Our goal is to decipher ingredient lists to help you **understand what\'s in your personal care items**. From moisturizers to makeup, we collect data on ingredients, allergens, and packaging to promote transparency in the cosmetics industry.';
+      'Målet vårt er å tyde ingredienslister for å hjelpe deg med å **forstå hva som finnes i dine personlige pleieprodukter**. Fra fuktighetskremer til sminke samler vi inn data om ingredienser, allergener og emballasje for å fremme åpenhet i kosmetikkindustrien.';
 
   @override
   String get guide_open_beauty_facts_features_title =>
-      'Features of Open Beauty Facts';
+      'Funksjoner ved åpne skjønnhetsfakta';
 
   @override
   String get guide_open_beauty_facts_features_arg1_title =>
-      'Get alerts for your unwanted ingredients';
+      'Få varsler om uønskede ingredienser';
 
   @override
   String get guide_open_beauty_facts_features_arg1_paragraph1 =>
-      'Are you allergic to any ingredients? Want to avoid comedogen substances? Want to steer away from controversial components ? You can set a list of cosmetic ingredients to avoid, right in the app!';
+      'Er du allergisk mot noen ingredienser? Vil du unngå komedogene stoffer? Vil du unngå kontroversielle komponenter? Du kan angi en liste over kosmetiske ingredienser du vil unngå, rett i appen!';
 
   @override
   String get guide_open_beauty_facts_tips_title =>
-      'Tips for taking great photos';
+      'Tips for å ta flotte bilder';
 
   @override
-  String get guide_open_beauty_facts_tips_arg1_title => 'Don’ts';
+  String get guide_open_beauty_facts_tips_arg1_title => 'Ikke gjør';
 
   @override
   String get guide_open_beauty_facts_tips_arg1_text1 =>
-      'Avoid shadows and glare.';
+      'Unngå skygger og gjenskinn.';
 
   @override
   String get guide_open_beauty_facts_tips_arg1_text2 =>
-      'No blurry or out-of-focus text.';
+      'Ingen uskarp eller uskarp tekst.';
 
   @override
   String get guide_open_beauty_facts_tips_arg1_text3 =>
-      'Don\'t crop out parts of the text.';
+      'Ikke beskjær ut deler av teksten.';
 
   @override
   String get guide_open_beauty_facts_tips_arg1_text4 =>
-      'Avoid busy backgrounds.';
+      'Unngå travle bakgrunner.';
 
   @override
-  String get guide_open_beauty_facts_tips_arg2_title => 'Do’s';
+  String get guide_open_beauty_facts_tips_arg2_title => 'Gjør-det-selv';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text1 =>
-      'Use good, even lighting.';
+      'Bruk god, jevn belysning.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text2 =>
-      'Ensure text is sharp and readable.';
+      'Sørg for at teksten er skarp og lesbar.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text3 =>
-      'Capture the entire ingredients list.';
+      'Ta opp hele ingredienslisten.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text4 =>
-      'Take as many picture as need if the bottle is curved.';
+      'Ta så mange bilder som nødvendig hvis flasken er buet.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text5 =>
-      'You might need to peel the label to see the list of ingredients.';
+      'Du må kanskje rive av etiketten for å se ingredienslisten.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text6 =>
-      'Keep the product on a flat surface.';
+      'Oppbevar produktet på en flat overflate.';
 
   @override
-  String get guide_open_beauty_facts_scores_title => 'A note on scoring';
+  String get guide_open_beauty_facts_scores_title =>
+      'En merknad om poengberegning';
 
   @override
   String get guide_open_beauty_facts_scores_paragraph1 =>
-      'Unlike food products, the world of cosmetics **does not have a universally recognized, government-backed scoring system like the Nutri-Score**. Ingredient effects can be highly personal and depend on skin type, allergies, and individual concerns.';
+      'I motsetning til matvarer har ikke kosmetikkverdenen et universelt anerkjent, myndighetsstøttet poengsystem som Nutri-Score. Ingrediensenes effekt kan være svært personlig og avhenge av hudtype, allergier og individuelle bekymringer.';
 
   @override
   String get guide_open_beauty_facts_share_link =>
       'https://world-nn.openbeautyfacts.org/discover';
 
   @override
-  String get guide_open_prices_title => 'Welcome to Open Prices!';
+  String get guide_open_prices_title => 'Velkommen til Åpne priser!';
 
   @override
   String get guide_open_prices_what_is_open_prices_title =>
-      'What is Open Prices?';
+      'Hva er åpningspriser?';
 
   @override
   String get guide_open_prices_what_is_open_prices_paragraph1 =>
-      'Open Prices is a project to **collect and share prices of products around the world**. It\'s a publicly available dataset that can be used for research, analysis, and more. Open Prices is developed and maintained by Open Food Facts.';
+      'Open Prices er et prosjekt for å **samle inn og dele priser på produkter over hele verden**. Det er et offentlig tilgjengelig datasett som kan brukes til forskning, analyse og mer. Open Prices er utviklet og vedlikeholdt av Open Food Facts.';
 
   @override
   String get guide_open_prices_what_is_open_prices_paragraph2 =>
       'There are currently few companies that own large databases of product prices at the barcode level. These prices are not freely available, but sold at a high price to private actors, researchers and other organizations that can afford them.';
 
   @override
-  String get guide_open_prices_how_title => 'How does Open Prices work?';
+  String get guide_open_prices_how_title => 'Hvordan fungerer åpne priser?';
 
   @override
   String get guide_open_prices_how_paragraph1 =>
-      '**We are crowdsourcing an open-source dataset of prices**. Prices can be added by users via this web app, or via the official Open Food Facts mobile app. Retailers or third-party apps can contribute as well by using our API.';
+      '**Vi bruker crowdsourcing til å finne et åpen kildekode-datasett med priser.** Priser kan legges til av brukere via denne nettappen eller via den offisielle Open Food Facts-mobilappen. Forhandlere eller tredjepartsapper kan også bidra ved å bruke API-et vårt.';
 
   @override
   String get guide_open_prices_how_arg1_title =>
-      'Collect photos of price tags in aisles';
+      'Samle bilder av prislapper i gangene';
 
   @override
-  String get guide_open_prices_how_arg2_title => 'Collect photos of receipts';
+  String get guide_open_prices_how_arg2_title => 'Samle bilder av kvitteringer';
 
   @override
   String get guide_open_prices_why_title =>
-      'Why is Open Food Facts doing this ?';
+      'Hvorfor gjør Open Food Facts dette?';
 
   @override
   String get guide_open_prices_why_paragraph1 =>
-      'Price information is of paramount importance to understand food systems. It\'s a key factor in understanding the cost of food and to promote healthier diets. Opening price data is a way to make it easier for researchers, journalists, and citizens to **have a better understanding of how food prices vary geographically and in time**.';
+      'Prisinformasjon er av største betydning for å forstå matsystemer. Det er en nøkkelfaktor for å forstå kostnadene ved mat og for å fremme sunnere kosthold. Å åpne prisdata er en måte å gjøre det enklere for forskere, journalister og innbyggere å **få en bedre forståelse av hvordan matprisene varierer geografisk og over tid**.';
 
   @override
   String get guide_open_prices_why_arg1_title =>
-      'Track the evolution of prices over time';
+      'Spor prisutviklingen over tid';
 
   @override
   String get guide_open_prices_why_arg1_text =>
-      'See the **evolution of prices**: shrinkflation, cheapflation, we can track them together!';
+      'Se **prisutviklingen**: krympeinflasjon, billiginflasjon, vi kan spore dem sammen!';
 
   @override
-  String get guide_open_prices_why_arg2_title => 'Compare prices near you';
+  String get guide_open_prices_why_arg2_title =>
+      'Sammenlign priser i nærheten av deg';
 
   @override
   String get guide_open_prices_why_arg2_text =>
-      'As we get more prices, you can spot **the cheapest stores around you**.';
+      'Etter hvert som vi får flere priser, kan du finne **de billigste butikkene i nærheten**.';
 
   @override
   String get guide_open_prices_scrapping_title =>
-      'Did you consider scraping prices from retailers\' websites?';
+      'Har du vurdert å hente priser fra forhandlernes nettsider?';
 
   @override
   String get guide_open_prices_scrapping_paragraph1 =>
-      'For legal and technical reasons, **we don\'t consider scraping prices from retailers\' websites as a valid way to contribute to Open Prices**. We want to make sure that the prices we collect are accurate and up-to-date, and receiving scraped prices from contributors doesn\'t allow us to do that.';
+      'Av juridiske og tekniske årsaker **anser vi ikke det å hente priser fra forhandlernes nettsteder som en gyldig måte å bidra til åpne priser**. Vi ønsker å sørge for at prisene vi samler inn er nøyaktige og oppdaterte, og det å motta hentede priser fra bidragsytere tillater oss ikke å gjøre det.';
 
   @override
   String get guide_open_prices_scrapping_paragraph2 =>
-      'Price scraping is a considered option in a future version of Open Prices, but it would be done by Open Prices itself so that we can have a proof of the price based on the HTML page.';
+      'Prisskraping er et vurdert alternativ i en fremtidig versjon av Open Prices, men det vil bli gjort av Open Prices selv, slik at vi kan ha et bevis på prisen basert på HTML-siden.';
 
   @override
   String get guide_open_prices_retailers_title =>
@@ -4904,7 +4948,7 @@ class AppLocalizationsNn extends AppLocalizations {
 
   @override
   String get guide_open_prices_retailers_paragraph1 =>
-      'You can contribute prices by using our API.\nIf you want to contribute prices at scale, please get in touch with us at prices@openfoodfacts.org.';
+      'Du kan bidra med priser ved å bruke API-et vårt.\nHvis du ønsker å bidra med priser i stor skala, kan du ta kontakt med oss på prices@openfoodfacts.org.';
 
   @override
   String get guide_open_prices_share_link =>
@@ -4912,149 +4956,148 @@ class AppLocalizationsNn extends AppLocalizations {
 
   @override
   String get guide_open_products_facts_title =>
-      'Welcome to Open Products Facts!';
+      'Velkommen til fakta om åpne produkter!';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_title =>
-      'What is Open Products Facts?';
+      'Hva er fakta om åpne produkter?';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_paragraph1 =>
-      'Open Products Facts is a massive, open database for **any product with a barcode, which is not food, cosmetic or pet food**.';
+      'Open Products Facts er en massiv, åpen database for **alle produkter med strekkode, som ikke er mat, kosmetikk eller dyrefôr**.';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_paragraph2 =>
-      'From **electronics** to **toys**, and **clothes** to **cleaning supplies**, if it has a barcode, it can be added. This project aims to create an \"Internet of Things\" for everyday objects, making information about them universally accessible.';
+      'Fra **elektronikk** til **leker**, og **klær** til **rengjøringsartikler**, hvis det har en strekkode, kan det legges til. Dette prosjektet har som mål å skape et «tingenes internett» for hverdagsgjenstander, og gjøre informasjon om dem universelt tilgjengelig.';
 
   @override
   String get guide_open_products_facts_features_title =>
-      'Features of Open Products Facts';
+      'Funksjoner i åpne produktfakta';
 
   @override
   String get guide_open_products_facts_features_text =>
-      'Open Products Facts aims to provide consumers to **extend the life of objects** by providing the circular solutions to maintain, **repair**, **recycle** their objects or give them a new owner.';
+      'Open Products Facts har som mål å gi forbrukere muligheten til å **forlenge levetiden til gjenstander** ved å tilby sirkulære løsninger for å vedlikeholde, **reparere**, **resirkulere** gjenstandene sine eller gi dem en ny eier.';
 
   @override
   String get guide_open_products_facts_features_arg1_title =>
-      'Carbon footprints for some products';
+      'Karbonavtrykk for noen produkter';
 
   @override
   String get guide_open_products_facts_features_arg1_text =>
-      '**Impact CO2** by French Environment Authority ADEME provides the **carbon impact** of many categories, make sure to categorize products precisely.';
+      '**CO2-påvirkning** fra den franske miljømyndigheten ADEME gir **karbonpåvirkningen** for mange kategorier. Sørg for å kategorisere produktene nøyaktig.';
 
   @override
   String get guide_open_products_facts_features_arg2_title =>
-      'Reparability index for many products';
+      'Reparasjonsindeks for mange produkter';
 
   @override
   String get guide_open_products_facts_features_arg2_text =>
-      'Whenever a French reparability index is available, we’ll display it. Moreover, **you can start collecting the variables using the Folksonomy Engine**; so that we can recompute it ourselves in the future, even in countries where it’s not available.';
+      'Når en fransk reparerbarhetsindeks er tilgjengelig, viser vi den. Dessuten **kan du begynne å samle inn variablene ved hjelp av Folksonomy Engine**, slik at vi kan beregne den på nytt selv i fremtiden, selv i land der den ikke er tilgjengelig.';
 
   @override
   String get guide_open_products_facts_features_arg3_title =>
-      'Find ways to donate/resell your product';
+      'Finn måter å donere/videreselge produktet ditt på';
 
   @override
   String get guide_open_products_facts_features_arg3_text =>
-      'We provide links to **third party circular friendly services** that help you get the kind of product you’re looking for, as a second hand product, to be more gentle on planetary resources.\nNote that we’re not paid to do that, and that the system only works as an example for two websites in France. You can help expand this system by documenting more sites on the wiki.';
+      'Vi tilbyr lenker til **tredjeparts sirkulærvennlige tjenester** som hjelper deg med å få den typen produkt du leter etter, som et bruktprodukt, for å være mer skånsom mot planetens ressurser.\nMerk at vi ikke får betalt for å gjøre det, og at systemet bare fungerer som et eksempel for to nettsteder i Frankrike. Du kan bidra til å utvide dette systemet ved å dokumentere flere nettsteder på wikien.';
 
   @override
   String get guide_open_products_facts_information_title =>
-      'What information is useful?';
+      'Hvilken informasjon er nyttig?';
 
   @override
   String get guide_open_products_facts_information_text =>
-      'For such a wide range of items, **the data we collect is flexible**. To do that, **we created the Folksonomy Engine**.';
+      'For et så bredt spekter av elementer er **dataene vi samler inn fleksible**. For å gjøre det har **vi laget Folksonomy Engine**.';
 
   @override
-  String get guide_open_products_facts_folksonomy_title =>
-      'The Folksonomy Engine';
+  String get guide_open_products_facts_folksonomy_title => 'Folksonomi-motoren';
 
   @override
   String get guide_open_products_facts_folksonomy_paragraph1 =>
-      'The Folksonomy Engine is a tool to help you complete products with relevant properties. This helps improve search and discoverability, but also compute and display interesting things in the future.';
+      'Folksonomy-motoren er et verktøy som hjelper deg med å fullføre produkter med relevante egenskaper. Dette bidrar til å forbedre søk og synlighet, men også beregne og vise interessante ting i fremtiden.';
 
   @override
   String get guide_open_products_facts_folksonomy_paragraph2 =>
-      'You can add any keys and values like: **compatibility_with_5G_mobile_network: yes**';
+      'Du kan legge til hvilke som helst nøkler og verdier som: **kompatibilitet_med_5G_mobilnettverk: ja**';
 
   @override
   String get guide_open_products_facts_folksonomy_paragraph3 =>
-      'You’ll get autosuggestion of possible properties, and you are very welcome to add and document new ones on your favorite kinds of products.';
+      'Du får automatiske forslag til mulige egenskaper, og du er hjertelig velkommen til å legge til og dokumentere nye på dine favorittprodukter.';
 
   @override
   String get guide_open_products_facts_share_link =>
       'https://world-nn.openproductsfacts.org/discover';
 
   @override
-  String get guide_open_preferences_button_title => 'Open food preferences';
+  String get guide_open_preferences_button_title => 'Åpne matpreferanser';
 
   @override
-  String get guide_coming_soon_button_title => 'Coming soon';
+  String get guide_coming_soon_button_title => 'Kommer snart';
 
   @override
-  String get guide_learn_more_subtitle => 'Tap to learn more';
+  String get guide_learn_more_subtitle => 'Trykk for å finne ut mer';
 
   @override
-  String get preview_badge => 'Preview';
+  String get preview_badge => 'Forhåndsvisning';
 
   @override
   String get prices_feedback_form =>
-      'Click here to send us your feedback about this new feature!';
+      'Klikk her for å sende oss din tilbakemelding om denne nye funksjonen!';
 
   @override
-  String get menu_button_list_actions => 'Select an action';
+  String get menu_button_list_actions => 'Velg en handling';
 
   @override
-  String get error_loading_photo => 'Error loading photo';
+  String get error_loading_photo => 'Feil ved lasting av bilde';
 
   @override
-  String get photo_viewer_action_use_picture_as => 'Use as…';
+  String get photo_viewer_action_use_picture_as => 'Bruk som…';
 
   @override
-  String get photo_viewer_use_picture_as_tooltip => 'Use this picture as…';
+  String get photo_viewer_use_picture_as_tooltip => 'Bruk dette bildet som…';
 
   @override
   String photo_viewer_use_picture_as_title(String language) {
-    return 'Use this picture as… ($language)';
+    return 'Bruk dette bildet som… ($language)';
   }
 
   @override
-  String get photo_viewer_details_button => 'Details';
+  String get photo_viewer_details_button => 'Detaljer';
 
   @override
   String get photo_viewer_details_button_accessibility_label =>
-      'Details of this photo';
+      'Detaljer om dette bildet';
 
   @override
-  String get photo_viewer_details_title => 'Details of the photo';
+  String get photo_viewer_details_title => 'Detaljer om bildet';
 
   @override
   String get photo_viewer_details_contributor_title => 'Bidrager';
 
   @override
-  String get photo_viewer_details_size_title => 'Size';
+  String get photo_viewer_details_size_title => 'Størrelse';
 
   @override
   String photo_viewer_details_size_value(int width, int height) {
-    return '$width x $height pixels';
+    return '$width x $height piksler';
   }
 
   @override
-  String get photo_viewer_details_date_title => 'Date';
+  String get photo_viewer_details_date_title => 'Dato';
 
   @override
-  String get photo_viewer_details_url_title => 'URL';
+  String get photo_viewer_details_url_title => 'URL-adresse';
 
   @override
-  String get product_page_compatibility_score => 'Compatible';
+  String get product_page_compatibility_score => 'Kompatibel';
 
   @override
-  String get user_lists_action_multi_select => 'Multi-select';
+  String get user_lists_action_multi_select => 'Flervalg';
 
   @override
   String product_page_compatibility_score_tooltip(String score) {
-    return 'Your compatibility score: $score%';
+    return 'Din kompatibilitetspoengsum: $score%';
   }
 
   @override
@@ -5065,164 +5108,165 @@ class AppLocalizationsNn extends AppLocalizations {
       'Ingredients picture';
 
   @override
-  String get product_image_nutrition_accessibility_label => 'Nutrition picture';
+  String get product_image_nutrition_accessibility_label => 'Ernæringsbilde';
 
   @override
-  String get product_image_packaging_accessibility_label => 'Packaging picture';
+  String get product_image_packaging_accessibility_label => 'Emballasjebilde';
 
   @override
-  String get product_image_other_accessibility_label => 'Other picture';
+  String get product_image_other_accessibility_label => 'Annet bilde';
 
   @override
-  String get product_image_outdated_message => 'This picture may be outdated';
+  String get product_image_outdated_message => 'Dette bildet kan være utdatert';
 
   @override
   String product_image_outdated_message_accessibility_label(String type) {
-    return '$type (this image may be outdated)';
+    return '$type (dette bildet kan være utdatert)';
   }
 
   @override
   String product_image_locked_message_accessibility_label(String type) {
-    return '$type (this image may be locked by the producer)';
+    return '$type (dette bildet kan være låst av produsenten)';
   }
 
   @override
-  String get product_image_error => 'Unable to load the image!';
+  String get product_image_error => 'Klarte ikke å laste inn bildet!';
 
   @override
   String product_image_error_accessibility_label(String type) {
-    return 'Unable to load the $type (network error?)';
+    return 'Kan ikke laste inn $type (nettverksfeil?)';
   }
 
   @override
-  String get product_page_image_no_image_available => 'No\nimage!';
+  String get product_page_image_no_image_available => 'Ikke noe\nbilde!';
 
   @override
   String get product_page_image_no_image_available_accessibility_label =>
-      'No picture available for this product';
+      'Ingen bilder tilgjengelig for dette produktet';
 
   @override
   String get product_page_action_bar_settings_accessibility_label =>
-      'Reorder or hide actions';
+      'Endre rekkefølgen på eller skjul handlinger';
 
   @override
-  String get product_page_action_bar_setting_modal_title => 'Edit actions';
+  String get product_page_action_bar_setting_modal_title =>
+      'Rediger handlinger';
 
   @override
-  String get product_page_action_bar_item_move_up => 'Move up';
+  String get product_page_action_bar_item_move_up => 'Flytt opp';
 
   @override
-  String get product_page_action_bar_item_move_down => 'Move down';
+  String get product_page_action_bar_item_move_down => 'Flytt ned';
 
   @override
-  String get product_page_action_bar_item_enable => 'Enable action';
+  String get product_page_action_bar_item_enable => 'Aktiver handling';
 
   @override
-  String get product_page_action_bar_item_disable => 'Disable action';
+  String get product_page_action_bar_item_disable => 'Deaktiver handling';
 
   @override
   String get product_page_pending_operations_banner_title =>
-      'Uploading your edits…';
+      'Laster opp redigeringene dine…';
 
   @override
   String get product_page_pending_operations_banner_message =>
-      'The data displayed on this page **does not yet reflect your modifications**.\nPlease wait a few seconds…';
+      'Dataene som vises på denne siden **gjenspeiler ikke endringene dine ennå**.\nVent noen sekunder…';
 
   @override
-  String get product_add_a_language => 'Add a language';
+  String get product_add_a_language => 'Legg til et språk';
 
   @override
   String barcode_accessibility_label(String barcode) {
-    return 'Barcode $barcode';
+    return 'Strekkode $barcode';
   }
 
   @override
-  String get carousel_close_tooltip => 'Remove this product from the carousel';
+  String get carousel_close_tooltip => 'Fjern dette produktet fra karusellen';
 
   @override
-  String get carousel_unsupported_header => 'Unsupported barcode!';
+  String get carousel_unsupported_header => 'Ustøttet strekkode!';
 
   @override
-  String get carousel_unsupported_title => 'Ooops!';
+  String get carousel_unsupported_title => 'Ups!';
 
   @override
   String get carousel_unsupported_text =>
-      'The barcode scanned is not supported by Open Food Facts!';
+      'Strekkoden som skannes støttes ikke av Open Food Facts!';
 
   @override
-  String get carousel_error_header => 'Error!';
+  String get carousel_error_header => 'Feil!';
 
   @override
-  String get carousel_error_title => 'It\'s a bummer!';
+  String get carousel_error_title => 'Det er kjipt!';
 
   @override
   String get carousel_error_text_1 =>
-      'We couldn\'t download information on this barcode:';
+      'Vi kunne ikke laste ned informasjon om denne strekkoden:';
 
   @override
   String get carousel_error_text_2 =>
-      'Please check your Internet connection or click this button:';
+      'Sjekk internettforbindelsen din, eller klikk på denne knappen:';
 
   @override
-  String get carousel_error_button => 'Retry';
+  String get carousel_error_button => 'Prøv på nytt';
 
   @override
-  String get carousel_unknown_product_header => 'Unknown product';
+  String get carousel_unknown_product_header => 'Ukjent produkt';
 
   @override
   String get carousel_unknown_product_title =>
-      'Congratulations!\nYou\'ve found __the rare gem!__';
+      'Gratulerer!\nDu har funnet __den sjeldne juvelen!__';
 
   @override
   String get carousel_unknown_product_text =>
-      'Our collaborative database contains more than **3 million products**, but this barcode doesn\'t exist: ';
+      'Vår samarbeidsdatabase inneholder mer enn **3 millioner produkter**, men denne strekkoden finnes ikke: ';
 
   @override
   String get carousel_unknown_product_button => 'Add this product';
 
   @override
-  String get carousel_loading_header => 'Loading information...';
+  String get carousel_loading_header => 'Laster inn informasjon ...';
 
   @override
   String get carousel_loading_title =>
-      'You\'ve just scanned a product with the following barcode:';
+      'Du har nettopp skannet et produkt med følgende strekkode:';
 
   @override
   String get carousel_loading_text =>
-      'We are searching for it in our database of more than **3 million products!**';
+      'Vi søker etter det i databasen vår med mer enn **3 millioner produkter!**';
 
   @override
-  String get product_type_subtitle_food => 'Vegetables, fruits, frozen food…';
+  String get product_type_subtitle_food => 'Grønnsaker, frukt, frossenmat…';
 
   @override
-  String get product_type_subtitle_beauty => 'Makeup, soaps, toothpastes…';
+  String get product_type_subtitle_beauty => 'Sminke, såper, tannkremer…';
 
   @override
-  String get product_type_subtitle_pet_food => 'Food for dogs, cats…';
+  String get product_type_subtitle_pet_food => 'Mat til hunder og katter…';
 
   @override
-  String get product_type_subtitle_product => 'Smartphones, furniture…';
+  String get product_type_subtitle_product => 'Smarttelefoner, møbler…';
 
   @override
-  String get photo_field_front => 'Product photo';
+  String get photo_field_front => 'Produktbilde';
 
   @override
-  String get photo_field_ingredients => 'Ingredients photo';
+  String get photo_field_ingredients => 'Ingredienser bilde';
 
   @override
-  String get photo_field_nutrition => 'Nutrition photo';
+  String get photo_field_nutrition => 'Næringsinnholdsbilde';
 
   @override
-  String get photo_field_packaging => 'Packaging information photo';
+  String get photo_field_packaging => 'Emballasjeinformasjonsbilde';
 
   @override
-  String get photo_already_exists => 'This photo already exists';
+  String get photo_already_exists => 'Dette bildet finnes allerede';
 
   @override
-  String get photo_missing => 'This photo is missing';
+  String get photo_missing => 'Dette bildet mangler';
 
   @override
-  String get date => 'Date';
+  String get date => 'Dato';
 
   @override
   String get photo_rotate_left => 'Rotate left';
@@ -5231,89 +5275,89 @@ class AppLocalizationsNn extends AppLocalizations {
   String get photo_rotate_right => 'Rotate right';
 
   @override
-  String get photo_undo_action => 'Undo the previous action';
+  String get photo_undo_action => 'Angre forrige handling';
 
   @override
   String knowledge_panel_world_map_accessibility_label(String location) {
-    return 'A world map of $location';
+    return 'Et verdenskart over $location';
   }
 
   @override
   String get open_street_map_contributor_attribution =>
-      'OpenStreetMap contributors';
+      'OpenStreetMap-bidragsytere';
 
   @override
-  String get not_applicable_short => 'N/A';
+  String get not_applicable_short => 'Ikke aktuelt';
 
   @override
   String get knowledge_panel_warning_text => 'Advarsel';
 
   @override
   String get knowledge_panel_nutriscore_banner_incorrect_score_title =>
-      'Why is this Nutri-Score different from the one on the package?';
+      'Hvorfor er denne næringsverdien forskjellig fra den på pakken?';
 
   @override
   String get knowledge_panel_nutriscore_banner_incorrect_score_message =>
-      'There are two possible explanations:\nThe list of ingredients and/or nutrition facts are not up-to-date.\n\nWe provide the \"New calculation\" of the Nutri-Score (or V2). Please check that you have the banner \"New calculation\" on the package.';
+      'Det er to mulige forklaringer:\nListen over ingredienser og/eller næringsinnholdet er ikke oppdatert.\n\nVi tilbyr den «nye beregningen» av Nutri-Score (eller V2). Sjekk at du har banneret «Ny beregning» på pakken.';
 
   @override
   String get knowledge_panel_nutriscore_banner_incorrect_score_button1 =>
-      'Check ingredients';
+      'Sjekk ingrediensene';
 
   @override
   String get knowledge_panel_nutriscore_banner_incorrect_score_button2 =>
-      'Check nutrition facts';
+      'Sjekk næringsinnholdet';
 
   @override
   String url_not_supported(String url) {
-    return 'Unfortunately, we can\'t open the URL:\n$url';
+    return 'Dessverre kan vi ikke åpne URL-en:\n$url';
   }
 
   @override
-  String get product_list_export => 'Export';
+  String get product_list_export => 'Eksport';
 
   @override
   String get product_list_import => 'Import';
 
   @override
-  String get product_footer_action_barcode => 'View barcode';
+  String get product_footer_action_barcode => 'Vis strekkode';
 
   @override
   String get product_footer_action_barcode_short => 'Strekkode';
 
   @override
-  String get product_footer_action_open_website => 'Open website';
+  String get product_footer_action_open_website => 'Åpne nettsiden';
 
   @override
-  String get product_footer_action_report => 'Report';
+  String get product_footer_action_report => 'Rapportere';
 
   @override
-  String get product_footer_action_contributor_guide => 'Help';
+  String get product_footer_action_contributor_guide => 'Hjelp';
 
   @override
-  String get product_footer_action_data_quality_tags => 'Data quality';
+  String get product_footer_action_data_quality_tags => 'Datakvalitet';
 
   @override
   String get product_page_tab_for_me => 'For meg';
 
   @override
-  String get product_page_tab_website => 'Website';
+  String get product_page_tab_website => 'Nettsted';
 
   @override
-  String get product_page_tab_prices => 'Prices';
+  String get product_page_tab_prices => 'Priser';
 
   @override
   String get prices_explanation_card_title => 'Hvorfor priser?';
 
   @override
   String get prices_explanation_card_line1 =>
-      '**Open Prices** is a project to collect and share prices of products around the world 🌍. Open Prices is developed and maintained by Open Food Facts.';
+      '**Åpne priser** er et prosjekt for å samle inn og dele priser på produkter over hele verden 🌍. Åpne priser er utviklet og vedlikeholdt av Open Food Facts.';
 
   @override
-  String get explanation_card_learn_more_button => 'Learn more';
+  String get explanation_card_learn_more_button => 'Lær mer';
 
   @override
-  String get product_page_tab_folksonomy => 'Folksonomy';
+  String get product_page_tab_folksonomy => 'Folkesonomi';
 
   @override
   String get folksonomy_explanation_card_title =>
@@ -5328,11 +5372,11 @@ class AppLocalizationsNn extends AppLocalizations {
       'Disse egenskapene er opprettet og arkivert av bidragsytere for alle typer bruk.';
 
   @override
-  String get folksonomy_action_external_link_title => 'Open external link';
+  String get folksonomy_action_external_link_title => 'Åpne ekstern lenke';
 
   @override
   String get folksonomy_action_external_link_warning =>
-      'External links may be unsafe. Do you really want to visit it?';
+      'Eksterne lenker kan være utrygge. Vil du virkelig besøke dem?';
 
   @override
   String get prices_products_empty_title => 'Ingen pris tilgjengelig';
@@ -5342,41 +5386,41 @@ class AppLocalizationsNn extends AppLocalizations {
 
   @override
   String prices_products_list_length_many_pages(int pageSize, int total) {
-    return 'Top $pageSize products (total: $total)';
+    return 'Topp $pageSize produkter (totalt: $total)';
   }
 
   @override
-  String get app_review_title => 'Are you enjoying this app?';
+  String get app_review_title => 'Liker du denne appen?';
 
   @override
-  String get app_review_low => 'Could do better';
+  String get app_review_low => 'Kunne gjort det bedre';
 
   @override
-  String get app_review_medium => 'Not bad';
+  String get app_review_medium => 'Ikke dårlig';
 
   @override
-  String get app_review_high => 'I love it!';
+  String get app_review_high => 'Jeg elsker det!';
 
   @override
   String get app_review_feedback_modal_title =>
-      'Help us improve our application';
+      'Hjelp oss med å forbedre applikasjonen vår';
 
   @override
   String get app_review_feedback_modal_content =>
-      'If you have a few minutes, could you answer this form so that **we can improve in future updates**:';
+      'Hvis du har noen minutter, kan du svare på dette skjemaet slik at **vi kan forbedre oss i fremtidige oppdateringer**:';
 
   @override
-  String get app_review_feedback_modal_open_form => 'Answer the form';
+  String get app_review_feedback_modal_open_form => 'Svar på skjemaet';
 
   @override
-  String get app_review_feedback_modal_later => 'Ask me later';
+  String get app_review_feedback_modal_later => 'Spør meg senere';
 
   @override
   String get nutrition_facts_extract_new =>
-      'NEW: You can automatically extract the nutrients from the picture!';
+      'NYTT: Du kan automatisk trekke ut næringsstoffene fra bildet!';
 
   @override
-  String get nutrition_facts_extract_button_text => 'Extract now';
+  String get nutrition_facts_extract_button_text => 'Uttrekk nå';
 
   @override
   String get nutrition_facts_extract_in_progress => 'Uttrekking pågår…';
@@ -5386,19 +5430,19 @@ class AppLocalizationsNn extends AppLocalizations {
 
   @override
   String get nutrition_facts_extract_failed =>
-      'Failed to extract nutrients from picture';
+      'Klarte ikke å hente ut næringsstoffer fra bildet';
 
   @override
   String get prices_discount => 'Discount';
 
   @override
-  String get prices_stats_statistics => 'Statistics';
+  String get prices_stats_statistics => 'Statistikk';
 
   @override
-  String get prices_stats_title => 'Prices Statistics';
+  String get prices_stats_title => 'Prisstatistikk';
 
   @override
-  String get prices_stats_prices_section => 'Prices';
+  String get prices_stats_prices_section => 'Priser';
 
   @override
   String get prices_stats_products_section => 'Produkter';
@@ -5416,7 +5460,7 @@ class AppLocalizationsNn extends AppLocalizations {
   String get prices_stats_experiments_section => 'Experiments';
 
   @override
-  String get prices_stats_misc_section => 'Miscellaneous';
+  String get prices_stats_misc_section => 'Diverse';
 
   @override
   String get prices_stats_total => 'Total';
@@ -5440,7 +5484,7 @@ class AppLocalizationsNn extends AppLocalizations {
   String get prices_stats_with_price => 'With a price';
 
   @override
-  String get prices_stats_food => 'Food';
+  String get prices_stats_food => 'Mat';
 
   @override
   String get prices_stats_beauty => 'Beauty';
@@ -5449,7 +5493,7 @@ class AppLocalizationsNn extends AppLocalizations {
   String get prices_stats_products => 'Produkter';
 
   @override
-  String get prices_stats_pet_food => 'Pet food';
+  String get prices_stats_pet_food => 'Kjæledyrfôr';
 
   @override
   String get prices_stats_osm => 'OpenStreetMap';
@@ -5461,10 +5505,10 @@ class AppLocalizationsNn extends AppLocalizations {
   String get prices_stats_countries => 'Countries';
 
   @override
-  String get prices_stats_price_tag => 'Price tag';
+  String get prices_stats_price_tag => 'Prislapp';
 
   @override
-  String get prices_stats_receipt => 'Receipt';
+  String get prices_stats_receipt => 'Kvittering';
 
   @override
   String get prices_stats_gdpr_request => 'GDPR request';
@@ -5488,35 +5532,36 @@ class AppLocalizationsNn extends AppLocalizations {
   String get prices_stats_by_source_title => 'Prices and proofs per source';
 
   @override
-  String get prices_stats_website => 'Website';
+  String get prices_stats_website => 'Nettsted';
 
   @override
   String get prices_stats_mobile_app => 'Mobile app';
 
   @override
-  String get prices_stats_api => 'API';
+  String get prices_stats_api => 'API-en';
 
   @override
   String get prices_stats_other => 'Other';
 
   @override
-  String get prices_stats_last_updated => 'Last updated on';
+  String get prices_stats_last_updated => 'Sist oppdatert';
 
   @override
   String get prices_stats_error =>
-      'An error occurred while loading statistics.';
+      'Det oppsto en feil under lasting av statistikk.';
 
   @override
-  String get product_edit_robotoff_question_answered => 'Question answered!';
+  String get product_edit_robotoff_question_answered =>
+      'Spørsmålet er besvart!';
 
   @override
-  String get product_edit_robotoff_proof => 'Proof';
+  String get product_edit_robotoff_proof => 'Bevis';
 
   @override
   String get preferences_card_general => 'General';
 
   @override
-  String get preferences_prices_title => 'Prices';
+  String get preferences_prices_title => 'Priser';
 
   @override
   String get preferences_prices_subtitle =>
@@ -5556,7 +5601,7 @@ class AppLocalizationsNn extends AppLocalizations {
   String get preferences_card_help => 'Hjelp og støtte';
 
   @override
-  String get preferences_faq_title => 'FAQ';
+  String get preferences_faq_title => 'Vanlige spørsmål';
 
   @override
   String get preferences_faq_subtitle => 'Få svar på spørsmålene dine';
@@ -5608,7 +5653,7 @@ class AppLocalizationsNn extends AppLocalizations {
       'Bruksvilkår, personvernregler og mer';
 
   @override
-  String get preferences_terms_of_use => 'Terms of use';
+  String get preferences_terms_of_use => 'Bruksvilkår';
 
   @override
   String get preferences_legal_mentions => 'Legal mentions';
@@ -5618,7 +5663,7 @@ class AppLocalizationsNn extends AppLocalizations {
       'Open Food Facts er en database med matvarer **laget av alle, for alle**.\nDu kan bruke den til å ta bedre matvalg, og siden den er **åpne data**, kan hvem som helst **gjenbruke den til ethvert formål**.';
 
   @override
-  String get preferences_privacy_policy => 'Privacy policy';
+  String get preferences_privacy_policy => 'Personvernerklæring';
 
   @override
   String get preferences_licenses => 'Lisenser';
@@ -5796,7 +5841,7 @@ class AppLocalizationsNn extends AppLocalizations {
 
   @override
   String get preferences_connect_community_calendar_title =>
-      'Subscribe to our community calendar';
+      'Abonner på vår fellesskapskalender';
 
   @override
   String get preferences_connect_community_calendar_subtitle =>
@@ -5902,7 +5947,7 @@ class AppLocalizationsNn extends AppLocalizations {
       'Enkle trinn for å øke åpenheten om mat i landet ditt';
 
   @override
-  String get preferences_contribute_data_quality_title => 'Data quality';
+  String get preferences_contribute_data_quality_title => 'Datakvalitet';
 
   @override
   String get preferences_contribute_data_quality_team_title =>
@@ -5929,10 +5974,10 @@ class AppLocalizationsNn extends AppLocalizations {
       'Alle ufullstendige produkter';
 
   @override
-  String get preferences_my_contributions_prices_title => 'Prices';
+  String get preferences_my_contributions_prices_title => 'Priser';
 
   @override
-  String get preferences_my_contributions_my_prices_title => 'My prices';
+  String get preferences_my_contributions_my_prices_title => 'Mine priser';
 
   @override
   String get preferences_my_contributions_my_prices_subtitle =>
@@ -6013,7 +6058,7 @@ class AppLocalizationsNn extends AppLocalizations {
 
   @override
   String get preferences_page_contribute_project_subtitle =>
-      'Simple ways to help Open Food Facts';
+      'Enkle måter å hjelpe på Åpne matfakta';
 
   @override
   String get preferences_page_faq_subtitle =>
@@ -6124,11 +6169,11 @@ class AppLocalizationsNn extends AppLocalizations {
       'Open Food Facts Labs';
 
   @override
-  String get preferences_root_account_title => 'Account';
+  String get preferences_root_account_title => 'Konto';
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Få åpne matfakta på språket ditt';
 
   @override
   String get preferences_contribute_enroll_alpha =>
@@ -6142,7 +6187,7 @@ class AppLocalizationsNn extends AppLocalizations {
       'Ikke vis folkesonomi';
 
   @override
-  String get preferences_account_title => 'Account';
+  String get preferences_account_title => 'Konto';
 
   @override
   String prices_adding_timestamp_tooltip(String created) {
@@ -6150,26 +6195,26 @@ class AppLocalizationsNn extends AppLocalizations {
   }
 
   @override
-  String get location_map_details_title => 'Location details';
+  String get location_map_details_title => 'Stedsdetaljer';
 
   @override
   String get location_map_details_name => 'Navn';
 
   @override
-  String get location_map_details_street => 'Street';
+  String get location_map_details_street => 'Gate';
 
   @override
-  String get location_map_details_city => 'City';
+  String get location_map_details_city => 'By';
 
   @override
-  String get location_map_details_postcode => 'Postcode';
+  String get location_map_details_postcode => 'Postnummer';
 
   @override
   String get location_map_details_country => 'Country';
 
   @override
-  String get location_map_details_coordinates => 'Coordinates';
+  String get location_map_details_coordinates => 'Koordinater';
 
   @override
-  String get location_map_details_osm_id => 'OSM ID';
+  String get location_map_details_osm_id => 'OSM-ID';
 }

--- a/packages/smooth_app/lib/l10n/app_localizations_no.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_no.dart
@@ -22,19 +22,19 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get account_delete_message =>
-      'Are you sure you want to delete your account?\nIf there is a specific reason, please share below';
+      'Er du sikker på at du vil slette kontoen din?\nHvis det er en spesifikk grunn, vennligst del den nedenfor.';
 
   @override
-  String get reason => 'Reason';
+  String get reason => 'Grunn';
 
   @override
-  String get okay => 'Okay';
+  String get okay => 'Greit';
 
   @override
   String get validate => 'Validate';
 
   @override
-  String get create => 'Create';
+  String get create => 'Skape';
 
   @override
   String get applyButtonText => 'Apply';
@@ -43,7 +43,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get next_label => 'Neste';
 
   @override
-  String get continue_label => 'Continue';
+  String get continue_label => 'Fortsette';
 
   @override
   String get exit_label => 'Exit';
@@ -52,13 +52,13 @@ class AppLocalizationsNo extends AppLocalizations {
   String get previous_label => 'Previous';
 
   @override
-  String get go_back_to_top => 'Go back to top';
+  String get go_back_to_top => 'Gå tilbake til toppen';
 
   @override
   String get save => 'Lagr';
 
   @override
-  String get save_confirmation => 'Are you sure you want to save?';
+  String get save_confirmation => 'Er du sikker på at du vil lagre?';
 
   @override
   String get skip => 'Skip';
@@ -67,7 +67,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get cancel => 'Cancel';
 
   @override
-  String get ignore => 'Ignore';
+  String get ignore => 'Overse';
 
   @override
   String get close => 'Close';
@@ -76,292 +76,297 @@ class AppLocalizationsNo extends AppLocalizations {
   String get no => 'Nei';
 
   @override
-  String get stop => 'Stop';
+  String get stop => 'Stoppe';
 
   @override
-  String get finish => 'Finish';
+  String get finish => 'Fullfør';
 
   @override
-  String get calculate => 'Calculate';
+  String get calculate => 'Kalkulere';
 
   @override
-  String get reset_food_prefs => 'Reset food preferences';
+  String get reset_food_prefs => 'Tilbakestill matpreferanser';
 
   @override
-  String get error => 'Something went wrong';
+  String get error => 'Noe gikk galt';
 
   @override
-  String get error_occurred => 'An error occurred';
+  String get error_occurred => 'Det oppsto en feil';
 
   @override
   String get featureInProgress =>
-      'We\'re still working on this feature, stay tuned';
+      'Vi jobber fortsatt med denne funksjonen, følg med';
 
   @override
-  String get label_web => 'View on the web';
+  String get label_web => 'Vis på nettet';
 
   @override
-  String get learnMore => 'Learn more';
+  String get learnMore => 'Lær mer';
 
   @override
-  String get unknown => 'Unknown';
+  String get unknown => 'Ukjent';
 
   @override
-  String get match_very_good => 'Very good match';
+  String get match_very_good => 'Veldig god kamp';
 
   @override
-  String get match_good => 'Good match';
+  String get match_good => 'God match';
 
   @override
-  String get match_poor => 'Poor match';
+  String get match_poor => 'Dårlig kamp';
 
   @override
   String get match_may_not => 'May not match';
 
   @override
-  String get match_does_not => 'Does not match';
+  String get match_does_not => 'Stemmer ikke overens';
 
   @override
-  String get match_unknown => 'Unknown match';
+  String get match_unknown => 'Ukjent treff';
 
   @override
-  String get match_short_very_good => 'Very good match';
+  String get match_short_very_good => 'Veldig god kamp';
 
   @override
-  String get match_short_good => 'Good match';
+  String get match_short_good => 'God match';
 
   @override
-  String get match_short_poor => 'Poor match';
+  String get match_short_poor => 'Dårlig kamp';
 
   @override
   String get match_short_may_not => 'May not match';
 
   @override
-  String get match_short_does_not => 'Does not match';
+  String get match_short_does_not => 'Stemmer ikke overens';
 
   @override
-  String get match_short_unknown => 'Unknown match';
+  String get match_short_unknown => 'Ukjent treff';
 
   @override
   String get licenses => 'Licences';
 
   @override
-  String get looking_for => 'Looking for';
+  String get looking_for => 'Leter etter';
 
   @override
-  String get welcomeToOpenFoodFacts => 'Welcome to Open Food Facts';
+  String get welcomeToOpenFoodFacts => 'Velkommen til Åpne matfakta';
 
   @override
   String get whatIsOff =>
-      'Open Food Facts is a global non-profit powered by local communities.';
+      'Open Food Facts er en global ideell organisasjon drevet av lokalsamfunn.';
 
   @override
   String get productDataUtility =>
-      'See the food data relevant to your preferences.';
+      'Se matdataene som er relevante for dine preferanser.';
 
   @override
-  String get healthCardUtility => 'Choose foods that are good for you.';
+  String get healthCardUtility => 'Velg matvarer som er bra for deg.';
 
   @override
-  String get ecoCardUtility => 'Choose foods that are good for the planet.';
+  String get ecoCardUtility => 'Velg matvarer som er bra for planeten.';
 
   @override
   String get server_error_open_new_issue =>
-      'No server response! You may open an issue with the following link.';
+      'Ingen serverrespons! Du kan åpne et problem med følgende lenke.';
 
   @override
   String get sign_in_text =>
-      'Sign in to your Open Food Facts account to save your contributions';
+      'Logg inn på Open Food Facts-kontoen din for å lagre bidragene dine';
 
   @override
-  String get incorrect_credentials => 'Incorrect username or password.';
+  String get incorrect_credentials => 'Feil brukernavn eller passord.';
 
   @override
   String get password_lost_incorrect_credentials =>
-      'This email or username doesn\'t exist. Please check your credentials.';
+      'Denne e-postadressen eller brukernavnet finnes ikke. Vennligst sjekk påloggingsinformasjonen din.';
 
   @override
   String get password_lost_server_unavailable =>
-      'We are currently experiencing slowdowns on our servers and we apologise for it. Please try again later.';
+      'Vi opplever for tiden nedgang på serverne våre, og vi beklager dette. Prøv igjen senere.';
 
   @override
   String get login => 'Username';
 
   @override
-  String get login_result_type_server_unreachable => 'Network is unreachable';
+  String get login_result_type_server_unreachable =>
+      'Nettverket er utilgjengelig';
 
   @override
   String get login_result_type_server_issue =>
-      'Problem on the server. Please try later.';
+      'Problem på serveren. Prøv senere.';
 
   @override
-  String get login_page_username_or_email => 'Please enter username or e-mail';
+  String get login_page_username_or_email =>
+      'Vennligst skriv inn brukernavn eller e-post';
 
   @override
-  String get login_page_password_error_empty => 'Please enter a password';
+  String get login_page_password_error_empty =>
+      'Vennligst skriv inn et passord';
 
   @override
-  String get create_account => 'Create account';
+  String get create_account => 'Opprett konto';
 
   @override
   String get sign_in => 'Logg inn';
 
   @override
-  String get sign_in_mandatory => 'For that feature we need you to sign in.';
+  String get sign_in_mandatory => 'For den funksjonen må du logge inn.';
 
   @override
   String get help_improve_country =>
-      'Help improve Open Food Facts in your country';
+      'Hjelp med å forbedre Open Food Facts i landet ditt';
 
   @override
-  String get sign_out => 'Sign out';
+  String get sign_out => 'Logg ut';
 
   @override
-  String get sign_out_confirmation => 'Are you sure you want to sign out?';
+  String get sign_out_confirmation => 'Er du sikker på at du vil logge ut?';
 
   @override
   String get password => 'Passord';
 
   @override
-  String get forgot_password => 'Forgot password';
+  String get forgot_password => 'Glemt passord';
 
   @override
   String get forgot_password_question => 'Glemt passord?';
 
   @override
-  String get view_profile => 'View profile';
+  String get view_profile => 'Vis profil';
 
   @override
-  String get reset_password => 'Reset password';
+  String get reset_password => 'Tilbakestill passord';
 
   @override
   String get reset_password_explanation_text =>
-      'In case of a forgotten password, enter your username or e-mail address to receive instructions for a password reset. Also, remember to check the Spam folder.';
+      'Hvis du har glemt passordet, skriv inn brukernavnet eller e-postadressen din for å motta instruksjoner for tilbakestilling av passord. Husk også å sjekke spam-mappen.';
 
   @override
-  String get username_or_email => 'Username or e-mail';
+  String get username_or_email => 'Brukernavn eller e-post';
 
   @override
   String get reset_password_done =>
-      'An e-mail with a link to reset your password has been sent to the e-mail address associated with your account. Also check your spam';
+      'En e-post med en lenke for å tilbakestille passordet ditt er sendt til e-postadressen som er knyttet til kontoen din. Sjekk også spam-mappen din.';
 
   @override
-  String get send_reset_password_mail => 'Change password';
+  String get send_reset_password_mail => 'Endre passord';
 
   @override
-  String get enter_some_text => 'Please enter some text';
+  String get enter_some_text => 'Vennligst skriv inn litt tekst';
 
   @override
-  String get sign_up_page_title => 'Sign Up';
+  String get sign_up_page_title => 'Registrer deg';
 
   @override
-  String get sign_up_page_action_button => 'Sign Up';
+  String get sign_up_page_action_button => 'Registrer deg';
 
   @override
-  String get sign_up_page_action_doing_it => 'Signing up…';
+  String get sign_up_page_action_doing_it => 'Registrering…';
 
   @override
   String get sign_up_page_action_ok =>
-      'Congratulations! Your account has just been created.';
+      'Gratulerer! Kontoen din er nettopp opprettet.';
 
   @override
   String get sign_up_page_display_name_hint => 'Navn';
 
   @override
   String get sign_up_page_display_name_error_empty =>
-      'Please enter the display name you want to use';
+      'Vennligst skriv inn visningsnavnet du vil bruke';
 
   @override
-  String get sign_up_page_email_hint => 'E-mail';
+  String get sign_up_page_email_hint => 'E-post';
 
   @override
-  String get sign_up_page_email_error_empty => 'E-mail is required';
+  String get sign_up_page_email_error_empty => 'E-post er påkrevd';
 
   @override
-  String get sign_up_page_email_error_invalid => 'Invalid e-mail';
+  String get sign_up_page_email_error_invalid => 'Ugyldig e-post';
 
   @override
-  String get sign_up_page_username_hint => 'Username: Publicly visible';
+  String get sign_up_page_username_hint => 'Brukernavn: Offentlig synlig';
 
   @override
-  String get sign_up_page_username_error_empty => 'Please enter a username';
+  String get sign_up_page_username_error_empty =>
+      'Vennligst skriv inn et brukernavn';
 
   @override
   String get sign_up_page_username_error_invalid =>
-      'Please enter a valid username';
+      'Vennligst skriv inn et gyldig brukernavn';
 
   @override
   String get sign_up_page_username_description =>
-      'Username cannot contains spaces, caps or special characters.';
+      'Brukernavnet kan ikke inneholde mellomrom, store bokstaver eller spesialtegn.';
 
   @override
   String sign_up_page_username_length_invalid(int value) {
-    return 'Username cannot exceed $value characters';
+    return 'Brukernavnet kan ikke overskride $value tegn';
   }
 
   @override
   String get sign_up_page_password_hint => 'Passord';
 
   @override
-  String get sign_up_page_password_error_empty => 'Please enter a password';
+  String get sign_up_page_password_error_empty =>
+      'Vennligst skriv inn et passord';
 
   @override
   String get sign_up_page_password_error_invalid =>
-      'Please enter a valid password (at least 6 characters)';
+      'Vennligst skriv inn et gyldig passord (minst 6 tegn)';
 
   @override
-  String get sign_up_page_confirm_password_hint => 'Confirm Password';
+  String get sign_up_page_confirm_password_hint => 'Bekreft passord';
 
   @override
   String get sign_up_page_confirm_password_error_empty =>
-      'Please confirm the password';
+      'Vennligst bekreft passordet';
 
   @override
   String get sign_up_page_confirm_password_error_invalid =>
-      'Passwords don\'t match';
+      'Passordene samsvarer ikke';
 
   @override
-  String get sign_up_page_agree_text => 'I agree to the Open Food Facts';
+  String get sign_up_page_agree_text => 'Jeg godtar de åpne matfaktaene';
 
   @override
-  String get sign_up_page_terms_text => 'terms of use and contribution';
+  String get sign_up_page_terms_text => 'bruksvilkår og bidrag';
 
   @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
   String get sign_up_page_agree_error_invalid =>
-      'When creating an account, agreeing to the Terms of Use is mandatory, however, anonymous contributions can still be made through the app';
+      'Når du oppretter en konto, er det obligatorisk å godta bruksvilkårene, men anonyme bidrag kan fortsatt gis gjennom appen.';
 
   @override
-  String get sign_up_page_producer_checkbox => 'I am a food producer';
+  String get sign_up_page_producer_checkbox => 'Jeg er en matprodusent';
 
   @override
-  String get sign_up_page_producer_hint => 'Producer/brand';
+  String get sign_up_page_producer_hint => 'Produsent/merke';
 
   @override
   String get sign_up_page_producer_error_empty =>
-      'Please enter a producer or a brand name';
+      'Vennligst skriv inn en produsent eller et merkenavn';
 
   @override
   String get sign_up_page_subscribe_checkbox =>
-      'I\'d like to subscribe to the Open Food Facts newsletter (You can unsubscribe from it at any time)';
+      'Jeg vil gjerne abonnere på nyhetsbrevet fra Open Food Facts (du kan når som helst melde deg av)';
 
   @override
   String get sign_up_page_user_name_already_used =>
-      'The user name already exists, please choose another username.';
+      'Brukernavnet finnes allerede, vennligst velg et annet brukernavn.';
 
   @override
   String get sign_up_page_email_already_exists =>
-      'already exists, login to the account or try with another email.';
+      'finnes allerede, logg inn på kontoen eller prøv med en annen e-postadresse.';
 
   @override
   String get sign_up_page_provide_valid_email =>
-      'Please provide a valid email address.';
+      'Vennligst oppgi en gyldig e-postadresse.';
 
   @override
   String get sign_up_page_server_busy =>
-      'We are deeply sorry, we have some technical difficulties to create your account. Please try again later.';
+      'Vi beklager på det sterkeste, men vi har hatt noen tekniske problemer med å opprette kontoen din. Prøv igjen senere.';
 
   @override
   String get settingsTitle => 'Innstillinger';
@@ -379,141 +384,140 @@ class AppLocalizationsNo extends AppLocalizations {
   String get darkmode_system_default => 'Systemstandard';
 
   @override
-  String get thanks_for_contributing => 'Thanks for contributing!';
+  String get thanks_for_contributing => 'Takk for bidraget!';
 
   @override
-  String get contributors_label => 'They are building the app';
+  String get contributors_label => 'De bygger appen';
 
   @override
   String get contributors_dialog_title => 'Bidragere';
 
   @override
   String contributors_dialog_entry_description(Object name) {
-    return 'Contributor: $name';
+    return 'Bidragsyter: $name';
   }
 
   @override
   String get contributors_description =>
-      'A list of all contributors of this app';
+      'En liste over alle bidragsytere til denne appen';
 
   @override
-  String get support => 'Support';
+  String get support => 'Støtte';
 
   @override
-  String get support_join_slack => 'Ask for help in our Slack channel';
+  String get support_join_slack => 'Be om hjelp i Slack-kanalen vår';
 
   @override
-  String get support_via_forum => 'Ask for help on our forum';
+  String get support_via_forum => 'Be om hjelp på forumet vårt';
 
   @override
-  String get support_via_email => 'Send us an e-mail';
+  String get support_via_email => 'Send oss en e-post';
 
   @override
-  String get support_via_email_include_logs_dialog_title => 'Send app logs?';
+  String get support_via_email_include_logs_dialog_title => 'Send applogger?';
 
   @override
   String get support_via_email_include_logs_dialog_body =>
-      'Do you wish to include application logs in attachment to your email?';
+      'Ønsker du å legge ved applikasjonslogger som vedlegg i e-posten din?';
 
   @override
-  String get termsOfUse => 'Terms of use';
+  String get termsOfUse => 'Bruksvilkår';
 
   @override
-  String get legalNotices => 'Legal notices';
+  String get legalNotices => 'Juridiske merknader';
 
   @override
-  String get privacy_policy => 'Privacy policy';
+  String get privacy_policy => 'Personvernerklæring';
 
   @override
-  String get about_this_app => 'About this app';
+  String get about_this_app => 'Om denne appen';
 
   @override
   String get contribute => 'Contribute';
 
   @override
-  String get contribute_sw_development => 'Software development';
+  String get contribute_sw_development => 'Programvareutvikling';
 
   @override
   String get contribute_develop_text =>
-      'The code for every Open Food Facts product is available on GitHub. You are welcome to reuse the code (it\'s open source) and help us improve it, for everyone, on all the planet.';
+      'Koden for alle Open Food Facts-produkter er tilgjengelig på GitHub. Du er velkommen til å gjenbruke koden (den er åpen kildekode) og hjelpe oss med å forbedre den, for alle, på hele planeten.';
 
   @override
   String get contribute_develop_text_2 =>
-      'You can join the Open Food Facts Slack chatroom which is the preferred way to ask questions.';
+      'Du kan bli med i Open Food Facts Slack-chatten, som er den foretrukne måten å stille spørsmål på.';
 
   @override
-  String get contribute_develop_dev_mode_title => 'DEV Mode?';
+  String get contribute_develop_dev_mode_title => 'DEV-modus?';
 
   @override
-  String get contribute_develop_dev_mode_subtitle => 'Activate the DEV Mode';
+  String get contribute_develop_dev_mode_subtitle => 'Aktiver DEV-modus';
 
   @override
   String get contribute_donate_title => 'Donate';
 
   @override
-  String get contribute_donate_header => 'Donate to Open Food Facts';
+  String get contribute_donate_header => 'Doner til Open Food Facts';
 
   @override
   String get contribute_enroll_alpha_warning =>
-      'Please acknowledge that with the internal alpha version, complete loss of data is possible, and the app may become unusable at any time !';
+      'Vær oppmerksom på at med den interne alfaversjonen er fullstendig tap av data mulig, og appen kan bli ubrukelig når som helst!';
 
   @override
   String get contribute_improve_ProductsToBeCompleted =>
-      'Products to be completed';
+      'Produkter som skal fullføres';
 
   @override
-  String get contribute_improve_header => 'Improving';
+  String get contribute_improve_header => 'Forbedring';
 
   @override
   String get contribute_improve_text =>
-      'The database is the core of the project. It\'s easy and very quick to help. You can download the mobile app for your phone, and start adding or improving products.\n\nOn the other hand, Open Food Facts website offers many ways to contribute: ';
+      'Databasen er kjernen i prosjektet. Det er enkelt og raskt å hjelpe. Du kan laste ned mobilappen til telefonen din og begynne å legge til eller forbedre produkter.\n\nPå den annen side tilbyr nettstedet Open Food Facts mange måter å bidra på: ';
 
   @override
-  String get contribute_translate_header => 'Translate';
+  String get contribute_translate_header => 'Oversett';
 
   @override
   String get contribute_data_quality => 'Data Quality';
 
   @override
-  String get contribute_translate_link_text => 'Start Translating';
+  String get contribute_translate_link_text => 'Begynn å oversette';
 
   @override
   String get contribute_translate_text =>
-      'Open Food Facts is a global project, containing products from more than 160 countries. Open Food Facts is translated into dozens of languages, with constantly evolving content.';
+      'Open Food Facts er et globalt prosjekt som inneholder produkter fra mer enn 160 land. Open Food Facts er oversatt til en rekke språk, med innhold i stadig utvikling.';
 
   @override
   String get contribute_translate_text_2 =>
-      'Translations is one of the key tasks of the project';
+      'Oversettelser er en av prosjektets hovedoppgaver';
 
   @override
   String get contribute_join_skill_pool =>
-      'Contribute your skills to Open Food Facts. Join the skill pool!';
+      'Bidra med ferdighetene dine til Open Food Facts. Bli med i ferdighetspoolen!';
 
   @override
-  String get contribute_share_header =>
-      'Share Open Food Facts with your friends';
+  String get contribute_share_header => 'Del Åpne matfakta med vennene dine';
 
   @override
   String get contribute_share_content =>
-      'I wanted to let you know about the app I\'ve been using, Open Food Facts, which allows you to get the health and environmental impacts of your food, in a personalized way. It works by scanning the barcodes on the packaging. Finally it\'s free, does not require registration, and you can even help increase the number of products decyphered. Here\'s the link to get it for your phone: https://openfoodfacts.app';
+      'Jeg ville fortelle deg om appen jeg har brukt, Open Food Facts, som lar deg få informasjon om helse- og miljøpåvirkningen av maten din på en personlig måte. Den fungerer ved å skanne strekkodene på emballasjen. Den er gratis, krever ikke registrering, og du kan til og med bidra til å øke antallet produkter som dekrypteres. Her er lenken for å laste den ned til telefonen din: https://openfoodfacts.app';
 
   @override
   String get contribute_prices_gdpr =>
-      'Contribute prices by requesting a GDPR export of your loyalty cards data';
+      'Bidra til priser ved å be om GDPR-eksport av lojalitetskortdataene dine';
 
   @override
-  String get tap_to_answer => 'Tap here to answer questions';
+  String get tap_to_answer => 'Trykk her for å svare på spørsmål';
 
   @override
   String get tap_to_answer_hint =>
-      'Tap here to answer questions about this product';
+      'Trykk her for å svare på spørsmål om dette produktet';
 
   @override
   String get robotoff_questions_loading_hint =>
-      'Please wait while questions about this product are loaded';
+      'Vent mens spørsmål om dette produktet lastes inn';
 
   @override
-  String get saving_answer => 'Saving your answer';
+  String get saving_answer => 'Lagrer svaret ditt';
 
   @override
   String get contribute_to_get_rewards =>
@@ -521,109 +525,110 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get question_sign_in_text =>
-      'Sign in to your Open Food Facts account to get credit for your contributions';
+      'Logg inn på Open Food Facts-kontoen din for å få kreditt for bidragene dine';
 
   @override
-  String get question_yes_button_accessibility_value => 'Answer with yes';
+  String get question_yes_button_accessibility_value => 'Svar med ja';
 
   @override
-  String get question_no_button_accessibility_value => 'Answer with no';
+  String get question_no_button_accessibility_value => 'Svar med nei';
 
   @override
-  String get question_skip_button_accessibility_value => 'Skip this question';
+  String get question_skip_button_accessibility_value =>
+      'Hopp over dette spørsmålet';
 
   @override
-  String get tap_to_edit_search => 'Tap to edit search';
+  String get tap_to_edit_search => 'Trykk for å redigere søket';
 
   @override
-  String get myPreferences => 'My preferences';
+  String get myPreferences => 'Mine preferanser';
 
   @override
   String get account_create_message =>
-      'Create your account and join the Open Food Facts community to help build food knowledge all over the world!';
+      'Opprett din konto og bli med i Open Food Facts-fellesskapet for å bidra til å bygge matkunnskap over hele verden!';
 
   @override
-  String get join_us => 'Join us';
+  String get join_us => 'Bli med oss';
 
   @override
-  String get myPreferences_profile_title => 'Your Profile';
+  String get myPreferences_profile_title => 'Din profil';
 
   @override
   String get myPreferences_profile_subtitle =>
-      'Manage your Open Food Facts contributor account.';
+      'Administrer din Open Food Facts-bidragsyterkonto.';
 
   @override
-  String get myPreferences_settings_title => 'App Settings';
+  String get myPreferences_settings_title => 'Appinnstillinger';
 
   @override
-  String get myPreferences_settings_subtitle => 'Dark mode, Languages…';
+  String get myPreferences_settings_subtitle => 'Mørk modus, Språk…';
 
   @override
-  String get myPreferences_food_title => 'Food Preferences';
+  String get myPreferences_food_title => 'Matpreferanser';
 
   @override
   String get myPreferences_food_subtitle =>
-      'Choose what information about food matters most to you.';
+      'Velg hvilken informasjon om mat som er viktigst for deg.';
 
   @override
   String get myPreferences_food_comment =>
-      'Choose what information about food matters most to you, in order to rank food according to your preferences, see the information you care about first, and get a compatibility summary. Those food preferences stay on your device, and are not associated with your Open Food Facts contributor account if you have one.';
+      'Velg hvilken informasjon om mat som er viktigst for deg, for å rangere mat i henhold til dine preferanser, se informasjonen du bryr deg om først, og få et kompatibilitetssammendrag. Disse matpreferansene forblir på enheten din, og er ikke knyttet til din Open Food Facts-bidragsyterkonto hvis du har en.';
 
   @override
-  String get confirmResetPreferences => 'Reset your food preferences?';
+  String get confirmResetPreferences => 'Tilbakestille matpreferansene dine?';
 
   @override
-  String get myPersonalizedRanking => 'My personalized ranking';
+  String get myPersonalizedRanking => 'Min personlige rangering';
 
   @override
   String get ranking_tab_all => 'All';
 
   @override
-  String get ranking_subtitle_match_yes => 'A great match for you';
+  String get ranking_subtitle_match_yes => 'En flott match for deg';
 
   @override
-  String get ranking_subtitle_match_no => 'Very poor match';
+  String get ranking_subtitle_match_no => 'Veldig dårlig kamp';
 
   @override
-  String get ranking_subtitle_match_maybe => 'Unknown match';
+  String get ranking_subtitle_match_maybe => 'Ukjent treff';
 
   @override
   String get refresh_with_new_preferences =>
-      'Refresh the list with your new preferences';
+      'Oppdater listen med de nye innstillingene dine';
 
   @override
   String get reloaded_with_new_preferences =>
-      'Reloaded with your new preferences';
+      'Lastet inn på nytt med dine nye preferanser';
 
   @override
   String get profile_navbar_label => 'Community';
 
   @override
-  String get scan_navbar_label => 'Scan';
+  String get scan_navbar_label => 'Skann';
 
   @override
   String get history_navbar_label => 'Logg';
 
   @override
-  String get list_navbar_label => 'Lists';
+  String get list_navbar_label => 'Lister';
 
   @override
-  String get category => 'Filter by category';
+  String get category => 'Filtrer etter kategori';
 
   @override
   String get category_all => 'All';
 
   @override
-  String get category_search => '(category search)';
+  String get category_search => '(kategorisøk)';
 
   @override
   String get filter => 'Filter';
 
   @override
-  String get scan => 'Products from the Scan screen';
+  String get scan => 'Produkter fra skanneskjermen';
 
   @override
-  String get scan_history => 'Scan history';
+  String get scan_history => 'Skanningshistorikk';
 
   @override
   String get search => 'Søk';
@@ -639,169 +644,173 @@ class AppLocalizationsNo extends AppLocalizations {
   String get search_history => 'Søkelogg';
 
   @override
-  String get search_store => 'Search for a store';
+  String get search_store => 'Søk etter en butikk';
 
   @override
   String get search_store_help => 'Hint: legg til byen eller landet';
 
   @override
-  String get tap_for_more => 'Tap to see more info…';
+  String get tap_for_more => 'Trykk for å se mer informasjon…';
 
   @override
   String get product => 'Produkt';
 
   @override
-  String get unknownBrand => 'Unknown brand';
+  String get unknownBrand => 'Ukjent merke';
 
   @override
-  String get unknownProductName => 'Unknown product name';
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
+  String get unknownProductName => 'Ukjent produktnavn';
 
   @override
   String get label_refresh => 'Refresh';
 
   @override
-  String get label_reload => 'Reload';
+  String get label_reload => 'Last inn på nytt';
 
   @override
-  String get image => 'Image';
+  String get image => 'Bilde';
 
   @override
-  String get front_photo => 'Front photo';
+  String get front_photo => 'Forsidebilde';
 
   @override
   String outdated_image_accessibility_label(Object imageType) {
-    return '$imageType (this image may be outdated)';
+    return '$imageType (dette bildet kan være utdatert)';
   }
 
   @override
-  String get outdated_image_short_label => 'may be outdated';
+  String get outdated_image_short_label => 'kan være utdatert';
 
   @override
   String get ingredients => 'Ingredienser';
 
   @override
   String get ingredients_editing_instructions =>
-      'Keep the original order. Indicate the percentage when specified. Separate with a comma or hyphen and use parentheses for ingredients of an ingredient.';
+      'Behold den opprinnelige rekkefølgen. Angi prosentandelen når den er spesifisert. Skill med komma eller bindestrek, og bruk parenteser for ingrediensene til en ingrediens.';
 
   @override
-  String get ingredients_editing_error => 'Failed to save the ingredients.';
+  String get ingredients_editing_error => 'Kunne ikke lagre ingrediensene.';
 
   @override
   String get ingredients_editing_image_error =>
-      'Failed to get a new ingredients image.';
+      'Klarte ikke å hente et nytt ingrediensbilde.';
 
   @override
-  String get ingredients_editing_title => 'Edit Ingredients';
+  String get ingredients_editing_title => 'Rediger ingredienser';
 
   @override
-  String get ingredients_photo => 'Ingredients photo';
+  String get ingredients_photo => 'Ingredienser bilde';
 
   @override
   String get packaging_editing_instructions =>
-      'List all packaging parts separated by a comma or line feed, with their amount (e.g. 1 or 6) type (e.g. bottle, box, can), material (e.g. plastic, metal, aluminium) and if available their size (e.g. 33cl) and recycling instructions.\nExample: 1 glass bottle to recycle, 1 plastic cork to throw away';
+      'List opp alle emballasjedeler atskilt med komma eller linjeskift, med mengde (f.eks. 1 eller 6), type (f.eks. flaske, eske, boks), materiale (f.eks. plast, metall, aluminium) og hvis tilgjengelig størrelse (f.eks. 33 cl) og resirkuleringsinstruksjoner.\nEksempel: 1 glassflaske til resirkulering, 1 plastkork til kasting';
 
   @override
-  String get packaging_editing_error => 'Failed to save the packaging.';
+  String get packaging_editing_error => 'Klarte ikke å lagre emballasjen.';
 
   @override
   String get packaging_editing_image_error =>
-      'Failed to get a new packaging image.';
+      'Klarte ikke å hente et nytt emballasjebilde.';
 
   @override
-  String get packaging_editing_title => 'Edit Packaging';
+  String get packaging_editing_title => 'Rediger emballasje';
 
   @override
   String get nutrition => 'Næring';
 
   @override
-  String get nutrition_facts_photo => 'Nutrition facts photo';
+  String get nutrition_facts_photo => 'Næringsinnholdsinformasjonsbilde';
 
   @override
-  String get nutrition_facts_editing_title => 'Edit Nutrition Facts';
+  String get nutrition_facts_editing_title => 'Rediger næringsinnhold';
 
   @override
-  String get packaging_information => 'Packaging information';
+  String get packaging_information => 'Emballasjeinformasjon';
 
   @override
-  String get packaging_information_photo => 'Packaging information photo';
+  String get packaging_information_photo => 'Emballasjeinformasjonsbilde';
 
   @override
-  String get missing_product => 'You found a new product!';
+  String get missing_product => 'Du har funnet et nytt produkt!';
 
   @override
   String get add_product_take_photos =>
-      'Take photos of the packaging to add this product to Open Food Facts';
+      'Ta bilder av emballasjen for å legge til dette produktet i Open Food Facts';
 
   @override
   String get add_product_take_photos_descriptive =>
-      'Please take some photos first. You may always complete the product at a later time.';
+      'Ta noen bilder først. Du kan alltids fullføre produktet senere.';
 
   @override
   String get add_product_information_button_label => 'Add product information';
 
   @override
-  String get new_product => 'New Product';
+  String get new_product => 'Nytt produkt';
 
   @override
-  String get new_product_found_title => 'New product found!';
+  String get new_product_found_title => 'Nytt produkt funnet!';
 
   @override
   String get new_product_found_text =>
-      'Our collaborative database contains more than **3 million products**, but this barcode doesn\'t exist: ';
+      'Vår samarbeidsdatabase inneholder mer enn **3 millioner produkter**, men denne strekkoden finnes ikke: ';
 
   @override
   String get new_product_found_button => 'Add this product';
 
   @override
-  String get new_product_leave_title => 'Leave this page?';
+  String get new_product_leave_title => 'Forlate denne siden?';
 
   @override
   String get new_product_leave_message =>
-      'It looks like you didn\'t input anything. Do you really want to leave this page?';
+      'Det ser ut som du ikke har skrevet inn noe. Vil du virkelig forlate denne siden?';
 
   @override
   String get new_product_dialog_description =>
-      'Please take photos of the packaging to add this product to our common database';
+      'Vennligst ta bilder av emballasjen for å legge dette produktet til i vår felles database.';
 
   @override
   String get new_product_dialog_illustration_description =>
-      'An illustration with unknown Nutri-Score and Green Score';
+      'En illustrasjon med ukjent Nutri-Score og Green Score';
 
   @override
-  String get front_packaging_photo_button_label => 'Front packaging photo';
+  String get front_packaging_photo_button_label =>
+      'Foto av forsiden av emballasjen';
 
   @override
   String get confirm_front_packaging_photo_button_label =>
-      'Confirm upload of Front packaging photo';
+      'Bekreft opplasting av bilde av frontemballasjen';
 
   @override
-  String get confirm_button_label => 'Confirm';
+  String get confirm_button_label => 'Bekrefte';
 
   @override
-  String get send_image_button_label => 'Send image';
+  String get send_image_button_label => 'Send bilde';
 
   @override
-  String get crop_page_action_saving => 'Saving the image…';
+  String get crop_page_action_saving => 'Lagrer bildet…';
 
   @override
-  String get crop_page_action_cropping => 'Cropping the image…';
+  String get crop_page_action_cropping => 'Beskjæring av bildet…';
 
   @override
-  String get crop_page_action_local => 'Saving a local version…';
+  String get crop_page_action_local => 'Lagre en lokal versjon…';
 
   @override
   String get crop_page_action_local_failed_title =>
-      'Oops… there\'s something with your photo!';
+      'Ups… det er noe galt med bildet ditt!';
 
   @override
   String get crop_page_action_local_failed_message =>
-      'We are unable to process the image locally, before sending it to our server. Please try again later or contact-us if the issue persists.';
+      'Vi kan ikke behandle bildet lokalt før vi sender det til serveren vår. Prøv igjen senere, eller kontakt oss hvis problemet vedvarer.';
 
   @override
-  String get crop_page_action_retake => 'Retake a photo';
+  String get crop_page_action_retake => 'Ta et bilde på nytt';
 
   @override
-  String get crop_page_too_small_image_title => 'The image is too small!';
+  String get crop_page_too_small_image_title => 'Bildet er for lite!';
 
   @override
   String crop_page_too_small_image_message(
@@ -810,23 +819,23 @@ class AppLocalizationsNo extends AppLocalizations {
     int actualWidth,
     int actualHeight,
   ) {
-    return 'The minimum size in pixels for picture upload is ${expectedMinWidth}x$expectedMinHeight. The current picture is ${actualWidth}x$actualHeight.';
+    return 'Minimumsstørrelsen i piksler for bildeopplasting er ${expectedMinWidth}x$expectedMinHeight. Det nåværende bildet er ${actualWidth}x$actualHeight.';
   }
 
   @override
-  String get crop_page_action_server => 'Preparing a call to the server…';
+  String get crop_page_action_server => 'Forbereder et kall til serveren…';
 
   @override
-  String get front_packaging_photo_title => 'Front Packaging Photo';
+  String get front_packaging_photo_title => 'Foto av forsiden av emballasjen';
 
   @override
-  String get ingredients_photo_title => 'Ingredients Photo';
+  String get ingredients_photo_title => 'Ingredienser Foto';
 
   @override
-  String get nutritional_facts_photo_title => 'Nutrition Facts Photo';
+  String get nutritional_facts_photo_title => 'Næringsinnhold Foto';
 
   @override
-  String get recycling_photo_title => 'Recycling Photo';
+  String get recycling_photo_title => 'Resirkuleringsfoto';
 
   @override
   String get take_photo_title => 'Ta et bilde';
@@ -835,159 +844,163 @@ class AppLocalizationsNo extends AppLocalizations {
   String get take_more_photo_title => 'Ta flere bilder';
 
   @override
-  String get front_photo_uploaded => 'Front photo uploaded';
+  String get front_photo_uploaded => 'Frontbilde lastet opp';
 
   @override
-  String get ingredients_photo_button_label => 'Ingredients photo';
+  String get ingredients_photo_button_label => 'Ingredienser bilde';
 
   @override
-  String get ingredients_photo_uploaded => 'Ingredients photo uploaded';
+  String get ingredients_photo_uploaded => 'Ingrediensbilde lastet opp';
 
   @override
   String get nutrition_cache_loading_error =>
-      'Unable to load nutrients from cache';
+      'Kan ikke laste inn næringsstoffer fra hurtigbufferen';
 
   @override
-  String get nutritional_facts_photo_button_label => 'Nutrition facts photo';
+  String get nutritional_facts_photo_button_label =>
+      'Næringsinnholdsinformasjonsbilde';
 
   @override
-  String get nutritional_facts_input_button_label => 'Fill nutrition facts';
+  String get nutritional_facts_input_button_label => 'Fyll inn næringsinnhold';
 
   @override
-  String get nutritional_facts_added => 'Nutrition facts added';
+  String get nutritional_facts_added => 'Næringsinnhold lagt til';
 
   @override
-  String get categories_added => 'Categories added';
+  String get categories_added => 'Kategorier lagt til';
 
   @override
-  String get new_product_title_nutriscore => 'Compute the Nutri-Score';
+  String get new_product_title_nutriscore => 'Beregn ernæringspoengsummen';
 
   @override
   String get new_product_subtitle_nutriscore =>
-      'Help us by filling at least a category and nutritional values';
+      'Hjelp oss ved å fylle ut minst én kategori og næringsverdier';
 
   @override
-  String get new_product_title_environmental_score => 'Compute the Green Score';
+  String get new_product_title_environmental_score =>
+      'Beregn den grønne poengsummen';
 
   @override
   String get new_product_subtitle_environmental_score =>
-      'Get it by filling at least a category';
+      'Få det ved å fylle ut minst én kategori';
 
   @override
   String get new_product_additional_environmental_score =>
-      'Make Green Score computation more precise with origins, packaging & more';
+      'Gjør beregningen av Green Score mer presis med opprinnelse, emballasje og mer';
 
   @override
-  String get new_product_title_nova =>
-      'Compute the food processing level (NOVA)';
+  String get new_product_title_nova => 'Beregn matforedlingsnivået (NOVA)';
 
   @override
   String get new_product_subtitle_nova =>
-      'Get it by filling the food category and ingredients';
+      'Få det ved å fylle ut matkategorien og ingrediensene';
 
   @override
-  String get new_product_desc_nova_unknown => 'Food processing level unknown';
+  String get new_product_desc_nova_unknown => 'Matforedlingsnivå ukjent';
 
   @override
-  String get new_product_title_pictures => 'New product';
+  String get new_product_title_pictures => 'Nytt produkt';
 
   @override
   String get new_product_title_pictures_details =>
-      'Please take the following photos and the Open Food Facts engine can work out the rest!';
+      'Ta følgende bilder, så kan Open Food Facts-motoren finne ut av resten!';
 
   @override
-  String get new_product_title_misc => 'And some basic data…';
+  String get new_product_title_misc => 'Og noen grunnleggende data…';
 
   @override
   String new_product_done_msg(String username) {
-    return 'Thanks for your contribution “$username”!';
+    return 'Takk for bidraget ditt «$username»!';
   }
 
   @override
-  String get new_product_done_msg_no_user => 'Thanks for your contribution!';
+  String get new_product_done_msg_no_user => 'Takk for bidraget ditt!';
 
   @override
-  String get new_product_done_button_label => 'Discover the completed product';
+  String get new_product_done_button_label => 'Oppdag det ferdige produktet';
 
   @override
   String get hey_incomplete_product_message =>
-      'Tap to answer 3 questions NOW to compute Nutri-Score, Green Score & Ultra-processing (NOVA)!';
+      'Trykk for å svare på 3 spørsmål NÅ for å beregne Nutri-Score, Green Score og Ultra-processing (NOVA)!';
 
   @override
   String get hey_incomplete_product_message_beauty =>
-      'Tap now to answer 2 questions to help analyze this cosmetic!';
+      'Trykk nå for å svare på to spørsmål som kan hjelpe deg med å analysere dette produktet!';
 
   @override
   String get hey_incomplete_product_message_pet_food =>
-      'Tap now to answer 3 questions to help analyze this pet food product!';
+      'Trykk nå for å svare på tre spørsmål som kan hjelpe deg med å analysere dette dyrefôrproduktet!';
 
   @override
   String get hey_incomplete_product_message_product =>
-      'Tap now to help complete this product!';
+      'Trykk nå for å fullføre dette produktet!';
 
   @override
   String get nutritional_facts_photo_uploaded =>
-      'Nutrition facts photo uploaded';
+      'Bilde av næringsinnhold lastet opp';
 
   @override
-  String get recycling_photo_button_label => 'Recycling photo';
+  String get recycling_photo_button_label => 'Resirkuleringsbilde';
 
   @override
-  String get recycling_photo_uploaded => 'Recycling photo uploaded';
+  String get recycling_photo_uploaded => 'Resirkuleringsbilde lastet opp';
 
   @override
   String get take_more_photo_button_label => 'Ta flere bilder';
 
   @override
-  String get other_photo_uploaded => 'Miscellaneous photo uploaded';
+  String get other_photo_uploaded => 'Diverse bilder lastet opp';
 
   @override
-  String get retake_photo_button_label => 'Retake';
+  String get retake_photo_button_label => 'Ta på nytt';
 
   @override
-  String get selecting_photo => 'Selecting photo';
+  String get selecting_photo => 'Velger bilde';
 
   @override
-  String get uploading_image => 'Uploading photo to the server';
+  String get uploading_image => 'Laster opp bilde til serveren';
 
   @override
   String get uploading_image_type_front =>
-      'Uploading front image to Open Food Facts';
+      'Laster opp frontbilde til Open Food Facts';
 
   @override
   String get uploading_image_type_ingredients =>
-      'Uploading ingredients image to Open Food Facts';
+      'Laster opp ingrediensbilde til Open Food Facts';
 
   @override
   String get uploading_image_type_nutrition =>
-      'Uploading nutrition image to Open Food Facts';
+      'Laster opp ernæringsbilde til Open Food Facts';
 
   @override
   String get uploading_image_type_packaging =>
-      'Uploading packaging image to Open Food Facts';
+      'Laster opp emballasjebilde til Open Food Facts';
 
   @override
   String get uploading_image_type_other =>
-      'Uploading other image to Open Food Facts';
+      'Laster opp et annet bilde til Open Food Facts';
 
   @override
   String get uploading_image_type_generic =>
-      'Uploading image to Open Food Facts';
+      'Laster opp bilde til Open Food Facts';
 
   @override
-  String get score_add_missing_ingredients => 'Add missing ingredients';
+  String get score_add_missing_ingredients => 'Legg til manglende ingredienser';
 
   @override
-  String get score_add_missing_packaging_image => 'Add missing packaging image';
+  String get score_add_missing_packaging_image =>
+      'Legg til manglende emballasjebilde';
 
   @override
-  String get score_add_missing_nutrition_facts => 'Add missing nutrition facts';
+  String get score_add_missing_nutrition_facts =>
+      'Legg til manglende næringsinnhold';
 
   @override
-  String get score_add_missing_product_traces => 'Add missing product traces';
+  String get score_add_missing_product_traces =>
+      'Legg til manglende produktspor';
 
   @override
-  String get score_add_missing_product_category => 'Select a category';
+  String get score_add_missing_product_category => 'Velg en kategori';
 
   @override
   String get score_add_missing_precise_product_category =>
@@ -995,36 +1008,40 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get score_add_missing_product_countries =>
-      'Add missing product countries';
+      'Legg til manglende produktland';
 
   @override
   String get score_add_missing_product_emb =>
-      'Add missing product traceability codes';
+      'Legg til manglende sporbarhetskoder for produkter';
 
   @override
-  String get score_add_missing_product_labels => 'Add missing product labels';
+  String get score_add_missing_product_labels =>
+      'Legg til manglende produktetiketter';
 
   @override
-  String get score_add_missing_product_origins => 'Add missing product origins';
+  String get score_add_missing_product_origins =>
+      'Legg til manglende produktopprinnelser';
 
   @override
-  String get score_add_missing_product_stores => 'Add missing product stores';
+  String get score_add_missing_product_stores =>
+      'Legg til manglende produktbutikker';
 
   @override
-  String get score_add_missing_product_brands => 'Add missing product brands';
+  String get score_add_missing_product_brands =>
+      'Legg til manglende produktmerker';
 
   @override
-  String get score_update_nutrition_facts => 'Update nutrition facts';
+  String get score_update_nutrition_facts => 'Oppdater næringsinnhold';
 
   @override
-  String get nutrition_page_title => 'Nutrition Facts';
+  String get nutrition_page_title => 'Næringsinnhold';
 
   @override
-  String get nutrition_page_nutritional_info_title => 'Nutritional information';
+  String get nutrition_page_nutritional_info_title => 'Næringsinnhold';
 
   @override
   String get nutrition_page_nutritional_info_label =>
-      'Values specified on the product:';
+      'Verdier spesifisert på produktet:';
 
   @override
   String get nutrition_page_nutritional_info_value_positive => 'Ja';
@@ -1033,61 +1050,61 @@ class AppLocalizationsNo extends AppLocalizations {
   String get nutrition_page_nutritional_info_value_negative => 'Nei';
 
   @override
-  String get nutrition_page_nutritional_info_open_photo => 'Open photo';
+  String get nutrition_page_nutritional_info_open_photo => 'Åpne bildet';
 
   @override
   String get nutrition_page_nutritional_info_explanation_title =>
-      'Good practices: Nutritional information';
+      'God praksis: Næringsinnhold';
 
   @override
   String get nutrition_page_nutritional_info_explanation_info1 =>
-      'Sometimes nutrition facts are **not specified on the packaging** or on a document given with the product. In this case, and only in this case, you can set the value to **NO**.';
+      'Noen ganger er næringsinnholdet **ikke spesifisert på emballasjen** eller på et dokument som følger med produktet. I dette tilfellet, og bare i dette tilfellet, kan du sette verdien til **NEI**.';
 
   @override
-  String get nutrition_page_serving_type_label => 'Nutritional values:';
+  String get nutrition_page_serving_type_label => 'Næringsinnhold:';
 
   @override
-  String get nutrition_page_per_100g => 'per 100g';
+  String get nutrition_page_per_100g => 'per 100 g';
 
   @override
-  String get nutrition_page_per_100g_100ml => 'per 100g/ml';
+  String get nutrition_page_per_100g_100ml => 'per 100 g/ml';
 
   @override
   String get nutrition_page_per_serving => 'per porsjon';
 
   @override
-  String get nutrition_page_add_nutrient => 'Add a nutrient';
+  String get nutrition_page_add_nutrient => 'Tilsett et næringsstoff';
 
   @override
   String get nutrition_page_serving_size => 'Porsjonstørrelse';
 
   @override
   String get nutrition_page_serving_size_hint =>
-      'Input a serving size (eg: 100g)';
+      'Skriv inn en porsjonsstørrelse (f.eks. 100 g)';
 
   @override
   String get nutrition_page_serving_size_explanation_title =>
-      'Good practices: Serving size';
+      'God praksis: Serveringsstørrelse';
 
   @override
   String get nutrition_page_serving_size_explanation_info1 =>
-      'This value helps to **make a proportional calculation of each nutrient per serving size**.';
+      'Denne verdien bidrar til å **lage en proporsjonal beregning av hvert næringsstoff per porsjonsstørrelse**.';
 
   @override
   String get nutrition_page_serving_size_explanation_info2 =>
-      '**Allowed units** are: kg, g, mg, µg, oz, l, dl, cl, ml, fl.oz, fl oz, г, мг, кг, л, дл, кл, мл, 毫克, 公斤, 毫升, 公升, 吨.';
+      '**Tillatte enheter** er: kg, g, mg, µg, oz, l, dl, cl, ml, fl.oz, fl oz, г, мг, кг, л, дл, кл, мл, 毫克, 公斤, 毫升, 公卨.';
 
   @override
   String get nutrition_page_serving_size_explanation_good_example1 =>
-      '**60 g**, **60g** or **60 G** (prefer the first one)';
+      '**60 g**, **60 g** eller **60 G** (foretrekk den første)';
 
   @override
   String get nutrition_page_serving_size_explanation_good_example2 =>
-      '**1000 ml** or **1L**';
+      '**1000 ml** eller **1 l**';
 
   @override
   String get nutrition_page_serving_size_explanation_bad_example1_explanation =>
-      'Invalid unit';
+      'Ugyldig enhet';
 
   @override
   String get nutrition_page_serving_size_explanation_bad_example1_example =>
@@ -1095,88 +1112,88 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get nutrition_page_serving_size_explanation_bad_example2_explanation =>
-      'Invalid units';
+      'Ugyldige enheter';
 
   @override
   String get nutrition_page_serving_size_explanation_bad_example2_example =>
-      '9 **candies** and 2 **biscuits**';
+      '9 **godteri** og 2 **kjeks**';
 
   @override
   String get nutrition_page_serving_size_explanation_bad_example3_explanation =>
-      'Missing unit';
+      'Manglende enhet';
 
   @override
   String get nutrition_page_serving_size_explanation_bad_example3_example =>
       '**30**';
 
   @override
-  String get nutrition_page_invalid_number => 'Invalid number';
+  String get nutrition_page_invalid_number => 'Ugyldig nummer';
 
   @override
   String get nutrition_page_update_running =>
-      'Updating the product on the server…';
+      'Oppdaterer produktet på serveren…';
 
   @override
-  String get nutrition_page_update_done => 'Product updated!';
+  String get nutrition_page_update_done => 'Produkt oppdatert!';
 
   @override
   String get nutrition_page_take_serving_size_from_product_quantity =>
-      'Use the product quantity as serving size';
+      'Bruk produktmengden som porsjonsstørrelse';
 
   @override
-  String get nutrition_page_photo_error => 'Unable to load the photo';
+  String get nutrition_page_photo_error => 'Kan ikke laste inn bildet';
 
   @override
-  String get more_photos => 'More interesting photos';
+  String get more_photos => 'Flere interessante bilder';
 
   @override
   String get view_more_photo_button =>
-      'View all existing photos for this product';
+      'Se alle eksisterende bilder for dette produktet';
 
   @override
-  String get no_product_found => 'No product found';
+  String get no_product_found => 'Ingen produkt funnet';
 
   @override
-  String get no_location_found => 'No location found';
+  String get no_location_found => 'Ingen plassering funnet';
 
   @override
-  String get not_found => 'not found:';
+  String get not_found => 'ikke funnet:';
 
   @override
-  String get refreshing_product => 'Refreshing product';
+  String get refreshing_product => 'Forfriskende produkt';
 
   @override
-  String get product_refreshed => 'Product refreshed';
+  String get product_refreshed => 'Produktet er oppdatert';
 
   @override
   String product_image_accessibility_label(String date) {
-    return 'Image taken on $date';
+    return 'Bilde tatt $date';
   }
 
   @override
   String product_image_outdated_accessibility_label(String date) {
-    return 'Image taken on $date. This image may be outdated';
+    return 'Bildet er tatt $date. Dette bildet kan være utdatert';
   }
 
   @override
-  String get product_image_outdated => 'This image may be outdated';
+  String get product_image_outdated => 'Dette bildet kan være utdatert';
 
   @override
   String get product_image_outdated_explanations_title =>
-      'This image may be outdated';
+      'Dette bildet kan være utdatert';
 
   @override
   String get product_image_outdated_explanations_content =>
-      'This image was taken more than a year ago.\n**Please check that\'s it\'s still up-to-date**.\n\nThis is **just a warning**. If the content is still the same, you can ignore this message.';
+      'Dette bildet ble tatt for over et år siden.\n**Sjekk at det fortsatt er oppdatert**.\n\nDette er **bare en advarsel**. Hvis innholdet fortsatt er det samme, kan du ignorere denne meldingen.';
 
   @override
   String product_image_action_replace_photo(String type) {
-    return 'Replace photo ($type)';
+    return 'Erstatt bilde ($type)';
   }
 
   @override
   String product_image_action_add_photo(String type) {
-    return 'Add a photo ($type)';
+    return 'Legg til et bilde ($type)';
   }
 
   @override
@@ -1186,92 +1203,91 @@ class AppLocalizationsNo extends AppLocalizations {
   String get product_image_action_take_picture => 'Ta et bilde';
 
   @override
-  String get product_image_action_from_gallery =>
-      'Select from your phone\'s gallery';
+  String get product_image_action_from_gallery => 'Velg fra telefonens galleri';
 
   @override
   String get product_image_action_choose_existing_photo =>
-      'Select from the product photos';
+      'Velg fra produktbildene';
 
   @override
-  String get product_image_details_label => 'Information about the photo';
+  String get product_image_details_label => 'Informasjon om bildet';
 
   @override
-  String get product_image_details_from_producer => 'From the producer';
+  String get product_image_details_from_producer => 'Fra produsenten';
 
   @override
   String get product_image_details_contributor => 'Bidrager';
 
   @override
   String get product_image_details_contributor_producer =>
-      'Contributor (producer)';
+      'Bidragsyter (produsent)';
 
   @override
-  String get product_image_details_date => 'Date';
+  String get product_image_details_date => 'Dato';
 
   @override
-  String get product_image_details_date_unknown => 'Unknown';
+  String get product_image_details_date_unknown => 'Ukjent';
 
   @override
   String get homepage_main_card_logo_description =>
-      'Welcome to Open Food Facts';
+      'Velkommen til Åpne matfakta';
 
   @override
   String get homepage_main_card_subheading =>
-      '**Scan** a barcode or\n**search** for a product';
+      '**Skann** en strekkode eller\n**søk** etter et produkt';
 
   @override
   String get homepage_main_card_search_field_hint => 'Søk etter et produkt';
 
   @override
-  String get homepage_main_card_search_field_tooltip => 'Start search';
+  String get homepage_main_card_search_field_tooltip => 'Start søk';
 
   @override
   String scan_tagline_news_item_accessibility(String news_title) {
-    return 'Latest news: $news_title';
+    return 'Siste nytt: $news_title';
   }
 
   @override
-  String get tagline_app_review => 'Do you like the app?';
+  String get tagline_app_review => 'Liker du appen?';
 
   @override
-  String get tagline_app_review_button_positive => 'I love it! 😍';
+  String get tagline_app_review_button_positive => 'Jeg elsker det! 😍';
 
   @override
-  String get tagline_app_review_button_negative => 'Not really…';
+  String get tagline_app_review_button_negative => 'Ikke egentlig…';
 
   @override
-  String get tagline_app_review_button_later => 'Ask me later';
+  String get tagline_app_review_button_later => 'Spør meg senere';
 
   @override
-  String get tagline_feed_news_button => 'Know more';
+  String get tagline_feed_news_button => 'Lær mer';
 
   @override
-  String get app_review_negative_modal_title => 'You don\'t like our app?';
+  String get app_review_negative_modal_title => 'Liker du ikke appen vår?';
 
   @override
   String get app_review_negative_modal_text =>
-      'Could you take a few seconds to tell us why?';
+      'Kan du bruke noen sekunder på å fortelle oss hvorfor?';
 
   @override
-  String get app_review_negative_modal_positive_button => 'Yes, absolutely!';
+  String get app_review_negative_modal_positive_button => 'Ja, absolutt!';
 
   @override
   String get app_review_negative_modal_negative_button => 'Nei';
 
   @override
-  String get could_not_refresh => 'Could not refresh product';
+  String get could_not_refresh => 'Kunne ikke oppdatere produktet';
 
   @override
-  String get product_internet_error_modal_title => 'An error has occurred!';
+  String get product_internet_error_modal_title => 'Det har oppstått en feil!';
 
   @override
   String product_internet_error_modal_message(String error) {
-    return 'We are unable to fetch information about this product due to a network error. Please check your internet connection and try again.\n\nInternal error:\n$error';
+    return 'Vi kan ikke hente informasjon om dette produktet på grunn av en nettverksfeil. Sjekk internettforbindelsen din og prøv på nytt.\n\nIntern feil:\n$error';
   }
 
   @override
-  String get product_tags_title => 'Product properties';
+  String get product_tags_title => 'Produktegenskaper';
 
   @override
   String get no_product_tags_found_message =>
@@ -1288,28 +1304,28 @@ class AppLocalizationsNo extends AppLocalizations {
   String get add_tag => 'Add property';
 
   @override
-  String get add_tags => 'Add properties';
+  String get add_tags => 'Legg til egenskaper';
 
   @override
-  String get add_edit_tags => 'Add or edit properties';
+  String get add_edit_tags => 'Legg til eller rediger egenskaper';
 
   @override
-  String get edit_tag => 'Edit property';
+  String get edit_tag => 'Rediger egenskap';
 
   @override
-  String get remove_tag => 'Remove property';
+  String get remove_tag => 'Fjern egenskap';
 
   @override
-  String get tag_key => 'Property';
+  String get tag_key => 'Eiendom';
 
   @override
   String get tag_keys => 'Eiendommer';
 
   @override
-  String get tag_key_uneditable => 'Property (uneditable)';
+  String get tag_key_uneditable => 'Egenskap (kan ikke redigeres)';
 
   @override
-  String get tag_key_input_hint => 'Input a property';
+  String get tag_key_input_hint => 'Skriv inn en egenskap';
 
   @override
   String get tag_value => 'Value';
@@ -1318,29 +1334,29 @@ class AppLocalizationsNo extends AppLocalizations {
   String get tag_values => 'Values';
 
   @override
-  String get tag_value_input_hint => 'Input a value';
+  String get tag_value_input_hint => 'Skriv inn en verdi';
 
   @override
-  String get tag_key_item => 'Property:';
+  String get tag_key_item => 'Eiendom:';
 
   @override
-  String get tag_value_item => 'Value:';
+  String get tag_value_item => 'Verdi:';
 
   @override
   String get tag_key_explanations =>
-      'A key must be lowercase and without any spaces.';
+      'En nøkkel må være liten og uten mellomrom.';
 
   @override
   String tag_key_already_exists(String property) {
-    return 'A tag with a property $property already exists!';
+    return 'En tagg med en egenskap $property finnes allerede!';
   }
 
   @override
   String get product_internet_error =>
-      'Impossible to fetch information about this product due to a network error.';
+      'Umulig å hente informasjon om dette produktet på grunn av en nettverksfeil.';
 
   @override
-  String get cached_results_from => 'Show results from:';
+  String get cached_results_from => 'Vis resultater fra:';
 
   @override
   String get product_search_same_category => 'Finn alternativer';
@@ -1350,40 +1366,40 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get product_search_same_category_error =>
-      'This feature can only be used for products with a category.\n\nPlease edit the product to add a category.';
+      'Denne funksjonen kan bare brukes for produkter med en kategori.\n\nVennligst rediger produktet for å legge til en kategori.';
 
   @override
   String get product_improvement_add_category =>
-      'Add a category to calculate the Nutri-Score.';
+      'Legg til en kategori for å beregne Nutri-Score.';
 
   @override
   String get product_improvement_add_nutrition_facts =>
-      'Add nutrition facts to calculate the Nutri-Score.';
+      'Legg til næringsinnhold for å beregne Nutri-Score.';
 
   @override
   String get product_improvement_add_nutrition_facts_and_category =>
-      'Add nutrition facts and a category to calculate the Nutri-Score.';
+      'Legg til næringsinnhold og en kategori for å beregne Nutri-Score.';
 
   @override
   String get product_improvement_categories_but_no_nutriscore =>
-      'The Nutri-Score for this product can\'t be calculated, which may be due to e.g. a non-standard category. If this is considered an error, please contact us.';
+      'Næringspoengsummen for dette produktet kan ikke beregnes, noe som for eksempel kan skyldes en ikke-standard kategori. Hvis dette anses som en feil, vennligst kontakt oss.';
 
   @override
   String get product_improvement_obsolete_nutrition_image =>
-      'The nutrition image is obsolete: please refresh it.';
+      'Ernæringsbildet er utdatert: vennligst oppdater det.';
 
   @override
   String get product_improvement_origins_to_be_completed =>
-      'The Green Score takes into account the origins of the ingredients. Please take a photo of the ingredient list and/or any geographic claim or edit the product, so they can be taken into account.';
+      'Den grønne poengsummen tar hensyn til ingrediensenes opprinnelse. Vennligst ta et bilde av ingredienslisten og/eller eventuelle geografiske påstander, eller rediger produktet, slik at de kan tas i betraktning.';
 
   @override
-  String get country_chooser_label => 'Please choose a country';
+  String get country_chooser_label => 'Vennligst velg et land';
 
   @override
   String get currency_chooser_label => 'Velg en valuta';
 
   @override
-  String get country_change_message => 'You have just changed countries.';
+  String get country_change_message => 'Du har nettopp byttet land.';
 
   @override
   String currency_auto_change_message(
@@ -1394,55 +1410,57 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get onboarding_country_chooser_label => 'Please choose a country:';
+  String get onboarding_country_chooser_label => 'Vennligst velg et land:';
 
   @override
-  String get country_chooser_label_from_settings => 'Your country';
+  String get country_chooser_label_from_settings => 'Landet ditt';
 
   @override
   String get country_selection_explanation =>
-      'Some environmental features are location-specific';
+      'Noen miljøtrekk er stedsspesifikke';
 
   @override
-  String get product_removed_comparison => 'Product removed from comparison';
+  String get product_removed_comparison =>
+      'Produkt fjernet fra sammenligningen';
 
   @override
-  String get native_app_settings => 'Native App Settings';
+  String get native_app_settings => 'Innstillinger for integrerte apper';
 
   @override
   String get native_app_description =>
-      'Open systems settings for Open Food Facts';
+      'Åpne systeminnstillinger for Åpne matfakta';
 
   @override
-  String get product_removed_history => 'Product removed from history';
+  String get product_removed_history => 'Produkt fjernet fra historikken';
 
   @override
-  String get product_removed_list => 'Product removed from list';
+  String get product_removed_list => 'Produkt fjernet fra listen';
 
   @override
-  String get product_could_not_remove => 'Could not remove product';
+  String get product_could_not_remove => 'Kunne ikke fjerne produktet';
 
   @override
-  String get no_prodcut_in_list => 'There is no product in this list';
+  String get no_prodcut_in_list => 'Det finnes ikke noe produkt i denne listen';
 
   @override
-  String get no_product_in_section => 'There is no product in this section';
+  String get no_product_in_section =>
+      'Det finnes ikke noe produkt i denne seksjonen';
 
   @override
-  String get recently_seen_products => 'All viewed products';
+  String get recently_seen_products => 'Alle viste produkter';
 
   @override
   String get clear => 'Tøm';
 
   @override
-  String get clear_long => 'Empty the list';
+  String get clear_long => 'Tøm listen';
 
   @override
-  String get really_clear => 'Do you really want to delete this list?';
+  String get really_clear => 'Vil du virkelig slette denne listen?';
 
   @override
   String pct_match(Object percent) {
-    return '$percent% match';
+    return '$percent% samsvar';
   }
 
   @override
@@ -1450,8 +1468,8 @@ class AppLocalizationsNo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count days ago',
-      one: 'one day ago',
+      other: '$count for dager siden',
+      one: 'for én dag siden',
     );
     return '$_temp0';
   }
@@ -1461,8 +1479,8 @@ class AppLocalizationsNo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count hours ago',
-      one: 'one hour ago',
+      other: '$count for timer siden',
+      one: 'for én time siden',
     );
     return '$_temp0';
   }
@@ -1472,9 +1490,9 @@ class AppLocalizationsNo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count minutes ago',
-      one: 'one minute ago',
-      zero: 'less than a minute ago',
+      other: '$count for minutter siden',
+      one: 'for ett minutt siden',
+      zero: 'for mindre enn ett minutt siden',
     );
     return '$_temp0';
   }
@@ -1484,8 +1502,8 @@ class AppLocalizationsNo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count months ago',
-      one: 'one month ago',
+      other: '$count for måneder siden',
+      one: 'for én måned siden',
     );
     return '$_temp0';
   }
@@ -1495,8 +1513,8 @@ class AppLocalizationsNo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count weeks ago',
-      one: 'one week ago',
+      other: '$count for uker siden',
+      one: 'for én uke siden',
     );
     return '$_temp0';
   }
@@ -1506,8 +1524,8 @@ class AppLocalizationsNo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'Compare $count Products',
-      one: 'Compare one Product',
+      other: 'Sammenlign $count Produkter',
+      one: 'Sammenlign ett produkt',
     );
     return '$_temp0';
   }
@@ -1517,86 +1535,86 @@ class AppLocalizationsNo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count selected products',
-      one: 'One selected product',
-      zero: 'No selected product',
+      other: '$count valgte produkter',
+      one: 'Ett valgt produkt',
+      zero: 'Ingen valgte produkter',
     );
     return '$_temp0';
   }
 
   @override
-  String get compare_products_mode => 'Compare selected products';
+  String get compare_products_mode => 'Sammenlign utvalgte produkter';
 
   @override
-  String get delete_products_mode => 'Delete selected products';
+  String get delete_products_mode => 'Slett valgte produkter';
 
   @override
-  String get select_all_products_mode => 'Select all products';
+  String get select_all_products_mode => 'Velg alle produkter';
 
   @override
-  String get select_none_products_mode => 'Select none';
+  String get select_none_products_mode => 'Velg ingen';
 
   @override
   String get compare_products_appbar_title => 'Compare products';
 
   @override
   String get compare_products_appbar_subtitle =>
-      'Please select at least two products';
+      'Vennligst velg minst to produkter';
 
   @override
-  String get retry_button_label => 'Retry';
+  String get retry_button_label => 'Prøv på nytt';
 
   @override
-  String get connect_with_us => 'Connect with us';
+  String get connect_with_us => 'Ta kontakt med oss';
 
   @override
-  String get tiktok => 'Follow us on TikTok';
+  String get tiktok => 'Følg oss på TikTok';
 
   @override
   String get tiktok_link => 'https://www.tiktok.com/@openfoodfacts';
 
   @override
-  String get instagram => 'Follow us on Instagram';
+  String get instagram => 'Følg oss på Instagram';
 
   @override
   String get instagram_link => 'https://instagram.com/open.food.facts';
 
   @override
-  String get twitter => 'Follow us on X (formerly Twitter)';
+  String get twitter => 'Følg oss på X (tidligere Twitter)';
 
   @override
   String get twitter_link => 'https://www.twitter.com/openfoodfacts';
 
   @override
-  String get mastodon => 'Follow us on Mastodon';
+  String get mastodon => 'Følg oss på Mastodon';
 
   @override
   String get mastodon_link => 'https://mastodon.social/@openfoodfacts';
 
   @override
-  String get bsky => 'Follow us on BlueSky';
+  String get bsky => 'Følg oss på BlueSky';
 
   @override
   String get bsky_link => 'https://bsky.app/profile/openfoodfacts.bsky.social';
 
   @override
-  String get blog => 'Blog';
+  String get blog => 'Blogg';
 
   @override
-  String get faq => 'FAQ';
+  String get faq => 'Vanlige spørsmål';
 
   @override
   String get discover => 'Utforsk';
 
   @override
-  String get how_to_contribute => 'How to Contribute';
+  String get how_to_contribute => 'Hvordan bidra';
 
   @override
   String get hint_knowledge_panel_message =>
-      'Your can tap on any part of the card to get more details about what you see. Try it now!';
+      'Du kan trykke på hvilken som helst del av kortet for å få mer informasjon om hva du ser. Prøv det nå!';
 
   @override
-  String get permissions_page_title => 'Camera access';
+  String get permissions_page_title => 'Kameratilgang';
 
   @override
   String get permissions_page_body1 =>
@@ -1604,7 +1622,7 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get permissions_page_body2 =>
-      'If you change your mind, this option can be enabled and disabled at any time from the settings.';
+      'Hvis du ombestemmer deg, kan dette alternativet aktiveres og deaktiveres når som helst fra innstillingene.';
 
   @override
   String contact_form_body_android(
@@ -1615,7 +1633,7 @@ class AppLocalizationsNo extends AppLocalizations {
     String? device,
     String? brand,
   ) {
-    return 'OS: Android (SDK Int: $sdkInt / Release: $release)\nModel: $model\nProduct: $product\nDevice: $device\nBrand:$brand';
+    return 'OS: Android (SDK Int: $sdkInt / Utgivelse: $release)\nModell: $model\nProdukt: $product\nEnhet: $device\nMerke:$brand';
   }
 
   @override
@@ -1624,7 +1642,7 @@ class AppLocalizationsNo extends AppLocalizations {
     String? model,
     String? localizedModel,
   ) {
-    return 'OS: iOS ($version)\nModel: $model\nLocalized model: $localizedModel';
+    return 'OS: iOS ($version)\nModell: $model\nLokalisert modell: $localizedModel';
   }
 
   @override
@@ -1634,67 +1652,67 @@ class AppLocalizationsNo extends AppLocalizations {
     String appBuildNumber,
     String appPackageName,
   ) {
-    return '$osContent\nApp version:$appVersion\nApp build number:$appBuildNumber\nApp package name:$appPackageName';
+    return '$osContent\nAppversjon:$appVersion\nAppens byggenummer:$appBuildNumber\nAppens pakkenavn:$appPackageName';
   }
 
   @override
   String get authorize_button_label => 'Authorise';
 
   @override
-  String get refuse_button_label => 'Refuse';
+  String get refuse_button_label => 'Avslå';
 
   @override
-  String get ask_me_later_button_label => 'Later';
+  String get ask_me_later_button_label => 'Seinere';
 
   @override
-  String get are_you_sure => 'Are you sure?';
+  String get are_you_sure => 'Er du sikker?';
 
   @override
   String knowledge_panel_text_source(String sourceName) {
-    return 'Go further on $sourceName';
+    return 'Gå videre på $sourceName';
   }
 
   @override
-  String get onboarding_home_welcome_text1 => 'Welcome !';
+  String get onboarding_home_welcome_text1 => 'Velkommen!';
 
   @override
   String get onboarding_home_welcome_text2 =>
-      'The app that helps you choose food that is good for **you** and the **planet**!';
+      'Appen som hjelper deg med å velge mat som er bra for **deg** og **planeten**!';
 
   @override
-  String get onboarding_continue_button => 'Continue';
+  String get onboarding_continue_button => 'Fortsette';
 
   @override
   String get onboarding_welcome_loading_dialog_title =>
-      'Loading your first example product';
+      'Laster inn ditt første eksempelprodukt';
 
   @override
   String get onboarding_welcome_warning =>
       'Beklager, dette er vårt eksempelprodukt, du kan ikke redigere det :)';
 
   @override
-  String get product_list_your_ranking => 'Your ranking';
+  String get product_list_your_ranking => 'Din rangering';
 
   @override
-  String get product_list_empty_icon_desc => 'History not available';
+  String get product_list_empty_icon_desc => 'Historikk ikke tilgjengelig';
 
   @override
-  String get product_list_empty_title => 'Start scanning';
+  String get product_list_empty_title => 'Start skanning';
 
   @override
   String get product_list_empty_message =>
-      'Scanned products will appear here and you can check detailed information about them';
+      'Skannede produkter vil vises her, og du kan sjekke detaljert informasjon om dem';
 
   @override
   String product_list_reloading_in_progress_multiple(num count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'products',
-      one: 'product',
-      zero: 'product',
+      other: 'produkter',
+      one: 'produkt',
+      zero: 'produkt',
     );
-    return 'Refreshing $_temp0 in your history';
+    return 'Oppdaterer $_temp0 i historikken din';
   }
 
   @override
@@ -1702,94 +1720,96 @@ class AppLocalizationsNo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'Products',
-      one: 'Product',
-      zero: 'Product',
+      other: 'Produkter',
+      one: 'Produkt',
+      zero: 'Produkt',
     );
-    return '$_temp0 refresh complete';
+    return '$_temp0 oppdatering fullført';
   }
 
   @override
   String get product_list_compare_side_by_side => 'Sammenlign side om side';
 
   @override
-  String get loading_dialog_default_title => 'Downloading data';
+  String get loading_dialog_default_title => 'Laster ned data';
 
   @override
-  String get loading_dialog_default_error_message => 'Could not download data';
+  String get loading_dialog_default_error_message =>
+      'Kunne ikke laste ned data';
 
   @override
-  String get account_delete => 'Delete account';
+  String get account_delete => 'Slett konto';
 
   @override
   String get account_delete_title => 'Slett kontoen min';
 
   @override
-  String get user_profile => 'Account';
+  String get user_profile => 'Konto';
 
   @override
-  String get user_profile_title_guest => 'Welcome!';
+  String get user_profile_title_guest => 'Velkomst!';
 
   @override
   String get user_profile_subtitle_guest =>
-      'Sign-in or sign-up to join the Open Food Facts community';
+      'Logg inn eller registrer deg for å bli med i Open Food Facts-fellesskapet';
 
   @override
   String user_profile_title_id_email(String email) {
-    return 'Open Food Facts login: $email';
+    return 'Åpne Matfakta-innlogging: $email';
   }
 
   @override
   String user_profile_title_id_default(String id) {
-    return 'Welcome $id!';
+    return 'Velkommen $id!';
   }
 
   @override
-  String get email_subject_account_deletion => 'Delete account';
+  String get email_subject_account_deletion => 'Slett konto';
 
   @override
   String email_body_account_deletion(String userId) {
-    return 'Hi there, please delete my Open Food Facts account: $userId';
+    return 'Hei, vennligst slett Open Food Facts-kontoen min: $userId';
   }
 
   @override
-  String get settings_app_app => 'Application';
+  String get settings_app_app => 'Søknad';
 
   @override
   String get settings_app_data => 'Privacy & monitoring';
 
   @override
-  String get settings_app_camera => 'Camera';
+  String get settings_app_camera => 'Kamera';
 
   @override
   String get settings_app_products => 'Produkter';
 
   @override
-  String get settings_app_miscellaneous => 'Miscellaneous';
+  String get settings_app_miscellaneous => 'Diverse';
 
   @override
-  String get camera_play_sound_title => 'Play a sound on scan';
+  String get camera_play_sound_title => 'Spill av en lyd ved skanning';
 
   @override
-  String get camera_play_sound_subtitle => 'Will beep on each successful scan';
+  String get camera_play_sound_subtitle =>
+      'Vil pipe ved hver vellykket skanning';
 
   @override
   String get camera_window_accessibility_label =>
-      'Scan a barcode with your camera';
+      'Skann en strekkode med kameraet ditt';
 
   @override
-  String get app_haptic_feedback_title => 'Vibration & Haptics';
+  String get app_haptic_feedback_title => 'Vibrasjon og haptikk';
 
   @override
   String get app_haptic_feedback_subtitle =>
-      'Vibrations after executing some actions (barcode decoded, product removed…).';
+      'Vibrasjoner etter utførelse av enkelte handlinger (strekkode dekodet, produkt fjernet…).';
 
   @override
   String get crash_reporting_toggle_title => 'Crash reporting';
 
   @override
   String get crash_reporting_toggle_subtitle =>
-      'When enabled, crash reports are automatically submitted to Open Food Facts\' error tracking system, so that bugs can be fixed and thus improve the app.';
+      'Når det er aktivert, sendes krasjrapporter automatisk til Open Food Facts\' feilsporingssystem, slik at feil kan rettes og dermed forbedre appen.';
 
   @override
   String get send_anonymous_data_toggle_title => 'Send anonymous data';
@@ -1799,149 +1819,157 @@ class AppLocalizationsNo extends AppLocalizations {
       'When enabled, some anonymous information regarding app usage will be sent to the Open Food Facts servers, so that we can understand how and how much features are used in order to improve them.';
 
   @override
-  String get product_edit_photo_title => 'Edit Photo';
+  String get product_edit_photo_title => 'Rediger bilde';
 
   @override
-  String get permission_photo_error => 'Error';
+  String get permission_photo_error => 'Feil';
 
   @override
   String get permission_photo_denied_title =>
-      'Allow camera use to scan barcodes';
+      'Tillat kamerabruk for å skanne strekkoder';
 
   @override
   String permission_photo_denied_message(String appName) {
-    return 'For an enhanced experience, please allow $appName to access your camera. You will be able to directly scan barcodes.';
+    return 'For en forbedret opplevelse, vennligst gi $appName tilgang til kameraet ditt. Du vil kunne skanne strekkoder direkte.';
   }
 
   @override
-  String get permission_photo_denied_button => 'Allow';
+  String get permission_photo_denied_button => 'Tillate';
 
   @override
   String get permission_photo_denied_dialog_settings_title =>
-      'Permission denied';
+      'Tillatelse nektet';
 
   @override
   String get permission_photo_denied_dialog_settings_message =>
-      'As you\'ve previously denied the camera permission, you must allow it manually from the Settings.';
+      'Siden du tidligere har nektet kameratillatelse, må du tillate det manuelt fra Innstillingene.';
 
   @override
   String get permission_photo_denied_dialog_settings_button_open =>
-      'Open settings';
+      'Åpne innstillinger';
 
   @override
   String get permission_photo_denied_dialog_settings_button_cancel => 'Cancel';
 
   @override
-  String get permission_photo_none_found => 'No camera detected';
+  String get permission_photo_none_found => 'Ingen kamera oppdaget';
 
   @override
-  String get permission_photo_denied => 'No camera access granted';
+  String get permission_photo_denied => 'Ingen kameratilgang gitt';
 
   @override
-  String get show_product_pictures => 'Show product pictures';
+  String get show_product_pictures => 'Vis produktbilder';
 
   @override
   String get edit_product_label => 'Redigér produkt';
 
   @override
   String get edit_product_pending_operations_banner_title =>
-      'Uploading your edits…';
+      'Laster opp redigeringene dine…';
 
   @override
   String get edit_product_pending_operations_banner_message =>
-      'Your edits are being **sent in the background** (or later in case of error).\nYou can continue editing other product fields.';
+      'Redigeringene dine sendes i bakgrunnen (eller senere ved feil).\nDu kan fortsette å redigere andre produktfelt.';
 
   @override
   String get edit_product_pending_operations_banner_short_message =>
-      'Your edits are being **sent in the background** (or later in case of error).';
+      'Redigerelsene dine sendes i bakgrunnen (eller senere ved feil).';
 
   @override
   String get edit_product_label_short => 'Edit';
 
   @override
   String edit_product_form_item_help(String value) {
-    return 'How to enter \"$value\"?';
+    return 'Hvordan skriver man inn «$value»?';
   }
 
   @override
   String get edit_product_form_item_error_empty =>
-      'Please enter a non-empty value!';
+      'Vennligst skriv inn en verdi som ikke er tom!';
 
   @override
   String get edit_product_form_item_error_existing =>
-      'This value is already there!';
+      'Denne verdien er allerede der!';
 
   @override
-  String get edit_product_form_item_add_action_brand => 'Add a new brand';
+  String get edit_product_form_item_add_action_brand =>
+      'Legg til et nytt merke';
 
   @override
-  String get edit_product_form_item_add_action_label => 'Add a new label';
+  String get edit_product_form_item_add_action_label =>
+      'Legg til en ny etikett';
 
   @override
-  String get edit_product_form_item_add_action_store => 'Add a new store';
+  String get edit_product_form_item_add_action_store => 'Legg til en ny butikk';
 
   @override
-  String get edit_product_form_item_add_action_origin => 'Add a new origin';
+  String get edit_product_form_item_add_action_origin =>
+      'Legg til en ny opprinnelse';
 
   @override
   String get edit_product_form_item_add_action_emb_code =>
-      'Add a new traceability code';
+      'Legg til en ny sporbarhetskode';
 
   @override
-  String get edit_product_form_item_add_action_country => 'Add a new country';
+  String get edit_product_form_item_add_action_country =>
+      'Legg til et nytt land';
 
   @override
-  String get edit_product_form_item_add_action_category => 'Add a new category';
+  String get edit_product_form_item_add_action_category =>
+      'Legg til en ny kategori';
 
   @override
-  String get edit_product_form_item_add_action_trace => 'Add a new trace';
+  String get edit_product_form_item_add_action_trace => 'Legg til et nytt spor';
 
   @override
-  String get edit_product_form_item_add_suggestion => 'Add suggestion';
+  String get edit_product_form_item_add_suggestion => 'Legg til forslag';
 
   @override
   String get edit_product_form_item_deny_suggestion => 'Avvis forslaget';
 
   @override
-  String get edit_product_form_item_details_title => 'Basic details';
+  String get edit_product_form_item_details_title => 'Grunnleggende detaljer';
 
   @override
   String get edit_product_form_item_details_subtitle =>
-      'Product name, brand, quantity';
+      'Produktnavn, merke, antall';
 
   @override
-  String get edit_product_form_item_other_details_title => 'Additional details';
+  String get edit_product_form_item_other_details_title =>
+      'Ytterligere detaljer';
 
   @override
-  String get edit_product_form_item_other_details_subtitle => 'Website…';
+  String get edit_product_form_item_other_details_subtitle => 'Nettsted…';
 
   @override
-  String get edit_product_form_item_photos_title => 'Photos';
+  String get edit_product_form_item_photos_title => 'Bilder';
 
   @override
-  String get edit_product_form_item_photos_subtitle => 'Add or refresh photos';
+  String get edit_product_form_item_photos_subtitle =>
+      'Legg til eller oppdater bilder';
 
   @override
-  String get edit_product_form_item_labels_title => 'Labels & Certifications';
+  String get edit_product_form_item_labels_title =>
+      'Etiketter og sertifiseringer';
 
   @override
   String get edit_product_form_item_labels_subtitle =>
-      'Environmental, Quality labels…';
+      'Miljø, kvalitetsmerker…';
 
   @override
   String get edit_product_form_item_labels_hint =>
-      'Input a label (eg: NutriScore)';
+      'Skriv inn en etikett (f.eks.: NutriScore)';
 
   @override
   String get edit_product_form_item_labels_type => 'etikett';
 
   @override
   String get edit_product_form_item_labels_explanation_title =>
-      'Good practices: Labels';
+      'God praksis: Etiketter';
 
   @override
   String get edit_product_form_item_labels_explanation_info1 =>
-      'Any characteristic of the product **which is factual** and different from the other fields.';
+      'Enhver egenskap ved produktet **som er faktisk** og forskjellig fra de andre feltene.';
 
   @override
   String get edit_product_form_item_labels_explanation_good_examples_1 =>
@@ -1949,7 +1977,7 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get edit_product_form_item_labels_explanation_good_examples_2 =>
-      'Made in Belgium, produced in Brittany…';
+      'Laget i Belgia, produsert i Bretagne…';
 
   @override
   String get edit_product_form_item_labels_explanation_good_examples_3 =>
@@ -1957,28 +1985,28 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get edit_product_form_item_labels_explanation_good_examples_4 =>
-      'Rich in fiber, source of iron…';
+      'Rik på fiber, kilde til jern…';
 
   @override
   String get edit_product_form_item_labels_explanation_good_examples_5 =>
-      'Fair trade, Max Havelaar…';
+      'Rettferdig handel, Max Havelaar…';
 
   @override
   String get edit_product_form_item_stores_title => 'Butikker';
 
   @override
-  String get edit_product_form_item_stores_hint => 'Input a store';
+  String get edit_product_form_item_stores_hint => 'Legg inn en butikk';
 
   @override
   String get edit_product_form_item_stores_type => 'butikk';
 
   @override
   String get edit_product_form_item_stores_explanation_title =>
-      'Good practices: Stores';
+      'God praksis: Butikker';
 
   @override
   String get edit_product_form_item_stores_explanation_info1 =>
-      'Input the store where you bought the product.';
+      'Skriv inn butikken der du kjøpte produktet.';
 
   @override
   String get edit_product_form_item_stores_explanation_good_examples_1 =>
@@ -1993,74 +2021,74 @@ class AppLocalizationsNo extends AppLocalizations {
       'Lidl';
 
   @override
-  String get edit_product_form_item_origins_title => 'Origins';
+  String get edit_product_form_item_origins_title => 'Opprinnelse';
 
   @override
   String get edit_product_form_item_origins_hint =>
-      'Input an origin (eg: Germany)';
+      'Skriv inn en opprinnelse (f.eks. Tyskland)';
 
   @override
   String get edit_product_form_item_origins_type => 'land';
 
   @override
   String get edit_product_form_item_origins_explanation_title =>
-      'Good practices: Origins';
+      'God praksis: Opprinnelse';
 
   @override
   String get edit_product_form_item_origins_explanation_info1 =>
-      'Add **any indications of origins you can find on the packaging**.\nYou need not worry about origins indicated directly in the ingredient list.';
+      'Legg til **eventuelle opprinnelsesangivelser du finner på emballasjen**.\nDu trenger ikke å bekymre deg for opprinnelsesangivelser som er angitt direkte i ingredienslisten.';
 
   @override
   String get edit_product_form_item_origins_explanation_good_examples_1 =>
-      'Beef from Argentina';
+      'Storfekjøtt fra Argentina';
 
   @override
   String get edit_product_form_item_origins_explanation_good_examples_2 =>
-      'The soy does not come from the European Union';
+      'Soyaen kommer ikke fra EU';
 
   @override
   String get edit_product_form_item_countries_title => 'Country';
 
   @override
   String get edit_product_form_item_countries_hint =>
-      'Input a country (eg: Germany)';
+      'Skriv inn et land (f.eks. Tyskland)';
 
   @override
   String get edit_product_form_item_countries_type => 'land';
 
   @override
   String get edit_product_form_item_countries_explanations_title =>
-      'Good practices: Countries';
+      'God praksis: Land';
 
   @override
   String get edit_product_form_item_countries_explanations_info1 =>
-      '**Countries where the product is widely available** (not including stores specialising in foreign products).';
+      '**Land der produktet er allment tilgjengelig** (ikke inkludert butikker som spesialiserer seg på utenlandske produkter).';
 
   @override
-  String get edit_product_form_item_emb_codes_title => 'Traceability codes';
+  String get edit_product_form_item_emb_codes_title => 'Sporbarhetskoder';
 
   @override
   String get edit_product_form_item_emb_codes_hint =>
-      'Input a code (eg: EMB 53062, FR 62.448.034 CE, 84 R 20, 33 RECOLTANT 522…)';
+      'Skriv inn en kode (f.eks.: EMB 53062, FR 62.448.034 CE, 84 R 20, 33 RECOLTANT 522…)';
 
   @override
-  String get edit_product_form_item_emb_codes_type => 'traceability code';
+  String get edit_product_form_item_emb_codes_type => 'sporbarhetskode';
 
   @override
   String get edit_product_form_item_emb_help_title =>
-      'Good practices: Traceability codes';
+      'God praksis: Sporbarhetskoder';
 
   @override
   String get edit_product_form_item_emb_help_info1 =>
-      'In this section, you can input codes related to **packaging marks**, **identification marks** or **health marks**.';
+      'I denne delen kan du legge inn koder relatert til **emballasjemerker**, **identifikasjonsmerker** eller **helsemerker**.';
 
   @override
   String get edit_product_form_item_emb_help_info2_title =>
-      'Examples of traceability codes';
+      'Eksempler på sporbarhetskoder';
 
   @override
   String get edit_product_form_item_emb_help_info2_item1_text =>
-      '**EC codes** used in the European Community to identify food producers or packagers:';
+      '**EF-koder** brukt i Det europeiske fellesskap for å identifisere matprodusenter eller -pakkere:';
 
   @override
   String get edit_product_form_item_emb_help_info2_item1_example =>
@@ -2068,11 +2096,11 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get edit_product_form_item_emb_help_info2_item1_explanation =>
-      '**FR**: country code of **France**\n**72.264.002**: geographic data\n**CE**: European Community';
+      '**FR**: landskode for **Frankrike**\n**72.264.002**: geografiske data\n**CE**: Det europeiske fellesskap';
 
   @override
   String get edit_product_form_item_emb_help_info2_item2_text =>
-      '**EMB codes** used in France:';
+      '**EMB-koder** brukt i Frankrike:';
 
   @override
   String get edit_product_form_item_emb_help_info2_item2_explanation =>
@@ -2086,7 +2114,7 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get edit_product_form_item_traces_type =>
-      'Input a trace (eg: Soy beans)';
+      'Skriv inn et spor (f.eks. soyabønner)';
 
   @override
   String get edit_product_form_item_categories_title => 'Kategorier';
@@ -2096,101 +2124,102 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get edit_product_form_item_categories_type =>
-      'Input a category (eg: Orange juice)';
+      'Skriv inn en kategori (f.eks.: Appelsinjuice)';
 
   @override
   String get edit_product_form_item_categories_explanation_title =>
-      'Good practices: Categories';
+      'God praksis: Kategorier';
 
   @override
   String get edit_product_form_item_categories_explanation_info1 =>
-      'Indicate **only the most specific category**.\nParent categories will be automatically added.';
+      'Angi **kun den mest spesifikke kategorien**.\nOverordnede kategorier vil bli lagt til automatisk.';
 
   @override
   String get edit_product_form_item_categories_explanation_info2_title =>
-      'Missing category?';
+      'Mangler kategori?';
 
   @override
   String get edit_product_form_item_categories_explanation_info2_content =>
-      'In case a category is **not available in autocomplete**, feel free to add it anyway.\nThis will help us improve Open Food Facts in your country.';
+      'Hvis en kategori **ikke er tilgjengelig i autofullføring**, kan du gjerne legge den til likevel.\nDette vil hjelpe oss med å forbedre Open Food Facts i landet ditt.';
 
   @override
   String get edit_product_form_item_categories_explanation_good_examples_1 =>
-      'Sardines in olive oil';
+      'Sardiner i olivenolje';
 
   @override
   String get edit_product_form_item_categories_explanation_good_examples_2 =>
-      'Orange juice from concentrate';
+      'Appelsinjuice fra konsentrat';
 
   @override
-  String get edit_product_form_item_exit_title => 'Quit without saving?';
+  String get edit_product_form_item_exit_title => 'Avslutte uten å lagre?';
 
   @override
   String get edit_product_form_item_exit_confirmation =>
-      'Do you want to save your changes before leaving this page?';
+      'Vil du lagre endringene dine før du forlater denne siden?';
 
   @override
   String get edit_product_form_item_exit_confirmation_positive_button =>
-      'Save changes';
+      'Lagre endringer';
 
   @override
   String get edit_product_form_item_exit_confirmation_negative_button =>
-      'Discard changes';
+      'Forkast endringer';
 
   @override
   String get edit_product_form_item_ingredients_title => 'Ingredienser';
 
   @override
   String get edit_product_form_item_ingredients_pinch_to_zoom_tooltip =>
-      'Zoom in and out by pinching the screen';
+      'Zoom inn og ut ved å klype skjermen';
 
   @override
   String get edit_product_form_item_ingredients_pinch_to_zoom_title =>
-      'Zoom in and out the photo';
+      'Zoom inn og ut av bildet';
 
   @override
   String get edit_product_form_item_ingredients_pinch_to_zoom_message =>
-      'Using the **Pinch-to-zoom gesture**, you can zoom in or out the photo:';
+      'Ved å bruke **Klyp-for-å-zoome-bevegelsen** kan du zoome inn eller ut av bildet:';
 
   @override
   String get edit_product_form_item_add_valid_item_tooltip => 'Legg til';
 
   @override
   String get edit_product_form_item_add_invalid_item_tooltip =>
-      'Please enter a text first';
+      'Vennligst skriv inn en tekst først';
 
   @override
-  String get edit_product_form_item_remove_item_tooltip => 'Remove';
+  String get edit_product_form_item_remove_item_tooltip => 'Fjerne';
 
   @override
-  String get edit_product_form_item_save_edit_item_tooltip => 'Save your edit';
+  String get edit_product_form_item_save_edit_item_tooltip =>
+      'Lagre redigeringen din';
 
   @override
   String get edit_product_form_item_cancel_edit_item_tooltip =>
-      'Cancel your edit';
+      'Avbryt redigeringen din';
 
   @override
   String get edit_product_form_item_packaging_title =>
-      'Recycling instructions photo';
+      'Instruksjoner for resirkulering, bilde';
 
   @override
   String get edit_product_form_item_nutrition_facts_title => 'Næringsfakta';
 
   @override
   String get edit_product_form_item_nutrition_facts_subtitle =>
-      'Nutrition, alcohol content…';
+      'Næringsinnhold, alkoholinnhold…';
 
   @override
   String get edit_product_form_item_nutrition_facts_explanation_title =>
-      'Good practices: Nutrition facts';
+      'God praksis: Næringsinnhold';
 
   @override
   String get edit_product_form_item_nutrition_facts_explanation_info1_title =>
-      'Nutritional values';
+      'Næringsverdier';
 
   @override
   String get edit_product_form_item_nutrition_facts_explanation_info1_content =>
-      'First, select if the **values are provided**:';
+      'Først velger du om **verdiene er oppgitt**:';
 
   @override
   String get edit_product_form_item_nutrition_facts_explanation_info2_title =>
@@ -2198,52 +2227,53 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get edit_product_form_item_nutrition_facts_explanation_info2_content =>
-      'Then, input the nutritional values **as indicated on the packaging**. If there is no value, you can click on the \"Eye\" icon.';
+      'Deretter skriver du inn næringsverdiene **som angitt på emballasjen**. Hvis det ikke finnes noen verdi, kan du klikke på «Øye»-ikonet.';
 
   @override
   String get edit_product_form_item_nutrition_facts_explanation_info3_title =>
-      'Missing field?';
+      'Mangler et felt?';
 
   @override
   String get edit_product_form_item_nutrition_facts_explanation_info3_content =>
-      'If an entry is missing, you can **click on the \"Plus\" icon** to add it (eg: vitamin D, magnesium…).';
+      'Hvis en oppføring mangler, kan du **klikke på «Pluss»-ikonet** for å legge den til (f.eks.: vitamin D, magnesium…).';
 
   @override
   String get edit_product_form_save => 'Edit';
 
   @override
-  String get edit_product_ingredients_photo_title => 'Ingredients photo';
+  String get edit_product_ingredients_photo_title => 'Ingredienser bilde';
 
   @override
   String get edit_product_ingredients_list_title => 'Ingrediensliste';
 
   @override
-  String get edit_product_packaging_photo_title => 'Packaging photo';
+  String get edit_product_packaging_photo_title => 'Emballasjebilde';
 
   @override
-  String get edit_product_packaging_list_title => 'Packaging list';
+  String get edit_product_packaging_list_title => 'Pakkeliste';
 
   @override
-  String get no_data_available => 'No data available';
+  String get no_data_available => 'Ingen data tilgjengelig';
 
   @override
-  String get product_field_website_title => 'Website';
+  String get product_field_website_title => 'Nettsted';
 
   @override
-  String get origins_editing_title => 'Edit Origins';
+  String get origins_editing_title => 'Rediger opprinnelse';
 
   @override
-  String get completed_basic_details_btn_text => 'Complete basic details';
+  String get completed_basic_details_btn_text =>
+      'Fullfør grunnleggende detaljer';
 
   @override
-  String get not_implemented_snackbar_text => 'Not implemented yet';
+  String get not_implemented_snackbar_text => 'Ikke implementert ennå';
 
   @override
   String get category_picker_page_appbar_text => 'Kategorier';
 
   @override
   String get edit_ingredients_extract_ingredients_btn_text =>
-      'Extract ingredients from the photo';
+      'Hent ut ingredienser fra bildet';
 
   @override
   String get edit_ingredients_extract_ingredients_btn_text_short =>
@@ -2251,204 +2281,204 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get edit_ingredients_extracting_ingredients_btn_text =>
-      'Extracting ingredients\nfrom the photo';
+      'Uttrekk av ingredienser\nfra bildet';
 
   @override
-  String get edit_ingredients_loading_photo_btn_text => 'Loading photo…';
+  String get edit_ingredients_loading_photo_btn_text => 'Laster inn bilde…';
 
   @override
   String get edit_ingredients_loading_photo_help_dialog_title =>
-      'Why do I see this message?';
+      'Hvorfor ser jeg denne meldingen?';
 
   @override
   String get edit_ingredients_loading_photo_help_dialog_body =>
-      'To use the \"Extract ingredients\" feature, the photo needs to be uploaded first.\n\nPlease wait a few seconds or enter them manually.';
+      'For å bruke funksjonen «Trekke ut ingredienser», må bildet lastes opp først.\n\nVent noen sekunder eller skriv dem inn manuelt.';
 
   @override
-  String get edit_ingredients_refresh_photo_btn_text => 'Refresh photo';
+  String get edit_ingredients_refresh_photo_btn_text => 'Oppdater bildet';
 
   @override
   String get edit_packaging_extract_btn_text =>
-      'Extract packaging\nfrom the photo';
+      'Hent ut emballasje\nfra bildet';
 
   @override
-  String get edit_packaging_extract_btn_text_short => 'Extract packaging';
+  String get edit_packaging_extract_btn_text_short => 'Ekstraktemballasje';
 
   @override
   String get edit_packaging_extracting_btn_text =>
-      'Extracting packaging from the photo';
+      'Utpakking av emballasje fra bildet';
 
   @override
-  String get edit_packaging_loading_photo_btn_text => 'Loading photo…';
+  String get edit_packaging_loading_photo_btn_text => 'Laster inn bilde…';
 
   @override
   String get edit_packaging_loading_photo_help_dialog_title =>
-      'Why do I see this message?';
+      'Hvorfor ser jeg denne meldingen?';
 
   @override
   String get edit_packaging_loading_photo_help_dialog_body =>
-      'To use the \"Extract packaging\" feature, the photo needs to be uploaded first.\n\nPlease wait a few seconds or enter them manually.';
+      'For å bruke funksjonen «Pakk ut emballasje» må bildet lastes opp først.\n\nVent noen sekunder eller skriv dem inn manuelt.';
 
   @override
-  String get edit_packaging_refresh_photo_btn_text => 'Refresh photo';
+  String get edit_packaging_refresh_photo_btn_text => 'Oppdater bildet';
 
   @override
-  String get edit_ocr_extract_failed => 'Failed to detect text in image.';
+  String get edit_ocr_extract_failed => 'Klarte ikke å oppdage tekst i bildet.';
 
   @override
-  String get edit_ocr_extract_disabled_title => 'No picture!';
+  String get edit_ocr_extract_disabled_title => 'Ikke noe bilde!';
 
   @override
   String get edit_ocr_extract_disabled_message =>
-      'In order to use the text extraction feature, you must first take a photo.';
+      'For å bruke tekstuttrekkingsfunksjonen må du først ta et bilde.';
 
   @override
-  String get user_list_dialog_new_title => 'New list of products';
+  String get user_list_dialog_new_title => 'Ny produktliste';
 
   @override
-  String get user_list_dialog_rename_title => 'Rename list';
+  String get user_list_dialog_rename_title => 'Gi nytt navn til listen';
 
   @override
-  String get user_list_subtitle_product => 'Lists';
+  String get user_list_subtitle_product => 'Lister';
 
   @override
   String get user_list_title => 'Your lists';
 
   @override
-  String get user_list_add_product => 'Add the product to your lists';
+  String get user_list_add_product => 'Legg produktet til i listene dine';
 
   @override
-  String get user_list_button_new => 'Create a new list';
+  String get user_list_button_new => 'Opprett en ny liste';
 
   @override
   String get user_list_empty_label =>
       'No list available yet, please start by creating one';
 
   @override
-  String get user_list_button_add_product => 'Add to list';
+  String get user_list_button_add_product => 'Legg til i listen';
 
   @override
-  String get added_to_list_msg => 'Added to list';
+  String get added_to_list_msg => 'Lagt til i listen';
 
   @override
-  String get user_list_popup_clear => 'Clear your history';
+  String get user_list_popup_clear => 'Tøm historikken din';
 
   @override
-  String get user_list_popup_rename => 'Rename';
+  String get user_list_popup_rename => 'Gi nytt navn';
 
   @override
-  String get user_list_name_hint => 'My list';
+  String get user_list_name_hint => 'Min liste';
 
   @override
-  String get user_list_name_error_empty => 'Name is mandatory';
+  String get user_list_name_error_empty => 'Navn er obligatorisk';
 
   @override
-  String get user_list_name_error_already => 'That name is already used';
+  String get user_list_name_error_already => 'Det navnet er allerede brukt';
 
   @override
-  String get user_list_name_error_same => 'That is the same name';
+  String get user_list_name_error_same => 'Det er det samme navnet';
 
   @override
-  String get user_list_name_input_hint => 'Name of the list';
+  String get user_list_name_input_hint => 'Navnet på listen';
 
   @override
-  String get try_again => 'Try Again';
+  String get try_again => 'Prøv igjen';
 
   @override
-  String get there_was_an_error => 'There was an error';
+  String get there_was_an_error => 'Det oppsto en feil';
 
   @override
   String category_picker_no_category_found_message(String items) {
-    return 'No category found for $items';
+    return 'Ingen kategori funnet for $items';
   }
 
   @override
-  String get camera_toggle_camera => 'Switch between back and front camera';
+  String get camera_toggle_camera => 'Bytt mellom bak- og frontkamera';
 
   @override
-  String get camera_toggle_flash => 'Turn ON or OFF the flash of the camera';
+  String get camera_toggle_flash => 'Slå PÅ eller AV blitsen på kameraet';
 
   @override
-  String get camera_enable_flash => 'Enable flash';
+  String get camera_enable_flash => 'Aktiver blits';
 
   @override
-  String get camera_disable_flash => 'Disable flash';
+  String get camera_disable_flash => 'Deaktiver blits';
 
   @override
-  String get camera_flash_error_dialog_title => 'An error occurred!';
+  String get camera_flash_error_dialog_title => 'Det oppsto en feil!';
 
   @override
   String get camera_flash_error_dialog_message =>
-      'An error occurred while changing the state of your flash. Please ensure your smartphone has not the torch already enabled.';
+      'Det oppsto en feil under endring av blitstilstanden. Sørg for at lommelykten ikke allerede er aktivert på smarttelefonen din.';
 
   @override
-  String get category_picker_no_category_found_button => 'Back';
+  String get category_picker_no_category_found_button => 'Tilbake';
 
   @override
   String get user_preferences_item_accessibility_hint =>
-      'Click to open in your browser or in the application (if installed)';
+      'Klikk for å åpne i nettleseren din eller i applikasjonen (hvis installert)';
 
   @override
-  String get dev_preferences_screen_title => 'DEV Mode';
+  String get dev_preferences_screen_title => 'DEV-modus';
 
   @override
   String get dev_preferences_screen_subtitle =>
       'Få tilgang til eksperimentelle funksjoner og utviklingsverktøy';
 
   @override
-  String get dev_preferences_reset_onboarding_title => 'Restart onboarding';
+  String get dev_preferences_reset_onboarding_title =>
+      'Start omstart av onboarding';
 
   @override
   String get dev_preferences_reset_onboarding_subtitle =>
-      'You then have to restart the App to see it again.';
+      'Deretter må du starte appen på nytt for å se den igjen.';
 
   @override
   String get dev_preferences_environment_switch_title =>
-      'Switch between openfoodfacts.org (PROD) and test env';
+      'Bytt mellom openfoodfacts.org (PROD) og testmiljø';
 
   @override
   String get dev_preferences_test_environment_title =>
-      'Test environment parameters';
+      'Parametere for testmiljø';
 
   @override
   String dev_preferences_test_environment_subtitle(String url) {
-    return 'Base URL for current test env: $url';
+    return 'Basis-URL for gjeldende testmiljø: $url';
   }
 
   @override
-  String get dev_preferences_test_environment_dialog_title =>
-      'Test environment host';
+  String get dev_preferences_test_environment_dialog_title => 'Testmiljøvert';
 
   @override
-  String get dev_preferences_ml_kit_title => 'Use ML Kit';
+  String get dev_preferences_ml_kit_title => 'Bruk ML-settet';
 
   @override
   String get dev_preferences_ml_kit_subtitle =>
-      'then you have to restart this app';
+      'så må du starte denne appen på nytt';
 
   @override
   String get dev_preferences_product_additional_features_title =>
-      'Additional button on product page';
+      'Ekstra knapp på produktsiden';
 
   @override
   String get dev_preferences_edit_ingredients_title =>
-      'Edit ingredients via a knowledge panel button';
+      'Rediger ingredienser via en kunnskapspanelknapp';
 
   @override
-  String get dev_preferences_export_history_title => 'Export History';
+  String get dev_preferences_export_history_title => 'Eksportlogg';
 
   @override
-  String get dev_preferences_export_history_progress_error => 'exception';
+  String get dev_preferences_export_history_progress_error => 'unntak';
 
   @override
-  String get dev_preferences_export_history_progress_found => 'product found';
+  String get dev_preferences_export_history_progress_found => 'produkt funnet';
 
   @override
   String get dev_preferences_export_history_progress_not_found =>
-      'product NOT found';
+      'produktet IKKE funnet';
 
   @override
-  String get dev_preferences_export_history_dialog_title => 'Export history';
+  String get dev_preferences_export_history_dialog_title => 'Eksportlogg';
 
   @override
   String get dev_preferences_button_positive => 'OK';
@@ -2457,7 +2487,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get dev_preferences_button_negative => 'Cancel';
 
   @override
-  String get dev_preferences_migration_title => 'Data migration from V1';
+  String get dev_preferences_migration_title => 'Datamigrering fra V1';
 
   @override
   String dev_preferences_migration_subtitle(String status) {
@@ -2466,91 +2496,91 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get dev_preferences_migration_status_already_done =>
-      'success or fresh install';
+      'suksess eller ny installasjon';
 
   @override
-  String get dev_preferences_migration_status_success => 'success';
+  String get dev_preferences_migration_status_success => 'suksess';
 
   @override
-  String get dev_preferences_migration_status_error => 'error';
+  String get dev_preferences_migration_status_error => 'feil';
 
   @override
-  String get dev_preferences_migration_status_in_progress => 'in progress';
+  String get dev_preferences_migration_status_in_progress => 'pågår';
 
   @override
   String get dev_preferences_migration_status_required =>
-      'required (click to start)';
+      'obligatorisk (klikk for å starte)';
 
   @override
-  String get dev_preferences_migration_status_not_started => 'unknown';
+  String get dev_preferences_migration_status_not_started => 'ukjent';
 
   @override
   String get dev_preferences_import_history_subtitle =>
-      'Will clear history and put 3 products in there';
+      'Vil slette historikken og legge inn 3 produkter der';
 
   @override
-  String get dev_preferences_news_custom_url_title => 'Custom URL for news';
+  String get dev_preferences_news_custom_url_title =>
+      'Tilpasset URL for nyheter';
 
   @override
   String get dev_preferences_news_custom_url_subtitle =>
-      'URL of the JSON file:';
+      'URL-adressen til JSON-filen:';
 
   @override
-  String get dev_preferences_news_custom_url_empty_value => 'Not set';
+  String get dev_preferences_news_custom_url_empty_value => 'Ikke angitt';
 
   @override
   String get dev_preferences_news_provider_status_title => 'Status';
 
   @override
   String dev_preferences_news_provider_status_subtitle(String date) {
-    return 'Last refresh: $date';
+    return 'Siste oppdatering: $date';
   }
 
   @override
-  String get product_type_label_food => 'Food';
+  String get product_type_label_food => 'Mat';
 
   @override
-  String get product_type_label_beauty => 'Personal care';
+  String get product_type_label_beauty => 'Personlig pleie';
 
   @override
-  String get product_type_label_pet_food => 'Pet food';
+  String get product_type_label_pet_food => 'Kjæledyrfôr';
 
   @override
   String get product_type_label_product => 'Other';
 
   @override
-  String get product_type_selection_title => 'Product type';
+  String get product_type_selection_title => 'Produkttype';
 
   @override
-  String get product_type_selection_subtitle =>
-      'Select the type of this product';
+  String get product_type_selection_subtitle => 'Velg typen av dette produktet';
 
   @override
   String get product_type_selection_empty =>
-      'You need to select a product type first!';
+      'Du må velge en produkttype først!';
 
   @override
   String product_type_selection_already(String productType) {
-    return 'You cannot change the product type ($productType)!';
+    return 'Du kan ikke endre produkttypen ($productType)!';
   }
 
   @override
   String get prices_app_dev_mode_flag =>
-      'Shortcut to Prices app on product page';
+      'Snarvei til Priser-appen på produktsiden';
 
   @override
-  String get prices_app_button => 'Go to Prices app';
+  String get prices_app_button => 'Gå til Priser-appen';
 
   @override
   String get prices_website_button => 'Åpne på nettsiden for åpne priser';
 
   @override
   String get prices_bulk_proof_upload_select =>
-      'Add price tags directly from gallery';
+      'Legg til prislapper direkte fra galleriet';
 
   @override
   String get prices_bulk_proof_upload_warning =>
-      'Once you\'ve selected images, you won\'t be able to edit them!';
+      'Når du har valgt bilder, kan du ikke redigere dem!';
 
   @override
   String get prices_bulk_proof_upload_warning_ai =>
@@ -2561,10 +2591,10 @@ class AppLocalizationsNo extends AppLocalizations {
       'La fellesskapet validere priser hentet ut av AI.';
 
   @override
-  String get prices_bulk_proof_upload_subtitle => 'Multiple Price Tags';
+  String get prices_bulk_proof_upload_subtitle => 'Flere prislapper';
 
   @override
-  String get prices_bulk_proof_upload_title => 'Bulk Proof Upload';
+  String get prices_bulk_proof_upload_title => 'Masseopplasting av bevis';
 
   @override
   String get prices_bulk_proof_upload_step_selecting => 'Velge filer';
@@ -2588,15 +2618,15 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get prices_generic_title => 'Prices';
+  String get prices_generic_title => 'Priser';
 
   @override
   String prices_add_n_prices(num count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'Add $count prices',
-      one: 'Add a price',
+      other: 'Legg til $count priser',
+      one: 'Legg til en pris',
     );
     return '$_temp0';
   }
@@ -2606,42 +2636,42 @@ class AppLocalizationsNo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'Send $count prices',
-      one: 'Send the price',
+      other: 'Send $count priser',
+      one: 'Send prisen',
     );
     return '$_temp0';
   }
 
   @override
-  String get prices_add_an_item => 'Add an item';
+  String get prices_add_an_item => 'Legg til et element';
 
   @override
-  String get prices_add_a_price => 'Add a price';
+  String get prices_add_a_price => 'Legg til en pris';
 
   @override
-  String get prices_add_a_receipt => 'Add a receipt';
+  String get prices_add_a_receipt => 'Legg til en kvittering';
 
   @override
-  String get prices_add_price_tags => 'Add price tags';
+  String get prices_add_price_tags => 'Legg til prislapper';
 
   @override
   String prices_barcode_already(String barcode) {
-    return 'This barcode ($barcode) is already in the list!';
+    return 'Denne strekkoden ($barcode) er allerede i listen!';
   }
 
   @override
   String get prices_barcode_search_not_found => 'Product not found';
 
   @override
-  String get prices_barcode_search_none_yet => 'No product yet';
+  String get prices_barcode_search_none_yet => 'Ingen produkt ennå';
 
   @override
   String prices_barcode_search_running(String barcode) {
-    return 'Looking for $barcode';
+    return 'Leter etter $barcode';
   }
 
   @override
-  String get prices_barcode_enter => 'Enter the Barcode';
+  String get prices_barcode_enter => 'Skriv inn strekkoden';
 
   @override
   String get prices_category_enter => 'Vare uten strekkode';
@@ -2668,10 +2698,10 @@ class AppLocalizationsNo extends AppLocalizations {
   String get prices_category_error_mandatory => 'Kategorien er obligatorisk';
 
   @override
-  String get prices_barcode_reader_action => 'Barcode reader';
+  String get prices_barcode_reader_action => 'Strekkodeleser';
 
   @override
-  String get prices_view_prices => 'View the prices';
+  String get prices_view_prices => 'Se prisene';
 
   @override
   String get prices_list_title => 'Prisliste';
@@ -2719,8 +2749,8 @@ class AppLocalizationsNo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count prices',
-      one: '1 price',
+      other: '$count priser',
+      one: '1 pris',
     );
     return '$_temp0 for $product';
   }
@@ -2730,16 +2760,16 @@ class AppLocalizationsNo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'All $count prices',
-      one: 'Only one price',
-      zero: 'No price yet',
+      other: 'Alle $count priser',
+      one: 'Kun én pris',
+      zero: 'Ingen pris ennå',
     );
     return '$_temp0';
   }
 
   @override
   String prices_list_length_many_pages(int pageSize, int total) {
-    return 'Latest $pageSize prices (total: $total)';
+    return 'Siste $pageSize priser (totalt: $total)';
   }
 
   @override
@@ -2749,32 +2779,32 @@ class AppLocalizationsNo extends AppLocalizations {
     String date,
     String user,
   ) {
-    return 'Price: $price / Store: \"$location\" / Published on $date by \"$user\"';
+    return 'Pris: $price / Butikk: \"$location\" / Publisert $date av \"$user\"';
   }
 
   @override
   String prices_open_user_proofs(String user) {
-    return 'Open proofs of \"$user\"';
+    return 'Åpne bevis for «$user»';
   }
 
   @override
-  String get prices_open_proof => 'Open price proof';
+  String get prices_open_proof => 'Åpen prisbevis';
 
   @override
   String prices_proofs_list_length_one_page(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'All $count proofs',
-      one: 'Only one proof',
-      zero: 'No proof yet',
+      other: 'Alle $count bevis',
+      one: 'Bare ett bevis',
+      zero: 'Ingen bevis ennå',
     );
     return '$_temp0';
   }
 
   @override
   String prices_proofs_list_length_many_pages(int pageSize, int total) {
-    return 'Latest $pageSize proofs (total: $total)';
+    return 'Siste $pageSize bevis (totalt: $total)';
   }
 
   @override
@@ -2786,7 +2816,7 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String prices_users_list_length_many_pages(int pageSize, int total) {
-    return 'Top $pageSize contributors (total: $total)';
+    return 'Topp $pageSize bidragsytere (totalt: $total)';
   }
 
   @override
@@ -2798,7 +2828,7 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String prices_locations_list_length_many_pages(int pageSize, int total) {
-    return 'Top $pageSize locations (total: $total)';
+    return 'Topp $pageSize steder (totalt: $total)';
   }
 
   @override
@@ -2806,9 +2836,9 @@ class AppLocalizationsNo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count proofs',
-      one: 'One proof',
-      zero: 'No proof',
+      other: '$count bevis',
+      one: 'Ett bevis',
+      zero: 'Ingen bevis',
     );
     return '$_temp0';
   }
@@ -2818,9 +2848,9 @@ class AppLocalizationsNo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count products',
-      one: 'One product',
-      zero: 'No product',
+      other: '$count produkter',
+      one: 'Ett produkt',
+      zero: 'Ingen produkter',
     );
     return '$_temp0';
   }
@@ -2830,9 +2860,9 @@ class AppLocalizationsNo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count users',
-      one: 'One user',
-      zero: 'No user',
+      other: '$count brukere',
+      one: 'Én bruker',
+      zero: 'Ingen bruker',
     );
     return '$_temp0';
   }
@@ -2842,9 +2872,9 @@ class AppLocalizationsNo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count prices',
-      one: 'One price',
-      zero: 'No price',
+      other: '$count priser',
+      one: 'Én pris',
+      zero: 'Ingen pris',
     );
     return '$_temp0';
   }
@@ -2853,50 +2883,50 @@ class AppLocalizationsNo extends AppLocalizations {
   String get prices_amount_existing_subtitle => 'Pris lagt til tidligere';
 
   @override
-  String get prices_amount_subtitle => 'Amount';
+  String get prices_amount_subtitle => 'Beløp';
 
   @override
-  String get prices_amount_is_discounted => 'Is discounted?';
+  String get prices_amount_is_discounted => 'Er det rabattert?';
 
   @override
-  String get prices_amount_price_normal => 'Price';
+  String get prices_amount_price_normal => 'Pris';
 
   @override
-  String get prices_amount_price_discounted => 'Discounted price';
+  String get prices_amount_price_discounted => 'Rabattert pris';
 
   @override
-  String get prices_amount_price_not_discounted => 'Original price';
+  String get prices_amount_price_not_discounted => 'Opprinnelig pris';
 
   @override
-  String get prices_amount_no_product => 'One product is missing!';
+  String get prices_amount_no_product => 'Ett produkt mangler!';
 
   @override
-  String get prices_amount_price_incorrect => 'Incorrect value';
+  String get prices_amount_price_incorrect => 'Feil verdi';
 
   @override
-  String get prices_amount_price_mandatory => 'Mandatory value';
+  String get prices_amount_price_mandatory => 'Obligatorisk verdi';
 
   @override
   String get prices_currency_subtitle => 'Valuta';
 
   @override
-  String get prices_date_subtitle => 'Date';
+  String get prices_date_subtitle => 'Dato';
 
   @override
-  String get prices_location_subtitle => 'Shop';
+  String get prices_location_subtitle => 'Butikk';
 
   @override
-  String get prices_location_find => 'Find a shop';
+  String get prices_location_find => 'Finn en butikk';
 
   @override
-  String get prices_location_mandatory => 'You need to select a shop!';
+  String get prices_location_mandatory => 'Du må velge en butikk!';
 
   @override
   String get prices_location_search_broader =>
-      'Couldn\'t find what you were looking for? Let\'s try a broader search!';
+      'Fant du ikke det du lette etter? La oss prøve et bredere søk!';
 
   @override
-  String get prices_proof_subtitle => 'Proof';
+  String get prices_proof_subtitle => 'Bevis';
 
   @override
   String get prices_proof_empty_title => 'Ingen bevis ennå!';
@@ -2906,103 +2936,104 @@ class AppLocalizationsNo extends AppLocalizations {
       'Start med å legge til et bilde av en **kvittering** eller en **prislapp**!';
 
   @override
-  String get prices_proof_find => 'Select a proof';
+  String get prices_proof_find => 'Velg et bevis';
 
   @override
-  String get prices_proof_change => 'Change proof';
+  String get prices_proof_change => 'Endringsbevis';
 
   @override
-  String get prices_proof_receipt => 'Receipt';
+  String get prices_proof_receipt => 'Kvittering';
 
   @override
-  String get prices_proof_price_tag => 'Price tag';
+  String get prices_proof_price_tag => 'Prislapp';
 
   @override
-  String get prices_proof_mandatory => 'You need to select a proof!';
+  String get prices_proof_mandatory => 'Du må velge et bevis!';
 
   @override
-  String get prices_add_validation_error => 'Validation error';
+  String get prices_add_validation_error => 'Valideringsfeil';
 
   @override
-  String get prices_privacy_warning_title => 'Privacy warning';
+  String get prices_privacy_warning_title => 'Personvernadvarsel';
 
   @override
-  String get prices_unknown_product => 'Unknown product';
+  String get prices_unknown_product => 'Ukjent produkt';
 
   @override
   String get prices_privacy_warning_main_message =>
-      'Prices **will be public**, along with the store they refer to.\n\nThat might allow people who know about your Open Food Facts pseudonym to:\n';
+      'Prisene **vil være offentlige**, sammen med butikken de refererer til.\n\nDet kan gjøre det mulig for folk som kjenner til pseudonymet ditt fra Open Food Facts å:\n';
 
   @override
   String get prices_privacy_warning_message_bullet_1 =>
-      'Infer in which area you live';
+      'Gjenkjenn hvilket område du bor i';
 
   @override
-  String get prices_privacy_warning_message_bullet_2 =>
-      'Know what you are buying';
+  String get prices_privacy_warning_message_bullet_2 => 'Vit hva du kjøper';
 
   @override
   String get prices_privacy_warning_sub_message =>
-      'If you are uneasy with that, please change your pseudonym, or create a new Open Food Facts account and log into the app with it.';
+      'Hvis du er usikker på det, kan du endre pseudonymet ditt, eller opprette en ny Open Food Facts-konto og logge inn på appen med den.';
 
   @override
-  String get i_refuse => 'I refuse';
+  String get i_refuse => 'Jeg nekter';
 
   @override
-  String get i_accept => 'I accept';
+  String get i_accept => 'Jeg aksepterer';
 
   @override
-  String get prices_currency_change_proposal_title => 'Change the currency?';
+  String get prices_currency_change_proposal_title => 'Endre valutaen?';
 
   @override
   String prices_currency_change_proposal_message(
     String currency,
     String newCurrency,
   ) {
-    return 'Your current currency is **$currency**. Would you like to change it to **$newCurrency**?';
+    return 'Din nåværende valuta er **$currency**. Vil du endre den til **$newCurrency**?';
   }
 
   @override
   String prices_currency_change_proposal_action_approve(String newCurrency) {
-    return 'Yes, use $newCurrency';
+    return 'Ja, bruk $newCurrency';
   }
 
   @override
   String prices_currency_change_proposal_action_cancel(String currency) {
-    return 'No, keep $currency';
+    return 'Nei, behold $currency';
   }
 
   @override
-  String get prices_menu_know_more => 'Know more about Open Prices';
+  String get prices_menu_know_more => 'Lær mer om åpne priser';
 
   @override
-  String get dev_preferences_import_history_result_success => 'Done';
+  String get dev_preferences_import_history_result_success => 'Ferdig';
 
   @override
-  String get dev_mode_section_server => 'Server configuration';
+  String get dev_mode_section_server => 'Serverkonfigurasjon';
 
   @override
-  String get dev_mode_section_news => 'News provider configuration';
+  String get dev_mode_section_news => 'Konfigurasjon av nyhetsleverandør';
 
   @override
-  String get dev_mode_section_product_page => 'Product page';
+  String get dev_mode_section_product_page => 'Produktside';
 
   @override
-  String get dev_mode_section_ui => 'User Interface';
+  String get dev_mode_section_ui => 'Brukergrensesnitt';
 
   @override
-  String get dev_mode_section_experimental_features => 'Experimental features';
+  String get dev_mode_section_experimental_features =>
+      'Eksperimentelle funksjoner';
 
   @override
-  String get dev_mode_hide_environmental_score_title => 'Exclude Green Score';
+  String get dev_mode_hide_environmental_score_title =>
+      'Ekskluder grønn poengsum';
 
   @override
   String get dev_mode_spellchecker_for_ocr_title =>
-      'Use a spellchecker for OCR screens';
+      'Bruk en stavekontroll for OCR-skjermer';
 
   @override
   String get dev_mode_spellchecker_for_ocr_subtitle =>
-      '(Ingredients and packaging)';
+      '(Ingredienser og emballasje)';
 
   @override
   String get dev_mode_reset_app_language_title => 'Tilbakestill appspråk';
@@ -3015,14 +3046,15 @@ class AppLocalizationsNo extends AppLocalizations {
       'Bytt mellom prices.openfoodfacts.org (PROD) og testmiljø';
 
   @override
-  String get search_history_item_edit_tooltip => 'Reuse and edit this search';
+  String get search_history_item_edit_tooltip =>
+      'Bruk og rediger dette søket på nytt';
 
   @override
-  String get search_history_item_remove_tooltip => 'Remove';
+  String get search_history_item_remove_tooltip => 'Fjerne';
 
   @override
   String product_search_no_more_results(int totalSize) {
-    return 'You\'ve downloaded all the $totalSize products.';
+    return 'Du har lastet ned alle $totalSize -produktene.';
   }
 
   @override
@@ -3031,38 +3063,39 @@ class AppLocalizationsNo extends AppLocalizations {
     int downloaded,
     int totalSize,
   ) {
-    return 'Download $count more products\nAlready downloaded $downloaded out of $totalSize.';
+    return 'Last ned $count flere produkter\nAllerede lastet ned $downloaded av $totalSize.';
   }
 
   @override
   String product_search_loading_message(Object search) {
-    return 'Your search of $search is in progress.\n\nPlease wait a few seconds…';
+    return 'Søket ditt etter $search pågår.\n\nVent noen sekunder…';
   }
 
   @override
-  String get user_search_contributor_title => 'Products I added';
+  String get user_search_contributor_title => 'Produkter jeg har lagt til';
 
   @override
-  String get user_search_informer_title => 'Products I edited';
+  String get user_search_informer_title => 'Produkter jeg redigerte';
 
   @override
-  String get user_search_photographer_title => 'Products I photographed';
+  String get user_search_photographer_title => 'Produkter jeg fotograferte';
 
   @override
-  String get user_search_to_be_completed_title => 'My to-be-completed products';
+  String get user_search_to_be_completed_title =>
+      'Mine produkter som skal fullføres';
 
   @override
-  String get user_search_prices_title => 'My prices';
+  String get user_search_prices_title => 'Mine priser';
 
   @override
-  String get user_search_proofs_title => 'My proofs';
+  String get user_search_proofs_title => 'Mine bevis';
 
   @override
-  String get user_search_proof_title => 'My proof';
+  String get user_search_proof_title => 'Mitt bevis';
 
   @override
   String search_proof_title(String user) {
-    return 'Proof from \"$user\"';
+    return 'Bevis fra «$user»';
   }
 
   @override
@@ -3071,17 +3104,17 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get all_search_prices_latest_title => 'Latest Prices added';
+  String get all_search_prices_latest_title => 'Siste priser lagt til';
 
   @override
-  String get all_search_prices_top_user_title => 'Top price contributors';
+  String get all_search_prices_top_user_title => 'De største prisbidragsyterne';
 
   @override
   String get all_search_prices_top_location_title =>
-      'Stores with the most prices';
+      'Butikkene med de høyeste prisene';
 
   @override
-  String get prices_contribution_assistant => 'Price Contribution Assistant';
+  String get prices_contribution_assistant => 'Assistent for prisbidrag';
 
   @override
   String get prices_validation_assistant => 'Price Validation Assistant';
@@ -3090,63 +3123,66 @@ class AppLocalizationsNo extends AppLocalizations {
   String get prices_challenges_page => 'Challenges';
 
   @override
-  String get prices_multiple_proof_addition_system => 'Add Multiple Proofs';
+  String get prices_multiple_proof_addition_system => 'Legg til flere bevis';
 
   @override
-  String get all_search_prices_top_location_single_title => 'Prices in a store';
+  String get all_search_prices_top_location_single_title =>
+      'Priser i en butikk';
 
   @override
   String get all_search_prices_top_product_title =>
-      'Products with the most prices';
+      'Produktene med høyest pris';
 
   @override
-  String get all_search_to_be_completed_title => 'All to-be-completed products';
+  String get all_search_to_be_completed_title =>
+      'Alle produkter som skal ferdigstilles';
 
   @override
   String get categorize_products_country_title =>
-      'Help categorize products in your country';
+      'Hjelp med å kategorisere produkter i landet ditt';
 
   @override
-  String get edit_product_action_retake_picture => 'Retake photo';
+  String get edit_product_action_retake_picture => 'Ta bildet på nytt';
 
   @override
-  String get edit_product_action_take_picture => 'Take photo';
+  String get edit_product_action_take_picture => 'Ta bilde';
 
   @override
-  String get edit_product_action_confirm => 'Confirm';
+  String get edit_product_action_confirm => 'Bekrefte';
 
   @override
   String get signup_page_terms_of_use_line1 =>
-      'I agree to the Open Food Facts ';
+      'Jeg godtar de åpne matfaktaene ';
 
   @override
-  String get signup_page_terms_of_use_line2 => 'terms of use and contribution';
+  String get signup_page_terms_of_use_line2 => 'bruksvilkår og bidrag';
 
   @override
-  String get analytics_consent_image_semantic_label => 'Analytics icon';
+  String get analytics_consent_image_semantic_label => 'Analytics-ikon';
 
   @override
   String knowledge_panel_page_loading_error(Object? error) {
-    return 'Fatal Error: $error';
+    return 'Fatal feil: $error';
   }
 
   @override
   String preferences_page_loading_error(Object? error) {
-    return 'Fatal Error: $error';
+    return 'Fatal feil: $error';
   }
 
   @override
-  String get summary_card_button_add_basic_details => 'Complete basic details';
+  String get summary_card_button_add_basic_details =>
+      'Fullfør grunnleggende detaljer';
 
   @override
   String get edit_photo_button_label => 'Edit';
 
   @override
-  String get edit_photo_unselect_button_label => 'Unselect photo';
+  String get edit_photo_unselect_button_label => 'Fjern valg av bilde';
 
   @override
   String get edit_photo_select_existing_button_label =>
-      'Select an existing image';
+      'Velg et eksisterende bilde';
 
   @override
   String get edit_photo_select_existing_all_label =>
@@ -3154,52 +3190,52 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get edit_photo_select_existing_all_subtitle =>
-      'Select an image by clicking on it';
+      'Velg et bilde ved å klikke på det';
 
   @override
   String get edit_photo_select_existing_download_label =>
-      'Retrieving existing images…';
+      'Henter eksisterende bilder…';
 
   @override
   String get edit_photo_select_existing_downloaded_none =>
-      'There are no images previously uploaded related to this product.';
+      'Det er ingen bilder lastet opp tidligere relatert til dette produktet.';
 
   @override
   String get edit_photo_language_not_this_one =>
-      'No image in that language yet';
+      'Ingen bilder på det språket ennå';
 
   @override
-  String get edit_photo_language_none => 'No image yet';
+  String get edit_photo_language_none => 'Ikke noe bilde ennå';
 
   @override
   String get category_picker_screen_title => 'Kategorier';
 
   @override
-  String get basic_details => 'Basic Details';
+  String get basic_details => 'Grunnleggende detaljer';
 
   @override
-  String get product_name => 'Product Name';
+  String get product_name => 'Produktnavn';
 
   @override
-  String get product_names => 'Product Names';
+  String get product_names => 'Produktnavn';
 
   @override
   String get add_basic_details_product_name_add_translation =>
-      'Add a new translation';
+      'Legg til en ny oversettelse';
 
   @override
   String get add_basic_details_product_name_warning_translations =>
-      'Before validating, please ensure you only add a translation **if the language is present on the packaging**';
+      'Før du validerer, må du bare legge til en oversettelse **hvis språket står på emballasjen**';
 
   @override
-  String get add_basic_details_product_name_open_photo => 'View front photo';
+  String get add_basic_details_product_name_open_photo => 'Se forsidebilde';
 
   @override
-  String get add_basic_details_product_name_take_photo => 'Take front photo';
+  String get add_basic_details_product_name_take_photo => 'Ta et bilde foran';
 
   @override
   String get add_basic_details_product_name_hint =>
-      'Input the name of the product (eg: Nutella)';
+      'Skriv inn navnet på produktet (f.eks. Nutella)';
 
   @override
   String get add_basic_details_product_name_change_main_language_title =>
@@ -3213,41 +3249,41 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get explanation_section_good_examples => 'Good examples';
+  String get explanation_section_good_examples => 'Gode eksempler';
 
   @override
-  String get explanation_section_bad_examples => 'Bad examples';
+  String get explanation_section_bad_examples => 'Dårlige eksempler';
 
   @override
   String get add_basic_details_product_name_help_title =>
-      'Good practices: Product name';
+      'God praksis: Produktnavn';
 
   @override
   String get add_basic_details_product_name_help_info1 =>
-      'The product name is the **main name printed on the packaging**. It can be a registered trademark.';
+      'Produktnavnet er **hovednavnet som er trykt på emballasjen**. Det kan være et registrert varemerke.';
 
   @override
   String get add_basic_details_product_name_help_info2 =>
-      '**Note:** Please don\'t add a translation **if the language is not present on the packaging**.';
+      '**Merk:** Vennligst ikke legg til en oversettelse **hvis språket ikke finnes på emballasjen**.';
 
   @override
   String get add_basic_details_product_name_help_good_examples_1 => 'Nesquik';
 
   @override
   String get add_basic_details_product_name_help_good_examples_2 =>
-      'Tomato Ketchup';
+      'Tomatketchup';
 
   @override
   String get add_basic_details_product_name_help_bad_examples_1_explanation =>
-      'Don\'t include the brand in the name';
+      'Ikke ta med merkevaren i navnet';
 
   @override
   String get add_basic_details_product_name_help_bad_examples_1_example =>
-      'Tomato Ketchup **by Heinz**';
+      'Tomatketchup **fra Heinz**';
 
   @override
   String get add_basic_details_product_name_help_bad_examples_2_explanation =>
-      'Don\'t use symbols ®, ™, © or similar';
+      'Ikke bruk symbolene ®, ™, © eller lignende';
 
   @override
   String get add_basic_details_product_name_help_bad_examples_2_example =>
@@ -3258,58 +3294,59 @@ class AppLocalizationsNo extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count other translations',
-      one: '$count other translation',
+      other: '$count andre oversettelser',
+      one: '$count annen oversettelse',
     );
     return '$_temp0';
   }
 
   @override
-  String get brand_name => 'Brand name';
+  String get brand_name => 'Merkenavn';
 
   @override
-  String get brand_names => 'Brand names';
+  String get brand_names => 'Merkenavn';
 
   @override
   String get add_basic_details_brand_name_error =>
-      'Please enter the brand name';
+      'Vennligst skriv inn merkenavnet';
 
   @override
-  String get add_basic_details_brand_names_hint => 'Input brands (eg: Ferrero)';
+  String get add_basic_details_brand_names_hint =>
+      'Merker av innsatsfaktorer (f.eks. Ferrero)';
 
   @override
   String get add_basic_details_product_brand_help_title =>
-      'Good practices: Brands';
+      'God praksis: Merker';
 
   @override
   String get add_basic_details_product_brand_help_info1 =>
-      'Input **all the brands of the product**.';
+      'Skriv inn **alle merkene til produktet**.';
 
   @override
-  String get add_basic_details_product_brand_help_info2_title => 'Main brand';
+  String get add_basic_details_product_brand_help_info2_title => 'Hovedmerke';
 
   @override
   String get add_basic_details_product_brand_help_info2_content =>
-      'The **main brand**, generally clearly displayed on the front pack, should be **entered first**.';
+      '**Hovedmerket**, som vanligvis vises tydelig på forsiden av pakken, skal **oppgis først**.';
 
   @override
-  String get add_basic_details_product_brand_help_info3_title => 'Other brands';
+  String get add_basic_details_product_brand_help_info3_title => 'Andre merker';
 
   @override
   String get add_basic_details_product_brand_help_info3_item1_text =>
-      'When sold **by a big company**:';
+      'Når det selges **av et stort selskap**:';
 
   @override
   String get add_basic_details_product_brand_help_info3_item1_explanation =>
-      '**Actimel** is sold by **Danone**';
+      '**Actimel** selges av **Danone**';
 
   @override
   String get add_basic_details_product_brand_help_info3_item2_text =>
-      'When sold with its brand **translated in multiple languages**:';
+      'Når det selges med sitt merke **oversatt til flere språk**:';
 
   @override
   String get add_basic_details_product_brand_help_info3_item2_explanation =>
-      '**Nature Valley** is sometimes written **Val Nature**';
+      '**Nature Valley** skrives noen ganger som **Val Nature**';
 
   @override
   String get add_basic_details_product_brand_help_good_examples_1 => 'Nutella';
@@ -3319,181 +3356,182 @@ class AppLocalizationsNo extends AppLocalizations {
       'Oreo, Mondelez';
 
   @override
-  String get quantity => 'Quantity and weight';
+  String get quantity => 'Mengde og vekt';
 
   @override
   String get add_basic_details_quantity_hint =>
-      'Input the weight and if needed the quantity (eg : 4x100g)';
+      'Skriv inn vekten og om nødvendig mengden (f.eks.: 4 x 100 g)';
 
   @override
   String get add_basic_details_product_quantity_help_title =>
-      'Good practices: Quantity';
+      'God praksis: Mengde';
 
   @override
   String get add_basic_details_product_quantity_help_info1 =>
-      'Copy the value indicated on the product and **don\'t forget the units**.';
+      'Kopier verdien som er angitt på produktet, og **ikke glem enhetene**.';
 
   @override
   String get add_basic_details_product_quantity_help_good_examples_1 =>
-      '**230g** or **230 g**';
+      '**230 g** eller **230 g**';
 
   @override
   String get add_basic_details_product_quantity_help_good_examples_2 =>
-      '**6** (for 6 eggs)';
+      '**6** (for 6 egg)';
 
   @override
   String get add_basic_details_product_quantity_help_good_examples_3 =>
-      '**3 x 150g**\n(for a product with 3 boxes, each of 150g)';
+      '**3 x 150 g**\n(for et produkt med 3 esker, hver på 150 g)';
 
   @override
   String get barcode => 'Strekkode';
 
   @override
   String barcode_barcode(String barcode) {
-    return 'Barcode: $barcode';
+    return 'Strekkode: $barcode';
   }
 
   @override
-  String get barcode_invalid_error => 'Invalid barcode';
+  String get barcode_invalid_error => 'Ugyldig strekkode';
 
   @override
-  String get basic_details_add_success => 'Basic details added successfully';
+  String get basic_details_add_success => 'Grunnleggende detaljer er lagt til';
 
   @override
   String get basic_details_add_error =>
-      'Unable to add basic details. Please try again after some time';
+      'Kan ikke legge til grunnleggende detaljer. Prøv igjen om en stund.';
 
   @override
-  String get clear_search => 'Clear your search';
+  String get clear_search => 'Fjern søket ditt';
 
   @override
   String get confirm_clear =>
-      'You\'re about to clear your entire history: are you sure you want to continue?';
+      'Du er i ferd med å slette hele historikken din: er du sikker på at du vil fortsette?';
 
   @override
   String get alert_clear_selected_user_list =>
-      'You\'re about to clear selected items in your history';
+      'Du er i ferd med å slette valgte elementer i historikken din';
 
   @override
   String get confirm_clear_selected_user_list =>
-      'Are you sure you want to continue?';
+      'Er du sikker på at du vil fortsette?';
 
   @override
   String get alert_select_items_to_clear =>
-      'Please select one or more items to clear';
+      'Vennligst velg ett eller flere elementer som skal fjernes';
 
   @override
   String confirm_clear_user_list(String name) {
-    return 'You\'re about to clear this list ($name): are you sure you want to continue?';
+    return 'Du er i ferd med å tømme denne listen ($name): er du sikker på at du vil fortsette?';
   }
 
   @override
-  String get confirm_delete_user_list_title => 'Delete the list?';
+  String get confirm_delete_user_list_title => 'Slette listen?';
 
   @override
   String confirm_delete_user_list_message(String name) {
-    return 'You\'re about to delete the list \"$name\".\nAre you sure you want to continue?';
+    return 'Du er i ferd med å slette listen «$name».\nEr du sikker på at du vil fortsette?';
   }
 
   @override
-  String get confirm_delete_user_list_button => 'Yes, I confirm';
+  String get confirm_delete_user_list_button => 'Ja, jeg bekrefter';
 
   @override
   String importance_label(String name, String id) {
-    return '$name importance: $id';
+    return '$name viktighet: $id';
   }
 
   @override
-  String get user_list_all_title => 'Lists';
+  String get user_list_all_title => 'Lister';
 
   @override
-  String get user_list_all_empty => 'Create your first list';
+  String get user_list_all_empty => 'Lag din første liste';
 
   @override
-  String get product_list_select => 'Select a list';
+  String get product_list_select => 'Velg en liste';
 
   @override
   String user_list_length(num count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count products',
-      one: 'One product',
-      zero: 'Empty list',
+      other: '$count produkter',
+      one: 'Ett produkt',
+      zero: 'Tom liste',
     );
     return '$_temp0';
   }
 
   @override
-  String get add_list_label => 'Add list';
+  String get add_list_label => 'Legg til liste';
 
   @override
-  String get open_food_preferences_tooltip => 'Edit your food preferences';
+  String get open_food_preferences_tooltip => 'Rediger matpreferansene dine';
 
   @override
-  String get add_photo_button_label => 'Add photo';
+  String get add_photo_button_label => 'Legg til bilde';
 
   @override
   String get add_packaging_photo_button_label =>
-      'Take photos of any packaging/recycling information';
+      'Ta bilder av all emballasje-/resirkuleringsinformasjon';
 
   @override
   String get add_origin_photo_button_label =>
-      'Take photos of any origin information';
+      'Ta bilder av all opprinnelsesinformasjon';
 
   @override
   String get add_emb_photo_button_label =>
-      'Take photos of any traceability code information';
+      'Ta bilder av all sporbarhetskodeinformasjon';
 
   @override
   String get add_label_photo_button_label =>
-      'Take photos of any labels & certifications information';
+      'Ta bilder av all informasjon om etiketter og sertifiseringer';
 
   @override
-  String get choose_image_source_title => 'Choose image source';
+  String get choose_image_source_title => 'Velg bildekilde';
 
   @override
-  String get choose_image_source_body => 'Please choose a image source';
+  String get choose_image_source_body => 'Vennligst velg en bildekilde';
 
   @override
-  String get gallery_source_label => 'Gallery';
+  String get gallery_source_label => 'Galleri';
 
   @override
-  String get gallery_source_access_denied_dialog_title => 'Access denied';
+  String get gallery_source_access_denied_dialog_title => 'Tilgang nektet';
 
   @override
   String get gallery_source_access_denied_dialog_message_ios =>
-      'Unfortunately, the application can\'t access your gallery, as you have previously denied the permission.\n\nPlease go to the app settings in your phone Settings -> Photos';
+      'Dessverre har ikke appen tilgang til galleriet ditt, siden du tidligere har nektet tillatelsen.\n\nGå til appinnstillingene i telefonen din Innstillinger -> Bilder';
 
   @override
-  String get gallery_source_access_denied_dialog_button => 'Open the Settings';
+  String get gallery_source_access_denied_dialog_button =>
+      'Åpne innstillingene';
 
   @override
   String get share => 'Del';
 
   @override
   String share_product_text(String url) {
-    return 'Have a look at this product on Open Food Facts: $url';
+    return 'Ta en titt på dette produktet på Open Food Facts: $url';
   }
 
   @override
   String share_product_text_beauty(String url) {
-    return 'Have a look at this product on Open Beauty Facts: $url';
+    return 'Ta en titt på dette produktet på Open Beauty Facts: $url';
   }
 
   @override
   String share_product_text_pet_food(String url) {
-    return 'Have a look at this product on Open PetFood Facts: $url';
+    return 'Ta en titt på dette produktet på Open PetFood Facts: $url';
   }
 
   @override
   String share_product_text_product(String url) {
-    return 'Have a look at this product on Open Products Facts: $url';
+    return 'Ta en titt på dette produktet på Åpne produktfakta: $url';
   }
 
   @override
   String share_product_list_text(String url) {
-    return 'Have a look at my list of products on Open Food Facts: $url';
+    return 'Ta en titt på produktlisten min på Open Food Facts: $url';
   }
 
   @override
@@ -3503,172 +3541,172 @@ class AppLocalizationsNo extends AppLocalizations {
   String get capture_new_picture => 'Ta et bilde';
 
   @override
-  String get choose_from_gallery => 'Choose from gallery';
+  String get choose_from_gallery => 'Velg fra galleriet';
 
   @override
   String get image_upload_queued =>
-      'The image will be uploaded in the background as soon as possible.';
+      'Bildet lastes opp i bakgrunnen så snart som mulig.';
 
   @override
   String get add_price_queued =>
-      'The price will be sent to the server as soon as possible.';
+      'Prisen vil bli sendt til serveren så snart som mulig.';
 
   @override
   String get background_task_title_full_refresh =>
-      'Starting the refresh of all the products locally stored';
+      'Starter oppdateringen av alle produktene som er lagret lokalt';
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Begynner å utføre serverhandlingene for folksonomi-oppdateringer som er lagret lokalt';
 
   @override
   String get background_task_title_top_n =>
-      'Starting the download of the most popular products';
+      'Starter nedlastingen av de mest populære produktene';
 
   @override
-  String get expand_nutrition_facts => 'Expand nutrition facts table';
+  String get expand_nutrition_facts => 'Utvid tabellen over næringsinnhold';
 
   @override
   String get expand_nutrition_facts_body =>
-      'Keep the nutrition facts table expanded';
+      'Hold næringsinnholdstabellen utvidet';
 
   @override
-  String get expand_ingredients => 'Expand ingredients';
+  String get expand_ingredients => 'Utvid ingredienser';
 
   @override
-  String get expand_ingredients_body => 'Keep the ingredients panel expanded';
+  String get expand_ingredients_body => 'Hold ingredienspanelet utvidet';
 
   @override
-  String get no_internet_connection => 'No internet connection';
+  String get no_internet_connection => 'Ingen internettforbindelse';
 
   @override
-  String get world_results_label => 'Entire world';
+  String get world_results_label => 'Hele verden';
 
   @override
-  String get world_results_action => 'Extend your search to the world';
+  String get world_results_action => 'Utvid søket ditt til verden';
 
   @override
-  String get copy_to_clipboard => 'Copy';
+  String get copy_to_clipboard => 'Kopiere';
 
   @override
-  String get paste_from_clipboard => 'Paste from clipboard';
+  String get paste_from_clipboard => 'Lim inn fra utklippstavlen';
 
   @override
   String get no_data_available_in_clipboard =>
-      'No data available in your clipboard';
+      'Ingen data tilgjengelig på utklippstavlen';
 
   @override
-  String get clipboard_barcode_copy => 'Copy barcode to clipboard';
+  String get clipboard_barcode_copy => 'Kopier strekkoden til utklippstavlen';
 
   @override
   String clipboard_barcode_copied(Object barcode) {
-    return 'Barcode $barcode copied to the clipboard!';
+    return 'Strekkode $barcode kopiert til utklippstavlen!';
   }
 
   @override
-  String get open_product_website => 'Open this product on the website';
+  String get open_product_website => 'Åpne dette produktet på nettsiden';
 
   @override
-  String get language_picker_label => 'Your language';
+  String get language_picker_label => 'Språket ditt';
 
   @override
-  String get country_picker_label => 'Your country';
+  String get country_picker_label => 'Landet ditt';
 
   @override
-  String get currency_picker_label => 'Your currency';
+  String get currency_picker_label => 'Din valuta';
 
   @override
-  String get help_with_openfoodfacts => 'Help with OpenFoodFacts';
+  String get help_with_openfoodfacts => 'Hjelp med OpenFoodFacts';
 
   @override
   String get product_task_background_schedule =>
-      'The product will be updated in the background as soon as possible.';
+      'Produktet vil bli oppdatert i bakgrunnen så snart som mulig.';
 
   @override
-  String get no_email_client_available_dialog_title => 'No email apps!';
+  String get no_email_client_available_dialog_title => 'Ingen e-postapper!';
 
   @override
   String get no_email_client_available_dialog_content =>
-      'Please send us manually an email to mobile@openfoodfacts.org';
+      'Send oss en e-post manuelt til mobile@openfoodfacts.org';
 
   @override
-  String get all_images => 'All Images';
+  String get all_images => 'Alle bilder';
 
   @override
-  String get selected_images => 'Selected Images';
+  String get selected_images => 'Utvalgte bilder';
 
   @override
-  String get product_card_remove_product_tooltip => 'Remove product';
+  String get product_card_remove_product_tooltip => 'Fjern produktet';
 
   @override
   String scan_announce_new_barcode(String barcode) {
-    return 'New barcode scanned: $barcode';
+    return 'Ny strekkode skannet: $barcode';
   }
 
   @override
   String get scan_header_clear_button_tooltip =>
-      'Remove all products from the carousel';
+      'Fjern alle produkter fra karusellen';
 
   @override
   String get scan_header_compare_button_invalid_state_tooltip =>
-      'Please scan at least two products to compare them';
+      'Vennligst skann minst to produkter for å sammenligne dem';
 
   @override
   String get scan_header_compare_button_valid_state_tooltip =>
-      'Click to compare the products you have scanned';
+      'Klikk for å sammenligne produktene du har skannet';
 
   @override
-  String get scan_product_loading => 'You have scanned\nthe barcode:';
+  String get scan_product_loading => 'Du har skannet\nstrekkoden:';
 
   @override
   String get scan_product_loading_initial =>
-      'We\'re looking for this product!\nPlease wait a few seconds…';
+      'Vi ser etter dette produktet!\nVent noen sekunder…';
 
   @override
   String get scan_product_loading_long_request =>
-      'We\'re still looking for this product!\nDo you find it takes a long time to load? So are we…';
+      'Vi leter fortsatt etter dette produktet!\nSynes du det tar lang tid å laste? Det gjør vi også…';
 
   @override
   String get scan_product_loading_unresponsive =>
-      'We\'re still looking for this product.\nWould you like to restart the search?';
+      'Vi leter fortsatt etter dette produktet.\nVil du starte søket på nytt?';
 
   @override
-  String get scan_product_loading_restart_button => 'Restart search';
+  String get scan_product_loading_restart_button => 'Start søket på nytt';
 
   @override
   String get portion_calculator_description =>
-      'Calculate nutrition facts for a specific quantity';
+      'Beregn næringsinnhold for en bestemt mengde';
 
   @override
-  String get portion_calculator_hint => 'Quantity in';
+  String get portion_calculator_hint => 'Antall i';
 
   @override
   String get portion_calculator_accessibility =>
-      'Input a quantity to calculate nutrition facts';
+      'Skriv inn en mengde for å beregne næringsinnhold';
 
   @override
   String portion_calculator_error(int min, int max) {
-    return 'Please enter a quantity between $min and $max g';
+    return 'Vennligst skriv inn en mengde mellom $min og $max g';
   }
 
   @override
   String get portion_calculator_computation_error =>
-      'Missing data. Calculation could not be performed.';
+      'Manglende data. Beregningen kunne ikke utføres.';
 
   @override
   String portion_calculator_result_title(int grams) {
-    return 'Nutrition facts for $grams g (or ml)';
+    return 'Næringsinnhold for $grams g (eller ml)';
   }
 
   @override
-  String get offline_data => 'Offline Data';
+  String get offline_data => 'Frakoblede data';
 
   @override
   String get ocr_image_upload_instruction =>
-      'Upload an image to automatically extract the information it contains.';
+      'Last opp et bilde for å automatisk hente ut informasjonen det inneholder.';
 
   @override
-  String get upload_image => 'Upload Photo';
+  String get upload_image => 'Last opp bilde';
 
   @override
   String get word_separator_char => ',';
@@ -3677,388 +3715,389 @@ class AppLocalizationsNo extends AppLocalizations {
   String get word_separator => ', ';
 
   @override
-  String get image_download_error => 'Failed to download image';
+  String get image_download_error => 'Kunne ikke laste ned bildet';
 
   @override
   String get image_edit_url_error =>
-      'Failed to edit image because the image URL was not set.';
+      'Kunne ikke redigere bildet fordi bilde-URL-en ikke ble angitt.';
 
   @override
-  String get user_picture_source_remember => 'Remember my choice';
+  String get user_picture_source_remember => 'Husk valget mitt';
 
   @override
-  String get user_picture_source_ask => 'Ask each time';
+  String get user_picture_source_ask => 'Spør hver gang';
 
   @override
-  String get robotoff_continue => 'Continue';
+  String get robotoff_continue => 'Fortsette';
 
   @override
   String robotoff_next_n_questions(num count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count questions',
-      one: 'question',
+      other: '$count spørsmål',
+      one: 'spørsmål',
     );
-    return 'Next $_temp0';
+    return 'Neste $_temp0';
   }
 
   @override
-  String get show_password => 'Show Password';
+  String get show_password => 'Vis passord';
 
   @override
-  String get owner_field_info_title => 'Producer provided values';
+  String get owner_field_info_title => 'Produsentens oppgitte verdier';
 
   @override
   String get owner_field_info_message =>
-      'With that logo we highlight data provided by the producer, and that may not be editable.';
+      'Med den logoen fremhever vi data levert av produsenten, og som kanskje ikke kan redigeres.';
 
   @override
-  String get owner_field_info_close_button => 'Close this info';
+  String get owner_field_info_close_button => 'Lukk denne informasjonen';
 
   @override
   String get owner_field_image =>
-      'This image is provided by the producer. It may not be editable.';
+      'Dette bildet er levert av produsenten. Det kan hende det ikke kan redigeres.';
 
   @override
-  String get edit_packagings_title => 'Packaging components';
+  String get edit_packagings_title => 'Emballasjekomponenter';
 
   @override
-  String get edit_packagings_element_add => 'Add a packaging component';
+  String get edit_packagings_element_add => 'Legg til en emballasjekomponent';
 
   @override
-  String get edit_packagings_completed => 'The packaging is complete';
+  String get edit_packagings_completed => 'Emballasjen er komplett';
 
   @override
   String edit_packagings_element_title(int index) {
-    return 'Packaging component #$index';
+    return 'Emballasjekomponent #$index';
   }
 
   @override
-  String get edit_packagings_element_field_units => 'Number of units';
+  String get edit_packagings_element_field_units => 'Antall enheter';
 
   @override
   String get edit_packagings_element_hint_units =>
-      'Enter the number of packaging units of the same shape and material contained in the product.';
+      'Angi antall emballasjeenheter av samme form og materiale som produktet inneholder.';
 
   @override
-  String get edit_packagings_element_field_shape => 'Shape';
+  String get edit_packagings_element_field_shape => 'Form';
 
   @override
   String get edit_packagings_element_hint_shape =>
-      'Enter the shape name listed in the recycling instructions if they are available, or select a shape.';
+      'Skriv inn formnavnet som er oppført i resirkuleringsinstruksjonene hvis de er tilgjengelige, eller velg en form.';
 
   @override
-  String get edit_packagings_element_example_shape => 'Bottle';
+  String get edit_packagings_element_example_shape => 'Flaske';
 
   @override
-  String get edit_packagings_element_field_material => 'Material';
+  String get edit_packagings_element_field_material => 'Materiale';
 
   @override
   String get edit_packagings_element_hint_material =>
-      'Enter the specific material if it can be determined (a material code inside a triangle can often be found on packaging parts), or a generic material (for instance plastic or metal) if you are unsure.';
+      'Oppgi det spesifikke materialet hvis det kan bestemmes (en materialkode inni en trekant finnes ofte på emballasjedelene), eller et generisk materiale (for eksempel plast eller metall) hvis du er usikker.';
 
   @override
   String get edit_packagings_element_example_material => 'Glass';
 
   @override
-  String get edit_packagings_element_field_recycling => 'Recycling instruction';
+  String get edit_packagings_element_field_recycling =>
+      'Instruksjoner for resirkulering';
 
   @override
   String get edit_packagings_element_hint_recycling =>
-      'Enter recycling instructions only if they are listed on the product.';
+      'Skriv bare inn resirkuleringsinstruksjoner hvis de er oppført på produktet.';
 
   @override
-  String get edit_packagings_element_example_recycling => 'Recycle';
+  String get edit_packagings_element_example_recycling => 'Resirkulere';
 
   @override
   String get edit_packagings_element_field_quantity =>
-      'Net quantity of product per unit';
+      'Netto mengde produkt per enhet';
 
   @override
   String get edit_packagings_element_hint_quantity =>
-      'Enter the net weight or net volume and indicate the unit (for example g or ml).';
+      'Skriv inn nettovekten eller nettovolumet og angi enheten (for eksempel g eller ml).';
 
   @override
-  String get edit_packagings_element_field_weight =>
-      'Weight of one empty unit (g)';
+  String get edit_packagings_element_field_weight => 'Vekt av én tom enhet (g)';
 
   @override
   String get edit_packagings_element_hint_weight =>
-      'Remove any remaining food and wash and dry the packaging part before weighing. If possible, use a scale with 0.1g or 0.01g precision.';
+      'Fjern eventuelle matrester og vask og tørk emballasjen før veiing. Bruk om mulig en vekt med 0,1 g eller 0,01 g presisjon.';
 
   @override
-  String get background_task_title => 'Pending contributions';
+  String get background_task_title => 'Ventende bidrag';
 
   @override
   String get background_task_subtitle =>
-      'Your contributions are automatically saved to our server, but not always in real-time.';
+      'Bidragene dine lagres automatisk på serveren vår, men ikke alltid i sanntid.';
 
   @override
-  String get background_task_list_empty => 'No Pending Background Tasks';
+  String get background_task_list_empty => 'Ingen ventende bakgrunnsoppgaver';
 
   @override
-  String get background_task_error_server_time_out => 'Server timeout';
+  String get background_task_error_server_time_out => 'Servertidsavbrudd';
 
   @override
   String get background_task_error_no_internet =>
-      'Internet connection error. Try later.';
+      'Internett-tilkoblingsfeil. Prøv senere.';
 
   @override
-  String get background_task_operation_unknown => 'unknown operation type';
+  String get background_task_operation_unknown => 'ukjent operasjonstype';
 
   @override
-  String get background_task_operation_details => 'detailed changes';
+  String get background_task_operation_details => 'detaljerte endringer';
 
   @override
-  String get background_task_operation_image => 'photo upload';
+  String get background_task_operation_image => 'bildeopplasting';
 
   @override
   String get background_task_operation_refresh =>
-      'refresh delayed after photo upload';
+      'oppdatering forsinket etter bildeopplasting';
 
   @override
-  String get background_task_run_started => 'started';
+  String get background_task_run_started => 'startet';
 
   @override
-  String get background_task_run_not_started => 'not started yet';
+  String get background_task_run_not_started => 'ikke startet ennå';
 
   @override
-  String get background_task_run_to_be_deleted => 'to be deleted';
+  String get background_task_run_to_be_deleted => 'skal slettes';
 
   @override
   String get background_task_question_stop =>
-      'Do you want to stop that task ASAP?';
+      'Vil du stoppe den oppgaven så fort som mulig?';
 
   @override
-  String get feed_back => 'Feedback';
+  String get feed_back => 'Tilbakemelding';
 
   @override
-  String get undo => 'Undo';
+  String get undo => 'Angre';
 
   @override
-  String get copy_email_to_clip_board => 'Copy email to clipboard';
+  String get copy_email_to_clip_board => 'Kopier e-post til utklippstavlen';
 
   @override
-  String get please_send_us_an_email_to =>
-      'Please send us manually an email to';
+  String get please_send_us_an_email_to => 'Send oss en e-post manuelt til';
 
   @override
-  String get email_copied_to_clip_board => 'Email copied to clipboard!';
+  String get email_copied_to_clip_board => 'E-post kopiert til utklippstavlen!';
 
   @override
-  String get select_accent_color => 'Select Accent Color';
+  String get select_accent_color => 'Velg aksentfarge';
 
   @override
   String get theme_amoled => 'AMOLED';
 
   @override
-  String get color_blue => 'Blue';
+  String get color_blue => 'Blå';
 
   @override
   String get color_cyan => 'Cyan';
 
   @override
-  String get color_green => 'Green';
+  String get color_green => 'Grønn';
 
   @override
-  String get color_light_brown => 'Default';
+  String get color_light_brown => 'Misligholde';
 
   @override
   String get color_magenta => 'Magenta';
 
   @override
-  String get color_orange => 'Orange';
+  String get color_orange => 'Oransje';
 
   @override
-  String get color_pink => 'Pink';
+  String get color_pink => 'Rosa';
 
   @override
-  String get color_red => 'Red';
+  String get color_red => 'Rød';
 
   @override
   String get color_rust => 'Rust';
 
   @override
-  String get color_teal => 'Teal';
+  String get color_teal => 'Blågrønn';
 
   @override
-  String get text_contrast_mode => 'Text Contrast';
+  String get text_contrast_mode => 'Tekstkontrast';
 
   @override
-  String get contrast_high => 'High';
+  String get contrast_high => 'Høy';
 
   @override
   String get contrast_medium => 'Medium';
 
   @override
-  String get contrast_low => 'Low';
+  String get contrast_low => 'Lav';
 
   @override
-  String get product_refresher_internet_not_found => 'Product not found!';
+  String get product_refresher_internet_not_found =>
+      'Produktet ble ikke funnet!';
 
   @override
   String get product_refresher_internet_not_connected =>
-      'You are not connected to internet!';
+      'Du er ikke koblet til internett!';
 
   @override
   String product_refresher_internet_no_ping(String? host) {
-    return 'Server down ($host)';
+    return 'Server nede ($host)';
   }
 
   @override
   String product_refresher_internet_error(String? exception) {
-    return 'Server error ($exception)';
+    return 'Serverfeil ($exception)';
   }
 
   @override
-  String get product_loader_not_found_title => 'Product not found!';
+  String get product_loader_not_found_title => 'Produktet ble ikke funnet!';
 
   @override
   String product_loader_not_found_message(String barcode) {
-    return 'A product with the following barcode doesn\'t exist in our database: $barcode';
+    return 'Et produkt med følgende strekkode finnes ikke i databasen vår: $barcode';
   }
 
   @override
-  String get product_loader_network_error_title => 'No internet connection!';
+  String get product_loader_network_error_title =>
+      'Ingen internettforbindelse!';
 
   @override
   String get product_loader_network_error_message =>
-      'Please check that your smartphone is on a WiFi network or has mobile data enabled';
+      'Sjekk at smarttelefonen din er på et WiFi-nettverk eller at mobildata er aktivert';
 
   @override
-  String get page_not_found_title => 'Page not found!';
+  String get page_not_found_title => 'Siden ble ikke funnet!';
 
   @override
-  String get page_not_found_button => 'Go back to the homepage';
+  String get page_not_found_button => 'Gå tilbake til hjemmesiden';
 
   @override
-  String get download_data => 'Download data';
+  String get download_data => 'Last ned data';
 
   @override
   String get download_top_products =>
-      'Download the top 1000 products in your country for instant scanning';
+      'Last ned de 1000 beste produktene i landet ditt for umiddelbar skanning';
 
   @override
   String download_top_n_products(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count products',
+      other: '$count produktene',
     );
-    return 'Download the top $_temp0 in your country for instant scanning';
+    return 'Last ned de beste $_temp0 i ditt land for umiddelbar skanning';
   }
 
   @override
-  String get download_in_progress => 'Downloading data\nThis may take a while';
+  String get download_in_progress => 'Laster ned data\nDette kan ta en stund';
 
   @override
   String downloaded_products(int num) {
-    return '$num products added';
+    return '$num produkter lagt til';
   }
 
   @override
-  String get update_offline_data => 'Update offline product data';
+  String get update_offline_data => 'Oppdater produktdata frakoblet';
 
   @override
   String get update_local_database_sub =>
-      'Update the local product database with the latest data from Open Food Facts';
+      'Oppdater den lokale produktdatabasen med de nyeste dataene fra Open Food Facts';
 
   @override
-  String get clear_local_database => 'Clear offline product data';
+  String get clear_local_database => 'Fjern produktdata frakoblet';
 
   @override
   String get clear_local_database_sub =>
-      'Clear all local product data from your app to free up space';
+      'Fjern all lokal produktdata fra appen din for å frigjøre plass';
 
   @override
   String deleted_products(int num) {
-    return '$num products deleted';
+    return '$num produkter slettet';
   }
 
   @override
   String get loading => 'Laster inn…';
 
   @override
-  String get know_more => 'Know More';
+  String get know_more => 'Lær mer';
 
   @override
-  String get offline_data_desc => 'Click to know more about offline data';
+  String get offline_data_desc => 'Klikk for å finne ut mer om frakoblet data';
 
   @override
-  String get offline_product_data_title => 'Offline product data';
+  String get offline_product_data_title => 'Produktdata frakoblet';
 
   @override
   String available_for_download(int num) {
-    return '$num products available for immediate scaning';
+    return '$num produkter tilgjengelig for umiddelbar skanning';
   }
 
   @override
-  String get country_selector_title => 'Select your country:';
+  String get country_selector_title => 'Velg ditt land:';
 
   @override
   String get currency_selector_title => 'Velg valuta:';
 
   @override
-  String get language_selector_title => 'Select your language:';
+  String get language_selector_title => 'Velg språk:';
 
   @override
-  String get language_selector_section_selected => 'Selected languages';
+  String get language_selector_section_selected => 'Valgte språk';
 
   @override
-  String get language_selector_section_frequently_used => 'Frequently used';
+  String get language_selector_section_frequently_used => 'Ofte brukt';
 
   @override
   String get action_delete_list => 'Slett';
 
   @override
-  String get action_change_list => 'Change the current list';
+  String get action_change_list => 'Endre gjeldende liste';
 
   @override
-  String get product_list_create => 'Create';
+  String get product_list_create => 'Skape';
 
   @override
-  String get product_list_create_tooltip => 'Create a new list';
+  String get product_list_create_tooltip => 'Opprett en ny liste';
 
   @override
   String get nutriscore_generic => 'Nutri-Score';
 
   @override
-  String get nutriscore_a => 'Nutri-Score A';
+  String get nutriscore_a => 'Næringsscore A';
 
   @override
-  String get nutriscore_b => 'Nutri-Score B';
+  String get nutriscore_b => 'Næringsscore B';
 
   @override
-  String get nutriscore_c => 'Nutri-Score C';
+  String get nutriscore_c => 'Næringsscore C';
 
   @override
-  String get nutriscore_d => 'Nutri-Score D';
+  String get nutriscore_d => 'Næringsscore D';
 
   @override
-  String get nutriscore_e => 'Nutri-Score E';
+  String get nutriscore_e => 'Næringsscore E';
 
   @override
   String nutriscore_new_formula(String letter) {
-    return 'Nutri-Score $letter (New calculation)';
+    return 'Nutri-Score $letter (Ny beregning)';
   }
 
   @override
-  String get nutriscore_new_formula_title => 'Nutri-Score (New calculation)';
+  String get nutriscore_new_formula_title => 'Nutri-Score (Ny beregning)';
 
   @override
-  String get nutriscore_unknown => 'Unknown Nutri-Score';
+  String get nutriscore_unknown => 'Ukjent ernæringspoengsum';
 
   @override
   String get nutriscore_unknown_new_formula =>
-      'Unknown Nutri-Score (New calculation)';
+      'Ukjent ernæringspoengsum (ny beregning)';
 
   @override
-  String get nutriscore_not_applicable => 'Nutri-Score is not applicable';
+  String get nutriscore_not_applicable => 'Nutri-Score er ikke aktuelt';
 
   @override
   String get nutriscore_not_applicable_new_formula =>
-      'Nutri-Score is not applicable (New calculation)';
+      'Nutri-Score er ikke aktuelt (ny beregning)';
 
   @override
   String get environmental_score_generic_new => 'Green-Score';
@@ -4089,93 +4128,93 @@ class AppLocalizationsNo extends AppLocalizations {
   String get nova_group_generic_new => 'Ultrabearbeidet mat - NOVA-grupper';
 
   @override
-  String get nova_group_1 => 'NOVA Group 1';
+  String get nova_group_1 => 'NOVA Gruppe 1';
 
   @override
-  String get nova_group_2 => 'NOVA Group 2';
+  String get nova_group_2 => 'NOVA Gruppe 2';
 
   @override
-  String get nova_group_3 => 'NOVA Group 3';
+  String get nova_group_3 => 'NOVA Gruppe 3';
 
   @override
-  String get nova_group_4 => 'NOVA Group 4';
+  String get nova_group_4 => 'NOVA Gruppe 4';
 
   @override
-  String get nova_group_unknown => 'Unknown NOVA Group';
+  String get nova_group_unknown => 'Ukjent NOVA-gruppe';
 
   @override
-  String get nutrition_facts => 'Nutrient Levels';
+  String get nutrition_facts => 'Næringsnivåer';
 
   @override
-  String get faq_title_partners => 'Partners & Patrons of the NGO';
+  String get faq_title_partners => 'Partnere og beskyttere av NGO-en';
 
   @override
   String get faq_title_vision =>
-      'The Open Food Facts Vision, Mission, Values and Programs';
+      'Open Food Facts visjon, oppdrag, verdier og programmer';
 
   @override
   String get faq_title_install_beauty =>
-      'Install Open Beauty Facts to create a cosmetic database';
+      'Installer Open Beauty Facts for å opprette en kosmetisk database';
 
   @override
   String get faq_title_install_pet =>
-      'Install Open Pet Food Facts to create a pet food database';
+      'Installer Open Pet Food Facts for å opprette en database med kjæledyrfôr';
 
   @override
   String get faq_title_install_product =>
-      'Install Open Products Facts to create a products database to extend the life of objects';
+      'Installer Open Products Facts for å opprette en produktdatabase for å forlenge levetiden til objekter.';
 
   @override
   String get faq_nutriscore_nutriscore =>
-      'New calculation of the Nutri-Score: what\'s new?';
+      'Ny beregning av Nutri-Score: hva er nytt?';
 
   @override
   String get contact_title_pro_page =>
-      'Pro? Import your products in Open Food Facts';
+      'Pro? Importer produktene dine i Open Food Facts';
 
   @override
-  String get contact_title_pro_email => 'Producer Contact';
+  String get contact_title_pro_email => 'Produsentkontakt';
 
   @override
-  String get contact_title_press_page => 'Press Page';
+  String get contact_title_press_page => 'Presseside';
 
   @override
-  String get contact_title_press_email => 'Press Contact';
+  String get contact_title_press_email => 'Pressekontakt';
 
   @override
   String get contact_title_newsletter => 'Subscribe to our newsletter';
 
   @override
-  String get contact_title_calendar => 'Subscribe to our community calendar';
+  String get contact_title_calendar => 'Abonner på vår fellesskapskalender';
 
   @override
-  String get hunger_games_loading_line1 => 'Please give us a few seconds…';
+  String get hunger_games_loading_line1 => 'Vennligst gi oss noen sekunder…';
 
   @override
-  String get hunger_games_loading_line2 => 'We\'re downloading the questions!';
+  String get hunger_games_loading_line2 => 'Vi laster ned spørsmålene!';
 
   @override
   String get hunger_games_error_label =>
-      'Argh! Something went wrong… and we couldn\'t load the questions.';
+      'Æsj! Noe gikk galt… , og vi kunne ikke laste inn spørsmålene.';
 
   @override
-  String get hunger_games_error_retry_button => 'Let\'s retry!';
+  String get hunger_games_error_retry_button => 'La oss prøve på nytt!';
 
   @override
-  String get reorder_attribute_action => 'Reorder the attributes';
+  String get reorder_attribute_action => 'Endre rekkefølgen på attributtene';
 
   @override
   String get link_cant_be_opened =>
-      'This link can\'t be opened on your device. Please check that you have a browser installed.';
+      'Denne lenken kan ikke åpnes på enheten din. Sjekk at du har en nettleser installert.';
 
   @override
   String knowledge_panel_page_title_no_title(String productName) {
-    return 'Details for $productName';
+    return 'Detaljer for $productName';
   }
 
   @override
   String knowledge_panel_page_title(String pageName, String productName) {
-    return 'Details for $pageName with $productName';
+    return 'Detaljer for $pageName med $productName';
   }
 
   @override
@@ -4264,15 +4303,15 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get guide_nutriscore_v2_where_title =>
-      'Where to find the new Nutri-Score calculation?';
+      'Hvor finner jeg den nye Nutri-Score-beregningen?';
 
   @override
   String get guide_nutriscore_v2_where_paragraph1 =>
-      'The Nutri-Score is applied in 7 countries: France, Germany, Belgium, Spain, Luxembourg, the Netherlands and Switzerland.';
+      'Nutri-Score brukes i 7 land: Frankrike, Tyskland, Belgia, Spania, Luxembourg, Nederland og Sveits.';
 
   @override
   String get guide_nutriscore_v2_where_paragraph2 =>
-      'Manufacturers have at most **2 years** at the latest after the signature of the decree **to replace** the old calculation with the new one.';
+      'Produsentene har maksimalt **2 år** etter at dekretet er undertegnet **til å erstatte** den gamle beregningen med den nye.';
 
   @override
   String get guide_nutriscore_v2_where_paragraph3 =>
@@ -4380,7 +4419,7 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get guide_greenscore_bonuses_penalties_intro =>
-      'To reward better products within a category, we then apply **bonuses & penalties based on several criterion**:';
+      'For å belønne bedre produkter innenfor en kategori, bruker vi deretter **bonuser og straffer basert på flere kriterier**:';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg1_title =>
@@ -4388,7 +4427,7 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get guide_greenscore_bonuses_penalties_arg1_text =>
-      'A **bonus** is awarded to products that have an **official label, a label or a certification that guarantees environmental benefits** (organic, fair trade, HVE, Label Rouge, Bleu Blanc Cœur, MSC/ASC).';
+      'En **bonus** gis til produkter som har en **offisiell etikett, en etikett eller en sertifisering som garanterer miljøfordeler** (økologisk, rettferdig handel, HVE, Label Rouge, Bleu Blanc Cœur, MSC/ASC).';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg2_title =>
@@ -4396,7 +4435,7 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get guide_greenscore_bonuses_penalties_arg2_text =>
-      'A **bonus** is awarded based on the origin of the ingredients. This bonus takes into account the **impact on transportation** and also the **environmental policy** of each producer\'s country.';
+      'En **bonus** tildeles basert på ingrediensenes opprinnelse. Denne bonusen tar hensyn til **påvirkningen på transport** og også **miljøpolitikken** i hver produsents land.';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg3_title =>
@@ -4404,14 +4443,14 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get guide_greenscore_bonuses_penalties_arg3_text =>
-      'A **penalty** is given to products that contain ingredients that have significant **negative impacts on biodiversity and ecosystems**, such as palm oil, the production of which is responsible for massive deforestation.';
+      'Det gis en **straff** til produkter som inneholder ingredienser som har betydelig **negativ innvirkning på biologisk mangfold og økosystemer**, som for eksempel palmeolje, hvis produksjon er ansvarlig for massiv avskoging.';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg4_title => 'Emballasje';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg4_text =>
-      'A **penalty** is calculated to take into account the **circularity of packaging** (use of recycled raw material and recyclability) and overpacking.';
+      'En **straff** beregnes for å ta hensyn til **emballasjens sirkularitet** (bruk av resirkulert råmateriale og resirkulerbarhet) og overpakking.';
 
   @override
   String get guide_greenscore_transparency_title =>
@@ -4419,19 +4458,19 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get guide_greenscore_transparency_intro1 =>
-      'To accurately calculate the Green-Score, it is necessary to have **information which is not necessarily specified on the packaging** (such as the origin and the exact percentage of each ingredient) or which is rarely available in usable form (such as a list of all the components of the packaging with the precise types of plastics used).';
+      'For å beregne Green-Score nøyaktig er det nødvendig med **informasjon som ikke nødvendigvis er spesifisert på emballasjen** (som opprinnelse og den nøyaktige prosentandelen av hver ingrediens) eller som sjelden er tilgjengelig i brukbar form (som en liste over alle komponentene i emballasjen med de nøyaktige plasttypene som brukes).';
 
   @override
   String get guide_greenscore_transparency_intro2 =>
-      '**Average values are used when this information is not yet available**, but we are now calling on everyone to help us collect this information which will be very useful for the Green-Score but also for many other uses.';
+      '**Gjennomsnittsverdier brukes når denne informasjonen ikke er tilgjengelig ennå**, men vi ber nå alle om å hjelpe oss med å samle inn denne informasjonen, som vil være svært nyttig for Green-Score, men også for mange andre bruksområder.';
 
   @override
   String get guide_greenscore_transparency_arg1_title =>
-      'How citizens can help?';
+      'Hvordan kan innbyggere hjelpe?';
 
   @override
   String get guide_greenscore_transparency_arg1_text =>
-      'All citizens can help us gather and structure the information that is present on products or that can be deduced from them, such as information on **packaging**: \"Mission Emballages\": a large-scale collaborative inventory of packaging for all food products (in French).';
+      'Alle borgere kan hjelpe oss med å samle og strukturere informasjonen som finnes på produkter eller som kan utledes fra dem, for eksempel informasjon om **emballasje**: «Mission Emballages»: en storstilt samarbeidende inventarisering av emballasje for alle matvarer (på fransk).';
 
   @override
   String get guide_greenscore_transparency_arg2_title =>
@@ -4505,7 +4544,7 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get guide_nova_groups_arg1_text =>
-      'Unprocessed (or natural) foods are the **edible parts of plants** (seeds, fruits, leaves, stems, roots) **or animals** (muscle, offal, eggs, milk), as well as fungi, algae, and water, after being separated from nature.';
+      'Ubearbeidet (eller naturlig) mat er de **spiselige delene av planter** (frø, frukt, blader, stilker, røtter) **eller dyr** (muskler, innmat, egg, melk), samt sopp, alger og vann, etter å ha blitt separert fra naturen.';
 
   @override
   String get guide_nova_groups_arg2_title => 'Processed culinary ingredients';
@@ -4538,7 +4577,7 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg1_text =>
-      'Many are **derived from further processing of food constituents**, such as hydrogenated or interesterified oils, hydrolyzed proteins, soy protein isolate, maltodextrin, invert sugar, and high-fructose corn syrup.';
+      'Mange er **utvunnet fra videre bearbeiding av matbestanddeler**, som hydrogenerte eller interesterifiserte oljer, hydrolyserte proteiner, soyaproteinisolat, maltodekstrin, invertsukker og maissirup med høyt fruktoseinnhold.';
 
   @override
   String get guide_nova_explanations_arg2_title =>
@@ -4546,7 +4585,7 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg2_text =>
-      'Additives in ultra-processed foods include some that are also used in processed foods, such as preservatives, antioxidants, and stabilizers. Classes of additives found only in ultra-processed products include those used **to imitate or enhance the sensory qualities of foods or to disguise unpalatable aspects of the final product**. These additives include dyes and other colors, color stabilizers; flavors, flavor enhancers, non-sugar sweeteners; and processing aids such as carbonating, firming, bulking and anti-bulking agents, de-foaming, anti-caking and glazing agents, emulsifiers, sequestrants, and humectants.';
+      'Tilsetningsstoffer i ultrabearbeidet mat inkluderer noen som også brukes i bearbeidet mat, for eksempel konserveringsmidler, antioksidanter og stabilisatorer. Klasser av tilsetningsstoffer som bare finnes i ultrabearbeidede produkter inkluderer de som brukes **for å imitere eller forbedre de sensoriske egenskapene til matvarer eller for å skjule usmakelige aspekter ved sluttproduktet**. Disse tilsetningsstoffene inkluderer fargestoffer og andre farger, fargestabilisatorer; smakstilsetninger, smaksforsterkere, ikke-sukkerholdige søtningsmidler; og prosesseringshjelpemidler som kullsyre-, fasthets-, fyllings- og antifylningsmidler, skumdempende, antiklumpe- og glaseringsmidler, emulgatorer, sekvestreringsmidler og fuktighetsbevarende midler.';
 
   @override
   String get guide_nova_explanations_arg3_title =>
@@ -4554,7 +4593,7 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg3_text =>
-      '**A multitude of sequences of processes is used** to combine the usually many ingredients and to create the final product (hence \'ultra-processed\'). The processes include several **with no domestic equivalents**, such as hydrogenation and hydrolysation, extrusion and moulding, and pre-processing for frying.';
+      '**En rekke prosesssekvenser brukes** for å kombinere de vanligvis mange ingrediensene og for å lage sluttproduktet (derav «ultraprosessert»). Prosessene inkluderer flere **uten innenlandske ekvivalenter**, som hydrogenering og hydrolysering, ekstrudering og støping, og forbehandling for steking.';
 
   @override
   String get guide_nova_explanations_arg4_title =>
@@ -4562,104 +4601,105 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg4_text =>
-      '**The overall purpose of ultra-processing is to create branded**, **convenient** (durable, ready to consume), **attractive** (hyper-palatable) and **highly profitable** (low-cost ingredients) food products designed to displace all other food groups. Ultra-processed food products are usually packaged attractively and marketed intensively.';
+      '**Det overordnede formålet med ultraprosessering er å skape merkevareprodukter som er **praktiske** (holdbare, klare til konsum), **attraktive** (hypervelsmakende) og **svært lønnsomme** (lavkostingredienser) og er utformet for å fortrenge alle andre matvaregrupper. Ultraprosesserte matvarer pakkes vanligvis attraktivt og markedsføres intensivt.**';
 
   @override
-  String get guide_nova_explanations_arg5_title => 'A health hazard';
+  String get guide_nova_explanations_arg5_title => 'En helsefare';
 
   @override
   String get guide_nova_explanations_arg5_text =>
-      'Since 2018, with NutriNet-Santé, the first links between **the consumption of ultra-processed foods and increased risks of cancer, cardiovascular diseases, and diabetes have been highlighted**. Today, more than 90 studies worldwide confirm these findings.\nThe strongest associations relate to **obesity, cardiovascular mortality, and depressive symptoms**. On children, the effects are primarily observed on weight and lipid imbalances.';
+      'Siden 2018 har de første koblingene mellom **forbruk av ultraprosessert mat og økt risiko for kreft, hjerte- og karsykdommer og diabetes blitt fremhevet** med NutriNet-Santé. I dag bekrefter mer enn 90 studier over hele verden disse funnene.\nDe sterkeste assosiasjonene er knyttet til **fedme, hjerte- og kardødelighet og depressive symptomer**. Hos barn observeres effektene primært på vekt og lipidubalanser.';
 
   @override
   String get guide_nova_explanations_arg6_title =>
-      'Countries recommend limiting them';
+      'Land anbefaler å begrense dem';
 
   @override
   String get guide_nova_explanations_arg6_text =>
-      'Some countries use the NOVA groups for their dietary guidelines or goals, for instance:\n\n- **🇧🇷 Brazil**\'s dietary guidelines **recommend to limit consumption** of processed food and avoid ultra-processed food.\n\n- **🇫🇷 France**\'s public health nutritional policy goals for 2018-2022 aims to **reduce consumption of group 4 ultra-processed foods by 20%**.';
+      'Noen land bruker NOVA-gruppene for sine kostholdsretningslinjer eller -mål, for eksempel:\n\n- **🇧🇷 Brasils** kostholdsretningslinjer **anbefaler å begrense forbruket** av bearbeidet mat og unngå ultrabearbeidet mat.\n\n- **🇫🇷 Frankrikes** ernæringspolitiske mål for folkehelse for 2018–2022 har som mål å **redusere forbruket av ultrabearbeidet mat i gruppe 4 med 20 %**.';
 
   @override
   String get guide_nova_share_link => 'https://world-no.openfoodfacts.org/nova';
 
   @override
-  String get guide_open_food_facts_title => 'Welcome to Open Food Facts!';
+  String get guide_open_food_facts_title => 'Velkommen til Åpne matfakta!';
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_title =>
-      'What is Open Food Facts?';
+      'Hva er åpne matfakta?';
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_paragraph1 =>
-      'Open Food Facts is a **collaborative**, **free**, and **open** database of food products from around the world.';
+      'Open Food Facts er en **samarbeidsbasert**, **gratis** og **åpen** database med matvarer fra hele verden.';
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_paragraph2 =>
-      'We believe that everyone should have access to information about what they eat. By collecting data on ingredients, allergens, nutrition facts, and more, **we empower consumers to make informed choices** and drive the food industry **toward greater transparency**.';
+      'Vi mener at alle bør ha tilgang til informasjon om hva de spiser. Ved å samle inn data om ingredienser, allergener, næringsinnhold og mer, **gir vi forbrukerne mulighet til å ta informerte valg** og driver matindustrien **mot større åpenhet**.';
 
   @override
   String get guide_open_food_facts_features_title =>
-      'Features of Open Food Facts';
+      'Funksjoner ved åpne matfakta';
 
   @override
   String get guide_open_food_facts_features_arg1_title =>
-      'Get alerts for your unwanted ingredients';
+      'Få varsler om uønskede ingredienser';
 
   @override
-  String get guide_open_food_facts_tips_title => 'Tips for taking great photos';
+  String get guide_open_food_facts_tips_title => 'Tips for å ta flotte bilder';
 
   @override
-  String get guide_open_food_facts_tips_arg1_title => 'Don’ts';
+  String get guide_open_food_facts_tips_arg1_title => 'Ikke gjør';
 
   @override
   String get guide_open_food_facts_tips_arg1_text1 =>
-      'Avoid shadows and glare.';
+      'Unngå skygger og gjenskinn.';
 
   @override
   String get guide_open_food_facts_tips_arg1_text2 =>
-      'No blurry or out-of-focus text.';
+      'Ingen uskarp eller uskarp tekst.';
 
   @override
   String get guide_open_food_facts_tips_arg1_text3 =>
-      'Don\'t crop out parts of the text.';
+      'Ikke beskjær ut deler av teksten.';
 
   @override
-  String get guide_open_food_facts_tips_arg1_text4 => 'Avoid busy backgrounds.';
+  String get guide_open_food_facts_tips_arg1_text4 =>
+      'Unngå travle bakgrunner.';
 
   @override
-  String get guide_open_food_facts_tips_arg2_title => 'Do’s';
+  String get guide_open_food_facts_tips_arg2_title => 'Gjør-det-selv';
 
   @override
   String get guide_open_food_facts_tips_arg2_text1 =>
-      'Use good, even lighting.';
+      'Bruk god, jevn belysning.';
 
   @override
   String get guide_open_food_facts_tips_arg2_text2 =>
-      'Ensure text is sharp and readable.';
+      'Sørg for at teksten er skarp og lesbar.';
 
   @override
   String get guide_open_food_facts_tips_arg2_text3 =>
-      'Capture the entire ingredients list.';
+      'Ta opp hele ingredienslisten.';
 
   @override
   String get guide_open_food_facts_tips_arg2_text4 =>
-      'Keep the product on a flat surface.';
+      'Oppbevar produktet på en flat overflate.';
 
   @override
   String get guide_open_food_facts_scores_title =>
-      'Help us build the \"Wikipedia of Food\"';
+      'Hjelp oss å bygge «Matens Wikipedia»';
 
   @override
   String get guide_open_food_facts_scores_arg1_title =>
-      'A score on the nutritional quality';
+      'En poengsum på næringskvaliteten';
 
   @override
   String get guide_open_food_facts_scores_arg2_title =>
-      'A score to avoid ultra-processed foods';
+      'En poengsum for å unngå ultraprosessert mat';
 
   @override
   String get guide_open_food_facts_scores_arg3_title =>
-      'A score for the planet';
+      'En poengsum for planeten';
 
   @override
   String get guide_open_food_facts_share_link =>
@@ -4667,236 +4707,240 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get guide_open_pet_food_facts_title =>
-      'Welcome to Open Pet Food Facts!';
+      'Velkommen til Åpne fakta om kjæledyrmat!';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_title =>
-      'What is Open Pet Food Facts?';
+      'Hva er åpne fakta om kjæledyrfôr?';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_paragraph1 =>
-      'Open Pet Food Facts extends our mission to our furry friends! It\'s a **database of pet food products for cats, dogs, and other companions**.';
+      'Open Pet Food Facts utvider vårt oppdrag til våre pelskledde venner! Det er en **database med kjæledyrfôrprodukter for katter, hunder og andre følgesvenner**.';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_paragraph2 =>
-      'We gather information on **ingredients**, **nutritional analysis**, and feeding guidelines to help pet owners choose the best food for their animals\' needs.';
+      'Vi samler informasjon om **ingredienser**, **ernæringsanalyse** og fôringsretningslinjer for å hjelpe dyreeiere med å velge det beste fôret for dyrenes behov.';
 
   @override
   String get guide_open_pet_food_facts_features_title =>
-      'Features of Open Pet Food Facts';
+      'Funksjoner ved åpne kjæledyrfôrfakta';
 
   @override
   String get guide_open_pet_food_facts_features_arg1_title =>
-      'Get alerts for your unwanted ingredients';
+      'Få varsler om uønskede ingredienser';
 
   @override
   String get guide_open_pet_food_facts_features_arg1_paragraph1 =>
-      'Is your pet allergic to any ingredients? You can set a list of cosmetic ingredients to avoid, right in the app!';
+      'Er kjæledyret ditt allergisk mot noen ingredienser? Du kan sette opp en liste over kosmetiske ingredienser du bør unngå, rett i appen!';
 
   @override
   String get guide_open_pet_food_facts_tips_title =>
-      'Tips for taking great photos';
+      'Tips for å ta flotte bilder';
 
   @override
-  String get guide_open_pet_food_facts_tips_arg1_title => 'Don’ts';
+  String get guide_open_pet_food_facts_tips_arg1_title => 'Ikke gjør';
 
   @override
   String get guide_open_pet_food_facts_tips_arg1_text1 =>
-      'Avoid shadows and glare.';
+      'Unngå skygger og gjenskinn.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg1_text2 =>
-      'No blurry or out-of-focus text.';
+      'Ingen uskarp eller uskarp tekst.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg1_text3 =>
-      'Don\'t crop out parts of the text.';
+      'Ikke beskjær ut deler av teksten.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg1_text4 =>
-      'Avoid busy backgrounds.';
+      'Unngå travle bakgrunner.';
 
   @override
-  String get guide_open_pet_food_facts_tips_arg2_title => 'Do’s';
+  String get guide_open_pet_food_facts_tips_arg2_title => 'Gjør-det-selv';
 
   @override
   String get guide_open_pet_food_facts_tips_arg2_text1 =>
-      'Use good, even lighting.';
+      'Bruk god, jevn belysning.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg2_text2 =>
-      'Ensure text is sharp and readable.';
+      'Sørg for at teksten er skarp og lesbar.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg2_text3 =>
-      'Capture the entire ingredients list.';
+      'Ta opp hele ingredienslisten.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg2_text4 =>
-      'Keep the product on a flat surface.';
+      'Oppbevar produktet på en flat overflate.';
 
   @override
-  String get guide_open_pet_food_facts_scores_title => 'A note on scoring';
+  String get guide_open_pet_food_facts_scores_title =>
+      'En merknad om poengberegning';
 
   @override
   String get guide_open_pet_food_facts_scores_paragraph1 =>
-      'Developing a scoring system for pet food **is not a priority right now**. The methodology would be complex, as nutritional needs vary greatly by species, age, and health condition. We haven’t found any independant scientific team yet, able to develop such a score.';
+      'Å utvikle et poengsystem for kjæledyrfôr **er ikke en prioritet akkurat nå**. Metodikken ville være kompleks, ettersom ernæringsbehovene varierer sterkt etter art, alder og helsetilstand. Vi har ennå ikke funnet noe uavhengig vitenskapelig team som er i stand til å utvikle en slik poengsum.';
 
   @override
   String get guide_open_pet_food_facts_share_link =>
       'https://world-no.openpetfoodfacts.org/discover';
 
   @override
-  String get guide_open_beauty_facts_title => 'Welcome to Open Beauty Facts!';
+  String get guide_open_beauty_facts_title =>
+      'Velkommen til Åpne skjønnhetsfakta!';
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_title =>
-      'What is Open Beauty Facts?';
+      'Hva er åpne skjønnhetsfakta?';
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_paragraph1 =>
-      'Open Beauty Facts is a collaborative database of **cosmetic products**.';
+      'Open Beauty Facts er en samarbeidende database med **kosmetikkprodukter**.';
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_paragraph2 =>
-      'Our goal is to decipher ingredient lists to help you **understand what\'s in your personal care items**. From moisturizers to makeup, we collect data on ingredients, allergens, and packaging to promote transparency in the cosmetics industry.';
+      'Målet vårt er å tyde ingredienslister for å hjelpe deg med å **forstå hva som finnes i dine personlige pleieprodukter**. Fra fuktighetskremer til sminke samler vi inn data om ingredienser, allergener og emballasje for å fremme åpenhet i kosmetikkindustrien.';
 
   @override
   String get guide_open_beauty_facts_features_title =>
-      'Features of Open Beauty Facts';
+      'Funksjoner ved åpne skjønnhetsfakta';
 
   @override
   String get guide_open_beauty_facts_features_arg1_title =>
-      'Get alerts for your unwanted ingredients';
+      'Få varsler om uønskede ingredienser';
 
   @override
   String get guide_open_beauty_facts_features_arg1_paragraph1 =>
-      'Are you allergic to any ingredients? Want to avoid comedogen substances? Want to steer away from controversial components ? You can set a list of cosmetic ingredients to avoid, right in the app!';
+      'Er du allergisk mot noen ingredienser? Vil du unngå komedogene stoffer? Vil du unngå kontroversielle komponenter? Du kan angi en liste over kosmetiske ingredienser du vil unngå, rett i appen!';
 
   @override
   String get guide_open_beauty_facts_tips_title =>
-      'Tips for taking great photos';
+      'Tips for å ta flotte bilder';
 
   @override
-  String get guide_open_beauty_facts_tips_arg1_title => 'Don’ts';
+  String get guide_open_beauty_facts_tips_arg1_title => 'Ikke gjør';
 
   @override
   String get guide_open_beauty_facts_tips_arg1_text1 =>
-      'Avoid shadows and glare.';
+      'Unngå skygger og gjenskinn.';
 
   @override
   String get guide_open_beauty_facts_tips_arg1_text2 =>
-      'No blurry or out-of-focus text.';
+      'Ingen uskarp eller uskarp tekst.';
 
   @override
   String get guide_open_beauty_facts_tips_arg1_text3 =>
-      'Don\'t crop out parts of the text.';
+      'Ikke beskjær ut deler av teksten.';
 
   @override
   String get guide_open_beauty_facts_tips_arg1_text4 =>
-      'Avoid busy backgrounds.';
+      'Unngå travle bakgrunner.';
 
   @override
-  String get guide_open_beauty_facts_tips_arg2_title => 'Do’s';
+  String get guide_open_beauty_facts_tips_arg2_title => 'Gjør-det-selv';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text1 =>
-      'Use good, even lighting.';
+      'Bruk god, jevn belysning.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text2 =>
-      'Ensure text is sharp and readable.';
+      'Sørg for at teksten er skarp og lesbar.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text3 =>
-      'Capture the entire ingredients list.';
+      'Ta opp hele ingredienslisten.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text4 =>
-      'Take as many picture as need if the bottle is curved.';
+      'Ta så mange bilder som nødvendig hvis flasken er buet.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text5 =>
-      'You might need to peel the label to see the list of ingredients.';
+      'Du må kanskje rive av etiketten for å se ingredienslisten.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text6 =>
-      'Keep the product on a flat surface.';
+      'Oppbevar produktet på en flat overflate.';
 
   @override
-  String get guide_open_beauty_facts_scores_title => 'A note on scoring';
+  String get guide_open_beauty_facts_scores_title =>
+      'En merknad om poengberegning';
 
   @override
   String get guide_open_beauty_facts_scores_paragraph1 =>
-      'Unlike food products, the world of cosmetics **does not have a universally recognized, government-backed scoring system like the Nutri-Score**. Ingredient effects can be highly personal and depend on skin type, allergies, and individual concerns.';
+      'I motsetning til matvarer har ikke kosmetikkverdenen et universelt anerkjent, myndighetsstøttet poengsystem som Nutri-Score. Ingrediensenes effekt kan være svært personlig og avhenge av hudtype, allergier og individuelle bekymringer.';
 
   @override
   String get guide_open_beauty_facts_share_link =>
       'https://world-no.openbeautyfacts.org/discover';
 
   @override
-  String get guide_open_prices_title => 'Welcome to Open Prices!';
+  String get guide_open_prices_title => 'Velkommen til Åpne priser!';
 
   @override
   String get guide_open_prices_what_is_open_prices_title =>
-      'What is Open Prices?';
+      'Hva er åpningspriser?';
 
   @override
   String get guide_open_prices_what_is_open_prices_paragraph1 =>
-      'Open Prices is a project to **collect and share prices of products around the world**. It\'s a publicly available dataset that can be used for research, analysis, and more. Open Prices is developed and maintained by Open Food Facts.';
+      'Open Prices er et prosjekt for å **samle inn og dele priser på produkter over hele verden**. Det er et offentlig tilgjengelig datasett som kan brukes til forskning, analyse og mer. Open Prices er utviklet og vedlikeholdt av Open Food Facts.';
 
   @override
   String get guide_open_prices_what_is_open_prices_paragraph2 =>
       'There are currently few companies that own large databases of product prices at the barcode level. These prices are not freely available, but sold at a high price to private actors, researchers and other organizations that can afford them.';
 
   @override
-  String get guide_open_prices_how_title => 'How does Open Prices work?';
+  String get guide_open_prices_how_title => 'Hvordan fungerer åpne priser?';
 
   @override
   String get guide_open_prices_how_paragraph1 =>
-      '**We are crowdsourcing an open-source dataset of prices**. Prices can be added by users via this web app, or via the official Open Food Facts mobile app. Retailers or third-party apps can contribute as well by using our API.';
+      '**Vi bruker crowdsourcing til å finne et åpen kildekode-datasett med priser.** Priser kan legges til av brukere via denne nettappen eller via den offisielle Open Food Facts-mobilappen. Forhandlere eller tredjepartsapper kan også bidra ved å bruke API-et vårt.';
 
   @override
   String get guide_open_prices_how_arg1_title =>
-      'Collect photos of price tags in aisles';
+      'Samle bilder av prislapper i gangene';
 
   @override
-  String get guide_open_prices_how_arg2_title => 'Collect photos of receipts';
+  String get guide_open_prices_how_arg2_title => 'Samle bilder av kvitteringer';
 
   @override
   String get guide_open_prices_why_title =>
-      'Why is Open Food Facts doing this ?';
+      'Hvorfor gjør Open Food Facts dette?';
 
   @override
   String get guide_open_prices_why_paragraph1 =>
-      'Price information is of paramount importance to understand food systems. It\'s a key factor in understanding the cost of food and to promote healthier diets. Opening price data is a way to make it easier for researchers, journalists, and citizens to **have a better understanding of how food prices vary geographically and in time**.';
+      'Prisinformasjon er av største betydning for å forstå matsystemer. Det er en nøkkelfaktor for å forstå kostnadene ved mat og for å fremme sunnere kosthold. Å åpne prisdata er en måte å gjøre det enklere for forskere, journalister og innbyggere å **få en bedre forståelse av hvordan matprisene varierer geografisk og over tid**.';
 
   @override
   String get guide_open_prices_why_arg1_title =>
-      'Track the evolution of prices over time';
+      'Spor prisutviklingen over tid';
 
   @override
   String get guide_open_prices_why_arg1_text =>
-      'See the **evolution of prices**: shrinkflation, cheapflation, we can track them together!';
+      'Se **prisutviklingen**: krympeinflasjon, billiginflasjon, vi kan spore dem sammen!';
 
   @override
-  String get guide_open_prices_why_arg2_title => 'Compare prices near you';
+  String get guide_open_prices_why_arg2_title =>
+      'Sammenlign priser i nærheten av deg';
 
   @override
   String get guide_open_prices_why_arg2_text =>
-      'As we get more prices, you can spot **the cheapest stores around you**.';
+      'Etter hvert som vi får flere priser, kan du finne **de billigste butikkene i nærheten**.';
 
   @override
   String get guide_open_prices_scrapping_title =>
-      'Did you consider scraping prices from retailers\' websites?';
+      'Har du vurdert å hente priser fra forhandlernes nettsider?';
 
   @override
   String get guide_open_prices_scrapping_paragraph1 =>
-      'For legal and technical reasons, **we don\'t consider scraping prices from retailers\' websites as a valid way to contribute to Open Prices**. We want to make sure that the prices we collect are accurate and up-to-date, and receiving scraped prices from contributors doesn\'t allow us to do that.';
+      'Av juridiske og tekniske årsaker **anser vi ikke det å hente priser fra forhandlernes nettsteder som en gyldig måte å bidra til åpne priser**. Vi ønsker å sørge for at prisene vi samler inn er nøyaktige og oppdaterte, og det å motta hentede priser fra bidragsytere tillater oss ikke å gjøre det.';
 
   @override
   String get guide_open_prices_scrapping_paragraph2 =>
-      'Price scraping is a considered option in a future version of Open Prices, but it would be done by Open Prices itself so that we can have a proof of the price based on the HTML page.';
+      'Prisskraping er et vurdert alternativ i en fremtidig versjon av Open Prices, men det vil bli gjort av Open Prices selv, slik at vi kan ha et bevis på prisen basert på HTML-siden.';
 
   @override
   String get guide_open_prices_retailers_title =>
@@ -4904,7 +4948,7 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get guide_open_prices_retailers_paragraph1 =>
-      'You can contribute prices by using our API.\nIf you want to contribute prices at scale, please get in touch with us at prices@openfoodfacts.org.';
+      'Du kan bidra med priser ved å bruke API-et vårt.\nHvis du ønsker å bidra med priser i stor skala, kan du ta kontakt med oss på prices@openfoodfacts.org.';
 
   @override
   String get guide_open_prices_share_link =>
@@ -4912,149 +4956,148 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get guide_open_products_facts_title =>
-      'Welcome to Open Products Facts!';
+      'Velkommen til fakta om åpne produkter!';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_title =>
-      'What is Open Products Facts?';
+      'Hva er fakta om åpne produkter?';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_paragraph1 =>
-      'Open Products Facts is a massive, open database for **any product with a barcode, which is not food, cosmetic or pet food**.';
+      'Open Products Facts er en massiv, åpen database for **alle produkter med strekkode, som ikke er mat, kosmetikk eller dyrefôr**.';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_paragraph2 =>
-      'From **electronics** to **toys**, and **clothes** to **cleaning supplies**, if it has a barcode, it can be added. This project aims to create an \"Internet of Things\" for everyday objects, making information about them universally accessible.';
+      'Fra **elektronikk** til **leker**, og **klær** til **rengjøringsartikler**, hvis det har en strekkode, kan det legges til. Dette prosjektet har som mål å skape et «tingenes internett» for hverdagsgjenstander, og gjøre informasjon om dem universelt tilgjengelig.';
 
   @override
   String get guide_open_products_facts_features_title =>
-      'Features of Open Products Facts';
+      'Funksjoner i åpne produktfakta';
 
   @override
   String get guide_open_products_facts_features_text =>
-      'Open Products Facts aims to provide consumers to **extend the life of objects** by providing the circular solutions to maintain, **repair**, **recycle** their objects or give them a new owner.';
+      'Open Products Facts har som mål å gi forbrukere muligheten til å **forlenge levetiden til gjenstander** ved å tilby sirkulære løsninger for å vedlikeholde, **reparere**, **resirkulere** gjenstandene sine eller gi dem en ny eier.';
 
   @override
   String get guide_open_products_facts_features_arg1_title =>
-      'Carbon footprints for some products';
+      'Karbonavtrykk for noen produkter';
 
   @override
   String get guide_open_products_facts_features_arg1_text =>
-      '**Impact CO2** by French Environment Authority ADEME provides the **carbon impact** of many categories, make sure to categorize products precisely.';
+      '**CO2-påvirkning** fra den franske miljømyndigheten ADEME gir **karbonpåvirkningen** for mange kategorier. Sørg for å kategorisere produktene nøyaktig.';
 
   @override
   String get guide_open_products_facts_features_arg2_title =>
-      'Reparability index for many products';
+      'Reparasjonsindeks for mange produkter';
 
   @override
   String get guide_open_products_facts_features_arg2_text =>
-      'Whenever a French reparability index is available, we’ll display it. Moreover, **you can start collecting the variables using the Folksonomy Engine**; so that we can recompute it ourselves in the future, even in countries where it’s not available.';
+      'Når en fransk reparerbarhetsindeks er tilgjengelig, viser vi den. Dessuten **kan du begynne å samle inn variablene ved hjelp av Folksonomy Engine**, slik at vi kan beregne den på nytt selv i fremtiden, selv i land der den ikke er tilgjengelig.';
 
   @override
   String get guide_open_products_facts_features_arg3_title =>
-      'Find ways to donate/resell your product';
+      'Finn måter å donere/videreselge produktet ditt på';
 
   @override
   String get guide_open_products_facts_features_arg3_text =>
-      'We provide links to **third party circular friendly services** that help you get the kind of product you’re looking for, as a second hand product, to be more gentle on planetary resources.\nNote that we’re not paid to do that, and that the system only works as an example for two websites in France. You can help expand this system by documenting more sites on the wiki.';
+      'Vi tilbyr lenker til **tredjeparts sirkulærvennlige tjenester** som hjelper deg med å få den typen produkt du leter etter, som et bruktprodukt, for å være mer skånsom mot planetens ressurser.\nMerk at vi ikke får betalt for å gjøre det, og at systemet bare fungerer som et eksempel for to nettsteder i Frankrike. Du kan bidra til å utvide dette systemet ved å dokumentere flere nettsteder på wikien.';
 
   @override
   String get guide_open_products_facts_information_title =>
-      'What information is useful?';
+      'Hvilken informasjon er nyttig?';
 
   @override
   String get guide_open_products_facts_information_text =>
-      'For such a wide range of items, **the data we collect is flexible**. To do that, **we created the Folksonomy Engine**.';
+      'For et så bredt spekter av elementer er **dataene vi samler inn fleksible**. For å gjøre det har **vi laget Folksonomy Engine**.';
 
   @override
-  String get guide_open_products_facts_folksonomy_title =>
-      'The Folksonomy Engine';
+  String get guide_open_products_facts_folksonomy_title => 'Folksonomi-motoren';
 
   @override
   String get guide_open_products_facts_folksonomy_paragraph1 =>
-      'The Folksonomy Engine is a tool to help you complete products with relevant properties. This helps improve search and discoverability, but also compute and display interesting things in the future.';
+      'Folksonomy-motoren er et verktøy som hjelper deg med å fullføre produkter med relevante egenskaper. Dette bidrar til å forbedre søk og synlighet, men også beregne og vise interessante ting i fremtiden.';
 
   @override
   String get guide_open_products_facts_folksonomy_paragraph2 =>
-      'You can add any keys and values like: **compatibility_with_5G_mobile_network: yes**';
+      'Du kan legge til hvilke som helst nøkler og verdier som: **kompatibilitet_med_5G_mobilnettverk: ja**';
 
   @override
   String get guide_open_products_facts_folksonomy_paragraph3 =>
-      'You’ll get autosuggestion of possible properties, and you are very welcome to add and document new ones on your favorite kinds of products.';
+      'Du får automatiske forslag til mulige egenskaper, og du er hjertelig velkommen til å legge til og dokumentere nye på dine favorittprodukter.';
 
   @override
   String get guide_open_products_facts_share_link =>
       'https://world-no.openproductsfacts.org/discover';
 
   @override
-  String get guide_open_preferences_button_title => 'Open food preferences';
+  String get guide_open_preferences_button_title => 'Åpne matpreferanser';
 
   @override
-  String get guide_coming_soon_button_title => 'Coming soon';
+  String get guide_coming_soon_button_title => 'Kommer snart';
 
   @override
-  String get guide_learn_more_subtitle => 'Tap to learn more';
+  String get guide_learn_more_subtitle => 'Trykk for å finne ut mer';
 
   @override
-  String get preview_badge => 'Preview';
+  String get preview_badge => 'Forhåndsvisning';
 
   @override
   String get prices_feedback_form =>
-      'Click here to send us your feedback about this new feature!';
+      'Klikk her for å sende oss din tilbakemelding om denne nye funksjonen!';
 
   @override
-  String get menu_button_list_actions => 'Select an action';
+  String get menu_button_list_actions => 'Velg en handling';
 
   @override
-  String get error_loading_photo => 'Error loading photo';
+  String get error_loading_photo => 'Feil ved lasting av bilde';
 
   @override
-  String get photo_viewer_action_use_picture_as => 'Use as…';
+  String get photo_viewer_action_use_picture_as => 'Bruk som…';
 
   @override
-  String get photo_viewer_use_picture_as_tooltip => 'Use this picture as…';
+  String get photo_viewer_use_picture_as_tooltip => 'Bruk dette bildet som…';
 
   @override
   String photo_viewer_use_picture_as_title(String language) {
-    return 'Use this picture as… ($language)';
+    return 'Bruk dette bildet som… ($language)';
   }
 
   @override
-  String get photo_viewer_details_button => 'Details';
+  String get photo_viewer_details_button => 'Detaljer';
 
   @override
   String get photo_viewer_details_button_accessibility_label =>
-      'Details of this photo';
+      'Detaljer om dette bildet';
 
   @override
-  String get photo_viewer_details_title => 'Details of the photo';
+  String get photo_viewer_details_title => 'Detaljer om bildet';
 
   @override
   String get photo_viewer_details_contributor_title => 'Bidrager';
 
   @override
-  String get photo_viewer_details_size_title => 'Size';
+  String get photo_viewer_details_size_title => 'Størrelse';
 
   @override
   String photo_viewer_details_size_value(int width, int height) {
-    return '$width x $height pixels';
+    return '$width x $height piksler';
   }
 
   @override
-  String get photo_viewer_details_date_title => 'Date';
+  String get photo_viewer_details_date_title => 'Dato';
 
   @override
-  String get photo_viewer_details_url_title => 'URL';
+  String get photo_viewer_details_url_title => 'URL-adresse';
 
   @override
-  String get product_page_compatibility_score => 'Compatible';
+  String get product_page_compatibility_score => 'Kompatibel';
 
   @override
-  String get user_lists_action_multi_select => 'Multi-select';
+  String get user_lists_action_multi_select => 'Flervalg';
 
   @override
   String product_page_compatibility_score_tooltip(String score) {
-    return 'Your compatibility score: $score%';
+    return 'Din kompatibilitetspoengsum: $score%';
   }
 
   @override
@@ -5065,164 +5108,165 @@ class AppLocalizationsNo extends AppLocalizations {
       'Ingredients picture';
 
   @override
-  String get product_image_nutrition_accessibility_label => 'Nutrition picture';
+  String get product_image_nutrition_accessibility_label => 'Ernæringsbilde';
 
   @override
-  String get product_image_packaging_accessibility_label => 'Packaging picture';
+  String get product_image_packaging_accessibility_label => 'Emballasjebilde';
 
   @override
-  String get product_image_other_accessibility_label => 'Other picture';
+  String get product_image_other_accessibility_label => 'Annet bilde';
 
   @override
-  String get product_image_outdated_message => 'This picture may be outdated';
+  String get product_image_outdated_message => 'Dette bildet kan være utdatert';
 
   @override
   String product_image_outdated_message_accessibility_label(String type) {
-    return '$type (this image may be outdated)';
+    return '$type (dette bildet kan være utdatert)';
   }
 
   @override
   String product_image_locked_message_accessibility_label(String type) {
-    return '$type (this image may be locked by the producer)';
+    return '$type (dette bildet kan være låst av produsenten)';
   }
 
   @override
-  String get product_image_error => 'Unable to load the image!';
+  String get product_image_error => 'Klarte ikke å laste inn bildet!';
 
   @override
   String product_image_error_accessibility_label(String type) {
-    return 'Unable to load the $type (network error?)';
+    return 'Kan ikke laste inn $type (nettverksfeil?)';
   }
 
   @override
-  String get product_page_image_no_image_available => 'No\nimage!';
+  String get product_page_image_no_image_available => 'Ikke noe\nbilde!';
 
   @override
   String get product_page_image_no_image_available_accessibility_label =>
-      'No picture available for this product';
+      'Ingen bilder tilgjengelig for dette produktet';
 
   @override
   String get product_page_action_bar_settings_accessibility_label =>
-      'Reorder or hide actions';
+      'Endre rekkefølgen på eller skjul handlinger';
 
   @override
-  String get product_page_action_bar_setting_modal_title => 'Edit actions';
+  String get product_page_action_bar_setting_modal_title =>
+      'Rediger handlinger';
 
   @override
-  String get product_page_action_bar_item_move_up => 'Move up';
+  String get product_page_action_bar_item_move_up => 'Flytt opp';
 
   @override
-  String get product_page_action_bar_item_move_down => 'Move down';
+  String get product_page_action_bar_item_move_down => 'Flytt ned';
 
   @override
-  String get product_page_action_bar_item_enable => 'Enable action';
+  String get product_page_action_bar_item_enable => 'Aktiver handling';
 
   @override
-  String get product_page_action_bar_item_disable => 'Disable action';
+  String get product_page_action_bar_item_disable => 'Deaktiver handling';
 
   @override
   String get product_page_pending_operations_banner_title =>
-      'Uploading your edits…';
+      'Laster opp redigeringene dine…';
 
   @override
   String get product_page_pending_operations_banner_message =>
-      'The data displayed on this page **does not yet reflect your modifications**.\nPlease wait a few seconds…';
+      'Dataene som vises på denne siden **gjenspeiler ikke endringene dine ennå**.\nVent noen sekunder…';
 
   @override
-  String get product_add_a_language => 'Add a language';
+  String get product_add_a_language => 'Legg til et språk';
 
   @override
   String barcode_accessibility_label(String barcode) {
-    return 'Barcode $barcode';
+    return 'Strekkode $barcode';
   }
 
   @override
-  String get carousel_close_tooltip => 'Remove this product from the carousel';
+  String get carousel_close_tooltip => 'Fjern dette produktet fra karusellen';
 
   @override
-  String get carousel_unsupported_header => 'Unsupported barcode!';
+  String get carousel_unsupported_header => 'Ustøttet strekkode!';
 
   @override
-  String get carousel_unsupported_title => 'Ooops!';
+  String get carousel_unsupported_title => 'Ups!';
 
   @override
   String get carousel_unsupported_text =>
-      'The barcode scanned is not supported by Open Food Facts!';
+      'Strekkoden som skannes støttes ikke av Open Food Facts!';
 
   @override
-  String get carousel_error_header => 'Error!';
+  String get carousel_error_header => 'Feil!';
 
   @override
-  String get carousel_error_title => 'It\'s a bummer!';
+  String get carousel_error_title => 'Det er kjipt!';
 
   @override
   String get carousel_error_text_1 =>
-      'We couldn\'t download information on this barcode:';
+      'Vi kunne ikke laste ned informasjon om denne strekkoden:';
 
   @override
   String get carousel_error_text_2 =>
-      'Please check your Internet connection or click this button:';
+      'Sjekk internettforbindelsen din, eller klikk på denne knappen:';
 
   @override
-  String get carousel_error_button => 'Retry';
+  String get carousel_error_button => 'Prøv på nytt';
 
   @override
-  String get carousel_unknown_product_header => 'Unknown product';
+  String get carousel_unknown_product_header => 'Ukjent produkt';
 
   @override
   String get carousel_unknown_product_title =>
-      'Congratulations!\nYou\'ve found __the rare gem!__';
+      'Gratulerer!\nDu har funnet __den sjeldne juvelen!__';
 
   @override
   String get carousel_unknown_product_text =>
-      'Our collaborative database contains more than **3 million products**, but this barcode doesn\'t exist: ';
+      'Vår samarbeidsdatabase inneholder mer enn **3 millioner produkter**, men denne strekkoden finnes ikke: ';
 
   @override
   String get carousel_unknown_product_button => 'Add this product';
 
   @override
-  String get carousel_loading_header => 'Loading information...';
+  String get carousel_loading_header => 'Laster inn informasjon ...';
 
   @override
   String get carousel_loading_title =>
-      'You\'ve just scanned a product with the following barcode:';
+      'Du har nettopp skannet et produkt med følgende strekkode:';
 
   @override
   String get carousel_loading_text =>
-      'We are searching for it in our database of more than **3 million products!**';
+      'Vi søker etter det i databasen vår med mer enn **3 millioner produkter!**';
 
   @override
-  String get product_type_subtitle_food => 'Vegetables, fruits, frozen food…';
+  String get product_type_subtitle_food => 'Grønnsaker, frukt, frossenmat…';
 
   @override
-  String get product_type_subtitle_beauty => 'Makeup, soaps, toothpastes…';
+  String get product_type_subtitle_beauty => 'Sminke, såper, tannkremer…';
 
   @override
-  String get product_type_subtitle_pet_food => 'Food for dogs, cats…';
+  String get product_type_subtitle_pet_food => 'Mat til hunder og katter…';
 
   @override
-  String get product_type_subtitle_product => 'Smartphones, furniture…';
+  String get product_type_subtitle_product => 'Smarttelefoner, møbler…';
 
   @override
-  String get photo_field_front => 'Product photo';
+  String get photo_field_front => 'Produktbilde';
 
   @override
-  String get photo_field_ingredients => 'Ingredients photo';
+  String get photo_field_ingredients => 'Ingredienser bilde';
 
   @override
-  String get photo_field_nutrition => 'Nutrition photo';
+  String get photo_field_nutrition => 'Næringsinnholdsbilde';
 
   @override
-  String get photo_field_packaging => 'Packaging information photo';
+  String get photo_field_packaging => 'Emballasjeinformasjonsbilde';
 
   @override
-  String get photo_already_exists => 'This photo already exists';
+  String get photo_already_exists => 'Dette bildet finnes allerede';
 
   @override
-  String get photo_missing => 'This photo is missing';
+  String get photo_missing => 'Dette bildet mangler';
 
   @override
-  String get date => 'Date';
+  String get date => 'Dato';
 
   @override
   String get photo_rotate_left => 'Rotate left';
@@ -5231,76 +5275,76 @@ class AppLocalizationsNo extends AppLocalizations {
   String get photo_rotate_right => 'Rotate right';
 
   @override
-  String get photo_undo_action => 'Undo the previous action';
+  String get photo_undo_action => 'Angre forrige handling';
 
   @override
   String knowledge_panel_world_map_accessibility_label(String location) {
-    return 'A world map of $location';
+    return 'Et verdenskart over $location';
   }
 
   @override
   String get open_street_map_contributor_attribution =>
-      'OpenStreetMap contributors';
+      'OpenStreetMap-bidragsytere';
 
   @override
-  String get not_applicable_short => 'N/A';
+  String get not_applicable_short => 'Ikke aktuelt';
 
   @override
   String get knowledge_panel_warning_text => 'Advarsel';
 
   @override
   String get knowledge_panel_nutriscore_banner_incorrect_score_title =>
-      'Why is this Nutri-Score different from the one on the package?';
+      'Hvorfor er denne næringsverdien forskjellig fra den på pakken?';
 
   @override
   String get knowledge_panel_nutriscore_banner_incorrect_score_message =>
-      'There are two possible explanations:\nThe list of ingredients and/or nutrition facts are not up-to-date.\n\nWe provide the \"New calculation\" of the Nutri-Score (or V2). Please check that you have the banner \"New calculation\" on the package.';
+      'Det er to mulige forklaringer:\nListen over ingredienser og/eller næringsinnholdet er ikke oppdatert.\n\nVi tilbyr den «nye beregningen» av Nutri-Score (eller V2). Sjekk at du har banneret «Ny beregning» på pakken.';
 
   @override
   String get knowledge_panel_nutriscore_banner_incorrect_score_button1 =>
-      'Check ingredients';
+      'Sjekk ingrediensene';
 
   @override
   String get knowledge_panel_nutriscore_banner_incorrect_score_button2 =>
-      'Check nutrition facts';
+      'Sjekk næringsinnholdet';
 
   @override
   String url_not_supported(String url) {
-    return 'Unfortunately, we can\'t open the URL:\n$url';
+    return 'Dessverre kan vi ikke åpne URL-en:\n$url';
   }
 
   @override
-  String get product_list_export => 'Export';
+  String get product_list_export => 'Eksport';
 
   @override
   String get product_list_import => 'Import';
 
   @override
-  String get product_footer_action_barcode => 'View barcode';
+  String get product_footer_action_barcode => 'Vis strekkode';
 
   @override
   String get product_footer_action_barcode_short => 'Strekkode';
 
   @override
-  String get product_footer_action_open_website => 'Open website';
+  String get product_footer_action_open_website => 'Åpne nettsiden';
 
   @override
-  String get product_footer_action_report => 'Report';
+  String get product_footer_action_report => 'Rapportere';
 
   @override
-  String get product_footer_action_contributor_guide => 'Help';
+  String get product_footer_action_contributor_guide => 'Hjelp';
 
   @override
-  String get product_footer_action_data_quality_tags => 'Data quality';
+  String get product_footer_action_data_quality_tags => 'Datakvalitet';
 
   @override
   String get product_page_tab_for_me => 'For meg';
 
   @override
-  String get product_page_tab_website => 'Website';
+  String get product_page_tab_website => 'Nettsted';
 
   @override
-  String get product_page_tab_prices => 'Prices';
+  String get product_page_tab_prices => 'Priser';
 
   @override
   String get prices_explanation_card_title => 'Hvorfor priser?';
@@ -5310,10 +5354,10 @@ class AppLocalizationsNo extends AppLocalizations {
       '**Open Prices** er et prosjekt for å samle inn og dele priser på produkter over hele verden 🌍. Open Prices er utviklet og vedlikeholdt av Open Food Facts.';
 
   @override
-  String get explanation_card_learn_more_button => 'Learn more';
+  String get explanation_card_learn_more_button => 'Lær mer';
 
   @override
-  String get product_page_tab_folksonomy => 'Folksonomy';
+  String get product_page_tab_folksonomy => 'Folkesonomi';
 
   @override
   String get folksonomy_explanation_card_title =>
@@ -5328,11 +5372,11 @@ class AppLocalizationsNo extends AppLocalizations {
       'Disse egenskapene er opprettet og arkivert av bidragsytere for alle typer bruk.';
 
   @override
-  String get folksonomy_action_external_link_title => 'Open external link';
+  String get folksonomy_action_external_link_title => 'Åpne ekstern lenke';
 
   @override
   String get folksonomy_action_external_link_warning =>
-      'External links may be unsafe. Do you really want to visit it?';
+      'Eksterne lenker kan være utrygge. Vil du virkelig besøke dem?';
 
   @override
   String get prices_products_empty_title => 'Ingen pris tilgjengelig';
@@ -5342,41 +5386,41 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String prices_products_list_length_many_pages(int pageSize, int total) {
-    return 'Top $pageSize products (total: $total)';
+    return 'Topp $pageSize produkter (totalt: $total)';
   }
 
   @override
-  String get app_review_title => 'Are you enjoying this app?';
+  String get app_review_title => 'Liker du denne appen?';
 
   @override
-  String get app_review_low => 'Could do better';
+  String get app_review_low => 'Kunne gjort det bedre';
 
   @override
-  String get app_review_medium => 'Not bad';
+  String get app_review_medium => 'Ikke dårlig';
 
   @override
-  String get app_review_high => 'I love it!';
+  String get app_review_high => 'Jeg elsker det!';
 
   @override
   String get app_review_feedback_modal_title =>
-      'Help us improve our application';
+      'Hjelp oss med å forbedre applikasjonen vår';
 
   @override
   String get app_review_feedback_modal_content =>
-      'If you have a few minutes, could you answer this form so that **we can improve in future updates**:';
+      'Hvis du har noen minutter, kan du svare på dette skjemaet slik at **vi kan forbedre oss i fremtidige oppdateringer**:';
 
   @override
-  String get app_review_feedback_modal_open_form => 'Answer the form';
+  String get app_review_feedback_modal_open_form => 'Svar på skjemaet';
 
   @override
-  String get app_review_feedback_modal_later => 'Ask me later';
+  String get app_review_feedback_modal_later => 'Spør meg senere';
 
   @override
   String get nutrition_facts_extract_new =>
-      'NEW: You can automatically extract the nutrients from the picture!';
+      'NYTT: Du kan automatisk trekke ut næringsstoffene fra bildet!';
 
   @override
-  String get nutrition_facts_extract_button_text => 'Extract now';
+  String get nutrition_facts_extract_button_text => 'Uttrekk nå';
 
   @override
   String get nutrition_facts_extract_in_progress => 'Uttrekking pågår…';
@@ -5386,19 +5430,19 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get nutrition_facts_extract_failed =>
-      'Failed to extract nutrients from picture';
+      'Klarte ikke å hente ut næringsstoffer fra bildet';
 
   @override
   String get prices_discount => 'Discount';
 
   @override
-  String get prices_stats_statistics => 'Statistics';
+  String get prices_stats_statistics => 'Statistikk';
 
   @override
-  String get prices_stats_title => 'Prices Statistics';
+  String get prices_stats_title => 'Prisstatistikk';
 
   @override
-  String get prices_stats_prices_section => 'Prices';
+  String get prices_stats_prices_section => 'Priser';
 
   @override
   String get prices_stats_products_section => 'Produkter';
@@ -5416,7 +5460,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get prices_stats_experiments_section => 'Experiments';
 
   @override
-  String get prices_stats_misc_section => 'Miscellaneous';
+  String get prices_stats_misc_section => 'Diverse';
 
   @override
   String get prices_stats_total => 'Total';
@@ -5440,7 +5484,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get prices_stats_with_price => 'With a price';
 
   @override
-  String get prices_stats_food => 'Food';
+  String get prices_stats_food => 'Mat';
 
   @override
   String get prices_stats_beauty => 'Beauty';
@@ -5449,7 +5493,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get prices_stats_products => 'Produkter';
 
   @override
-  String get prices_stats_pet_food => 'Pet food';
+  String get prices_stats_pet_food => 'Kjæledyrfôr';
 
   @override
   String get prices_stats_osm => 'OpenStreetMap';
@@ -5461,10 +5505,10 @@ class AppLocalizationsNo extends AppLocalizations {
   String get prices_stats_countries => 'Countries';
 
   @override
-  String get prices_stats_price_tag => 'Price tag';
+  String get prices_stats_price_tag => 'Prislapp';
 
   @override
-  String get prices_stats_receipt => 'Receipt';
+  String get prices_stats_receipt => 'Kvittering';
 
   @override
   String get prices_stats_gdpr_request => 'GDPR request';
@@ -5488,35 +5532,36 @@ class AppLocalizationsNo extends AppLocalizations {
   String get prices_stats_by_source_title => 'Prices and proofs per source';
 
   @override
-  String get prices_stats_website => 'Website';
+  String get prices_stats_website => 'Nettsted';
 
   @override
   String get prices_stats_mobile_app => 'Mobile app';
 
   @override
-  String get prices_stats_api => 'API';
+  String get prices_stats_api => 'API-en';
 
   @override
   String get prices_stats_other => 'Other';
 
   @override
-  String get prices_stats_last_updated => 'Last updated on';
+  String get prices_stats_last_updated => 'Sist oppdatert';
 
   @override
   String get prices_stats_error =>
-      'An error occurred while loading statistics.';
+      'Det oppsto en feil under lasting av statistikk.';
 
   @override
-  String get product_edit_robotoff_question_answered => 'Question answered!';
+  String get product_edit_robotoff_question_answered =>
+      'Spørsmålet er besvart!';
 
   @override
-  String get product_edit_robotoff_proof => 'Proof';
+  String get product_edit_robotoff_proof => 'Bevis';
 
   @override
   String get preferences_card_general => 'General';
 
   @override
-  String get preferences_prices_title => 'Prices';
+  String get preferences_prices_title => 'Priser';
 
   @override
   String get preferences_prices_subtitle =>
@@ -5556,7 +5601,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get preferences_card_help => 'Hjelp og støtte';
 
   @override
-  String get preferences_faq_title => 'FAQ';
+  String get preferences_faq_title => 'Vanlige spørsmål';
 
   @override
   String get preferences_faq_subtitle => 'Få svar på spørsmålene dine';
@@ -5608,7 +5653,7 @@ class AppLocalizationsNo extends AppLocalizations {
       'Bruksvilkår, personvernregler og mer';
 
   @override
-  String get preferences_terms_of_use => 'Terms of use';
+  String get preferences_terms_of_use => 'Bruksvilkår';
 
   @override
   String get preferences_legal_mentions => 'Legal mentions';
@@ -5618,7 +5663,7 @@ class AppLocalizationsNo extends AppLocalizations {
       'Open Food Facts er en database med matvarer **laget av alle, for alle**.\nDu kan bruke den til å ta bedre matvalg, og siden den er **åpne data**, kan hvem som helst **gjenbruke den til ethvert formål**.';
 
   @override
-  String get preferences_privacy_policy => 'Privacy policy';
+  String get preferences_privacy_policy => 'Personvernerklæring';
 
   @override
   String get preferences_licenses => 'Lisenser';
@@ -5796,7 +5841,7 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get preferences_connect_community_calendar_title =>
-      'Subscribe to our community calendar';
+      'Abonner på vår fellesskapskalender';
 
   @override
   String get preferences_connect_community_calendar_subtitle =>
@@ -5902,7 +5947,7 @@ class AppLocalizationsNo extends AppLocalizations {
       'Enkle trinn for å øke åpenheten om mat i landet ditt';
 
   @override
-  String get preferences_contribute_data_quality_title => 'Data quality';
+  String get preferences_contribute_data_quality_title => 'Datakvalitet';
 
   @override
   String get preferences_contribute_data_quality_team_title =>
@@ -5929,10 +5974,10 @@ class AppLocalizationsNo extends AppLocalizations {
       'Alle ufullstendige produkter';
 
   @override
-  String get preferences_my_contributions_prices_title => 'Prices';
+  String get preferences_my_contributions_prices_title => 'Priser';
 
   @override
-  String get preferences_my_contributions_my_prices_title => 'My prices';
+  String get preferences_my_contributions_my_prices_title => 'Mine priser';
 
   @override
   String get preferences_my_contributions_my_prices_subtitle =>
@@ -6124,11 +6169,11 @@ class AppLocalizationsNo extends AppLocalizations {
       'Open Food Facts Labs';
 
   @override
-  String get preferences_root_account_title => 'Account';
+  String get preferences_root_account_title => 'Konto';
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Få åpne matfakta på språket ditt';
 
   @override
   String get preferences_contribute_enroll_alpha =>
@@ -6142,7 +6187,7 @@ class AppLocalizationsNo extends AppLocalizations {
       'Ikke vis folkesonomi';
 
   @override
-  String get preferences_account_title => 'Account';
+  String get preferences_account_title => 'Konto';
 
   @override
   String prices_adding_timestamp_tooltip(String created) {
@@ -6150,26 +6195,26 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
-  String get location_map_details_title => 'Location details';
+  String get location_map_details_title => 'Stedsdetaljer';
 
   @override
   String get location_map_details_name => 'Navn';
 
   @override
-  String get location_map_details_street => 'Street';
+  String get location_map_details_street => 'Gate';
 
   @override
-  String get location_map_details_city => 'City';
+  String get location_map_details_city => 'By';
 
   @override
-  String get location_map_details_postcode => 'Postcode';
+  String get location_map_details_postcode => 'Postnummer';
 
   @override
   String get location_map_details_country => 'Country';
 
   @override
-  String get location_map_details_coordinates => 'Coordinates';
+  String get location_map_details_coordinates => 'Koordinater';
 
   @override
-  String get location_map_details_osm_id => 'OSM ID';
+  String get location_map_details_osm_id => 'OSM-ID';
 }

--- a/packages/smooth_app/lib/l10n/app_localizations_no.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_no.dart
@@ -659,7 +659,7 @@ class AppLocalizationsNo extends AppLocalizations {
   String get unknownBrand => 'Ukjent merke';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Ukjent produktnavn';

--- a/packages/smooth_app/lib/l10n/app_localizations_nr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_nr.dart
@@ -653,7 +653,7 @@ class AppLocalizationsNr extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_nr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_nr.dart
@@ -653,6 +653,9 @@ class AppLocalizationsNr extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_oc.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_oc.dart
@@ -654,6 +654,9 @@ class AppLocalizationsOc extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3523,7 +3526,7 @@ class AppLocalizationsOc extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Començant a realizar las accions del servidor per las mesas a jorn de folksonomia enregistradas localament';
 
   @override
   String get background_task_title_top_n =>
@@ -5818,7 +5821,8 @@ class AppLocalizationsOc extends AppLocalizations {
       'Participatz-vos en assistissent a un de nòstres eveniments virtuals';
 
   @override
-  String get preferences_connect_blog_title => 'The Open Food Facts blog';
+  String get preferences_connect_blog_title =>
+      'Lo blòg dels faches de l\'alimentacion dobèrta';
 
   @override
   String get preferences_connect_blog_subtitle =>
@@ -6034,7 +6038,7 @@ class AppLocalizationsOc extends AppLocalizations {
 
   @override
   String get preferences_page_contribute_project_subtitle =>
-      'Simple ways to help Open Food Facts';
+      'De biaisses simples d\'ajudar a dobrir los faches alimentaris';
 
   @override
   String get preferences_page_faq_subtitle =>
@@ -6149,7 +6153,7 @@ class AppLocalizationsOc extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Portatz de faches alimentaris dobèrts a vòstra lenga';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_oc.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_oc.dart
@@ -654,7 +654,7 @@ class AppLocalizationsOc extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_or.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_or.dart
@@ -657,7 +657,7 @@ class AppLocalizationsOr extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_or.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_or.dart
@@ -657,6 +657,9 @@ class AppLocalizationsOr extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3524,7 +3527,7 @@ class AppLocalizationsOr extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'ସ୍ଥାନୀୟ ଭାବରେ ସଂରକ୍ଷିତ ଲୋକସମ୍ବନ୍ଧୀୟ ଅପଡେଟ୍ ପାଇଁ ସର୍ଭର କାର୍ଯ୍ୟଗୁଡ଼ିକ କରିବା ଆରମ୍ଭ କରୁଛି';
 
   @override
   String get background_task_title_top_n =>
@@ -5313,7 +5316,7 @@ class AppLocalizationsOr extends AppLocalizations {
 
   @override
   String get prices_explanation_card_line1 =>
-      '**Open Prices** is a project to collect and share prices of products around the world 🌍. Open Prices is developed and maintained by Open Food Facts.';
+      '**ଓପନ୍ ପ୍ରାଇସେସ୍** ହେଉଛି ସାରା ବିଶ୍ୱରେ ଉତ୍ପାଦଗୁଡ଼ିକର ମୂଲ୍ୟ ସଂଗ୍ରହ ଏବଂ ଅଂଶୀଦାର କରିବା ପାଇଁ ଏକ ପ୍ରକଳ୍ପ 🌍। ଓପନ୍ ପ୍ରାଇସେସ୍ Open Food Facts ଦ୍ୱାରା ବିକଶିତ ଏବଂ ରକ୍ଷଣାବେକ୍ଷଣ କରାଯାଏ।';
 
   @override
   String get explanation_card_learn_more_button => 'ଅଧିକ ଜାଣନ୍ତୁ';
@@ -5590,7 +5593,7 @@ class AppLocalizationsOr extends AppLocalizations {
 
   @override
   String get preferences_app_bar_search_hint =>
-      'Search for a setting (e.g. Nutri-Score)';
+      'ଏକ ସେଟିଂ ଖୋଜନ୍ତୁ (ଯଥା ନ୍ୟୁଟ୍ରି-ସ୍କୋର)';
 
   @override
   String get preferences_accessibility_show_emoji =>
@@ -5668,7 +5671,7 @@ class AppLocalizationsOr extends AppLocalizations {
   String get preferences_tips => 'ପରାମର୍ଶ';
 
   @override
-  String get tips_discover_nutriscore => 'Discover the new Nutri-Score';
+  String get tips_discover_nutriscore => 'ନୂଆ ନ୍ୟୁଟ୍ରି-ସ୍କୋର ଆବିଷ୍କାର କରନ୍ତୁ';
 
   @override
   String get preferences_on_off_website_subtitle => 'Open Food Facts ୱେବସାଇଟରେ';
@@ -5756,7 +5759,7 @@ class AppLocalizationsOr extends AppLocalizations {
 
   @override
   String get preferences_faq_nutriscore_subtitle =>
-      'Discover how the Nutri-Score is computed';
+      'ନ୍ୟୁଟ୍ରି-ସ୍କୋର କିପରି ଗଣନା କରାଯାଏ ତାହା ଜାଣନ୍ତୁ';
 
   @override
   String get preferences_faq_nutriscore_v2_subtitle =>
@@ -5950,7 +5953,7 @@ class AppLocalizationsOr extends AppLocalizations {
 
   @override
   String get preferences_contributions_categorize_subtitle =>
-      'Help compute the Nutri-Score & Green-Score in your country';
+      'ଆପଣଙ୍କ ଦେଶରେ ନ୍ୟୁଟ୍ରି-ସ୍କୋର୍ ଏବଂ ଗ୍ରୀନ୍-ସ୍କୋର୍ ଗଣନା କରିବାରେ ସାହାଯ୍ୟ କରନ୍ତୁ';
 
   @override
   String get preferences_prices_user_prices_subtitle => 'ମୁଁ ଦେଇଥିବା ମୂଲ୍ୟ';
@@ -6020,7 +6023,7 @@ class AppLocalizationsOr extends AppLocalizations {
 
   @override
   String get preferences_page_contribute_project_subtitle =>
-      'Simple ways to help Open Food Facts';
+      'ଖାଦ୍ୟ ତଥ୍ୟ ଖୋଲିବାରେ ସାହାଯ୍ୟ କରିବାର ସରଳ ଉପାୟ';
 
   @override
   String get preferences_page_faq_subtitle =>

--- a/packages/smooth_app/lib/l10n/app_localizations_pa.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_pa.dart
@@ -653,7 +653,7 @@ class AppLocalizationsPa extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_pa.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_pa.dart
@@ -653,6 +653,9 @@ class AppLocalizationsPa extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3519,7 +3522,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'ਸਥਾਨਕ ਤੌਰ \'ਤੇ ਸਟੋਰ ਕੀਤੇ ਲੋਕ-ਸੰਬੰਧੀ ਅੱਪਡੇਟਾਂ ਲਈ ਸਰਵਰ ਕਾਰਵਾਈਆਂ ਕਰਨਾ ਸ਼ੁਰੂ ਕਰ ਰਿਹਾ ਹੈ';
 
   @override
   String get background_task_title_top_n =>
@@ -5306,7 +5309,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String get prices_explanation_card_line1 =>
-      '**Open Prices** is a project to collect and share prices of products around the world 🌍. Open Prices is developed and maintained by Open Food Facts.';
+      '**ਓਪਨ ਪ੍ਰਾਈਸ** ਦੁਨੀਆ ਭਰ ਦੇ ਉਤਪਾਦਾਂ ਦੀਆਂ ਕੀਮਤਾਂ ਇਕੱਠੀਆਂ ਕਰਨ ਅਤੇ ਸਾਂਝੀਆਂ ਕਰਨ ਦਾ ਇੱਕ ਪ੍ਰੋਜੈਕਟ ਹੈ 🌍। ਓਪਨ ਪ੍ਰਾਈਸ Open Food Facts ਦੁਆਰਾ ਵਿਕਸਤ ਅਤੇ ਸੰਭਾਲਿਆ ਜਾਂਦਾ ਹੈ।';
 
   @override
   String get explanation_card_learn_more_button => 'Learn more';
@@ -5583,7 +5586,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String get preferences_app_bar_search_hint =>
-      'Search for a setting (e.g. Nutri-Score)';
+      'ਇੱਕ ਸੈਟਿੰਗ ਦੀ ਖੋਜ ਕਰੋ (ਜਿਵੇਂ ਕਿ ਨਿਊਟਰੀ-ਸਕੋਰ)';
 
   @override
   String get preferences_accessibility_show_emoji => 'ਪਹੁੰਚਯੋਗਤਾ: ਇਮੋਜੀ ਦਿਖਾਓ';
@@ -5659,7 +5662,7 @@ class AppLocalizationsPa extends AppLocalizations {
   String get preferences_tips => 'ਸੁਝਾਅ';
 
   @override
-  String get tips_discover_nutriscore => 'Discover the new Nutri-Score';
+  String get tips_discover_nutriscore => 'ਨਵੇਂ ਨਿਊਟ੍ਰੀ-ਸਕੋਰ ਦੀ ਖੋਜ ਕਰੋ';
 
   @override
   String get preferences_on_off_website_subtitle =>
@@ -5747,7 +5750,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String get preferences_faq_nutriscore_subtitle =>
-      'Discover how the Nutri-Score is computed';
+      'ਖੋਜੋ ਕਿ ਨਿਊਟ੍ਰੀ-ਸਕੋਰ ਦੀ ਗਣਨਾ ਕਿਵੇਂ ਕੀਤੀ ਜਾਂਦੀ ਹੈ';
 
   @override
   String get preferences_faq_nutriscore_v2_subtitle =>
@@ -5938,7 +5941,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String get preferences_contributions_categorize_subtitle =>
-      'Help compute the Nutri-Score & Green-Score in your country';
+      'ਆਪਣੇ ਦੇਸ਼ ਵਿੱਚ ਨਿਊਟ੍ਰੀ-ਸਕੋਰ ਅਤੇ ਗ੍ਰੀਨ-ਸਕੋਰ ਦੀ ਗਣਨਾ ਕਰਨ ਵਿੱਚ ਮਦਦ ਕਰੋ';
 
   @override
   String get preferences_prices_user_prices_subtitle =>
@@ -5960,7 +5963,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String get preferences_prices_newest_subtitle =>
-      'Latest prices added by the Open Prices community';
+      'ਓਪਨ ਪ੍ਰਾਈਸ ਕਮਿਊਨਿਟੀ ਦੁਆਰਾ ਜੋੜੀਆਂ ਗਈਆਂ ਨਵੀਨਤਮ ਕੀਮਤਾਂ';
 
   @override
   String get preferences_prices_top_contributors_title =>
@@ -6008,7 +6011,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String get preferences_page_contribute_project_subtitle =>
-      'Simple ways to help Open Food Facts';
+      'ਭੋਜਨ ਦੇ ਤੱਥਾਂ ਨੂੰ ਖੋਲ੍ਹਣ ਵਿੱਚ ਮਦਦ ਕਰਨ ਦੇ ਸਰਲ ਤਰੀਕੇ';
 
   @override
   String get preferences_page_faq_subtitle =>
@@ -6123,7 +6126,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'ਆਪਣੀ ਭਾਸ਼ਾ ਵਿੱਚ ਖੁੱਲ੍ਹੇ ਭੋਜਨ ਦੇ ਤੱਥ ਲਿਆਓ';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_pl.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_pl.dart
@@ -664,7 +664,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get unknownBrand => 'Nieznana marka';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Nieznana nazwa produktu';

--- a/packages/smooth_app/lib/l10n/app_localizations_pl.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_pl.dart
@@ -664,6 +664,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get unknownBrand => 'Nieznana marka';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Nieznana nazwa produktu';
 
   @override
@@ -3012,7 +3015,7 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String get prices_menu_know_more => 'Know more about Open Prices';
+  String get prices_menu_know_more => 'Dowiedz się więcej o cenach otwartych';
 
   @override
   String get dev_preferences_import_history_result_success => 'Gotowe';
@@ -3570,7 +3573,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Rozpoczęcie wykonywania działań serwerowych dla aktualizacji folksonomii przechowywanych lokalnie';
 
   @override
   String get background_task_title_top_n =>
@@ -4084,7 +4087,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get nutriscore_generic => 'Nutri-Score';
 
   @override
-  String get nutriscore_a => 'Nutri-Score A';
+  String get nutriscore_a => 'Wskaźnik odżywczy A';
 
   @override
   String get nutriscore_b => 'Wynik Nutri-Score B';
@@ -4662,7 +4665,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get guide_open_food_facts_features_title =>
-      'Features of Open Food Facts';
+      'Cechy otwartych informacji o żywności';
 
   @override
   String get guide_open_food_facts_features_arg1_title =>
@@ -4746,7 +4749,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get guide_open_pet_food_facts_features_title =>
-      'Features of Open Pet Food Facts';
+      'Cechy otwartych informacji o karmie dla zwierząt';
 
   @override
   String get guide_open_pet_food_facts_features_arg1_title =>
@@ -4904,7 +4907,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get guide_open_prices_what_is_open_prices_title =>
-      'What is Open Prices?';
+      'Czym są ceny otwarte?';
 
   @override
   String get guide_open_prices_what_is_open_prices_paragraph1 =>
@@ -4915,7 +4918,7 @@ class AppLocalizationsPl extends AppLocalizations {
       'There are currently few companies that own large databases of product prices at the barcode level. These prices are not freely available, but sold at a high price to private actors, researchers and other organizations that can afford them.';
 
   @override
-  String get guide_open_prices_how_title => 'How does Open Prices work?';
+  String get guide_open_prices_how_title => 'Jak działają Ceny Otwarte?';
 
   @override
   String get guide_open_prices_how_paragraph1 =>
@@ -4991,7 +4994,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get guide_open_products_facts_features_title =>
-      'Features of Open Products Facts';
+      'Cechy produktów otwartych Fakty';
 
   @override
   String get guide_open_products_facts_features_text =>
@@ -6081,7 +6084,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get preferences_page_contribute_project_subtitle =>
-      'Simple ways to help Open Food Facts';
+      'Proste sposoby na pomoc w otwarciu Food Facts';
 
   @override
   String get preferences_page_faq_subtitle =>
@@ -6196,7 +6199,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Przenieś Open Food Fakty do swojego języka';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_pt.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_pt.dart
@@ -664,7 +664,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get unknownBrand => 'Marca desconhecida';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Nome de produto desconhecido';

--- a/packages/smooth_app/lib/l10n/app_localizations_pt.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_pt.dart
@@ -664,6 +664,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get unknownBrand => 'Marca desconhecida';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Nome de produto desconhecido';
 
   @override
@@ -2963,7 +2966,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get prices_proof_find => 'Selecionar um comprovativo';
 
   @override
-  String get prices_proof_change => 'Change proof';
+  String get prices_proof_change => 'Prova de alteração';
 
   @override
   String get prices_proof_receipt => 'Talão';
@@ -3026,7 +3029,7 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get prices_menu_know_more => 'Know more about Open Prices';
+  String get prices_menu_know_more => 'Saiba mais sobre os Open Prices';
 
   @override
   String get dev_preferences_import_history_result_success => 'Concluído';
@@ -3118,7 +3121,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String search_proof_title(String user) {
-    return 'Proof from \"$user\"';
+    return 'Prova de \"$user\"';
   }
 
   @override
@@ -3584,7 +3587,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Iniciando a execução das ações do servidor para atualizações de folksonomia armazenadas localmente.';
 
   @override
   String get background_task_title_top_n =>
@@ -4141,22 +4144,22 @@ class AppLocalizationsPt extends AppLocalizations {
   String get environmental_score_generic_new => 'Green-Score';
 
   @override
-  String get environmental_score_a_new => 'Pontuação Verde A';
+  String get environmental_score_a_new => 'Green-Score A';
 
   @override
-  String get environmental_score_b_new => 'Pontuação Verde B';
+  String get environmental_score_b_new => 'Green-Score B';
 
   @override
-  String get environmental_score_c_new => 'Pontuação Verde C';
+  String get environmental_score_c_new => 'Green-Score C';
 
   @override
-  String get environmental_score_d_new => 'Pontuação Verde D';
+  String get environmental_score_d_new => 'Green-Score D';
 
   @override
-  String get environmental_score_e_new => 'Pontuação Verde E';
+  String get environmental_score_e_new => 'Green-Score E';
 
   @override
-  String get environmental_score_unknown_new => 'Pontuação Verde Desconhecida';
+  String get environmental_score_unknown_new => 'Green-Score Desconhecida';
 
   @override
   String get environmental_score_not_applicable_new =>
@@ -4464,7 +4467,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get guide_greenscore_bonuses_penalties_intro =>
-      'To reward better products within a category, we then apply **bonuses & penalties based on several criterion**:';
+      'Para premiar os melhores produtos dentro de uma categoria, aplicamos **bónus e penalizações com base em vários critérios**:';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg1_title =>
@@ -4472,7 +4475,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get guide_greenscore_bonuses_penalties_arg1_text =>
-      'A **bonus** is awarded to products that have an **official label, a label or a certification that guarantees environmental benefits** (organic, fair trade, HVE, Label Rouge, Bleu Blanc Cœur, MSC/ASC).';
+      'É atribuído um **bónus** aos produtos que possuam um **rótulo oficial, um selo ou uma certificação que garanta benefícios ambientais** (biológico, comércio justo, HVE, Label Rouge, Bleu Blanc Cœur, MSC/ASC).';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg2_title =>
@@ -4480,7 +4483,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get guide_greenscore_bonuses_penalties_arg2_text =>
-      'A **bonus** is awarded based on the origin of the ingredients. This bonus takes into account the **impact on transportation** and also the **environmental policy** of each producer\'s country.';
+      'Um **bónus** é atribuído com base na origem dos ingredientes. Este bónus tem em conta o **impacto no transporte** e também a **política ambiental** do país de cada produtor.';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg3_title =>
@@ -4488,14 +4491,14 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get guide_greenscore_bonuses_penalties_arg3_text =>
-      'A **penalty** is given to products that contain ingredients that have significant **negative impacts on biodiversity and ecosystems**, such as palm oil, the production of which is responsible for massive deforestation.';
+      'É aplicada uma **penalidade** aos produtos que contêm ingredientes que têm impactos negativos significativos na biodiversidade e nos ecossistemas, como o óleo de palma, cuja produção é responsável pela desflorestação em grande escala.';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg4_title => 'Embalagem';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg4_text =>
-      'A **penalty** is calculated to take into account the **circularity of packaging** (use of recycled raw material and recyclability) and overpacking.';
+      'Uma **penalidade** é calculada tendo em conta a **circularidade da embalagem** (utilização de matéria-prima reciclada e reciclabilidade) e o excesso de embalagem.';
 
   @override
   String get guide_greenscore_transparency_title =>
@@ -4503,19 +4506,19 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get guide_greenscore_transparency_intro1 =>
-      'To accurately calculate the Green-Score, it is necessary to have **information which is not necessarily specified on the packaging** (such as the origin and the exact percentage of each ingredient) or which is rarely available in usable form (such as a list of all the components of the packaging with the precise types of plastics used).';
+      'Para calcular com precisão o Green-Score, é necessário dispor de **informações que nem sempre estão especificadas na embalagem** (como a origem e a percentagem exata de cada ingrediente) ou que raramente estão disponíveis em formato utilizável (como uma lista de todos os componentes da embalagem com os tipos precisos de plásticos utilizados).';
 
   @override
   String get guide_greenscore_transparency_intro2 =>
-      '**Average values are used when this information is not yet available**, but we are now calling on everyone to help us collect this information which will be very useful for the Green-Score but also for many other uses.';
+      '**São utilizados valores médios quando esta informação ainda não está disponível**, mas agora pedimos a todos que nos ajudem a recolher esta informação, que será muito útil para o Green-Score, mas também para muitas outras utilizações.';
 
   @override
   String get guide_greenscore_transparency_arg1_title =>
-      'How citizens can help?';
+      'Como podem os cidadãos ajudar?';
 
   @override
   String get guide_greenscore_transparency_arg1_text =>
-      'All citizens can help us gather and structure the information that is present on products or that can be deduced from them, such as information on **packaging**: \"Mission Emballages\": a large-scale collaborative inventory of packaging for all food products (in French).';
+      'Todos os cidadãos podem ajudar-nos a reunir e estruturar a informação presente nos produtos ou que pode ser deduzida a partir dos mesmos, como por exemplo informação sobre **embalagens**: \"Mission Emballages\": um inventário colaborativo de grande escala de embalagens para todos os produtos alimentares (em francês).';
 
   @override
   String get guide_greenscore_transparency_arg2_title =>
@@ -4589,7 +4592,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get guide_nova_groups_arg1_text =>
-      'Unprocessed (or natural) foods are the **edible parts of plants** (seeds, fruits, leaves, stems, roots) **or animals** (muscle, offal, eggs, milk), as well as fungi, algae, and water, after being separated from nature.';
+      'Os alimentos não processados (ou naturais) são as **partes comestíveis das plantas** (sementes, frutos, folhas, caules, raízes) **ou animais** (músculos, vísceras, ovos, leite), bem como os fungos, algas e água, após serem separados da natureza.';
 
   @override
   String get guide_nova_groups_arg2_title =>
@@ -4623,7 +4626,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg1_text =>
-      'Many are **derived from further processing of food constituents**, such as hydrogenated or interesterified oils, hydrolyzed proteins, soy protein isolate, maltodextrin, invert sugar, and high-fructose corn syrup.';
+      'Muitos são **derivados do processamento adicional de componentes alimentares**, como óleos hidrogenados ou interesterificados, proteínas hidrolisadas, proteína isolada de soja, maltodextrina, açúcar invertido e xarope de milho rico em frutose.';
 
   @override
   String get guide_nova_explanations_arg2_title =>
@@ -4631,7 +4634,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg2_text =>
-      'Additives in ultra-processed foods include some that are also used in processed foods, such as preservatives, antioxidants, and stabilizers. Classes of additives found only in ultra-processed products include those used **to imitate or enhance the sensory qualities of foods or to disguise unpalatable aspects of the final product**. These additives include dyes and other colors, color stabilizers; flavors, flavor enhancers, non-sugar sweeteners; and processing aids such as carbonating, firming, bulking and anti-bulking agents, de-foaming, anti-caking and glazing agents, emulsifiers, sequestrants, and humectants.';
+      'Os aditivos em alimentos ultraprocessados incluem alguns que também são utilizados em alimentos processados, como conservantes, antioxidantes e estabilizantes. As classes de aditivos que se encontram apenas nos produtos ultraprocessados incluem os utilizados**para imitar ou realçar as qualidades sensoriais dos alimentos ou para disfarçar aspetos desagradáveis do produto final**. Estes aditivos incluem corantes e outras cores, estabilizantes de cor; aromatizantes, intensificadores de sabor, adoçantes não calóricos; e auxiliares de processamento, tais como agentes carbonatantes, firmantes, de volume e anti-volume, antiespumantes, antiaglomerantes e de revestimento, emulsionantes, sequestrantes e humectantes.';
 
   @override
   String get guide_nova_explanations_arg3_title =>
@@ -4639,7 +4642,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg3_text =>
-      '**A multitude of sequences of processes is used** to combine the usually many ingredients and to create the final product (hence \'ultra-processed\'). The processes include several **with no domestic equivalents**, such as hydrogenation and hydrolysation, extrusion and moulding, and pre-processing for frying.';
+      '**É utilizada uma infinidade de sequências de processos** para combinar os vários ingredientes e criar o produto final (daí o termo \"ultraprocessado\"). Os processos incluem vários **sem equivalentes domésticos**, como hidrogenação e hidrólise, extrusão e moldagem, e pré-processamento para fritura.';
 
   @override
   String get guide_nova_explanations_arg4_title =>
@@ -4647,10 +4650,10 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg4_text =>
-      '**The overall purpose of ultra-processing is to create branded**, **convenient** (durable, ready to consume), **attractive** (hyper-palatable) and **highly profitable** (low-cost ingredients) food products designed to displace all other food groups. Ultra-processed food products are usually packaged attractively and marketed intensively.';
+      'O objetivo geral do ultraprocessamento é criar produtos alimentares de marca, convenientes (duráveis e prontos a consumir), atraentes (hiperpalatáveis) e altamente rentáveis (com ingredientes de baixo custo), concebidos para substituir todos os outros grupos alimentares. Os alimentos ultraprocessados são geralmente embalados de forma atrativa e comercializados de forma intensiva.';
 
   @override
-  String get guide_nova_explanations_arg5_title => 'A health hazard';
+  String get guide_nova_explanations_arg5_title => 'Um risco para a saúde';
 
   @override
   String get guide_nova_explanations_arg5_text =>
@@ -4658,93 +4661,96 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg6_title =>
-      'Countries recommend limiting them';
+      'Os países recomendam limitá-los';
 
   @override
   String get guide_nova_explanations_arg6_text =>
-      'Some countries use the NOVA groups for their dietary guidelines or goals, for instance:\n\n- **🇧🇷 Brazil**\'s dietary guidelines **recommend to limit consumption** of processed food and avoid ultra-processed food.\n\n- **🇫🇷 France**\'s public health nutritional policy goals for 2018-2022 aims to **reduce consumption of group 4 ultra-processed foods by 20%**.';
+      'Alguns países utilizam os grupos NOVA para as suas diretrizes ou metas alimentares, por exemplo:\n\n- As diretrizes alimentares do **Brasil** recomendam limitar o consumo de alimentos processados e evitar alimentos ultraprocessados.\n\n- As metas da política de saúde pública nutricional da **França** para 2018-2022 visam reduzir o consumo de alimentos ultraprocessados do grupo 4 em 20%.';
 
   @override
   String get guide_nova_share_link => 'https://world-pt.openfoodfacts.org/nova';
 
   @override
-  String get guide_open_food_facts_title => 'Welcome to Open Food Facts!';
+  String get guide_open_food_facts_title => 'Bem-vindo(a) ao Open Food Facts!';
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_title =>
-      'What is Open Food Facts?';
+      'O que é o Open Food Facts?';
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_paragraph1 =>
-      'Open Food Facts is a **collaborative**, **free**, and **open** database of food products from around the world.';
+      'O Open Food Facts é uma base de dados **colaborativa**, **gratuita** e **aberta** de produtos alimentares de todo o mundo.';
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_paragraph2 =>
-      'We believe that everyone should have access to information about what they eat. By collecting data on ingredients, allergens, nutrition facts, and more, **we empower consumers to make informed choices** and drive the food industry **toward greater transparency**.';
+      'Acreditamos que todos devem ter acesso a informação sobre o que comem. Ao recolher dados sobre ingredientes, alergénios, informação nutricional e muito mais, **capacitamos os consumidores para fazerem escolhas conscientes** e impulsionamos a indústria alimentar **rumo a uma maior transparência**.';
 
   @override
   String get guide_open_food_facts_features_title =>
-      'Features of Open Food Facts';
+      'Características do Open Food Facts';
 
   @override
   String get guide_open_food_facts_features_arg1_title =>
-      'Get alerts for your unwanted ingredients';
+      'Receba alertas sobre ingredientes indesejados.';
 
   @override
-  String get guide_open_food_facts_tips_title => 'Tips for taking great photos';
+  String get guide_open_food_facts_tips_title =>
+      'Dicas para tirar fotografias incríveis';
 
   @override
-  String get guide_open_food_facts_tips_arg1_title => 'Don’ts';
+  String get guide_open_food_facts_tips_arg1_title =>
+      'Coisas que não se devem fazer';
 
   @override
   String get guide_open_food_facts_tips_arg1_text1 =>
-      'Avoid shadows and glare.';
+      'Evite sombras e reflexos.';
 
   @override
   String get guide_open_food_facts_tips_arg1_text2 =>
-      'No blurry or out-of-focus text.';
+      'Sem texto desfocado ou desfocado.';
 
   @override
   String get guide_open_food_facts_tips_arg1_text3 =>
-      'Don\'t crop out parts of the text.';
+      'Não recorte partes do texto.';
 
   @override
-  String get guide_open_food_facts_tips_arg1_text4 => 'Avoid busy backgrounds.';
+  String get guide_open_food_facts_tips_arg1_text4 =>
+      'Evite fundos muito carregados.';
 
   @override
-  String get guide_open_food_facts_tips_arg2_title => 'Do’s';
+  String get guide_open_food_facts_tips_arg2_title => 'Faça';
 
   @override
   String get guide_open_food_facts_tips_arg2_text1 =>
-      'Use good, even lighting.';
+      'Utilize uma iluminação boa e uniforme.';
 
   @override
   String get guide_open_food_facts_tips_arg2_text2 =>
-      'Ensure text is sharp and readable.';
+      'Certifique-se de que o texto é nítido e legível.';
 
   @override
   String get guide_open_food_facts_tips_arg2_text3 =>
-      'Capture the entire ingredients list.';
+      'Capte a lista completa de ingredientes.';
 
   @override
   String get guide_open_food_facts_tips_arg2_text4 =>
-      'Keep the product on a flat surface.';
+      'Coloque o produto sobre uma superfície plana.';
 
   @override
   String get guide_open_food_facts_scores_title =>
-      'Help us build the \"Wikipedia of Food\"';
+      'Ajude-nos a construir a \"Wikipédia da Alimentação\"';
 
   @override
   String get guide_open_food_facts_scores_arg1_title =>
-      'A score on the nutritional quality';
+      'Uma pontuação sobre a qualidade nutricional.';
 
   @override
   String get guide_open_food_facts_scores_arg2_title =>
-      'A score to avoid ultra-processed foods';
+      'Uma lista de alimentos ultraprocessados que ajudam a evitar.';
 
   @override
   String get guide_open_food_facts_scores_arg3_title =>
-      'A score for the planet';
+      'Uma partitura para o planeta';
 
   @override
   String get guide_open_food_facts_share_link =>
@@ -4752,236 +4758,241 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get guide_open_pet_food_facts_title =>
-      'Welcome to Open Pet Food Facts!';
+      'Bem-vindo(a) ao Open Pet Food Facts!';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_title =>
-      'What is Open Pet Food Facts?';
+      'O que é o Open Pet Food Facts?';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_paragraph1 =>
-      'Open Pet Food Facts extends our mission to our furry friends! It\'s a **database of pet food products for cats, dogs, and other companions**.';
+      'O Open Pet Food Facts estende a nossa missão aos nossos amigos patudos! É uma **base de dados de produtos alimentares para gatos, cães e outros animais de estimação**.';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_paragraph2 =>
-      'We gather information on **ingredients**, **nutritional analysis**, and feeding guidelines to help pet owners choose the best food for their animals\' needs.';
+      'Reunimos informações sobre **ingredientes**, **análise nutricional** e orientações alimentares para ajudar os donos de animais de estimação a escolher o melhor alimento para as necessidades dos seus animais.';
 
   @override
   String get guide_open_pet_food_facts_features_title =>
-      'Features of Open Pet Food Facts';
+      'Características dos Alimentos para Animais de Estimação Open Pet Food Facts';
 
   @override
   String get guide_open_pet_food_facts_features_arg1_title =>
-      'Get alerts for your unwanted ingredients';
+      'Receba alertas sobre ingredientes indesejados.';
 
   @override
   String get guide_open_pet_food_facts_features_arg1_paragraph1 =>
-      'Is your pet allergic to any ingredients? You can set a list of cosmetic ingredients to avoid, right in the app!';
+      'O seu animal de estimação tem alergia a algum ingrediente? Pode criar uma lista de ingredientes cosméticos a evitar, diretamente na aplicação!';
 
   @override
   String get guide_open_pet_food_facts_tips_title =>
-      'Tips for taking great photos';
+      'Dicas para tirar fotografias incríveis';
 
   @override
-  String get guide_open_pet_food_facts_tips_arg1_title => 'Don’ts';
+  String get guide_open_pet_food_facts_tips_arg1_title =>
+      'Coisas que não se devem fazer';
 
   @override
   String get guide_open_pet_food_facts_tips_arg1_text1 =>
-      'Avoid shadows and glare.';
+      'Evite sombras e reflexos.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg1_text2 =>
-      'No blurry or out-of-focus text.';
+      'Sem texto desfocado ou desfocado.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg1_text3 =>
-      'Don\'t crop out parts of the text.';
+      'Não recorte partes do texto.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg1_text4 =>
-      'Avoid busy backgrounds.';
+      'Evite fundos muito carregados.';
 
   @override
-  String get guide_open_pet_food_facts_tips_arg2_title => 'Do’s';
+  String get guide_open_pet_food_facts_tips_arg2_title => 'Faça';
 
   @override
   String get guide_open_pet_food_facts_tips_arg2_text1 =>
-      'Use good, even lighting.';
+      'Utilize uma iluminação boa e uniforme.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg2_text2 =>
-      'Ensure text is sharp and readable.';
+      'Certifique-se de que o texto é nítido e legível.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg2_text3 =>
-      'Capture the entire ingredients list.';
+      'Capte a lista completa de ingredientes.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg2_text4 =>
-      'Keep the product on a flat surface.';
+      'Coloque o produto sobre uma superfície plana.';
 
   @override
-  String get guide_open_pet_food_facts_scores_title => 'A note on scoring';
+  String get guide_open_pet_food_facts_scores_title =>
+      'Uma nota sobre a pontuação.';
 
   @override
   String get guide_open_pet_food_facts_scores_paragraph1 =>
-      'Developing a scoring system for pet food **is not a priority right now**. The methodology would be complex, as nutritional needs vary greatly by species, age, and health condition. We haven’t found any independant scientific team yet, able to develop such a score.';
+      'Desenvolver um sistema de pontuação para alimentos para animais de estimação **não é uma prioridade neste momento**. A metodologia seria complexa, uma vez que as necessidades nutricionais variam muito de acordo com a espécie, idade e condição de saúde. Ainda não encontrámos nenhuma equipa científica independente capaz de desenvolver um sistema de pontuação deste tipo.';
 
   @override
   String get guide_open_pet_food_facts_share_link =>
       'https://world-pt.openpetfoodfacts.org/discover';
 
   @override
-  String get guide_open_beauty_facts_title => 'Welcome to Open Beauty Facts!';
+  String get guide_open_beauty_facts_title =>
+      'Bem-vindo(a) ao Open Beauty Facts!';
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_title =>
-      'What is Open Beauty Facts?';
+      'O que é o Open Beauty Facts?';
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_paragraph1 =>
-      'Open Beauty Facts is a collaborative database of **cosmetic products**.';
+      'Open Beauty Facts é uma base de dados colaborativa de **produtos cosméticos**.';
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_paragraph2 =>
-      'Our goal is to decipher ingredient lists to help you **understand what\'s in your personal care items**. From moisturizers to makeup, we collect data on ingredients, allergens, and packaging to promote transparency in the cosmetics industry.';
+      'O nosso objetivo é decifrar as listas de ingredientes para o ajudar a **compreender o que contém os seus produtos de higiene pessoal**. De hidratantes a maquilhagem, recolhemos dados sobre ingredientes, alergénios e embalagens para promover a transparência na indústria cosmética.';
 
   @override
   String get guide_open_beauty_facts_features_title =>
-      'Features of Open Beauty Facts';
+      'Características do Open Beauty Facts';
 
   @override
   String get guide_open_beauty_facts_features_arg1_title =>
-      'Get alerts for your unwanted ingredients';
+      'Receba alertas sobre ingredientes indesejados.';
 
   @override
   String get guide_open_beauty_facts_features_arg1_paragraph1 =>
-      'Are you allergic to any ingredients? Want to avoid comedogen substances? Want to steer away from controversial components ? You can set a list of cosmetic ingredients to avoid, right in the app!';
+      'Tem alergia a algum ingrediente? Quer evitar substâncias comedogénicas? Quer manter-se longe de componentes controversos? Pode criar uma lista de ingredientes cosméticos que deseja evitar, diretamente na aplicação!';
 
   @override
   String get guide_open_beauty_facts_tips_title =>
-      'Tips for taking great photos';
+      'Dicas para tirar fotografias incríveis';
 
   @override
-  String get guide_open_beauty_facts_tips_arg1_title => 'Don’ts';
+  String get guide_open_beauty_facts_tips_arg1_title =>
+      'Coisas que não se devem fazer';
 
   @override
   String get guide_open_beauty_facts_tips_arg1_text1 =>
-      'Avoid shadows and glare.';
+      'Evite sombras e reflexos.';
 
   @override
   String get guide_open_beauty_facts_tips_arg1_text2 =>
-      'No blurry or out-of-focus text.';
+      'Sem texto desfocado ou desfocado.';
 
   @override
   String get guide_open_beauty_facts_tips_arg1_text3 =>
-      'Don\'t crop out parts of the text.';
+      'Não recorte partes do texto.';
 
   @override
   String get guide_open_beauty_facts_tips_arg1_text4 =>
-      'Avoid busy backgrounds.';
+      'Evite fundos muito carregados.';
 
   @override
-  String get guide_open_beauty_facts_tips_arg2_title => 'Do’s';
+  String get guide_open_beauty_facts_tips_arg2_title => 'Faça';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text1 =>
-      'Use good, even lighting.';
+      'Utilize uma iluminação boa e uniforme.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text2 =>
-      'Ensure text is sharp and readable.';
+      'Certifique-se de que o texto é nítido e legível.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text3 =>
-      'Capture the entire ingredients list.';
+      'Capte a lista completa de ingredientes.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text4 =>
-      'Take as many picture as need if the bottle is curved.';
+      'Tire as fotografias necessárias se a garrafa for curva.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text5 =>
-      'You might need to peel the label to see the list of ingredients.';
+      'Talvez seja necessário remover o rótulo para ver a lista de ingredientes.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text6 =>
-      'Keep the product on a flat surface.';
+      'Coloque o produto sobre uma superfície plana.';
 
   @override
-  String get guide_open_beauty_facts_scores_title => 'A note on scoring';
+  String get guide_open_beauty_facts_scores_title =>
+      'Uma nota sobre a pontuação.';
 
   @override
   String get guide_open_beauty_facts_scores_paragraph1 =>
-      'Unlike food products, the world of cosmetics **does not have a universally recognized, government-backed scoring system like the Nutri-Score**. Ingredient effects can be highly personal and depend on skin type, allergies, and individual concerns.';
+      'Ao contrário dos produtos alimentares, o mundo dos cosméticos **não possui um sistema de pontuação universalmente reconhecido e apoiado pelo governo, como o Nutri-Score**. Os efeitos dos ingredientes podem ser muito pessoais e dependem do tipo de pele, das alergias e das preocupações individuais.';
 
   @override
   String get guide_open_beauty_facts_share_link =>
       'https://world-pt.openbeautyfacts.org/discover';
 
   @override
-  String get guide_open_prices_title => 'Welcome to Open Prices!';
+  String get guide_open_prices_title => 'Bem-vindo(a) ao Open Prices!';
 
   @override
   String get guide_open_prices_what_is_open_prices_title =>
-      'What is Open Prices?';
+      'O que são Open Prices?';
 
   @override
   String get guide_open_prices_what_is_open_prices_paragraph1 =>
-      'Open Prices is a project to **collect and share prices of products around the world**. It\'s a publicly available dataset that can be used for research, analysis, and more. Open Prices is developed and maintained by Open Food Facts.';
+      'O Open Prices é um projeto para **recolher e partilhar preços de produtos em todo o mundo**. Trata-se de um conjunto de dados público que pode ser utilizado para pesquisa, análise e muito mais. O Open Prices é desenvolvido e mantido pela Open Food Facts.';
 
   @override
   String get guide_open_prices_what_is_open_prices_paragraph2 =>
       'Atualmente, são poucas as empresas que possuem grandes bases de dados de preços de produtos ao nível do código de barras. Estes preços não estão disponíveis gratuitamente, mas são vendidos a um preço elevado a agentes privados, investigadores e outras organizações que os podem pagar.';
 
   @override
-  String get guide_open_prices_how_title => 'How does Open Prices work?';
+  String get guide_open_prices_how_title => 'Como funciona o Open Prices?';
 
   @override
   String get guide_open_prices_how_paragraph1 =>
-      '**We are crowdsourcing an open-source dataset of prices**. Prices can be added by users via this web app, or via the official Open Food Facts mobile app. Retailers or third-party apps can contribute as well by using our API.';
+      '**Estamos a criar um conjunto de dados de preços de código aberto através de crowdsourcing**. Os utilizadores podem adicionar preços através desta aplicação web ou da aplicação móvel oficial Open Food Facts. Os lojistas e as aplicações de terceiros também podem contribuir usando a nossa API.';
 
   @override
   String get guide_open_prices_how_arg1_title =>
-      'Collect photos of price tags in aisles';
+      'Recolha fotos das etiquetas de preço nos corredores.';
 
   @override
-  String get guide_open_prices_how_arg2_title => 'Collect photos of receipts';
+  String get guide_open_prices_how_arg2_title => 'Recolher fotos de recibos';
 
   @override
   String get guide_open_prices_why_title =>
-      'Why is Open Food Facts doing this ?';
+      'Por que razão a Open Food Facts está a fazer isto?';
 
   @override
   String get guide_open_prices_why_paragraph1 =>
-      'Price information is of paramount importance to understand food systems. It\'s a key factor in understanding the cost of food and to promote healthier diets. Opening price data is a way to make it easier for researchers, journalists, and citizens to **have a better understanding of how food prices vary geographically and in time**.';
+      'A informação sobre os preços é de primordial importância para a compreensão dos sistemas alimentares. É um fator-chave para compreender o custo dos alimentos e promover dietas mais saudáveis. A divulgação de dados sobre os preços facilita o trabalho dos investigadores, jornalistas e cidadãos, permitindo-lhes compreender melhor como os preços dos alimentos variam geograficamente e ao longo do tempo.';
 
   @override
   String get guide_open_prices_why_arg1_title =>
-      'Track the evolution of prices over time';
+      'Acompanhe a evolução dos preços ao longo do tempo.';
 
   @override
   String get guide_open_prices_why_arg1_text =>
-      'See the **evolution of prices**: shrinkflation, cheapflation, we can track them together!';
+      'Veja-se a **evolução dos preços**: inflação de preços baixos, inflação de preços baixos, podemos acompanhá-las simultaneamente!';
 
   @override
-  String get guide_open_prices_why_arg2_title => 'Compare prices near you';
+  String get guide_open_prices_why_arg2_title => 'Compare preços perto de si';
 
   @override
   String get guide_open_prices_why_arg2_text =>
-      'As we get more prices, you can spot **the cheapest stores around you**.';
+      'À medida que obtivermos mais preços, poderá identificar **as lojas mais baratas perto de si**.';
 
   @override
   String get guide_open_prices_scrapping_title =>
-      'Did you consider scraping prices from retailers\' websites?';
+      'Considerou a possibilidade de extrair preços dos sites dos retalhistas?';
 
   @override
   String get guide_open_prices_scrapping_paragraph1 =>
-      'For legal and technical reasons, **we don\'t consider scraping prices from retailers\' websites as a valid way to contribute to Open Prices**. We want to make sure that the prices we collect are accurate and up-to-date, and receiving scraped prices from contributors doesn\'t allow us to do that.';
+      'Por razões legais e técnicas, **não consideramos a extração de preços dos sites dos retalhistas como uma forma válida de contribuir para o Open Prices**. Queremos garantir que os preços que recolhemos são precisos e atualizados, e receber preços extraídos dos colaboradores não nos permite fazê-lo.';
 
   @override
   String get guide_open_prices_scrapping_paragraph2 =>
-      'Price scraping is a considered option in a future version of Open Prices, but it would be done by Open Prices itself so that we can have a proof of the price based on the HTML page.';
+      'A extração de preços é uma opção considerada para uma versão futura do Open Prices, mas seria feita pelo próprio Open Prices para que pudéssemos ter uma prova do preço com base na página HTML.';
 
   @override
   String get guide_open_prices_retailers_title =>
@@ -4989,7 +5000,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get guide_open_prices_retailers_paragraph1 =>
-      'You can contribute prices by using our API.\nIf you want to contribute prices at scale, please get in touch with us at prices@openfoodfacts.org.';
+      'Pode contribuir com preços usando a nossa API.\nSe desejar contribuir com preços em grande escala, por favor contacte-nos através do endereço prices@openfoodfacts.org.';
 
   @override
   String get guide_open_prices_share_link =>
@@ -4997,88 +5008,89 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get guide_open_products_facts_title =>
-      'Welcome to Open Products Facts!';
+      'Bem-vindo(a) ao Open Products Facts!';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_title =>
-      'What is Open Products Facts?';
+      'O que é o Open Products Facts?';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_paragraph1 =>
-      'Open Products Facts is a massive, open database for **any product with a barcode, which is not food, cosmetic or pet food**.';
+      'O Open Products Facts é uma enorme base de dados aberta para **qualquer produto com código de barras, exceto alimentos, cosméticos e alimentos para animais de estimação**.';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_paragraph2 =>
-      'From **electronics** to **toys**, and **clothes** to **cleaning supplies**, if it has a barcode, it can be added. This project aims to create an \"Internet of Things\" for everyday objects, making information about them universally accessible.';
+      'De **eletrónica** a **brinquedos**, e de **roupa** a **produtos de limpeza**, se tiver um código de barras, pode ser adicionado. Este projeto visa criar uma \"Internet das Coisas\" para objetos do quotidiano, tornando a informação sobre os mesmos universalmente acessível.';
 
   @override
   String get guide_open_products_facts_features_title =>
-      'Features of Open Products Facts';
+      'Características dos Factos sobre Produtos Abertos';
 
   @override
   String get guide_open_products_facts_features_text =>
-      'Open Products Facts aims to provide consumers to **extend the life of objects** by providing the circular solutions to maintain, **repair**, **recycle** their objects or give them a new owner.';
+      'A Open Products Facts tem como objectivo proporcionar aos consumidores a possibilidade de **prolongar a vida útil dos objectos**, oferecendo soluções circulares para a manutenção, **reparação**, **reciclagem** dos seus objectos ou para que estes sejam entregues a um novo proprietário.';
 
   @override
   String get guide_open_products_facts_features_arg1_title =>
-      'Carbon footprints for some products';
+      'Pegada de carbono para alguns produtos';
 
   @override
   String get guide_open_products_facts_features_arg1_text =>
-      '**Impact CO2** by French Environment Authority ADEME provides the **carbon impact** of many categories, make sure to categorize products precisely.';
+      '**Impacto do CO2**, da ADEME (Autoridade Francesa do Ambiente), fornece o **impacto do carbono** de várias categorias. Certifique-se de que categoriza os produtos corretamente.';
 
   @override
   String get guide_open_products_facts_features_arg2_title =>
-      'Reparability index for many products';
+      'Índice de reparabilidade para muitos produtos';
 
   @override
   String get guide_open_products_facts_features_arg2_text =>
-      'Whenever a French reparability index is available, we’ll display it. Moreover, **you can start collecting the variables using the Folksonomy Engine**; so that we can recompute it ourselves in the future, even in countries where it’s not available.';
+      'Sempre que um índice de reparabilidade francês estiver disponível, iremos exibi-lo. Além disso, **pode começar a recolher as variáveis utilizando o Folksonomy Engine**, para que possamos recalculá-lo no futuro, mesmo em países onde não está disponível.';
 
   @override
   String get guide_open_products_facts_features_arg3_title =>
-      'Find ways to donate/resell your product';
+      'Encontre formas de doar/revender o seu produto';
 
   @override
   String get guide_open_products_facts_features_arg3_text =>
-      'We provide links to **third party circular friendly services** that help you get the kind of product you’re looking for, as a second hand product, to be more gentle on planetary resources.\nNote that we’re not paid to do that, and that the system only works as an example for two websites in France. You can help expand this system by documenting more sites on the wiki.';
+      'Fornecemos links para **serviços de terceiros que respeitam a economia circular**, que o ajudam a obter o tipo de produto que procura, como um produto em segunda mão, para ser mais gentil com os recursos do planeta.\nNote-se que não somos pagos para o fazer e que o sistema funciona apenas como exemplo para dois sites em França. Pode ajudar a expandir este sistema documentando mais sites na wiki.';
 
   @override
   String get guide_open_products_facts_information_title =>
-      'What information is useful?';
+      'Que informações são úteis?';
 
   @override
   String get guide_open_products_facts_information_text =>
-      'For such a wide range of items, **the data we collect is flexible**. To do that, **we created the Folksonomy Engine**.';
+      'Para uma gama tão vasta de artigos, **os dados que recolhemos são flexíveis**. Para isso, **criámos o Folksonomy Engine**.';
 
   @override
   String get guide_open_products_facts_folksonomy_title =>
-      'The Folksonomy Engine';
+      'O Motor de Folksonomia';
 
   @override
   String get guide_open_products_facts_folksonomy_paragraph1 =>
-      'The Folksonomy Engine is a tool to help you complete products with relevant properties. This helps improve search and discoverability, but also compute and display interesting things in the future.';
+      'O Folksonomy Engine é uma ferramenta que ajuda a complementar produtos com propriedades relevantes. Isto contribui para melhorar a pesquisa e a visibilidade, além de gerar e exibir informações interessantes no futuro.';
 
   @override
   String get guide_open_products_facts_folksonomy_paragraph2 =>
-      'You can add any keys and values like: **compatibility_with_5G_mobile_network: yes**';
+      'Pode adicionar quaisquer chaves e valores, tais como: **compatibility_with_5G_mobile_network: yes**';
 
   @override
   String get guide_open_products_facts_folksonomy_paragraph3 =>
-      'You’ll get autosuggestion of possible properties, and you are very welcome to add and document new ones on your favorite kinds of products.';
+      'Receberá sugestões automáticas de possíveis propriedades e terá muito gosto em adicionar e documentar novas propriedades relacionadas com os seus tipos de produtos favoritos.';
 
   @override
   String get guide_open_products_facts_share_link =>
       'https://world-pt.openproductsfacts.org/discover';
 
   @override
-  String get guide_open_preferences_button_title => 'Open food preferences';
+  String get guide_open_preferences_button_title =>
+      'preferências alimentares abertas';
 
   @override
-  String get guide_coming_soon_button_title => 'Coming soon';
+  String get guide_coming_soon_button_title => 'Em breve';
 
   @override
-  String get guide_learn_more_subtitle => 'Tap to learn more';
+  String get guide_learn_more_subtitle => 'Toque para saber mais';
 
   @override
   String get preview_badge => 'Pré-visualizar';
@@ -5417,11 +5429,11 @@ class AppLocalizationsPt extends AppLocalizations {
       'Estas propriedades são criadas e arquivadas pelos colaboradores para qualquer tipo de utilização.';
 
   @override
-  String get folksonomy_action_external_link_title => 'Open external link';
+  String get folksonomy_action_external_link_title => 'Abrir link externo';
 
   @override
   String get folksonomy_action_external_link_warning =>
-      'External links may be unsafe. Do you really want to visit it?';
+      'Os links externos podem ser inseguros. Deseja realmente acessá-los?';
 
   @override
   String get prices_products_empty_title => 'Sem preço disponível';
@@ -5864,7 +5876,7 @@ class AppLocalizationsPt extends AppLocalizations {
       'Discover Open Pet Food Facts';
 
   @override
-  String get preferences_faq_discover_op_title => 'Discover Open Prices';
+  String get preferences_faq_discover_op_title => 'Descubra os Open Prices';
 
   @override
   String get preferences_faq_discover_opf_title =>
@@ -6246,28 +6258,28 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get location_map_details_title => 'Location details';
+  String get location_map_details_title => 'Detalhes da localização';
 
   @override
   String get location_map_details_name => 'Nome';
 
   @override
-  String get location_map_details_street => 'Street';
+  String get location_map_details_street => 'Rua';
 
   @override
-  String get location_map_details_city => 'City';
+  String get location_map_details_city => 'Cidade';
 
   @override
-  String get location_map_details_postcode => 'Postcode';
+  String get location_map_details_postcode => 'código postal';
 
   @override
   String get location_map_details_country => 'Country';
 
   @override
-  String get location_map_details_coordinates => 'Coordinates';
+  String get location_map_details_coordinates => 'Coordenadas';
 
   @override
-  String get location_map_details_osm_id => 'OSM ID';
+  String get location_map_details_osm_id => 'ID do OSM';
 }
 
 /// The translations for Portuguese, as used in Brazil (`pt_BR`).
@@ -9290,7 +9302,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   }
 
   @override
-  String get prices_menu_know_more => 'Know more about Open Prices';
+  String get prices_menu_know_more => 'Saiba mais sobre Open Prices';
 
   @override
   String get dev_preferences_import_history_result_success => 'Concluído';
@@ -9847,6 +9859,10 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
       'A iniciar a atualização de todos os produtos armazenados localmente';
 
   @override
+  String get background_task_title_folksonomy =>
+      'Iniciando a execução das ações do servidor para atualizações de folksonomia armazenadas localmente.';
+
+  @override
   String get background_task_title_top_n =>
       'Iniciar o descarregamento dos produtos mais populares';
 
@@ -10401,22 +10417,22 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get environmental_score_generic_new => 'Eco-Pontuação';
 
   @override
-  String get environmental_score_a_new => 'Pontuação Verde A';
+  String get environmental_score_a_new => 'Green-Score A';
 
   @override
-  String get environmental_score_b_new => 'Pontuação Verde B';
+  String get environmental_score_b_new => 'Green-Score B';
 
   @override
-  String get environmental_score_c_new => 'Pontuação Verde C';
+  String get environmental_score_c_new => 'Green-Score C';
 
   @override
-  String get environmental_score_d_new => 'Pontuação Verde D';
+  String get environmental_score_d_new => 'Green-Score D';
 
   @override
-  String get environmental_score_e_new => 'Pontuação Verde E';
+  String get environmental_score_e_new => 'Green-Score E';
 
   @override
-  String get environmental_score_unknown_new => 'Pontuação Verde Desconhecida';
+  String get environmental_score_unknown_new => 'Green-Score Desconhecida';
 
   @override
   String get environmental_score_not_applicable_new =>
@@ -10762,11 +10778,11 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String get guide_greenscore_transparency_intro1 =>
-      'Para calcular com exatidão a Pontuação Verde, é necessário ter **informações que não são necessariamente especificados na embalagem** (tal como a origem ou exata porcentagem de cada ingrediente) ou os quais são raramente disponíveis em formas utilizáveis (como a lista com todos os componentes da embalagem com os tipos precisos de plásticos usados).';
+      'Para calcular com exatidão a Green-Score, é necessário ter **informações que não são necessariamente especificados na embalagem** (tal como a origem ou exata porcentagem de cada ingrediente) ou os quais são raramente disponíveis em formas utilizáveis (como a lista com todos os componentes da embalagem com os tipos precisos de plásticos usados).';
 
   @override
   String get guide_greenscore_transparency_intro2 =>
-      'Valores médios são usados quando essas informações ainda não estão disponíveis, mas agora estamos convocando todos para nos ajudar a coletar esses dados, que serão muito úteis para a Pontuação Verde e outros usos.';
+      'Valores médios são usados quando essas informações ainda não estão disponíveis, mas agora estamos convocando todos para nos ajudar a coletar esses dados, que serão muito úteis para a Green-Score e outros usos.';
 
   @override
   String get guide_greenscore_transparency_arg1_title =>
@@ -11176,7 +11192,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String get guide_open_beauty_facts_scores_paragraph1 =>
-      'Unlike food products, the world of cosmetics **does not have a universally recognized, government-backed scoring system like the Nutri-Score**. Ingredient effects can be highly personal and depend on skin type, allergies, and individual concerns.';
+      'Diferente dos produtos alimentícios, o mundo dos cosméticos **não possui um sistema de pontuação reconhecido e respaldado por governos, como o Nutri-Score**. Os efeitos dos ingredientes podem ser altamente pessoais e depender do tom de pele, alergias e preocupações individuais.';
 
   @override
   String get guide_open_beauty_facts_share_link =>
@@ -12120,7 +12136,7 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get preferences_faq_discover_project_title => 'Descubra o projeto';
 
   @override
-  String get preferences_faq_discover_off_title => 'Discover Open Food Facts';
+  String get preferences_faq_discover_off_title => 'Descubra Open Food Facts';
 
   @override
   String get preferences_faq_discover_obf_title =>

--- a/packages/smooth_app/lib/l10n/app_localizations_qu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_qu.dart
@@ -654,6 +654,9 @@ class AppLocalizationsQu extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3015,7 +3018,7 @@ class AppLocalizationsQu extends AppLocalizations {
 
   @override
   String get dev_mode_openprices_switch_env_title =>
-      'Switch between prices.openfoodfacts.org (PROD) and test env';
+      'Prices.openfoodfacts.org (PROD) kaqmanta chaymanta prueba env kaqmanta tikray';
 
   @override
   String get search_history_item_edit_tooltip => 'Reuse and edit this search';
@@ -3522,7 +3525,7 @@ class AppLocalizationsQu extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Servidor ruwaykunata ruwayta qallariy folksonomy musuqyachiykunapaq kitipi waqaychasqa';
 
   @override
   String get background_task_title_top_n =>
@@ -4067,23 +4070,22 @@ class AppLocalizationsQu extends AppLocalizations {
   String get environmental_score_generic_new => 'Green-Score';
 
   @override
-  String get environmental_score_a_new => 'Verde-Puntuación A';
+  String get environmental_score_a_new => 'Green-Score A';
 
   @override
-  String get environmental_score_b_new => 'Verde-Puntuación B';
+  String get environmental_score_b_new => 'Green-Score B';
 
   @override
-  String get environmental_score_c_new => 'Verde-Puntuación C';
+  String get environmental_score_c_new => 'Green-Score C';
 
   @override
-  String get environmental_score_d_new => 'Verde-Puntuación D';
+  String get environmental_score_d_new => 'Green-Score D';
 
   @override
-  String get environmental_score_e_new => 'Verde-Puntuación E';
+  String get environmental_score_e_new => 'Green-Score E';
 
   @override
-  String get environmental_score_unknown_new =>
-      'Mana riqsisqa Verde-Puntuación';
+  String get environmental_score_unknown_new => 'Mana riqsisqa Green-Score';
 
   @override
   String get environmental_score_not_applicable_new =>
@@ -4311,7 +4313,7 @@ class AppLocalizationsQu extends AppLocalizations {
 
   @override
   String get guide_greenscore_logos_caption =>
-      'Chay Verde-Puntuación nisqa logotipokuna';
+      'Chay Green-Score nisqa logotipokuna';
 
   @override
   String get guide_greenscore_lca_title =>
@@ -4476,7 +4478,7 @@ class AppLocalizationsQu extends AppLocalizations {
 
   @override
   String get guide_greenscore_better_product_arg3_text =>
-      'Sustentable mikhuy akllayqa sasachakuymi sientekunman. Etiquetakunaqa pantasqam, willakuykunapas achka kutipim faltan. Verde-Puntuación nisqa ruwasqa karqan mana sasa kananpaq, **sut’i**, **ciencia nisqapi ruwasqa**, hinallataq **chuya** pachamamamanta chaninchayta qusunki mikhuy rurukunapaq, maypichus necesitasqaykipipuni: rantikuchkaptiyki.';
+      'Sustentable mikhuy akllayqa sasachakuymi sientekunman. Etiquetakunaqa pantasqam, willakuykunapas achka kutipim faltan. Green-Score nisqa ruwasqa karqan mana sasa kananpaq, **sut’i**, **ciencia nisqapi ruwasqa**, hinallataq **chuya** pachamamamanta chaninchayta qusunki mikhuy rurukunapaq, maypichus necesitasqaykipipuni: rantikuchkaptiyki.';
 
   @override
   String get guide_greenscore_better_product_arg4_title =>
@@ -4484,7 +4486,7 @@ class AppLocalizationsQu extends AppLocalizations {
 
   @override
   String get guide_greenscore_better_product_arg4_text =>
-      'Mana propiedad etiquetakuna hinachu, Verde-Puntuación yupayqa **tukuy kichasqa** chaymanta **pillapas chiqaqchasqa kayta atin**.';
+      'Mana propiedad etiquetakuna hinachu, Green-Score yupayqa **tukuy kichasqa** chaymanta **pillapas chiqaqchasqa kayta atin**.';
 
   @override
   String get guide_nova_title => 'Ultra-processed foods';
@@ -5319,7 +5321,7 @@ class AppLocalizationsQu extends AppLocalizations {
 
   @override
   String get prices_explanation_card_line1 =>
-      '**Open Prices** is a project to collect and share prices of products around the world 🌍. Open Prices is developed and maintained by Open Food Facts.';
+      '**Precios Abiertos** nisqaqa huk proyectom, pachantinpi rurukunapa chaninkunata huñunapaq hinaspa rakinapaq 🌍. Kichasqa Precios nisqakunaqa Kichasqa Mikhuy Chiqapkuna nisqawanmi ruwasqa hinaspa waqaychasqa.';
 
   @override
   String get explanation_card_learn_more_button => 'Learn more';
@@ -5628,7 +5630,7 @@ class AppLocalizationsQu extends AppLocalizations {
 
   @override
   String get preferences_legal_header =>
-      'Open Food Facts is a food products database **made by everyone, for everyone**.\nYou can use it to make better food choices, and as it is **open data**, anyone can **re-use it for any purpose**.';
+      'Kichasqa Mikhuy Chiqap willakuykunaqa mikhuy rurukunap willay tantana wasim **llapa runap rurasqan, llapa runapaq**.\nAswan allin mikhuy akllanapaq llamk\'achiy atikunki, chaymanta **kichasqa willay** kasqanrayku, pipas **imapaqpas wakmanta llamk\'achiyta atin**.';
 
   @override
   String get preferences_privacy_policy => 'Privacy policy';
@@ -5679,7 +5681,7 @@ class AppLocalizationsQu extends AppLocalizations {
 
   @override
   String get preferences_on_off_website_subtitle =>
-      'On the Open Food Facts website';
+      'Kichasqa Mikhuy Chiqap web nisqapi';
 
   @override
   String get preferences_manage_account_title => 'Cuentayta kamachiy';
@@ -5796,7 +5798,8 @@ class AppLocalizationsQu extends AppLocalizations {
   String get preferences_faq_faq_title => 'FAQ - Sapa kuti tapusqa tapukuykuna';
 
   @override
-  String get preferences_faq_off_ngo_title => 'The Open Food Facts NGO';
+  String get preferences_faq_off_ngo_title =>
+      'Kichasqa Mikhuymanta Chiqap ONG nisqa';
 
   @override
   String get preferences_about_information_title => 'Information';
@@ -5818,7 +5821,8 @@ class AppLocalizationsQu extends AppLocalizations {
       'Huknin virtual ruwayniykuman rispa involucrakuy';
 
   @override
-  String get preferences_connect_blog_title => 'The Open Food Facts blog';
+  String get preferences_connect_blog_title =>
+      'Kichasqa Mikhuy Chiqap blog nisqa';
 
   @override
   String get preferences_connect_blog_subtitle =>
@@ -5982,7 +5986,7 @@ class AppLocalizationsQu extends AppLocalizations {
 
   @override
   String get preferences_prices_newest_subtitle =>
-      'Latest prices added by the Open Prices community';
+      'Kichasqa Chanikuna ayllumanta yapasqa qhipa chaninkuna';
 
   @override
   String get preferences_prices_top_contributors_title =>
@@ -6031,7 +6035,7 @@ class AppLocalizationsQu extends AppLocalizations {
 
   @override
   String get preferences_page_contribute_project_subtitle =>
-      'Simple ways to help Open Food Facts';
+      'Kichasqa Mikhuy Chiqap yanapakuykunata yanapanapaq sasan ñankuna';
 
   @override
   String get preferences_page_faq_subtitle =>
@@ -6148,7 +6152,7 @@ class AppLocalizationsQu extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Kichasqa Mikhuy Chiqap willakuykunata simiykiman apamuy';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_qu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_qu.dart
@@ -654,7 +654,7 @@ class AppLocalizationsQu extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_rm.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_rm.dart
@@ -653,6 +653,9 @@ class AppLocalizationsRm extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_rm.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_rm.dart
@@ -653,7 +653,7 @@ class AppLocalizationsRm extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_ro.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ro.dart
@@ -662,6 +662,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get unknownBrand => 'Marcă necunoscută';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Produs cu nume necunoscut';
 
   @override
@@ -1386,15 +1389,15 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get product_improvement_add_nutrition_facts =>
-      'Add nutrition facts to calculate the Nutri-Score.';
+      'Adăugați informații nutriționale pentru a calcula Scorul Nutrițional.';
 
   @override
   String get product_improvement_add_nutrition_facts_and_category =>
-      'Add nutrition facts and a category to calculate the Nutri-Score.';
+      'Adăugați informații nutriționale și o categorie pentru a calcula Scorul Nutrițional.';
 
   @override
   String get product_improvement_categories_but_no_nutriscore =>
-      'The Nutri-Score for this product can\'t be calculated, which may be due to e.g. a non-standard category. If this is considered an error, please contact us.';
+      'Scorul Nutritiv pentru acest produs nu poate fi calculat, ceea ce se poate datora, de exemplu, unei categorii nestandard. Dacă aceasta este considerată o eroare, vă rugăm să ne contactați.';
 
   @override
   String get product_improvement_obsolete_nutrition_image =>
@@ -3589,7 +3592,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Începerea efectuării acțiunilor serverului pentru actualizările folksonomy stocate local';
 
   @override
   String get background_task_title_top_n =>
@@ -4133,11 +4136,11 @@ class AppLocalizationsRo extends AppLocalizations {
       'Nutri-Score necunoscut (calcul nou)';
 
   @override
-  String get nutriscore_not_applicable => 'Nutri-Score is not applicable';
+  String get nutriscore_not_applicable => 'Scorul nutrițional nu se aplică';
 
   @override
   String get nutriscore_not_applicable_new_formula =>
-      'Nutri-Score is not applicable (New calculation)';
+      'Scorul Nutri nu este aplicabil (calcul nou)';
 
   @override
   String get environmental_score_generic_new => 'Scor Ecologic';
@@ -4757,7 +4760,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_title =>
-      'What is Open Pet Food Facts?';
+      'Care sunt informațiile despre hrana pentru animale de companie?';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_paragraph1 =>
@@ -4769,7 +4772,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get guide_open_pet_food_facts_features_title =>
-      'Features of Open Pet Food Facts';
+      'Caracteristicile hranei deschise pentru animale de companie';
 
   @override
   String get guide_open_pet_food_facts_features_arg1_title =>
@@ -4926,7 +4929,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get guide_open_prices_what_is_open_prices_title =>
-      'What is Open Prices?';
+      'Ce sunt prețurile deschise?';
 
   @override
   String get guide_open_prices_what_is_open_prices_paragraph1 =>
@@ -4937,7 +4940,8 @@ class AppLocalizationsRo extends AppLocalizations {
       'There are currently few companies that own large databases of product prices at the barcode level. These prices are not freely available, but sold at a high price to private actors, researchers and other organizations that can afford them.';
 
   @override
-  String get guide_open_prices_how_title => 'How does Open Prices work?';
+  String get guide_open_prices_how_title =>
+      'Cum funcționează Prețurile Deschise?';
 
   @override
   String get guide_open_prices_how_paragraph1 =>
@@ -5005,7 +5009,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_title =>
-      'What is Open Products Facts?';
+      'Care sunt informațiile despre produsele deschise?';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_paragraph1 =>
@@ -5017,7 +5021,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get guide_open_products_facts_features_title =>
-      'Features of Open Products Facts';
+      'Caracteristici ale produselor deschise';
 
   @override
   String get guide_open_products_facts_features_text =>
@@ -6119,7 +6123,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get preferences_page_contribute_project_subtitle =>
-      'Simple ways to help Open Food Facts';
+      'Modalități simple de a ajuta la Open Food Informations';
 
   @override
   String get preferences_page_faq_subtitle =>
@@ -6234,7 +6238,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Adu informații despre alimentele deschise în limba ta';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_ro.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ro.dart
@@ -662,7 +662,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get unknownBrand => 'Marcă necunoscută';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Produs cu nume necunoscut';

--- a/packages/smooth_app/lib/l10n/app_localizations_ru.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ru.dart
@@ -663,6 +663,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get unknownBrand => 'Неизвестный бренд';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Неизвестный продукт';
 
   @override
@@ -2063,7 +2066,7 @@ class AppLocalizationsRu extends AppLocalizations {
       'Соя не из Европейского Союза';
 
   @override
-  String get edit_product_form_item_countries_title => 'Country';
+  String get edit_product_form_item_countries_title => 'Страна';
 
   @override
   String get edit_product_form_item_countries_hint =>
@@ -3045,7 +3048,7 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
-  String get prices_menu_know_more => 'Know more about Open Prices';
+  String get prices_menu_know_more => 'Узнайте больше об открытых ценах';
 
   @override
   String get dev_preferences_import_history_result_success => 'Готово';
@@ -3084,7 +3087,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get dev_mode_openprices_switch_env_title =>
-      'Switch between prices.openfoodfacts.org (PROD) and test env';
+      'Переключение между pricing.openfoodfacts.org (PROD) и тестовой средой';
 
   @override
   String get search_history_item_edit_tooltip =>
@@ -3603,7 +3606,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Начало выполнения действий сервера для обновлений folksonomy, хранящихся локально.';
 
   @override
   String get background_task_title_top_n =>
@@ -4959,7 +4962,7 @@ class AppLocalizationsRu extends AppLocalizations {
       'В настоящее время лишь немногие компании владеют большими базами данных цен на продукты на уровне штрих-кодов. Эти цены не находятся в свободном доступе, а продаются по высокой цене частным лицам, исследователям и другим организациям, которые могут себе их позволить.';
 
   @override
-  String get guide_open_prices_how_title => 'How does Open Prices work?';
+  String get guide_open_prices_how_title => 'Как работают цены открытия?';
 
   @override
   String get guide_open_prices_how_paragraph1 =>
@@ -5882,7 +5885,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get preferences_faq_discover_off_title => 'Discover Open Food Facts';
 
   @override
-  String get preferences_faq_discover_obf_title => 'Discover Open Beauty Facts';
+  String get preferences_faq_discover_obf_title =>
+      'Откройте для себя Open Beauty Factsе';
 
   @override
   String get preferences_faq_discover_opff_title =>
@@ -5899,7 +5903,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get preferences_faq_faq_title => 'FAQ — часто задаваемые вопросы';
 
   @override
-  String get preferences_faq_off_ngo_title => 'The Open Food Facts NGO';
+  String get preferences_faq_off_ngo_title => 'НПО «Открытые факты о еде»';
 
   @override
   String get preferences_about_information_title => 'Информация';
@@ -6285,7 +6289,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get location_map_details_postcode => 'Почтовый индекс';
 
   @override
-  String get location_map_details_country => 'Country';
+  String get location_map_details_country => 'Страна';
 
   @override
   String get location_map_details_coordinates => 'Координаты';

--- a/packages/smooth_app/lib/l10n/app_localizations_ru.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ru.dart
@@ -663,7 +663,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get unknownBrand => 'Неизвестный бренд';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Неизвестный продукт';

--- a/packages/smooth_app/lib/l10n/app_localizations_sa.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sa.dart
@@ -654,7 +654,7 @@ class AppLocalizationsSa extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_sa.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sa.dart
@@ -654,6 +654,9 @@ class AppLocalizationsSa extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3519,7 +3522,7 @@ class AppLocalizationsSa extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'स्थानीयरूपेण संगृहीतस्य folksonomy अद्यतनस्य कृते सर्वरक्रियाः कर्तुं आरभते';
 
   @override
   String get background_task_title_top_n =>

--- a/packages/smooth_app/lib/l10n/app_localizations_sc.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sc.dart
@@ -653,6 +653,9 @@ class AppLocalizationsSc extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_sc.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sc.dart
@@ -653,7 +653,7 @@ class AppLocalizationsSc extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_sd.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sd.dart
@@ -653,7 +653,7 @@ class AppLocalizationsSd extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_sd.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sd.dart
@@ -653,6 +653,9 @@ class AppLocalizationsSd extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3516,7 +3519,7 @@ class AppLocalizationsSd extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'مقامي طور تي ذخيرو ٿيل فولڪ سونامي اپڊيٽس لاءِ سرور ڪارروايون ڪرڻ شروع ڪري رهيو آهي';
 
   @override
   String get background_task_title_top_n =>
@@ -4082,7 +4085,7 @@ class AppLocalizationsSd extends AppLocalizations {
   String get environmental_score_not_applicable_new => 'گرين اسڪور لاڳو ناهي';
 
   @override
-  String get nova_group_generic_new => 'Ultra-processed foods - NOVA groups';
+  String get nova_group_generic_new => 'الٽرا پروسيس ٿيل کاڌو - نووا گروپس';
 
   @override
   String get nova_group_1 => 'NOVA Group 1';
@@ -4488,7 +4491,7 @@ class AppLocalizationsSd extends AppLocalizations {
   String get guide_nova_logos_caption => 'NOVA لوگو';
 
   @override
-  String get guide_nova_groups_title => 'The 4 NOVA groups';
+  String get guide_nova_groups_title => '4 نووا گروپ';
 
   @override
   String get guide_nova_groups_intro =>
@@ -5301,7 +5304,7 @@ class AppLocalizationsSd extends AppLocalizations {
 
   @override
   String get prices_explanation_card_line1 =>
-      '**Open Prices** is a project to collect and share prices of products around the world 🌍. Open Prices is developed and maintained by Open Food Facts.';
+      '**Open Prices** دنيا جي مختلف ملڪن ۾ شين جي قيمتن کي گڏ ڪرڻ ۽ شيئر ڪرڻ جو هڪ منصوبو آهي 🌍. Open Prices اوپن فوڊ فيڪٽس پاران تيار ۽ برقرار رکيا ويا آهن.';
 
   @override
   String get explanation_card_learn_more_button => 'Learn more';
@@ -5607,7 +5610,7 @@ class AppLocalizationsSd extends AppLocalizations {
 
   @override
   String get preferences_legal_header =>
-      'Open Food Facts is a food products database **made by everyone, for everyone**.\nYou can use it to make better food choices, and as it is **open data**, anyone can **re-use it for any purpose**.';
+      'اوپن فوڊ فيڪٽس هڪ کاڌي جي شين جو ڊيٽابيس آهي **هر ڪنهن پاران، هر ڪنهن لاءِ ٺاهيو ويو آهي**.\nتوهان ان کي بهتر کاڌي جي چونڊ ڪرڻ لاءِ استعمال ڪري سگهو ٿا، ۽ جيئن ته اهو **کليل ڊيٽا** آهي، ڪو به ان کي **ڪنهن به مقصد لاءِ ٻيهر استعمال ڪري سگهي ٿو**.';
 
   @override
   String get preferences_privacy_policy => 'Privacy policy';
@@ -5658,7 +5661,7 @@ class AppLocalizationsSd extends AppLocalizations {
 
   @override
   String get preferences_on_off_website_subtitle =>
-      'On the Open Food Facts website';
+      'اوپن فوڊ فيڪٽس ويب سائيٽ تي';
 
   @override
   String get preferences_manage_account_title => 'منهنجو اڪائونٽ منظم ڪريو';
@@ -5741,7 +5744,7 @@ class AppLocalizationsSd extends AppLocalizations {
 
   @override
   String get preferences_faq_nutriscore_subtitle =>
-      'Discover how the Nutri-Score is computed';
+      'دريافت ڪريو ته نيوٽري-اسڪور ڪيئن ڳڻيو ويندو آهي';
 
   @override
   String get preferences_faq_nutriscore_v2_subtitle =>
@@ -5771,7 +5774,7 @@ class AppLocalizationsSd extends AppLocalizations {
   String get preferences_faq_faq_title => 'سوال - اڪثر پڇيا ويندڙ سوال';
 
   @override
-  String get preferences_faq_off_ngo_title => 'The Open Food Facts NGO';
+  String get preferences_faq_off_ngo_title => 'دي اوپن فوڊ فيڪٽس اين جي او';
 
   @override
   String get preferences_about_information_title => 'Information';
@@ -5793,7 +5796,7 @@ class AppLocalizationsSd extends AppLocalizations {
       'اسان جي ورچوئل تقريب ۾ شرڪت ڪندي شامل ٿيو';
 
   @override
-  String get preferences_connect_blog_title => 'The Open Food Facts blog';
+  String get preferences_connect_blog_title => 'اوپن فوڊ فيڪٽس بلاگ';
 
   @override
   String get preferences_connect_blog_subtitle =>
@@ -5908,7 +5911,7 @@ class AppLocalizationsSd extends AppLocalizations {
 
   @override
   String get preferences_contributions_new_products_subtitle =>
-      'New products I added to Open Food Facts';
+      'اوپن فوڊ فيڪٽس ۾ مون نوان پراڊڪٽس شامل ڪيا آهن.';
 
   @override
   String get preferences_contributions_to_be_completed_title =>
@@ -5934,7 +5937,7 @@ class AppLocalizationsSd extends AppLocalizations {
 
   @override
   String get preferences_contributions_categorize_subtitle =>
-      'Help compute the Nutri-Score & Green-Score in your country';
+      'پنهنجي ملڪ ۾ نيوٽري-اسڪور ۽ گرين-اسڪور جي ڳڻپ ۾ مدد ڪريو.';
 
   @override
   String get preferences_prices_user_prices_subtitle => 'منهنجي ڏنل قيمتون';
@@ -6002,7 +6005,7 @@ class AppLocalizationsSd extends AppLocalizations {
 
   @override
   String get preferences_page_contribute_project_subtitle =>
-      'Simple ways to help Open Food Facts';
+      'کاڌي جي حقيقتن کي کولڻ ۾ مدد ڪرڻ جا آسان طريقا';
 
   @override
   String get preferences_page_faq_subtitle =>
@@ -6115,7 +6118,7 @@ class AppLocalizationsSd extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'پنهنجي ٻولي ۾ کليل کاڌي جا حقيقت آڻيو';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_sg.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sg.dart
@@ -653,7 +653,7 @@ class AppLocalizationsSg extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_sg.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sg.dart
@@ -653,6 +653,9 @@ class AppLocalizationsSg extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_si.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_si.dart
@@ -654,6 +654,9 @@ class AppLocalizationsSi extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3524,7 +3527,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'දේශීයව ගබඩා කර ඇති ජන විද්‍යාව යාවත්කාලීන කිරීම් සඳහා සේවාදායක ක්‍රියා සිදු කිරීමට පටන් ගැනීම';
 
   @override
   String get background_task_title_top_n =>
@@ -6124,7 +6127,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String get preferences_page_open_food_facts_labs_title =>
-      'Open Food Facts රසායනාගාර';
+      'Open Food Facts Labs';
 
   @override
   String get preferences_root_account_title => 'Account';

--- a/packages/smooth_app/lib/l10n/app_localizations_si.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_si.dart
@@ -654,7 +654,7 @@ class AppLocalizationsSi extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_sk.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sk.dart
@@ -663,7 +663,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get unknownBrand => 'Neznáma značka';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Neznámy názov výrobku';

--- a/packages/smooth_app/lib/l10n/app_localizations_sk.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sk.dart
@@ -663,6 +663,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get unknownBrand => 'Neznáma značka';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Neznámy názov výrobku';
 
   @override
@@ -2935,7 +2938,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get prices_proof_find => 'Vyberte potvrdenie';
 
   @override
-  String get prices_proof_change => 'Change proof';
+  String get prices_proof_change => 'Dôkaz o zmene';
 
   @override
   String get prices_proof_receipt => 'Účtenka';
@@ -2999,7 +3002,8 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
-  String get prices_menu_know_more => 'Know more about Open Prices';
+  String get prices_menu_know_more =>
+      'Získajte viac informácií o otvorených cenách';
 
   @override
   String get dev_preferences_import_history_result_success => 'Hotovo';
@@ -3090,7 +3094,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String search_proof_title(String user) {
-    return 'Proof from \"$user\"';
+    return 'Dôkaz z „$user“';
   }
 
   @override
@@ -3552,7 +3556,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Spustenie vykonávania akcií servera pre lokálne uložené aktualizácie folksonomy';
 
   @override
   String get background_task_title_top_n =>
@@ -4161,7 +4165,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get faq_title_install_product =>
-      'Install Open Products Facts to create a products database to extend the life of objects';
+      'Nainštalujte si fakty o otvorených produktoch na vytvorenie databázy produktov na predĺženie životnosti objektov';
 
   @override
   String get faq_nutriscore_nutriscore =>
@@ -4421,35 +4425,35 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get guide_greenscore_bonuses_penalties_intro =>
-      'To reward better products within a category, we then apply **bonuses & penalties based on several criterion**:';
+      'Aby sme odmenili lepšie produkty v rámci kategórie, uplatňujeme **bonusy a penalizácie na základe niekoľkých kritérií**:';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg1_title => 'Spôsob výroby';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg1_text =>
-      'A **bonus** is awarded to products that have an **official label, a label or a certification that guarantees environmental benefits** (organic, fair trade, HVE, Label Rouge, Bleu Blanc Cœur, MSC/ASC).';
+      '**Bonus** sa udeľuje produktom, ktoré majú **oficiálnu etiketu, etiketu alebo certifikáciu, ktorá zaručuje environmentálne prínosy** (bio, fair trade, HVE, Label Rouge, Bleu Blanc Cœur, MSC/ASC).';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg2_title => 'Pôvod surovín';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg2_text =>
-      'A **bonus** is awarded based on the origin of the ingredients. This bonus takes into account the **impact on transportation** and also the **environmental policy** of each producer\'s country.';
+      '**Bonus** sa udeľuje na základe pôvodu surovín. Tento bonus zohľadňuje **vplyv na dopravu** a tiež **environmentálnu politiku** krajiny každého výrobcu.';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg3_title => 'Ohrozené druhy';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg3_text =>
-      'A **penalty** is given to products that contain ingredients that have significant **negative impacts on biodiversity and ecosystems**, such as palm oil, the production of which is responsible for massive deforestation.';
+      '**Pokuta** sa udeľuje výrobkom, ktoré obsahujú zložky s významným **negatívnym vplyvom na biodiverzitu a ekosystémy**, ako napríklad palmový olej, ktorého výroba je zodpovedná za masívne odlesňovanie.';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg4_title => 'Balenie';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg4_text =>
-      'A **penalty** is calculated to take into account the **circularity of packaging** (use of recycled raw material and recyclability) and overpacking.';
+      'Výška pokuty sa vypočíta s ohľadom na **obehovosť obalov** (použitie recyklovaných surovín a recyklovateľnosť) a nadmerné balenie.';
 
   @override
   String get guide_greenscore_transparency_title =>
@@ -4457,19 +4461,19 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get guide_greenscore_transparency_intro1 =>
-      'To accurately calculate the Green-Score, it is necessary to have **information which is not necessarily specified on the packaging** (such as the origin and the exact percentage of each ingredient) or which is rarely available in usable form (such as a list of all the components of the packaging with the precise types of plastics used).';
+      'Na presný výpočet Green-Score je potrebné mať **informácie, ktoré nie sú nevyhnutne uvedené na obale** (ako napríklad pôvod a presné percento každej zložky) alebo ktoré sú zriedkavo dostupné v použiteľnej forme (ako napríklad zoznam všetkých zložiek obalu s presným uvedením použitých typov plastov).';
 
   @override
   String get guide_greenscore_transparency_intro2 =>
-      '**Average values are used when this information is not yet available**, but we are now calling on everyone to help us collect this information which will be very useful for the Green-Score but also for many other uses.';
+      '**Priemerné hodnoty sa používajú, keď tieto informácie ešte nie sú k dispozícii**, ale teraz vyzývame všetkých, aby nám pomohli zhromaždiť tieto informácie, ktoré budú veľmi užitočné pre Green-Score, ale aj pre mnoho ďalších použití.';
 
   @override
   String get guide_greenscore_transparency_arg1_title =>
-      'How citizens can help?';
+      'Ako môžu občania pomôcť?';
 
   @override
   String get guide_greenscore_transparency_arg1_text =>
-      'All citizens can help us gather and structure the information that is present on products or that can be deduced from them, such as information on **packaging**: \"Mission Emballages\": a large-scale collaborative inventory of packaging for all food products (in French).';
+      'Všetci občania nám môžu pomôcť zhromaždiť a štruktúrovať informácie, ktoré sú uvedené na výrobkoch alebo ktoré sa z nich dajú odvodiť, ako napríklad informácie o **obaloch**: „Misia Emballages“: rozsiahly kolaboratívny inventár obalov pre všetky potravinárske výrobky (vo francúzštine).';
 
   @override
   String get guide_greenscore_transparency_arg2_title =>
@@ -4543,7 +4547,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get guide_nova_groups_arg1_text =>
-      'Unprocessed (or natural) foods are the **edible parts of plants** (seeds, fruits, leaves, stems, roots) **or animals** (muscle, offal, eggs, milk), as well as fungi, algae, and water, after being separated from nature.';
+      'Nespracované (alebo prírodné) potraviny sú **jedlé časti rastlín** (semená, plody, listy, stonky, korene) **alebo zvierat** (svaly, vnútornosti, vajcia, mlieko), ako aj huby, riasy a voda po oddelení od prírody.';
 
   @override
   String get guide_nova_groups_arg2_title => 'Spracované kulinárske prísady';
@@ -4575,7 +4579,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg1_text =>
-      'Many are **derived from further processing of food constituents**, such as hydrogenated or interesterified oils, hydrolyzed proteins, soy protein isolate, maltodextrin, invert sugar, and high-fructose corn syrup.';
+      'Mnohé z nich pochádzajú z **ďalšieho spracovania zložiek potravín**, ako sú hydrogenované alebo interesterifikované oleje, hydrolyzované bielkoviny, izolát sójových bielkovín, maltodextrín, invertný cukor a kukuričný sirup s vysokým obsahom fruktózy.';
 
   @override
   String get guide_nova_explanations_arg2_title =>
@@ -4583,7 +4587,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg2_text =>
-      'Additives in ultra-processed foods include some that are also used in processed foods, such as preservatives, antioxidants, and stabilizers. Classes of additives found only in ultra-processed products include those used **to imitate or enhance the sensory qualities of foods or to disguise unpalatable aspects of the final product**. These additives include dyes and other colors, color stabilizers; flavors, flavor enhancers, non-sugar sweeteners; and processing aids such as carbonating, firming, bulking and anti-bulking agents, de-foaming, anti-caking and glazing agents, emulsifiers, sequestrants, and humectants.';
+      'Medzi prísady v ultraspracovaných potravinách patria niektoré, ktoré sa používajú aj v spracovaných potravinách, ako sú konzervačné látky, antioxidanty a stabilizátory. Medzi triedy prísad, ktoré sa nachádzajú iba v ultraspracovaných výrobkoch, patria tie, ktoré sa používajú **na napodobnenie alebo zlepšenie senzorických vlastností potravín alebo na zamaskovanie nechutných aspektov konečného výrobku**. Medzi tieto prísady patria farbivá a iné farby, stabilizátory farieb; arómy, zvýrazňovače chuti, necukrové sladidlá; a pomocné látky pri spracovaní, ako sú sýtiace, spevňujúce, objemové a protihrudkujúce látky, odpeňovacie, protihrudkujúce a leštiace látky, emulgátory, sekvestranty a zvlhčovadlá.';
 
   @override
   String get guide_nova_explanations_arg3_title =>
@@ -4591,7 +4595,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg3_text =>
-      '**A multitude of sequences of processes is used** to combine the usually many ingredients and to create the final product (hence \'ultra-processed\'). The processes include several **with no domestic equivalents**, such as hydrogenation and hydrolysation, extrusion and moulding, and pre-processing for frying.';
+      'Na skombinovanie zvyčajne veľkého množstva zložiek a vytvorenie konečného produktu (odtiaľ „ultra spracovaný“) sa používa **množstvo postupov**. Medzi tieto procesy patrí niekoľko **ktorých neexistuje žiadny domáci ekvivalent**, ako je hydrogenácia a hydrolýza, extrúzia a tvarovanie a predbežné spracovanie na vyprážanie.';
 
   @override
   String get guide_nova_explanations_arg4_title =>
@@ -4599,104 +4603,105 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg4_text =>
-      '**The overall purpose of ultra-processing is to create branded**, **convenient** (durable, ready to consume), **attractive** (hyper-palatable) and **highly profitable** (low-cost ingredients) food products designed to displace all other food groups. Ultra-processed food products are usually packaged attractively and marketed intensively.';
+      'Celkovým cieľom ultraspracovania je vytvoriť značkové, pohodlné (trvanlivé, pripravené na konzumáciu), atraktívne (hyperchutné) a vysoko ziskové (s nízkonákladovými zložkami) potravinárske výrobky určené na nahradenie všetkých ostatných skupín potravín. Ultraspracované potraviny sú zvyčajne atraktívne balené a intenzívne sa predávajú.';
 
   @override
-  String get guide_nova_explanations_arg5_title => 'A health hazard';
+  String get guide_nova_explanations_arg5_title => 'Zdravotné riziko';
 
   @override
   String get guide_nova_explanations_arg5_text =>
-      'Since 2018, with NutriNet-Santé, the first links between **the consumption of ultra-processed foods and increased risks of cancer, cardiovascular diseases, and diabetes have been highlighted**. Today, more than 90 studies worldwide confirm these findings.\nThe strongest associations relate to **obesity, cardiovascular mortality, and depressive symptoms**. On children, the effects are primarily observed on weight and lipid imbalances.';
+      'Od roku 2018 boli vďaka projektu NutriNet-Santé zdôraznené prvé súvislosti medzi **konzumáciou ultraspracovaných potravín a zvýšeným rizikom rakoviny, kardiovaskulárnych ochorení a cukrovky**. Dnes tieto zistenia potvrdzuje viac ako 90 štúdií na celom svete.\nNajsilnejšie súvislosti sa týkajú **obezity, kardiovaskulárnej úmrtnosti a depresívnych symptómov**. U detí sa účinky pozorujú predovšetkým na hmotnosti a nerovnováhe lipidov.';
 
   @override
   String get guide_nova_explanations_arg6_title =>
-      'Countries recommend limiting them';
+      'Krajiny odporúčajú ich obmedzenie';
 
   @override
   String get guide_nova_explanations_arg6_text =>
-      'Some countries use the NOVA groups for their dietary guidelines or goals, for instance:\n\n- **🇧🇷 Brazil**\'s dietary guidelines **recommend to limit consumption** of processed food and avoid ultra-processed food.\n\n- **🇫🇷 France**\'s public health nutritional policy goals for 2018-2022 aims to **reduce consumption of group 4 ultra-processed foods by 20%**.';
+      'Niektoré krajiny používajú skupiny NOVA pre svoje stravovacie odporúčania alebo ciele, napríklad:\n\n- **🇧🇷 Brazílske** stravovacie odporúčania **odporúčajú obmedziť** konzumáciu spracovaných potravín a vyhýbať sa ultraspracovaným potravinám.\n\n- **🇫🇷 Francúzsko** má za cieľ **znížiť konzumáciu ultraspracovaných potravín skupiny 4 o 20 %**.';
 
   @override
   String get guide_nova_share_link => 'https://world.openfoodfacts.org/nova';
 
   @override
-  String get guide_open_food_facts_title => 'Welcome to Open Food Facts!';
+  String get guide_open_food_facts_title =>
+      'Vitajte na stránke Otvorené fakty o jedle!';
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_title =>
-      'What is Open Food Facts?';
+      'Čo je to Otvorené fakty o jedle?';
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_paragraph1 =>
-      'Open Food Facts is a **collaborative**, **free**, and **open** database of food products from around the world.';
+      'Open Food Facts je **kolaboratívna**, **bezplatná** a **otvorená** databáza potravinárskych výrobkov z celého sveta.';
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_paragraph2 =>
-      'We believe that everyone should have access to information about what they eat. By collecting data on ingredients, allergens, nutrition facts, and more, **we empower consumers to make informed choices** and drive the food industry **toward greater transparency**.';
+      'Veríme, že každý by mal mať prístup k informáciám o tom, čo konzumuje. Zhromažďovaním údajov o zložkách, alergénoch, nutričných hodnotách a ďalších údajoch **posilňujeme spotrebiteľov, aby sa mohli informovane rozhodovať** a posúvame potravinársky priemysel **k väčšej transparentnosti**.';
 
   @override
-  String get guide_open_food_facts_features_title =>
-      'Features of Open Food Facts';
+  String get guide_open_food_facts_features_title => 'Funkcie Open Food Facts';
 
   @override
   String get guide_open_food_facts_features_arg1_title =>
-      'Get alerts for your unwanted ingredients';
+      'Dostávajte upozornenia na nežiaduce zložky';
 
   @override
-  String get guide_open_food_facts_tips_title => 'Tips for taking great photos';
+  String get guide_open_food_facts_tips_title =>
+      'Tipy na fotografovanie skvelých fotografií';
 
   @override
-  String get guide_open_food_facts_tips_arg1_title => 'Don’ts';
+  String get guide_open_food_facts_tips_arg1_title => 'Čo nerobiť';
 
   @override
   String get guide_open_food_facts_tips_arg1_text1 =>
-      'Avoid shadows and glare.';
+      'Vyhnite sa tieňom a oslneniu.';
 
   @override
   String get guide_open_food_facts_tips_arg1_text2 =>
-      'No blurry or out-of-focus text.';
+      'Žiadny rozmazaný alebo nezaostrený text.';
 
   @override
   String get guide_open_food_facts_tips_arg1_text3 =>
-      'Don\'t crop out parts of the text.';
+      'Nevystrihujte časti textu.';
 
   @override
-  String get guide_open_food_facts_tips_arg1_text4 => 'Avoid busy backgrounds.';
+  String get guide_open_food_facts_tips_arg1_text4 =>
+      'Vyhnite sa rušnému pozadiu.';
 
   @override
-  String get guide_open_food_facts_tips_arg2_title => 'Do’s';
+  String get guide_open_food_facts_tips_arg2_title => 'Čo robiť';
 
   @override
   String get guide_open_food_facts_tips_arg2_text1 =>
-      'Use good, even lighting.';
+      'Používajte dobré, rovnomerné osvetlenie.';
 
   @override
   String get guide_open_food_facts_tips_arg2_text2 =>
-      'Ensure text is sharp and readable.';
+      'Uistite sa, že text je ostrý a čitateľný.';
 
   @override
   String get guide_open_food_facts_tips_arg2_text3 =>
-      'Capture the entire ingredients list.';
+      'Zaznamenajte si celý zoznam ingrediencií.';
 
   @override
   String get guide_open_food_facts_tips_arg2_text4 =>
-      'Keep the product on a flat surface.';
+      'Výrobok uchovávajte na rovnom povrchu.';
 
   @override
   String get guide_open_food_facts_scores_title =>
-      'Help us build the \"Wikipedia of Food\"';
+      'Pomôžte nám vytvoriť „Wikipédiu jedla“';
 
   @override
   String get guide_open_food_facts_scores_arg1_title =>
-      'A score on the nutritional quality';
+      'Skóre za nutričnú kvalitu';
 
   @override
   String get guide_open_food_facts_scores_arg2_title =>
-      'A score to avoid ultra-processed foods';
+      'Skóre, ako sa vyhnúť ultraspracovaným potravinám';
 
   @override
-  String get guide_open_food_facts_scores_arg3_title =>
-      'A score for the planet';
+  String get guide_open_food_facts_scores_arg3_title => 'Skóre pre planétu';
 
   @override
   String get guide_open_food_facts_share_link =>
@@ -4704,236 +4709,238 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get guide_open_pet_food_facts_title =>
-      'Welcome to Open Pet Food Facts!';
+      'Vitajte na stránke Open Pet Food Facts!';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_title =>
-      'What is Open Pet Food Facts?';
+      'Čo je Open Pet Food Facts?';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_paragraph1 =>
-      'Open Pet Food Facts extends our mission to our furry friends! It\'s a **database of pet food products for cats, dogs, and other companions**.';
+      'Open Pet Food Facts rozširuje naše poslanie aj na našich chlpatých priateľov! Je to **databáza krmiva pre mačky, psy a iných domácich miláčikov**.';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_paragraph2 =>
-      'We gather information on **ingredients**, **nutritional analysis**, and feeding guidelines to help pet owners choose the best food for their animals\' needs.';
+      'Zhromažďujeme informácie o **zložkách**, **nutričnej analýze** a pokynoch na kŕmenie, aby sme majiteľom domácich zvierat pomohli vybrať si najlepšie krmivo pre potreby ich zvierat.';
 
   @override
   String get guide_open_pet_food_facts_features_title =>
-      'Features of Open Pet Food Facts';
+      'Vlastnosti Open Pet Food Facts';
 
   @override
   String get guide_open_pet_food_facts_features_arg1_title =>
-      'Get alerts for your unwanted ingredients';
+      'Dostávajte upozornenia na nežiaduce zložky';
 
   @override
   String get guide_open_pet_food_facts_features_arg1_paragraph1 =>
-      'Is your pet allergic to any ingredients? You can set a list of cosmetic ingredients to avoid, right in the app!';
+      'Je váš maznáčik alergický na nejaké zložky? Priamo v aplikácii si môžete nastaviť zoznam kozmetických zložiek, ktorým sa chcete vyhnúť!';
 
   @override
   String get guide_open_pet_food_facts_tips_title =>
-      'Tips for taking great photos';
+      'Tipy na fotografovanie skvelých fotografií';
 
   @override
-  String get guide_open_pet_food_facts_tips_arg1_title => 'Don’ts';
+  String get guide_open_pet_food_facts_tips_arg1_title => 'Čo nerobiť';
 
   @override
   String get guide_open_pet_food_facts_tips_arg1_text1 =>
-      'Avoid shadows and glare.';
+      'Vyhnite sa tieňom a oslneniu.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg1_text2 =>
-      'No blurry or out-of-focus text.';
+      'Žiadny rozmazaný alebo nezaostrený text.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg1_text3 =>
-      'Don\'t crop out parts of the text.';
+      'Nevystrihujte časti textu.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg1_text4 =>
-      'Avoid busy backgrounds.';
+      'Vyhnite sa rušnému pozadiu.';
 
   @override
-  String get guide_open_pet_food_facts_tips_arg2_title => 'Do’s';
+  String get guide_open_pet_food_facts_tips_arg2_title => 'Čo robiť';
 
   @override
   String get guide_open_pet_food_facts_tips_arg2_text1 =>
-      'Use good, even lighting.';
+      'Používajte dobré, rovnomerné osvetlenie.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg2_text2 =>
-      'Ensure text is sharp and readable.';
+      'Uistite sa, že text je ostrý a čitateľný.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg2_text3 =>
-      'Capture the entire ingredients list.';
+      'Zaznamenajte si celý zoznam ingrediencií.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg2_text4 =>
-      'Keep the product on a flat surface.';
+      'Výrobok uchovávajte na rovnom povrchu.';
 
   @override
-  String get guide_open_pet_food_facts_scores_title => 'A note on scoring';
+  String get guide_open_pet_food_facts_scores_title => 'Poznámka k bodovaniu';
 
   @override
   String get guide_open_pet_food_facts_scores_paragraph1 =>
-      'Developing a scoring system for pet food **is not a priority right now**. The methodology would be complex, as nutritional needs vary greatly by species, age, and health condition. We haven’t found any independant scientific team yet, able to develop such a score.';
+      'Vytvorenie systému hodnotenia krmiva pre domáce zvieratá **nie je momentálne prioritou**. Metodika by bola zložitá, pretože nutričné potreby sa značne líšia v závislosti od druhu, veku a zdravotného stavu. Zatiaľ sme nenašli žiadny nezávislý vedecký tím, ktorý by bol schopný vyvinúť takéto hodnotenie.';
 
   @override
   String get guide_open_pet_food_facts_share_link =>
       'https://world-sk.openpetfoodfacts.org/discover';
 
   @override
-  String get guide_open_beauty_facts_title => 'Welcome to Open Beauty Facts!';
+  String get guide_open_beauty_facts_title =>
+      'Vitajte na stránke Otvorené fakty o kráse!';
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_title =>
-      'What is Open Beauty Facts?';
+      'Čo je to Otvorené fakty o kráse?';
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_paragraph1 =>
-      'Open Beauty Facts is a collaborative database of **cosmetic products**.';
+      'Open Beauty Facts je spoločná databáza **kozmetických produktov**.';
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_paragraph2 =>
-      'Our goal is to decipher ingredient lists to help you **understand what\'s in your personal care items**. From moisturizers to makeup, we collect data on ingredients, allergens, and packaging to promote transparency in the cosmetics industry.';
+      'Naším cieľom je rozlúštiť zoznamy zložiek, aby ste **pochopili, čo sa nachádza vo vašich produktoch osobnej starostlivosti**. Od hydratačných krémov až po mejkap zhromažďujeme údaje o zložkách, alergénoch a obaloch s cieľom podporiť transparentnosť v kozmetickom priemysle.';
 
   @override
   String get guide_open_beauty_facts_features_title =>
-      'Features of Open Beauty Facts';
+      'Funkcie Open Beauty Facts';
 
   @override
   String get guide_open_beauty_facts_features_arg1_title =>
-      'Get alerts for your unwanted ingredients';
+      'Dostávajte upozornenia na nežiaduce zložky';
 
   @override
   String get guide_open_beauty_facts_features_arg1_paragraph1 =>
-      'Are you allergic to any ingredients? Want to avoid comedogen substances? Want to steer away from controversial components ? You can set a list of cosmetic ingredients to avoid, right in the app!';
+      'Ste alergický/á na nejaké zložky? Chcete sa vyhnúť komedogénnym látkam? Chcete sa vyhnúť kontroverzným zložkám? Priamo v aplikácii si môžete nastaviť zoznam kozmetických zložiek, ktorým sa chcete vyhnúť!';
 
   @override
   String get guide_open_beauty_facts_tips_title =>
-      'Tips for taking great photos';
+      'Tipy na fotografovanie skvelých fotografií';
 
   @override
-  String get guide_open_beauty_facts_tips_arg1_title => 'Don’ts';
+  String get guide_open_beauty_facts_tips_arg1_title => 'Čo nerobiť';
 
   @override
   String get guide_open_beauty_facts_tips_arg1_text1 =>
-      'Avoid shadows and glare.';
+      'Vyhnite sa tieňom a oslneniu.';
 
   @override
   String get guide_open_beauty_facts_tips_arg1_text2 =>
-      'No blurry or out-of-focus text.';
+      'Žiadny rozmazaný alebo nezaostrený text.';
 
   @override
   String get guide_open_beauty_facts_tips_arg1_text3 =>
-      'Don\'t crop out parts of the text.';
+      'Nevystrihujte časti textu.';
 
   @override
   String get guide_open_beauty_facts_tips_arg1_text4 =>
-      'Avoid busy backgrounds.';
+      'Vyhnite sa rušnému pozadiu.';
 
   @override
-  String get guide_open_beauty_facts_tips_arg2_title => 'Do’s';
+  String get guide_open_beauty_facts_tips_arg2_title => 'Čo robiť';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text1 =>
-      'Use good, even lighting.';
+      'Používajte dobré, rovnomerné osvetlenie.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text2 =>
-      'Ensure text is sharp and readable.';
+      'Uistite sa, že text je ostrý a čitateľný.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text3 =>
-      'Capture the entire ingredients list.';
+      'Zaznamenajte si celý zoznam ingrediencií.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text4 =>
-      'Take as many picture as need if the bottle is curved.';
+      'Ak je fľaša zakrivená, urobte toľko fotiek, koľko potrebujete.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text5 =>
-      'You might need to peel the label to see the list of ingredients.';
+      'Možno budete musieť odlepiť štítok, aby ste videli zoznam zložiek.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text6 =>
-      'Keep the product on a flat surface.';
+      'Výrobok uchovávajte na rovnom povrchu.';
 
   @override
-  String get guide_open_beauty_facts_scores_title => 'A note on scoring';
+  String get guide_open_beauty_facts_scores_title => 'Poznámka k bodovaniu';
 
   @override
   String get guide_open_beauty_facts_scores_paragraph1 =>
-      'Unlike food products, the world of cosmetics **does not have a universally recognized, government-backed scoring system like the Nutri-Score**. Ingredient effects can be highly personal and depend on skin type, allergies, and individual concerns.';
+      'Na rozdiel od potravinárskych výrobkov, svet kozmetiky **nemá všeobecne uznávaný, vládou podporovaný systém hodnotenia ako Nutri-Score**. Účinky zložiek môžu byť veľmi individuálne a závisia od typu pleti, alergií a individuálnych obáv.';
 
   @override
   String get guide_open_beauty_facts_share_link =>
       'https://world-sk.openbeautyfacts.org/discover';
 
   @override
-  String get guide_open_prices_title => 'Welcome to Open Prices!';
+  String get guide_open_prices_title => 'Vitajte v sekcii Otvorené ceny!';
 
   @override
   String get guide_open_prices_what_is_open_prices_title =>
-      'What is Open Prices?';
+      'Čo sú to otváracie ceny?';
 
   @override
   String get guide_open_prices_what_is_open_prices_paragraph1 =>
-      'Open Prices is a project to **collect and share prices of products around the world**. It\'s a publicly available dataset that can be used for research, analysis, and more. Open Prices is developed and maintained by Open Food Facts.';
+      'Open Prices je projekt na **zhromažďovanie a zdieľanie cien produktov z celého sveta**. Ide o verejne dostupný súbor údajov, ktorý možno použiť na výskum, analýzu a ďalšie účely. Open Prices vyvíja a spravuje spoločnosť Open Food Facts.';
 
   @override
   String get guide_open_prices_what_is_open_prices_paragraph2 =>
       'There are currently few companies that own large databases of product prices at the barcode level. These prices are not freely available, but sold at a high price to private actors, researchers and other organizations that can afford them.';
 
   @override
-  String get guide_open_prices_how_title => 'How does Open Prices work?';
+  String get guide_open_prices_how_title => 'Ako fungujú otváracie ceny?';
 
   @override
   String get guide_open_prices_how_paragraph1 =>
-      '**We are crowdsourcing an open-source dataset of prices**. Prices can be added by users via this web app, or via the official Open Food Facts mobile app. Retailers or third-party apps can contribute as well by using our API.';
+      '**Zhromažďujeme súbor údajov o cenách s otvoreným zdrojovým kódom**. Ceny môžu pridávať používatelia prostredníctvom tejto webovej aplikácie alebo prostredníctvom oficiálnej mobilnej aplikácie Open Food Facts. Prispieť môžu aj maloobchodníci alebo aplikácie tretích strán pomocou nášho API.';
 
   @override
   String get guide_open_prices_how_arg1_title =>
-      'Collect photos of price tags in aisles';
+      'Zbierajte fotografie cenovok v uličkách';
 
   @override
-  String get guide_open_prices_how_arg2_title => 'Collect photos of receipts';
+  String get guide_open_prices_how_arg2_title =>
+      'Zbierajte fotografie účteniek';
 
   @override
-  String get guide_open_prices_why_title =>
-      'Why is Open Food Facts doing this ?';
+  String get guide_open_prices_why_title => 'Prečo to Open Food Facts robí?';
 
   @override
   String get guide_open_prices_why_paragraph1 =>
-      'Price information is of paramount importance to understand food systems. It\'s a key factor in understanding the cost of food and to promote healthier diets. Opening price data is a way to make it easier for researchers, journalists, and citizens to **have a better understanding of how food prices vary geographically and in time**.';
+      'Informácie o cenách sú mimoriadne dôležité pre pochopenie potravinových systémov. Sú kľúčovým faktorom pre pochopenie nákladov na potraviny a pre podporu zdravšieho stravovania. Údaje o počiatočných cenách sú spôsob, ako uľahčiť výskumníkom, novinárom a občanom **lepšie pochopenie toho, ako sa ceny potravín menia geograficky a v čase**.';
 
   @override
   String get guide_open_prices_why_arg1_title =>
-      'Track the evolution of prices over time';
+      'Sledujte vývoj cien v priebehu času';
 
   @override
   String get guide_open_prices_why_arg1_text =>
-      'See the **evolution of prices**: shrinkflation, cheapflation, we can track them together!';
+      'Pozrite sa na **vývoj cien**: zmenšujúca sa inflácia, lacná inflácia, môžeme ich sledovať spoločne!';
 
   @override
-  String get guide_open_prices_why_arg2_title => 'Compare prices near you';
+  String get guide_open_prices_why_arg2_title =>
+      'Porovnajte ceny vo vašom okolí';
 
   @override
   String get guide_open_prices_why_arg2_text =>
-      'As we get more prices, you can spot **the cheapest stores around you**.';
+      'Ako budeme dostávať viac cien, môžete nájsť **najlacnejšie obchody vo vašom okolí**.';
 
   @override
   String get guide_open_prices_scrapping_title =>
-      'Did you consider scraping prices from retailers\' websites?';
+      'Zvažovali ste zhromaždenie cien z webových stránok predajcov?';
 
   @override
   String get guide_open_prices_scrapping_paragraph1 =>
-      'For legal and technical reasons, **we don\'t consider scraping prices from retailers\' websites as a valid way to contribute to Open Prices**. We want to make sure that the prices we collect are accurate and up-to-date, and receiving scraped prices from contributors doesn\'t allow us to do that.';
+      'Z právnych a technických dôvodov **nepovažujeme získavanie cien z webových stránok maloobchodníkov za platný spôsob prispievania do Open Prices**. Chceme sa uistiť, že ceny, ktoré zhromažďujeme, sú presné a aktuálne, a prijímanie získaných cien od prispievateľov nám to neumožňuje.';
 
   @override
   String get guide_open_prices_scrapping_paragraph2 =>
-      'Price scraping is a considered option in a future version of Open Prices, but it would be done by Open Prices itself so that we can have a proof of the price based on the HTML page.';
+      'Zber údajov o cenách je v budúcej verzii Open Prices zvažovanou možnosťou, ale vykonával by ho samotný Open Prices, aby sme mali dôkaz o cene na základe HTML stránky.';
 
   @override
   String get guide_open_prices_retailers_title =>
@@ -4941,7 +4948,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get guide_open_prices_retailers_paragraph1 =>
-      'You can contribute prices by using our API.\nIf you want to contribute prices at scale, please get in touch with us at prices@openfoodfacts.org.';
+      'Ceny môžete prispieť pomocou nášho API.\nAk chcete prispieť cenami vo veľkom, kontaktujte nás na adrese prices@openfoodfacts.org.';
 
   @override
   String get guide_open_prices_share_link =>
@@ -4949,88 +4956,88 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get guide_open_products_facts_title =>
-      'Welcome to Open Products Facts!';
+      'Vitajte na stránke Otvorené fakty o produktoch!';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_title =>
-      'What is Open Products Facts?';
+      'Čo sú to fakty o otvorených produktoch?';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_paragraph1 =>
-      'Open Products Facts is a massive, open database for **any product with a barcode, which is not food, cosmetic or pet food**.';
+      'Open Products Facts je rozsiahla otvorená databáza pre **akýkoľvek produkt s čiarovým kódom, ktorý nie je potravinou, kozmetikou ani krmivom pre domáce zvieratá**.';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_paragraph2 =>
-      'From **electronics** to **toys**, and **clothes** to **cleaning supplies**, if it has a barcode, it can be added. This project aims to create an \"Internet of Things\" for everyday objects, making information about them universally accessible.';
+      'Od **elektroniky** po **hračky** a od **oblečenia** po **čistiace prostriedky**, ak má niečo čiarový kód, je možné ho pridať. Cieľom tohto projektu je vytvoriť „internet vecí“ pre predmety každodennej potreby a sprístupniť informácie o nich univerzálne.';
 
   @override
   String get guide_open_products_facts_features_title =>
-      'Features of Open Products Facts';
+      'Funkcie otvorených produktov Fakty';
 
   @override
   String get guide_open_products_facts_features_text =>
-      'Open Products Facts aims to provide consumers to **extend the life of objects** by providing the circular solutions to maintain, **repair**, **recycle** their objects or give them a new owner.';
+      'Cieľom Open Products Facts je poskytnúť spotrebiteľom možnosť **predĺžiť životnosť predmetov** poskytovaním obehových riešení na údržbu, **opravu**, **recykláciu** ich predmetov alebo im dať nového majiteľa.';
 
   @override
   String get guide_open_products_facts_features_arg1_title =>
-      'Carbon footprints for some products';
+      'Uhlíková stopa niektorých produktov';
 
   @override
   String get guide_open_products_facts_features_arg1_text =>
-      '**Impact CO2** by French Environment Authority ADEME provides the **carbon impact** of many categories, make sure to categorize products precisely.';
+      '**Vplyv CO2** od francúzskeho úradu pre životné prostredie ADEME poskytuje **vplyv uhlíka** z mnohých kategórií, uistite sa, že produkty presne kategorizujete.';
 
   @override
   String get guide_open_products_facts_features_arg2_title =>
-      'Reparability index for many products';
+      'Index opraviteľnosti pre mnoho produktov';
 
   @override
   String get guide_open_products_facts_features_arg2_text =>
-      'Whenever a French reparability index is available, we’ll display it. Moreover, **you can start collecting the variables using the Folksonomy Engine**; so that we can recompute it ourselves in the future, even in countries where it’s not available.';
+      'Vždy, keď bude k dispozícii francúzsky index opraviteľnosti, zobrazíme ho. Okrem toho **môžete začať zhromažďovať premenné pomocou nástroja Folksonomy Engine**, aby sme ho v budúcnosti mohli prepočítať sami, a to aj v krajinách, kde nie je k dispozícii.';
 
   @override
   String get guide_open_products_facts_features_arg3_title =>
-      'Find ways to donate/resell your product';
+      'Nájdite spôsoby, ako darovať/ďalšie predať svoj produkt';
 
   @override
   String get guide_open_products_facts_features_arg3_text =>
-      'We provide links to **third party circular friendly services** that help you get the kind of product you’re looking for, as a second hand product, to be more gentle on planetary resources.\nNote that we’re not paid to do that, and that the system only works as an example for two websites in France. You can help expand this system by documenting more sites on the wiki.';
+      'Poskytujeme odkazy na **služby tretích strán priateľské k obehovému hospodárstvu**, ktoré vám pomôžu získať požadovaný druh produktu, napríklad z druhej ruky, aby sme boli šetrnejší k planetárnym zdrojom.\nUpozorňujeme, že za to nie sme platení a že systém funguje iba ako príklad pre dve webové stránky vo Francúzsku. Môžete pomôcť rozšíriť tento systém zdokumentovaním ďalších stránok na wiki.';
 
   @override
   String get guide_open_products_facts_information_title =>
-      'What information is useful?';
+      'Aké informácie sú užitočné?';
 
   @override
   String get guide_open_products_facts_information_text =>
-      'For such a wide range of items, **the data we collect is flexible**. To do that, **we created the Folksonomy Engine**.';
+      'Pre takú širokú škálu položiek sú **údaje, ktoré zhromažďujeme, flexibilné**. Na tento účel sme **vytvorili Folksonomy Engine**.';
 
   @override
   String get guide_open_products_facts_folksonomy_title =>
-      'The Folksonomy Engine';
+      'Folksonomický motor';
 
   @override
   String get guide_open_products_facts_folksonomy_paragraph1 =>
-      'The Folksonomy Engine is a tool to help you complete products with relevant properties. This helps improve search and discoverability, but also compute and display interesting things in the future.';
+      'Folksonomy Engine je nástroj, ktorý vám pomôže doplniť produkty relevantnými vlastnosťami. To pomáha zlepšiť vyhľadávanie a objaviteľnosť, ale aj vypočítať a zobraziť zaujímavé veci v budúcnosti.';
 
   @override
   String get guide_open_products_facts_folksonomy_paragraph2 =>
-      'You can add any keys and values like: **compatibility_with_5G_mobile_network: yes**';
+      'Môžete pridať ľubovoľné kľúče a hodnoty, ako napríklad: **compatibility_with_5G_mobile_network: yes**';
 
   @override
   String get guide_open_products_facts_folksonomy_paragraph3 =>
-      'You’ll get autosuggestion of possible properties, and you are very welcome to add and document new ones on your favorite kinds of products.';
+      'Dostanete automatické návrhy možných vlastností a budete môcť pridávať a dokumentovať nové vlastnosti pre vaše obľúbené druhy produktov.';
 
   @override
   String get guide_open_products_facts_share_link =>
       'https://world-sk.openproductsfacts.org/discover';
 
   @override
-  String get guide_open_preferences_button_title => 'Open food preferences';
+  String get guide_open_preferences_button_title => 'Otvorte preferencie jedál';
 
   @override
-  String get guide_coming_soon_button_title => 'Coming soon';
+  String get guide_coming_soon_button_title => 'Čoskoro';
 
   @override
-  String get guide_learn_more_subtitle => 'Tap to learn more';
+  String get guide_learn_more_subtitle => 'Klepnutím sa dozviete viac';
 
   @override
   String get preview_badge => 'Náhľad';
@@ -5355,7 +5362,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get explanation_card_learn_more_button => 'Zistiť viac';
 
   @override
-  String get product_page_tab_folksonomy => 'Folksonomy';
+  String get product_page_tab_folksonomy => 'Folksonomia';
 
   @override
   String get folksonomy_explanation_card_title =>
@@ -5370,11 +5377,11 @@ class AppLocalizationsSk extends AppLocalizations {
       'Tieto vlastnosti vytvárajú a ukladajú prispievatelia pre akékoľvek použitie.';
 
   @override
-  String get folksonomy_action_external_link_title => 'Open external link';
+  String get folksonomy_action_external_link_title => 'Otvoriť externý odkaz';
 
   @override
   String get folksonomy_action_external_link_warning =>
-      'External links may be unsafe. Do you really want to visit it?';
+      'Externé odkazy môžu byť nebezpečné. Naozaj to chcete navštíviť?';
 
   @override
   String get prices_products_empty_title => 'Nie je k dispozícii žiadna cena';
@@ -5847,7 +5854,7 @@ class AppLocalizationsSk extends AppLocalizations {
       'Zapojte sa účasťou na jednom z našich virtuálnych podujatí';
 
   @override
-  String get preferences_connect_blog_title => 'The Open Food Facts blog';
+  String get preferences_connect_blog_title => 'Blog Otvorené fakty o jedle';
 
   @override
   String get preferences_connect_blog_subtitle =>
@@ -6175,7 +6182,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Prineste fakty o otvorených potravinách do svojho jazyka';
 
   @override
   String get preferences_contribute_enroll_alpha =>
@@ -6198,26 +6205,26 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
-  String get location_map_details_title => 'Location details';
+  String get location_map_details_title => 'Podrobnosti o polohe';
 
   @override
   String get location_map_details_name => 'Názov';
 
   @override
-  String get location_map_details_street => 'Street';
+  String get location_map_details_street => 'Ulica';
 
   @override
-  String get location_map_details_city => 'City';
+  String get location_map_details_city => 'Mesto';
 
   @override
-  String get location_map_details_postcode => 'Postcode';
+  String get location_map_details_postcode => 'PSČ';
 
   @override
   String get location_map_details_country => 'Country';
 
   @override
-  String get location_map_details_coordinates => 'Coordinates';
+  String get location_map_details_coordinates => 'Súradnice';
 
   @override
-  String get location_map_details_osm_id => 'OSM ID';
+  String get location_map_details_osm_id => 'ID OSM';
 }

--- a/packages/smooth_app/lib/l10n/app_localizations_sl.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sl.dart
@@ -657,7 +657,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get unknownBrand => 'Neznana znamka';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Neznano ime izdelka';

--- a/packages/smooth_app/lib/l10n/app_localizations_sl.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sl.dart
@@ -657,6 +657,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get unknownBrand => 'Neznana znamka';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Neznano ime izdelka';
 
   @override
@@ -2998,7 +3001,7 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
-  String get prices_menu_know_more => 'Know more about Open Prices';
+  String get prices_menu_know_more => 'Več o odprtih cenah';
 
   @override
   String get dev_preferences_import_history_result_success => 'Opravljeno';
@@ -3555,7 +3558,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Začetek izvajanja dejanj strežnika za lokalno shranjene posodobitve folksonomy';
 
   @override
   String get background_task_title_top_n =>
@@ -4068,7 +4071,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get nutriscore_generic => 'Nutri-Score';
 
   @override
-  String get nutriscore_a => 'Nutri-Score A';
+  String get nutriscore_a => 'Nutri-ocena A';
 
   @override
   String get nutriscore_b => 'Nutri-Score B';
@@ -4091,11 +4094,11 @@ class AppLocalizationsSl extends AppLocalizations {
   String get nutriscore_new_formula_title => 'Nutri-Score (nov izračun)';
 
   @override
-  String get nutriscore_unknown => 'Unknown Nutri-Score';
+  String get nutriscore_unknown => 'Neznana hranilna vrednost';
 
   @override
   String get nutriscore_unknown_new_formula =>
-      'Unknown Nutri-Score (New calculation)';
+      'Neznan nutri-rezultat (nov izračun)';
 
   @override
   String get nutriscore_not_applicable => 'Nutri-Score se ne uporablja.';
@@ -4156,7 +4159,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get faq_title_vision =>
-      'The Open Food Facts Vision, Mission, Values and Programs';
+      'Vizija, poslanstvo, vrednote in programi Odprtega programa za živila';
 
   @override
   String get faq_title_install_beauty =>
@@ -4632,7 +4635,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_title =>
-      'What is Open Food Facts?';
+      'Kaj so odprta dejstva o hrani?';
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_paragraph1 =>
@@ -4644,7 +4647,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get guide_open_food_facts_features_title =>
-      'Features of Open Food Facts';
+      'Značilnosti odprtih dejstev o hrani';
 
   @override
   String get guide_open_food_facts_features_arg1_title =>
@@ -4729,7 +4732,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get guide_open_pet_food_facts_features_title =>
-      'Features of Open Pet Food Facts';
+      'Značilnosti odprtih dejstev o hrani za hišne ljubljenčke';
 
   @override
   String get guide_open_pet_food_facts_features_arg1_title =>
@@ -4799,7 +4802,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_title =>
-      'What is Open Beauty Facts?';
+      'Kaj so odprta dejstva o lepoti?';
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_paragraph1 =>
@@ -4883,11 +4886,11 @@ class AppLocalizationsSl extends AppLocalizations {
       'https://world-sl.openbeautyfacts.org/discover';
 
   @override
-  String get guide_open_prices_title => 'Welcome to Open Prices!';
+  String get guide_open_prices_title => 'Dobrodošli na Odprtih cenah!';
 
   @override
   String get guide_open_prices_what_is_open_prices_title =>
-      'What is Open Prices?';
+      'Kaj so odprte cene?';
 
   @override
   String get guide_open_prices_what_is_open_prices_paragraph1 =>
@@ -4898,7 +4901,7 @@ class AppLocalizationsSl extends AppLocalizations {
       'There are currently few companies that own large databases of product prices at the barcode level. These prices are not freely available, but sold at a high price to private actors, researchers and other organizations that can afford them.';
 
   @override
-  String get guide_open_prices_how_title => 'How does Open Prices work?';
+  String get guide_open_prices_how_title => 'Kako delujejo odprte cene?';
 
   @override
   String get guide_open_prices_how_paragraph1 =>
@@ -4964,7 +4967,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_title =>
-      'What is Open Products Facts?';
+      'Kaj so dejstva o odprtih izdelkih?';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_paragraph1 =>
@@ -4976,7 +4979,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get guide_open_products_facts_features_title =>
-      'Features of Open Products Facts';
+      'Značilnosti odprtih izdelkov Dejstva';
 
   @override
   String get guide_open_products_facts_features_text =>
@@ -6182,7 +6185,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Prinesite odprta dejstva o hrani v svoj jezik';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_sn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sn.dart
@@ -653,6 +653,9 @@ class AppLocalizationsSn extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3518,7 +3521,7 @@ class AppLocalizationsSn extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Kutanga kuita sevha zviito zvefolksonomy updates zvakachengetwa munharaunda';
 
   @override
   String get background_task_title_top_n =>
@@ -5308,7 +5311,7 @@ class AppLocalizationsSn extends AppLocalizations {
 
   @override
   String get prices_explanation_card_line1 =>
-      '**Open Prices** is a project to collect and share prices of products around the world 🌍. Open Prices is developed and maintained by Open Food Facts.';
+      '**Vhura Mitengo** ipurojekiti yekuunganidza nekugovana mitengo yezvigadzirwa pasi rese 🌍. Mitengo yakavhurika inogadzirwa uye inochengetwa neOpen Food Chokwadi.';
 
   @override
   String get explanation_card_learn_more_button => 'Learn more';
@@ -5614,7 +5617,7 @@ class AppLocalizationsSn extends AppLocalizations {
 
   @override
   String get preferences_legal_header =>
-      'Open Food Facts is a food products database **made by everyone, for everyone**.\nYou can use it to make better food choices, and as it is **open data**, anyone can **re-use it for any purpose**.';
+      'Vhura Chikafu Chokwadi idura rezvigadzirwa zvekudya ** rakagadzirwa nemunhu wese, kune wese **.\nUnogona kuishandisa kuita sarudzo dzekudya zviri nani, uye sezvazviri ** yakavhurika data **, chero munhu anogona ** kuishandisa zvakare kune chero chinangwa **.';
 
   @override
   String get preferences_privacy_policy => 'Privacy policy';
@@ -5780,7 +5783,7 @@ class AppLocalizationsSn extends AppLocalizations {
   String get preferences_faq_faq_title => 'FAQ - Mibvunzo Inowanzo bvunzwa';
 
   @override
-  String get preferences_faq_off_ngo_title => 'The Open Food Facts NGO';
+  String get preferences_faq_off_ngo_title => 'Iyo Open Food Chokwadi NGO';
 
   @override
   String get preferences_about_information_title => 'Information';
@@ -5915,7 +5918,7 @@ class AppLocalizationsSn extends AppLocalizations {
 
   @override
   String get preferences_contributions_new_products_subtitle =>
-      'New products I added to Open Food Facts';
+      'Zvigadzirwa zvitsva zvandakawedzera kune Open Food Chokwadi';
 
   @override
   String get preferences_contributions_to_be_completed_title =>
@@ -6011,7 +6014,7 @@ class AppLocalizationsSn extends AppLocalizations {
 
   @override
   String get preferences_page_contribute_project_subtitle =>
-      'Simple ways to help Open Food Facts';
+      'Nzira dzakareruka dzekubatsira Vhura Zvokudya Zvokudya';
 
   @override
   String get preferences_page_faq_subtitle =>
@@ -6126,7 +6129,7 @@ class AppLocalizationsSn extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Hunza Zvakavhurika Zvekudya Chokwadi kumutauro wako';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_sn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sn.dart
@@ -653,7 +653,7 @@ class AppLocalizationsSn extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_so.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_so.dart
@@ -653,7 +653,7 @@ class AppLocalizationsSo extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_so.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_so.dart
@@ -653,6 +653,9 @@ class AppLocalizationsSo extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3519,7 +3522,7 @@ class AppLocalizationsSo extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Bilaabida samaynta ficilada serverka ee cusboonaysiinta folksonomi ee lagu kaydiyay gudaha';
 
   @override
   String get background_task_title_top_n =>
@@ -6024,7 +6027,7 @@ class AppLocalizationsSo extends AppLocalizations {
 
   @override
   String get preferences_page_contribute_project_subtitle =>
-      'Simple ways to help Open Food Facts';
+      'Siyaabaha fudud ee lagu caawin karo Furitaanka Xaqiiqooyinka Cuntada';
 
   @override
   String get preferences_page_faq_subtitle =>
@@ -6139,7 +6142,7 @@ class AppLocalizationsSo extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Keen Xaqiiqo Cunno Furan luqadaada';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_sq.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sq.dart
@@ -662,7 +662,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get unknownBrand => 'Markë e panjohur';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Emer i panjohur produkti.';

--- a/packages/smooth_app/lib/l10n/app_localizations_sq.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sq.dart
@@ -662,6 +662,9 @@ class AppLocalizationsSq extends AppLocalizations {
   String get unknownBrand => 'Markë e panjohur';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Emer i panjohur produkti.';
 
   @override
@@ -3533,7 +3536,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Duke filluar të kryhen veprimet e serverit për përditësimet e folksonomisë të ruajtura lokalisht';
 
   @override
   String get background_task_title_top_n =>
@@ -5823,7 +5826,8 @@ class AppLocalizationsSq extends AppLocalizations {
       'Angazhohuni duke marrë pjesë në një nga eventet tona virtuale';
 
   @override
-  String get preferences_connect_blog_title => 'The Open Food Facts blog';
+  String get preferences_connect_blog_title =>
+      'Blogu i Fakte të Hapura Ushqimore';
 
   @override
   String get preferences_connect_blog_subtitle =>
@@ -5989,7 +5993,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String get preferences_prices_newest_subtitle =>
-      'Latest prices added by the Open Prices community';
+      'Çmimet më të fundit të shtuara nga komuniteti i Çmimeve të Hapura';
 
   @override
   String get preferences_prices_top_contributors_title =>
@@ -6038,7 +6042,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String get preferences_page_contribute_project_subtitle =>
-      'Simple ways to help Open Food Facts';
+      'Mënyra të thjeshta për të ndihmuar në Hapjen e Fakte Ushqimore';
 
   @override
   String get preferences_page_faq_subtitle =>
@@ -6153,7 +6157,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Sillni Fakte Ushqimore të Hapura në gjuhën tuaj';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_sr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sr.dart
@@ -653,6 +653,9 @@ class AppLocalizationsSr extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -5783,7 +5786,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get preferences_faq_faq_title => 'ЧПП - Често постављана питања';
 
   @override
-  String get preferences_faq_off_ngo_title => 'The Open Food Facts NGO';
+  String get preferences_faq_off_ngo_title => 'НВО Отворене чињенице о храни';
 
   @override
   String get preferences_about_information_title => 'Informacija';
@@ -5805,7 +5808,8 @@ class AppLocalizationsSr extends AppLocalizations {
       'Укључите се тако што ћете присуствовати једном од наших виртуелних догађаја';
 
   @override
-  String get preferences_connect_blog_title => 'The Open Food Facts blog';
+  String get preferences_connect_blog_title =>
+      'Блог „Чињенице о отвореној храни“';
 
   @override
   String get preferences_connect_blog_subtitle =>

--- a/packages/smooth_app/lib/l10n/app_localizations_sr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sr.dart
@@ -653,7 +653,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_ss.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ss.dart
@@ -653,6 +653,9 @@ class AppLocalizationsSs extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3015,7 +3018,7 @@ class AppLocalizationsSs extends AppLocalizations {
 
   @override
   String get dev_mode_openprices_switch_env_title =>
-      'Switch between prices.openfoodfacts.org (PROD) and test env';
+      'Shintja emkhatsini wemanani.vula emaciniso ekudla.org (PROD) kanye nekuhlola env';
 
   @override
   String get search_history_item_edit_tooltip => 'Reuse and edit this search';
@@ -3522,7 +3525,7 @@ class AppLocalizationsSs extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Kucala kwenta tento teseva tetibuyeketo te-folksonomy letigcinwe endzaweni';
 
   @override
   String get background_task_title_top_n =>
@@ -5676,7 +5679,7 @@ class AppLocalizationsSs extends AppLocalizations {
 
   @override
   String get preferences_on_off_website_subtitle =>
-      'On the Open Food Facts website';
+      'Kuwebhusayithi yeMaciniso Ekudla Lokuvulekile .';
 
   @override
   String get preferences_manage_account_title => 'Lawula i-akhawunti yami';
@@ -5792,7 +5795,8 @@ class AppLocalizationsSs extends AppLocalizations {
   String get preferences_faq_faq_title => 'FAQ - Imibuto Levame Kubutwa';
 
   @override
-  String get preferences_faq_off_ngo_title => 'The Open Food Facts NGO';
+  String get preferences_faq_off_ngo_title =>
+      'I-NGO yeMaciniso Ekudla Lokuvulekile';
 
   @override
   String get preferences_about_information_title => 'Information';
@@ -5814,7 +5818,8 @@ class AppLocalizationsSs extends AppLocalizations {
       'Tibandzakanye ngekuya kulomunye wemicimbi yetfu lebonakalako';
 
   @override
-  String get preferences_connect_blog_title => 'The Open Food Facts blog';
+  String get preferences_connect_blog_title =>
+      'Ibhulogi Yemaciniso Ekudla Lokuvulekile';
 
   @override
   String get preferences_connect_blog_subtitle =>
@@ -6027,7 +6032,7 @@ class AppLocalizationsSs extends AppLocalizations {
 
   @override
   String get preferences_page_contribute_project_subtitle =>
-      'Simple ways to help Open Food Facts';
+      'Tindlela letilula tekusita Vula Emaciniso Ekudla .';
 
   @override
   String get preferences_page_faq_subtitle =>

--- a/packages/smooth_app/lib/l10n/app_localizations_ss.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ss.dart
@@ -653,7 +653,7 @@ class AppLocalizationsSs extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_st.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_st.dart
@@ -653,6 +653,9 @@ class AppLocalizationsSt extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3519,7 +3522,7 @@ class AppLocalizationsSt extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Ho qala ho etsa liketso tsa seva bakeng sa liapdeite tsa folksonomy tse bolokiloeng sebakeng sa heno';
 
   @override
   String get background_task_title_top_n =>
@@ -6022,7 +6025,7 @@ class AppLocalizationsSt extends AppLocalizations {
 
   @override
   String get preferences_page_contribute_project_subtitle =>
-      'Simple ways to help Open Food Facts';
+      'Mekhoa e bonolo ea ho thusa Bula Lintlha tsa Lijo';
 
   @override
   String get preferences_page_faq_subtitle =>
@@ -6137,7 +6140,7 @@ class AppLocalizationsSt extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Tlisa Lintlha tse Bulehileng tsa Lijo puong ea hau';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_st.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_st.dart
@@ -653,7 +653,7 @@ class AppLocalizationsSt extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_sv.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sv.dart
@@ -515,7 +515,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get contribute_to_get_rewards =>
-      'Become an actor of food transparency';
+      'Bli en aktör för livsmedelstransparens';
 
   @override
   String get question_sign_in_text =>
@@ -651,6 +651,9 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get unknownBrand => 'Okänt varumärke';
+
+  @override
+  String get unknownQuantity => 'Unknown brand';
 
   @override
   String get unknownProductName => 'Okänt produktnamn';
@@ -2042,7 +2045,7 @@ class AppLocalizationsSv extends AppLocalizations {
       'Sojan kommer inte från Europeiska unionen';
 
   @override
-  String get edit_product_form_item_countries_title => 'Country';
+  String get edit_product_form_item_countries_title => 'Land';
 
   @override
   String get edit_product_form_item_countries_hint =>
@@ -2578,7 +2581,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get prices_bulk_proof_upload_warning_ai =>
-      'AI will run on your proofs to extract prices.';
+      'AI kommer att använda dina bevis för att extrahera priser.';
 
   @override
   String get prices_bulk_proof_upload_community_switch =>
@@ -2996,7 +2999,7 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
-  String get prices_menu_know_more => 'Know more about Open Prices';
+  String get prices_menu_know_more => 'Läs mer om öppna priser';
 
   @override
   String get dev_preferences_import_history_result_success => 'Klar';
@@ -3110,7 +3113,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get prices_contribution_assistant => 'Prisbidragsassistent';
 
   @override
-  String get prices_validation_assistant => 'Price Validation Assistant';
+  String get prices_validation_assistant => 'Prisvalideringsassistent';
 
   @override
   String get prices_challenges_page => 'Utmaningar';
@@ -3548,7 +3551,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Börjar utföra serveråtgärderna för folksonomy-uppdateringar som lagras lokalt';
 
   @override
   String get background_task_title_top_n =>
@@ -4223,7 +4226,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get guide_nutriscore_v2_what_is_nutriscore_title =>
-      'What is the Nutri-Score?';
+      'Vad är Nutri-Score?';
 
   @override
   String get guide_nutriscore_v2_what_is_nutriscore_paragraph1 =>
@@ -4450,7 +4453,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get guide_greenscore_transparency_title =>
-      'An increased need for transparency to better measure and reduce environmental impacts';
+      'Ett ökat behov av transparens för att bättre mäta och minska miljöpåverkan';
 
   @override
   String get guide_greenscore_transparency_intro1 =>
@@ -4622,7 +4625,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_title =>
-      'What is Open Food Facts?';
+      'Vad är öppna matfakta?';
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_paragraph1 =>
@@ -4875,11 +4878,11 @@ class AppLocalizationsSv extends AppLocalizations {
       'https://world-sv.openbeautyfacts.org/discover';
 
   @override
-  String get guide_open_prices_title => 'Welcome to Open Prices!';
+  String get guide_open_prices_title => 'Välkommen till Öppna Priser!';
 
   @override
   String get guide_open_prices_what_is_open_prices_title =>
-      'What is Open Prices?';
+      'Vad är öppningspriser?';
 
   @override
   String get guide_open_prices_what_is_open_prices_paragraph1 =>
@@ -4887,10 +4890,10 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get guide_open_prices_what_is_open_prices_paragraph2 =>
-      'There are currently few companies that own large databases of product prices at the barcode level. These prices are not freely available, but sold at a high price to private actors, researchers and other organizations that can afford them.';
+      'Det finns för närvarande få företag som äger stora databaser med produktpriser på streckkodsnivå. Dessa priser är inte fritt tillgängliga, utan säljs till ett högt pris till privata aktörer, forskare och andra organisationer som har råd med dem.';
 
   @override
-  String get guide_open_prices_how_title => 'How does Open Prices work?';
+  String get guide_open_prices_how_title => 'Hur fungerar öppna priser?';
 
   @override
   String get guide_open_prices_how_paragraph1 =>
@@ -4931,7 +4934,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get guide_open_prices_scrapping_paragraph1 =>
-      'For legal and technical reasons, **we don\'t consider scraping prices from retailers\' websites as a valid way to contribute to Open Prices**. We want to make sure that the prices we collect are accurate and up-to-date, and receiving scraped prices from contributors doesn\'t allow us to do that.';
+      'Av juridiska och tekniska skäl **anser vi inte att det är ett giltigt sätt att bidra till öppna priser att hämta priser från återförsäljares webbplatser.** Vi vill se till att de priser vi samlar in är korrekta och aktuella, och att ta emot hämtade priser från bidragsgivare tillåter oss inte att göra det.';
 
   @override
   String get guide_open_prices_scrapping_paragraph2 =>
@@ -4939,7 +4942,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get guide_open_prices_retailers_title =>
-      'I\'m a retailer and I want to contribute prices. How can I do that?';
+      'Jag är en återförsäljare och jag vill bidra med priser. Hur kan jag göra det?';
 
   @override
   String get guide_open_prices_retailers_paragraph1 =>
@@ -4955,7 +4958,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_title =>
-      'What is Open Products Facts?';
+      'Vad är fakta om öppna produkter?';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_paragraph1 =>
@@ -4967,7 +4970,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get guide_open_products_facts_features_title =>
-      'Features of Open Products Facts';
+      'Funktioner i öppna produktfakta';
 
   @override
   String get guide_open_products_facts_features_text =>
@@ -5507,10 +5510,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get prices_stats_receipt => 'Kvitto';
 
   @override
-  String get prices_stats_gdpr_request => 'GDPR request';
+  String get prices_stats_gdpr_request => 'GDPR-begäran';
 
   @override
-  String get prices_stats_shop_import => 'Shop import';
+  String get prices_stats_shop_import => 'Butiksimport';
 
   @override
   String get prices_stats_challenges => 'Utmaningar';
@@ -5649,7 +5652,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get preferences_terms_of_use => 'Användningsvillkor';
 
   @override
-  String get preferences_legal_mentions => 'Legal mentions';
+  String get preferences_legal_mentions => 'Juridiska omnämnanden';
 
   @override
   String get preferences_legal_header =>
@@ -6203,7 +6206,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get location_map_details_postcode => 'Postnummer';
 
   @override
-  String get location_map_details_country => 'Country';
+  String get location_map_details_country => 'Land';
 
   @override
   String get location_map_details_coordinates => 'Koordinater';

--- a/packages/smooth_app/lib/l10n/app_localizations_sv.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sv.dart
@@ -653,7 +653,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get unknownBrand => 'Okänt varumärke';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Okänt produktnamn';

--- a/packages/smooth_app/lib/l10n/app_localizations_sw.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sw.dart
@@ -22,19 +22,19 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get account_delete_message =>
-      'Are you sure you want to delete your account?\nIf there is a specific reason, please share below';
+      'Je, una uhakika unataka kufuta akaunti yako?\nIkiwa kuna sababu maalum, tafadhali shiriki hapa chini';
 
   @override
-  String get reason => 'Reason';
+  String get reason => 'Sababu';
 
   @override
-  String get okay => 'Okay';
+  String get okay => 'Sawa';
 
   @override
   String get validate => 'Validate';
 
   @override
-  String get create => 'Create';
+  String get create => 'Unda';
 
   @override
   String get applyButtonText => 'Apply';
@@ -43,7 +43,7 @@ class AppLocalizationsSw extends AppLocalizations {
   String get next_label => 'Next';
 
   @override
-  String get continue_label => 'Continue';
+  String get continue_label => 'Endelea';
 
   @override
   String get exit_label => 'Exit';
@@ -52,13 +52,13 @@ class AppLocalizationsSw extends AppLocalizations {
   String get previous_label => 'Previous';
 
   @override
-  String get go_back_to_top => 'Go back to top';
+  String get go_back_to_top => 'Rudi juu';
 
   @override
   String get save => 'Hifadhi';
 
   @override
-  String get save_confirmation => 'Are you sure you want to save?';
+  String get save_confirmation => 'Je, una uhakika unataka kuhifadhi?';
 
   @override
   String get skip => 'Skip';
@@ -67,7 +67,7 @@ class AppLocalizationsSw extends AppLocalizations {
   String get cancel => 'Ghairi';
 
   @override
-  String get ignore => 'Ignore';
+  String get ignore => 'Puuza';
 
   @override
   String get close => 'Funga';
@@ -76,443 +76,446 @@ class AppLocalizationsSw extends AppLocalizations {
   String get no => 'No';
 
   @override
-  String get stop => 'Stop';
+  String get stop => 'Acha';
 
   @override
-  String get finish => 'Finish';
+  String get finish => 'Maliza';
 
   @override
-  String get calculate => 'Calculate';
+  String get calculate => 'Kokotoa';
 
   @override
-  String get reset_food_prefs => 'Reset food preferences';
+  String get reset_food_prefs => 'Weka upya mapendeleo ya chakula';
 
   @override
   String get error => 'Kuna kitu ilienda mrama';
 
   @override
-  String get error_occurred => 'An error occurred';
+  String get error_occurred => 'Hitilafu imetokea';
 
   @override
   String get featureInProgress =>
-      'We\'re still working on this feature, stay tuned';
+      'Bado tunafanyia kazi kipengele hiki, endelea kufuatilia';
 
   @override
-  String get label_web => 'View on the web';
+  String get label_web => 'Tazama kwenye wavuti';
 
   @override
-  String get learnMore => 'Learn more';
+  String get learnMore => 'Jifunze zaidi';
 
   @override
-  String get unknown => 'Unknown';
+  String get unknown => 'Haijulikani';
 
   @override
-  String get match_very_good => 'Very good match';
+  String get match_very_good => 'Mechi nzuri sana';
 
   @override
-  String get match_good => 'Good match';
+  String get match_good => 'Mechi nzuri';
 
   @override
-  String get match_poor => 'Poor match';
+  String get match_poor => 'Mechi mbaya';
 
   @override
   String get match_may_not => 'May not match';
 
   @override
-  String get match_does_not => 'Does not match';
+  String get match_does_not => 'hailingani';
 
   @override
-  String get match_unknown => 'Unknown match';
+  String get match_unknown => 'Ulinganifu usiojulikana';
 
   @override
-  String get match_short_very_good => 'Very good match';
+  String get match_short_very_good => 'Mechi nzuri sana';
 
   @override
-  String get match_short_good => 'Good match';
+  String get match_short_good => 'Mechi nzuri';
 
   @override
-  String get match_short_poor => 'Poor match';
+  String get match_short_poor => 'Mechi mbaya';
 
   @override
   String get match_short_may_not => 'May not match';
 
   @override
-  String get match_short_does_not => 'Does not match';
+  String get match_short_does_not => 'hailingani';
 
   @override
-  String get match_short_unknown => 'Unknown match';
+  String get match_short_unknown => 'Ulinganifu usiojulikana';
 
   @override
   String get licenses => 'Licences';
 
   @override
-  String get looking_for => 'Looking for';
+  String get looking_for => 'Kutafuta';
 
   @override
-  String get welcomeToOpenFoodFacts => 'Welcome to Open Food Facts';
+  String get welcomeToOpenFoodFacts => 'Karibu kwa Open Food Facts';
 
   @override
   String get whatIsOff =>
-      'Open Food Facts is a global non-profit powered by local communities.';
+      'Open Food Facts ni shirika lisilo la faida la kimataifa linaloendeshwa na jumuiya za wenyeji.';
 
   @override
   String get productDataUtility =>
-      'See the food data relevant to your preferences.';
+      'Tazama data ya chakula inayohusiana na mapendeleo yako.';
 
   @override
-  String get healthCardUtility => 'Choose foods that are good for you.';
+  String get healthCardUtility => 'Chagua vyakula ambavyo vinafaa kwako.';
 
   @override
-  String get ecoCardUtility => 'Choose foods that are good for the planet.';
+  String get ecoCardUtility => 'Chagua vyakula ambavyo ni nzuri kwa sayari.';
 
   @override
   String get server_error_open_new_issue =>
-      'No server response! You may open an issue with the following link.';
+      'Hakuna jibu la seva! Unaweza kufungua suala kwa kiungo kifuatacho.';
 
   @override
   String get sign_in_text =>
-      'Sign in to your Open Food Facts account to save your contributions';
+      'Ingia katika akaunti yako ya Open Food Facts ili kuhifadhi michango yako';
 
   @override
-  String get incorrect_credentials => 'Incorrect username or password.';
+  String get incorrect_credentials => 'Jina la mtumiaji au nenosiri si sahihi.';
 
   @override
   String get password_lost_incorrect_credentials =>
-      'This email or username doesn\'t exist. Please check your credentials.';
+      'Barua pepe hii au jina la mtumiaji halipo. Tafadhali angalia stakabadhi zako.';
 
   @override
   String get password_lost_server_unavailable =>
-      'We are currently experiencing slowdowns on our servers and we apologise for it. Please try again later.';
+      'Kwa sasa tunakumbwa na kushuka kwa kasi kwa seva zetu na tunaomba radhi kwa hilo. Tafadhali jaribu tena baadaye.';
 
   @override
   String get login => 'Login';
 
   @override
-  String get login_result_type_server_unreachable => 'Network is unreachable';
+  String get login_result_type_server_unreachable => 'Mtandao haupatikani';
 
   @override
   String get login_result_type_server_issue =>
-      'Problem on the server. Please try later.';
+      'Tatizo kwenye seva. Tafadhali jaribu baadaye.';
 
   @override
-  String get login_page_username_or_email => 'Please enter username or e-mail';
+  String get login_page_username_or_email =>
+      'Tafadhali ingiza jina la mtumiaji au barua pepe';
 
   @override
-  String get login_page_password_error_empty => 'Please enter a password';
+  String get login_page_password_error_empty => 'Tafadhali weka nenosiri';
 
   @override
-  String get create_account => 'Create account';
+  String get create_account => 'Fungua akaunti';
 
   @override
-  String get sign_in => 'Sign in';
+  String get sign_in => 'Ingia';
 
   @override
-  String get sign_in_mandatory => 'For that feature we need you to sign in.';
+  String get sign_in_mandatory => 'Kwa kipengele hicho tunahitaji uingie.';
 
   @override
   String get help_improve_country =>
-      'Help improve Open Food Facts in your country';
+      'Saidia kuboresha Ukweli wa Chakula Huria katika nchi yako';
 
   @override
-  String get sign_out => 'Sign out';
+  String get sign_out => 'Ondoka';
 
   @override
-  String get sign_out_confirmation => 'Are you sure you want to sign out?';
+  String get sign_out_confirmation => 'Je, una uhakika unataka kuondoka?';
 
   @override
-  String get password => 'Password';
+  String get password => 'Nenosiri';
 
   @override
-  String get forgot_password => 'Forgot password';
+  String get forgot_password => 'Umesahau nenosiri';
 
   @override
   String get forgot_password_question => 'Umesahau nenosiri?';
 
   @override
-  String get view_profile => 'View profile';
+  String get view_profile => 'Tazama wasifu';
 
   @override
-  String get reset_password => 'Reset password';
+  String get reset_password => 'Weka upya nenosiri';
 
   @override
   String get reset_password_explanation_text =>
-      'In case of a forgotten password, enter your username or e-mail address to receive instructions for a password reset. Also, remember to check the Spam folder.';
+      'Ikiwa nenosiri limesahaulika, ingiza jina lako la mtumiaji au anwani ya barua pepe ili kupokea maagizo ya kuweka upya nenosiri. Pia, kumbuka kuangalia folda ya Barua taka.';
 
   @override
-  String get username_or_email => 'Username or e-mail';
+  String get username_or_email => 'Jina la mtumiaji au barua pepe';
 
   @override
   String get reset_password_done =>
-      'An e-mail with a link to reset your password has been sent to the e-mail address associated with your account. Also check your spam';
+      'Barua pepe iliyo na kiungo cha kuweka upya nenosiri lako imetumwa kwa anwani ya barua pepe inayohusishwa na akaunti yako. Pia angalia barua taka zako';
 
   @override
-  String get send_reset_password_mail => 'Change password';
+  String get send_reset_password_mail => 'Badilisha nenosiri';
 
   @override
-  String get enter_some_text => 'Please enter some text';
+  String get enter_some_text => 'Tafadhali weka maandishi';
 
   @override
-  String get sign_up_page_title => 'Sign Up';
+  String get sign_up_page_title => 'Jisajili';
 
   @override
-  String get sign_up_page_action_button => 'Sign Up';
+  String get sign_up_page_action_button => 'Jisajili';
 
   @override
-  String get sign_up_page_action_doing_it => 'Signing up…';
+  String get sign_up_page_action_doing_it => 'Inajisajili…';
 
   @override
   String get sign_up_page_action_ok =>
-      'Congratulations! Your account has just been created.';
+      'Hongera! Akaunti yako imeundwa hivi punde.';
 
   @override
-  String get sign_up_page_display_name_hint => 'Name';
+  String get sign_up_page_display_name_hint => 'Jina';
 
   @override
   String get sign_up_page_display_name_error_empty =>
-      'Please enter the display name you want to use';
+      'Tafadhali ingiza jina la onyesho unalotaka kutumia';
 
   @override
-  String get sign_up_page_email_hint => 'E-mail';
+  String get sign_up_page_email_hint => 'Barua pepe';
 
   @override
-  String get sign_up_page_email_error_empty => 'E-mail is required';
+  String get sign_up_page_email_error_empty => 'Barua pepe inahitajika';
 
   @override
-  String get sign_up_page_email_error_invalid => 'Invalid e-mail';
+  String get sign_up_page_email_error_invalid => 'Barua pepe si sahihi';
 
   @override
-  String get sign_up_page_username_hint => 'Username: Publicly visible';
+  String get sign_up_page_username_hint =>
+      'Jina la mtumiaji: Inaonekana hadharani';
 
   @override
-  String get sign_up_page_username_error_empty => 'Please enter a username';
+  String get sign_up_page_username_error_empty =>
+      'Tafadhali weka jina la mtumiaji';
 
   @override
   String get sign_up_page_username_error_invalid =>
-      'Please enter a valid username';
+      'Tafadhali weka jina la mtumiaji halali';
 
   @override
   String get sign_up_page_username_description =>
-      'Username cannot contains spaces, caps or special characters.';
+      'Jina la mtumiaji haliwezi kuwa na nafasi, kofia au herufi maalum.';
 
   @override
   String sign_up_page_username_length_invalid(int value) {
-    return 'Username cannot exceed $value characters';
+    return 'Jina la mtumiaji haliwezi kuzidi vibambo $value';
   }
 
   @override
-  String get sign_up_page_password_hint => 'Password';
+  String get sign_up_page_password_hint => 'Nenosiri';
 
   @override
-  String get sign_up_page_password_error_empty => 'Please enter a password';
+  String get sign_up_page_password_error_empty => 'Tafadhali weka nenosiri';
 
   @override
   String get sign_up_page_password_error_invalid =>
-      'Please enter a valid password (at least 6 characters)';
+      'Tafadhali weka nenosiri halali (angalau vibambo 6)';
 
   @override
-  String get sign_up_page_confirm_password_hint => 'Confirm Password';
+  String get sign_up_page_confirm_password_hint => 'Thibitisha Nenosiri';
 
   @override
   String get sign_up_page_confirm_password_error_empty =>
-      'Please confirm the password';
+      'Tafadhali thibitisha nenosiri';
 
   @override
   String get sign_up_page_confirm_password_error_invalid =>
-      'Passwords don\'t match';
+      'Manenosiri hayalingani';
 
   @override
-  String get sign_up_page_agree_text => 'I agree to the Open Food Facts';
+  String get sign_up_page_agree_text => 'Ninakubali Ukweli wa Chakula Huria';
 
   @override
-  String get sign_up_page_terms_text => 'terms of use and contribution';
+  String get sign_up_page_terms_text => 'masharti ya matumizi na mchango';
 
   @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
   String get sign_up_page_agree_error_invalid =>
-      'When creating an account, agreeing to the Terms of Use is mandatory, however, anonymous contributions can still be made through the app';
+      'Wakati wa kuunda akaunti, kukubaliana na Sheria na Masharti ni lazima, hata hivyo, michango isiyojulikana bado inaweza kufanywa kupitia programu.';
 
   @override
-  String get sign_up_page_producer_checkbox => 'I am a food producer';
+  String get sign_up_page_producer_checkbox => 'Mimi ni mzalishaji wa chakula';
 
   @override
-  String get sign_up_page_producer_hint => 'Producer/brand';
+  String get sign_up_page_producer_hint => 'Mtayarishaji/chapa';
 
   @override
   String get sign_up_page_producer_error_empty =>
-      'Please enter a producer or a brand name';
+      'Tafadhali weka mzalishaji au jina la biashara';
 
   @override
   String get sign_up_page_subscribe_checkbox =>
-      'I\'d like to subscribe to the Open Food Facts newsletter (You can unsubscribe from it at any time)';
+      'Ningependa kujiandikisha kwa jarida la Open Food Facts (Unaweza kujiondoa kutoka kwalo wakati wowote)';
 
   @override
   String get sign_up_page_user_name_already_used =>
-      'The user name already exists, please choose another username.';
+      'Jina la mtumiaji tayari lipo, tafadhali chagua jina lingine la mtumiaji.';
 
   @override
   String get sign_up_page_email_already_exists =>
-      'already exists, login to the account or try with another email.';
+      'tayari ipo, ingia kwenye akaunti au jaribu na barua pepe nyingine.';
 
   @override
   String get sign_up_page_provide_valid_email =>
-      'Please provide a valid email address.';
+      'Tafadhali toa barua pepe halali.';
 
   @override
   String get sign_up_page_server_busy =>
-      'We are deeply sorry, we have some technical difficulties to create your account. Please try again later.';
+      'Samahani sana, tuna matatizo ya kiufundi kuunda akaunti yako. Tafadhali jaribu tena baadaye.';
 
   @override
   String get settingsTitle => 'Mipangilio';
 
   @override
-  String get darkmode => 'Theme';
+  String get darkmode => 'Mandhari';
 
   @override
-  String get darkmode_dark => 'Dark';
+  String get darkmode_dark => 'Giza';
 
   @override
-  String get darkmode_light => 'Light';
+  String get darkmode_light => 'Mwanga';
 
   @override
-  String get darkmode_system_default => 'System default';
+  String get darkmode_system_default => 'Chaguomsingi ya mfumo';
 
   @override
-  String get thanks_for_contributing => 'Thanks for contributing!';
+  String get thanks_for_contributing => 'Asante kwa kuchangia!';
 
   @override
-  String get contributors_label => 'They are building the app';
+  String get contributors_label => 'Wanatengeneza programu';
 
   @override
   String get contributors_dialog_title => 'Contributors';
 
   @override
   String contributors_dialog_entry_description(Object name) {
-    return 'Contributor: $name';
+    return 'Mchangiaji: $name';
   }
 
   @override
   String get contributors_description =>
-      'A list of all contributors of this app';
+      'Orodha ya wachangiaji wote wa programu hii';
 
   @override
-  String get support => 'Support';
+  String get support => 'Msaada';
 
   @override
-  String get support_join_slack => 'Ask for help in our Slack channel';
+  String get support_join_slack => 'Omba usaidizi katika kituo chetu cha Slack';
 
   @override
-  String get support_via_forum => 'Ask for help on our forum';
+  String get support_via_forum => 'Omba msaada kwenye jukwaa letu';
 
   @override
-  String get support_via_email => 'Send us an e-mail';
+  String get support_via_email => 'Tutumie barua pepe';
 
   @override
-  String get support_via_email_include_logs_dialog_title => 'Send app logs?';
+  String get support_via_email_include_logs_dialog_title =>
+      'Ungependa kutuma kumbukumbu za programu?';
 
   @override
   String get support_via_email_include_logs_dialog_body =>
-      'Do you wish to include application logs in attachment to your email?';
+      'Je, ungependa kujumuisha kumbukumbu za maombi kwenye kiambatisho cha barua pepe yako?';
 
   @override
-  String get termsOfUse => 'Terms of use';
+  String get termsOfUse => 'Masharti ya matumizi';
 
   @override
-  String get legalNotices => 'Legal notices';
+  String get legalNotices => 'Matangazo ya kisheria';
 
   @override
-  String get privacy_policy => 'Privacy policy';
+  String get privacy_policy => 'Sera ya faragha';
 
   @override
-  String get about_this_app => 'About this app';
+  String get about_this_app => 'Kuhusu programu hii';
 
   @override
   String get contribute => 'Contribute';
 
   @override
-  String get contribute_sw_development => 'Software development';
+  String get contribute_sw_development => 'Maendeleo ya programu';
 
   @override
   String get contribute_develop_text =>
-      'The code for every Open Food Facts product is available on GitHub. You are welcome to reuse the code (it\'s open source) and help us improve it, for everyone, on all the planet.';
+      'Nambari ya kila bidhaa ya Open Food Facts inapatikana kwenye GitHub. Unakaribishwa kutumia tena msimbo (ni chanzo huria) na utusaidie kuuboresha, kwa kila mtu, kwenye sayari yote.';
 
   @override
   String get contribute_develop_text_2 =>
-      'You can join the Open Food Facts Slack chatroom which is the preferred way to ask questions.';
+      'Unaweza kujiunga na mazungumzo ya Open Food Facts Slack ambayo ndiyo njia inayopendelewa ya kuuliza maswali.';
 
   @override
-  String get contribute_develop_dev_mode_title => 'DEV Mode?';
+  String get contribute_develop_dev_mode_title => 'Hali ya DEV?';
 
   @override
-  String get contribute_develop_dev_mode_subtitle => 'Activate the DEV Mode';
+  String get contribute_develop_dev_mode_subtitle => 'Washa Hali ya DEV';
 
   @override
   String get contribute_donate_title => 'Donate';
 
   @override
-  String get contribute_donate_header => 'Donate to Open Food Facts';
+  String get contribute_donate_header => 'Changia Kufungua Ukweli wa Chakula';
 
   @override
   String get contribute_enroll_alpha_warning => '!';
 
   @override
-  String get contribute_improve_ProductsToBeCompleted =>
-      'Products to be completed';
+  String get contribute_improve_ProductsToBeCompleted => 'Bidhaa kukamilika';
 
   @override
-  String get contribute_improve_header => 'Improving';
+  String get contribute_improve_header => 'Kuboresha';
 
   @override
   String get contribute_improve_text =>
-      'The database is the core of the project. It\'s easy and very quick to help. You can download the mobile app for your phone, and start adding or improving products.\n\nOn the other hand, Open Food Facts website offers many ways to contribute: ';
+      'Hifadhidata ndio msingi wa mradi. Ni rahisi na haraka sana kusaidia. Unaweza kupakua programu ya simu kwa simu yako, na kuanza kuongeza au kuboresha bidhaa.\n\nKwa upande mwingine, tovuti ya Open Food Facts inatoa njia nyingi za kuchangia: ';
 
   @override
-  String get contribute_translate_header => 'Translate';
+  String get contribute_translate_header => 'Tafsiri';
 
   @override
   String get contribute_data_quality => 'Data Quality';
 
   @override
-  String get contribute_translate_link_text => 'Start Translating';
+  String get contribute_translate_link_text => 'Anza Kutafsiri';
 
   @override
   String get contribute_translate_text =>
-      'Open Food Facts is a global project, containing products from more than 160 countries. Open Food Facts is translated into dozens of languages, with constantly evolving content.';
+      'Open Food Facts ni mradi wa kimataifa, unaojumuisha bidhaa kutoka zaidi ya nchi 160. Ukweli wa Chakula cha Open hutafsiriwa katika lugha kadhaa, na maudhui yanayobadilika kila mara.';
 
   @override
   String get contribute_translate_text_2 =>
-      'Translations is one of the key tasks of the project';
+      'Tafsiri ni moja wapo ya kazi kuu za mradi';
 
   @override
   String get contribute_join_skill_pool =>
-      'Contribute your skills to Open Food Facts. Join the skill pool!';
+      'Changia ujuzi wako kwa Fungua Ukweli wa Chakula. Jiunge na bwawa la ujuzi!';
 
   @override
   String get contribute_share_header =>
-      'Share Open Food Facts with your friends';
+      'Shiriki Ukweli wa Chakula cha Open na marafiki zako';
 
   @override
   String get contribute_share_content =>
-      'I wanted to let you know about the app I\'ve been using, Open Food Facts, which allows you to get the health and environmental impacts of your food, in a personalized way. It works by scanning the barcodes on the packaging. Finally it\'s free, does not require registration, and you can even help increase the number of products decyphered. Here\'s the link to get it for your phone: https://openfoodfacts.app';
+      'Nilitaka kukujulisha kuhusu programu ambayo nimekuwa nikitumia, Ukweli wa Chakula cha Open, ambayo hukuruhusu kupata athari za kiafya na mazingira za chakula chako, kwa njia iliyobinafsishwa. Inafanya kazi kwa kuchanganua misimbopau kwenye kifurushi. Hatimaye ni bure, hauhitaji usajili, na unaweza hata kusaidia kuongeza idadi ya bidhaa decyphered. Hiki hapa ni kiungo cha kuipata kwa simu yako: https://openfoodfacts.app';
 
   @override
   String get contribute_prices_gdpr =>
-      'Contribute prices by requesting a GDPR export of your loyalty cards data';
+      'Changia bei kwa kuomba uhamishaji wa data ya kadi zako za uaminifu kwa GDPR';
 
   @override
-  String get tap_to_answer => 'Tap here to answer questions';
+  String get tap_to_answer => 'Gonga hapa ili kujibu maswali';
 
   @override
   String get tap_to_answer_hint =>
-      'Tap here to answer questions about this product';
+      'Gusa hapa ili kujibu maswali kuhusu bidhaa hii';
 
   @override
   String get robotoff_questions_loading_hint =>
-      'Please wait while questions about this product are loaded';
+      'Tafadhali subiri wakati maswali kuhusu bidhaa hii yanapakiwa';
 
   @override
-  String get saving_answer => 'Saving your answer';
+  String get saving_answer => 'Inahifadhi jibu lako';
 
   @override
   String get contribute_to_get_rewards =>
@@ -520,109 +523,110 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get question_sign_in_text =>
-      'Sign in to your Open Food Facts account to get credit for your contributions';
+      'Ingia katika akaunti yako ya Open Food Facts ili upate mkopo kwa michango yako';
 
   @override
-  String get question_yes_button_accessibility_value => 'Answer with yes';
+  String get question_yes_button_accessibility_value => 'Jibu na ndiyo';
 
   @override
-  String get question_no_button_accessibility_value => 'Answer with no';
+  String get question_no_button_accessibility_value => 'Jibu kwa hapana';
 
   @override
-  String get question_skip_button_accessibility_value => 'Skip this question';
+  String get question_skip_button_accessibility_value => 'Ruka swali hili';
 
   @override
-  String get tap_to_edit_search => 'Tap to edit search';
+  String get tap_to_edit_search => 'Gusa ili kuhariri utafutaji';
 
   @override
-  String get myPreferences => 'My preferences';
+  String get myPreferences => 'Mapendeleo yangu';
 
   @override
   String get account_create_message =>
-      'Create your account and join the Open Food Facts community to help build food knowledge all over the world!';
+      'Fungua akaunti yako na ujiunge na jumuiya ya Open Food Facts ili kusaidia kujenga ujuzi wa chakula duniani kote!';
 
   @override
-  String get join_us => 'Join us';
+  String get join_us => 'Jiunge nasi';
 
   @override
-  String get myPreferences_profile_title => 'Your Profile';
+  String get myPreferences_profile_title => 'Wasifu wako';
 
   @override
   String get myPreferences_profile_subtitle =>
-      'Manage your Open Food Facts contributor account.';
+      'Dhibiti akaunti yako ya mchangiaji wa Open Food Facts.';
 
   @override
-  String get myPreferences_settings_title => 'App Settings';
+  String get myPreferences_settings_title => 'Mipangilio ya Programu';
 
   @override
-  String get myPreferences_settings_subtitle => 'Dark mode, Languages…';
+  String get myPreferences_settings_subtitle => 'Hali nyeusi, Lugha…';
 
   @override
-  String get myPreferences_food_title => 'Food Preferences';
+  String get myPreferences_food_title => 'Mapendeleo ya Chakula';
 
   @override
   String get myPreferences_food_subtitle =>
-      'Choose what information about food matters most to you.';
+      'Chagua ni taarifa gani kuhusu chakula muhimu zaidi kwako.';
 
   @override
   String get myPreferences_food_comment =>
-      'Choose what information about food matters most to you, in order to rank food according to your preferences, see the information you care about first, and get a compatibility summary. Those food preferences stay on your device, and are not associated with your Open Food Facts contributor account if you have one.';
+      'Chagua ni taarifa gani kuhusu chakula muhimu zaidi kwako, ili kupanga chakula kulingana na mapendeleo yako, angalia maelezo unayojali kwanza, na upate muhtasari wa uoanifu. Mapendeleo hayo ya chakula hukaa kwenye kifaa chako, na hayahusiani na akaunti yako ya mchangiaji wa Ukweli wa Chakula Huria ikiwa unayo.';
 
   @override
-  String get confirmResetPreferences => 'Reset your food preferences?';
+  String get confirmResetPreferences =>
+      'Ungependa kuweka upya mapendeleo yako ya chakula?';
 
   @override
-  String get myPersonalizedRanking => 'My personalized ranking';
+  String get myPersonalizedRanking => 'Nafasi yangu iliyobinafsishwa';
 
   @override
   String get ranking_tab_all => 'All';
 
   @override
-  String get ranking_subtitle_match_yes => 'A great match for you';
+  String get ranking_subtitle_match_yes => 'Mechi nzuri kwako';
 
   @override
-  String get ranking_subtitle_match_no => 'Very poor match';
+  String get ranking_subtitle_match_no => 'Mechi mbaya sana';
 
   @override
-  String get ranking_subtitle_match_maybe => 'Unknown match';
+  String get ranking_subtitle_match_maybe => 'Ulinganifu usiojulikana';
 
   @override
   String get refresh_with_new_preferences =>
-      'Refresh the list with your new preferences';
+      'Onyesha upya orodha na mapendeleo yako mapya';
 
   @override
   String get reloaded_with_new_preferences =>
-      'Reloaded with your new preferences';
+      'Imepakiwa upya na mapendeleo yako mapya';
 
   @override
   String get profile_navbar_label => 'Community';
 
   @override
-  String get scan_navbar_label => 'Scan';
+  String get scan_navbar_label => 'Changanua';
 
   @override
-  String get history_navbar_label => 'History';
+  String get history_navbar_label => 'Historia';
 
   @override
-  String get list_navbar_label => 'Lists';
+  String get list_navbar_label => 'Orodha';
 
   @override
-  String get category => 'Filter by category';
+  String get category => 'Chuja kwa kategoria';
 
   @override
   String get category_all => 'All';
 
   @override
-  String get category_search => '(category search)';
+  String get category_search => '(tafuta kategoria)';
 
   @override
-  String get filter => 'Filter';
+  String get filter => 'Chuja';
 
   @override
-  String get scan => 'Products from the Scan screen';
+  String get scan => 'Bidhaa kutoka skrini ya Scan';
 
   @override
-  String get scan_history => 'Scan history';
+  String get scan_history => 'Historia ya kuchanganua';
 
   @override
   String get search => 'Tafuta';
@@ -637,169 +641,173 @@ class AppLocalizationsSw extends AppLocalizations {
   String get search_history => 'Historia ya utafutaji';
 
   @override
-  String get search_store => 'Search for a store';
+  String get search_store => 'Tafuta duka';
 
   @override
   String get search_store_help => 'Kidokezo: ongeza jiji au nchi';
 
   @override
-  String get tap_for_more => 'Tap to see more info…';
+  String get tap_for_more => 'Gusa ili kuona maelezo zaidi…';
 
   @override
   String get product => 'Product';
 
   @override
-  String get unknownBrand => 'Unknown brand';
+  String get unknownBrand => 'Chapa isiyojulikana';
 
   @override
-  String get unknownProductName => 'Unknown product name';
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
+  String get unknownProductName => 'Jina la bidhaa lisilojulikana';
 
   @override
   String get label_refresh => 'Refresh';
 
   @override
-  String get label_reload => 'Reload';
+  String get label_reload => 'Pakia upya';
 
   @override
-  String get image => 'Image';
+  String get image => 'Picha';
 
   @override
-  String get front_photo => 'Front photo';
+  String get front_photo => 'Picha ya mbele';
 
   @override
   String outdated_image_accessibility_label(Object imageType) {
-    return '$imageType (this image may be outdated)';
+    return '$imageType (picha hii inaweza kuwa imepitwa na wakati)';
   }
 
   @override
-  String get outdated_image_short_label => 'may be outdated';
+  String get outdated_image_short_label => 'inaweza kuwa imepitwa na wakati';
 
   @override
   String get ingredients => 'Viungo';
 
   @override
   String get ingredients_editing_instructions =>
-      'Keep the original order. Indicate the percentage when specified. Separate with a comma or hyphen and use parentheses for ingredients of an ingredient.';
+      'Weka agizo asili. Onyesha asilimia unapobainishwa. Tenganisha kwa koma au hyphen na utumie mabano kwa viungo vya kiungo.';
 
   @override
-  String get ingredients_editing_error => 'Failed to save the ingredients.';
+  String get ingredients_editing_error => 'Imeshindwa kuhifadhi viungo.';
 
   @override
   String get ingredients_editing_image_error =>
-      'Failed to get a new ingredients image.';
+      'Imeshindwa kupata picha ya viungo vipya.';
 
   @override
-  String get ingredients_editing_title => 'Edit Ingredients';
+  String get ingredients_editing_title => 'Hariri Viungo';
 
   @override
-  String get ingredients_photo => 'Ingredients photo';
+  String get ingredients_photo => 'Picha ya viungo';
 
   @override
   String get packaging_editing_instructions =>
-      'List all packaging parts separated by a comma or line feed, with their amount (e.g. 1 or 6) type (e.g. bottle, box, can), material (e.g. plastic, metal, aluminium) and if available their size (e.g. 33cl) and recycling instructions.\nExample: 1 glass bottle to recycle, 1 plastic cork to throw away';
+      'Orodhesha sehemu zote za ufungashaji zilizotenganishwa na koma au mlisho wa laini, na kiasi chake (km 1 au 6) aina (km chupa, sanduku, kopo), nyenzo (km plastiki, chuma, alumini) na ikiwa inapatikana saizi yake (km 33cl) na maagizo ya kuchakata tena.\nMfano: chupa 1 ya glasi ya kuchakata tena, kizibo 1 cha plastiki cha kutupa';
 
   @override
-  String get packaging_editing_error => 'Failed to save the packaging.';
+  String get packaging_editing_error => 'Imeshindwa kuhifadhi kifurushi.';
 
   @override
   String get packaging_editing_image_error =>
-      'Failed to get a new packaging image.';
+      'Imeshindwa kupata picha ya kifungashio kipya.';
 
   @override
-  String get packaging_editing_title => 'Edit Packaging';
+  String get packaging_editing_title => 'Badilisha Ufungaji';
 
   @override
   String get nutrition => 'Lishe';
 
   @override
-  String get nutrition_facts_photo => 'Nutrition facts photo';
+  String get nutrition_facts_photo => 'Picha za ukweli wa lishe';
 
   @override
-  String get nutrition_facts_editing_title => 'Edit Nutrition Facts';
+  String get nutrition_facts_editing_title => 'Hariri Ukweli wa Lishe';
 
   @override
-  String get packaging_information => 'Packaging information';
+  String get packaging_information => 'Maelezo ya ufungaji';
 
   @override
-  String get packaging_information_photo => 'Packaging information photo';
+  String get packaging_information_photo => 'Picha ya habari ya ufungaji';
 
   @override
-  String get missing_product => 'You found a new product!';
+  String get missing_product => 'Umepata bidhaa mpya!';
 
   @override
   String get add_product_take_photos =>
-      'Take photos of the packaging to add this product to Open Food Facts';
+      'Piga picha za kifurushi ili kuongeza bidhaa hii kwenye Ukweli wa Chakula cha Open';
 
   @override
   String get add_product_take_photos_descriptive =>
-      'Please take some photos first. You may always complete the product at a later time.';
+      'Tafadhali piga picha kadhaa kwanza. Unaweza kukamilisha bidhaa wakati wowote baadaye.';
 
   @override
   String get add_product_information_button_label => 'Add product information';
 
   @override
-  String get new_product => 'New Product';
+  String get new_product => 'Bidhaa Mpya';
 
   @override
-  String get new_product_found_title => 'New product found!';
+  String get new_product_found_title => 'Bidhaa mpya imepatikana!';
 
   @override
   String get new_product_found_text =>
-      'Our collaborative database contains more than **3 million products**, but this barcode doesn\'t exist: ';
+      'Hifadhidata yetu shirikishi ina zaidi ya **bidhaa milioni 3**, lakini msimbopau huu haupo: ';
 
   @override
   String get new_product_found_button => 'Add this product';
 
   @override
-  String get new_product_leave_title => 'Leave this page?';
+  String get new_product_leave_title =>
+      'Ungependa kuondoka kwenye ukurasa huu?';
 
   @override
   String get new_product_leave_message =>
-      'It looks like you didn\'t input anything. Do you really want to leave this page?';
+      'Inaonekana hukuweka chochote. Je, kweli unataka kuondoka kwenye ukurasa huu?';
 
   @override
   String get new_product_dialog_description =>
-      'Please take photos of the packaging to add this product to our common database';
+      'Tafadhali piga picha za kifurushi ili kuongeza bidhaa hii kwenye hifadhidata yetu ya kawaida';
 
   @override
   String get new_product_dialog_illustration_description =>
-      'An illustration with unknown Nutri-Score and Green Score';
+      'Mchoro wa Nutri-Alama na Alama ya Kijani isiyojulikana';
 
   @override
-  String get front_packaging_photo_button_label => 'Front packaging photo';
+  String get front_packaging_photo_button_label => 'Picha ya ufungaji wa mbele';
 
   @override
   String get confirm_front_packaging_photo_button_label =>
-      'Confirm upload of Front packaging photo';
+      'Thibitisha upakiaji wa picha ya kifungashio cha Mbele';
 
   @override
-  String get confirm_button_label => 'Confirm';
+  String get confirm_button_label => 'Thibitisha';
 
   @override
-  String get send_image_button_label => 'Send image';
+  String get send_image_button_label => 'Tuma picha';
 
   @override
-  String get crop_page_action_saving => 'Saving the image…';
+  String get crop_page_action_saving => 'Inahifadhi picha…';
 
   @override
-  String get crop_page_action_cropping => 'Cropping the image…';
+  String get crop_page_action_cropping => 'Inapunguza picha…';
 
   @override
-  String get crop_page_action_local => 'Saving a local version…';
+  String get crop_page_action_local => 'Inahifadhi toleo la ndani…';
 
   @override
   String get crop_page_action_local_failed_title =>
-      'Oops… there\'s something with your photo!';
+      'Lo… kuna kitu na picha yako!';
 
   @override
   String get crop_page_action_local_failed_message =>
-      'We are unable to process the image locally, before sending it to our server. Please try again later or contact-us if the issue persists.';
+      'Hatuwezi kuchakata picha ndani ya nchi, kabla ya kuituma kwa seva yetu. Tafadhali jaribu tena baadaye au wasiliana nasi kama tatizo litaendelea.';
 
   @override
-  String get crop_page_action_retake => 'Retake a photo';
+  String get crop_page_action_retake => 'Piga picha tena';
 
   @override
-  String get crop_page_too_small_image_title => 'The image is too small!';
+  String get crop_page_too_small_image_title => 'Picha ni ndogo mno!';
 
   @override
   String crop_page_too_small_image_message(
@@ -808,184 +816,189 @@ class AppLocalizationsSw extends AppLocalizations {
     int actualWidth,
     int actualHeight,
   ) {
-    return 'The minimum size in pixels for picture upload is ${expectedMinWidth}x$expectedMinHeight. The current picture is ${actualWidth}x$actualHeight.';
+    return 'Ukubwa wa chini zaidi katika pikseli kwa upakiaji wa picha ni ${expectedMinWidth}x$expectedMinHeight. Picha ya sasa ni ${actualWidth}x$actualHeight.';
   }
 
   @override
-  String get crop_page_action_server => 'Preparing a call to the server…';
+  String get crop_page_action_server => 'Inatayarisha simu kwa seva…';
 
   @override
-  String get front_packaging_photo_title => 'Front Packaging Photo';
+  String get front_packaging_photo_title => 'Picha ya Ufungaji wa Mbele';
 
   @override
-  String get ingredients_photo_title => 'Ingredients Photo';
+  String get ingredients_photo_title => 'Picha ya viungo';
 
   @override
-  String get nutritional_facts_photo_title => 'Nutrition Facts Photo';
+  String get nutritional_facts_photo_title => 'Picha ya Ukweli wa Lishe';
 
   @override
-  String get recycling_photo_title => 'Recycling Photo';
+  String get recycling_photo_title => 'Usafishaji Picha';
 
   @override
   String get take_photo_title => 'Piga picha';
 
   @override
-  String get take_more_photo_title => 'Take more pictures';
+  String get take_more_photo_title => 'Piga picha zaidi';
 
   @override
-  String get front_photo_uploaded => 'Front photo uploaded';
+  String get front_photo_uploaded => 'Picha ya mbele imepakiwa';
 
   @override
-  String get ingredients_photo_button_label => 'Ingredients photo';
+  String get ingredients_photo_button_label => 'Picha ya viungo';
 
   @override
-  String get ingredients_photo_uploaded => 'Ingredients photo uploaded';
+  String get ingredients_photo_uploaded => 'Picha ya viungo imepakiwa';
 
   @override
   String get nutrition_cache_loading_error =>
-      'Unable to load nutrients from cache';
+      'Haiwezi kupakia virutubishi kutoka kwa akiba';
 
   @override
-  String get nutritional_facts_photo_button_label => 'Nutrition facts photo';
+  String get nutritional_facts_photo_button_label => 'Picha za ukweli wa lishe';
 
   @override
-  String get nutritional_facts_input_button_label => 'Fill nutrition facts';
+  String get nutritional_facts_input_button_label => 'Jaza ukweli wa lishe';
 
   @override
-  String get nutritional_facts_added => 'Nutrition facts added';
+  String get nutritional_facts_added => 'Ukweli wa lishe umeongezwa';
 
   @override
-  String get categories_added => 'Categories added';
+  String get categories_added => 'Kategoria zimeongezwa';
 
   @override
-  String get new_product_title_nutriscore => 'Compute the Nutri-Score';
+  String get new_product_title_nutriscore => 'Kuhesabu Nutri-Alama';
 
   @override
   String get new_product_subtitle_nutriscore =>
-      'Help us by filling at least a category and nutritional values';
+      'Tusaidie kwa kujaza angalau kategoria na maadili ya lishe';
 
   @override
-  String get new_product_title_environmental_score => 'Compute the Green Score';
+  String get new_product_title_environmental_score =>
+      'Kuhesabu Alama ya Kijani';
 
   @override
   String get new_product_subtitle_environmental_score =>
-      'Get it by filling at least a category';
+      'Ipate kwa kujaza angalau kategoria';
 
   @override
   String get new_product_additional_environmental_score =>
-      'Make Green Score computation more precise with origins, packaging & more';
+      'Fanya hesabu ya Alama ya Kijani iwe sahihi zaidi ukitumia asili, vifungashio na zaidi';
 
   @override
   String get new_product_title_nova =>
-      'Compute the food processing level (NOVA)';
+      'Kuhesabu kiwango cha usindikaji wa chakula (NOVA)';
 
   @override
   String get new_product_subtitle_nova =>
-      'Get it by filling the food category and ingredients';
+      'Ipate kwa kujaza kategoria ya chakula na viungo';
 
   @override
-  String get new_product_desc_nova_unknown => 'Food processing level unknown';
+  String get new_product_desc_nova_unknown =>
+      'Kiwango cha usindikaji wa chakula hakijulikani';
 
   @override
-  String get new_product_title_pictures => 'New product';
+  String get new_product_title_pictures => 'Bidhaa mpya';
 
   @override
   String get new_product_title_pictures_details =>
-      'Please take the following photos and the Open Food Facts engine can work out the rest!';
+      'Tafadhali piga picha zifuatazo na injini ya Open Food Facts inaweza kusuluhisha zingine!';
 
   @override
-  String get new_product_title_misc => 'And some basic data…';
+  String get new_product_title_misc => 'Na baadhi ya data msingi…';
 
   @override
   String new_product_done_msg(String username) {
-    return 'Thanks for your contribution “$username”!';
+    return 'Asante kwa mchango wako “$username”!';
   }
 
   @override
-  String get new_product_done_msg_no_user => 'Thanks for your contribution!';
+  String get new_product_done_msg_no_user => 'Asante kwa mchango wako!';
 
   @override
-  String get new_product_done_button_label => 'Discover the completed product';
+  String get new_product_done_button_label => 'Gundua bidhaa iliyokamilishwa';
 
   @override
   String get hey_incomplete_product_message =>
-      'Tap to answer 3 questions NOW to compute Nutri-Score, Green Score & Ultra-processing (NOVA)!';
+      'Gusa ili ujibu maswali 3 SASA ili kukokotoa Nutri-Score, Green Score & Ultra-processing (NOVA)!';
 
   @override
   String get hey_incomplete_product_message_beauty =>
-      'Tap now to answer 2 questions to help analyze this cosmetic!';
+      'Gusa sasa ili kujibu maswali 2 ili kukusaidia kuchanganua kipodozi hiki!';
 
   @override
   String get hey_incomplete_product_message_pet_food =>
-      'Tap now to answer 3 questions to help analyze this pet food product!';
+      'Gusa sasa ili kujibu maswali 3 ili kusaidia kuchanganua bidhaa hii ya chakula pendwa!';
 
   @override
   String get hey_incomplete_product_message_product =>
-      'Tap now to help complete this product!';
+      'Gusa sasa ili kusaidia kukamilisha bidhaa hii!';
 
   @override
   String get nutritional_facts_photo_uploaded =>
-      'Nutrition facts photo uploaded';
+      'Picha ya ukweli wa lishe imepakiwa';
 
   @override
-  String get recycling_photo_button_label => 'Recycling photo';
+  String get recycling_photo_button_label => 'Inarejeleza picha';
 
   @override
-  String get recycling_photo_uploaded => 'Recycling photo uploaded';
+  String get recycling_photo_uploaded => 'Picha ya kuchakata imepakiwa';
 
   @override
-  String get take_more_photo_button_label => 'Take more pictures';
+  String get take_more_photo_button_label => 'Piga picha zaidi';
 
   @override
-  String get other_photo_uploaded => 'Miscellaneous photo uploaded';
+  String get other_photo_uploaded => 'Picha mbalimbali zimepakiwa';
 
   @override
-  String get retake_photo_button_label => 'Retake';
+  String get retake_photo_button_label => 'Chukua tena';
 
   @override
-  String get selecting_photo => 'Selecting photo';
+  String get selecting_photo => 'Inachagua picha';
 
   @override
-  String get uploading_image => 'Uploading photo to the server';
+  String get uploading_image => 'Inapakia picha kwenye seva';
 
   @override
   String get uploading_image_type_front =>
-      'Uploading front image to Open Food Facts';
+      'Inapakia picha ya mbele kwa Fungua Ukweli wa Chakula';
 
   @override
   String get uploading_image_type_ingredients =>
-      'Uploading ingredients image to Open Food Facts';
+      'Inapakia picha ya viungo kwa Fungua Ukweli wa Chakula';
 
   @override
   String get uploading_image_type_nutrition =>
-      'Uploading nutrition image to Open Food Facts';
+      'Inapakia picha ya lishe kwa Fungua Ukweli wa Chakula';
 
   @override
   String get uploading_image_type_packaging =>
-      'Uploading packaging image to Open Food Facts';
+      'Inapakia picha ya kifungashio kwa Fungua Ukweli wa Chakula';
 
   @override
   String get uploading_image_type_other =>
-      'Uploading other image to Open Food Facts';
+      'Inapakia picha nyingine kwa Fungua Ukweli wa Chakula';
 
   @override
   String get uploading_image_type_generic =>
-      'Uploading image to Open Food Facts';
+      'Inapakia picha kwenye Fungua Ukweli wa Chakula';
 
   @override
-  String get score_add_missing_ingredients => 'Add missing ingredients';
+  String get score_add_missing_ingredients => 'Ongeza viungo vilivyokosekana';
 
   @override
-  String get score_add_missing_packaging_image => 'Add missing packaging image';
+  String get score_add_missing_packaging_image =>
+      'Ongeza picha ya kifungashio ambayo haipo';
 
   @override
-  String get score_add_missing_nutrition_facts => 'Add missing nutrition facts';
+  String get score_add_missing_nutrition_facts =>
+      'Ongeza ukweli wa lishe unaokosekana';
 
   @override
-  String get score_add_missing_product_traces => 'Add missing product traces';
+  String get score_add_missing_product_traces =>
+      'Ongeza alama za bidhaa ambazo hazipo';
 
   @override
-  String get score_add_missing_product_category => 'Select a category';
+  String get score_add_missing_product_category => 'Chagua kategoria';
 
   @override
   String get score_add_missing_precise_product_category =>
@@ -993,36 +1006,40 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get score_add_missing_product_countries =>
-      'Add missing product countries';
+      'Ongeza nchi za bidhaa ambazo hazipo';
 
   @override
   String get score_add_missing_product_emb =>
-      'Add missing product traceability codes';
+      'Ongeza misimbo ya ufuatiliaji wa bidhaa ambayo haipo';
 
   @override
-  String get score_add_missing_product_labels => 'Add missing product labels';
+  String get score_add_missing_product_labels =>
+      'Ongeza lebo za bidhaa ambazo hazipo';
 
   @override
-  String get score_add_missing_product_origins => 'Add missing product origins';
+  String get score_add_missing_product_origins =>
+      'Ongeza asili ya bidhaa inayokosekana';
 
   @override
-  String get score_add_missing_product_stores => 'Add missing product stores';
+  String get score_add_missing_product_stores =>
+      'Ongeza maduka ya bidhaa ambayo hayapo';
 
   @override
-  String get score_add_missing_product_brands => 'Add missing product brands';
+  String get score_add_missing_product_brands =>
+      'Ongeza chapa za bidhaa zinazokosekana';
 
   @override
-  String get score_update_nutrition_facts => 'Update nutrition facts';
+  String get score_update_nutrition_facts => 'Sasisha ukweli wa lishe';
 
   @override
-  String get nutrition_page_title => 'Nutrition Facts';
+  String get nutrition_page_title => 'Ukweli wa Lishe';
 
   @override
-  String get nutrition_page_nutritional_info_title => 'Nutritional information';
+  String get nutrition_page_nutritional_info_title => 'Taarifa za lishe';
 
   @override
   String get nutrition_page_nutritional_info_label =>
-      'Values specified on the product:';
+      'Thamani zilizoainishwa kwenye bidhaa:';
 
   @override
   String get nutrition_page_nutritional_info_value_positive => 'Yes';
@@ -1031,61 +1048,61 @@ class AppLocalizationsSw extends AppLocalizations {
   String get nutrition_page_nutritional_info_value_negative => 'No';
 
   @override
-  String get nutrition_page_nutritional_info_open_photo => 'Open photo';
+  String get nutrition_page_nutritional_info_open_photo => 'Fungua picha';
 
   @override
   String get nutrition_page_nutritional_info_explanation_title =>
-      'Good practices: Nutritional information';
+      'Mazoea mazuri: Taarifa za lishe';
 
   @override
   String get nutrition_page_nutritional_info_explanation_info1 =>
-      'Sometimes nutrition facts are **not specified on the packaging** or on a document given with the product. In this case, and only in this case, you can set the value to **NO**.';
+      'Wakati mwingine ukweli wa lishe **haujabainishwa kwenye kifungashio** au kwenye hati iliyotolewa pamoja na bidhaa. Katika kesi hii, na tu katika kesi hii, unaweza kuweka thamani kwa ** NO **.';
 
   @override
-  String get nutrition_page_serving_type_label => 'Nutritional values:';
+  String get nutrition_page_serving_type_label => 'Thamani za lishe:';
 
   @override
-  String get nutrition_page_per_100g => 'per 100g';
+  String get nutrition_page_per_100g => 'kwa 100g';
 
   @override
-  String get nutrition_page_per_100g_100ml => 'per 100g/ml';
+  String get nutrition_page_per_100g_100ml => 'kwa 100g/ml';
 
   @override
-  String get nutrition_page_per_serving => 'per serving';
+  String get nutrition_page_per_serving => 'kwa kuwahudumia';
 
   @override
-  String get nutrition_page_add_nutrient => 'Add a nutrient';
+  String get nutrition_page_add_nutrient => 'Ongeza virutubisho';
 
   @override
-  String get nutrition_page_serving_size => 'Serving size';
+  String get nutrition_page_serving_size => 'Saizi ya kutumikia';
 
   @override
   String get nutrition_page_serving_size_hint =>
-      'Input a serving size (eg: 100g)';
+      'Weka ukubwa wa kuhudumia (km: 100g)';
 
   @override
   String get nutrition_page_serving_size_explanation_title =>
-      'Good practices: Serving size';
+      'Mazoea mazuri: saizi ya kutumikia';
 
   @override
   String get nutrition_page_serving_size_explanation_info1 =>
-      'This value helps to **make a proportional calculation of each nutrient per serving size**.';
+      'Thamani hii husaidia **kufanya hesabu ya sawia ya kila kirutubisho kwa saizi ya kuhudumia**.';
 
   @override
   String get nutrition_page_serving_size_explanation_info2 =>
-      '**Allowed units** are: kg, g, mg, µg, oz, l, dl, cl, ml, fl.oz, fl oz, г, мг, кг, л, дл, кл, мл, 毫克, 公斤, 毫升, 公升, 吨.';
+      '**Vizio vinavyoruhusiwa** ni: kg, g, mg, µg, oz, l, dl, cl, ml, fl.oz, fl oz, г, мг, кг, л, дл, кл, мл, 毫克, 公斤, 毫嬍, 公斤, 毫嬍, 公斤, 毫嬍, 公斤, 毫嬍';
 
   @override
   String get nutrition_page_serving_size_explanation_good_example1 =>
-      '**60 g**, **60g** or **60 G** (prefer the first one)';
+      '**60 g**, **60g** au **60 G** (pendelea ya kwanza)';
 
   @override
   String get nutrition_page_serving_size_explanation_good_example2 =>
-      '**1000 ml** or **1L**';
+      '**1000 ml** au **1L**';
 
   @override
   String get nutrition_page_serving_size_explanation_bad_example1_explanation =>
-      'Invalid unit';
+      'Kitengo batili';
 
   @override
   String get nutrition_page_serving_size_explanation_bad_example1_example =>
@@ -1093,88 +1110,88 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get nutrition_page_serving_size_explanation_bad_example2_explanation =>
-      'Invalid units';
+      'Vizio batili';
 
   @override
   String get nutrition_page_serving_size_explanation_bad_example2_example =>
-      '9 **candies** and 2 **biscuits**';
+      '9 **pipi** na 2 **biskuti**';
 
   @override
   String get nutrition_page_serving_size_explanation_bad_example3_explanation =>
-      'Missing unit';
+      'Kitengo kinakosekana';
 
   @override
   String get nutrition_page_serving_size_explanation_bad_example3_example =>
       '**30**';
 
   @override
-  String get nutrition_page_invalid_number => 'Invalid number';
+  String get nutrition_page_invalid_number => 'Nambari batili';
 
   @override
-  String get nutrition_page_update_running =>
-      'Updating the product on the server…';
+  String get nutrition_page_update_running => 'Kusasisha bidhaa kwenye seva…';
 
   @override
-  String get nutrition_page_update_done => 'Product updated!';
+  String get nutrition_page_update_done => 'Bidhaa imesasishwa!';
 
   @override
   String get nutrition_page_take_serving_size_from_product_quantity =>
-      'Use the product quantity as serving size';
+      'Tumia kiasi cha bidhaa kama saizi ya kuhudumia';
 
   @override
-  String get nutrition_page_photo_error => 'Unable to load the photo';
+  String get nutrition_page_photo_error => 'Imeshindwa kupakia picha';
 
   @override
-  String get more_photos => 'More interesting photos';
+  String get more_photos => 'Picha za kuvutia zaidi';
 
   @override
   String get view_more_photo_button =>
-      'View all existing photos for this product';
+      'Tazama picha zote zilizopo za bidhaa hii';
 
   @override
-  String get no_product_found => 'No product found';
+  String get no_product_found => 'Hakuna bidhaa iliyopatikana';
 
   @override
-  String get no_location_found => 'No location found';
+  String get no_location_found => 'Hakuna eneo lililopatikana';
 
   @override
-  String get not_found => 'not found:';
+  String get not_found => 'haijapatikana:';
 
   @override
-  String get refreshing_product => 'Refreshing product';
+  String get refreshing_product => 'Bidhaa ya kuburudisha';
 
   @override
-  String get product_refreshed => 'Product refreshed';
+  String get product_refreshed => 'Bidhaa imeonyeshwa upya';
 
   @override
   String product_image_accessibility_label(String date) {
-    return 'Image taken on $date';
+    return 'Picha ilipigwa tarehe $date';
   }
 
   @override
   String product_image_outdated_accessibility_label(String date) {
-    return 'Image taken on $date. This image may be outdated';
+    return 'Picha iliyopigwa tarehe $date. Picha hii inaweza kuwa imepitwa na wakati';
   }
 
   @override
-  String get product_image_outdated => 'This image may be outdated';
+  String get product_image_outdated =>
+      'Picha hii inaweza kuwa imepitwa na wakati';
 
   @override
   String get product_image_outdated_explanations_title =>
-      'This image may be outdated';
+      'Picha hii inaweza kuwa imepitwa na wakati';
 
   @override
   String get product_image_outdated_explanations_content =>
-      'This image was taken more than a year ago.\n**Please check that\'s it\'s still up-to-date**.\n\nThis is **just a warning**. If the content is still the same, you can ignore this message.';
+      'Picha hii ilipigwa zaidi ya mwaka mmoja uliopita.\n**Tafadhali angalia kwamba bado ni ya kisasa**.\n\nHili ni **onyo tu**. Ikiwa maudhui bado ni sawa, unaweza kupuuza ujumbe huu.';
 
   @override
   String product_image_action_replace_photo(String type) {
-    return 'Replace photo ($type)';
+    return 'Badilisha picha ($type)';
   }
 
   @override
   String product_image_action_add_photo(String type) {
-    return 'Add a photo ($type)';
+    return 'Ongeza picha ($type)';
   }
 
   @override
@@ -1185,91 +1202,91 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get product_image_action_from_gallery =>
-      'Select from your phone\'s gallery';
+      'Chagua kutoka kwenye ghala ya simu yako';
 
   @override
   String get product_image_action_choose_existing_photo =>
-      'Select from the product photos';
+      'Chagua kutoka kwa picha za bidhaa';
 
   @override
-  String get product_image_details_label => 'Information about the photo';
+  String get product_image_details_label => 'Taarifa kuhusu picha';
 
   @override
-  String get product_image_details_from_producer => 'From the producer';
+  String get product_image_details_from_producer => 'Kutoka kwa mtayarishaji';
 
   @override
   String get product_image_details_contributor => 'Contributor';
 
   @override
   String get product_image_details_contributor_producer =>
-      'Contributor (producer)';
+      'Mchangiaji (mtayarishaji)';
 
   @override
-  String get product_image_details_date => 'Date';
+  String get product_image_details_date => 'Tarehe';
 
   @override
-  String get product_image_details_date_unknown => 'Unknown';
+  String get product_image_details_date_unknown => 'Haijulikani';
 
   @override
   String get homepage_main_card_logo_description =>
-      'Welcome to Open Food Facts';
+      'Karibu kwa Open Food Facts';
 
   @override
   String get homepage_main_card_subheading =>
-      '**Scan** a barcode or\n**search** for a product';
+      '**Changanua** msimbo pau au\n**tafuta** bidhaa';
 
   @override
-  String get homepage_main_card_search_field_hint => 'Search for a product';
+  String get homepage_main_card_search_field_hint => 'Tafuta bidhaa';
 
   @override
-  String get homepage_main_card_search_field_tooltip => 'Start search';
+  String get homepage_main_card_search_field_tooltip => 'Anza kutafuta';
 
   @override
   String scan_tagline_news_item_accessibility(String news_title) {
-    return 'Latest news: $news_title';
+    return 'Habari za hivi punde: $news_title';
   }
 
   @override
-  String get tagline_app_review => 'Do you like the app?';
+  String get tagline_app_review => 'Je, unapenda programu?';
 
   @override
-  String get tagline_app_review_button_positive => 'I love it! 😍';
+  String get tagline_app_review_button_positive => 'Naipenda! 😍';
 
   @override
-  String get tagline_app_review_button_negative => 'Not really…';
+  String get tagline_app_review_button_negative => 'Si kweli…';
 
   @override
-  String get tagline_app_review_button_later => 'Ask me later';
+  String get tagline_app_review_button_later => 'Niulize baadaye';
 
   @override
-  String get tagline_feed_news_button => 'Know more';
+  String get tagline_feed_news_button => 'Jua zaidi';
 
   @override
-  String get app_review_negative_modal_title => 'You don\'t like our app?';
+  String get app_review_negative_modal_title => 'Hupendi programu yetu?';
 
   @override
   String get app_review_negative_modal_text =>
-      'Could you take a few seconds to tell us why?';
+      'Unaweza kuchukua sekunde chache kutuambia kwa nini?';
 
   @override
-  String get app_review_negative_modal_positive_button => 'Yes, absolutely!';
+  String get app_review_negative_modal_positive_button => 'Ndiyo, kabisa!';
 
   @override
   String get app_review_negative_modal_negative_button => 'No';
 
   @override
-  String get could_not_refresh => 'Could not refresh product';
+  String get could_not_refresh => 'Haikuweza kuonyesha upya bidhaa';
 
   @override
-  String get product_internet_error_modal_title => 'An error has occurred!';
+  String get product_internet_error_modal_title => 'Hitilafu imetokea!';
 
   @override
   String product_internet_error_modal_message(String error) {
-    return 'We are unable to fetch information about this product due to a network error. Please check your internet connection and try again.\n\nInternal error:\n$error';
+    return 'Hatujaweza kupata maelezo kuhusu bidhaa hii kwa sababu ya hitilafu ya mtandao. Tafadhali angalia muunganisho wako wa intaneti na ujaribu tena.\n\nHitilafu ya ndani:\n$error';
   }
 
   @override
-  String get product_tags_title => 'Product properties';
+  String get product_tags_title => 'Tabia za bidhaa';
 
   @override
   String get no_product_tags_found_message =>
@@ -1286,28 +1303,28 @@ class AppLocalizationsSw extends AppLocalizations {
   String get add_tag => 'Add property';
 
   @override
-  String get add_tags => 'Add properties';
+  String get add_tags => 'Ongeza sifa';
 
   @override
-  String get add_edit_tags => 'Add or edit properties';
+  String get add_edit_tags => 'Ongeza au hariri sifa';
 
   @override
-  String get edit_tag => 'Edit property';
+  String get edit_tag => 'Hariri mali';
 
   @override
-  String get remove_tag => 'Remove property';
+  String get remove_tag => 'Ondoa mali';
 
   @override
-  String get tag_key => 'Property';
+  String get tag_key => 'Mali';
 
   @override
   String get tag_keys => 'Mali';
 
   @override
-  String get tag_key_uneditable => 'Property (uneditable)';
+  String get tag_key_uneditable => 'Mali (isiyoweza kuhaririwa)';
 
   @override
-  String get tag_key_input_hint => 'Input a property';
+  String get tag_key_input_hint => 'Ingiza mali';
 
   @override
   String get tag_value => 'Value';
@@ -1316,29 +1333,29 @@ class AppLocalizationsSw extends AppLocalizations {
   String get tag_values => 'Values';
 
   @override
-  String get tag_value_input_hint => 'Input a value';
+  String get tag_value_input_hint => 'Ingiza thamani';
 
   @override
-  String get tag_key_item => 'Property:';
+  String get tag_key_item => 'Mali:';
 
   @override
-  String get tag_value_item => 'Value:';
+  String get tag_value_item => 'Thamani:';
 
   @override
   String get tag_key_explanations =>
-      'A key must be lowercase and without any spaces.';
+      'Ufunguo lazima uwe na herufi ndogo na bila nafasi yoyote.';
 
   @override
   String tag_key_already_exists(String property) {
-    return 'A tag with a property $property already exists!';
+    return 'Lebo iliyo na sifa $property tayari ipo!';
   }
 
   @override
   String get product_internet_error =>
-      'Impossible to fetch information about this product due to a network error.';
+      'Haiwezekani kuleta maelezo kuhusu bidhaa hii kwa sababu ya hitilafu ya mtandao.';
 
   @override
-  String get cached_results_from => 'Show results from:';
+  String get cached_results_from => 'Onyesha matokeo kutoka:';
 
   @override
   String get product_search_same_category => 'Tafuta njia mbadala';
@@ -1348,99 +1365,100 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get product_search_same_category_error =>
-      'This feature can only be used for products with a category.\n\nPlease edit the product to add a category.';
+      'Kipengele hiki kinaweza kutumika tu kwa bidhaa zilizo na kitengo.\n\nTafadhali hariri bidhaa ili kuongeza kategoria.';
 
   @override
   String get product_improvement_add_category =>
-      'Add a category to calculate the Nutri-Score.';
+      'Ongeza kategoria ili kukokotoa Nutri-Alama.';
 
   @override
   String get product_improvement_add_nutrition_facts =>
-      'Add nutrition facts to calculate the Nutri-Score.';
+      'Ongeza ukweli wa lishe ili kukokotoa Nutri-Score.';
 
   @override
   String get product_improvement_add_nutrition_facts_and_category =>
-      'Add nutrition facts and a category to calculate the Nutri-Score.';
+      'Ongeza ukweli wa lishe na kategoria ili kukokotoa Alama ya Nutri.';
 
   @override
   String get product_improvement_categories_but_no_nutriscore =>
-      'The Nutri-Score for this product can\'t be calculated, which may be due to e.g. a non-standard category. If this is considered an error, please contact us.';
+      'Nutri-Alama ya bidhaa hii haiwezi kuhesabiwa, ambayo inaweza kuwa kutokana na mfano kategoria isiyo ya kawaida. Ikiwa hii inachukuliwa kuwa kosa, tafadhali wasiliana nasi.';
 
   @override
   String get product_improvement_obsolete_nutrition_image =>
-      'The nutrition image is obsolete: please refresh it.';
+      'Picha ya lishe imepitwa na wakati: tafadhali ionyeshe upya.';
 
   @override
   String get product_improvement_origins_to_be_completed =>
-      'The Green Score takes into account the origins of the ingredients. Please take a photo of the ingredient list and/or any geographic claim or edit the product, so they can be taken into account.';
+      'Alama ya Kijani huzingatia asili ya viungo. Tafadhali piga picha ya orodha ya viambato na/au dai lolote la kijiografia au uhariri bidhaa, ili ziweze kuzingatiwa.';
 
   @override
-  String get country_chooser_label => 'Please choose a country';
+  String get country_chooser_label => 'Tafadhali chagua nchi';
 
   @override
-  String get currency_chooser_label => 'Please choose a currency';
+  String get currency_chooser_label => 'Tafadhali chagua sarafu';
 
   @override
-  String get country_change_message => 'You have just changed countries.';
+  String get country_change_message => 'Umebadilisha nchi.';
 
   @override
   String currency_auto_change_message(
     String previousCurrency,
     String possibleCurrency,
   ) {
-    return 'Do you want to change the currency from $previousCurrency to $possibleCurrency?';
+    return 'Je, ungependa kubadilisha sarafu kutoka $previousCurrency hadi $possibleCurrency?';
   }
 
   @override
-  String get onboarding_country_chooser_label => 'Please choose a country:';
+  String get onboarding_country_chooser_label => 'Tafadhali chagua nchi:';
 
   @override
-  String get country_chooser_label_from_settings => 'Your country';
+  String get country_chooser_label_from_settings => 'Nchi yako';
 
   @override
   String get country_selection_explanation =>
-      'Some environmental features are location-specific';
+      'Baadhi ya vipengele vya mazingira ni mahususi kwa eneo';
 
   @override
-  String get product_removed_comparison => 'Product removed from comparison';
+  String get product_removed_comparison =>
+      'Bidhaa imeondolewa kutoka kwa kulinganisha';
 
   @override
-  String get native_app_settings => 'Native App Settings';
+  String get native_app_settings => 'Mipangilio ya Programu Asilia';
 
   @override
   String get native_app_description =>
-      'Open systems settings for Open Food Facts';
+      'Fungua mipangilio ya mifumo ya Ukweli wa Chakula Huria';
 
   @override
-  String get product_removed_history => 'Product removed from history';
+  String get product_removed_history => 'Bidhaa imeondolewa kwenye historia';
 
   @override
-  String get product_removed_list => 'Product removed from list';
+  String get product_removed_list => 'Bidhaa imeondolewa kwenye orodha';
 
   @override
-  String get product_could_not_remove => 'Could not remove product';
+  String get product_could_not_remove => 'Haikuweza kuondoa bidhaa';
 
   @override
-  String get no_prodcut_in_list => 'There is no product in this list';
+  String get no_prodcut_in_list => 'Hakuna bidhaa katika orodha hii';
 
   @override
-  String get no_product_in_section => 'There is no product in this section';
+  String get no_product_in_section => 'Hakuna bidhaa katika sehemu hii';
 
   @override
-  String get recently_seen_products => 'All viewed products';
+  String get recently_seen_products => 'Bidhaa zote zilizotazamwa';
 
   @override
-  String get clear => 'Clear';
+  String get clear => 'Wazi';
 
   @override
-  String get clear_long => 'Empty the list';
+  String get clear_long => 'Futa orodha';
 
   @override
-  String get really_clear => 'Do you really want to delete this list?';
+  String get really_clear => 'Je, kweli unataka kufuta orodha hii?';
 
   @override
   String pct_match(Object percent) {
-    return '$percent% match';
+    return '$percent% inayolingana';
   }
 
   @override
@@ -1448,8 +1466,8 @@ class AppLocalizationsSw extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count days ago',
-      one: 'one day ago',
+      other: '$count siku zilizopita',
+      one: 'siku moja iliyopita',
     );
     return '$_temp0';
   }
@@ -1459,8 +1477,8 @@ class AppLocalizationsSw extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count hours ago',
-      one: 'one hour ago',
+      other: '$count masaa iliyopita',
+      one: 'saa moja iliyopita',
     );
     return '$_temp0';
   }
@@ -1471,8 +1489,8 @@ class AppLocalizationsSw extends AppLocalizations {
       count,
       locale: localeName,
       other: '$count minutes ago',
-      one: 'one minute ago',
-      zero: 'less than a minute ago',
+      one: 'dakika moja iliyopita',
+      zero: 'chini ya dakika moja iliyopita',
     );
     return '$_temp0';
   }
@@ -1482,8 +1500,8 @@ class AppLocalizationsSw extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count months ago',
-      one: 'one month ago',
+      other: '$count miezi iliyopita',
+      one: 'mwezi mmoja uliopita',
     );
     return '$_temp0';
   }
@@ -1493,8 +1511,8 @@ class AppLocalizationsSw extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count weeks ago',
-      one: 'one week ago',
+      other: '$count wiki zilizopita',
+      one: 'wiki moja iliyopita',
     );
     return '$_temp0';
   }
@@ -1504,8 +1522,8 @@ class AppLocalizationsSw extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'Compare $count Products',
-      one: 'Compare one Product',
+      other: 'Linganisha $count Bidhaa',
+      one: 'Linganisha Bidhaa moja',
     );
     return '$_temp0';
   }
@@ -1515,86 +1533,86 @@ class AppLocalizationsSw extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count selected products',
-      one: 'One selected product',
-      zero: 'No selected product',
+      other: '$count bidhaa zilizochaguliwa',
+      one: 'Bidhaa moja iliyochaguliwa',
+      zero: 'Hakuna bidhaa iliyochaguliwa',
     );
     return '$_temp0';
   }
 
   @override
-  String get compare_products_mode => 'Compare selected products';
+  String get compare_products_mode => 'Linganisha bidhaa zilizochaguliwa';
 
   @override
-  String get delete_products_mode => 'Delete selected products';
+  String get delete_products_mode => 'Futa bidhaa zilizochaguliwa';
 
   @override
-  String get select_all_products_mode => 'Select all products';
+  String get select_all_products_mode => 'Chagua bidhaa zote';
 
   @override
-  String get select_none_products_mode => 'Select none';
+  String get select_none_products_mode => 'Usichague yoyote';
 
   @override
   String get compare_products_appbar_title => 'Compare products';
 
   @override
   String get compare_products_appbar_subtitle =>
-      'Please select at least two products';
+      'Tafadhali chagua angalau bidhaa mbili';
 
   @override
-  String get retry_button_label => 'Retry';
+  String get retry_button_label => 'Jaribu tena';
 
   @override
-  String get connect_with_us => 'Connect with us';
+  String get connect_with_us => 'Ungana nasi';
 
   @override
-  String get tiktok => 'Follow us on TikTok';
+  String get tiktok => 'Tufuate kwenye TikTok';
 
   @override
   String get tiktok_link => 'https://www.tiktok.com/@openfoodfacts';
 
   @override
-  String get instagram => 'Follow us on Instagram';
+  String get instagram => 'Tufuate kwenye Instagram';
 
   @override
   String get instagram_link => 'https://instagram.com/open.food.facts';
 
   @override
-  String get twitter => 'Follow us on X (formerly Twitter)';
+  String get twitter => 'Tufuate kwenye X (zamani Twitter)';
 
   @override
   String get twitter_link => 'https://www.twitter.com/openfoodfacts';
 
   @override
-  String get mastodon => 'Follow us on Mastodon';
+  String get mastodon => 'Tufuate kwenye Mastodon';
 
   @override
   String get mastodon_link => 'https://mastodon.social/@openfoodfacts';
 
   @override
-  String get bsky => 'Follow us on BlueSky';
+  String get bsky => 'Tufuate kwenye BlueSky';
 
   @override
   String get bsky_link => 'https://bsky.app/profile/openfoodfacts.bsky.social';
 
   @override
-  String get blog => 'Blog';
+  String get blog => 'Blogu';
 
   @override
-  String get faq => 'FAQ';
+  String get faq => 'Maswali Yanayoulizwa Mara kwa Mara';
 
   @override
   String get discover => 'Gundua';
 
   @override
-  String get how_to_contribute => 'How to Contribute';
+  String get how_to_contribute => 'Jinsi ya Kuchangia';
 
   @override
   String get hint_knowledge_panel_message =>
-      'Your can tap on any part of the card to get more details about what you see. Try it now!';
+      'Unaweza kugonga sehemu yoyote ya kadi ili kupata maelezo zaidi kuhusu unachokiona. Ijaribu sasa!';
 
   @override
-  String get permissions_page_title => 'Camera access';
+  String get permissions_page_title => 'Ufikiaji wa kamera';
 
   @override
   String get permissions_page_body1 =>
@@ -1602,7 +1620,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get permissions_page_body2 =>
-      'If you change your mind, this option can be enabled and disabled at any time from the settings.';
+      'Ukibadilisha nia yako, chaguo hili linaweza kuwashwa na kuzimwa wakati wowote kutoka kwa mipangilio.';
 
   @override
   String contact_form_body_android(
@@ -1622,7 +1640,7 @@ class AppLocalizationsSw extends AppLocalizations {
     String? model,
     String? localizedModel,
   ) {
-    return 'OS: iOS ($version)\nModel: $model\nLocalized model: $localizedModel';
+    return 'Mfumo wa Uendeshaji: iOS ($version)\nMuundo: $model\nMuundo uliojanibishwa: $localizedModel';
   }
 
   @override
@@ -1632,67 +1650,67 @@ class AppLocalizationsSw extends AppLocalizations {
     String appBuildNumber,
     String appPackageName,
   ) {
-    return '$osContent\nApp version:$appVersion\nApp build number:$appBuildNumber\nApp package name:$appPackageName';
+    return '$osContent\nToleo la programu:$appVersion\nNambari ya muundo wa programu:$appBuildNumber\nJina la kifurushi cha programu:$appPackageName';
   }
 
   @override
   String get authorize_button_label => 'Authorise';
 
   @override
-  String get refuse_button_label => 'Refuse';
+  String get refuse_button_label => 'Kataa';
 
   @override
-  String get ask_me_later_button_label => 'Later';
+  String get ask_me_later_button_label => 'Baadaye';
 
   @override
-  String get are_you_sure => 'Are you sure?';
+  String get are_you_sure => 'Je, una uhakika?';
 
   @override
   String knowledge_panel_text_source(String sourceName) {
-    return 'Go further on $sourceName';
+    return 'Nenda zaidi kwenye $sourceName';
   }
 
   @override
-  String get onboarding_home_welcome_text1 => 'Welcome !';
+  String get onboarding_home_welcome_text1 => 'Karibu !';
 
   @override
   String get onboarding_home_welcome_text2 =>
-      'The app that helps you choose food that is good for **you** and the **planet**!';
+      'Programu inayokusaidia kuchagua chakula ambacho kinafaa kwa **wewe** na **sayari**!';
 
   @override
-  String get onboarding_continue_button => 'Continue';
+  String get onboarding_continue_button => 'Endelea';
 
   @override
   String get onboarding_welcome_loading_dialog_title =>
-      'Loading your first example product';
+      'Inapakia mfano wa bidhaa yako ya kwanza';
 
   @override
   String get onboarding_welcome_warning =>
       'Samahani, ni mfano wetu wa bidhaa, huwezi kuihariri :)';
 
   @override
-  String get product_list_your_ranking => 'Your ranking';
+  String get product_list_your_ranking => 'Nafasi yako';
 
   @override
-  String get product_list_empty_icon_desc => 'History not available';
+  String get product_list_empty_icon_desc => 'Historia haipatikani';
 
   @override
-  String get product_list_empty_title => 'Start scanning';
+  String get product_list_empty_title => 'Anza kuchanganua';
 
   @override
   String get product_list_empty_message =>
-      'Scanned products will appear here and you can check detailed information about them';
+      'Bidhaa zilizochanganuliwa zitaonekana hapa na unaweza kuangalia maelezo ya kina kuzihusu';
 
   @override
   String product_list_reloading_in_progress_multiple(num count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'products',
+      other: 'bidhaa',
       one: 'product',
       zero: 'product',
     );
-    return 'Refreshing $_temp0 in your history';
+    return 'Inaonyesha upya $_temp0 katika historia yako';
   }
 
   @override
@@ -1700,11 +1718,11 @@ class AppLocalizationsSw extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'Products',
-      one: 'Product',
-      zero: 'Product',
+      other: 'Bidhaa',
+      one: 'Bidhaa',
+      zero: 'Bidhaa',
     );
-    return '$_temp0 refresh complete';
+    return '$_temp0 onyesha upya umekamilika';
   }
 
   @override
@@ -1712,83 +1730,84 @@ class AppLocalizationsSw extends AppLocalizations {
       'Linganisha upande kwa upande';
 
   @override
-  String get loading_dialog_default_title => 'Downloading data';
+  String get loading_dialog_default_title => 'Inapakua data';
 
   @override
-  String get loading_dialog_default_error_message => 'Could not download data';
+  String get loading_dialog_default_error_message => 'Haikuweza kupakua data';
 
   @override
-  String get account_delete => 'Delete account';
+  String get account_delete => 'Futa akaunti';
 
   @override
   String get account_delete_title => 'Futa akaunti yangu';
 
   @override
-  String get user_profile => 'Account';
+  String get user_profile => 'Akaunti';
 
   @override
-  String get user_profile_title_guest => 'Welcome!';
+  String get user_profile_title_guest => 'Karibu!';
 
   @override
   String get user_profile_subtitle_guest =>
-      'Sign-in or sign-up to join the Open Food Facts community';
+      'Ingia au ujisajili ili ujiunge na jumuiya ya Open Food Facts';
 
   @override
   String user_profile_title_id_email(String email) {
-    return 'Open Food Facts login: $email';
+    return 'Fungua kuingia kwa Ukweli wa Chakula: $email';
   }
 
   @override
   String user_profile_title_id_default(String id) {
-    return 'Welcome $id!';
+    return 'Karibu $id!';
   }
 
   @override
-  String get email_subject_account_deletion => 'Delete account';
+  String get email_subject_account_deletion => 'Futa akaunti';
 
   @override
   String email_body_account_deletion(String userId) {
-    return 'Hi there, please delete my Open Food Facts account: $userId';
+    return 'Hujambo, tafadhali futa akaunti yangu ya Open Food Facts: $userId';
   }
 
   @override
-  String get settings_app_app => 'Application';
+  String get settings_app_app => 'Maombi';
 
   @override
   String get settings_app_data => 'Privacy & monitoring';
 
   @override
-  String get settings_app_camera => 'Camera';
+  String get settings_app_camera => 'Kamera';
 
   @override
-  String get settings_app_products => 'Products';
+  String get settings_app_products => 'Bidhaa';
 
   @override
-  String get settings_app_miscellaneous => 'Miscellaneous';
+  String get settings_app_miscellaneous => 'Mbalimbali';
 
   @override
-  String get camera_play_sound_title => 'Play a sound on scan';
+  String get camera_play_sound_title => 'Cheza sauti kwenye uchanganuzi';
 
   @override
-  String get camera_play_sound_subtitle => 'Will beep on each successful scan';
+  String get camera_play_sound_subtitle =>
+      'Italia kwenye kila uchanganuzi uliofaulu';
 
   @override
   String get camera_window_accessibility_label =>
-      'Scan a barcode with your camera';
+      'Changanua msimbopau kwa kamera yako';
 
   @override
   String get app_haptic_feedback_title => 'Vibration & Haptics';
 
   @override
   String get app_haptic_feedback_subtitle =>
-      'Vibrations after executing some actions (barcode decoded, product removed…).';
+      'Mitetemo baada ya kutekeleza baadhi ya vitendo (msimbo pau umewekwa, bidhaa imeondolewa…).';
 
   @override
   String get crash_reporting_toggle_title => 'Crash reporting';
 
   @override
   String get crash_reporting_toggle_subtitle =>
-      'When enabled, crash reports are automatically submitted to Open Food Facts\' error tracking system, so that bugs can be fixed and thus improve the app.';
+      'Ikiwashwa, ripoti za kuacha kufanya kazi huwasilishwa kiotomatiki kwenye mfumo wa kufuatilia makosa ya Open Food Facts, ili hitilafu ziweze kurekebishwa na hivyo kuboresha programu.';
 
   @override
   String get send_anonymous_data_toggle_title => 'Send anonymous data';
@@ -1798,149 +1817,150 @@ class AppLocalizationsSw extends AppLocalizations {
       'When enabled, some anonymous information regarding app usage will be sent to the Open Food Facts servers, so that we can understand how and how much features are used in order to improve them.';
 
   @override
-  String get product_edit_photo_title => 'Edit Photo';
+  String get product_edit_photo_title => 'Hariri Picha';
 
   @override
-  String get permission_photo_error => 'Error';
+  String get permission_photo_error => 'Hitilafu';
 
   @override
   String get permission_photo_denied_title =>
-      'Allow camera use to scan barcodes';
+      'Ruhusu matumizi ya kamera kuchanganua misimbopau';
 
   @override
   String permission_photo_denied_message(String appName) {
-    return 'For an enhanced experience, please allow $appName to access your camera. You will be able to directly scan barcodes.';
+    return 'Kwa matumizi yaliyoboreshwa, tafadhali ruhusu $appName kufikia kamera yako. Utaweza kuchanganua misimbopau moja kwa moja.';
   }
 
   @override
-  String get permission_photo_denied_button => 'Allow';
+  String get permission_photo_denied_button => 'Ruhusu';
 
   @override
   String get permission_photo_denied_dialog_settings_title =>
-      'Permission denied';
+      'Ruhusa imekataliwa';
 
   @override
   String get permission_photo_denied_dialog_settings_message =>
-      'As you\'ve previously denied the camera permission, you must allow it manually from the Settings.';
+      'Kwa vile hapo awali ulinyima ruhusa ya kamera, lazima uiruhusu wewe mwenyewe kutoka kwa Mipangilio.';
 
   @override
   String get permission_photo_denied_dialog_settings_button_open =>
-      'Open settings';
+      'Fungua mipangilio';
 
   @override
   String get permission_photo_denied_dialog_settings_button_cancel => 'Ghairi';
 
   @override
-  String get permission_photo_none_found => 'No camera detected';
+  String get permission_photo_none_found => 'Hakuna kamera iliyotambuliwa';
 
   @override
-  String get permission_photo_denied => 'No camera access granted';
+  String get permission_photo_denied => 'Hakuna ufikiaji wa kamera uliopewa';
 
   @override
-  String get show_product_pictures => 'Show product pictures';
+  String get show_product_pictures => 'Onyesha picha za bidhaa';
 
   @override
-  String get edit_product_label => 'Edit product';
+  String get edit_product_label => 'Hariri bidhaa';
 
   @override
   String get edit_product_pending_operations_banner_title =>
-      'Uploading your edits…';
+      'Inapakia masahihisho yako…';
 
   @override
   String get edit_product_pending_operations_banner_message =>
-      'Your edits are being **sent in the background** (or later in case of error).\nYou can continue editing other product fields.';
+      'Mabadiliko yako yanatumwa **chinichini** (au baadaye iwapo kutatokea hitilafu).\nUnaweza kuendelea kuhariri sehemu zingine za bidhaa.';
 
   @override
   String get edit_product_pending_operations_banner_short_message =>
-      'Your edits are being **sent in the background** (or later in case of error).';
+      'Mabadiliko yako yanatumwa **chinichini** (au baadaye iwapo kutatokea hitilafu).';
 
   @override
   String get edit_product_label_short => 'Hariri';
 
   @override
   String edit_product_form_item_help(String value) {
-    return 'How to enter \"$value\"?';
+    return 'Jinsi ya kuingiza \"$value\"?';
   }
 
   @override
   String get edit_product_form_item_error_empty =>
-      'Please enter a non-empty value!';
+      'Tafadhali weka thamani isiyo tupu!';
 
   @override
-  String get edit_product_form_item_error_existing =>
-      'This value is already there!';
+  String get edit_product_form_item_error_existing => 'Thamani hii tayari ipo!';
 
   @override
-  String get edit_product_form_item_add_action_brand => 'Add a new brand';
+  String get edit_product_form_item_add_action_brand => 'Ongeza chapa mpya';
 
   @override
-  String get edit_product_form_item_add_action_label => 'Add a new label';
+  String get edit_product_form_item_add_action_label => 'Ongeza lebo mpya';
 
   @override
-  String get edit_product_form_item_add_action_store => 'Add a new store';
+  String get edit_product_form_item_add_action_store => 'Ongeza duka jipya';
 
   @override
-  String get edit_product_form_item_add_action_origin => 'Add a new origin';
+  String get edit_product_form_item_add_action_origin => 'Ongeza asili mpya';
 
   @override
   String get edit_product_form_item_add_action_emb_code =>
-      'Add a new traceability code';
+      'Ongeza msimbo mpya wa ufuatiliaji';
 
   @override
-  String get edit_product_form_item_add_action_country => 'Add a new country';
+  String get edit_product_form_item_add_action_country => 'Ongeza nchi mpya';
 
   @override
-  String get edit_product_form_item_add_action_category => 'Add a new category';
+  String get edit_product_form_item_add_action_category => 'Ongeza aina mpya';
 
   @override
-  String get edit_product_form_item_add_action_trace => 'Add a new trace';
+  String get edit_product_form_item_add_action_trace =>
+      'Ongeza ufuatiliaji mpya';
 
   @override
-  String get edit_product_form_item_add_suggestion => 'Add suggestion';
+  String get edit_product_form_item_add_suggestion => 'Ongeza pendekezo';
 
   @override
   String get edit_product_form_item_deny_suggestion => 'Kataa pendekezo';
 
   @override
-  String get edit_product_form_item_details_title => 'Basic details';
+  String get edit_product_form_item_details_title => 'Maelezo ya msingi';
 
   @override
   String get edit_product_form_item_details_subtitle =>
-      'Product name, brand, quantity';
+      'Jina la bidhaa, chapa, wingi';
 
   @override
-  String get edit_product_form_item_other_details_title => 'Additional details';
+  String get edit_product_form_item_other_details_title => 'Maelezo ya ziada';
 
   @override
-  String get edit_product_form_item_other_details_subtitle => 'Website…';
+  String get edit_product_form_item_other_details_subtitle => 'Tovuti…';
 
   @override
-  String get edit_product_form_item_photos_title => 'Photos';
+  String get edit_product_form_item_photos_title => 'Picha';
 
   @override
-  String get edit_product_form_item_photos_subtitle => 'Add or refresh photos';
+  String get edit_product_form_item_photos_subtitle =>
+      'Ongeza au onyesha upya picha';
 
   @override
-  String get edit_product_form_item_labels_title => 'Labels & Certifications';
+  String get edit_product_form_item_labels_title => 'Lebo na Vyeti';
 
   @override
   String get edit_product_form_item_labels_subtitle =>
-      'Environmental, Quality labels…';
+      'Lebo za Mazingira, Ubora…';
 
   @override
   String get edit_product_form_item_labels_hint =>
-      'Input a label (eg: NutriScore)';
+      'Ingiza lebo (km: NutriScore)';
 
   @override
   String get edit_product_form_item_labels_type => 'label';
 
   @override
   String get edit_product_form_item_labels_explanation_title =>
-      'Good practices: Labels';
+      'Mazoea mazuri: Lebo';
 
   @override
   String get edit_product_form_item_labels_explanation_info1 =>
-      'Any characteristic of the product **which is factual** and different from the other fields.';
+      'Tabia yoyote ya bidhaa **ambayo ni ya kweli** na tofauti na nyanja zingine.';
 
   @override
   String get edit_product_form_item_labels_explanation_good_examples_1 =>
@@ -1948,7 +1968,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get edit_product_form_item_labels_explanation_good_examples_2 =>
-      'Made in Belgium, produced in Brittany…';
+      'Imetengenezwa Ubelgiji, imetolewa nchini Brittany…';
 
   @override
   String get edit_product_form_item_labels_explanation_good_examples_3 =>
@@ -1956,28 +1976,28 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get edit_product_form_item_labels_explanation_good_examples_4 =>
-      'Rich in fiber, source of iron…';
+      'Tajiri katika nyuzi, chanzo cha chuma…';
 
   @override
   String get edit_product_form_item_labels_explanation_good_examples_5 =>
-      'Fair trade, Max Havelaar…';
+      'Biashara ya haki, Max Havelaar…';
 
   @override
-  String get edit_product_form_item_stores_title => 'Stores';
+  String get edit_product_form_item_stores_title => 'Maduka';
 
   @override
-  String get edit_product_form_item_stores_hint => 'Input a store';
+  String get edit_product_form_item_stores_hint => 'Ingiza duka';
 
   @override
-  String get edit_product_form_item_stores_type => 'store';
+  String get edit_product_form_item_stores_type => 'duka';
 
   @override
   String get edit_product_form_item_stores_explanation_title =>
-      'Good practices: Stores';
+      'Mazoea mazuri: Maduka';
 
   @override
   String get edit_product_form_item_stores_explanation_info1 =>
-      'Input the store where you bought the product.';
+      'Ingiza duka ambapo ulinunua bidhaa.';
 
   @override
   String get edit_product_form_item_stores_explanation_good_examples_1 =>
@@ -1992,74 +2012,74 @@ class AppLocalizationsSw extends AppLocalizations {
       'Lidl';
 
   @override
-  String get edit_product_form_item_origins_title => 'Origins';
+  String get edit_product_form_item_origins_title => 'Asili';
 
   @override
   String get edit_product_form_item_origins_hint =>
-      'Input an origin (eg: Germany)';
+      'Ingizo asili (km: Ujerumani)';
 
   @override
   String get edit_product_form_item_origins_type => 'country';
 
   @override
   String get edit_product_form_item_origins_explanation_title =>
-      'Good practices: Origins';
+      'Mazoea mazuri: Asili';
 
   @override
   String get edit_product_form_item_origins_explanation_info1 =>
-      'Add **any indications of origins you can find on the packaging**.\nYou need not worry about origins indicated directly in the ingredient list.';
+      'Ongeza **viashiria vyovyote vya asili unavyoweza kupata kwenye kifurushi**.\nHuhitaji kuwa na wasiwasi kuhusu asili zilizoonyeshwa moja kwa moja kwenye orodha ya viambato.';
 
   @override
   String get edit_product_form_item_origins_explanation_good_examples_1 =>
-      'Beef from Argentina';
+      'Nyama ya ng\'ombe kutoka Argentina';
 
   @override
   String get edit_product_form_item_origins_explanation_good_examples_2 =>
-      'The soy does not come from the European Union';
+      'Soya haitoki Umoja wa Ulaya';
 
   @override
   String get edit_product_form_item_countries_title => 'Country';
 
   @override
   String get edit_product_form_item_countries_hint =>
-      'Input a country (eg: Germany)';
+      'Ingiza nchi (km: Ujerumani)';
 
   @override
   String get edit_product_form_item_countries_type => 'country';
 
   @override
   String get edit_product_form_item_countries_explanations_title =>
-      'Good practices: Countries';
+      'Mazoea mazuri: Nchi';
 
   @override
   String get edit_product_form_item_countries_explanations_info1 =>
-      '**Countries where the product is widely available** (not including stores specialising in foreign products).';
+      '**Nchi ambazo bidhaa hiyo inapatikana kwa wingi** (bila kujumuisha maduka maalumu kwa bidhaa za kigeni).';
 
   @override
-  String get edit_product_form_item_emb_codes_title => 'Traceability codes';
+  String get edit_product_form_item_emb_codes_title => 'Misimbo ya ufuatiliaji';
 
   @override
   String get edit_product_form_item_emb_codes_hint =>
-      'Input a code (eg: EMB 53062, FR 62.448.034 CE, 84 R 20, 33 RECOLTANT 522…)';
+      'Ingiza msimbo (km: EMB 53062, FR 62.448.034 CE, 84 R 20, 33 RECOLTANT 522…)';
 
   @override
-  String get edit_product_form_item_emb_codes_type => 'traceability code';
+  String get edit_product_form_item_emb_codes_type => 'msimbo wa ufuatiliaji';
 
   @override
   String get edit_product_form_item_emb_help_title =>
-      'Good practices: Traceability codes';
+      'Mbinu nzuri: Misimbo ya ufuatiliaji';
 
   @override
   String get edit_product_form_item_emb_help_info1 =>
-      'In this section, you can input codes related to **packaging marks**, **identification marks** or **health marks**.';
+      'Katika sehemu hii, unaweza kuingiza misimbo inayohusiana na **alama za kifungashio**, **alama za utambulisho** au **alama za afya**.';
 
   @override
   String get edit_product_form_item_emb_help_info2_title =>
-      'Examples of traceability codes';
+      'Mifano ya misimbo ya ufuatiliaji';
 
   @override
   String get edit_product_form_item_emb_help_info2_item1_text =>
-      '**EC codes** used in the European Community to identify food producers or packagers:';
+      '**Misimbo ya EC** inayotumika katika Jumuiya ya Ulaya kutambua wazalishaji au vifurushi vya chakula:';
 
   @override
   String get edit_product_form_item_emb_help_info2_item1_example =>
@@ -2067,11 +2087,11 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get edit_product_form_item_emb_help_info2_item1_explanation =>
-      '**FR**: country code of **France**\n**72.264.002**: geographic data\n**CE**: European Community';
+      '**FR**: msimbo wa nchi wa **Ufaransa**\n**72.264.002**: data ya kijiografia\n**CE**: Jumuiya ya Ulaya';
 
   @override
   String get edit_product_form_item_emb_help_info2_item2_text =>
-      '**EMB codes** used in France:';
+      '**Misimbo ya EMB** inayotumika Ufaransa:';
 
   @override
   String get edit_product_form_item_emb_help_info2_item2_explanation =>
@@ -2085,7 +2105,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get edit_product_form_item_traces_type =>
-      'Input a trace (eg: Soy beans)';
+      'Ingiza alama (kwa mfano: maharagwe ya soya)';
 
   @override
   String get edit_product_form_item_categories_title => 'Categories';
@@ -2095,101 +2115,103 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get edit_product_form_item_categories_type =>
-      'Input a category (eg: Orange juice)';
+      'Ingiza kategoria (km: Juisi ya chungwa)';
 
   @override
   String get edit_product_form_item_categories_explanation_title =>
-      'Good practices: Categories';
+      'Mazoea mazuri: Kategoria';
 
   @override
   String get edit_product_form_item_categories_explanation_info1 =>
-      'Indicate **only the most specific category**.\nParent categories will be automatically added.';
+      'Onyesha **kategoria mahususi pekee**.\nKategoria za wazazi zitaongezwa kiotomatiki.';
 
   @override
   String get edit_product_form_item_categories_explanation_info2_title =>
-      'Missing category?';
+      'Kategoria inakosa?';
 
   @override
   String get edit_product_form_item_categories_explanation_info2_content =>
-      'In case a category is **not available in autocomplete**, feel free to add it anyway.\nThis will help us improve Open Food Facts in your country.';
+      'Iwapo kategoria haipatikani katika kukamilisha kiotomatiki**, jisikie huru kuiongeza hata hivyo.\nHii itatusaidia kuboresha Ukweli wa Chakula Huria katika nchi yako.';
 
   @override
   String get edit_product_form_item_categories_explanation_good_examples_1 =>
-      'Sardines in olive oil';
+      'Sardini katika mafuta';
 
   @override
   String get edit_product_form_item_categories_explanation_good_examples_2 =>
-      'Orange juice from concentrate';
+      'Juisi ya machungwa kutoka kwa makini';
 
   @override
-  String get edit_product_form_item_exit_title => 'Quit without saving?';
+  String get edit_product_form_item_exit_title =>
+      'Ungependa kuacha bila kuhifadhi?';
 
   @override
   String get edit_product_form_item_exit_confirmation =>
-      'Do you want to save your changes before leaving this page?';
+      'Je, ungependa kuhifadhi mabadiliko yako kabla ya kuondoka kwenye ukurasa huu?';
 
   @override
   String get edit_product_form_item_exit_confirmation_positive_button =>
-      'Save changes';
+      'Hifadhi mabadiliko';
 
   @override
   String get edit_product_form_item_exit_confirmation_negative_button =>
-      'Discard changes';
+      'Tupa mabadiliko';
 
   @override
   String get edit_product_form_item_ingredients_title => 'Viungo';
 
   @override
   String get edit_product_form_item_ingredients_pinch_to_zoom_tooltip =>
-      'Zoom in and out by pinching the screen';
+      'Vuta ndani na nje kwa kubana skrini';
 
   @override
   String get edit_product_form_item_ingredients_pinch_to_zoom_title =>
-      'Zoom in and out the photo';
+      'Kuza ndani na nje picha';
 
   @override
   String get edit_product_form_item_ingredients_pinch_to_zoom_message =>
-      'Using the **Pinch-to-zoom gesture**, you can zoom in or out the photo:';
+      'Kwa kutumia ishara **Bana-ili-kukuza**, unaweza kuvuta ndani au nje picha:';
 
   @override
   String get edit_product_form_item_add_valid_item_tooltip => 'Ongeza';
 
   @override
   String get edit_product_form_item_add_invalid_item_tooltip =>
-      'Please enter a text first';
+      'Tafadhali ingiza maandishi kwanza';
 
   @override
-  String get edit_product_form_item_remove_item_tooltip => 'Remove';
+  String get edit_product_form_item_remove_item_tooltip => 'Ondoa';
 
   @override
-  String get edit_product_form_item_save_edit_item_tooltip => 'Save your edit';
+  String get edit_product_form_item_save_edit_item_tooltip =>
+      'Hifadhi hariri yako';
 
   @override
   String get edit_product_form_item_cancel_edit_item_tooltip =>
-      'Cancel your edit';
+      'Ghairi uhariri wako';
 
   @override
   String get edit_product_form_item_packaging_title =>
-      'Recycling instructions photo';
+      'Maagizo ya kuchakata picha';
 
   @override
   String get edit_product_form_item_nutrition_facts_title => 'Nutrition facts';
 
   @override
   String get edit_product_form_item_nutrition_facts_subtitle =>
-      'Nutrition, alcohol content…';
+      'Lishe, maudhui ya pombe…';
 
   @override
   String get edit_product_form_item_nutrition_facts_explanation_title =>
-      'Good practices: Nutrition facts';
+      'Mazoea mazuri: Ukweli wa lishe';
 
   @override
   String get edit_product_form_item_nutrition_facts_explanation_info1_title =>
-      'Nutritional values';
+      'Maadili ya lishe';
 
   @override
   String get edit_product_form_item_nutrition_facts_explanation_info1_content =>
-      'First, select if the **values are provided**:';
+      'Kwanza, chagua ikiwa **maadili yametolewa**:';
 
   @override
   String get edit_product_form_item_nutrition_facts_explanation_info2_title =>
@@ -2197,52 +2219,52 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get edit_product_form_item_nutrition_facts_explanation_info2_content =>
-      'Then, input the nutritional values **as indicated on the packaging**. If there is no value, you can click on the \"Eye\" icon.';
+      'Kisha, ingiza thamani za lishe **kama ilivyoonyeshwa kwenye kifungashio**. Ikiwa hakuna thamani, unaweza kubofya kwenye icon ya \"Jicho\".';
 
   @override
   String get edit_product_form_item_nutrition_facts_explanation_info3_title =>
-      'Missing field?';
+      'Umekosa uwanja?';
 
   @override
   String get edit_product_form_item_nutrition_facts_explanation_info3_content =>
-      'If an entry is missing, you can **click on the \"Plus\" icon** to add it (eg: vitamin D, magnesium…).';
+      'Ingizo likikosekana, unaweza **kubofya ikoni ya \"Plus\"** ili kuliongeza (km: vitamini D, magnesiamu…).';
 
   @override
   String get edit_product_form_save => 'Hariri';
 
   @override
-  String get edit_product_ingredients_photo_title => 'Ingredients photo';
+  String get edit_product_ingredients_photo_title => 'Picha ya viungo';
 
   @override
   String get edit_product_ingredients_list_title => 'List of ingredients';
 
   @override
-  String get edit_product_packaging_photo_title => 'Packaging photo';
+  String get edit_product_packaging_photo_title => 'Picha ya ufungaji';
 
   @override
-  String get edit_product_packaging_list_title => 'Packaging list';
+  String get edit_product_packaging_list_title => 'Orodha ya ufungaji';
 
   @override
-  String get no_data_available => 'No data available';
+  String get no_data_available => 'Hakuna data inayopatikana';
 
   @override
-  String get product_field_website_title => 'Website';
+  String get product_field_website_title => 'Tovuti';
 
   @override
-  String get origins_editing_title => 'Edit Origins';
+  String get origins_editing_title => 'Hariri Asili';
 
   @override
-  String get completed_basic_details_btn_text => 'Complete basic details';
+  String get completed_basic_details_btn_text => 'Kamilisha maelezo ya msingi';
 
   @override
-  String get not_implemented_snackbar_text => 'Not implemented yet';
+  String get not_implemented_snackbar_text => 'Bado haijatekelezwa';
 
   @override
   String get category_picker_page_appbar_text => 'Categories';
 
   @override
   String get edit_ingredients_extract_ingredients_btn_text =>
-      'Extract ingredients from the photo';
+      'Chambua viungo kutoka kwa picha';
 
   @override
   String get edit_ingredients_extract_ingredients_btn_text_short =>
@@ -2250,306 +2272,308 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get edit_ingredients_extracting_ingredients_btn_text =>
-      'Extracting ingredients\nfrom the photo';
+      'Kuchimba viungo\nkutoka kwenye picha';
 
   @override
-  String get edit_ingredients_loading_photo_btn_text => 'Loading photo…';
+  String get edit_ingredients_loading_photo_btn_text => 'Inapakia picha…';
 
   @override
   String get edit_ingredients_loading_photo_help_dialog_title =>
-      'Why do I see this message?';
+      'Kwa nini naona ujumbe huu?';
 
   @override
   String get edit_ingredients_loading_photo_help_dialog_body =>
-      'To use the \"Extract ingredients\" feature, the photo needs to be uploaded first.\n\nPlease wait a few seconds or enter them manually.';
+      'Ili kutumia kipengele cha \"Nyoa viungo\", picha inahitaji kupakiwa kwanza.\n\nTafadhali subiri sekunde chache au uziweke wewe mwenyewe.';
 
   @override
-  String get edit_ingredients_refresh_photo_btn_text => 'Refresh photo';
+  String get edit_ingredients_refresh_photo_btn_text => 'Onyesha upya picha';
 
   @override
   String get edit_packaging_extract_btn_text =>
-      'Extract packaging\nfrom the photo';
+      'Dondoo kifungashio\nkutoka kwenye picha';
 
   @override
-  String get edit_packaging_extract_btn_text_short => 'Extract packaging';
+  String get edit_packaging_extract_btn_text_short => 'Dondoo ufungaji';
 
   @override
   String get edit_packaging_extracting_btn_text =>
-      'Extracting packaging from the photo';
+      'Kuchimba ufungaji kutoka kwa picha';
 
   @override
-  String get edit_packaging_loading_photo_btn_text => 'Loading photo…';
+  String get edit_packaging_loading_photo_btn_text => 'Inapakia picha…';
 
   @override
   String get edit_packaging_loading_photo_help_dialog_title =>
-      'Why do I see this message?';
+      'Kwa nini naona ujumbe huu?';
 
   @override
   String get edit_packaging_loading_photo_help_dialog_body =>
-      'To use the \"Extract packaging\" feature, the photo needs to be uploaded first.\n\nPlease wait a few seconds or enter them manually.';
+      'Ili kutumia kipengele cha \"Dondoo la ufungashaji\", picha inahitaji kupakiwa kwanza.\n\nTafadhali subiri sekunde chache au uziweke wewe mwenyewe.';
 
   @override
-  String get edit_packaging_refresh_photo_btn_text => 'Refresh photo';
+  String get edit_packaging_refresh_photo_btn_text => 'Onyesha upya picha';
 
   @override
-  String get edit_ocr_extract_failed => 'Failed to detect text in image.';
+  String get edit_ocr_extract_failed =>
+      'Imeshindwa kugundua maandishi kwenye picha.';
 
   @override
-  String get edit_ocr_extract_disabled_title => 'No picture!';
+  String get edit_ocr_extract_disabled_title => 'Hakuna picha!';
 
   @override
   String get edit_ocr_extract_disabled_message =>
-      'In order to use the text extraction feature, you must first take a photo.';
+      'Ili kutumia kipengele cha uchimbaji wa maandishi, lazima kwanza upige picha.';
 
   @override
-  String get user_list_dialog_new_title => 'New list of products';
+  String get user_list_dialog_new_title => 'Orodha mpya ya bidhaa';
 
   @override
-  String get user_list_dialog_rename_title => 'Rename list';
+  String get user_list_dialog_rename_title => 'Ipe orodha jina upya';
 
   @override
-  String get user_list_subtitle_product => 'Lists';
+  String get user_list_subtitle_product => 'Orodha';
 
   @override
   String get user_list_title => 'Your lists';
 
   @override
-  String get user_list_add_product => 'Add the product to your lists';
+  String get user_list_add_product => 'Ongeza bidhaa kwenye orodha zako';
 
   @override
-  String get user_list_button_new => 'Create a new list';
+  String get user_list_button_new => 'Unda orodha mpya';
 
   @override
   String get user_list_empty_label =>
       'No list available yet, please start by creating one';
 
   @override
-  String get user_list_button_add_product => 'Add to list';
+  String get user_list_button_add_product => 'Ongeza kwenye orodha';
 
   @override
-  String get added_to_list_msg => 'Added to list';
+  String get added_to_list_msg => 'Imeongezwa kwenye orodha';
 
   @override
-  String get user_list_popup_clear => 'Clear your history';
+  String get user_list_popup_clear => 'Futa historia yako';
 
   @override
-  String get user_list_popup_rename => 'Rename';
+  String get user_list_popup_rename => 'Badilisha jina';
 
   @override
-  String get user_list_name_hint => 'My list';
+  String get user_list_name_hint => 'Orodha yangu';
 
   @override
-  String get user_list_name_error_empty => 'Name is mandatory';
+  String get user_list_name_error_empty => 'Jina ni lazima';
 
   @override
-  String get user_list_name_error_already => 'That name is already used';
+  String get user_list_name_error_already => 'Jina hilo tayari limetumika';
 
   @override
-  String get user_list_name_error_same => 'That is the same name';
+  String get user_list_name_error_same => 'Hilo ni jina moja';
 
   @override
-  String get user_list_name_input_hint => 'Name of the list';
+  String get user_list_name_input_hint => 'Jina la orodha';
 
   @override
-  String get try_again => 'Try Again';
+  String get try_again => 'Jaribu Tena';
 
   @override
-  String get there_was_an_error => 'There was an error';
+  String get there_was_an_error => 'Kulikuwa na hitilafu';
 
   @override
   String category_picker_no_category_found_message(String items) {
-    return 'No category found for $items';
+    return 'Hakuna kategoria iliyopatikana ya $items';
   }
 
   @override
-  String get camera_toggle_camera => 'Switch between back and front camera';
+  String get camera_toggle_camera =>
+      'Badilisha kati ya kamera ya nyuma na ya mbele';
 
   @override
-  String get camera_toggle_flash => 'Turn ON or OFF the flash of the camera';
+  String get camera_toggle_flash => 'WASHA au ZIMA mweko wa kamera';
 
   @override
-  String get camera_enable_flash => 'Enable flash';
+  String get camera_enable_flash => 'Washa mweko';
 
   @override
-  String get camera_disable_flash => 'Disable flash';
+  String get camera_disable_flash => 'Zima flash';
 
   @override
-  String get camera_flash_error_dialog_title => 'An error occurred!';
+  String get camera_flash_error_dialog_title => 'Hitilafu imetokea!';
 
   @override
   String get camera_flash_error_dialog_message =>
-      'An error occurred while changing the state of your flash. Please ensure your smartphone has not the torch already enabled.';
+      'Hitilafu imetokea wakati wa kubadilisha hali ya mweko wako. Tafadhali hakikisha kuwa simu yako mahiri bado haijawashwa tochi.';
 
   @override
   String get category_picker_no_category_found_button => 'Nyuma';
 
   @override
   String get user_preferences_item_accessibility_hint =>
-      'Click to open in your browser or in the application (if installed)';
+      'Bofya ili kufungua katika kivinjari chako au katika programu (ikiwa imesakinishwa)';
 
   @override
-  String get dev_preferences_screen_title => 'DEV Mode';
+  String get dev_preferences_screen_title => 'Hali ya DEV';
 
   @override
   String get dev_preferences_screen_subtitle =>
       'Fikia vipengele vya majaribio na zana za ukuzaji';
 
   @override
-  String get dev_preferences_reset_onboarding_title => 'Restart onboarding';
+  String get dev_preferences_reset_onboarding_title => 'Anzisha upya kuabiri';
 
   @override
   String get dev_preferences_reset_onboarding_subtitle =>
-      'You then have to restart the App to see it again.';
+      'Kisha unapaswa kuanzisha upya Programu ili kuiona tena.';
 
   @override
   String get dev_preferences_environment_switch_title =>
-      'Switch between openfoodfacts.org (PROD) and test env';
+      'Badili kati ya openfoodfacts.org (PROD) na test env';
 
   @override
   String get dev_preferences_test_environment_title =>
-      'Test environment parameters';
+      'Vigezo vya mazingira ya mtihani';
 
   @override
   String dev_preferences_test_environment_subtitle(String url) {
-    return 'Base URL for current test env: $url';
+    return 'URL ya msingi kwa env ya jaribio la sasa: $url';
   }
 
   @override
   String get dev_preferences_test_environment_dialog_title =>
-      'Test environment host';
+      'Mpangilio wa mazingira wa majaribio';
 
   @override
-  String get dev_preferences_ml_kit_title => 'Use ML Kit';
+  String get dev_preferences_ml_kit_title => 'Tumia ML Kit';
 
   @override
   String get dev_preferences_ml_kit_subtitle =>
-      'then you have to restart this app';
+      'basi unapaswa kuanzisha upya programu hii';
 
   @override
   String get dev_preferences_product_additional_features_title =>
-      'Additional button on product page';
+      'Kitufe cha ziada kwenye ukurasa wa bidhaa';
 
   @override
   String get dev_preferences_edit_ingredients_title =>
-      'Edit ingredients via a knowledge panel button';
+      'Badilisha viungo kupitia kitufe cha paneli ya muhtasari';
 
   @override
-  String get dev_preferences_export_history_title => 'Export History';
+  String get dev_preferences_export_history_title => 'Hamisha Historia';
 
   @override
-  String get dev_preferences_export_history_progress_error => 'exception';
+  String get dev_preferences_export_history_progress_error => 'ubaguzi';
 
   @override
-  String get dev_preferences_export_history_progress_found => 'product found';
+  String get dev_preferences_export_history_progress_found =>
+      'bidhaa kupatikana';
 
   @override
   String get dev_preferences_export_history_progress_not_found =>
-      'product NOT found';
+      'bidhaa HAIJAPATIKANA';
 
   @override
-  String get dev_preferences_export_history_dialog_title => 'Export history';
+  String get dev_preferences_export_history_dialog_title => 'Hamisha historia';
 
   @override
-  String get dev_preferences_button_positive => 'OK';
+  String get dev_preferences_button_positive => 'Sawa';
 
   @override
   String get dev_preferences_button_negative => 'Ghairi';
 
   @override
-  String get dev_preferences_migration_title => 'Data migration from V1';
+  String get dev_preferences_migration_title => 'Uhamisho wa data kutoka V1';
 
   @override
   String dev_preferences_migration_subtitle(String status) {
-    return 'Status: $status';
+    return 'Hali: $status';
   }
 
   @override
   String get dev_preferences_migration_status_already_done =>
-      'success or fresh install';
+      'mafanikio au usakinishaji mpya';
 
   @override
-  String get dev_preferences_migration_status_success => 'success';
+  String get dev_preferences_migration_status_success => 'mafanikio';
 
   @override
-  String get dev_preferences_migration_status_error => 'error';
+  String get dev_preferences_migration_status_error => 'kosa';
 
   @override
-  String get dev_preferences_migration_status_in_progress => 'in progress';
+  String get dev_preferences_migration_status_in_progress => 'inaendelea';
 
   @override
   String get dev_preferences_migration_status_required =>
-      'required (click to start)';
+      'inahitajika (bofya ili kuanza)';
 
   @override
-  String get dev_preferences_migration_status_not_started => 'unknown';
+  String get dev_preferences_migration_status_not_started => 'haijulikani';
 
   @override
   String get dev_preferences_import_history_subtitle =>
-      'Will clear history and put 3 products in there';
+      'Itafuta historia na kuweka bidhaa 3 hapo';
 
   @override
-  String get dev_preferences_news_custom_url_title => 'Custom URL for news';
+  String get dev_preferences_news_custom_url_title => 'URL maalum ya habari';
 
   @override
   String get dev_preferences_news_custom_url_subtitle =>
-      'URL of the JSON file:';
+      'URL ya faili ya JSON:';
 
   @override
-  String get dev_preferences_news_custom_url_empty_value => 'Not set';
+  String get dev_preferences_news_custom_url_empty_value => 'Haijawekwa';
 
   @override
   String get dev_preferences_news_provider_status_title => 'Status';
 
   @override
   String dev_preferences_news_provider_status_subtitle(String date) {
-    return 'Last refresh: $date';
+    return 'Kuonyeshwa upya mara ya mwisho: $date';
   }
 
   @override
-  String get product_type_label_food => 'Food';
+  String get product_type_label_food => 'Chakula';
 
   @override
-  String get product_type_label_beauty => 'Personal care';
+  String get product_type_label_beauty => 'Utunzaji wa kibinafsi';
 
   @override
-  String get product_type_label_pet_food => 'Pet food';
+  String get product_type_label_pet_food => 'Chakula cha kipenzi';
 
   @override
   String get product_type_label_product => 'Other';
 
   @override
-  String get product_type_selection_title => 'Product type';
+  String get product_type_selection_title => 'Aina ya bidhaa';
 
   @override
-  String get product_type_selection_subtitle =>
-      'Select the type of this product';
+  String get product_type_selection_subtitle => 'Chagua aina ya bidhaa hii';
 
   @override
   String get product_type_selection_empty =>
-      'You need to select a product type first!';
+      'Unahitaji kuchagua aina ya bidhaa kwanza!';
 
   @override
   String product_type_selection_already(String productType) {
-    return 'You cannot change the product type ($productType)!';
+    return 'Huwezi kubadilisha aina ya bidhaa ($productType)!';
   }
 
   @override
   String get prices_app_dev_mode_flag =>
-      'Shortcut to Prices app on product page';
+      'Njia ya mkato ya programu ya Bei kwenye ukurasa wa bidhaa';
 
   @override
-  String get prices_app_button => 'Go to Prices app';
+  String get prices_app_button => 'Nenda kwenye programu ya Bei';
 
   @override
   String get prices_website_button => 'Fungua kwenye tovuti ya Bei Fungua';
 
   @override
   String get prices_bulk_proof_upload_select =>
-      'Add price tags directly from gallery';
+      'Ongeza lebo za bei moja kwa moja kutoka kwa ghala';
 
   @override
   String get prices_bulk_proof_upload_warning =>
-      'Once you\'ve selected images, you won\'t be able to edit them!';
+      'Ukishachagua picha, hutaweza kuzihariri!';
 
   @override
   String get prices_bulk_proof_upload_warning_ai =>
@@ -2560,10 +2584,10 @@ class AppLocalizationsSw extends AppLocalizations {
       'Ruhusu jumuiya kuthibitisha bei zilizotolewa na AI.';
 
   @override
-  String get prices_bulk_proof_upload_subtitle => 'Multiple Price Tags';
+  String get prices_bulk_proof_upload_subtitle => 'Lebo za Bei Nyingi';
 
   @override
-  String get prices_bulk_proof_upload_title => 'Bulk Proof Upload';
+  String get prices_bulk_proof_upload_title => 'Upakiaji wa Uthibitisho Wingi';
 
   @override
   String get prices_bulk_proof_upload_step_selecting => 'Kuchagua faili';
@@ -2587,15 +2611,15 @@ class AppLocalizationsSw extends AppLocalizations {
   }
 
   @override
-  String get prices_generic_title => 'Prices';
+  String get prices_generic_title => 'Bei';
 
   @override
   String prices_add_n_prices(num count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'Add $count prices',
-      one: 'Add a price',
+      other: 'Ongeza $count bei',
+      one: 'Ongeza bei',
     );
     return '$_temp0';
   }
@@ -2605,42 +2629,42 @@ class AppLocalizationsSw extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'Send $count prices',
-      one: 'Send the price',
+      other: 'Tuma $count bei',
+      one: 'Tuma bei',
     );
     return '$_temp0';
   }
 
   @override
-  String get prices_add_an_item => 'Add an item';
+  String get prices_add_an_item => 'Ongeza kipengee';
 
   @override
-  String get prices_add_a_price => 'Add a price';
+  String get prices_add_a_price => 'Ongeza bei';
 
   @override
-  String get prices_add_a_receipt => 'Add a receipt';
+  String get prices_add_a_receipt => 'Ongeza risiti';
 
   @override
-  String get prices_add_price_tags => 'Add price tags';
+  String get prices_add_price_tags => 'Ongeza lebo za bei';
 
   @override
   String prices_barcode_already(String barcode) {
-    return 'This barcode ($barcode) is already in the list!';
+    return 'Msimbopau huu ($barcode) tayari uko kwenye orodha!';
   }
 
   @override
   String get prices_barcode_search_not_found => 'Product not found';
 
   @override
-  String get prices_barcode_search_none_yet => 'No product yet';
+  String get prices_barcode_search_none_yet => 'Hakuna bidhaa bado';
 
   @override
   String prices_barcode_search_running(String barcode) {
-    return 'Looking for $barcode';
+    return 'Inatafuta $barcode';
   }
 
   @override
-  String get prices_barcode_enter => 'Enter the Barcode';
+  String get prices_barcode_enter => 'Weka Msimbo Pau';
 
   @override
   String get prices_category_enter => 'Kipengee kisicho na msimbopau';
@@ -2667,10 +2691,10 @@ class AppLocalizationsSw extends AppLocalizations {
   String get prices_category_error_mandatory => 'Jamii ni ya lazima';
 
   @override
-  String get prices_barcode_reader_action => 'Barcode reader';
+  String get prices_barcode_reader_action => 'Msomaji wa barcode';
 
   @override
-  String get prices_view_prices => 'View the prices';
+  String get prices_view_prices => 'Tazama bei';
 
   @override
   String get prices_list_title => 'Orodha ya bei';
@@ -2719,10 +2743,10 @@ class AppLocalizationsSw extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count prices',
-      one: '1 price',
+      other: '$count bei',
+      one: 'bei 1',
     );
-    return '$_temp0 for $product';
+    return '$_temp0 kwa $product';
   }
 
   @override
@@ -2730,16 +2754,16 @@ class AppLocalizationsSw extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'All $count prices',
-      one: 'Only one price',
-      zero: 'No price yet',
+      other: 'Zote $count bei',
+      one: 'Bei moja tu',
+      zero: 'Hakuna bei bado',
     );
     return '$_temp0';
   }
 
   @override
   String prices_list_length_many_pages(int pageSize, int total) {
-    return 'Latest $pageSize prices (total: $total)';
+    return 'Bei $pageSize za hivi punde (jumla: $total)';
   }
 
   @override
@@ -2749,32 +2773,32 @@ class AppLocalizationsSw extends AppLocalizations {
     String date,
     String user,
   ) {
-    return 'Price: $price / Store: \"$location\" / Published on $date by \"$user\"';
+    return 'Bei: $price / Store: \"$location\" / Imechapishwa kwenye $date na \"$user\"';
   }
 
   @override
   String prices_open_user_proofs(String user) {
-    return 'Open proofs of \"$user\"';
+    return 'Uthibitisho wazi wa \"$user\"';
   }
 
   @override
-  String get prices_open_proof => 'Open price proof';
+  String get prices_open_proof => 'Fungua uthibitisho wa bei';
 
   @override
   String prices_proofs_list_length_one_page(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'All $count proofs',
-      one: 'Only one proof',
-      zero: 'No proof yet',
+      other: 'All $count uthibitisho',
+      one: 'Ushahidi mmoja tu',
+      zero: 'Bado hakuna uthibitisho',
     );
     return '$_temp0';
   }
 
   @override
   String prices_proofs_list_length_many_pages(int pageSize, int total) {
-    return 'Latest $pageSize proofs (total: $total)';
+    return 'Uthibitisho wa hivi punde $pageSize (jumla: $total)';
   }
 
   @override
@@ -2785,7 +2809,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String prices_users_list_length_many_pages(int pageSize, int total) {
-    return 'Top $pageSize contributors (total: $total)';
+    return 'Wachangiaji wakuu $pageSize (jumla: $total)';
   }
 
   @override
@@ -2797,7 +2821,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String prices_locations_list_length_many_pages(int pageSize, int total) {
-    return 'Top $pageSize locations (total: $total)';
+    return 'Maeneo ya juu $pageSize (jumla: $total)';
   }
 
   @override
@@ -2805,9 +2829,9 @@ class AppLocalizationsSw extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count proofs',
-      one: 'One proof',
-      zero: 'No proof',
+      other: '$count uthibitisho',
+      one: 'Ushahidi mmoja',
+      zero: 'Hakuna uthibitisho',
     );
     return '$_temp0';
   }
@@ -2817,9 +2841,9 @@ class AppLocalizationsSw extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count products',
-      one: 'One product',
-      zero: 'No product',
+      other: '$count bidhaa',
+      one: 'Bidhaa moja',
+      zero: 'Hakuna bidhaa',
     );
     return '$_temp0';
   }
@@ -2829,9 +2853,9 @@ class AppLocalizationsSw extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count users',
-      one: 'One user',
-      zero: 'No user',
+      other: '$count watumiaji',
+      one: 'Mtumiaji mmoja',
+      zero: 'Hakuna mtumiaji',
     );
     return '$_temp0';
   }
@@ -2841,9 +2865,9 @@ class AppLocalizationsSw extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count prices',
-      one: 'One price',
-      zero: 'No price',
+      other: '$count bei',
+      one: 'Bei moja',
+      zero: 'Hakuna bei',
     );
     return '$_temp0';
   }
@@ -2852,50 +2876,50 @@ class AppLocalizationsSw extends AppLocalizations {
   String get prices_amount_existing_subtitle => 'Bei iliongezwa hapo awali';
 
   @override
-  String get prices_amount_subtitle => 'Amount';
+  String get prices_amount_subtitle => 'Kiasi';
 
   @override
-  String get prices_amount_is_discounted => 'Is discounted?';
+  String get prices_amount_is_discounted => 'Je, imepunguzwa bei?';
 
   @override
-  String get prices_amount_price_normal => 'Price';
+  String get prices_amount_price_normal => 'Bei';
 
   @override
-  String get prices_amount_price_discounted => 'Discounted price';
+  String get prices_amount_price_discounted => 'Bei iliyopunguzwa';
 
   @override
-  String get prices_amount_price_not_discounted => 'Original price';
+  String get prices_amount_price_not_discounted => 'Bei ya asili';
 
   @override
-  String get prices_amount_no_product => 'One product is missing!';
+  String get prices_amount_no_product => 'Bidhaa moja haipo!';
 
   @override
-  String get prices_amount_price_incorrect => 'Incorrect value';
+  String get prices_amount_price_incorrect => 'Thamani isiyo sahihi';
 
   @override
-  String get prices_amount_price_mandatory => 'Mandatory value';
+  String get prices_amount_price_mandatory => 'Thamani ya lazima';
 
   @override
-  String get prices_currency_subtitle => 'Currency';
+  String get prices_currency_subtitle => 'Sarafu';
 
   @override
-  String get prices_date_subtitle => 'Date';
+  String get prices_date_subtitle => 'Tarehe';
 
   @override
-  String get prices_location_subtitle => 'Shop';
+  String get prices_location_subtitle => 'Duka';
 
   @override
-  String get prices_location_find => 'Find a shop';
+  String get prices_location_find => 'Tafuta duka';
 
   @override
-  String get prices_location_mandatory => 'You need to select a shop!';
+  String get prices_location_mandatory => 'Unahitaji kuchagua duka!';
 
   @override
   String get prices_location_search_broader =>
-      'Couldn\'t find what you were looking for? Let\'s try a broader search!';
+      'Je, hukuweza kupata ulichokuwa unatafuta? Hebu tujaribu utafutaji mpana zaidi!';
 
   @override
-  String get prices_proof_subtitle => 'Proof';
+  String get prices_proof_subtitle => 'Ushahidi';
 
   @override
   String get prices_proof_empty_title => 'Hakuna ushahidi bado!';
@@ -2905,103 +2929,103 @@ class AppLocalizationsSw extends AppLocalizations {
       'Anza kwa kuongeza picha ya **risiti** au ** lebo ya bei**!';
 
   @override
-  String get prices_proof_find => 'Select a proof';
+  String get prices_proof_find => 'Chagua uthibitisho';
 
   @override
-  String get prices_proof_change => 'Change proof';
+  String get prices_proof_change => 'Badilisha uthibitisho';
 
   @override
-  String get prices_proof_receipt => 'Receipt';
+  String get prices_proof_receipt => 'Risiti';
 
   @override
-  String get prices_proof_price_tag => 'Price tag';
+  String get prices_proof_price_tag => 'Lebo ya bei';
 
   @override
-  String get prices_proof_mandatory => 'You need to select a proof!';
+  String get prices_proof_mandatory => 'Unahitaji kuchagua uthibitisho!';
 
   @override
-  String get prices_add_validation_error => 'Validation error';
+  String get prices_add_validation_error => 'Hitilafu ya uthibitishaji';
 
   @override
-  String get prices_privacy_warning_title => 'Privacy warning';
+  String get prices_privacy_warning_title => 'Onyo la faragha';
 
   @override
-  String get prices_unknown_product => 'Unknown product';
+  String get prices_unknown_product => 'Bidhaa isiyojulikana';
 
   @override
   String get prices_privacy_warning_main_message =>
-      'Prices **will be public**, along with the store they refer to.\n\nThat might allow people who know about your Open Food Facts pseudonym to:\n';
+      'Bei **zitakuwa za umma**, pamoja na duka wanalorejelea.\n\nHuenda hilo likaruhusu watu wanaojua kuhusu jina lako bandia la Open Food Facts:\n';
 
   @override
   String get prices_privacy_warning_message_bullet_1 =>
-      'Infer in which area you live';
+      'Eleza ni eneo gani unaishi';
 
   @override
-  String get prices_privacy_warning_message_bullet_2 =>
-      'Know what you are buying';
+  String get prices_privacy_warning_message_bullet_2 => 'Jua unachonunua';
 
   @override
   String get prices_privacy_warning_sub_message =>
-      'If you are uneasy with that, please change your pseudonym, or create a new Open Food Facts account and log into the app with it.';
+      'Ikiwa huna wasiwasi na hilo, tafadhali badilisha jina lako bandia, au ufungue akaunti mpya ya Open Food Facts na uingie kwenye programu nayo.';
 
   @override
-  String get i_refuse => 'I refuse';
+  String get i_refuse => 'nakataa';
 
   @override
-  String get i_accept => 'I accept';
+  String get i_accept => 'Nakubali';
 
   @override
-  String get prices_currency_change_proposal_title => 'Change the currency?';
+  String get prices_currency_change_proposal_title =>
+      'Ungependa kubadilisha sarafu?';
 
   @override
   String prices_currency_change_proposal_message(
     String currency,
     String newCurrency,
   ) {
-    return 'Your current currency is **$currency**. Would you like to change it to **$newCurrency**?';
+    return 'Sarafu yako ya sasa ni **$currency**. Je, ungependa kuibadilisha kuwa **$newCurrency**?';
   }
 
   @override
   String prices_currency_change_proposal_action_approve(String newCurrency) {
-    return 'Yes, use $newCurrency';
+    return 'Ndiyo, tumia $newCurrency';
   }
 
   @override
   String prices_currency_change_proposal_action_cancel(String currency) {
-    return 'No, keep $currency';
+    return 'Hapana, weka $currency';
   }
 
   @override
-  String get prices_menu_know_more => 'Know more about Open Prices';
+  String get prices_menu_know_more => 'Jua zaidi kuhusu Bei Huria';
 
   @override
-  String get dev_preferences_import_history_result_success => 'Done';
+  String get dev_preferences_import_history_result_success => 'Imekamilika';
 
   @override
-  String get dev_mode_section_server => 'Server configuration';
+  String get dev_mode_section_server => 'Usanidi wa seva';
 
   @override
-  String get dev_mode_section_news => 'News provider configuration';
+  String get dev_mode_section_news => 'Usanidi wa mtoaji wa habari';
 
   @override
-  String get dev_mode_section_product_page => 'Product page';
+  String get dev_mode_section_product_page => 'Ukurasa wa bidhaa';
 
   @override
-  String get dev_mode_section_ui => 'User Interface';
+  String get dev_mode_section_ui => 'Kiolesura cha Mtumiaji';
 
   @override
-  String get dev_mode_section_experimental_features => 'Experimental features';
+  String get dev_mode_section_experimental_features =>
+      'Vipengele vya majaribio';
 
   @override
-  String get dev_mode_hide_environmental_score_title => 'Exclude Green Score';
+  String get dev_mode_hide_environmental_score_title => 'Ondoa Alama ya Kijani';
 
   @override
   String get dev_mode_spellchecker_for_ocr_title =>
-      'Use a spellchecker for OCR screens';
+      'Tumia kikagua tahajia kwa skrini za OCR';
 
   @override
-  String get dev_mode_spellchecker_for_ocr_subtitle =>
-      '(Ingredients and packaging)';
+  String get dev_mode_spellchecker_for_ocr_subtitle => '(Viungo na ufungaji)';
 
   @override
   String get dev_mode_reset_app_language_title => 'Weka upya lugha ya programu';
@@ -3014,14 +3038,15 @@ class AppLocalizationsSw extends AppLocalizations {
       'Badili kati ya prices.openfoodfacts.org (PROD) na test env';
 
   @override
-  String get search_history_item_edit_tooltip => 'Reuse and edit this search';
+  String get search_history_item_edit_tooltip =>
+      'Tumia tena na uhariri utafutaji huu';
 
   @override
-  String get search_history_item_remove_tooltip => 'Remove';
+  String get search_history_item_remove_tooltip => 'Ondoa';
 
   @override
   String product_search_no_more_results(int totalSize) {
-    return 'You\'ve downloaded all the $totalSize products.';
+    return 'Umepakua $totalSize bidhaa zote.';
   }
 
   @override
@@ -3030,38 +3055,39 @@ class AppLocalizationsSw extends AppLocalizations {
     int downloaded,
     int totalSize,
   ) {
-    return 'Download $count more products\nAlready downloaded $downloaded out of $totalSize.';
+    return 'Pakua $count bidhaa zaidi\nTayari zimepakuliwa $downloaded kati ya $totalSize.';
   }
 
   @override
   String product_search_loading_message(Object search) {
-    return 'Your search of $search is in progress.\n\nPlease wait a few seconds…';
+    return 'Utafutaji wako wa $search unaendelea.\n\nTafadhali subiri sekunde chache…';
   }
 
   @override
-  String get user_search_contributor_title => 'Products I added';
+  String get user_search_contributor_title => 'Bidhaa nilizoongeza';
 
   @override
-  String get user_search_informer_title => 'Products I edited';
+  String get user_search_informer_title => 'Bidhaa nilizohariri';
 
   @override
-  String get user_search_photographer_title => 'Products I photographed';
+  String get user_search_photographer_title => 'Bidhaa nilizopiga picha';
 
   @override
-  String get user_search_to_be_completed_title => 'My to-be-completed products';
+  String get user_search_to_be_completed_title =>
+      'Bidhaa zangu za-kuwa-kukamilika';
 
   @override
-  String get user_search_prices_title => 'My prices';
+  String get user_search_prices_title => 'Bei zangu';
 
   @override
-  String get user_search_proofs_title => 'My proofs';
+  String get user_search_proofs_title => 'Ushahidi wangu';
 
   @override
-  String get user_search_proof_title => 'My proof';
+  String get user_search_proof_title => 'Ushahidi wangu';
 
   @override
   String search_proof_title(String user) {
-    return 'Proof from \"$user\"';
+    return 'Uthibitisho kutoka kwa \"$user\"';
   }
 
   @override
@@ -3070,17 +3096,17 @@ class AppLocalizationsSw extends AppLocalizations {
   }
 
   @override
-  String get all_search_prices_latest_title => 'Latest Prices added';
+  String get all_search_prices_latest_title => 'Bei za Hivi Punde zimeongezwa';
 
   @override
-  String get all_search_prices_top_user_title => 'Top price contributors';
+  String get all_search_prices_top_user_title => 'Wachangiaji wa bei ya juu';
 
   @override
   String get all_search_prices_top_location_title =>
-      'Stores with the most prices';
+      'Maduka yenye bei nyingi zaidi';
 
   @override
-  String get prices_contribution_assistant => 'Price Contribution Assistant';
+  String get prices_contribution_assistant => 'Msaidizi wa Mchango wa Bei';
 
   @override
   String get prices_validation_assistant => 'Price Validation Assistant';
@@ -3089,63 +3115,65 @@ class AppLocalizationsSw extends AppLocalizations {
   String get prices_challenges_page => 'Challenges';
 
   @override
-  String get prices_multiple_proof_addition_system => 'Add Multiple Proofs';
+  String get prices_multiple_proof_addition_system =>
+      'Ongeza Uthibitisho Nyingi';
 
   @override
-  String get all_search_prices_top_location_single_title => 'Prices in a store';
+  String get all_search_prices_top_location_single_title => 'Bei katika duka';
 
   @override
   String get all_search_prices_top_product_title =>
-      'Products with the most prices';
+      'Bidhaa zilizo na bei nyingi zaidi';
 
   @override
-  String get all_search_to_be_completed_title => 'All to-be-completed products';
+  String get all_search_to_be_completed_title => 'Bidhaa zote za kukamilika';
 
   @override
   String get categorize_products_country_title =>
-      'Help categorize products in your country';
+      'Saidia kuainisha bidhaa katika nchi yako';
 
   @override
-  String get edit_product_action_retake_picture => 'Retake photo';
+  String get edit_product_action_retake_picture => 'Piga picha tena';
 
   @override
-  String get edit_product_action_take_picture => 'Take photo';
+  String get edit_product_action_take_picture => 'Piga picha';
 
   @override
-  String get edit_product_action_confirm => 'Confirm';
+  String get edit_product_action_confirm => 'Thibitisha';
 
   @override
   String get signup_page_terms_of_use_line1 =>
-      'I agree to the Open Food Facts ';
+      'Ninakubali Ukweli wa Chakula Huria ';
 
   @override
-  String get signup_page_terms_of_use_line2 => 'terms of use and contribution';
+  String get signup_page_terms_of_use_line2 =>
+      'masharti ya matumizi na mchango';
 
   @override
-  String get analytics_consent_image_semantic_label => 'Analytics icon';
+  String get analytics_consent_image_semantic_label => 'Aikoni ya uchanganuzi';
 
   @override
   String knowledge_panel_page_loading_error(Object? error) {
-    return 'Fatal Error: $error';
+    return 'Hitilafu mbaya: $error';
   }
 
   @override
   String preferences_page_loading_error(Object? error) {
-    return 'Fatal Error: $error';
+    return 'Hitilafu mbaya: $error';
   }
 
   @override
-  String get summary_card_button_add_basic_details => 'Complete basic details';
+  String get summary_card_button_add_basic_details =>
+      'Kamilisha maelezo ya msingi';
 
   @override
   String get edit_photo_button_label => 'Hariri';
 
   @override
-  String get edit_photo_unselect_button_label => 'Unselect photo';
+  String get edit_photo_unselect_button_label => 'Acha kuchagua picha';
 
   @override
-  String get edit_photo_select_existing_button_label =>
-      'Select an existing image';
+  String get edit_photo_select_existing_button_label => 'Chagua picha iliyopo';
 
   @override
   String get edit_photo_select_existing_all_label =>
@@ -3153,52 +3181,53 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get edit_photo_select_existing_all_subtitle =>
-      'Select an image by clicking on it';
+      'Chagua picha kwa kubofya';
 
   @override
   String get edit_photo_select_existing_download_label =>
-      'Retrieving existing images…';
+      'Inarejesha picha zilizopo…';
 
   @override
   String get edit_photo_select_existing_downloaded_none =>
-      'There are no images previously uploaded related to this product.';
+      'Hakuna picha zilizopakiwa hapo awali zinazohusiana na bidhaa hii.';
 
   @override
   String get edit_photo_language_not_this_one =>
-      'No image in that language yet';
+      'Bado hakuna picha katika lugha hiyo';
 
   @override
-  String get edit_photo_language_none => 'No image yet';
+  String get edit_photo_language_none => 'Hakuna picha bado';
 
   @override
   String get category_picker_screen_title => 'Categories';
 
   @override
-  String get basic_details => 'Basic Details';
+  String get basic_details => 'Maelezo ya Msingi';
 
   @override
-  String get product_name => 'Product Name';
+  String get product_name => 'Jina la Bidhaa';
 
   @override
-  String get product_names => 'Product Names';
+  String get product_names => 'Majina ya Bidhaa';
 
   @override
   String get add_basic_details_product_name_add_translation =>
-      'Add a new translation';
+      'Ongeza tafsiri mpya';
 
   @override
   String get add_basic_details_product_name_warning_translations =>
-      'Before validating, please ensure you only add a translation **if the language is present on the packaging**';
+      'Kabla ya kuthibitisha, tafadhali hakikisha kuwa unaongeza tafsiri tu **ikiwa lugha ipo kwenye kifurushi**';
 
   @override
-  String get add_basic_details_product_name_open_photo => 'View front photo';
+  String get add_basic_details_product_name_open_photo =>
+      'Tazama picha ya mbele';
 
   @override
-  String get add_basic_details_product_name_take_photo => 'Take front photo';
+  String get add_basic_details_product_name_take_photo => 'Piga picha ya mbele';
 
   @override
   String get add_basic_details_product_name_hint =>
-      'Input the name of the product (eg: Nutella)';
+      'Ingiza jina la bidhaa (kwa mfano: Nutella)';
 
   @override
   String get add_basic_details_product_name_change_main_language_title =>
@@ -3212,41 +3241,41 @@ class AppLocalizationsSw extends AppLocalizations {
   }
 
   @override
-  String get explanation_section_good_examples => 'Good examples';
+  String get explanation_section_good_examples => 'Mifano mizuri';
 
   @override
-  String get explanation_section_bad_examples => 'Bad examples';
+  String get explanation_section_bad_examples => 'Mifano mbaya';
 
   @override
   String get add_basic_details_product_name_help_title =>
-      'Good practices: Product name';
+      'Mazoea mazuri: Jina la bidhaa';
 
   @override
   String get add_basic_details_product_name_help_info1 =>
-      'The product name is the **main name printed on the packaging**. It can be a registered trademark.';
+      'Jina la bidhaa ni **jina kuu lililochapishwa kwenye kifurushi**. Inaweza kuwa alama ya biashara iliyosajiliwa.';
 
   @override
   String get add_basic_details_product_name_help_info2 =>
-      '**Note:** Please don\'t add a translation **if the language is not present on the packaging**.';
+      '**Kumbuka:** Tafadhali usiongeze tafsiri **ikiwa lugha haipo kwenye kifungashio**.';
 
   @override
   String get add_basic_details_product_name_help_good_examples_1 => 'Nesquik';
 
   @override
   String get add_basic_details_product_name_help_good_examples_2 =>
-      'Tomato Ketchup';
+      'Ketchup ya Nyanya';
 
   @override
   String get add_basic_details_product_name_help_bad_examples_1_explanation =>
-      'Don\'t include the brand in the name';
+      'Usijumuishe chapa kwenye jina';
 
   @override
   String get add_basic_details_product_name_help_bad_examples_1_example =>
-      'Tomato Ketchup **by Heinz**';
+      'Ketchup ya Nyanya ** na Heinz **';
 
   @override
   String get add_basic_details_product_name_help_bad_examples_2_explanation =>
-      'Don\'t use symbols ®, ™, © or similar';
+      'Usitumie alama ®, ™, © au zinazofanana';
 
   @override
   String get add_basic_details_product_name_help_bad_examples_2_example =>
@@ -3257,58 +3286,60 @@ class AppLocalizationsSw extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count other translations',
-      one: '$count other translation',
+      other: '$count tafsiri zingine',
+      one: '$count tafsiri nyingine',
     );
     return '$_temp0';
   }
 
   @override
-  String get brand_name => 'Brand name';
+  String get brand_name => 'Jina la chapa';
 
   @override
-  String get brand_names => 'Brand names';
+  String get brand_names => 'Majina ya chapa';
 
   @override
   String get add_basic_details_brand_name_error =>
-      'Please enter the brand name';
+      'Tafadhali ingiza jina la chapa';
 
   @override
-  String get add_basic_details_brand_names_hint => 'Input brands (eg: Ferrero)';
+  String get add_basic_details_brand_names_hint =>
+      'Chapa za ingizo (km: Ferrero)';
 
   @override
   String get add_basic_details_product_brand_help_title =>
-      'Good practices: Brands';
+      'Mazoea mazuri: Chapa';
 
   @override
   String get add_basic_details_product_brand_help_info1 =>
-      'Input **all the brands of the product**.';
+      'Ingiza **aina zote za bidhaa**.';
 
   @override
-  String get add_basic_details_product_brand_help_info2_title => 'Main brand';
+  String get add_basic_details_product_brand_help_info2_title => 'Chapa kuu';
 
   @override
   String get add_basic_details_product_brand_help_info2_content =>
-      'The **main brand**, generally clearly displayed on the front pack, should be **entered first**.';
+      '**Chapa kuu**, kwa ujumla inayoonyeshwa wazi kwenye pakiti ya mbele, inapaswa **kuingizwa kwanza**.';
 
   @override
-  String get add_basic_details_product_brand_help_info3_title => 'Other brands';
+  String get add_basic_details_product_brand_help_info3_title =>
+      'Bidhaa zingine';
 
   @override
   String get add_basic_details_product_brand_help_info3_item1_text =>
-      'When sold **by a big company**:';
+      'Inapouzwa **na kampuni kubwa**:';
 
   @override
   String get add_basic_details_product_brand_help_info3_item1_explanation =>
-      '**Actimel** is sold by **Danone**';
+      '**Actimel** inauzwa na **Danone**';
 
   @override
   String get add_basic_details_product_brand_help_info3_item2_text =>
-      'When sold with its brand **translated in multiple languages**:';
+      'Inapouzwa na chapa yake **iliyotafsiriwa katika lugha nyingi**:';
 
   @override
   String get add_basic_details_product_brand_help_info3_item2_explanation =>
-      '**Nature Valley** is sometimes written **Val Nature**';
+      '**Bonde la Asili** wakati mwingine huandikwa **Val Nature**';
 
   @override
   String get add_basic_details_product_brand_help_good_examples_1 => 'Nutella';
@@ -3318,181 +3349,184 @@ class AppLocalizationsSw extends AppLocalizations {
       'Oreo, Mondelez';
 
   @override
-  String get quantity => 'Quantity and weight';
+  String get quantity => 'Kiasi na uzito';
 
   @override
   String get add_basic_details_quantity_hint =>
-      'Input the weight and if needed the quantity (eg : 4x100g)';
+      'Ingiza uzito na ikihitajika kiasi (kwa mfano: 4x100g)';
 
   @override
   String get add_basic_details_product_quantity_help_title =>
-      'Good practices: Quantity';
+      'Mazoea mazuri: Kiasi';
 
   @override
   String get add_basic_details_product_quantity_help_info1 =>
-      'Copy the value indicated on the product and **don\'t forget the units**.';
+      'Nakili thamani iliyoonyeshwa kwenye bidhaa na **usisahau vizio**.';
 
   @override
   String get add_basic_details_product_quantity_help_good_examples_1 =>
-      '**230g** or **230 g**';
+      '**230g** au **230g**';
 
   @override
   String get add_basic_details_product_quantity_help_good_examples_2 =>
-      '**6** (for 6 eggs)';
+      '**6** (kwa mayai 6)';
 
   @override
   String get add_basic_details_product_quantity_help_good_examples_3 =>
-      '**3 x 150g**\n(for a product with 3 boxes, each of 150g)';
+      '**3 x 150g**\n(kwa bidhaa yenye masanduku 3, kila moja ya 150g)';
 
   @override
   String get barcode => 'Barcode';
 
   @override
   String barcode_barcode(String barcode) {
-    return 'Barcode: $barcode';
+    return 'Msimbo pau: $barcode';
   }
 
   @override
-  String get barcode_invalid_error => 'Invalid barcode';
+  String get barcode_invalid_error => 'Msimbopau batili';
 
   @override
-  String get basic_details_add_success => 'Basic details added successfully';
+  String get basic_details_add_success =>
+      'Maelezo ya msingi yameongezwa kwa mafanikio';
 
   @override
   String get basic_details_add_error =>
-      'Unable to add basic details. Please try again after some time';
+      'Imeshindwa kuongeza maelezo ya msingi. Tafadhali jaribu tena baada ya muda';
 
   @override
-  String get clear_search => 'Clear your search';
+  String get clear_search => 'Futa utafutaji wako';
 
   @override
   String get confirm_clear =>
-      'You\'re about to clear your entire history: are you sure you want to continue?';
+      'Unakaribia kufuta historia yako yote: una uhakika ungependa kuendelea?';
 
   @override
   String get alert_clear_selected_user_list =>
-      'You\'re about to clear selected items in your history';
+      'Unakaribia kufuta vipengee vilivyochaguliwa katika historia yako';
 
   @override
   String get confirm_clear_selected_user_list =>
-      'Are you sure you want to continue?';
+      'Je, una uhakika ungependa kuendelea?';
 
   @override
   String get alert_select_items_to_clear =>
-      'Please select one or more items to clear';
+      'Tafadhali chagua kipengee kimoja au zaidi ili kufuta';
 
   @override
   String confirm_clear_user_list(String name) {
-    return 'You\'re about to clear this list ($name): are you sure you want to continue?';
+    return 'Unakaribia kufuta orodha hii ($name): una uhakika ungependa kuendelea?';
   }
 
   @override
-  String get confirm_delete_user_list_title => 'Delete the list?';
+  String get confirm_delete_user_list_title => 'Ungependa kufuta orodha?';
 
   @override
   String confirm_delete_user_list_message(String name) {
-    return 'You\'re about to delete the list \"$name\".\nAre you sure you want to continue?';
+    return 'Unakaribia kufuta orodha \"$name\".\nJe, una uhakika ungependa kuendelea?';
   }
 
   @override
-  String get confirm_delete_user_list_button => 'Yes, I confirm';
+  String get confirm_delete_user_list_button => 'Ndiyo, nathibitisha';
 
   @override
   String importance_label(String name, String id) {
-    return '$name importance: $id';
+    return '$name umuhimu: $id';
   }
 
   @override
-  String get user_list_all_title => 'Lists';
+  String get user_list_all_title => 'Orodha';
 
   @override
-  String get user_list_all_empty => 'Create your first list';
+  String get user_list_all_empty => 'Unda orodha yako ya kwanza';
 
   @override
-  String get product_list_select => 'Select a list';
+  String get product_list_select => 'Chagua orodha';
 
   @override
   String user_list_length(num count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count products',
-      one: 'One product',
-      zero: 'Empty list',
+      other: '$count bidhaa',
+      one: 'Bidhaa moja',
+      zero: 'Orodha tupu',
     );
     return '$_temp0';
   }
 
   @override
-  String get add_list_label => 'Add list';
+  String get add_list_label => 'Ongeza orodha';
 
   @override
-  String get open_food_preferences_tooltip => 'Edit your food preferences';
+  String get open_food_preferences_tooltip =>
+      'Badilisha mapendeleo yako ya chakula';
 
   @override
-  String get add_photo_button_label => 'Add photo';
+  String get add_photo_button_label => 'Ongeza picha';
 
   @override
   String get add_packaging_photo_button_label =>
-      'Take photos of any packaging/recycling information';
+      'Piga picha za maelezo yoyote ya ufungashaji/usafishaji';
 
   @override
   String get add_origin_photo_button_label =>
-      'Take photos of any origin information';
+      'Piga picha za maelezo yoyote ya asili';
 
   @override
   String get add_emb_photo_button_label =>
-      'Take photos of any traceability code information';
+      'Piga picha za maelezo yoyote ya msimbo wa ufuatiliaji';
 
   @override
   String get add_label_photo_button_label =>
-      'Take photos of any labels & certifications information';
+      'Piga picha za maelezo ya lebo na vyeti vyovyote';
 
   @override
-  String get choose_image_source_title => 'Choose image source';
+  String get choose_image_source_title => 'Chagua chanzo cha picha';
 
   @override
-  String get choose_image_source_body => 'Please choose a image source';
+  String get choose_image_source_body => 'Tafadhali chagua chanzo cha picha';
 
   @override
-  String get gallery_source_label => 'Gallery';
+  String get gallery_source_label => 'Matunzio';
 
   @override
-  String get gallery_source_access_denied_dialog_title => 'Access denied';
+  String get gallery_source_access_denied_dialog_title =>
+      'Ufikiaji umekataliwa';
 
   @override
   String get gallery_source_access_denied_dialog_message_ios =>
-      'Unfortunately, the application can\'t access your gallery, as you have previously denied the permission.\n\nPlease go to the app settings in your phone Settings -> Photos';
+      'Kwa bahati mbaya, programu haiwezi kufikia matunzio yako, kwa kuwa hapo awali ulinyima ruhusa.\n\nTafadhali nenda kwenye mipangilio ya programu katika Mipangilio ya simu yako -> Picha';
 
   @override
-  String get gallery_source_access_denied_dialog_button => 'Open the Settings';
+  String get gallery_source_access_denied_dialog_button => 'Fungua Mipangilio';
 
   @override
-  String get share => 'Share';
+  String get share => 'Shiriki';
 
   @override
   String share_product_text(String url) {
-    return 'Have a look at this product on Open Food Facts: $url';
+    return 'Tazama bidhaa hii kwenye Open Food Facts: $url';
   }
 
   @override
   String share_product_text_beauty(String url) {
-    return 'Have a look at this product on Open Beauty Facts: $url';
+    return 'Tazama bidhaa hii kwenye Open Beauty Facts: $url';
   }
 
   @override
   String share_product_text_pet_food(String url) {
-    return 'Have a look at this product on Open PetFood Facts: $url';
+    return 'Tazama bidhaa hii kwenye Open PetFood Facts: $url';
   }
 
   @override
   String share_product_text_product(String url) {
-    return 'Have a look at this product on Open Products Facts: $url';
+    return 'Tazama bidhaa hii kwenye Ukweli wa Bidhaa Huria: $url';
   }
 
   @override
   String share_product_list_text(String url) {
-    return 'Have a look at my list of products on Open Food Facts: $url';
+    return 'Tazama orodha yangu ya bidhaa kwenye Open Food Facts: $url';
   }
 
   @override
@@ -3502,172 +3536,173 @@ class AppLocalizationsSw extends AppLocalizations {
   String get capture_new_picture => 'Piga picha';
 
   @override
-  String get choose_from_gallery => 'Choose from gallery';
+  String get choose_from_gallery => 'Chagua kutoka kwenye ghala';
 
   @override
   String get image_upload_queued =>
-      'The image will be uploaded in the background as soon as possible.';
+      'Picha itapakiwa chinichini haraka iwezekanavyo.';
 
   @override
-  String get add_price_queued =>
-      'The price will be sent to the server as soon as possible.';
+  String get add_price_queued => 'Bei itatumwa kwa seva haraka iwezekanavyo.';
 
   @override
   String get background_task_title_full_refresh =>
-      'Starting the refresh of all the products locally stored';
+      'Kuanzisha uonyeshaji upya wa bidhaa zote zilizohifadhiwa ndani';
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Inaanza kutekeleza vitendo vya seva kwa masasisho ya folksonomy yaliyohifadhiwa ndani';
 
   @override
   String get background_task_title_top_n =>
-      'Starting the download of the most popular products';
+      'Kuanzia upakuaji wa bidhaa maarufu zaidi';
 
   @override
-  String get expand_nutrition_facts => 'Expand nutrition facts table';
+  String get expand_nutrition_facts => 'Panua jedwali la ukweli wa lishe';
 
   @override
   String get expand_nutrition_facts_body =>
-      'Keep the nutrition facts table expanded';
+      'Weka jedwali la ukweli wa lishe kupanuliwa';
 
   @override
-  String get expand_ingredients => 'Expand ingredients';
+  String get expand_ingredients => 'Panua viungo';
 
   @override
-  String get expand_ingredients_body => 'Keep the ingredients panel expanded';
+  String get expand_ingredients_body => 'Weka jopo la viungo kupanuliwa';
 
   @override
-  String get no_internet_connection => 'No internet connection';
+  String get no_internet_connection => 'Hakuna muunganisho wa intaneti';
 
   @override
-  String get world_results_label => 'Entire world';
+  String get world_results_label => 'Dunia nzima';
 
   @override
-  String get world_results_action => 'Extend your search to the world';
+  String get world_results_action => 'Panua utafutaji wako kwa ulimwengu';
 
   @override
-  String get copy_to_clipboard => 'Copy';
+  String get copy_to_clipboard => 'Nakili';
 
   @override
-  String get paste_from_clipboard => 'Paste from clipboard';
+  String get paste_from_clipboard => 'Bandika kutoka kwenye ubao wa kunakili';
 
   @override
   String get no_data_available_in_clipboard =>
-      'No data available in your clipboard';
+      'Hakuna data inayopatikana kwenye ubao wako wa kunakili';
 
   @override
-  String get clipboard_barcode_copy => 'Copy barcode to clipboard';
+  String get clipboard_barcode_copy =>
+      'Nakili msimbo pau kwenye ubao wa kunakili';
 
   @override
   String clipboard_barcode_copied(Object barcode) {
-    return 'Barcode $barcode copied to the clipboard!';
+    return 'Msimbo upau $barcode umenakiliwa kwenye ubao wa kunakili!';
   }
 
   @override
-  String get open_product_website => 'Open this product on the website';
+  String get open_product_website => 'Fungua bidhaa hii kwenye wavuti';
 
   @override
-  String get language_picker_label => 'Your language';
+  String get language_picker_label => 'Lugha yako';
 
   @override
-  String get country_picker_label => 'Your country';
+  String get country_picker_label => 'Nchi yako';
 
   @override
-  String get currency_picker_label => 'Your currency';
+  String get currency_picker_label => 'Sarafu yako';
 
   @override
-  String get help_with_openfoodfacts => 'Help with OpenFoodFacts';
+  String get help_with_openfoodfacts => 'Msaada na OpenFoodFacts';
 
   @override
   String get product_task_background_schedule =>
-      'The product will be updated in the background as soon as possible.';
+      'Bidhaa itasasishwa chinichini haraka iwezekanavyo.';
 
   @override
-  String get no_email_client_available_dialog_title => 'No email apps!';
+  String get no_email_client_available_dialog_title =>
+      'Hakuna programu za barua pepe!';
 
   @override
   String get no_email_client_available_dialog_content =>
-      'Please send us manually an email to mobile@openfoodfacts.org';
+      'Tafadhali tutumie mwenyewe barua pepe kwa mobile@openfoodfacts.org';
 
   @override
-  String get all_images => 'All Images';
+  String get all_images => 'Picha Zote';
 
   @override
-  String get selected_images => 'Selected Images';
+  String get selected_images => 'Picha Zilizochaguliwa';
 
   @override
-  String get product_card_remove_product_tooltip => 'Remove product';
+  String get product_card_remove_product_tooltip => 'Ondoa bidhaa';
 
   @override
   String scan_announce_new_barcode(String barcode) {
-    return 'New barcode scanned: $barcode';
+    return 'Msimbopau mpya umechanganuliwa: $barcode';
   }
 
   @override
   String get scan_header_clear_button_tooltip =>
-      'Remove all products from the carousel';
+      'Ondoa bidhaa zote kutoka kwa jukwa';
 
   @override
   String get scan_header_compare_button_invalid_state_tooltip =>
-      'Please scan at least two products to compare them';
+      'Tafadhali changanua angalau bidhaa mbili ili kuzilinganisha';
 
   @override
   String get scan_header_compare_button_valid_state_tooltip =>
-      'Click to compare the products you have scanned';
+      'Bofya ili kulinganisha bidhaa ulizochanganua';
 
   @override
-  String get scan_product_loading => 'You have scanned\nthe barcode:';
+  String get scan_product_loading => 'Umechanganua\nmsimbo pau:';
 
   @override
   String get scan_product_loading_initial =>
-      'We\'re looking for this product!\nPlease wait a few seconds…';
+      'Tunatafuta bidhaa hii!\nTafadhali subiri sekunde chache…';
 
   @override
   String get scan_product_loading_long_request =>
-      'We\'re still looking for this product!\nDo you find it takes a long time to load? So are we…';
+      'Bado tunatafuta bidhaa hii!\nJe, unaona kuwa inachukua muda mrefu kupakia? Vivyo hivyo na sisi…';
 
   @override
   String get scan_product_loading_unresponsive =>
-      'We\'re still looking for this product.\nWould you like to restart the search?';
+      'Bado tunatafuta bidhaa hii.\nJe, ungependa kuanzisha upya utafutaji?';
 
   @override
-  String get scan_product_loading_restart_button => 'Restart search';
+  String get scan_product_loading_restart_button => 'Anzisha upya utafutaji';
 
   @override
   String get portion_calculator_description =>
-      'Calculate nutrition facts for a specific quantity';
+      'Kuhesabu ukweli wa lishe kwa idadi maalum';
 
   @override
-  String get portion_calculator_hint => 'Quantity in';
+  String get portion_calculator_hint => 'Kiasi ndani';
 
   @override
   String get portion_calculator_accessibility =>
-      'Input a quantity to calculate nutrition facts';
+      'Ingiza kiasi ili kukokotoa ukweli wa lishe';
 
   @override
   String portion_calculator_error(int min, int max) {
-    return 'Please enter a quantity between $min and $max g';
+    return 'Tafadhali weka kiasi kati ya $min na $max g';
   }
 
   @override
   String get portion_calculator_computation_error =>
-      'Missing data. Calculation could not be performed.';
+      'Data haipo. Hesabu haikuweza kufanywa.';
 
   @override
   String portion_calculator_result_title(int grams) {
-    return 'Nutrition facts for $grams g (or ml)';
+    return 'Ukweli wa lishe kwa $grams g (au ml)';
   }
 
   @override
-  String get offline_data => 'Offline Data';
+  String get offline_data => 'Data ya Nje ya Mtandao';
 
   @override
   String get ocr_image_upload_instruction =>
-      'Upload an image to automatically extract the information it contains.';
+      'Pakia picha ili kutoa maelezo yaliyomo kiotomatiki.';
 
   @override
-  String get upload_image => 'Upload Photo';
+  String get upload_image => 'Pakia Picha';
 
   @override
   String get word_separator_char => ',';
@@ -3676,388 +3711,396 @@ class AppLocalizationsSw extends AppLocalizations {
   String get word_separator => ', ';
 
   @override
-  String get image_download_error => 'Failed to download image';
+  String get image_download_error => 'Imeshindwa kupakua picha';
 
   @override
   String get image_edit_url_error =>
-      'Failed to edit image because the image URL was not set.';
+      'Imeshindwa kuhariri picha kwa sababu URL ya picha haikuwekwa.';
 
   @override
-  String get user_picture_source_remember => 'Remember my choice';
+  String get user_picture_source_remember => 'Kumbuka chaguo langu';
 
   @override
-  String get user_picture_source_ask => 'Ask each time';
+  String get user_picture_source_ask => 'Uliza kila wakati';
 
   @override
-  String get robotoff_continue => 'Continue';
+  String get robotoff_continue => 'Endelea';
 
   @override
   String robotoff_next_n_questions(num count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count questions',
-      one: 'question',
+      other: '$count maswali',
+      one: 'swali',
     );
-    return 'Next $_temp0';
+    return 'Swali linalofuata $_temp0';
   }
 
   @override
-  String get show_password => 'Show Password';
+  String get show_password => 'Onyesha Nenosiri';
 
   @override
-  String get owner_field_info_title => 'Producer provided values';
+  String get owner_field_info_title => 'Mtayarishaji alitoa maadili';
 
   @override
   String get owner_field_info_message =>
-      'With that logo we highlight data provided by the producer, and that may not be editable.';
+      'Kwa nembo hiyo tunaangazia data iliyotolewa na mtayarishaji, na ambayo inaweza isiweze kuhaririwa.';
 
   @override
-  String get owner_field_info_close_button => 'Close this info';
+  String get owner_field_info_close_button => 'Funga maelezo haya';
 
   @override
   String get owner_field_image =>
-      'This image is provided by the producer. It may not be editable.';
+      'Picha hii imetolewa na mtayarishaji. Huenda isiweze kuhaririwa.';
 
   @override
-  String get edit_packagings_title => 'Packaging components';
+  String get edit_packagings_title => 'Vipengele vya ufungaji';
 
   @override
-  String get edit_packagings_element_add => 'Add a packaging component';
+  String get edit_packagings_element_add => 'Ongeza sehemu ya ufungaji';
 
   @override
-  String get edit_packagings_completed => 'The packaging is complete';
+  String get edit_packagings_completed => 'Ufungaji umekamilika';
 
   @override
   String edit_packagings_element_title(int index) {
-    return 'Packaging component #$index';
+    return 'Sehemu ya ufungashaji #$index';
   }
 
   @override
-  String get edit_packagings_element_field_units => 'Number of units';
+  String get edit_packagings_element_field_units => 'Idadi ya vitengo';
 
   @override
   String get edit_packagings_element_hint_units =>
-      'Enter the number of packaging units of the same shape and material contained in the product.';
+      'Ingiza idadi ya vitengo vya ufungaji vya sura sawa na nyenzo zilizomo kwenye bidhaa.';
 
   @override
-  String get edit_packagings_element_field_shape => 'Shape';
+  String get edit_packagings_element_field_shape => 'Umbo';
 
   @override
   String get edit_packagings_element_hint_shape =>
-      'Enter the shape name listed in the recycling instructions if they are available, or select a shape.';
+      'Ingiza jina la umbo lililoorodheshwa katika maagizo ya kuchakata ikiwa yanapatikana, au chagua umbo.';
 
   @override
-  String get edit_packagings_element_example_shape => 'Bottle';
+  String get edit_packagings_element_example_shape => 'Chupa';
 
   @override
-  String get edit_packagings_element_field_material => 'Material';
+  String get edit_packagings_element_field_material => 'Nyenzo';
 
   @override
   String get edit_packagings_element_hint_material =>
-      'Enter the specific material if it can be determined (a material code inside a triangle can often be found on packaging parts), or a generic material (for instance plastic or metal) if you are unsure.';
+      'Weka nyenzo mahususi ikiwa inaweza kubainishwa (msimbo wa nyenzo ndani ya pembetatu mara nyingi unaweza kupatikana kwenye sehemu za vifungashio), au nyenzo ya jumla (kwa mfano plastiki au chuma) ikiwa huna uhakika.';
 
   @override
-  String get edit_packagings_element_example_material => 'Glass';
+  String get edit_packagings_element_example_material => 'Kioo';
 
   @override
-  String get edit_packagings_element_field_recycling => 'Recycling instruction';
+  String get edit_packagings_element_field_recycling =>
+      'Maagizo ya kuchakata tena';
 
   @override
   String get edit_packagings_element_hint_recycling =>
-      'Enter recycling instructions only if they are listed on the product.';
+      'Ingiza maagizo ya kuchakata tu ikiwa yameorodheshwa kwenye bidhaa.';
 
   @override
   String get edit_packagings_element_example_recycling => 'Recycle';
 
   @override
   String get edit_packagings_element_field_quantity =>
-      'Net quantity of product per unit';
+      'Kiasi halisi cha bidhaa kwa kila kitengo';
 
   @override
   String get edit_packagings_element_hint_quantity =>
-      'Enter the net weight or net volume and indicate the unit (for example g or ml).';
+      'Ingiza uzito wa wavu au ujazo wa wavu na uonyeshe kitengo (kwa mfano g au ml).';
 
   @override
   String get edit_packagings_element_field_weight =>
-      'Weight of one empty unit (g)';
+      'Uzito wa kitengo tupu (g)';
 
   @override
   String get edit_packagings_element_hint_weight =>
-      'Remove any remaining food and wash and dry the packaging part before weighing. If possible, use a scale with 0.1g or 0.01g precision.';
+      'Ondoa chakula chochote kilichobaki na osha na kavu sehemu ya ufungaji kabla ya kupima. Ikiwezekana, tumia mizani iliyo na usahihi wa 0.1g au 0.01g.';
 
   @override
-  String get background_task_title => 'Pending contributions';
+  String get background_task_title => 'Michango inayosubiri';
 
   @override
   String get background_task_subtitle =>
-      'Your contributions are automatically saved to our server, but not always in real-time.';
+      'Michango yako inahifadhiwa kiotomatiki kwenye seva yetu, lakini si mara zote katika muda halisi.';
 
   @override
-  String get background_task_list_empty => 'No Pending Background Tasks';
+  String get background_task_list_empty =>
+      'Hakuna Majukumu ya Mandharinyuma Yanayosubiri';
 
   @override
-  String get background_task_error_server_time_out => 'Server timeout';
+  String get background_task_error_server_time_out => 'Muda wa seva umekwisha';
 
   @override
   String get background_task_error_no_internet =>
-      'Internet connection error. Try later.';
+      'Hitilafu ya muunganisho wa mtandao. Jaribu baadaye.';
 
   @override
-  String get background_task_operation_unknown => 'unknown operation type';
+  String get background_task_operation_unknown =>
+      'aina ya operesheni isiyojulikana';
 
   @override
-  String get background_task_operation_details => 'detailed changes';
+  String get background_task_operation_details => 'mabadiliko ya kina';
 
   @override
-  String get background_task_operation_image => 'photo upload';
+  String get background_task_operation_image => 'kupakia picha';
 
   @override
   String get background_task_operation_refresh =>
-      'refresh delayed after photo upload';
+      'kuonyesha upya kumechelewa baada ya upakiaji wa picha';
 
   @override
-  String get background_task_run_started => 'started';
+  String get background_task_run_started => 'ilianza';
 
   @override
-  String get background_task_run_not_started => 'not started yet';
+  String get background_task_run_not_started => 'haijaanza bado';
 
   @override
-  String get background_task_run_to_be_deleted => 'to be deleted';
+  String get background_task_run_to_be_deleted => 'kufutwa';
 
   @override
   String get background_task_question_stop =>
-      'Do you want to stop that task ASAP?';
+      'Je, ungependa kusitisha jukumu hilo HARAKA?';
 
   @override
-  String get feed_back => 'Feedback';
+  String get feed_back => 'Maoni';
 
   @override
-  String get undo => 'Undo';
+  String get undo => 'Tendua';
 
   @override
-  String get copy_email_to_clip_board => 'Copy email to clipboard';
+  String get copy_email_to_clip_board =>
+      'Nakili barua pepe kwenye ubao wa kunakili';
 
   @override
   String get please_send_us_an_email_to =>
-      'Please send us manually an email to';
+      'Tafadhali tutumie mwenyewe barua pepe kwa';
 
   @override
-  String get email_copied_to_clip_board => 'Email copied to clipboard!';
+  String get email_copied_to_clip_board =>
+      'Barua pepe imenakiliwa kwenye ubao wa kunakili!';
 
   @override
-  String get select_accent_color => 'Select Accent Color';
+  String get select_accent_color => 'Chagua Rangi ya Lafudhi';
 
   @override
   String get theme_amoled => 'AMOLED';
 
   @override
-  String get color_blue => 'Blue';
+  String get color_blue => 'Bluu';
 
   @override
   String get color_cyan => 'Cyan';
 
   @override
-  String get color_green => 'Green';
+  String get color_green => 'Kijani';
 
   @override
-  String get color_light_brown => 'Default';
+  String get color_light_brown => 'Chaguomsingi';
 
   @override
   String get color_magenta => 'Magenta';
 
   @override
-  String get color_orange => 'Orange';
+  String get color_orange => 'Chungwa';
 
   @override
   String get color_pink => 'Pink';
 
   @override
-  String get color_red => 'Red';
+  String get color_red => 'Nyekundu';
 
   @override
-  String get color_rust => 'Rust';
+  String get color_rust => 'Kutu';
 
   @override
   String get color_teal => 'Teal';
 
   @override
-  String get text_contrast_mode => 'Text Contrast';
+  String get text_contrast_mode => 'Utofautishaji wa Maandishi';
 
   @override
-  String get contrast_high => 'High';
+  String get contrast_high => 'Juu';
 
   @override
-  String get contrast_medium => 'Medium';
+  String get contrast_medium => 'Kati';
 
   @override
-  String get contrast_low => 'Low';
+  String get contrast_low => 'Chini';
 
   @override
-  String get product_refresher_internet_not_found => 'Product not found!';
+  String get product_refresher_internet_not_found => 'Bidhaa haijapatikana!';
 
   @override
   String get product_refresher_internet_not_connected =>
-      'You are not connected to internet!';
+      'Hujaunganishwa kwenye intaneti!';
 
   @override
   String product_refresher_internet_no_ping(String? host) {
-    return 'Server down ($host)';
+    return 'Seva chini ($host)';
   }
 
   @override
   String product_refresher_internet_error(String? exception) {
-    return 'Server error ($exception)';
+    return 'Hitilafu ya seva ($exception)';
   }
 
   @override
-  String get product_loader_not_found_title => 'Product not found!';
+  String get product_loader_not_found_title => 'Bidhaa haijapatikana!';
 
   @override
   String product_loader_not_found_message(String barcode) {
-    return 'A product with the following barcode doesn\'t exist in our database: $barcode';
+    return 'Bidhaa iliyo na msimbopau ifuatayo haipo kwenye hifadhidata yetu: $barcode';
   }
 
   @override
-  String get product_loader_network_error_title => 'No internet connection!';
+  String get product_loader_network_error_title =>
+      'Hakuna muunganisho wa mtandao!';
 
   @override
   String get product_loader_network_error_message =>
-      'Please check that your smartphone is on a WiFi network or has mobile data enabled';
+      'Tafadhali hakikisha kwamba simu yako mahiri iko kwenye mtandao wa WiFi au imewasha data ya simu ya mkononi';
 
   @override
-  String get page_not_found_title => 'Page not found!';
+  String get page_not_found_title => 'Ukurasa haujapatikana!';
 
   @override
-  String get page_not_found_button => 'Go back to the homepage';
+  String get page_not_found_button => 'Rudi kwenye ukurasa wa nyumbani';
 
   @override
-  String get download_data => 'Download data';
+  String get download_data => 'Pakua data';
 
   @override
   String get download_top_products =>
-      'Download the top 1000 products in your country for instant scanning';
+      'Pakua bidhaa 1000 bora katika nchi yako ili uchanganue papo hapo';
 
   @override
   String download_top_n_products(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count products',
+      other: '$count bidhaa',
     );
-    return 'Download the top $_temp0 in your country for instant scanning';
+    return 'Pakua bidhaa bora $_temp0 katika nchi yako ili uchanganue papo hapo';
   }
 
   @override
-  String get download_in_progress => 'Downloading data\nThis may take a while';
+  String get download_in_progress => 'Kupakua data\nHii inaweza kuchukua muda';
 
   @override
   String downloaded_products(int num) {
-    return '$num products added';
+    return '$num bidhaa zimeongezwa';
   }
 
   @override
-  String get update_offline_data => 'Update offline product data';
+  String get update_offline_data => 'Sasisha data ya bidhaa nje ya mtandao';
 
   @override
   String get update_local_database_sub =>
-      'Update the local product database with the latest data from Open Food Facts';
+      'Sasisha hifadhidata ya bidhaa za ndani kwa data ya hivi punde kutoka Ukweli wa Open Food';
 
   @override
-  String get clear_local_database => 'Clear offline product data';
+  String get clear_local_database => 'Futa data ya bidhaa nje ya mtandao';
 
   @override
   String get clear_local_database_sub =>
-      'Clear all local product data from your app to free up space';
+      'Futa data yote ya bidhaa za ndani kutoka kwa programu yako ili kupata nafasi';
 
   @override
   String deleted_products(int num) {
-    return '$num products deleted';
+    return '$num bidhaa zimefutwa';
   }
 
   @override
   String get loading => 'Loading…';
 
   @override
-  String get know_more => 'Know More';
+  String get know_more => 'Fahamu Zaidi';
 
   @override
-  String get offline_data_desc => 'Click to know more about offline data';
+  String get offline_data_desc =>
+      'Bofya ili kujua zaidi kuhusu data ya nje ya mtandao';
 
   @override
-  String get offline_product_data_title => 'Offline product data';
+  String get offline_product_data_title => 'Data ya bidhaa nje ya mtandao';
 
   @override
   String available_for_download(int num) {
-    return '$num products available for immediate scaning';
+    return '$num bidhaa zinazopatikana kwa kuchanganua mara moja';
   }
 
   @override
-  String get country_selector_title => 'Select your country:';
+  String get country_selector_title => 'Chagua nchi yako:';
 
   @override
-  String get currency_selector_title => 'Select your currency:';
+  String get currency_selector_title => 'Chagua sarafu yako:';
 
   @override
-  String get language_selector_title => 'Select your language:';
+  String get language_selector_title => 'Chagua lugha yako:';
 
   @override
-  String get language_selector_section_selected => 'Selected languages';
+  String get language_selector_section_selected => 'Lugha zilizochaguliwa';
 
   @override
-  String get language_selector_section_frequently_used => 'Frequently used';
+  String get language_selector_section_frequently_used =>
+      'Inatumika mara kwa mara';
 
   @override
-  String get action_delete_list => 'Delete';
+  String get action_delete_list => 'Futa';
 
   @override
-  String get action_change_list => 'Change the current list';
+  String get action_change_list => 'Badilisha orodha ya sasa';
 
   @override
-  String get product_list_create => 'Create';
+  String get product_list_create => 'Unda';
 
   @override
-  String get product_list_create_tooltip => 'Create a new list';
+  String get product_list_create_tooltip => 'Unda orodha mpya';
 
   @override
   String get nutriscore_generic => 'Nutri-Score';
 
   @override
-  String get nutriscore_a => 'Nutri-Score A';
+  String get nutriscore_a => 'Nutri-Alama A';
 
   @override
-  String get nutriscore_b => 'Nutri-Score B';
+  String get nutriscore_b => 'Nutri-Alama B';
 
   @override
-  String get nutriscore_c => 'Nutri-Score C';
+  String get nutriscore_c => 'Nutri-Alama C';
 
   @override
-  String get nutriscore_d => 'Nutri-Score D';
+  String get nutriscore_d => 'Nutri-Alama D';
 
   @override
-  String get nutriscore_e => 'Nutri-Score E';
+  String get nutriscore_e => 'Nutri-Alama E';
 
   @override
   String nutriscore_new_formula(String letter) {
-    return 'Nutri-Score $letter (New calculation)';
+    return 'Nutri-Alama $letter (Hesabu mpya)';
   }
 
   @override
-  String get nutriscore_new_formula_title => 'Nutri-Score (New calculation)';
+  String get nutriscore_new_formula_title => 'Nutri-Alama (Hesabu Mpya)';
 
   @override
-  String get nutriscore_unknown => 'Unknown Nutri-Score';
+  String get nutriscore_unknown => 'Alama ya Nutri isiyojulikana';
 
   @override
   String get nutriscore_unknown_new_formula =>
-      'Unknown Nutri-Score (New calculation)';
+      'Nutri-Alama Isiyojulikana (Hesabu Mpya)';
 
   @override
-  String get nutriscore_not_applicable => 'Nutri-Score is not applicable';
+  String get nutriscore_not_applicable => 'Nutri-Alama haitumiki';
 
   @override
   String get nutriscore_not_applicable_new_formula =>
-      'Nutri-Score is not applicable (New calculation)';
+      'Nutri-Alama haitumiki (Hesabu mpya)';
 
   @override
   String get environmental_score_generic_new => 'Green-Score';
@@ -4088,100 +4131,100 @@ class AppLocalizationsSw extends AppLocalizations {
       'Vyakula vilivyosindikwa zaidi - vikundi vya NOVA';
 
   @override
-  String get nova_group_1 => 'NOVA Group 1';
+  String get nova_group_1 => 'Kundi la 1 la NOVA';
 
   @override
-  String get nova_group_2 => 'NOVA Group 2';
+  String get nova_group_2 => 'Kundi la 2 la NOVA';
 
   @override
-  String get nova_group_3 => 'NOVA Group 3';
+  String get nova_group_3 => 'Kundi la 3 la NOVA';
 
   @override
-  String get nova_group_4 => 'NOVA Group 4';
+  String get nova_group_4 => 'Kundi la 4 la NOVA';
 
   @override
-  String get nova_group_unknown => 'Unknown NOVA Group';
+  String get nova_group_unknown => 'Kikundi kisichojulikana cha NOVA';
 
   @override
-  String get nutrition_facts => 'Nutrient Levels';
+  String get nutrition_facts => 'Viwango vya Virutubisho';
 
   @override
-  String get faq_title_partners => 'Partners & Patrons of the NGO';
+  String get faq_title_partners => 'Washirika na Walezi wa NGO';
 
   @override
   String get faq_title_vision =>
-      'The Open Food Facts Vision, Mission, Values and Programs';
+      'Dira ya Ukweli kuhusu Chakula, Dhamira, Maadili na Mipango';
 
   @override
   String get faq_title_install_beauty =>
-      'Install Open Beauty Facts to create a cosmetic database';
+      'Sakinisha Fungua Ukweli wa Urembo ili kuunda hifadhidata ya vipodozi';
 
   @override
   String get faq_title_install_pet =>
-      'Install Open Pet Food Facts to create a pet food database';
+      'Sakinisha Ukweli wa Wazi wa Chakula cha Kipenzi ili kuunda hifadhidata ya vyakula vipenzi';
 
   @override
   String get faq_title_install_product =>
-      'Install Open Products Facts to create a products database to extend the life of objects';
+      'Sakinisha Ukweli wa Bidhaa Huria ili kuunda hifadhidata ya bidhaa ili kupanua maisha ya vitu';
 
   @override
   String get faq_nutriscore_nutriscore =>
-      'New calculation of the Nutri-Score: what\'s new?';
+      'Hesabu mpya ya Alama ya Nutri: ni nini kipya?';
 
   @override
   String get contact_title_pro_page =>
-      'Pro? Import your products in Open Food Facts';
+      'Pro? Ingiza bidhaa zako katika Ukweli wa Chakula Huria';
 
   @override
-  String get contact_title_pro_email => 'Producer Contact';
+  String get contact_title_pro_email => 'Mawasiliano ya Mtayarishaji';
 
   @override
-  String get contact_title_press_page => 'Press Page';
+  String get contact_title_press_page => 'Bonyeza Ukurasa';
 
   @override
-  String get contact_title_press_email => 'Press Contact';
+  String get contact_title_press_email => 'Bonyeza Anwani';
 
   @override
   String get contact_title_newsletter => 'Subscribe to our newsletter';
 
   @override
-  String get contact_title_calendar => 'Subscribe to our community calendar';
+  String get contact_title_calendar => 'Jiandikishe kwa kalenda yetu ya jamii';
 
   @override
-  String get hunger_games_loading_line1 => 'Please give us a few seconds…';
+  String get hunger_games_loading_line1 => 'Tafadhali tupe sekunde chache…';
 
   @override
-  String get hunger_games_loading_line2 => 'We\'re downloading the questions!';
+  String get hunger_games_loading_line2 => 'Tunapakua maswali!';
 
   @override
   String get hunger_games_error_label =>
-      'Argh! Something went wrong… and we couldn\'t load the questions.';
+      'Argh! Hitilafu fulani imetokea… na hatukuweza kupakia maswali.';
 
   @override
-  String get hunger_games_error_retry_button => 'Let\'s retry!';
+  String get hunger_games_error_retry_button => 'Hebu tujaribu tena!';
 
   @override
-  String get reorder_attribute_action => 'Reorder the attributes';
+  String get reorder_attribute_action => 'Panga upya sifa';
 
   @override
   String get link_cant_be_opened =>
-      'This link can\'t be opened on your device. Please check that you have a browser installed.';
+      'Kiungo hiki hakiwezi kufunguliwa kwenye kifaa chako. Tafadhali hakikisha kuwa umesakinisha kivinjari.';
 
   @override
   String knowledge_panel_page_title_no_title(String productName) {
-    return 'Details for $productName';
+    return 'Maelezo ya $productName';
   }
 
   @override
   String knowledge_panel_page_title(String pageName, String productName) {
-    return 'Details for $pageName with $productName';
+    return 'Maelezo ya $pageName na $productName';
   }
 
   @override
   String get guide_title => 'Guide';
 
   @override
-  String get guide_share_label => 'Share';
+  String get guide_share_label => 'Shiriki';
 
   @override
   String get guide_nutriscore_v2_title =>
@@ -4263,15 +4306,15 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get guide_nutriscore_v2_where_title =>
-      'Where to find the new Nutri-Score calculation?';
+      'Wapi kupata hesabu mpya ya Nutri-Score?';
 
   @override
   String get guide_nutriscore_v2_where_paragraph1 =>
-      'The Nutri-Score is applied in 7 countries: France, Germany, Belgium, Spain, Luxembourg, the Netherlands and Switzerland.';
+      'Nutri-Alama inatumika katika nchi 7: Ufaransa, Ujerumani, Ubelgiji, Uhispania, Luxemburg, Uholanzi na Uswizi.';
 
   @override
   String get guide_nutriscore_v2_where_paragraph2 =>
-      'Manufacturers have at most **2 years** at the latest after the signature of the decree **to replace** the old calculation with the new one.';
+      'Watengenezaji wana angalau miaka **2** hivi punde zaidi baada ya kutia saini amri **kubadilisha** hesabu ya zamani na mpya.';
 
   @override
   String get guide_nutriscore_v2_where_paragraph3 =>
@@ -4381,7 +4424,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get guide_greenscore_bonuses_penalties_intro =>
-      'To reward better products within a category, we then apply **bonuses & penalties based on several criterion**:';
+      'Ili zawadi bidhaa bora ndani ya kitengo, sisi kisha kuweka ** bonasi na adhabu kulingana na vigezo kadhaa **:';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg1_title =>
@@ -4389,7 +4432,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get guide_greenscore_bonuses_penalties_arg1_text =>
-      'A **bonus** is awarded to products that have an **official label, a label or a certification that guarantees environmental benefits** (organic, fair trade, HVE, Label Rouge, Bleu Blanc Cœur, MSC/ASC).';
+      '**Bonasi** hutolewa kwa bidhaa ambazo zina **lebo rasmi, lebo au uthibitisho unaohakikisha manufaa ya kimazingira** (biashara ya kikaboni, haki, HVE, Label Rouge, Bleu Blanc Cœur, MSC/ASC).';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg2_title =>
@@ -4397,7 +4440,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get guide_greenscore_bonuses_penalties_arg2_text =>
-      'A **bonus** is awarded based on the origin of the ingredients. This bonus takes into account the **impact on transportation** and also the **environmental policy** of each producer\'s country.';
+      '** bonasi** hutolewa kulingana na asili ya viungo. Bonasi hii inazingatia **athari kwa usafiri** na pia **sera ya mazingira** ya kila nchi ya mzalishaji.';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg3_title =>
@@ -4405,14 +4448,14 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get guide_greenscore_bonuses_penalties_arg3_text =>
-      'A **penalty** is given to products that contain ingredients that have significant **negative impacts on biodiversity and ecosystems**, such as palm oil, the production of which is responsible for massive deforestation.';
+      '**Adhabu** inatolewa kwa bidhaa ambazo zina viambato ambavyo vina athari kubwa **hasi kwa viumbe hai na mifumo ikolojia**, kama vile mafuta ya mawese, ambayo uzalishaji wake unawajibika kwa ukataji miti mkubwa.';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg4_title => 'Packaging';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg4_text =>
-      'A **penalty** is calculated to take into account the **circularity of packaging** (use of recycled raw material and recyclability) and overpacking.';
+      '**Adhabu** inakokotolewa ili kuzingatia **uduara wa kifungashio** (matumizi ya malighafi iliyosindikwa na kutumika tena) na upakiaji kupita kiasi.';
 
   @override
   String get guide_greenscore_transparency_title =>
@@ -4420,19 +4463,19 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get guide_greenscore_transparency_intro1 =>
-      'To accurately calculate the Green-Score, it is necessary to have **information which is not necessarily specified on the packaging** (such as the origin and the exact percentage of each ingredient) or which is rarely available in usable form (such as a list of all the components of the packaging with the precise types of plastics used).';
+      'Ili kuhesabu kwa usahihi Alama ya Kijani, ni muhimu kuwa na **maelezo ambayo si lazima yabainishwe kwenye kifurushi** (kama vile asili na asilimia kamili ya kila kiungo) au ambayo ni nadra kupatikana katika muundo unaoweza kutumika (kama vile orodha ya vipengele vyote vya kifungashio na aina sahihi za plastiki zinazotumika).';
 
   @override
   String get guide_greenscore_transparency_intro2 =>
-      '**Average values are used when this information is not yet available**, but we are now calling on everyone to help us collect this information which will be very useful for the Green-Score but also for many other uses.';
+      '**Thamani za wastani hutumiwa wakati maelezo haya bado hayajapatikana**, lakini sasa tunatoa wito kwa kila mtu atusaidie kukusanya taarifa hii ambayo itakuwa muhimu sana kwa Alama ya Kijani lakini pia kwa matumizi mengine mengi.';
 
   @override
   String get guide_greenscore_transparency_arg1_title =>
-      'How citizens can help?';
+      'Wananchi wanawezaje kusaidia?';
 
   @override
   String get guide_greenscore_transparency_arg1_text =>
-      'All citizens can help us gather and structure the information that is present on products or that can be deduced from them, such as information on **packaging**: \"Mission Emballages\": a large-scale collaborative inventory of packaging for all food products (in French).';
+      'Wananchi wote wanaweza kutusaidia kukusanya na kupanga taarifa zilizopo kwenye bidhaa au zinazoweza kutolewa kutoka kwao, kama vile taarifa kuhusu **ufungaji**: \"Mission Emballages\": hesabu kubwa ya shirikishi ya ufungaji wa bidhaa zote za chakula (kwa Kifaransa).';
 
   @override
   String get guide_greenscore_transparency_arg2_title =>
@@ -4507,7 +4550,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get guide_nova_groups_arg1_text =>
-      'Unprocessed (or natural) foods are the **edible parts of plants** (seeds, fruits, leaves, stems, roots) **or animals** (muscle, offal, eggs, milk), as well as fungi, algae, and water, after being separated from nature.';
+      'Vyakula ambavyo havijachakatwa (au asili) ni **sehemu zinazoweza kuliwa za mimea** (mbegu, matunda, majani, shina, mizizi) **au wanyama** (misuli, nyasi, mayai, maziwa), pamoja na fangasi, mwani, na maji, baada ya kutenganishwa na maumbile.';
 
   @override
   String get guide_nova_groups_arg2_title => 'Processed culinary ingredients';
@@ -4540,7 +4583,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg1_text =>
-      'Many are **derived from further processing of food constituents**, such as hydrogenated or interesterified oils, hydrolyzed proteins, soy protein isolate, maltodextrin, invert sugar, and high-fructose corn syrup.';
+      'Nyingi **zinatokana na uchakataji zaidi wa viambajengo vya chakula**, kama vile mafuta ya hidrojeni au ya kuvutia, protini za hidrolisisi, kitenganishi cha protini ya soya, maltodextrin, geuza sukari, na sharubati ya mahindi yenye fructose nyingi.';
 
   @override
   String get guide_nova_explanations_arg2_title =>
@@ -4548,7 +4591,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg2_text =>
-      'Additives in ultra-processed foods include some that are also used in processed foods, such as preservatives, antioxidants, and stabilizers. Classes of additives found only in ultra-processed products include those used **to imitate or enhance the sensory qualities of foods or to disguise unpalatable aspects of the final product**. These additives include dyes and other colors, color stabilizers; flavors, flavor enhancers, non-sugar sweeteners; and processing aids such as carbonating, firming, bulking and anti-bulking agents, de-foaming, anti-caking and glazing agents, emulsifiers, sequestrants, and humectants.';
+      'Viungio katika vyakula vilivyochakatwa zaidi ni pamoja na vingine ambavyo hutumika pia katika vyakula vilivyochakatwa, kama vile vihifadhi, viondoa sumu mwilini, na vidhibiti. Aina za viongezeo vinavyopatikana tu katika bidhaa zilizochakatwa zaidi ni pamoja na zile zinazotumiwa **kuiga au kuboresha sifa za hisia za vyakula au kuficha vipengele visivyopendeza vya bidhaa ya mwisho**. Viongezeo hivi ni pamoja na rangi na rangi nyingine, vidhibiti vya rangi; ladha, viboreshaji vya ladha, vitamu visivyo na sukari; na vifaa vya usindikaji kama vile kaboni, uimarishaji, bulking na mawakala wa kuzuia bulking, de-povu, anti-caking na ukaushaji mawakala, emulsifiers, sequestrants, na humectants.';
 
   @override
   String get guide_nova_explanations_arg3_title =>
@@ -4556,7 +4599,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg3_text =>
-      '**A multitude of sequences of processes is used** to combine the usually many ingredients and to create the final product (hence \'ultra-processed\'). The processes include several **with no domestic equivalents**, such as hydrogenation and hydrolysation, extrusion and moulding, and pre-processing for frying.';
+      '**Msururu wa mfuatano wa michakato hutumika** kuchanganya viambato vingi vya kawaida na kuunda bidhaa ya mwisho (kwa hivyo \'kuchakatwa zaidi\'). Michakato hiyo ni pamoja na **isiyo na vilinganishi vya nyumbani** kadhaa, kama vile utiaji hidrojeni na uwekaji hidrolisisi, utoboaji na ukingo, na uchakataji wa awali kwa kukaangia.';
 
   @override
   String get guide_nova_explanations_arg4_title =>
@@ -4564,104 +4607,104 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg4_text =>
-      '**The overall purpose of ultra-processing is to create branded**, **convenient** (durable, ready to consume), **attractive** (hyper-palatable) and **highly profitable** (low-cost ingredients) food products designed to displace all other food groups. Ultra-processed food products are usually packaged attractively and marketed intensively.';
+      '**Madhumuni ya jumla ya usindikaji wa hali ya juu ni kuunda bidhaa za chakula zenye chapa**, **rahisi** (inayodumu, tayari kutumika), **ya kuvutia** (inayopendeza sana) na **yenye faida kubwa** (viungo vya bei ya chini) vilivyoundwa kuondoa vikundi vingine vyote vya chakula. Bidhaa za chakula zilizochakatwa kwa kiwango cha juu huwekwa kwenye vifurushi vya kuvutia na kuuzwa kwa kasi.';
 
   @override
-  String get guide_nova_explanations_arg5_title => 'A health hazard';
+  String get guide_nova_explanations_arg5_title => 'Hatari kwa afya';
 
   @override
   String get guide_nova_explanations_arg5_text =>
-      'Since 2018, with NutriNet-Santé, the first links between **the consumption of ultra-processed foods and increased risks of cancer, cardiovascular diseases, and diabetes have been highlighted**. Today, more than 90 studies worldwide confirm these findings.\nThe strongest associations relate to **obesity, cardiovascular mortality, and depressive symptoms**. On children, the effects are primarily observed on weight and lipid imbalances.';
+      'Tangu 2018, kupitia NutriNet-Santé, viungo vya kwanza kati ya **utumiaji wa vyakula vilivyochakatwa na kuongezeka kwa hatari za saratani, magonjwa ya moyo na mishipa na kisukari vimeangaziwa**. Leo, zaidi ya tafiti 90 ulimwenguni kote zinathibitisha matokeo haya.\nUhusiano thabiti zaidi unahusiana na **unene kupita kiasi, vifo vya moyo na mishipa, na dalili za mfadhaiko**. Kwa watoto, athari huzingatiwa hasa kwa uzito na usawa wa lipid.';
 
   @override
   String get guide_nova_explanations_arg6_title =>
-      'Countries recommend limiting them';
+      'Nchi zinapendekeza kuziwekea kikomo';
 
   @override
   String get guide_nova_explanations_arg6_text =>
-      'Some countries use the NOVA groups for their dietary guidelines or goals, for instance:\n\n- **🇧🇷 Brazil**\'s dietary guidelines **recommend to limit consumption** of processed food and avoid ultra-processed food.\n\n- **🇫🇷 France**\'s public health nutritional policy goals for 2018-2022 aims to **reduce consumption of group 4 ultra-processed foods by 20%**.';
+      'Baadhi ya nchi hutumia vikundi vya NOVA kwa miongozo au malengo yao ya lishe, kwa mfano:\n\n- **🇧🇷 Miongozo ya lishe ya Brazil** **inapendekeza kupunguza matumizi** ya chakula kilichochakatwa na kuepuka vyakula vilivyochakatwa zaidi.\n\n- **🇫🇷 Malengo ya sera ya lishe ya afya ya umma ya Ufaransa** 2018-2022 yanalenga **kupunguza ulaji wa vyakula vya kundi la 4 vilivyosindikwa zaidi kwa 20%**.';
 
   @override
   String get guide_nova_share_link => 'https://world.openfoodfacts.org/nova';
 
   @override
-  String get guide_open_food_facts_title => 'Welcome to Open Food Facts!';
+  String get guide_open_food_facts_title =>
+      'Karibu kwenye Ukweli wa Chakula Huria!';
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_title =>
-      'What is Open Food Facts?';
+      'Ukweli wa Chakula cha Open ni nini?';
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_paragraph1 =>
-      'Open Food Facts is a **collaborative**, **free**, and **open** database of food products from around the world.';
+      'Open Food Facts ni **hifadhi data shirikishi**, **bila malipo**, na **wazi** ya bidhaa za chakula kutoka duniani kote.';
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_paragraph2 =>
-      'We believe that everyone should have access to information about what they eat. By collecting data on ingredients, allergens, nutrition facts, and more, **we empower consumers to make informed choices** and drive the food industry **toward greater transparency**.';
+      'Tunaamini kwamba kila mtu anapaswa kupata taarifa kuhusu kile anachokula. Kwa kukusanya data kuhusu viambato, vizio, ukweli wa lishe, na zaidi, **tunawawezesha watumiaji kufanya maamuzi sahihi** na kuendeleza sekta ya chakula **kuelekea uwazi zaidi**.';
 
   @override
   String get guide_open_food_facts_features_title =>
-      'Features of Open Food Facts';
+      'Vipengele vya Ukweli wa Chakula cha Open';
 
   @override
   String get guide_open_food_facts_features_arg1_title =>
-      'Get alerts for your unwanted ingredients';
+      'Pata arifa za viungo vyako visivyotakikana';
 
   @override
-  String get guide_open_food_facts_tips_title => 'Tips for taking great photos';
+  String get guide_open_food_facts_tips_title =>
+      'Vidokezo vya kupiga picha nzuri';
 
   @override
-  String get guide_open_food_facts_tips_arg1_title => 'Don’ts';
+  String get guide_open_food_facts_tips_arg1_title => 'Usifanye';
 
   @override
-  String get guide_open_food_facts_tips_arg1_text1 =>
-      'Avoid shadows and glare.';
+  String get guide_open_food_facts_tips_arg1_text1 => 'Epuka vivuli na glare.';
 
   @override
   String get guide_open_food_facts_tips_arg1_text2 =>
-      'No blurry or out-of-focus text.';
+      'Hakuna maandishi yenye ukungu au yaliyo nje ya umakini.';
 
   @override
   String get guide_open_food_facts_tips_arg1_text3 =>
-      'Don\'t crop out parts of the text.';
+      'Usipunguze sehemu za maandishi.';
 
   @override
-  String get guide_open_food_facts_tips_arg1_text4 => 'Avoid busy backgrounds.';
+  String get guide_open_food_facts_tips_arg1_text4 =>
+      'Epuka mandharinyuma yenye shughuli nyingi.';
 
   @override
-  String get guide_open_food_facts_tips_arg2_title => 'Do’s';
+  String get guide_open_food_facts_tips_arg2_title => 'Fanya';
 
   @override
-  String get guide_open_food_facts_tips_arg2_text1 =>
-      'Use good, even lighting.';
+  String get guide_open_food_facts_tips_arg2_text1 => 'Tumia vizuri, hata taa.';
 
   @override
   String get guide_open_food_facts_tips_arg2_text2 =>
-      'Ensure text is sharp and readable.';
+      'Hakikisha maandishi ni makali na yanasomeka.';
 
   @override
   String get guide_open_food_facts_tips_arg2_text3 =>
-      'Capture the entire ingredients list.';
+      'Rekodi orodha nzima ya viungo.';
 
   @override
   String get guide_open_food_facts_tips_arg2_text4 =>
-      'Keep the product on a flat surface.';
+      'Weka bidhaa kwenye uso wa gorofa.';
 
   @override
   String get guide_open_food_facts_scores_title =>
-      'Help us build the \"Wikipedia of Food\"';
+      'Tusaidie kujenga \"Wikipedia ya Chakula\"';
 
   @override
   String get guide_open_food_facts_scores_arg1_title =>
-      'A score on the nutritional quality';
+      'Alama juu ya ubora wa lishe';
 
   @override
   String get guide_open_food_facts_scores_arg2_title =>
-      'A score to avoid ultra-processed foods';
+      'Alama ya kuepuka vyakula vilivyosindikwa zaidi';
 
   @override
-  String get guide_open_food_facts_scores_arg3_title =>
-      'A score for the planet';
+  String get guide_open_food_facts_scores_arg3_title => 'Alama kwa sayari';
 
   @override
   String get guide_open_food_facts_share_link =>
@@ -4669,236 +4712,241 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get guide_open_pet_food_facts_title =>
-      'Welcome to Open Pet Food Facts!';
+      'Karibu kwa Open Pet Food Facts!';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_title =>
-      'What is Open Pet Food Facts?';
+      'Ukweli wa Open Pet Food ni nini?';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_paragraph1 =>
-      'Open Pet Food Facts extends our mission to our furry friends! It\'s a **database of pet food products for cats, dogs, and other companions**.';
+      'Fungua Ukweli wa Chakula cha Kipenzi huongeza dhamira yetu kwa marafiki wetu wenye manyoya! Ni **database ya bidhaa za vyakula vipenzi vya paka, mbwa na wenza wengine**.';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_paragraph2 =>
-      'We gather information on **ingredients**, **nutritional analysis**, and feeding guidelines to help pet owners choose the best food for their animals\' needs.';
+      'Tunakusanya maelezo kuhusu **viungo**, **uchambuzi wa lishe**, na miongozo ya ulishaji ili kuwasaidia wamiliki wa wanyama vipenzi kuchagua chakula bora kwa mahitaji ya wanyama wao.';
 
   @override
   String get guide_open_pet_food_facts_features_title =>
-      'Features of Open Pet Food Facts';
+      'Vipengele vya Ukweli wa Chakula cha Wanyama wa Kipenzi';
 
   @override
   String get guide_open_pet_food_facts_features_arg1_title =>
-      'Get alerts for your unwanted ingredients';
+      'Pata arifa za viungo vyako visivyotakikana';
 
   @override
   String get guide_open_pet_food_facts_features_arg1_paragraph1 =>
-      'Is your pet allergic to any ingredients? You can set a list of cosmetic ingredients to avoid, right in the app!';
+      'Je, mnyama wako ana mzio wa viungo vyovyote? Unaweza kuweka orodha ya viungo vya vipodozi ili kuepuka, moja kwa moja kwenye programu!';
 
   @override
   String get guide_open_pet_food_facts_tips_title =>
-      'Tips for taking great photos';
+      'Vidokezo vya kupiga picha nzuri';
 
   @override
-  String get guide_open_pet_food_facts_tips_arg1_title => 'Don’ts';
+  String get guide_open_pet_food_facts_tips_arg1_title => 'Usifanye';
 
   @override
   String get guide_open_pet_food_facts_tips_arg1_text1 =>
-      'Avoid shadows and glare.';
+      'Epuka vivuli na glare.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg1_text2 =>
-      'No blurry or out-of-focus text.';
+      'Hakuna maandishi yenye ukungu au yaliyo nje ya umakini.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg1_text3 =>
-      'Don\'t crop out parts of the text.';
+      'Usipunguze sehemu za maandishi.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg1_text4 =>
-      'Avoid busy backgrounds.';
+      'Epuka mandharinyuma yenye shughuli nyingi.';
 
   @override
-  String get guide_open_pet_food_facts_tips_arg2_title => 'Do’s';
+  String get guide_open_pet_food_facts_tips_arg2_title => 'Fanya';
 
   @override
   String get guide_open_pet_food_facts_tips_arg2_text1 =>
-      'Use good, even lighting.';
+      'Tumia vizuri, hata taa.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg2_text2 =>
-      'Ensure text is sharp and readable.';
+      'Hakikisha maandishi ni makali na yanasomeka.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg2_text3 =>
-      'Capture the entire ingredients list.';
+      'Rekodi orodha nzima ya viungo.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg2_text4 =>
-      'Keep the product on a flat surface.';
+      'Weka bidhaa kwenye uso wa gorofa.';
 
   @override
-  String get guide_open_pet_food_facts_scores_title => 'A note on scoring';
+  String get guide_open_pet_food_facts_scores_title =>
+      'Ujumbe juu ya kufunga bao';
 
   @override
   String get guide_open_pet_food_facts_scores_paragraph1 =>
-      'Developing a scoring system for pet food **is not a priority right now**. The methodology would be complex, as nutritional needs vary greatly by species, age, and health condition. We haven’t found any independant scientific team yet, able to develop such a score.';
+      'Kutengeneza mfumo wa alama kwa chakula cha wanyama kipenzi **sio kipaumbele kwa sasa**. Mbinu hiyo itakuwa ngumu, kwani mahitaji ya lishe hutofautiana sana kulingana na spishi, umri, na hali ya afya. Bado hatujapata timu yoyote ya kisayansi inayojitegemea, inayoweza kutengeneza alama kama hiyo.';
 
   @override
   String get guide_open_pet_food_facts_share_link =>
       'https://world-sw.openpetfoodfacts.org/discover';
 
   @override
-  String get guide_open_beauty_facts_title => 'Welcome to Open Beauty Facts!';
+  String get guide_open_beauty_facts_title =>
+      'Karibu kwenye Fungua Ukweli wa Urembo!';
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_title =>
-      'What is Open Beauty Facts?';
+      'Ukweli wa Uzuri wa Open ni nini?';
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_paragraph1 =>
-      'Open Beauty Facts is a collaborative database of **cosmetic products**.';
+      'Fungua Ukweli wa Urembo ni hifadhidata shirikishi ya **bidhaa za vipodozi**.';
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_paragraph2 =>
-      'Our goal is to decipher ingredient lists to help you **understand what\'s in your personal care items**. From moisturizers to makeup, we collect data on ingredients, allergens, and packaging to promote transparency in the cosmetics industry.';
+      'Lengo letu ni kubainisha orodha za viambato ili kukusaidia **kuelewa ni nini kilicho katika vitu vyako vya utunzaji wa kibinafsi**. Kuanzia vilainishi hadi vipodozi, tunakusanya data kuhusu viambato, vizio, na vifungashio ili kukuza uwazi katika tasnia ya vipodozi.';
 
   @override
   String get guide_open_beauty_facts_features_title =>
-      'Features of Open Beauty Facts';
+      'Vipengele vya Ukweli wa Urembo wazi';
 
   @override
   String get guide_open_beauty_facts_features_arg1_title =>
-      'Get alerts for your unwanted ingredients';
+      'Pata arifa za viungo vyako visivyotakikana';
 
   @override
   String get guide_open_beauty_facts_features_arg1_paragraph1 =>
-      'Are you allergic to any ingredients? Want to avoid comedogen substances? Want to steer away from controversial components ? You can set a list of cosmetic ingredients to avoid, right in the app!';
+      'Je, una mzio wa viungo vyovyote? Unataka kuepuka dutu za comedogen? Je, ungependa kujiepusha na vipengele vyenye utata? Unaweza kuweka orodha ya viungo vya vipodozi ili kuepuka, moja kwa moja kwenye programu!';
 
   @override
   String get guide_open_beauty_facts_tips_title =>
-      'Tips for taking great photos';
+      'Vidokezo vya kupiga picha nzuri';
 
   @override
-  String get guide_open_beauty_facts_tips_arg1_title => 'Don’ts';
+  String get guide_open_beauty_facts_tips_arg1_title => 'Usifanye';
 
   @override
   String get guide_open_beauty_facts_tips_arg1_text1 =>
-      'Avoid shadows and glare.';
+      'Epuka vivuli na glare.';
 
   @override
   String get guide_open_beauty_facts_tips_arg1_text2 =>
-      'No blurry or out-of-focus text.';
+      'Hakuna maandishi yenye ukungu au yaliyo nje ya umakini.';
 
   @override
   String get guide_open_beauty_facts_tips_arg1_text3 =>
-      'Don\'t crop out parts of the text.';
+      'Usipunguze sehemu za maandishi.';
 
   @override
   String get guide_open_beauty_facts_tips_arg1_text4 =>
-      'Avoid busy backgrounds.';
+      'Epuka mandharinyuma yenye shughuli nyingi.';
 
   @override
-  String get guide_open_beauty_facts_tips_arg2_title => 'Do’s';
+  String get guide_open_beauty_facts_tips_arg2_title => 'Fanya';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text1 =>
-      'Use good, even lighting.';
+      'Tumia vizuri, hata taa.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text2 =>
-      'Ensure text is sharp and readable.';
+      'Hakikisha maandishi ni makali na yanasomeka.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text3 =>
-      'Capture the entire ingredients list.';
+      'Rekodi orodha nzima ya viungo.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text4 =>
-      'Take as many picture as need if the bottle is curved.';
+      'Piga picha nyingi kadri inavyohitajika ikiwa chupa imejipinda.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text5 =>
-      'You might need to peel the label to see the list of ingredients.';
+      'Huenda ukahitaji kumenya lebo ili kuona orodha ya viungo.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text6 =>
-      'Keep the product on a flat surface.';
+      'Weka bidhaa kwenye uso wa gorofa.';
 
   @override
-  String get guide_open_beauty_facts_scores_title => 'A note on scoring';
+  String get guide_open_beauty_facts_scores_title =>
+      'Ujumbe juu ya kufunga bao';
 
   @override
   String get guide_open_beauty_facts_scores_paragraph1 =>
-      'Unlike food products, the world of cosmetics **does not have a universally recognized, government-backed scoring system like the Nutri-Score**. Ingredient effects can be highly personal and depend on skin type, allergies, and individual concerns.';
+      'Tofauti na bidhaa za vyakula, ulimwengu wa vipodozi **hauna mfumo wa alama unaotambulika ulimwenguni kote, unaoungwa mkono na serikali kama Nutri-Alama**. Madhara ya viungo yanaweza kuwa ya kibinafsi sana na yanategemea aina ya ngozi, mizio, na wasiwasi wa mtu binafsi.';
 
   @override
   String get guide_open_beauty_facts_share_link =>
       'https://world-sw.openbeautyfacts.org/discover';
 
   @override
-  String get guide_open_prices_title => 'Welcome to Open Prices!';
+  String get guide_open_prices_title => 'Karibu kwa Fungua Bei!';
 
   @override
   String get guide_open_prices_what_is_open_prices_title =>
-      'What is Open Prices?';
+      'Bei Zilizofunguliwa ni nini?';
 
   @override
   String get guide_open_prices_what_is_open_prices_paragraph1 =>
-      'Open Prices is a project to **collect and share prices of products around the world**. It\'s a publicly available dataset that can be used for research, analysis, and more. Open Prices is developed and maintained by Open Food Facts.';
+      'Fungua Bei ni mradi wa **kukusanya na kushiriki bei za bidhaa kote ulimwenguni**. Ni mkusanyiko wa data unaopatikana kwa umma ambao unaweza kutumika kwa utafiti, uchanganuzi na zaidi. Bei Huzi hutengenezwa na kudumishwa na Open Food Facts.';
 
   @override
   String get guide_open_prices_what_is_open_prices_paragraph2 =>
       'There are currently few companies that own large databases of product prices at the barcode level. These prices are not freely available, but sold at a high price to private actors, researchers and other organizations that can afford them.';
 
   @override
-  String get guide_open_prices_how_title => 'How does Open Prices work?';
+  String get guide_open_prices_how_title =>
+      'Je, Bei za Open hufanya kazi vipi?';
 
   @override
   String get guide_open_prices_how_paragraph1 =>
-      '**We are crowdsourcing an open-source dataset of prices**. Prices can be added by users via this web app, or via the official Open Food Facts mobile app. Retailers or third-party apps can contribute as well by using our API.';
+      '**Tunatafuta mkusanyiko wa data wa chanzo huria wa bei**. Bei zinaweza kuongezwa na watumiaji kupitia programu hii ya wavuti, au kupitia programu rasmi ya Open Food Facts ya simu ya mkononi. Wauzaji wa reja reja au programu za wahusika wengine wanaweza kuchangia pia kwa kutumia API yetu.';
 
   @override
   String get guide_open_prices_how_arg1_title =>
-      'Collect photos of price tags in aisles';
+      'Kusanya picha za lebo za bei kwenye njia';
 
   @override
-  String get guide_open_prices_how_arg2_title => 'Collect photos of receipts';
+  String get guide_open_prices_how_arg2_title => 'Kusanya picha za risiti';
 
   @override
   String get guide_open_prices_why_title =>
-      'Why is Open Food Facts doing this ?';
+      'Kwa nini Open Food Facts inafanya hivi?';
 
   @override
   String get guide_open_prices_why_paragraph1 =>
-      'Price information is of paramount importance to understand food systems. It\'s a key factor in understanding the cost of food and to promote healthier diets. Opening price data is a way to make it easier for researchers, journalists, and citizens to **have a better understanding of how food prices vary geographically and in time**.';
+      'Taarifa za bei ni muhimu sana kuelewa mifumo ya chakula. Ni jambo muhimu katika kuelewa gharama ya chakula na kukuza lishe bora. Kufungua data ya bei ni njia ya kurahisisha watafiti, wanahabari, na wananchi **kuwa na ufahamu bora wa jinsi bei za vyakula zinavyotofautiana kijiografia na kwa wakati**.';
 
   @override
   String get guide_open_prices_why_arg1_title =>
-      'Track the evolution of prices over time';
+      'Fuatilia mabadiliko ya bei kwa wakati';
 
   @override
   String get guide_open_prices_why_arg1_text =>
-      'See the **evolution of prices**: shrinkflation, cheapflation, we can track them together!';
+      'Angalia **mabadiliko ya bei**: kushuka kwa bei, bei nafuu, tunaweza kuzifuatilia pamoja!';
 
   @override
-  String get guide_open_prices_why_arg2_title => 'Compare prices near you';
+  String get guide_open_prices_why_arg2_title =>
+      'Linganisha bei zilizo karibu nawe';
 
   @override
   String get guide_open_prices_why_arg2_text =>
-      'As we get more prices, you can spot **the cheapest stores around you**.';
+      'Tunapopata bei zaidi, unaweza kuona **maduka nafuu yaliyo karibu nawe**.';
 
   @override
   String get guide_open_prices_scrapping_title =>
-      'Did you consider scraping prices from retailers\' websites?';
+      'Je, ulizingatia kuondoa bei kutoka kwa tovuti za wauzaji reja reja?';
 
   @override
   String get guide_open_prices_scrapping_paragraph1 =>
-      'For legal and technical reasons, **we don\'t consider scraping prices from retailers\' websites as a valid way to contribute to Open Prices**. We want to make sure that the prices we collect are accurate and up-to-date, and receiving scraped prices from contributors doesn\'t allow us to do that.';
+      'Kwa sababu za kisheria na kiufundi, **hatuzingatii kuondoa bei kwenye tovuti za wauzaji reja reja kama njia halali ya kuchangia Bei Huria**. Tunataka kuhakikisha kuwa bei tunazokusanya ni sahihi na zimesasishwa, na kupokea bei zilizoondolewa kutoka kwa wachangiaji hakuturuhusu kufanya hivyo.';
 
   @override
   String get guide_open_prices_scrapping_paragraph2 =>
-      'Price scraping is a considered option in a future version of Open Prices, but it would be done by Open Prices itself so that we can have a proof of the price based on the HTML page.';
+      'Kuondoa bei ni chaguo linalozingatiwa katika toleo la baadaye la Bei Huria, lakini itafanywa na Bei Huria yenyewe ili tuweze kuwa na uthibitisho wa bei kulingana na ukurasa wa HTML.';
 
   @override
   String get guide_open_prices_retailers_title =>
@@ -4906,7 +4954,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get guide_open_prices_retailers_paragraph1 =>
-      'You can contribute prices by using our API.\nIf you want to contribute prices at scale, please get in touch with us at prices@openfoodfacts.org.';
+      'Unaweza kuchangia bei kwa kutumia API yetu.\nIwapo ungependa kuchangia bei kwa kiwango kikubwa, tafadhali wasiliana nasi kwa prices@openfoodfacts.org.';
 
   @override
   String get guide_open_prices_share_link =>
@@ -4914,149 +4962,150 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get guide_open_products_facts_title =>
-      'Welcome to Open Products Facts!';
+      'Karibu kwenye Fungua Ukweli wa Bidhaa!';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_title =>
-      'What is Open Products Facts?';
+      'Ukweli wa Bidhaa Huria ni nini?';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_paragraph1 =>
-      'Open Products Facts is a massive, open database for **any product with a barcode, which is not food, cosmetic or pet food**.';
+      'Fungua Ukweli wa Bidhaa ni hifadhidata kubwa, iliyo wazi ya **bidhaa yoyote iliyo na msimbopau, ambayo si chakula, vipodozi au chakula cha kipenzi**.';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_paragraph2 =>
-      'From **electronics** to **toys**, and **clothes** to **cleaning supplies**, if it has a barcode, it can be added. This project aims to create an \"Internet of Things\" for everyday objects, making information about them universally accessible.';
+      'Kutoka **elektroniki** hadi **vichezeo**, na **nguo** hadi **vifaa vya kusafisha**, ikiwa ina msimbopau, inaweza kuongezwa. Mradi huu unalenga kuunda \"Mtandao wa Vitu\" kwa vitu vya kila siku, na kufanya habari kuzihusu zipatikane kwa wote.';
 
   @override
   String get guide_open_products_facts_features_title =>
-      'Features of Open Products Facts';
+      'Vipengele vya Ukweli wa Bidhaa Huria';
 
   @override
   String get guide_open_products_facts_features_text =>
-      'Open Products Facts aims to provide consumers to **extend the life of objects** by providing the circular solutions to maintain, **repair**, **recycle** their objects or give them a new owner.';
+      'Ukweli wa Bidhaa za Open unalenga kuwapa wateja **kurefusha maisha ya vitu** kwa kutoa masuluhisho ya mviringo ili kudumisha, **kurekebisha**, **kusaga** vitu vyao au kumpa mmiliki mpya.';
 
   @override
   String get guide_open_products_facts_features_arg1_title =>
-      'Carbon footprints for some products';
+      'Nyayo za kaboni kwa baadhi ya bidhaa';
 
   @override
   String get guide_open_products_facts_features_arg1_text =>
-      '**Impact CO2** by French Environment Authority ADEME provides the **carbon impact** of many categories, make sure to categorize products precisely.';
+      '**Athari CO2** na Mamlaka ya Mazingira ya Ufaransa ADEME hutoa **athari ya kaboni** ya aina nyingi, hakikisha kuwa umeweka bidhaa katika aina kwa njia ipasavyo.';
 
   @override
   String get guide_open_products_facts_features_arg2_title =>
-      'Reparability index for many products';
+      'Fahirisi ya urekebishaji kwa bidhaa nyingi';
 
   @override
   String get guide_open_products_facts_features_arg2_text =>
-      'Whenever a French reparability index is available, we’ll display it. Moreover, **you can start collecting the variables using the Folksonomy Engine**; so that we can recompute it ourselves in the future, even in countries where it’s not available.';
+      'Wakati wowote faharasa ya urekebishaji ya Kifaransa inapatikana, tutaionyesha. Zaidi ya hayo, **unaweza kuanza kukusanya viambajengo kwa kutumia Injini ya Folksonomy**; ili tuweze kuihesabu wenyewe katika siku zijazo, hata katika nchi ambazo haipatikani.';
 
   @override
   String get guide_open_products_facts_features_arg3_title =>
-      'Find ways to donate/resell your product';
+      'Tafuta njia za kuchangia/kuuza tena bidhaa yako';
 
   @override
   String get guide_open_products_facts_features_arg3_text =>
-      'We provide links to **third party circular friendly services** that help you get the kind of product you’re looking for, as a second hand product, to be more gentle on planetary resources.\nNote that we’re not paid to do that, and that the system only works as an example for two websites in France. You can help expand this system by documenting more sites on the wiki.';
+      'Tunatoa viungo vya **huduma za mduara za wahusika wengine** ambazo hukusaidia kupata aina ya bidhaa unayotafuta, kama bidhaa ya mitumba, ili kuwa mpole zaidi kwenye rasilimali za sayari.\nKumbuka kuwa hatulipwi kufanya hivyo, na kwamba mfumo hufanya kazi kama mfano kwa tovuti mbili nchini Ufaransa pekee. Unaweza kusaidia kupanua mfumo huu kwa kuweka kumbukumbu za tovuti zaidi kwenye wiki.';
 
   @override
   String get guide_open_products_facts_information_title =>
-      'What information is useful?';
+      'Ni habari gani muhimu?';
 
   @override
   String get guide_open_products_facts_information_text =>
-      'For such a wide range of items, **the data we collect is flexible**. To do that, **we created the Folksonomy Engine**.';
+      'Kwa anuwai kama hiyo ya bidhaa, **data tunayokusanya inaweza kunyumbulika**. Ili kufanya hivyo, **tuliunda Injini ya Folksonomy**.';
 
   @override
   String get guide_open_products_facts_folksonomy_title =>
-      'The Folksonomy Engine';
+      'Injini ya Folksonomy';
 
   @override
   String get guide_open_products_facts_folksonomy_paragraph1 =>
-      'The Folksonomy Engine is a tool to help you complete products with relevant properties. This helps improve search and discoverability, but also compute and display interesting things in the future.';
+      'Injini ya Folksonomy ni zana ya kukusaidia kukamilisha bidhaa zenye sifa zinazofaa. Hii husaidia kuboresha utafutaji na ugunduzi, lakini pia kukokotoa na kuonyesha mambo ya kuvutia katika siku zijazo.';
 
   @override
   String get guide_open_products_facts_folksonomy_paragraph2 =>
-      'You can add any keys and values like: **compatibility_with_5G_mobile_network: yes**';
+      'Unaweza kuongeza funguo na thamani zozote kama vile: **compatibility_with_5G_mobile_network: ndiyo**';
 
   @override
   String get guide_open_products_facts_folksonomy_paragraph3 =>
-      'You’ll get autosuggestion of possible properties, and you are very welcome to add and document new ones on your favorite kinds of products.';
+      'Utapata mapendekezo ya kiotomatiki ya sifa zinazowezekana, na unakaribishwa sana kuongeza na kuweka kumbukumbu mpya kwenye aina unazopenda za bidhaa.';
 
   @override
   String get guide_open_products_facts_share_link =>
       'https://world-sw.openproductsfacts.org/discover';
 
   @override
-  String get guide_open_preferences_button_title => 'Open food preferences';
+  String get guide_open_preferences_button_title =>
+      'Fungua upendeleo wa chakula';
 
   @override
-  String get guide_coming_soon_button_title => 'Coming soon';
+  String get guide_coming_soon_button_title => 'Inakuja hivi karibuni';
 
   @override
-  String get guide_learn_more_subtitle => 'Tap to learn more';
+  String get guide_learn_more_subtitle => 'Gusa ili upate maelezo zaidi';
 
   @override
-  String get preview_badge => 'Preview';
+  String get preview_badge => 'Hakiki';
 
   @override
   String get prices_feedback_form =>
-      'Click here to send us your feedback about this new feature!';
+      'Bofya hapa ili kututumia maoni yako kuhusu kipengele hiki kipya!';
 
   @override
-  String get menu_button_list_actions => 'Select an action';
+  String get menu_button_list_actions => 'Chagua kitendo';
 
   @override
-  String get error_loading_photo => 'Error loading photo';
+  String get error_loading_photo => 'Hitilafu katika kupakia picha';
 
   @override
-  String get photo_viewer_action_use_picture_as => 'Use as…';
+  String get photo_viewer_action_use_picture_as => 'Tumia kama…';
 
   @override
-  String get photo_viewer_use_picture_as_tooltip => 'Use this picture as…';
+  String get photo_viewer_use_picture_as_tooltip => 'Tumia picha hii kama…';
 
   @override
   String photo_viewer_use_picture_as_title(String language) {
-    return 'Use this picture as… ($language)';
+    return 'Tumia picha hii kama… ($language)';
   }
 
   @override
-  String get photo_viewer_details_button => 'Details';
+  String get photo_viewer_details_button => 'Maelezo';
 
   @override
   String get photo_viewer_details_button_accessibility_label =>
-      'Details of this photo';
+      'Maelezo ya picha hii';
 
   @override
-  String get photo_viewer_details_title => 'Details of the photo';
+  String get photo_viewer_details_title => 'Maelezo ya picha';
 
   @override
   String get photo_viewer_details_contributor_title => 'Contributor';
 
   @override
-  String get photo_viewer_details_size_title => 'Size';
+  String get photo_viewer_details_size_title => 'Ukubwa';
 
   @override
   String photo_viewer_details_size_value(int width, int height) {
-    return '$width x $height pixels';
+    return '$width x $height pikseli';
   }
 
   @override
-  String get photo_viewer_details_date_title => 'Date';
+  String get photo_viewer_details_date_title => 'Tarehe';
 
   @override
   String get photo_viewer_details_url_title => 'URL';
 
   @override
-  String get product_page_compatibility_score => 'Compatible';
+  String get product_page_compatibility_score => 'Sambamba';
 
   @override
-  String get user_lists_action_multi_select => 'Multi-select';
+  String get user_lists_action_multi_select => 'Chagua nyingi';
 
   @override
   String product_page_compatibility_score_tooltip(String score) {
-    return 'Your compatibility score: $score%';
+    return 'Alama yako ya uoanifu: $score%';
   }
 
   @override
@@ -5067,164 +5116,166 @@ class AppLocalizationsSw extends AppLocalizations {
       'Ingredients picture';
 
   @override
-  String get product_image_nutrition_accessibility_label => 'Nutrition picture';
+  String get product_image_nutrition_accessibility_label => 'Picha ya lishe';
 
   @override
-  String get product_image_packaging_accessibility_label => 'Packaging picture';
+  String get product_image_packaging_accessibility_label => 'Picha ya ufungaji';
 
   @override
-  String get product_image_other_accessibility_label => 'Other picture';
+  String get product_image_other_accessibility_label => 'Picha nyingine';
 
   @override
-  String get product_image_outdated_message => 'This picture may be outdated';
+  String get product_image_outdated_message =>
+      'Picha hii inaweza kuwa ya zamani';
 
   @override
   String product_image_outdated_message_accessibility_label(String type) {
-    return '$type (this image may be outdated)';
+    return '$type (picha hii inaweza kuwa imepitwa na wakati)';
   }
 
   @override
   String product_image_locked_message_accessibility_label(String type) {
-    return '$type (this image may be locked by the producer)';
+    return '$type (picha hii inaweza kufungwa na mtayarishaji)';
   }
 
   @override
-  String get product_image_error => 'Unable to load the image!';
+  String get product_image_error => 'Imeshindwa kupakia picha!';
 
   @override
   String product_image_error_accessibility_label(String type) {
-    return 'Unable to load the $type (network error?)';
+    return 'Imeshindwa kupakia $type (hitilafu ya mtandao?)';
   }
 
   @override
-  String get product_page_image_no_image_available => 'No\nimage!';
+  String get product_page_image_no_image_available => 'Hakuna picha\n!';
 
   @override
   String get product_page_image_no_image_available_accessibility_label =>
-      'No picture available for this product';
+      'Hakuna picha inayopatikana kwa bidhaa hii';
 
   @override
   String get product_page_action_bar_settings_accessibility_label =>
-      'Reorder or hide actions';
+      'Panga upya au ufiche vitendo';
 
   @override
-  String get product_page_action_bar_setting_modal_title => 'Edit actions';
+  String get product_page_action_bar_setting_modal_title => 'Badilisha vitendo';
 
   @override
-  String get product_page_action_bar_item_move_up => 'Move up';
+  String get product_page_action_bar_item_move_up => 'Sogeza juu';
 
   @override
-  String get product_page_action_bar_item_move_down => 'Move down';
+  String get product_page_action_bar_item_move_down => 'Sogeza chini';
 
   @override
-  String get product_page_action_bar_item_enable => 'Enable action';
+  String get product_page_action_bar_item_enable => 'Washa kitendo';
 
   @override
-  String get product_page_action_bar_item_disable => 'Disable action';
+  String get product_page_action_bar_item_disable => 'Zima kitendo';
 
   @override
   String get product_page_pending_operations_banner_title =>
-      'Uploading your edits…';
+      'Inapakia masahihisho yako…';
 
   @override
   String get product_page_pending_operations_banner_message =>
-      'The data displayed on this page **does not yet reflect your modifications**.\nPlease wait a few seconds…';
+      'Data iliyoonyeshwa kwenye ukurasa huu **bado haionyeshi marekebisho yako**.\nTafadhali subiri sekunde chache…';
 
   @override
-  String get product_add_a_language => 'Add a language';
+  String get product_add_a_language => 'Ongeza lugha';
 
   @override
   String barcode_accessibility_label(String barcode) {
-    return 'Barcode $barcode';
+    return 'Msimbo pau $barcode';
   }
 
   @override
-  String get carousel_close_tooltip => 'Remove this product from the carousel';
+  String get carousel_close_tooltip => 'Ondoa bidhaa hii kutoka kwa jukwa';
 
   @override
-  String get carousel_unsupported_header => 'Unsupported barcode!';
+  String get carousel_unsupported_header => 'Msimbopau hautumiki!';
 
   @override
-  String get carousel_unsupported_title => 'Ooops!';
+  String get carousel_unsupported_title => 'Lo!';
 
   @override
   String get carousel_unsupported_text =>
-      'The barcode scanned is not supported by Open Food Facts!';
+      'Msimbopau uliochanganuliwa hautumiki kwa Open Food Facts!';
 
   @override
-  String get carousel_error_header => 'Error!';
+  String get carousel_error_header => 'Hitilafu!';
 
   @override
-  String get carousel_error_title => 'It\'s a bummer!';
+  String get carousel_error_title => 'Ni bummer!';
 
   @override
   String get carousel_error_text_1 =>
-      'We couldn\'t download information on this barcode:';
+      'Hatukuweza kupakua maelezo kwenye msimbopau huu:';
 
   @override
   String get carousel_error_text_2 =>
-      'Please check your Internet connection or click this button:';
+      'Tafadhali angalia muunganisho wako wa Mtandao au ubofye kitufe hiki:';
 
   @override
-  String get carousel_error_button => 'Retry';
+  String get carousel_error_button => 'Jaribu tena';
 
   @override
-  String get carousel_unknown_product_header => 'Unknown product';
+  String get carousel_unknown_product_header => 'Bidhaa isiyojulikana';
 
   @override
   String get carousel_unknown_product_title =>
-      'Congratulations!\nYou\'ve found __the rare gem!__';
+      'Hongera!\nUmepata __vito adimu!__';
 
   @override
   String get carousel_unknown_product_text =>
-      'Our collaborative database contains more than **3 million products**, but this barcode doesn\'t exist: ';
+      'Hifadhidata yetu shirikishi ina zaidi ya **bidhaa milioni 3**, lakini msimbopau huu haupo: ';
 
   @override
   String get carousel_unknown_product_button => 'Add this product';
 
   @override
-  String get carousel_loading_header => 'Loading information...';
+  String get carousel_loading_header => 'Inapakia maelezo...';
 
   @override
   String get carousel_loading_title =>
-      'You\'ve just scanned a product with the following barcode:';
+      'Umechanganua bidhaa kwa kutumia msimbopau ufuatao:';
 
   @override
   String get carousel_loading_text =>
-      'We are searching for it in our database of more than **3 million products!**';
+      'Tunaitafuta katika hifadhidata yetu ya zaidi ya bidhaa **milioni 3!**';
 
   @override
-  String get product_type_subtitle_food => 'Vegetables, fruits, frozen food…';
+  String get product_type_subtitle_food =>
+      'Mboga, matunda, vyakula vilivyogandishwa…';
 
   @override
-  String get product_type_subtitle_beauty => 'Makeup, soaps, toothpastes…';
+  String get product_type_subtitle_beauty => 'Vipodozi, sabuni, dawa za meno…';
 
   @override
-  String get product_type_subtitle_pet_food => 'Food for dogs, cats…';
+  String get product_type_subtitle_pet_food => 'Chakula cha mbwa, paka…';
 
   @override
-  String get product_type_subtitle_product => 'Smartphones, furniture…';
+  String get product_type_subtitle_product => 'Simu mahiri, samani…';
 
   @override
-  String get photo_field_front => 'Product photo';
+  String get photo_field_front => 'Picha ya bidhaa';
 
   @override
-  String get photo_field_ingredients => 'Ingredients photo';
+  String get photo_field_ingredients => 'Picha ya viungo';
 
   @override
-  String get photo_field_nutrition => 'Nutrition photo';
+  String get photo_field_nutrition => 'Picha ya lishe';
 
   @override
-  String get photo_field_packaging => 'Packaging information photo';
+  String get photo_field_packaging => 'Picha ya habari ya ufungaji';
 
   @override
-  String get photo_already_exists => 'This photo already exists';
+  String get photo_already_exists => 'Picha hii tayari ipo';
 
   @override
-  String get photo_missing => 'This photo is missing';
+  String get photo_missing => 'Picha hii haipo';
 
   @override
-  String get date => 'Date';
+  String get date => 'Tarehe';
 
   @override
   String get photo_rotate_left => 'Rotate left';
@@ -5233,16 +5284,16 @@ class AppLocalizationsSw extends AppLocalizations {
   String get photo_rotate_right => 'Rotate right';
 
   @override
-  String get photo_undo_action => 'Undo the previous action';
+  String get photo_undo_action => 'Tendua kitendo kilichotangulia';
 
   @override
   String knowledge_panel_world_map_accessibility_label(String location) {
-    return 'A world map of $location';
+    return 'Ramani ya dunia ya $location';
   }
 
   @override
   String get open_street_map_contributor_attribution =>
-      'OpenStreetMap contributors';
+      'Wachangiaji wa OpenStreetMap';
 
   @override
   String get not_applicable_short => 'N/A';
@@ -5252,70 +5303,70 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get knowledge_panel_nutriscore_banner_incorrect_score_title =>
-      'Why is this Nutri-Score different from the one on the package?';
+      'Kwa nini Nutri-Alama hii ni tofauti na ile iliyo kwenye kifurushi?';
 
   @override
   String get knowledge_panel_nutriscore_banner_incorrect_score_message =>
-      'There are two possible explanations:\nThe list of ingredients and/or nutrition facts are not up-to-date.\n\nWe provide the \"New calculation\" of the Nutri-Score (or V2). Please check that you have the banner \"New calculation\" on the package.';
+      'Kuna maelezo mawili yanayowezekana:\nOrodha ya viungo na/au ukweli wa lishe si ya kisasa.\n\nTunatoa \"Hesabu Mpya\" ya Nutri-Score (au V2). Tafadhali hakikisha kuwa una bango \"Hesabu Mpya\" kwenye kifurushi.';
 
   @override
   String get knowledge_panel_nutriscore_banner_incorrect_score_button1 =>
-      'Check ingredients';
+      'Angalia viungo';
 
   @override
   String get knowledge_panel_nutriscore_banner_incorrect_score_button2 =>
-      'Check nutrition facts';
+      'Angalia ukweli wa lishe';
 
   @override
   String url_not_supported(String url) {
-    return 'Unfortunately, we can\'t open the URL:\n$url';
+    return 'Kwa bahati mbaya, hatuwezi kufungua URL:\n$url';
   }
 
   @override
-  String get product_list_export => 'Export';
+  String get product_list_export => 'Hamisha';
 
   @override
-  String get product_list_import => 'Import';
+  String get product_list_import => 'Ingiza';
 
   @override
-  String get product_footer_action_barcode => 'View barcode';
+  String get product_footer_action_barcode => 'Tazama msimbopau';
 
   @override
   String get product_footer_action_barcode_short => 'Barcode';
 
   @override
-  String get product_footer_action_open_website => 'Open website';
+  String get product_footer_action_open_website => 'Fungua tovuti';
 
   @override
-  String get product_footer_action_report => 'Report';
+  String get product_footer_action_report => 'Ripoti';
 
   @override
-  String get product_footer_action_contributor_guide => 'Help';
+  String get product_footer_action_contributor_guide => 'Msaada';
 
   @override
-  String get product_footer_action_data_quality_tags => 'Data quality';
+  String get product_footer_action_data_quality_tags => 'Ubora wa data';
 
   @override
   String get product_page_tab_for_me => 'Kwa ajili yangu';
 
   @override
-  String get product_page_tab_website => 'Website';
+  String get product_page_tab_website => 'Tovuti';
 
   @override
-  String get product_page_tab_prices => 'Prices';
+  String get product_page_tab_prices => 'Bei';
 
   @override
   String get prices_explanation_card_title => 'Kwa nini bei?';
 
   @override
   String get prices_explanation_card_line1 =>
-      '**Open Prices** is a project to collect and share prices of products around the world 🌍. Open Prices is developed and maintained by Open Food Facts.';
+      '**Bei Huria** ni mradi wa kukusanya na kushiriki bei za bidhaa kote ulimwenguni 🌍. Bei Huzi hutengenezwa na kudumishwa na Open Food Facts.';
 
   @override
-  String get explanation_card_learn_more_button => 'Learn more';
+  String get explanation_card_learn_more_button => 'Jifunze zaidi';
 
   @override
-  String get product_page_tab_folksonomy => 'Folksonomy';
+  String get product_page_tab_folksonomy => 'Folksonomia';
 
   @override
   String get folksonomy_explanation_card_title => 'Sifa za Folksonomy ni zipi?';
@@ -5329,11 +5380,11 @@ class AppLocalizationsSw extends AppLocalizations {
       'Sifa hizi huundwa na kuwasilishwa na wachangiaji kwa matumizi ya aina yoyote.';
 
   @override
-  String get folksonomy_action_external_link_title => 'Open external link';
+  String get folksonomy_action_external_link_title => 'Fungua kiungo cha nje';
 
   @override
   String get folksonomy_action_external_link_warning =>
-      'External links may be unsafe. Do you really want to visit it?';
+      'Viungo vya nje vinaweza kuwa si salama. Je, kweli ungependa kuitembelea?';
 
   @override
   String get prices_products_empty_title => 'Hakuna bei inayopatikana';
@@ -5343,41 +5394,41 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String prices_products_list_length_many_pages(int pageSize, int total) {
-    return 'Top $pageSize products (total: $total)';
+    return 'Bidhaa maarufu $pageSize (jumla: $total)';
   }
 
   @override
-  String get app_review_title => 'Are you enjoying this app?';
+  String get app_review_title => 'Je, unafurahia programu hii?';
 
   @override
-  String get app_review_low => 'Could do better';
+  String get app_review_low => 'Inaweza kufanya vizuri zaidi';
 
   @override
-  String get app_review_medium => 'Not bad';
+  String get app_review_medium => 'Sio mbaya';
 
   @override
-  String get app_review_high => 'I love it!';
+  String get app_review_high => 'Naipenda!';
 
   @override
   String get app_review_feedback_modal_title =>
-      'Help us improve our application';
+      'Tusaidie kuboresha programu yetu';
 
   @override
   String get app_review_feedback_modal_content =>
-      'If you have a few minutes, could you answer this form so that **we can improve in future updates**:';
+      'Ikiwa una dakika chache, unaweza kujibu fomu hii ili **tuweze kuboresha katika masasisho yajayo**:';
 
   @override
-  String get app_review_feedback_modal_open_form => 'Answer the form';
+  String get app_review_feedback_modal_open_form => 'Jibu fomu';
 
   @override
-  String get app_review_feedback_modal_later => 'Ask me later';
+  String get app_review_feedback_modal_later => 'Niulize baadaye';
 
   @override
   String get nutrition_facts_extract_new =>
-      'NEW: You can automatically extract the nutrients from the picture!';
+      'MPYA: Unaweza kutoa virutubisho kiotomatiki kutoka kwenye picha!';
 
   @override
-  String get nutrition_facts_extract_button_text => 'Extract now';
+  String get nutrition_facts_extract_button_text => 'Dondoo sasa';
 
   @override
   String get nutrition_facts_extract_in_progress => 'Uchimbaji unaendelea…';
@@ -5387,22 +5438,22 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get nutrition_facts_extract_failed =>
-      'Failed to extract nutrients from picture';
+      'Imeshindwa kutoa virutubisho kutoka kwa picha';
 
   @override
   String get prices_discount => 'Discount';
 
   @override
-  String get prices_stats_statistics => 'Statistics';
+  String get prices_stats_statistics => 'Takwimu';
 
   @override
-  String get prices_stats_title => 'Prices Statistics';
+  String get prices_stats_title => 'Takwimu za Bei';
 
   @override
-  String get prices_stats_prices_section => 'Prices';
+  String get prices_stats_prices_section => 'Bei';
 
   @override
-  String get prices_stats_products_section => 'Products';
+  String get prices_stats_products_section => 'Bidhaa';
 
   @override
   String get prices_stats_locations_section => 'Locations';
@@ -5417,7 +5468,7 @@ class AppLocalizationsSw extends AppLocalizations {
   String get prices_stats_experiments_section => 'Experiments';
 
   @override
-  String get prices_stats_misc_section => 'Miscellaneous';
+  String get prices_stats_misc_section => 'Mbalimbali';
 
   @override
   String get prices_stats_total => 'Total';
@@ -5441,16 +5492,16 @@ class AppLocalizationsSw extends AppLocalizations {
   String get prices_stats_with_price => 'With a price';
 
   @override
-  String get prices_stats_food => 'Food';
+  String get prices_stats_food => 'Chakula';
 
   @override
   String get prices_stats_beauty => 'Beauty';
 
   @override
-  String get prices_stats_products => 'Products';
+  String get prices_stats_products => 'Bidhaa';
 
   @override
-  String get prices_stats_pet_food => 'Pet food';
+  String get prices_stats_pet_food => 'Chakula cha kipenzi';
 
   @override
   String get prices_stats_osm => 'OpenStreetMap';
@@ -5462,10 +5513,10 @@ class AppLocalizationsSw extends AppLocalizations {
   String get prices_stats_countries => 'Countries';
 
   @override
-  String get prices_stats_price_tag => 'Price tag';
+  String get prices_stats_price_tag => 'Lebo ya bei';
 
   @override
-  String get prices_stats_receipt => 'Receipt';
+  String get prices_stats_receipt => 'Risiti';
 
   @override
   String get prices_stats_gdpr_request => 'GDPR request';
@@ -5489,7 +5540,7 @@ class AppLocalizationsSw extends AppLocalizations {
   String get prices_stats_by_source_title => 'Prices and proofs per source';
 
   @override
-  String get prices_stats_website => 'Website';
+  String get prices_stats_website => 'Tovuti';
 
   @override
   String get prices_stats_mobile_app => 'Mobile app';
@@ -5501,23 +5552,23 @@ class AppLocalizationsSw extends AppLocalizations {
   String get prices_stats_other => 'Other';
 
   @override
-  String get prices_stats_last_updated => 'Last updated on';
+  String get prices_stats_last_updated => 'Ilisasishwa mwisho';
 
   @override
   String get prices_stats_error =>
-      'An error occurred while loading statistics.';
+      'Hitilafu ilitokea wakati wa kupakia takwimu.';
 
   @override
-  String get product_edit_robotoff_question_answered => 'Question answered!';
+  String get product_edit_robotoff_question_answered => 'Swali limejibiwa!';
 
   @override
-  String get product_edit_robotoff_proof => 'Proof';
+  String get product_edit_robotoff_proof => 'Ushahidi';
 
   @override
   String get preferences_card_general => 'General';
 
   @override
-  String get preferences_prices_title => 'Prices';
+  String get preferences_prices_title => 'Bei';
 
   @override
   String get preferences_prices_subtitle => 'Dhibiti mapendeleo yako ya bei';
@@ -5555,7 +5606,7 @@ class AppLocalizationsSw extends AppLocalizations {
   String get preferences_card_help => 'Usaidizi na Usaidizi';
 
   @override
-  String get preferences_faq_title => 'FAQ';
+  String get preferences_faq_title => 'Maswali Yanayoulizwa Mara kwa Mara';
 
   @override
   String get preferences_faq_subtitle => 'Pata majibu ya maswali yako';
@@ -5592,7 +5643,7 @@ class AppLocalizationsSw extends AppLocalizations {
   String get preferences_accessibility_remove_colors => 'Ufikiaji: Ondoa rangi';
 
   @override
-  String get preferences_app_settings_products => 'Products';
+  String get preferences_app_settings_products => 'Bidhaa';
 
   @override
   String get preferences_card_about => 'Kuhusu';
@@ -5605,17 +5656,17 @@ class AppLocalizationsSw extends AppLocalizations {
       'Masharti ya matumizi, sera ya faragha na zaidi';
 
   @override
-  String get preferences_terms_of_use => 'Terms of use';
+  String get preferences_terms_of_use => 'Masharti ya matumizi';
 
   @override
   String get preferences_legal_mentions => 'Legal mentions';
 
   @override
   String get preferences_legal_header =>
-      'Open Food Facts is a food products database **made by everyone, for everyone**.\nYou can use it to make better food choices, and as it is **open data**, anyone can **re-use it for any purpose**.';
+      'Fungua Ukweli wa Chakula ni hifadhidata ya bidhaa za chakula **iliyoundwa na kila mtu, kwa kila mtu**.\nUnaweza kuitumia kufanya chaguo bora zaidi za chakula, na kwa vile ni **data wazi**, mtu yeyote anaweza **kuitumia tena kwa madhumuni yoyote**.';
 
   @override
-  String get preferences_privacy_policy => 'Privacy policy';
+  String get preferences_privacy_policy => 'Sera ya faragha';
 
   @override
   String get preferences_licenses => 'Leseni';
@@ -5659,7 +5710,7 @@ class AppLocalizationsSw extends AppLocalizations {
   String get preferences_tips => 'Vidokezo';
 
   @override
-  String get tips_discover_nutriscore => 'Discover the new Nutri-Score';
+  String get tips_discover_nutriscore => 'Gundua Nutri-Alama mpya';
 
   @override
   String get preferences_on_off_website_subtitle =>
@@ -5795,7 +5846,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get preferences_connect_community_calendar_title =>
-      'Subscribe to our community calendar';
+      'Jiandikishe kwa kalenda yetu ya jamii';
 
   @override
   String get preferences_connect_community_calendar_subtitle =>
@@ -5901,7 +5952,7 @@ class AppLocalizationsSw extends AppLocalizations {
       'Hatua rahisi za kukuza uwazi wa chakula katika nchi yako';
 
   @override
-  String get preferences_contribute_data_quality_title => 'Data quality';
+  String get preferences_contribute_data_quality_title => 'Ubora wa data';
 
   @override
   String get preferences_contribute_data_quality_team_title =>
@@ -5928,10 +5979,10 @@ class AppLocalizationsSw extends AppLocalizations {
       'Bidhaa zote ambazo hazijakamilika';
 
   @override
-  String get preferences_my_contributions_prices_title => 'Prices';
+  String get preferences_my_contributions_prices_title => 'Bei';
 
   @override
-  String get preferences_my_contributions_my_prices_title => 'My prices';
+  String get preferences_my_contributions_my_prices_title => 'Bei zangu';
 
   @override
   String get preferences_my_contributions_my_prices_subtitle =>
@@ -5964,7 +6015,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get preferences_prices_newest_subtitle =>
-      'Latest prices added by the Open Prices community';
+      'Bei za hivi punde zilizoongezwa na jumuiya ya Bei Huria';
 
   @override
   String get preferences_prices_top_contributors_title =>
@@ -6011,7 +6062,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get preferences_page_contribute_project_subtitle =>
-      'Simple ways to help Open Food Facts';
+      'Njia rahisi za kusaidia Fungua Ukweli wa Chakula';
 
   @override
   String get preferences_page_faq_subtitle =>
@@ -6122,11 +6173,11 @@ class AppLocalizationsSw extends AppLocalizations {
       'Open Food Facts Labs';
 
   @override
-  String get preferences_root_account_title => 'Account';
+  String get preferences_root_account_title => 'Akaunti';
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Leta Ukweli wa Chakula Huria kwa lugha yako';
 
   @override
   String get preferences_contribute_enroll_alpha =>
@@ -6140,7 +6191,7 @@ class AppLocalizationsSw extends AppLocalizations {
       'Usionyeshe Folksonomy';
 
   @override
-  String get preferences_account_title => 'Account';
+  String get preferences_account_title => 'Akaunti';
 
   @override
   String prices_adding_timestamp_tooltip(String created) {
@@ -6148,26 +6199,26 @@ class AppLocalizationsSw extends AppLocalizations {
   }
 
   @override
-  String get location_map_details_title => 'Location details';
+  String get location_map_details_title => 'Maelezo ya eneo';
 
   @override
-  String get location_map_details_name => 'Name';
+  String get location_map_details_name => 'Jina';
 
   @override
-  String get location_map_details_street => 'Street';
+  String get location_map_details_street => 'Mtaa';
 
   @override
-  String get location_map_details_city => 'City';
+  String get location_map_details_city => 'Jiji';
 
   @override
-  String get location_map_details_postcode => 'Postcode';
+  String get location_map_details_postcode => 'Msimbo wa posta';
 
   @override
   String get location_map_details_country => 'Country';
 
   @override
-  String get location_map_details_coordinates => 'Coordinates';
+  String get location_map_details_coordinates => 'Kuratibu';
 
   @override
-  String get location_map_details_osm_id => 'OSM ID';
+  String get location_map_details_osm_id => 'Kitambulisho cha OSM';
 }

--- a/packages/smooth_app/lib/l10n/app_localizations_sw.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sw.dart
@@ -656,7 +656,7 @@ class AppLocalizationsSw extends AppLocalizations {
   String get unknownBrand => 'Chapa isiyojulikana';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Jina la bidhaa lisilojulikana';

--- a/packages/smooth_app/lib/l10n/app_localizations_ta.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ta.dart
@@ -669,7 +669,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get unknownBrand => 'தெரியாத பிராண்ட்';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'தெரியாத தயாரிப்பு பெயர்';

--- a/packages/smooth_app/lib/l10n/app_localizations_ta.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ta.dart
@@ -22,10 +22,10 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get account_delete_message =>
-      'Are you sure you want to delete your account?\nIf there is a specific reason, please share below';
+      'உங்கள் கணக்கை நீக்க விரும்புகிறீர்களா?\nகுறிப்பிட்ட காரணம் இருந்தால், கீழே பகிரவும்.';
 
   @override
-  String get reason => 'Reason';
+  String get reason => 'காரணம்';
 
   @override
   String get okay => 'சரி';
@@ -43,7 +43,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get next_label => 'Next';
 
   @override
-  String get continue_label => 'Continue';
+  String get continue_label => 'தொடரவும்';
 
   @override
   String get exit_label => 'வெளியேறு';
@@ -79,10 +79,10 @@ class AppLocalizationsTa extends AppLocalizations {
   String get stop => 'நிறுத்து';
 
   @override
-  String get finish => 'Finish';
+  String get finish => 'முடித்தல்';
 
   @override
-  String get calculate => 'Calculate';
+  String get calculate => 'கணக்கிடுங்கள்';
 
   @override
   String get reset_food_prefs => 'உணவு விருப்பங்களை மீட்டமைக்கவும்';
@@ -104,405 +104,415 @@ class AppLocalizationsTa extends AppLocalizations {
   String get learnMore => 'மேலும்அறிய';
 
   @override
-  String get unknown => 'Unknown';
+  String get unknown => 'தெரியவில்லை';
 
   @override
-  String get match_very_good => 'Very good match';
+  String get match_very_good => 'மிகவும் நல்ல பொருத்தம்';
 
   @override
-  String get match_good => 'Good match';
+  String get match_good => 'நல்ல பொருத்தம்';
 
   @override
-  String get match_poor => 'Poor match';
+  String get match_poor => 'மோசமான பொருத்தம்';
 
   @override
   String get match_may_not => 'May not match';
 
   @override
-  String get match_does_not => 'Does not match';
+  String get match_does_not => 'பொருந்தவில்லை';
 
   @override
-  String get match_unknown => 'Unknown match';
+  String get match_unknown => 'தெரியாத பொருத்தம்';
 
   @override
-  String get match_short_very_good => 'Very good match';
+  String get match_short_very_good => 'மிகவும் நல்ல பொருத்தம்';
 
   @override
-  String get match_short_good => 'Good match';
+  String get match_short_good => 'நல்ல பொருத்தம்';
 
   @override
-  String get match_short_poor => 'Poor match';
+  String get match_short_poor => 'மோசமான பொருத்தம்';
 
   @override
   String get match_short_may_not => 'May not match';
 
   @override
-  String get match_short_does_not => 'Does not match';
+  String get match_short_does_not => 'பொருந்தவில்லை';
 
   @override
-  String get match_short_unknown => 'Unknown match';
+  String get match_short_unknown => 'தெரியாத பொருத்தம்';
 
   @override
   String get licenses => 'Licences';
 
   @override
-  String get looking_for => 'Looking for';
+  String get looking_for => 'தேடுகிறேன்';
 
   @override
-  String get welcomeToOpenFoodFacts => 'Welcome to Open Food Facts';
+  String get welcomeToOpenFoodFacts => 'திறந்த உணவு உண்மைகளுக்கு வருக.';
 
   @override
   String get whatIsOff =>
-      'Open Food Facts is a global non-profit powered by local communities.';
+      'ஓபன் ஃபுட் ஃபேக்ட்ஸ் என்பது உள்ளூர் சமூகங்களால் இயக்கப்படும் உலகளாவிய இலாப நோக்கற்ற அமைப்பாகும்.';
 
   @override
   String get productDataUtility =>
-      'See the food data relevant to your preferences.';
+      'உங்கள் விருப்பங்களுக்கு பொருத்தமான உணவுத் தரவைப் பார்க்கவும்.';
 
   @override
-  String get healthCardUtility => 'Choose foods that are good for you.';
+  String get healthCardUtility => 'உங்களுக்கு ஏற்ற உணவுகளைத் தேர்ந்தெடுங்கள்.';
 
   @override
-  String get ecoCardUtility => 'Choose foods that are good for the planet.';
+  String get ecoCardUtility => 'கிரகத்திற்கு நல்ல உணவுகளைத் தேர்ந்தெடுங்கள்.';
 
   @override
   String get server_error_open_new_issue =>
-      'No server response! You may open an issue with the following link.';
+      'சேவையக பதில் இல்லை! பின்வரும் இணைப்பைப் பயன்படுத்தி நீங்கள் ஒரு சிக்கலைத் தொடங்கலாம்.';
 
   @override
   String get sign_in_text =>
-      'Sign in to your Open Food Facts account to save your contributions';
+      'உங்கள் பங்களிப்புகளைச் சேமிக்க உங்கள் Open Food Facts கணக்கில் உள்நுழையவும்.';
 
   @override
-  String get incorrect_credentials => 'Incorrect username or password.';
+  String get incorrect_credentials => 'தவறான பயனர்பெயர் அல்லது கடவுச்சொல்.';
 
   @override
   String get password_lost_incorrect_credentials =>
-      'This email or username doesn\'t exist. Please check your credentials.';
+      'இந்த மின்னஞ்சல் முகவரி அல்லது பயனர்பெயர் இல்லை. உங்கள் சான்றுகளைச் சரிபார்க்கவும்.';
 
   @override
   String get password_lost_server_unavailable =>
-      'We are currently experiencing slowdowns on our servers and we apologise for it. Please try again later.';
+      'எங்கள் சேவையகங்களில் தற்போது மந்தநிலை ஏற்பட்டுள்ளது, அதற்காக நாங்கள் வருந்துகிறோம். தயவுசெய்து பின்னர் மீண்டும் முயற்சிக்கவும்.';
 
   @override
   String get login => 'Login';
 
   @override
-  String get login_result_type_server_unreachable => 'Network is unreachable';
+  String get login_result_type_server_unreachable =>
+      'நெட்வொர்க்கை அணுக முடியவில்லை.';
 
   @override
   String get login_result_type_server_issue =>
-      'Problem on the server. Please try later.';
+      'சர்வரில் சிக்கல். பிறகு முயற்சிக்கவும்.';
 
   @override
-  String get login_page_username_or_email => 'Please enter username or e-mail';
+  String get login_page_username_or_email =>
+      'பயனர்பெயர் அல்லது மின்னஞ்சலை உள்ளிடவும்.';
 
   @override
-  String get login_page_password_error_empty => 'Please enter a password';
+  String get login_page_password_error_empty => 'கடவுச்சொல்லை உள்ளிடவும்.';
 
   @override
-  String get create_account => 'Create account';
+  String get create_account => 'கணக்கை உருவாக்கு';
 
   @override
   String get sign_in => 'உள்நுழை';
 
   @override
-  String get sign_in_mandatory => 'For that feature we need you to sign in.';
+  String get sign_in_mandatory =>
+      'அந்த அம்சத்திற்கு நீங்கள் உள்நுழைய வேண்டும்.';
 
   @override
   String get help_improve_country =>
       'உங்கள் நாட்டில் Open Food Facts உண்மைகளை மேம்படுத்த உதவுங்கள்.';
 
   @override
-  String get sign_out => 'Sign out';
+  String get sign_out => 'வெளியேறு';
 
   @override
-  String get sign_out_confirmation => 'Are you sure you want to sign out?';
+  String get sign_out_confirmation =>
+      'நீங்கள் நிச்சயமாக வெளியேற விரும்புகிறீர்களா?';
 
   @override
   String get password => 'கடவுச்சொல்';
 
   @override
-  String get forgot_password => 'Forgot password';
+  String get forgot_password => 'கடவுச்சொல் மறந்துவிட்டது';
 
   @override
   String get forgot_password_question => 'கடவுச்சொல்லை மறந்துவிட்டீர்களா?';
 
   @override
-  String get view_profile => 'View profile';
+  String get view_profile => 'சுயவிவரத்தைக் காண்க';
 
   @override
-  String get reset_password => 'Reset password';
+  String get reset_password => 'கடவுச்சொல்லை மீட்டமைக்க';
 
   @override
   String get reset_password_explanation_text =>
-      'In case of a forgotten password, enter your username or e-mail address to receive instructions for a password reset. Also, remember to check the Spam folder.';
+      'கடவுச்சொல் மறந்துவிட்டால், கடவுச்சொல்லை மீட்டமைப்பதற்கான வழிமுறைகளைப் பெற உங்கள் பயனர்பெயர் அல்லது மின்னஞ்சல் முகவரியை உள்ளிடவும். மேலும், ஸ்பேம் கோப்புறையைச் சரிபார்க்கவும்.';
 
   @override
-  String get username_or_email => 'Username or e-mail';
+  String get username_or_email => 'பயனர்பெயர் அல்லது மின்னஞ்சல்';
 
   @override
   String get reset_password_done =>
-      'An e-mail with a link to reset your password has been sent to the e-mail address associated with your account. Also check your spam';
+      'உங்கள் கடவுச்சொல்லை மீட்டமைப்பதற்கான இணைப்புடன் கூடிய மின்னஞ்சல் உங்கள் கணக்குடன் தொடர்புடைய மின்னஞ்சல் முகவரிக்கு அனுப்பப்பட்டுள்ளது. உங்கள் ஸ்பேமையும் சரிபார்க்கவும்.';
 
   @override
-  String get send_reset_password_mail => 'Change password';
+  String get send_reset_password_mail => 'கடவுச்சொல்லை மாற்றுக';
 
   @override
-  String get enter_some_text => 'Please enter some text';
+  String get enter_some_text => 'தயவுசெய்து சில உரையை உள்ளிடவும்.';
 
   @override
-  String get sign_up_page_title => 'Sign Up';
+  String get sign_up_page_title => 'பதிவு செய்';
 
   @override
-  String get sign_up_page_action_button => 'Sign Up';
+  String get sign_up_page_action_button => 'பதிவு செய்';
 
   @override
-  String get sign_up_page_action_doing_it => 'Signing up…';
+  String get sign_up_page_action_doing_it => '…பதிவு செய்தல்';
 
   @override
   String get sign_up_page_action_ok =>
-      'Congratulations! Your account has just been created.';
+      'வாழ்த்துக்கள்! உங்கள் கணக்கு இப்போதுதான் உருவாக்கப்பட்டது.';
 
   @override
-  String get sign_up_page_display_name_hint => 'Name';
+  String get sign_up_page_display_name_hint => 'பெயர்';
 
   @override
   String get sign_up_page_display_name_error_empty =>
-      'Please enter the display name you want to use';
+      'நீங்கள் பயன்படுத்த விரும்பும் காட்சிப் பெயரை உள்ளிடவும்.';
 
   @override
-  String get sign_up_page_email_hint => 'E-mail';
+  String get sign_up_page_email_hint => 'மின்னஞ்சல்';
 
   @override
-  String get sign_up_page_email_error_empty => 'E-mail is required';
+  String get sign_up_page_email_error_empty => 'மின்னஞ்சல் அவசியம்';
 
   @override
-  String get sign_up_page_email_error_invalid => 'Invalid e-mail';
+  String get sign_up_page_email_error_invalid => 'தவறான மின்னஞ்சல்';
 
   @override
-  String get sign_up_page_username_hint => 'Username: Publicly visible';
+  String get sign_up_page_username_hint => 'பயனர்பெயர்: பொதுவில் தெரியும்';
 
   @override
-  String get sign_up_page_username_error_empty => 'Please enter a username';
+  String get sign_up_page_username_error_empty =>
+      'தயவுசெய்து ஒரு பயனர்பெயரை உள்ளிடவும்.';
 
   @override
   String get sign_up_page_username_error_invalid =>
-      'Please enter a valid username';
+      'தயவுசெய்து ஒரு செல்லுபடியாகும் பயனர்பெயரை உள்ளிடவும்.';
 
   @override
   String get sign_up_page_username_description =>
-      'Username cannot contains spaces, caps or special characters.';
+      'பயனர்பெயரில் இடைவெளிகள், பெரிய எழுத்துக்கள் அல்லது சிறப்பு எழுத்துக்கள் இருக்கக்கூடாது.';
 
   @override
   String sign_up_page_username_length_invalid(int value) {
-    return 'Username cannot exceed $value characters';
+    return 'பயனர்பெயர் $value எழுத்துகளுக்கு மேல் இருக்கக்கூடாது';
   }
 
   @override
   String get sign_up_page_password_hint => 'கடவுச்சொல்';
 
   @override
-  String get sign_up_page_password_error_empty => 'Please enter a password';
+  String get sign_up_page_password_error_empty => 'கடவுச்சொல்லை உள்ளிடவும்.';
 
   @override
   String get sign_up_page_password_error_invalid =>
-      'Please enter a valid password (at least 6 characters)';
+      'தயவுசெய்து செல்லுபடியாகும் கடவுச்சொல்லை உள்ளிடவும் (குறைந்தது 6 எழுத்துகள்)';
 
   @override
-  String get sign_up_page_confirm_password_hint => 'Confirm Password';
+  String get sign_up_page_confirm_password_hint =>
+      'கடவுச்சொல்லை உறுதிப்படுத்தவும்';
 
   @override
   String get sign_up_page_confirm_password_error_empty =>
-      'Please confirm the password';
+      'கடவுச்சொல்லை உறுதிப்படுத்தவும்.';
 
   @override
   String get sign_up_page_confirm_password_error_invalid =>
-      'Passwords don\'t match';
+      'கடவுச்சொற்கள் பொருந்தவில்லை.';
 
   @override
-  String get sign_up_page_agree_text => 'I agree to the Open Food Facts';
+  String get sign_up_page_agree_text =>
+      'திறந்த உணவு உண்மைகளை நான் ஒப்புக்கொள்கிறேன்.';
 
   @override
-  String get sign_up_page_terms_text => 'terms of use and contribution';
+  String get sign_up_page_terms_text =>
+      'பயன்பாட்டு விதிமுறைகள் மற்றும் பங்களிப்பு';
 
   @override
   String get donate_url => 'https://donate.openfoodfacts.org/';
 
   @override
   String get sign_up_page_agree_error_invalid =>
-      'When creating an account, agreeing to the Terms of Use is mandatory, however, anonymous contributions can still be made through the app';
+      'ஒரு கணக்கை உருவாக்கும் போது, பயன்பாட்டு விதிமுறைகளை ஒப்புக்கொள்வது கட்டாயமாகும், இருப்பினும், பயன்பாட்டின் மூலம் அநாமதேய பங்களிப்புகளைச் செய்யலாம்.';
 
   @override
-  String get sign_up_page_producer_checkbox => 'I am a food producer';
+  String get sign_up_page_producer_checkbox => 'நான் ஒரு உணவு தயாரிப்பாளர்.';
 
   @override
-  String get sign_up_page_producer_hint => 'Producer/brand';
+  String get sign_up_page_producer_hint => 'தயாரிப்பாளர்/பிராண்ட்';
 
   @override
   String get sign_up_page_producer_error_empty =>
-      'Please enter a producer or a brand name';
+      'தயவுசெய்து ஒரு தயாரிப்பாளர் அல்லது ஒரு பிராண்ட் பெயரை உள்ளிடவும்.';
 
   @override
   String get sign_up_page_subscribe_checkbox =>
-      'I\'d like to subscribe to the Open Food Facts newsletter (You can unsubscribe from it at any time)';
+      'நான் திறந்த உணவு உண்மைகள் செய்திமடலுக்கு குழுசேர விரும்புகிறேன் (நீங்கள் எந்த நேரத்திலும் அதிலிருந்து குழுவிலகலாம்)';
 
   @override
   String get sign_up_page_user_name_already_used =>
-      'The user name already exists, please choose another username.';
+      'பயனர் பெயர் ஏற்கனவே உள்ளது, தயவுசெய்து வேறு பயனர்பெயரைத் தேர்வுசெய்க.';
 
   @override
   String get sign_up_page_email_already_exists =>
-      'already exists, login to the account or try with another email.';
+      'ஏற்கனவே உள்ளது, கணக்கில் உள்நுழையவும் அல்லது வேறு மின்னஞ்சலைப் பயன்படுத்தி முயற்சிக்கவும்.';
 
   @override
   String get sign_up_page_provide_valid_email =>
-      'Please provide a valid email address.';
+      'சரியான மின்னஞ்சல் முகவரியை வழங்கவும்.';
 
   @override
   String get sign_up_page_server_busy =>
-      'We are deeply sorry, we have some technical difficulties to create your account. Please try again later.';
+      'மன்னிக்கவும், உங்கள் கணக்கை உருவாக்குவதில் சில தொழில்நுட்ப சிக்கல்கள் உள்ளன. தயவுசெய்து பின்னர் மீண்டும் முயற்சிக்கவும்.';
 
   @override
   String get settingsTitle => 'அமைப்புகள்';
 
   @override
-  String get darkmode => 'Theme';
+  String get darkmode => 'தீம்';
 
   @override
-  String get darkmode_dark => 'Dark';
+  String get darkmode_dark => 'இருள்';
 
   @override
-  String get darkmode_light => 'Light';
+  String get darkmode_light => 'ஒளி';
 
   @override
-  String get darkmode_system_default => 'System default';
+  String get darkmode_system_default => 'கணினி இயல்புநிலை';
 
   @override
-  String get thanks_for_contributing => 'Thanks for contributing!';
+  String get thanks_for_contributing => 'பங்களித்ததற்கு நன்றி!';
 
   @override
-  String get contributors_label => 'They are building the app';
+  String get contributors_label => 'அவர்கள் செயலியை உருவாக்குகிறார்கள்.';
 
   @override
   String get contributors_dialog_title => 'Contributors';
 
   @override
   String contributors_dialog_entry_description(Object name) {
-    return 'Contributor: $name';
+    return 'பங்களிப்பாளர்: $name';
   }
 
   @override
   String get contributors_description =>
-      'A list of all contributors of this app';
+      'இந்த செயலியின் அனைத்து பங்களிப்பாளர்களின் பட்டியல்';
 
   @override
-  String get support => 'Support';
+  String get support => 'ஆதரவு';
 
   @override
-  String get support_join_slack => 'Ask for help in our Slack channel';
+  String get support_join_slack => 'எங்கள் ஸ்லாக் சேனலில் உதவி கேளுங்கள்.';
 
   @override
   String get support_via_forum => 'உதவிக்கு எங்கள் மன்றத்தை நாடவும்';
 
   @override
-  String get support_via_email => 'Send us an e-mail';
+  String get support_via_email => 'எங்களுக்கு ஒரு மின்னஞ்சல் அனுப்புங்கள்.';
 
   @override
-  String get support_via_email_include_logs_dialog_title => 'Send app logs?';
+  String get support_via_email_include_logs_dialog_title =>
+      'ஆப் பதிவுகளை அனுப்பவா?';
 
   @override
   String get support_via_email_include_logs_dialog_body =>
-      'Do you wish to include application logs in attachment to your email?';
+      'உங்கள் மின்னஞ்சலில் இணைப்பில் பயன்பாட்டுப் பதிவுகளைச் சேர்க்க விரும்புகிறீர்களா?';
 
   @override
-  String get termsOfUse => 'Terms of use';
+  String get termsOfUse => 'பயன்பாட்டு விதிமுறைகள்';
 
   @override
   String get legalNotices => 'சட்ட அறிவிப்புகள்';
 
   @override
-  String get privacy_policy => 'Privacy policy';
+  String get privacy_policy => 'தனியுரிமைக் கொள்கை';
 
   @override
-  String get about_this_app => 'About this app';
+  String get about_this_app => 'இந்த ஆப்ஸ் பற்றி';
 
   @override
   String get contribute => 'Contribute';
 
   @override
-  String get contribute_sw_development => 'Software development';
+  String get contribute_sw_development => 'மென்பொருள் மேம்பாடு';
 
   @override
   String get contribute_develop_text =>
-      'The code for every Open Food Facts product is available on GitHub. You are welcome to reuse the code (it\'s open source) and help us improve it, for everyone, on all the planet.';
+      'ஒவ்வொரு Open Food Facts தயாரிப்புக்கான குறியீடும் GitHub இல் கிடைக்கிறது. இந்தக் குறியீட்டை மீண்டும் பயன்படுத்தவும் (இது திறந்த மூலமாகும்) மேலும், உலகம் முழுவதும் உள்ள அனைவருக்கும் அதை மேம்படுத்த எங்களுக்கு உதவவும் உங்களை வரவேற்கிறோம்.';
 
   @override
   String get contribute_develop_text_2 =>
-      'You can join the Open Food Facts Slack chatroom which is the preferred way to ask questions.';
+      'நீங்கள் ஓபன் ஃபுட் ஃபேக்ட்ஸ் ஸ்லாக் அரட்டை அறையில் சேரலாம், இது கேள்விகளைக் கேட்க விருப்பமான வழியாகும்.';
 
   @override
-  String get contribute_develop_dev_mode_title => 'DEV Mode?';
+  String get contribute_develop_dev_mode_title => 'DEV பயன்முறையா?';
 
   @override
-  String get contribute_develop_dev_mode_subtitle => 'Activate the DEV Mode';
+  String get contribute_develop_dev_mode_subtitle => 'DEV பயன்முறையை இயக்கவும்';
 
   @override
   String get contribute_donate_title => 'நன்கொடை';
 
   @override
-  String get contribute_donate_header => 'Donate to Open Food Facts';
+  String get contribute_donate_header =>
+      'திறந்த உணவு உண்மைகளுக்கு நன்கொடை அளிக்கவும்';
 
   @override
   String get contribute_enroll_alpha_warning =>
-      'Please acknowledge that with the internal alpha version, complete loss of data is possible, and the app may become unusable at any time !';
+      'உள் ஆல்பா பதிப்பில், தரவு முழுமையாக இழக்க நேரிடும் என்பதையும், எந்த நேரத்திலும் பயன்பாடு பயன்படுத்த முடியாததாகிவிடும் என்பதையும் ஒப்புக்கொள்ளுங்கள்!';
 
   @override
   String get contribute_improve_ProductsToBeCompleted =>
-      'Products to be completed';
+      'முடிக்க வேண்டிய தயாரிப்புகள்';
 
   @override
-  String get contribute_improve_header => 'Improving';
+  String get contribute_improve_header => 'மேம்படுத்துதல்';
 
   @override
   String get contribute_improve_text =>
-      'The database is the core of the project. It\'s easy and very quick to help. You can download the mobile app for your phone, and start adding or improving products.\n\nOn the other hand, Open Food Facts website offers many ways to contribute: ';
+      'இந்தத் திட்டத்தின் மையக் கருத்துத் தரவுத்தளம். இது உதவுவது எளிதானது மற்றும் மிக விரைவானது. உங்கள் தொலைபேசிக்கான மொபைல் செயலியைப் பதிவிறக்கம் செய்து, தயாரிப்புகளைச் சேர்க்க அல்லது மேம்படுத்தத் தொடங்கலாம்.\n\nமறுபுறம், ஓபன் ஃபுட் ஃபேக்ட்ஸ் வலைத்தளம் பங்களிக்க பல வழிகளை வழங்குகிறது: ';
 
   @override
-  String get contribute_translate_header => 'Translate';
+  String get contribute_translate_header => 'மொழிபெயர்';
 
   @override
   String get contribute_data_quality => 'Data Quality';
 
   @override
-  String get contribute_translate_link_text => 'Start Translating';
+  String get contribute_translate_link_text => 'மொழிபெயர்க்கத் தொடங்குங்கள்';
 
   @override
   String get contribute_translate_text =>
-      'Open Food Facts is a global project, containing products from more than 160 countries. Open Food Facts is translated into dozens of languages, with constantly evolving content.';
+      'ஓபன் ஃபுட் ஃபேக்ட்ஸ் என்பது 160க்கும் மேற்பட்ட நாடுகளின் தயாரிப்புகளைக் கொண்ட ஒரு உலகளாவிய திட்டமாகும். ஓபன் ஃபுட் ஃபேக்ட்ஸ் என்பது டஜன் கணக்கான மொழிகளில் மொழிபெயர்க்கப்பட்டுள்ளது, தொடர்ந்து வளர்ந்து வரும் உள்ளடக்கத்துடன்.';
 
   @override
   String get contribute_translate_text_2 =>
-      'Translations is one of the key tasks of the project';
+      'மொழிபெயர்ப்புகள் திட்டத்தின் முக்கிய பணிகளில் ஒன்றாகும்.';
 
   @override
   String get contribute_join_skill_pool =>
-      'Contribute your skills to Open Food Facts. Join the skill pool!';
+      'திறந்த உணவு உண்மைகளுக்கு உங்கள் திறமைகளைப் பங்களிக்கவும். திறன் குழுவில் சேருங்கள்!';
 
   @override
   String get contribute_share_header =>
-      'Share Open Food Facts with your friends';
+      'உணவு பற்றிய திறந்த உண்மைகளை உங்கள் நண்பர்களுடன் பகிர்ந்து கொள்ளுங்கள்.';
 
   @override
   String get contribute_share_content =>
-      'I wanted to let you know about the app I\'ve been using, Open Food Facts, which allows you to get the health and environmental impacts of your food, in a personalized way. It works by scanning the barcodes on the packaging. Finally it\'s free, does not require registration, and you can even help increase the number of products decyphered. Here\'s the link to get it for your phone: https://openfoodfacts.app';
+      'நான் பயன்படுத்தி வரும் Open Food Facts என்ற செயலியைப் பற்றி உங்களுக்குத் தெரிவிக்க விரும்பினேன். இது உங்கள் உணவின் ஆரோக்கியம் மற்றும் சுற்றுச்சூழல் பாதிப்புகளை தனிப்பயனாக்கப்பட்ட முறையில் பெற உங்களை அனுமதிக்கிறது. இது பேக்கேஜிங்கில் உள்ள பார்கோடுகளை ஸ்கேன் செய்வதன் மூலம் செயல்படுகிறது. இறுதியாக இது இலவசம், பதிவு தேவையில்லை, மேலும் டிசைஃபர் செய்யப்பட்ட பொருட்களின் எண்ணிக்கையை அதிகரிக்கவும் நீங்கள் உதவலாம். உங்கள் தொலைபேசியில் இதைப் பெறுவதற்கான இணைப்பு இங்கே: https://openfoodfacts.app';
 
   @override
   String get contribute_prices_gdpr =>
-      'Contribute prices by requesting a GDPR export of your loyalty cards data';
+      'உங்கள் லாயல்டி கார்டுகளின் தரவை GDPR ஏற்றுமதி செய்யக் கோருவதன் மூலம் விலைகளை பங்களிக்கவும்.';
 
   @override
-  String get tap_to_answer => 'Tap here to answer questions';
+  String get tap_to_answer => 'கேள்விகளுக்கு பதிலளிக்க இங்கே தட்டவும்';
 
   @override
   String get tap_to_answer_hint =>
@@ -513,7 +523,7 @@ class AppLocalizationsTa extends AppLocalizations {
       'இந்தத் தயாரிப்புபற்றிய கேள்விகள் ஏற்றப்படும் வரை காத்திருக்கவும்';
 
   @override
-  String get saving_answer => 'Saving your answer';
+  String get saving_answer => 'உங்கள் பதிலைச் சேமிக்கிறது';
 
   @override
   String get contribute_to_get_rewards =>
@@ -521,79 +531,83 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get question_sign_in_text =>
-      'Sign in to your Open Food Facts account to get credit for your contributions';
+      'உங்கள் பங்களிப்புகளுக்கு கிரெடிட்டைப் பெற உங்கள் Open Food Facts கணக்கில் உள்நுழையவும்.';
 
   @override
-  String get question_yes_button_accessibility_value => 'Answer with yes';
+  String get question_yes_button_accessibility_value =>
+      'ஆம் என்று பதிலளிக்கவும்';
 
   @override
-  String get question_no_button_accessibility_value => 'Answer with no';
+  String get question_no_button_accessibility_value =>
+      'இல்லை என்று பதிலளிக்கவும்';
 
   @override
-  String get question_skip_button_accessibility_value => 'Skip this question';
+  String get question_skip_button_accessibility_value =>
+      'இந்தக் கேள்வியைத் தவிர்.';
 
   @override
-  String get tap_to_edit_search => 'Tap to edit search';
+  String get tap_to_edit_search => 'தேடலைத் திருத்த தட்டவும்';
 
   @override
-  String get myPreferences => 'My preferences';
+  String get myPreferences => 'எனது விருப்பத்தேர்வுகள்';
 
   @override
   String get account_create_message =>
-      'Create your account and join the Open Food Facts community to help build food knowledge all over the world!';
+      'உலகம் முழுவதும் உணவு அறிவை வளர்க்க உதவ, உங்கள் கணக்கை உருவாக்கி, திறந்த உணவு உண்மைகள் சமூகத்தில் சேருங்கள்!';
 
   @override
-  String get join_us => 'Join us';
+  String get join_us => 'எங்களுடன் சேருங்கள்';
 
   @override
-  String get myPreferences_profile_title => 'Your Profile';
+  String get myPreferences_profile_title => 'உங்கள் சுயவிவரம்';
 
   @override
   String get myPreferences_profile_subtitle =>
-      'Manage your Open Food Facts contributor account.';
+      'உங்கள் திறந்த உணவு உண்மைகள் பங்களிப்பாளர் கணக்கை நிர்வகிக்கவும்.';
 
   @override
-  String get myPreferences_settings_title => 'App Settings';
+  String get myPreferences_settings_title => 'பயன்பாட்டு அமைப்புகள்';
 
   @override
   String get myPreferences_settings_subtitle => 'இருண்ட பயன்முறை, மொழிகள்…';
 
   @override
-  String get myPreferences_food_title => 'Food Preferences';
+  String get myPreferences_food_title => 'உணவு விருப்பத்தேர்வுகள்';
 
   @override
   String get myPreferences_food_subtitle =>
-      'Choose what information about food matters most to you.';
+      'உணவு பற்றிய எந்தத் தகவல் உங்களுக்கு மிகவும் முக்கியமானது என்பதைத் தேர்வுசெய்யவும்.';
 
   @override
   String get myPreferences_food_comment =>
-      'Choose what information about food matters most to you, in order to rank food according to your preferences, see the information you care about first, and get a compatibility summary. Those food preferences stay on your device, and are not associated with your Open Food Facts contributor account if you have one.';
+      'உங்கள் விருப்பங்களுக்கு ஏற்ப உணவை தரவரிசைப்படுத்த, முதலில் நீங்கள் அக்கறை கொள்ளும் தகவலைப் பார்த்து, பொருந்தக்கூடிய சுருக்கத்தைப் பெற, உணவைப் பற்றிய எந்தத் தகவல் உங்களுக்கு மிகவும் முக்கியமானது என்பதைத் தேர்வுசெய்யவும். அந்த உணவு விருப்பத்தேர்வுகள் உங்கள் சாதனத்திலேயே இருக்கும், மேலும் உங்களிடம் Open Food Facts பங்களிப்பாளர் கணக்கு இருந்தால் அதனுடன் தொடர்புடையதாக இருக்காது.';
 
   @override
-  String get confirmResetPreferences => 'Reset your food preferences?';
+  String get confirmResetPreferences =>
+      'உங்கள் உணவு விருப்பங்களை மீட்டமைக்கவா?';
 
   @override
-  String get myPersonalizedRanking => 'My personalized ranking';
+  String get myPersonalizedRanking => 'எனது தனிப்பயனாக்கப்பட்ட தரவரிசை';
 
   @override
   String get ranking_tab_all => 'All';
 
   @override
-  String get ranking_subtitle_match_yes => 'A great match for you';
+  String get ranking_subtitle_match_yes => 'உங்களுக்கு ஒரு சிறந்த போட்டி';
 
   @override
-  String get ranking_subtitle_match_no => 'Very poor match';
+  String get ranking_subtitle_match_no => 'மிகவும் மோசமான பொருத்தம்';
 
   @override
-  String get ranking_subtitle_match_maybe => 'Unknown match';
+  String get ranking_subtitle_match_maybe => 'தெரியாத பொருத்தம்';
 
   @override
   String get refresh_with_new_preferences =>
-      'Refresh the list with your new preferences';
+      'உங்கள் புதிய விருப்பத்தேர்வுகளுடன் பட்டியலைப் புதுப்பிக்கவும்.';
 
   @override
   String get reloaded_with_new_preferences =>
-      'Reloaded with your new preferences';
+      'உங்கள் புதிய விருப்பத்தேர்வுகளுடன் மீண்டும் ஏற்றப்பட்டது';
 
   @override
   String get profile_navbar_label => 'Community';
@@ -605,22 +619,22 @@ class AppLocalizationsTa extends AppLocalizations {
   String get history_navbar_label => 'வரலாறு';
 
   @override
-  String get list_navbar_label => 'Lists';
+  String get list_navbar_label => 'பட்டியல்கள்';
 
   @override
-  String get category => 'Filter by category';
+  String get category => 'வகையின்படி வடிகட்டவும்';
 
   @override
   String get category_all => 'All';
 
   @override
-  String get category_search => '(category search)';
+  String get category_search => '(வகை தேடல்)';
 
   @override
-  String get filter => 'Filter';
+  String get filter => 'வடிகட்டி';
 
   @override
-  String get scan => 'Products from the Scan screen';
+  String get scan => 'ஸ்கேன் திரையில் இருந்து தயாரிப்புகள்';
 
   @override
   String get scan_history => 'வரலாற்றை ஸ்கேன் செய்யவும்';
@@ -646,16 +660,19 @@ class AppLocalizationsTa extends AppLocalizations {
       'குறிப்பு: நகரம் அல்லது நாட்டைச் சேர்க்கவும்.';
 
   @override
-  String get tap_for_more => 'Tap to see more info…';
+  String get tap_for_more => 'மேலும் தகவலைப் பார்க்க…தட்டவும்';
 
   @override
   String get product => 'Product';
 
   @override
-  String get unknownBrand => 'Unknown brand';
+  String get unknownBrand => 'தெரியாத பிராண்ட்';
 
   @override
-  String get unknownProductName => 'Unknown product name';
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
+  String get unknownProductName => 'தெரியாத தயாரிப்பு பெயர்';
 
   @override
   String get label_refresh => 'Refresh';
@@ -664,14 +681,14 @@ class AppLocalizationsTa extends AppLocalizations {
   String get label_reload => 'மீண்டும் ஏற்றவும்';
 
   @override
-  String get image => 'Image';
+  String get image => 'படம்';
 
   @override
-  String get front_photo => 'Front photo';
+  String get front_photo => 'முன்பக்க புகைப்படம்';
 
   @override
   String outdated_image_accessibility_label(Object imageType) {
-    return '$imageType (this image may be outdated)';
+    return '$imageType (இந்தப் படம் காலாவதியானதாக இருக்கலாம்)';
   }
 
   @override
@@ -685,125 +702,127 @@ class AppLocalizationsTa extends AppLocalizations {
       'அசல் ஆர்டரை வைத்திருங்கள். குறிப்பிடப்படும்போது சதவீதத்தைக் குறிக்கவும். காற்புள்ளி அல்லது ஹைபனுடன் பிரித்து, மூலப்பொருளின் பொருட்களுக்கு அடைப்புக்குறிகளைப் பயன்படுத்தவும்.';
 
   @override
-  String get ingredients_editing_error => 'Failed to save the ingredients.';
+  String get ingredients_editing_error => 'பொருட்களைச் சேமிக்க முடியவில்லை.';
 
   @override
   String get ingredients_editing_image_error =>
-      'Failed to get a new ingredients image.';
+      'புதிய மூலப்பொருட்கள் படத்தைப் பெற முடியவில்லை.';
 
   @override
-  String get ingredients_editing_title => 'Edit Ingredients';
+  String get ingredients_editing_title => 'தேவையான பொருட்களைத் திருத்து';
 
   @override
-  String get ingredients_photo => 'Ingredients photo';
+  String get ingredients_photo => 'பொருட்கள் புகைப்படம்';
 
   @override
   String get packaging_editing_instructions =>
-      'List all packaging parts separated by a comma or line feed, with their amount (e.g. 1 or 6) type (e.g. bottle, box, can), material (e.g. plastic, metal, aluminium) and if available their size (e.g. 33cl) and recycling instructions.\nExample: 1 glass bottle to recycle, 1 plastic cork to throw away';
+      'காற்புள்ளி அல்லது வரி ஊட்டத்தால் பிரிக்கப்பட்ட அனைத்து பேக்கேஜிங் பாகங்களையும் பட்டியலிடுங்கள், அவற்றின் அளவு (எ.கா. 1 அல்லது 6) வகை (எ.கா. பாட்டில், பெட்டி, கேன்), பொருள் (எ.கா. பிளாஸ்டிக், உலோகம், அலுமினியம்) மற்றும் கிடைத்தால் அவற்றின் அளவு (எ.கா. 33cl) மற்றும் மறுசுழற்சி வழிமுறைகளுடன்.\nஎடுத்துக்காட்டு: மறுசுழற்சி செய்ய 1 கண்ணாடி பாட்டில், தூக்கி எறிய 1 பிளாஸ்டிக் கார்க்';
 
   @override
-  String get packaging_editing_error => 'Failed to save the packaging.';
+  String get packaging_editing_error => 'தொகுப்பைச் சேமிக்க முடியவில்லை.';
 
   @override
   String get packaging_editing_image_error =>
-      'Failed to get a new packaging image.';
+      'புதிய பேக்கேஜிங் படத்தைப் பெற முடியவில்லை.';
 
   @override
-  String get packaging_editing_title => 'Edit Packaging';
+  String get packaging_editing_title => 'பேக்கேஜிங்கைத் திருத்து';
 
   @override
   String get nutrition => 'ஊட்டச்சத்து';
 
   @override
-  String get nutrition_facts_photo => 'Nutrition facts photo';
+  String get nutrition_facts_photo => 'ஊட்டச்சத்து உண்மைகள் புகைப்படம்';
 
   @override
   String get nutrition_facts_editing_title =>
       'ஊட்டச்சத்து உண்மைகளைத் திருத்தவும்';
 
   @override
-  String get packaging_information => 'Packaging information';
+  String get packaging_information => 'பேக்கேஜிங் தகவல்';
 
   @override
-  String get packaging_information_photo => 'Packaging information photo';
+  String get packaging_information_photo => 'பேக்கேஜிங் தகவல் புகைப்படம்';
 
   @override
-  String get missing_product => 'You found a new product!';
+  String get missing_product =>
+      'நீங்கள் ஒரு புதிய தயாரிப்பைக் கண்டுபிடித்தீர்கள்!';
 
   @override
   String get add_product_take_photos =>
-      'Take photos of the packaging to add this product to Open Food Facts';
+      'இந்த தயாரிப்பை Open Food Facts இல் சேர்க்க, பேக்கேஜிங்கின் புகைப்படங்களை எடுக்கவும்.';
 
   @override
   String get add_product_take_photos_descriptive =>
-      'Please take some photos first. You may always complete the product at a later time.';
+      'முதலில் சில புகைப்படங்களை எடுத்துக் கொள்ளுங்கள். நீங்கள் எப்போதும் தயாரிப்பை பின்னர் முடிக்கலாம்.';
 
   @override
   String get add_product_information_button_label => 'Add product information';
 
   @override
-  String get new_product => 'New Product';
+  String get new_product => 'புதிய தயாரிப்பு';
 
   @override
   String get new_product_found_title => 'புதிய தயாரிப்பு கிடைத்தது!';
 
   @override
   String get new_product_found_text =>
-      'Our collaborative database contains more than **3 million products**, but this barcode doesn\'t exist: ';
+      'எங்கள் கூட்டு தரவுத்தளத்தில் **3 மில்லியனுக்கும் அதிகமான தயாரிப்புகள்** உள்ளன, ஆனால் இந்த பார்கோடு இல்லை: ';
 
   @override
   String get new_product_found_button => 'Add this product';
 
   @override
-  String get new_product_leave_title => 'Leave this page?';
+  String get new_product_leave_title => 'இந்தப் பக்கத்தை விட்டு வெளியேறவா?';
 
   @override
   String get new_product_leave_message =>
-      'It looks like you didn\'t input anything. Do you really want to leave this page?';
+      'நீங்கள் எதையும் உள்ளிடவில்லை போலிருக்கிறது. இந்தப் பக்கத்தை விட்டு வெளியேற விரும்புகிறீர்களா?';
 
   @override
   String get new_product_dialog_description =>
-      'Please take photos of the packaging to add this product to our common database';
+      'இந்த தயாரிப்பை எங்கள் பொதுவான தரவுத்தளத்தில் சேர்க்க, பேக்கேஜிங்கின் புகைப்படங்களை எடுக்கவும்.';
 
   @override
   String get new_product_dialog_illustration_description =>
-      'An illustration with unknown Nutri-Score and Green Score';
+      'தெரியாத நியூட்ரி-ஸ்கோர் மற்றும் கிரீன் ஸ்கோர் கொண்ட ஒரு விளக்கம்';
 
   @override
-  String get front_packaging_photo_button_label => 'Front packaging photo';
+  String get front_packaging_photo_button_label =>
+      'முன்பக்க பேக்கேஜிங் புகைப்படம்';
 
   @override
   String get confirm_front_packaging_photo_button_label =>
-      'Confirm upload of Front packaging photo';
+      'முன்பக்க பேக்கேஜிங் புகைப்படத்தைப் பதிவேற்றுவதை உறுதிப்படுத்தவும்.';
 
   @override
-  String get confirm_button_label => 'Confirm';
+  String get confirm_button_label => 'உறுதிப்படுத்தவும்';
 
   @override
-  String get send_image_button_label => 'Send image';
+  String get send_image_button_label => 'படத்தை அனுப்பு';
 
   @override
-  String get crop_page_action_saving => 'Saving the image…';
+  String get crop_page_action_saving => 'படத்தைச் சேமிக்கிறது…';
 
   @override
-  String get crop_page_action_cropping => 'Cropping the image…';
+  String get crop_page_action_cropping => 'படத்தை செதுக்குதல்…';
 
   @override
-  String get crop_page_action_local => 'Saving a local version…';
+  String get crop_page_action_local => 'உள்ளூர் பதிப்பைச் சேமிக்கிறது…';
 
   @override
   String get crop_page_action_local_failed_title =>
-      'Oops… there\'s something with your photo!';
+      'ஐயோ… உங்க போட்டோல ஏதோ இருக்கு!';
 
   @override
   String get crop_page_action_local_failed_message =>
-      'We are unable to process the image locally, before sending it to our server. Please try again later or contact-us if the issue persists.';
+      'எங்கள் சேவையகத்திற்கு அனுப்புவதற்கு முன்பு, படத்தை உள்ளூரில் செயலாக்க முடியவில்லை. தயவுசெய்து பின்னர் மீண்டும் முயற்சிக்கவும் அல்லது சிக்கல் தொடர்ந்தால் எங்களைத் தொடர்பு கொள்ளவும்.';
 
   @override
   String get crop_page_action_retake => 'மீண்டும் ஒரு புகைப்படம் எடுக்கவும்';
 
   @override
-  String get crop_page_too_small_image_title => 'The image is too small!';
+  String get crop_page_too_small_image_title => 'படம் ரொம்ப சின்னதா இருக்கு!';
 
   @override
   String crop_page_too_small_image_message(
@@ -812,23 +831,24 @@ class AppLocalizationsTa extends AppLocalizations {
     int actualWidth,
     int actualHeight,
   ) {
-    return 'The minimum size in pixels for picture upload is ${expectedMinWidth}x$expectedMinHeight. The current picture is ${actualWidth}x$actualHeight.';
+    return 'படத்தைப் பதிவேற்றுவதற்கான குறைந்தபட்ச பிக்சல் அளவு ${expectedMinWidth}x$expectedMinHeightஆகும். தற்போதைய படம் ${actualWidth}x$actualHeightஆகும்.';
   }
 
   @override
-  String get crop_page_action_server => 'Preparing a call to the server…';
+  String get crop_page_action_server =>
+      'சேவையகத்திற்கு அழைப்பைத் தயார்படுத்துதல்…';
 
   @override
-  String get front_packaging_photo_title => 'Front Packaging Photo';
+  String get front_packaging_photo_title => 'முன்பக்க பேக்கேஜிங் புகைப்படம்';
 
   @override
-  String get ingredients_photo_title => 'Ingredients Photo';
+  String get ingredients_photo_title => 'பொருட்கள் புகைப்படம்';
 
   @override
-  String get nutritional_facts_photo_title => 'Nutrition Facts Photo';
+  String get nutritional_facts_photo_title => 'ஊட்டச்சத்து உண்மைகள் புகைப்படம்';
 
   @override
-  String get recycling_photo_title => 'Recycling Photo';
+  String get recycling_photo_title => 'மறுசுழற்சி புகைப்படம்';
 
   @override
   String get take_photo_title => 'ஒரு படம் எடு';
@@ -837,159 +857,171 @@ class AppLocalizationsTa extends AppLocalizations {
   String get take_more_photo_title => 'Take more photos';
 
   @override
-  String get front_photo_uploaded => 'Front photo uploaded';
+  String get front_photo_uploaded => 'முன்பக்கப் புகைப்படம் பதிவேற்றப்பட்டது';
 
   @override
-  String get ingredients_photo_button_label => 'Ingredients photo';
+  String get ingredients_photo_button_label => 'பொருட்கள் புகைப்படம்';
 
   @override
-  String get ingredients_photo_uploaded => 'Ingredients photo uploaded';
+  String get ingredients_photo_uploaded =>
+      'தேவையான பொருட்கள் புகைப்படம் பதிவேற்றப்பட்டது';
 
   @override
   String get nutrition_cache_loading_error =>
-      'Unable to load nutrients from cache';
+      'தற்காலிக சேமிப்பிலிருந்து ஊட்டச்சத்துக்களை ஏற்ற முடியவில்லை.';
 
   @override
-  String get nutritional_facts_photo_button_label => 'Nutrition facts photo';
+  String get nutritional_facts_photo_button_label =>
+      'ஊட்டச்சத்து உண்மைகள் புகைப்படம்';
 
   @override
-  String get nutritional_facts_input_button_label => 'Fill nutrition facts';
+  String get nutritional_facts_input_button_label =>
+      'ஊட்டச்சத்து உண்மைகளை நிரப்பவும்.';
 
   @override
-  String get nutritional_facts_added => 'Nutrition facts added';
+  String get nutritional_facts_added => 'ஊட்டச்சத்து உண்மைகள் சேர்க்கப்பட்டன';
 
   @override
-  String get categories_added => 'Categories added';
+  String get categories_added => 'வகைகள் சேர்க்கப்பட்டன';
 
   @override
-  String get new_product_title_nutriscore => 'Compute the Nutri-Score';
+  String get new_product_title_nutriscore => 'நியூட்ரி-ஸ்கோரைக் கணக்கிடுங்கள்';
 
   @override
   String get new_product_subtitle_nutriscore =>
       'உணவு வகை மற்றும் ஊட்டச்சத்து மதிப்புகளை நிரப்புவதன் மூலம் அதைப் பெறுங்கள்';
 
   @override
-  String get new_product_title_environmental_score => 'Compute the Green Score';
+  String get new_product_title_environmental_score =>
+      'பச்சை மதிப்பெண்ணைக் கணக்கிடுங்கள்';
 
   @override
   String get new_product_subtitle_environmental_score =>
-      'Get it by filling at least a category';
+      'குறைந்தபட்சம் ஒரு வகையையாவது நிரப்புவதன் மூலம் அதைப் பெறுங்கள்.';
 
   @override
   String get new_product_additional_environmental_score =>
-      'Make Green Score computation more precise with origins, packaging & more';
+      'தோற்றம், பேக்கேஜிங் மற்றும் பலவற்றைக் கொண்டு பசுமை மதிப்பெண் கணக்கீட்டை மிகவும் துல்லியமாக்குங்கள்.';
 
   @override
   String get new_product_title_nova =>
-      'Compute the food processing level (NOVA)';
+      'உணவு பதப்படுத்தும் அளவை (NOVA) கணக்கிடுங்கள்.';
 
   @override
   String get new_product_subtitle_nova =>
-      'Get it by filling the food category and ingredients';
+      'உணவு வகை மற்றும் பொருட்களை நிரப்புவதன் மூலம் அதைப் பெறுங்கள்.';
 
   @override
-  String get new_product_desc_nova_unknown => 'Food processing level unknown';
+  String get new_product_desc_nova_unknown =>
+      'உணவு பதப்படுத்தும் நிலை தெரியவில்லை';
 
   @override
-  String get new_product_title_pictures => 'New product';
+  String get new_product_title_pictures => 'புதிய தயாரிப்பு';
 
   @override
   String get new_product_title_pictures_details =>
-      'Please take the following photos and the Open Food Facts engine can work out the rest!';
+      'பின்வரும் புகைப்படங்களை எடுங்கள், மீதமுள்ளவற்றை ஓபன் ஃபுட் ஃபேக்ட்ஸ் எஞ்சின் சரிசெய்யும்!';
 
   @override
-  String get new_product_title_misc => 'And some basic data…';
+  String get new_product_title_misc => 'மேலும் சில அடிப்படைத் தரவு…';
 
   @override
   String new_product_done_msg(String username) {
-    return 'Thanks for your contribution “$username”!';
+    return 'உங்கள் பங்களிப்புக்கு நன்றி “$username”!';
   }
 
   @override
-  String get new_product_done_msg_no_user => 'Thanks for your contribution!';
+  String get new_product_done_msg_no_user => 'உங்கள் பங்களிப்புக்கு நன்றி!';
 
   @override
-  String get new_product_done_button_label => 'Discover the completed product';
+  String get new_product_done_button_label =>
+      'முடிக்கப்பட்ட தயாரிப்பைக் கண்டறியவும்.';
 
   @override
   String get hey_incomplete_product_message =>
-      'Tap to answer 3 questions NOW to compute Nutri-Score, Green Score & Ultra-processing (NOVA)!';
+      'நியூட்ரி-ஸ்கோர், கிரீன் ஸ்கோர் & அல்ட்ரா-பிராசசிங் (NOVA) ஆகியவற்றைக் கணக்கிட 3 கேள்விகளுக்கு இப்போதே பதிலளிக்க தட்டவும்!';
 
   @override
   String get hey_incomplete_product_message_beauty =>
-      'Tap now to answer 2 questions to help analyze this cosmetic!';
+      'இந்த அழகுசாதனப் பொருளை பகுப்பாய்வு செய்ய உதவும் 2 கேள்விகளுக்கு பதிலளிக்க இப்போதே தட்டவும்!';
 
   @override
   String get hey_incomplete_product_message_pet_food =>
-      'Tap now to answer 3 questions to help analyze this pet food product!';
+      'இந்த செல்லப்பிராணி உணவு தயாரிப்பை பகுப்பாய்வு செய்ய உதவும் 3 கேள்விகளுக்கு பதிலளிக்க இப்போதே தட்டவும்!';
 
   @override
   String get hey_incomplete_product_message_product =>
-      'Tap now to help complete this product!';
+      'இந்த தயாரிப்பை முடிக்க உதவ இப்போது தட்டவும்!';
 
   @override
   String get nutritional_facts_photo_uploaded =>
-      'Nutrition facts photo uploaded';
+      'ஊட்டச்சத்து உண்மைகள் புகைப்படம் பதிவேற்றப்பட்டது';
 
   @override
-  String get recycling_photo_button_label => 'Recycling photo';
+  String get recycling_photo_button_label => 'மறுசுழற்சி புகைப்படம்';
 
   @override
-  String get recycling_photo_uploaded => 'Recycling photo uploaded';
+  String get recycling_photo_uploaded =>
+      'மறுசுழற்சி புகைப்படம் பதிவேற்றப்பட்டது';
 
   @override
   String get take_more_photo_button_label => 'Take more photos';
 
   @override
-  String get other_photo_uploaded => 'Miscellaneous photo uploaded';
+  String get other_photo_uploaded => 'பல்வேறு புகைப்படம் பதிவேற்றப்பட்டது';
 
   @override
-  String get retake_photo_button_label => 'Retake';
+  String get retake_photo_button_label => 'மீண்டும் எடு';
 
   @override
-  String get selecting_photo => 'Selecting photo';
+  String get selecting_photo => 'புகைப்படத்தைத் தேர்ந்தெடுக்கிறது';
 
   @override
-  String get uploading_image => 'Uploading photo to the server';
+  String get uploading_image => 'புகைப்படத்தை சேவையகத்தில் பதிவேற்றுகிறது';
 
   @override
   String get uploading_image_type_front =>
-      'Uploading front image to Open Food Facts';
+      'திறந்த உணவு உண்மைகளுக்கு முன் படத்தை பதிவேற்றுகிறது';
 
   @override
   String get uploading_image_type_ingredients =>
-      'Uploading ingredients image to Open Food Facts';
+      'உணவு உண்மைகள் திறந்தநிலையில் பொருட்களின் படத்தை பதிவேற்றுகிறது';
 
   @override
   String get uploading_image_type_nutrition =>
-      'Uploading nutrition image to Open Food Facts';
+      'ஊட்டச்சத்து படத்தை திறந்த உணவு உண்மைகளில் பதிவேற்றுகிறது';
 
   @override
   String get uploading_image_type_packaging =>
-      'Uploading packaging image to Open Food Facts';
+      'திறந்த உணவு உண்மைகளுக்கு பேக்கேஜிங் படத்தை பதிவேற்றுதல்';
 
   @override
   String get uploading_image_type_other =>
-      'Uploading other image to Open Food Facts';
+      'திறந்த உணவு உண்மைகளுக்கு மற்றொரு படத்தை பதிவேற்றுகிறது';
 
   @override
   String get uploading_image_type_generic =>
-      'Uploading image to Open Food Facts';
+      'திறந்த உணவு உண்மைகளுக்கு படத்தை பதிவேற்றுகிறது';
 
   @override
-  String get score_add_missing_ingredients => 'Add missing ingredients';
+  String get score_add_missing_ingredients =>
+      'விடுபட்ட பொருட்களைச் சேர்க்கவும்';
 
   @override
-  String get score_add_missing_packaging_image => 'Add missing packaging image';
+  String get score_add_missing_packaging_image =>
+      'விடுபட்ட பேக்கேஜிங் படத்தைச் சேர்க்கவும்';
 
   @override
-  String get score_add_missing_nutrition_facts => 'Add missing nutrition facts';
+  String get score_add_missing_nutrition_facts =>
+      'விடுபட்ட ஊட்டச்சத்து உண்மைகளைச் சேர்க்கவும்.';
 
   @override
-  String get score_add_missing_product_traces => 'Add missing product traces';
+  String get score_add_missing_product_traces =>
+      'விடுபட்ட தயாரிப்பு தடயங்களைச் சேர்க்கவும்.';
 
   @override
-  String get score_add_missing_product_category => 'Select a category';
+  String get score_add_missing_product_category =>
+      'ஒரு வகையைத் தேர்ந்தெடுக்கவும்';
 
   @override
   String get score_add_missing_precise_product_category =>
@@ -997,26 +1029,31 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get score_add_missing_product_countries =>
-      'Add missing product countries';
+      'விடுபட்ட தயாரிப்பு நாடுகளைச் சேர்க்கவும்';
 
   @override
   String get score_add_missing_product_emb =>
-      'Add missing product traceability codes';
+      'விடுபட்ட தயாரிப்பு கண்காணிப்பு குறியீடுகளைச் சேர்க்கவும்.';
 
   @override
-  String get score_add_missing_product_labels => 'Add missing product labels';
+  String get score_add_missing_product_labels =>
+      'விடுபட்ட தயாரிப்பு லேபிள்களைச் சேர்க்கவும்.';
 
   @override
-  String get score_add_missing_product_origins => 'Add missing product origins';
+  String get score_add_missing_product_origins =>
+      'விடுபட்ட தயாரிப்பு மூலங்களைச் சேர்க்கவும்';
 
   @override
-  String get score_add_missing_product_stores => 'Add missing product stores';
+  String get score_add_missing_product_stores =>
+      'விடுபட்ட தயாரிப்பு கடைகளைச் சேர்க்கவும்.';
 
   @override
-  String get score_add_missing_product_brands => 'Add missing product brands';
+  String get score_add_missing_product_brands =>
+      'விடுபட்ட தயாரிப்பு பிராண்டுகளைச் சேர்க்கவும்.';
 
   @override
-  String get score_update_nutrition_facts => 'Update nutrition facts';
+  String get score_update_nutrition_facts =>
+      'ஊட்டச்சத்து உண்மைகளைப் புதுப்பிக்கவும்';
 
   @override
   String get nutrition_page_title => 'ஊட்டச்சத்து தகவல்கள்';
@@ -1040,29 +1077,29 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get nutrition_page_nutritional_info_explanation_title =>
-      'Good practices: Nutritional information';
+      'நல்ல நடைமுறைகள்: ஊட்டச்சத்து தகவல்கள்';
 
   @override
   String get nutrition_page_nutritional_info_explanation_info1 =>
-      'Sometimes nutrition facts are **not specified on the packaging** or on a document given with the product. In this case, and only in this case, you can set the value to **NO**.';
+      'சில நேரங்களில் ஊட்டச்சத்து உண்மைகள் **பேக்கேஜிங்கில்** அல்லது தயாரிப்புடன் கொடுக்கப்பட்ட ஆவணத்தில் குறிப்பிடப்படவில்லை. இந்த விஷயத்தில், இந்த விஷயத்தில் மட்டுமே, நீங்கள் மதிப்பை **இல்லை** என்று அமைக்கலாம்.';
 
   @override
   String get nutrition_page_serving_type_label => 'ஊட்டச்சத்து மதிப்புகள்:';
 
   @override
-  String get nutrition_page_per_100g => 'per 100g';
+  String get nutrition_page_per_100g => '100 கிராமுக்கு';
 
   @override
   String get nutrition_page_per_100g_100ml => '100 கிராம்/மிலிக்கு';
 
   @override
-  String get nutrition_page_per_serving => 'per serving';
+  String get nutrition_page_per_serving => 'ஒரு பரிமாறலுக்கு';
 
   @override
-  String get nutrition_page_add_nutrient => 'Add a nutrient';
+  String get nutrition_page_add_nutrient => 'ஒரு ஊட்டச்சத்தைச் சேர்க்கவும்.';
 
   @override
-  String get nutrition_page_serving_size => 'Serving size';
+  String get nutrition_page_serving_size => 'பரிமாறும் அளவு';
 
   @override
   String get nutrition_page_serving_size_hint =>
@@ -1070,86 +1107,86 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get nutrition_page_serving_size_explanation_title =>
-      'Good practices: Serving size';
+      'நல்ல நடைமுறைகள்: பரிமாறும் அளவு';
 
   @override
   String get nutrition_page_serving_size_explanation_info1 =>
-      'This value helps to **make a proportional calculation of each nutrient per serving size**.';
+      'இந்த மதிப்பு **பரிமாறும் அளவிற்கு ஒவ்வொரு ஊட்டச்சத்தின் விகிதாசார கணக்கீட்டைச் செய்ய** உதவுகிறது.';
 
   @override
   String get nutrition_page_serving_size_explanation_info2 =>
-      '**Allowed units** are: kg, g, mg, µg, oz, l, dl, cl, ml, fl.oz, fl oz, г, мг, кг, л, дл, кл, мл, 毫克, 公斤, 毫升, 公升, 吨.';
+      '**அனுமதிக்கப்பட்ட அலகுகள்**: kg, g, mg, µg, oz, l, dl, cl, ml, fl.oz, fl oz, г, мг, кг, л, дл, кл, мл, 毫克, 公斤, 毫娍,';
 
   @override
   String get nutrition_page_serving_size_explanation_good_example1 =>
-      '**60 g**, **60g** or **60 G** (prefer the first one)';
+      '**60 கிராம்**, **60 கிராம்** அல்லது **60 கிராம்** (முதலாவது ஒன்றை விரும்புங்கள்)';
 
   @override
   String get nutrition_page_serving_size_explanation_good_example2 =>
-      '**1000 ml** or **1L**';
+      '**1000 மிலி** அல்லது **1லி**';
 
   @override
   String get nutrition_page_serving_size_explanation_bad_example1_explanation =>
-      'Invalid unit';
+      'தவறான அலகு';
 
   @override
   String get nutrition_page_serving_size_explanation_bad_example1_example =>
-      '30 **gr**';
+      '30 **கிராம்**';
 
   @override
   String get nutrition_page_serving_size_explanation_bad_example2_explanation =>
-      'Invalid units';
+      'தவறான அலகுகள்';
 
   @override
   String get nutrition_page_serving_size_explanation_bad_example2_example =>
-      '9 **candies** and 2 **biscuits**';
+      '9 **மிட்டாய்கள்** மற்றும் 2 **பிஸ்கட்டுகள்**';
 
   @override
   String get nutrition_page_serving_size_explanation_bad_example3_explanation =>
-      'Missing unit';
+      'அலகு இல்லை';
 
   @override
   String get nutrition_page_serving_size_explanation_bad_example3_example =>
       '**30**';
 
   @override
-  String get nutrition_page_invalid_number => 'Invalid number';
+  String get nutrition_page_invalid_number => 'தவறான எண்';
 
   @override
   String get nutrition_page_update_running =>
-      'Updating the product on the server…';
+      'சேவையகத்தில் தயாரிப்பைப் புதுப்பித்தல்…';
 
   @override
-  String get nutrition_page_update_done => 'Product updated!';
+  String get nutrition_page_update_done => 'தயாரிப்பு புதுப்பிக்கப்பட்டது!';
 
   @override
   String get nutrition_page_take_serving_size_from_product_quantity =>
-      'Use the product quantity as serving size';
+      'தயாரிப்பு அளவை பரிமாறும் அளவாகப் பயன்படுத்தவும்.';
 
   @override
   String get nutrition_page_photo_error => 'புகைப்படத்தை ஏற்ற முடியவில்லை';
 
   @override
-  String get more_photos => 'More interesting photos';
+  String get more_photos => 'மேலும் சுவாரஸ்யமான புகைப்படங்கள்';
 
   @override
   String get view_more_photo_button =>
-      'View all existing photos for this product';
+      'இந்த தயாரிப்புக்கான ஏற்கனவே உள்ள அனைத்து புகைப்படங்களையும் காண்க.';
 
   @override
-  String get no_product_found => 'No product found';
+  String get no_product_found => 'எந்த தயாரிப்பும் கிடைக்கவில்லை.';
 
   @override
-  String get no_location_found => 'No location found';
+  String get no_location_found => 'எந்த இடமும் கிடைக்கவில்லை.';
 
   @override
-  String get not_found => 'not found:';
+  String get not_found => 'கிடைக்கவில்லை:';
 
   @override
-  String get refreshing_product => 'Refreshing product';
+  String get refreshing_product => 'புத்துணர்ச்சியூட்டும் தயாரிப்பு';
 
   @override
-  String get product_refreshed => 'Product refreshed';
+  String get product_refreshed => 'தயாரிப்பு புதுப்பிக்கப்பட்டது';
 
   @override
   String product_image_accessibility_label(String date) {
@@ -1158,28 +1195,28 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String product_image_outdated_accessibility_label(String date) {
-    return 'Image taken on $date. This image may be outdated';
+    return '$dateஅன்று எடுக்கப்பட்ட படம். இந்தப் படம் காலாவதியானதாக இருக்கலாம்.';
   }
 
   @override
-  String get product_image_outdated => 'This image may be outdated';
+  String get product_image_outdated => 'இந்தப் படம் காலாவதியானதாக இருக்கலாம்.';
 
   @override
   String get product_image_outdated_explanations_title =>
-      'This image may be outdated';
+      'இந்தப் படம் காலாவதியானதாக இருக்கலாம்.';
 
   @override
   String get product_image_outdated_explanations_content =>
-      'This image was taken more than a year ago.\n**Please check that\'s it\'s still up-to-date**.\n\nThis is **just a warning**. If the content is still the same, you can ignore this message.';
+      'இந்தப் படம் ஒரு வருடத்திற்கு முன்பு எடுக்கப்பட்டது.\n**இது இன்னும் புதுப்பித்த நிலையில் உள்ளதா எனப் பார்க்கவும்**.\n\nஇது **வெறும் எச்சரிக்கை**. உள்ளடக்கம் இன்னும் அப்படியே இருந்தால், இந்தச் செய்தியை நீங்கள் புறக்கணிக்கலாம்.';
 
   @override
   String product_image_action_replace_photo(String type) {
-    return 'Replace photo ($type)';
+    return 'புகைப்படத்தை மாற்றவும் ($type)';
   }
 
   @override
   String product_image_action_add_photo(String type) {
-    return 'Add a photo ($type)';
+    return 'ஒரு புகைப்படத்தைச் சேர்க்கவும் ($type)';
   }
 
   @override
@@ -1190,11 +1227,11 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get product_image_action_from_gallery =>
-      'Select from your phone\'s gallery';
+      'உங்கள் தொலைபேசியின் கேலரியில் இருந்து தேர்ந்தெடுக்கவும்';
 
   @override
   String get product_image_action_choose_existing_photo =>
-      'Select from the product photos';
+      'தயாரிப்பு புகைப்படங்களிலிருந்து தேர்ந்தெடுக்கவும்';
 
   @override
   String get product_image_details_label => 'புகைப்படம் பற்றிய தகவல்';
@@ -1210,71 +1247,74 @@ class AppLocalizationsTa extends AppLocalizations {
       'பங்களிப்பாளர் (தயாரிப்பாளர்)';
 
   @override
-  String get product_image_details_date => 'Date';
+  String get product_image_details_date => 'தேதி';
 
   @override
-  String get product_image_details_date_unknown => 'Unknown';
+  String get product_image_details_date_unknown => 'தெரியவில்லை';
 
   @override
   String get homepage_main_card_logo_description =>
-      'Welcome to Open Food Facts';
+      'திறந்த உணவு உண்மைகளுக்கு வருக.';
 
   @override
   String get homepage_main_card_subheading =>
-      '**Scan** a barcode or\n**search** for a product';
+      '**பார்கோடை ஸ்கேன்** அல்லது\n**ஒரு பொருளைத் தேடுங்கள்**';
 
   @override
-  String get homepage_main_card_search_field_hint => 'Search for a product';
+  String get homepage_main_card_search_field_hint =>
+      'ஒரு தயாரிப்பைத் தேடுங்கள்';
 
   @override
-  String get homepage_main_card_search_field_tooltip => 'Start search';
+  String get homepage_main_card_search_field_tooltip => 'தேடலைத் தொடங்கு';
 
   @override
   String scan_tagline_news_item_accessibility(String news_title) {
-    return 'Latest news: $news_title';
+    return 'சமீபத்திய செய்திகள்: $news_title';
   }
 
   @override
-  String get tagline_app_review => 'Do you like the app?';
+  String get tagline_app_review => 'உங்களுக்கு இந்த ஆப்ஸ் பிடிக்குமா?';
 
   @override
-  String get tagline_app_review_button_positive => 'I love it! 😍';
+  String get tagline_app_review_button_positive =>
+      'எனக்கு ரொம்பப் பிடிச்சிருக்கு! 😍';
 
   @override
-  String get tagline_app_review_button_negative => 'Not really…';
+  String get tagline_app_review_button_negative => 'உண்மையில் இல்லை…';
 
   @override
-  String get tagline_app_review_button_later => 'Ask me later';
+  String get tagline_app_review_button_later => 'பிறகு கேளுங்கள்.';
 
   @override
-  String get tagline_feed_news_button => 'Know more';
+  String get tagline_feed_news_button => 'மேலும் அறிக';
 
   @override
-  String get app_review_negative_modal_title => 'You don\'t like our app?';
+  String get app_review_negative_modal_title =>
+      'எங்கள் பயன்பாடு உங்களுக்குப் பிடிக்கவில்லையா?';
 
   @override
   String get app_review_negative_modal_text =>
-      'Could you take a few seconds to tell us why?';
+      'ஏன் என்று சொல்ல சில வினாடிகள் ஒதுக்க முடியுமா?';
 
   @override
-  String get app_review_negative_modal_positive_button => 'Yes, absolutely!';
+  String get app_review_negative_modal_positive_button => 'ஆம், முற்றிலும்!';
 
   @override
   String get app_review_negative_modal_negative_button => 'இல்லை';
 
   @override
-  String get could_not_refresh => 'Could not refresh product';
+  String get could_not_refresh => 'தயாரிப்பைப் புதுப்பிக்க முடியவில்லை.';
 
   @override
-  String get product_internet_error_modal_title => 'An error has occurred!';
+  String get product_internet_error_modal_title => 'ஒரு பிழை ஏற்பட்டுள்ளது!';
 
   @override
   String product_internet_error_modal_message(String error) {
-    return 'We are unable to fetch information about this product due to a network error. Please check your internet connection and try again.\n\nInternal error:\n$error';
+    return 'நெட்வொர்க் பிழை காரணமாக இந்தத் தயாரிப்பு பற்றிய தகவலை எங்களால் பெற முடியவில்லை. உங்கள் இணைய இணைப்பைச் சரிபார்த்து மீண்டும் முயற்சிக்கவும்.\n\nஉள் பிழை:\n$error';
   }
 
   @override
-  String get product_tags_title => 'Product properties';
+  String get product_tags_title => 'தயாரிப்பு பண்புகள்';
 
   @override
   String get no_product_tags_found_message =>
@@ -1297,13 +1337,13 @@ class AppLocalizationsTa extends AppLocalizations {
   String get add_edit_tags => 'பண்புகளைச் சேர்க்கவும் அல்லது திருத்தவும்';
 
   @override
-  String get edit_tag => 'Edit property';
+  String get edit_tag => 'பண்பைத் திருத்து';
 
   @override
-  String get remove_tag => 'Remove property';
+  String get remove_tag => 'சொத்தை அகற்று';
 
   @override
-  String get tag_key => 'Property';
+  String get tag_key => 'சொத்து';
 
   @override
   String get tag_keys => 'பண்புகள்';
@@ -1340,10 +1380,10 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get product_internet_error =>
-      'Impossible to fetch information about this product due to a network error.';
+      'நெட்வொர்க் பிழை காரணமாக இந்தத் தயாரிப்பு பற்றிய தகவலைப் பெறுவது சாத்தியமில்லை.';
 
   @override
-  String get cached_results_from => 'Show results from:';
+  String get cached_results_from => 'இதிலிருந்து முடிவுகளைக் காட்டு:';
 
   @override
   String get product_search_same_category => 'மாற்று வழிகளைக் கண்டறியவும்';
@@ -1353,34 +1393,35 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get product_search_same_category_error =>
-      'This feature can only be used for products with a category.\n\nPlease edit the product to add a category.';
+      'இந்த அம்சத்தை வகையைக் கொண்ட தயாரிப்புகளுக்கு மட்டுமே பயன்படுத்த முடியும்.\n\nவகையைச் சேர்க்க தயாரிப்பைத் திருத்தவும்.';
 
   @override
   String get product_improvement_add_category =>
-      'Add a category to calculate the Nutri-Score.';
+      'நியூட்ரி-ஸ்கோரைக் கணக்கிட ஒரு வகையைச் சேர்க்கவும்.';
 
   @override
   String get product_improvement_add_nutrition_facts =>
-      'Add nutrition facts to calculate the Nutri-Score.';
+      'நியூட்ரி-ஸ்கோரைக் கணக்கிட ஊட்டச்சத்து உண்மைகளைச் சேர்க்கவும்.';
 
   @override
   String get product_improvement_add_nutrition_facts_and_category =>
-      'Add nutrition facts and a category to calculate the Nutri-Score.';
+      'ஊட்டச்சத்து மதிப்பெண்ணைக் கணக்கிட ஊட்டச்சத்து உண்மைகளையும் ஒரு வகையையும் சேர்க்கவும்.';
 
   @override
   String get product_improvement_categories_but_no_nutriscore =>
-      'The Nutri-Score for this product can\'t be calculated, which may be due to e.g. a non-standard category. If this is considered an error, please contact us.';
+      'இந்த தயாரிப்புக்கான நியூட்ரி-ஸ்கோரை கணக்கிட முடியாது, இது ஒரு தரமற்ற வகை காரணமாக இருக்கலாம். இது ஒரு பிழையாகக் கருதப்பட்டால், தயவுசெய்து எங்களைத் தொடர்பு கொள்ளவும்.';
 
   @override
   String get product_improvement_obsolete_nutrition_image =>
-      'The nutrition image is obsolete: please refresh it.';
+      'ஊட்டச்சத்து படம் காலாவதியானது: தயவுசெய்து அதைப் புதுப்பிக்கவும்.';
 
   @override
   String get product_improvement_origins_to_be_completed =>
-      'The Green Score takes into account the origins of the ingredients. Please take a photo of the ingredient list and/or any geographic claim or edit the product, so they can be taken into account.';
+      'பச்சை மதிப்பெண், பொருட்களின் தோற்றத்தை கணக்கில் எடுத்துக்கொள்கிறது. தயவுசெய்து மூலப்பொருள் பட்டியல் மற்றும்/அல்லது ஏதேனும் புவியியல் உரிமைகோரலை புகைப்படம் எடுக்கவும் அல்லது தயாரிப்பைத் திருத்தவும், இதனால் அவை கணக்கில் எடுத்துக்கொள்ளப்படும்.';
 
   @override
-  String get country_chooser_label => 'Please choose a country';
+  String get country_chooser_label =>
+      'தயவுசெய்து ஒரு நாட்டைத் தேர்ந்தெடுக்கவும்.';
 
   @override
   String get currency_chooser_label => 'நாணயத்தைத் தேர்வு செய்யவும்';
@@ -1398,55 +1439,60 @@ class AppLocalizationsTa extends AppLocalizations {
   }
 
   @override
-  String get onboarding_country_chooser_label => 'Please choose a country:';
+  String get onboarding_country_chooser_label =>
+      'தயவுசெய்து ஒரு நாட்டைத் தேர்ந்தெடுக்கவும்:';
 
   @override
-  String get country_chooser_label_from_settings => 'Your country';
+  String get country_chooser_label_from_settings => 'உங்கள் நாடு';
 
   @override
   String get country_selection_explanation =>
-      'Some environmental features are location-specific';
+      'சில சுற்றுச்சூழல் அம்சங்கள் இடம் சார்ந்தவை.';
 
   @override
-  String get product_removed_comparison => 'Product removed from comparison';
+  String get product_removed_comparison =>
+      'ஒப்பீட்டிலிருந்து தயாரிப்பு அகற்றப்பட்டது';
 
   @override
-  String get native_app_settings => 'Native App Settings';
+  String get native_app_settings => 'சொந்த பயன்பாட்டு அமைப்புகள்';
 
   @override
   String get native_app_description =>
-      'Open systems settings for Open Food Facts';
+      'திறந்த உணவு உண்மைகளுக்கான திறந்த அமைப்பு அமைப்புகள்';
 
   @override
-  String get product_removed_history => 'Product removed from history';
+  String get product_removed_history =>
+      'வரலாற்றிலிருந்து தயாரிப்பு நீக்கப்பட்டது';
 
   @override
-  String get product_removed_list => 'Product removed from list';
+  String get product_removed_list =>
+      'பட்டியலிலிருந்து தயாரிப்பு நீக்கப்பட்டது.';
 
   @override
-  String get product_could_not_remove => 'Could not remove product';
+  String get product_could_not_remove => 'தயாரிப்பை அகற்ற முடியவில்லை.';
 
   @override
-  String get no_prodcut_in_list => 'There is no product in this list';
+  String get no_prodcut_in_list => 'இந்தப் பட்டியலில் எந்தப் பொருளும் இல்லை.';
 
   @override
-  String get no_product_in_section => 'There is no product in this section';
+  String get no_product_in_section => 'இந்தப் பிரிவில் எந்தப் பொருளும் இல்லை.';
 
   @override
-  String get recently_seen_products => 'All viewed products';
+  String get recently_seen_products => 'பார்த்த அனைத்து தயாரிப்புகளும்';
 
   @override
-  String get clear => 'Clear';
+  String get clear => 'தெளிவு';
 
   @override
-  String get clear_long => 'Empty the list';
+  String get clear_long => 'பட்டியலை காலி செய்.';
 
   @override
-  String get really_clear => 'Do you really want to delete this list?';
+  String get really_clear =>
+      'இந்தப் பட்டியலை உண்மையிலேயே நீக்க விரும்புகிறீர்களா?';
 
   @override
   String pct_match(Object percent) {
-    return '$percent% match';
+    return '$percent% பொருத்தம்';
   }
 
   @override
@@ -1454,8 +1500,8 @@ class AppLocalizationsTa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count days ago',
-      one: 'one day ago',
+      other: '$count நாட்களுக்கு முன்பு',
+      one: 'ஒரு நாள் முன்பு',
     );
     return '$_temp0';
   }
@@ -1465,8 +1511,8 @@ class AppLocalizationsTa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count hours ago',
-      one: 'one hour ago',
+      other: '$count மணிநேரங்களுக்கு முன்பு',
+      one: 'ஒரு மணி நேரத்திற்கு முன்பு',
     );
     return '$_temp0';
   }
@@ -1476,9 +1522,9 @@ class AppLocalizationsTa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count minutes ago',
-      one: 'one minute ago',
-      zero: 'less than a minute ago',
+      other: '$count நிமிடங்களுக்கு முன்பு',
+      one: 'ஒரு நிமிடத்திற்கு முன்பு',
+      zero: 'ஒரு நிமிடத்திற்கும் குறைவான நேரத்திற்கு முன்பு',
     );
     return '$_temp0';
   }
@@ -1488,8 +1534,8 @@ class AppLocalizationsTa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count months ago',
-      one: 'one month ago',
+      other: '$count மாதங்களுக்கு முன்பு',
+      one: 'ஒரு மாதத்திற்கு முன்பு',
     );
     return '$_temp0';
   }
@@ -1499,8 +1545,8 @@ class AppLocalizationsTa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count weeks ago',
-      one: 'one week ago',
+      other: '$count வாரங்களுக்கு முன்பு',
+      one: 'ஒரு வாரத்திற்கு முன்பு',
     );
     return '$_temp0';
   }
@@ -1510,8 +1556,8 @@ class AppLocalizationsTa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'Compare $count Products',
-      one: 'Compare one Product',
+      other: 'ஒப்பிடுக $count தயாரிப்புகள்',
+      one: 'ஒரு தயாரிப்பை ஒப்பிடுக',
     );
     return '$_temp0';
   }
@@ -1521,86 +1567,88 @@ class AppLocalizationsTa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count selected products',
-      one: 'One selected product',
-      zero: 'No selected product',
+      other: '$count தேர்ந்தெடுக்கப்பட்ட தயாரிப்புகள்',
+      one: 'ஒரு தேர்ந்தெடுக்கப்பட்ட தயாரிப்பு',
+      zero: 'தேர்ந்தெடுக்கப்பட்ட தயாரிப்பு இல்லை',
     );
     return '$_temp0';
   }
 
   @override
-  String get compare_products_mode => 'Compare selected products';
+  String get compare_products_mode =>
+      'தேர்ந்தெடுக்கப்பட்ட தயாரிப்புகளை ஒப்பிடுக';
 
   @override
-  String get delete_products_mode => 'Delete selected products';
+  String get delete_products_mode => 'தேர்ந்தெடுத்த தயாரிப்புகளை நீக்கு';
 
   @override
-  String get select_all_products_mode => 'Select all products';
+  String get select_all_products_mode =>
+      'அனைத்து தயாரிப்புகளையும் தேர்ந்தெடுக்கவும்';
 
   @override
-  String get select_none_products_mode => 'Select none';
+  String get select_none_products_mode => 'எதையும் தேர்ந்தெடுக்க வேண்டாம்';
 
   @override
   String get compare_products_appbar_title => 'Compare products';
 
   @override
   String get compare_products_appbar_subtitle =>
-      'Please select at least two products';
+      'குறைந்தது இரண்டு தயாரிப்புகளைத் தேர்ந்தெடுக்கவும்.';
 
   @override
   String get retry_button_label => 'மீண்டும் முயல்க';
 
   @override
-  String get connect_with_us => 'Connect with us';
+  String get connect_with_us => 'எங்களைத் தொடர்பு கொள்ளுங்கள்';
 
   @override
-  String get tiktok => 'Follow us on TikTok';
+  String get tiktok => 'TikTok-இல் எங்களைப் பின்தொடரவும்';
 
   @override
   String get tiktok_link => 'https://www.tiktok.com/@openfoodfacts';
 
   @override
-  String get instagram => 'Follow us on Instagram';
+  String get instagram => 'எங்களை Instagram இல் பின்தொடரவும்';
 
   @override
   String get instagram_link => 'https://instagram.com/open.food.facts';
 
   @override
-  String get twitter => 'Follow us on X (formerly Twitter)';
+  String get twitter => 'X இல் (முன்னர் ட்விட்டர்) எங்களைப் பின்தொடருங்கள்.';
 
   @override
   String get twitter_link => 'https://www.twitter.com/openfoodfacts';
 
   @override
-  String get mastodon => 'Follow us on Mastodon';
+  String get mastodon => 'மாஸ்டோடனில் எங்களைப் பின்தொடருங்கள்';
 
   @override
   String get mastodon_link => 'https://mastodon.social/@openfoodfacts';
 
   @override
-  String get bsky => 'Follow us on BlueSky';
+  String get bsky => 'BlueSky இல் எங்களைப் பின்தொடருங்கள்.';
 
   @override
   String get bsky_link => 'https://bsky.app/profile/openfoodfacts.bsky.social';
 
   @override
-  String get blog => 'Blog';
+  String get blog => 'வலைப்பதிவு';
 
   @override
-  String get faq => 'FAQ';
+  String get faq => 'அடிக்கடி கேட்கப்படும் கேள்விகள்';
 
   @override
   String get discover => 'Discover';
 
   @override
-  String get how_to_contribute => 'How to Contribute';
+  String get how_to_contribute => 'பங்களிப்பது எப்படி';
 
   @override
   String get hint_knowledge_panel_message =>
-      'Your can tap on any part of the card to get more details about what you see. Try it now!';
+      'நீங்கள் பார்ப்பதைப் பற்றிய கூடுதல் விவரங்களைப் பெற, கார்டின் எந்தப் பகுதியையும் தட்டலாம். இப்போதே முயற்சிக்கவும்!';
 
   @override
-  String get permissions_page_title => 'Camera access';
+  String get permissions_page_title => 'கேமரா அணுகல்';
 
   @override
   String get permissions_page_body1 =>
@@ -1608,7 +1656,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get permissions_page_body2 =>
-      'If you change your mind, this option can be enabled and disabled at any time from the settings.';
+      'நீங்கள் உங்கள் மனதை மாற்றிக்கொண்டால், இந்த விருப்பத்தை அமைப்புகளிலிருந்து எந்த நேரத்திலும் இயக்கலாம் அல்லது முடக்கலாம்.';
 
   @override
   String contact_form_body_android(
@@ -1619,7 +1667,7 @@ class AppLocalizationsTa extends AppLocalizations {
     String? device,
     String? brand,
   ) {
-    return 'OS: Android (SDK Int: $sdkInt / Release: $release)\nModel: $model\nProduct: $product\nDevice: $device\nBrand:$brand';
+    return 'OS: Android (SDK Int: $sdkInt / வெளியீடு: $release)\nமாடல்: $model\nதயாரிப்பு: $product\nசாதனம்: $device\nபிராண்ட்:$brand';
   }
 
   @override
@@ -1628,7 +1676,7 @@ class AppLocalizationsTa extends AppLocalizations {
     String? model,
     String? localizedModel,
   ) {
-    return 'OS: iOS ($version)\nModel: $model\nLocalized model: $localizedModel';
+    return 'OS: iOS ($version)\nமாடல்: $model\nஉள்ளூர்மயமாக்கப்பட்ட மாடல்: $localizedModel';
   }
 
   @override
@@ -1638,67 +1686,67 @@ class AppLocalizationsTa extends AppLocalizations {
     String appBuildNumber,
     String appPackageName,
   ) {
-    return '$osContent\nApp version:$appVersion\nApp build number:$appBuildNumber\nApp package name:$appPackageName';
+    return '$osContent\nஆப் பதிப்பு:$appVersion\nஆப் கட்டமைப்பு எண்:$appBuildNumber\nஆப் தொகுப்பு பெயர்:$appPackageName';
   }
 
   @override
   String get authorize_button_label => 'Authorise';
 
   @override
-  String get refuse_button_label => 'Refuse';
+  String get refuse_button_label => 'மறுக்கவும்';
 
   @override
-  String get ask_me_later_button_label => 'Later';
+  String get ask_me_later_button_label => 'பின்னர்';
 
   @override
-  String get are_you_sure => 'Are you sure?';
+  String get are_you_sure => 'நீ சொல்வது உறுதியா?';
 
   @override
   String knowledge_panel_text_source(String sourceName) {
-    return 'Go further on $sourceName';
+    return '$sourceNameமேலும் செல்லவும்';
   }
 
   @override
-  String get onboarding_home_welcome_text1 => 'Welcome !';
+  String get onboarding_home_welcome_text1 => 'வரவேற்பு!';
 
   @override
   String get onboarding_home_welcome_text2 =>
-      'The app that helps you choose food that is good for **you** and the **planet**!';
+      '**உங்களுக்கும்** **கிரகத்திற்கும்** ஏற்ற உணவைத் தேர்வுசெய்ய உதவும் ஆப்!';
 
   @override
-  String get onboarding_continue_button => 'Continue';
+  String get onboarding_continue_button => 'தொடரவும்';
 
   @override
   String get onboarding_welcome_loading_dialog_title =>
-      'Loading your first example product';
+      'உங்கள் முதல் மாதிரி தயாரிப்பை ஏற்றுகிறது.';
 
   @override
   String get onboarding_welcome_warning =>
       'மன்னிக்கவும், இது எங்கள் உதாரண தயாரிப்பு, நீங்கள் அதைத் திருத்த முடியாது :)';
 
   @override
-  String get product_list_your_ranking => 'Your ranking';
+  String get product_list_your_ranking => 'உங்கள் தரவரிசை';
 
   @override
-  String get product_list_empty_icon_desc => 'History not available';
+  String get product_list_empty_icon_desc => 'வரலாறு கிடைக்கவில்லை.';
 
   @override
-  String get product_list_empty_title => 'Start scanning';
+  String get product_list_empty_title => 'ஸ்கேன் செய்யத் தொடங்கு';
 
   @override
   String get product_list_empty_message =>
-      'Scanned products will appear here and you can check detailed information about them';
+      'ஸ்கேன் செய்யப்பட்ட தயாரிப்புகள் இங்கே தோன்றும், அவற்றைப் பற்றிய விரிவான தகவல்களை நீங்கள் பார்க்கலாம்.';
 
   @override
   String product_list_reloading_in_progress_multiple(num count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'products',
-      one: 'product',
-      zero: 'product',
+      other: 'தயாரிப்புகள்',
+      one: 'தயாரிப்பு',
+      zero: 'தயாரிப்பு',
     );
-    return 'Refreshing $_temp0 in your history';
+    return 'உங்கள் வரலாற்றில் $_temp0 புதுப்பிக்கிறது';
   }
 
   @override
@@ -1706,87 +1754,89 @@ class AppLocalizationsTa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'Products',
-      one: 'Product',
-      zero: 'Product',
+      other: 'தயாரிப்புகள்',
+      one: 'தயாரிப்பு',
+      zero: 'தயாரிப்பு',
     );
-    return '$_temp0 refresh complete';
+    return '$_temp0 புதுப்பிப்பு முடிந்தது';
   }
 
   @override
   String get product_list_compare_side_by_side => 'அருகருகே ஒப்பிடுக';
 
   @override
-  String get loading_dialog_default_title => 'Downloading data';
+  String get loading_dialog_default_title => 'தரவைப் பதிவிறக்குகிறது';
 
   @override
-  String get loading_dialog_default_error_message => 'Could not download data';
+  String get loading_dialog_default_error_message =>
+      'தரவைப் பதிவிறக்க முடியவில்லை.';
 
   @override
-  String get account_delete => 'Delete account';
+  String get account_delete => 'கணக்கை நீக்கு';
 
   @override
   String get account_delete_title => 'எனது கணக்கை நீக்கு.';
 
   @override
-  String get user_profile => 'Account';
+  String get user_profile => 'கணக்கு';
 
   @override
   String get user_profile_title_guest => 'நல்வரவு!';
 
   @override
   String get user_profile_subtitle_guest =>
-      'Sign-in or sign-up to join the Open Food Facts community';
+      'திறந்த உணவு உண்மைகள் சமூகத்தில் சேர உள்நுழையவும் அல்லது பதிவு செய்யவும்.';
 
   @override
   String user_profile_title_id_email(String email) {
-    return 'Open Food Facts login: $email';
+    return 'திறந்த உணவு உண்மைகள் உள்நுழைவு: $email';
   }
 
   @override
   String user_profile_title_id_default(String id) {
-    return 'Welcome $id!';
+    return 'வரவேற்கிறோம் $id!';
   }
 
   @override
-  String get email_subject_account_deletion => 'Delete account';
+  String get email_subject_account_deletion => 'கணக்கை நீக்கு';
 
   @override
   String email_body_account_deletion(String userId) {
-    return 'Hi there, please delete my Open Food Facts account: $userId';
+    return 'வணக்கம், தயவுசெய்து எனது திறந்த உணவு உண்மைகள் கணக்கை நீக்கவும்: $userId';
   }
 
   @override
-  String get settings_app_app => 'Application';
+  String get settings_app_app => 'விண்ணப்பம்';
 
   @override
   String get settings_app_data => 'அம்சங்கள் & செயலிழப்பு கண்காணிப்பு';
 
   @override
-  String get settings_app_camera => 'Camera';
+  String get settings_app_camera => 'கேமரா';
 
   @override
-  String get settings_app_products => 'Products';
+  String get settings_app_products => 'தயாரிப்புகள்';
 
   @override
-  String get settings_app_miscellaneous => 'Miscellaneous';
+  String get settings_app_miscellaneous => 'இதர';
 
   @override
-  String get camera_play_sound_title => 'Play a sound on scan';
+  String get camera_play_sound_title => 'ஸ்கேன் செய்யும்போது ஒலியை இயக்கு.';
 
   @override
-  String get camera_play_sound_subtitle => 'Will beep on each successful scan';
+  String get camera_play_sound_subtitle =>
+      'ஒவ்வொரு வெற்றிகரமான ஸ்கேன் செய்யும்போதும் பீப் ஒலிக்கும்.';
 
   @override
   String get camera_window_accessibility_label =>
-      'Scan a barcode with your camera';
+      'உங்கள் கேமராவைப் பயன்படுத்தி பார்கோடை ஸ்கேன் செய்யுங்கள்';
 
   @override
-  String get app_haptic_feedback_title => 'Vibration & Haptics';
+  String get app_haptic_feedback_title => 'அதிர்வு & தொடுதல்கள்';
 
   @override
   String get app_haptic_feedback_subtitle =>
-      'Vibrations after executing some actions (barcode decoded, product removed…).';
+      'சில செயல்களைச் செய்த பிறகு ஏற்படும் அதிர்வுகள் (பார்கோடு டிகோட் செய்யப்பட்டது, தயாரிப்பு அகற்றப்பட்டது…).';
 
   @override
   String get crash_reporting_toggle_title =>
@@ -1794,7 +1844,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get crash_reporting_toggle_subtitle =>
-      'When enabled, crash reports are automatically submitted to Open Food Facts\' error tracking system, so that bugs can be fixed and thus improve the app.';
+      'இயக்கப்பட்டால், செயலிழப்பு அறிக்கைகள் தானாகவே Open Food Facts இன் பிழை கண்காணிப்பு அமைப்பில் சமர்ப்பிக்கப்படும், இதனால் பிழைகள் சரிசெய்யப்பட்டு செயலிழப்பை மேம்படுத்த முடியும்.';
 
   @override
   String get send_anonymous_data_toggle_title =>
@@ -1805,49 +1855,49 @@ class AppLocalizationsTa extends AppLocalizations {
       'இயக்கப்பட்டால், அம்சத்தைப் பயன்படுத்துவது தொடர்பான கண்டிப்பாக அநாமதேயத் தகவல்கள், ஓபன் ஃபுட் ஃபேக்ட்ஸ் சர்வர்களுக்கு அனுப்பப்படும், இதன் மூலம் அம்சங்களை மேம்படுத்தும் வகையில் அம்சங்கள் எவ்வாறு பயன்படுத்தப்படுகின்றன என்பதை நாம் புரிந்து கொள்ள முடியும். இல்லையெனில், 0 ஐடி அனுப்பப்படும்.';
 
   @override
-  String get product_edit_photo_title => 'Edit Photo';
+  String get product_edit_photo_title => 'புகைப்படத்தைத் திருத்து';
 
   @override
-  String get permission_photo_error => 'Error';
+  String get permission_photo_error => 'பிழை';
 
   @override
   String get permission_photo_denied_title =>
-      'Allow camera use to scan barcodes';
+      'பார்கோடுகளை ஸ்கேன் செய்ய கேமரா பயன்பாட்டை அனுமதிக்கவும்.';
 
   @override
   String permission_photo_denied_message(String appName) {
-    return 'For an enhanced experience, please allow $appName to access your camera. You will be able to directly scan barcodes.';
+    return 'மேம்பட்ட அனுபவத்திற்கு, $appName உங்கள் கேமராவை அணுக அனுமதிக்கவும். நீங்கள் நேரடியாக பார்கோடுகளை ஸ்கேன் செய்ய முடியும்.';
   }
 
   @override
-  String get permission_photo_denied_button => 'Allow';
+  String get permission_photo_denied_button => 'அனுமதி';
 
   @override
   String get permission_photo_denied_dialog_settings_title =>
-      'Permission denied';
+      'அனுமதி மறுக்கப்பட்டது';
 
   @override
   String get permission_photo_denied_dialog_settings_message =>
-      'As you\'ve previously denied the camera permission, you must allow it manually from the Settings.';
+      'நீங்கள் முன்பு கேமரா அனுமதியை மறுத்துவிட்டதால், அமைப்புகளில் இருந்து அதை கைமுறையாக அனுமதிக்க வேண்டும்.';
 
   @override
   String get permission_photo_denied_dialog_settings_button_open =>
-      'Open settings';
+      'அமைப்புகளைத் திற';
 
   @override
   String get permission_photo_denied_dialog_settings_button_cancel => 'Cancel';
 
   @override
-  String get permission_photo_none_found => 'No camera detected';
+  String get permission_photo_none_found => 'கேமரா எதுவும் கண்டறியப்படவில்லை.';
 
   @override
-  String get permission_photo_denied => 'No camera access granted';
+  String get permission_photo_denied => 'கேமரா அணுகல் வழங்கப்படவில்லை.';
 
   @override
   String get show_product_pictures => 'தயாரிப்பு படங்களைக் காட்டு';
 
   @override
-  String get edit_product_label => 'Edit product';
+  String get edit_product_label => 'தயாரிப்பைத் திருத்து';
 
   @override
   String get edit_product_pending_operations_banner_title =>
@@ -1859,7 +1909,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get edit_product_pending_operations_banner_short_message =>
-      'Your edits are being **sent in the background** (or later in case of error).';
+      'உங்கள் திருத்தங்கள் **பின்னணியில்** அனுப்பப்படுகின்றன (அல்லது பிழை ஏற்பட்டால் பின்னர் அனுப்பப்படும்).';
 
   @override
   String get edit_product_label_short => 'திருத்து';
@@ -1875,64 +1925,68 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get edit_product_form_item_error_existing =>
-      'This value is already there!';
+      'இந்த மதிப்பு ஏற்கனவே உள்ளது!';
 
   @override
-  String get edit_product_form_item_add_action_brand => 'Add a new brand';
+  String get edit_product_form_item_add_action_brand =>
+      'புதிய பிராண்டைச் சேர்க்கவும்';
 
   @override
-  String get edit_product_form_item_add_action_label => 'Add a new label';
+  String get edit_product_form_item_add_action_label =>
+      'புதிய லேபிளைச் சேர்க்கவும்';
 
   @override
-  String get edit_product_form_item_add_action_store => 'Add a new store';
+  String get edit_product_form_item_add_action_store => 'புதிய கடையைச் சேர்';
 
   @override
-  String get edit_product_form_item_add_action_origin => 'Add a new origin';
+  String get edit_product_form_item_add_action_origin =>
+      'புதிய மூலத்தைச் சேர்க்கவும்';
 
   @override
   String get edit_product_form_item_add_action_emb_code =>
-      'Add a new traceability code';
+      'புதிய கண்டறியும் குறியீட்டைச் சேர்க்கவும்.';
 
   @override
-  String get edit_product_form_item_add_action_country => 'Add a new country';
+  String get edit_product_form_item_add_action_country => 'புதிய நாட்டைச் சேர்';
 
   @override
-  String get edit_product_form_item_add_action_category => 'Add a new category';
+  String get edit_product_form_item_add_action_category => 'புதிய வகையைச் சேர்';
 
   @override
-  String get edit_product_form_item_add_action_trace => 'Add a new trace';
+  String get edit_product_form_item_add_action_trace => 'புதிய தடத்தைச் சேர்';
 
   @override
-  String get edit_product_form_item_add_suggestion => 'Add suggestion';
+  String get edit_product_form_item_add_suggestion => 'பரிந்துரையைச் சேர்';
 
   @override
   String get edit_product_form_item_deny_suggestion => 'பரிந்துரையை நிராகரி';
 
   @override
-  String get edit_product_form_item_details_title => 'Basic details';
+  String get edit_product_form_item_details_title => 'அடிப்படை விவரங்கள்';
 
   @override
   String get edit_product_form_item_details_subtitle =>
-      'Product name, brand, quantity';
+      'தயாரிப்பு பெயர், பிராண்ட், அளவு';
 
   @override
-  String get edit_product_form_item_other_details_title => 'Additional details';
+  String get edit_product_form_item_other_details_title => 'கூடுதல் விவரங்கள்';
 
   @override
-  String get edit_product_form_item_other_details_subtitle => 'Website…';
+  String get edit_product_form_item_other_details_subtitle => 'வலைத்தளம்…';
 
   @override
   String get edit_product_form_item_photos_title => 'புகைப்படங்கள்';
 
   @override
-  String get edit_product_form_item_photos_subtitle => 'Add or refresh photos';
+  String get edit_product_form_item_photos_subtitle =>
+      'புகைப்படங்களைச் சேர்க்கவும் அல்லது புதுப்பிக்கவும்';
 
   @override
-  String get edit_product_form_item_labels_title => 'Labels & Certifications';
+  String get edit_product_form_item_labels_title => 'லேபிள்கள் & சான்றிதழ்கள்';
 
   @override
   String get edit_product_form_item_labels_subtitle =>
-      'Environmental, Quality labels…';
+      'சுற்றுச்சூழல், தர லேபிள்கள்…';
 
   @override
   String get edit_product_form_item_labels_hint =>
@@ -1943,19 +1997,19 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get edit_product_form_item_labels_explanation_title =>
-      'Good practices: Labels';
+      'நல்ல நடைமுறைகள்: லேபிள்கள்';
 
   @override
   String get edit_product_form_item_labels_explanation_info1 =>
-      'Any characteristic of the product **which is factual** and different from the other fields.';
+      'தயாரிப்பின் ஏதேனும் பண்பு **உண்மையானது** மற்றும் பிற துறைகளிலிருந்து வேறுபட்டது.';
 
   @override
   String get edit_product_form_item_labels_explanation_good_examples_1 =>
-      'Nutri-Score, NOVA…';
+      'நியூட்ரி-ஸ்கோர், நோவா…';
 
   @override
   String get edit_product_form_item_labels_explanation_good_examples_2 =>
-      'Made in Belgium, produced in Brittany…';
+      'பெல்ஜியத்தில் தயாரிக்கப்பட்டது, பிரிட்டானியில் தயாரிக்கப்பட்டது…';
 
   @override
   String get edit_product_form_item_labels_explanation_good_examples_3 =>
@@ -1963,43 +2017,43 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get edit_product_form_item_labels_explanation_good_examples_4 =>
-      'Rich in fiber, source of iron…';
+      'நார்ச்சத்து நிறைந்தது, இரும்பின் மூலமாகும்…';
 
   @override
   String get edit_product_form_item_labels_explanation_good_examples_5 =>
-      'Fair trade, Max Havelaar…';
+      'நியாயமான வர்த்தகம், மேக்ஸ் ஹவேலார்…';
 
   @override
-  String get edit_product_form_item_stores_title => 'Stores';
+  String get edit_product_form_item_stores_title => 'கடைகள்';
 
   @override
   String get edit_product_form_item_stores_hint => 'ஒரு கடையை உள்ளிடவும்';
 
   @override
-  String get edit_product_form_item_stores_type => 'store';
+  String get edit_product_form_item_stores_type => 'கடை';
 
   @override
   String get edit_product_form_item_stores_explanation_title =>
-      'Good practices: Stores';
+      'நல்ல நடைமுறைகள்: கடைகள்';
 
   @override
   String get edit_product_form_item_stores_explanation_info1 =>
-      'Input the store where you bought the product.';
+      'நீங்கள் பொருளை வாங்கிய கடையின் பெயரை உள்ளிடவும்.';
 
   @override
   String get edit_product_form_item_stores_explanation_good_examples_1 =>
-      'Walmart';
+      'வால்மார்ட்';
 
   @override
   String get edit_product_form_item_stores_explanation_good_examples_2 =>
-      'Carrefour';
+      'கேரிஃபோர்';
 
   @override
   String get edit_product_form_item_stores_explanation_good_examples_3 =>
-      'Lidl';
+      'லிட்ல்';
 
   @override
-  String get edit_product_form_item_origins_title => 'Origins';
+  String get edit_product_form_item_origins_title => 'தோற்றம்';
 
   @override
   String get edit_product_form_item_origins_hint =>
@@ -2010,19 +2064,19 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get edit_product_form_item_origins_explanation_title =>
-      'Good practices: Origins';
+      'நல்ல நடைமுறைகள்: தோற்றம்';
 
   @override
   String get edit_product_form_item_origins_explanation_info1 =>
-      'Add **any indications of origins you can find on the packaging**.\nYou need not worry about origins indicated directly in the ingredient list.';
+      '**பேக்கேஜிங்கில் நீங்கள் காணக்கூடிய **எந்தவொரு மூலப்பொருட்களின் அறிகுறிகளையும் சேர்க்கவும்**.\nமூலப்பொருள் பட்டியலில் நேரடியாகக் குறிப்பிடப்பட்டுள்ள மூலப்பொருட்களைப் பற்றி நீங்கள் கவலைப்படத் தேவையில்லை.';
 
   @override
   String get edit_product_form_item_origins_explanation_good_examples_1 =>
-      'Beef from Argentina';
+      'அர்ஜென்டினாவிலிருந்து மாட்டிறைச்சி';
 
   @override
   String get edit_product_form_item_origins_explanation_good_examples_2 =>
-      'The soy does not come from the European Union';
+      'சோயா ஐரோப்பிய ஒன்றியத்திலிருந்து வரவில்லை.';
 
   @override
   String get edit_product_form_item_countries_title => 'Country';
@@ -2036,37 +2090,38 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get edit_product_form_item_countries_explanations_title =>
-      'Good practices: Countries';
+      'நல்ல நடைமுறைகள்: நாடுகள்';
 
   @override
   String get edit_product_form_item_countries_explanations_info1 =>
-      '**Countries where the product is widely available** (not including stores specialising in foreign products).';
+      '**தயாரிப்பு பரவலாகக் கிடைக்கும் நாடுகள்** (வெளிநாட்டு தயாரிப்புகளில் நிபுணத்துவம் பெற்ற கடைகள் சேர்க்கப்படவில்லை).';
 
   @override
-  String get edit_product_form_item_emb_codes_title => 'Traceability codes';
+  String get edit_product_form_item_emb_codes_title =>
+      'கண்டறியக்கூடிய குறியீடுகள்';
 
   @override
   String get edit_product_form_item_emb_codes_hint =>
       'குறியீட்டை உள்ளிடவும் (எ. கா: EMB 53062, FR 62.448.034 CE, 84 R 20, 33 RECOLTANT 522…)';
 
   @override
-  String get edit_product_form_item_emb_codes_type => 'traceability code';
+  String get edit_product_form_item_emb_codes_type => 'கண்டறியும் குறியீடு';
 
   @override
   String get edit_product_form_item_emb_help_title =>
-      'Good practices: Traceability codes';
+      'நல்ல நடைமுறைகள்: கண்டறியக்கூடிய குறியீடுகள்';
 
   @override
   String get edit_product_form_item_emb_help_info1 =>
-      'In this section, you can input codes related to **packaging marks**, **identification marks** or **health marks**.';
+      'இந்தப் பிரிவில், **பேக்கேஜிங் மதிப்பெண்கள்**, **அடையாளக் குறிகள்** அல்லது **சுகாதாரக் குறிகள்** தொடர்பான குறியீடுகளை நீங்கள் உள்ளிடலாம்.';
 
   @override
   String get edit_product_form_item_emb_help_info2_title =>
-      'Examples of traceability codes';
+      'கண்டறியக்கூடிய குறியீடுகளின் எடுத்துக்காட்டுகள்';
 
   @override
   String get edit_product_form_item_emb_help_info2_item1_text =>
-      '**EC codes** used in the European Community to identify food producers or packagers:';
+      'உணவு உற்பத்தியாளர்கள் அல்லது பேக்கேஜ் செய்பவர்களை அடையாளம் காண ஐரோப்பிய சமூகத்தில் பயன்படுத்தப்படும் **EC குறியீடுகள்**:';
 
   @override
   String get edit_product_form_item_emb_help_info2_item1_example =>
@@ -2074,11 +2129,11 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get edit_product_form_item_emb_help_info2_item1_explanation =>
-      '**FR**: country code of **France**\n**72.264.002**: geographic data\n**CE**: European Community';
+      '**FR**: **பிரான்ஸ் நாட்டின் குறியீடு**\n**72.264.002**: புவியியல் தரவு\n**CE**: ஐரோப்பிய சமூகம்';
 
   @override
   String get edit_product_form_item_emb_help_info2_item2_text =>
-      '**EMB codes** used in France:';
+      '**பிரான்சில் பயன்படுத்தப்படும் EMB குறியீடுகள்**:';
 
   @override
   String get edit_product_form_item_emb_help_info2_item2_explanation =>
@@ -2092,7 +2147,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get edit_product_form_item_traces_type =>
-      'Input a trace (eg: Soy beans)';
+      'ஒரு சுவடு உள்ளிடவும் (எ.கா: சோயா பீன்ஸ்)';
 
   @override
   String get edit_product_form_item_categories_title => 'Categories';
@@ -2106,42 +2161,42 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get edit_product_form_item_categories_explanation_title =>
-      'Good practices: Categories';
+      'நல்ல நடைமுறைகள்: வகைகள்';
 
   @override
   String get edit_product_form_item_categories_explanation_info1 =>
-      'Indicate **only the most specific category**.\nParent categories will be automatically added.';
+      '**மிகவும் குறிப்பிட்ட வகையை மட்டும்** குறிப்பிடவும்.\nபெற்றோர் வகைகள் தானாகவே சேர்க்கப்படும்.';
 
   @override
   String get edit_product_form_item_categories_explanation_info2_title =>
-      'Missing category?';
+      'வகை இல்லையா?';
 
   @override
   String get edit_product_form_item_categories_explanation_info2_content =>
-      'In case a category is **not available in autocomplete**, feel free to add it anyway.\nThis will help us improve Open Food Facts in your country.';
+      'ஒரு வகை **தானியங்கி நிரப்புதலில்** கிடைக்கவில்லை என்றால், அதை எப்படியும் சேர்க்க தயங்க வேண்டாம்.\nஇது உங்கள் நாட்டில் திறந்த உணவு உண்மைகளை மேம்படுத்த எங்களுக்கு உதவும்.';
 
   @override
   String get edit_product_form_item_categories_explanation_good_examples_1 =>
-      'Sardines in olive oil';
+      'ஆலிவ் எண்ணெயில் மத்தி';
 
   @override
   String get edit_product_form_item_categories_explanation_good_examples_2 =>
-      'Orange juice from concentrate';
+      'அடர் ஆரஞ்சு சாறு';
 
   @override
   String get edit_product_form_item_exit_title => 'சேமிக்காமல் வெளியேறு?';
 
   @override
   String get edit_product_form_item_exit_confirmation =>
-      'Do you want to save your changes before leaving this page?';
+      'இந்தப் பக்கத்தை விட்டு வெளியேறுவதற்கு முன் உங்கள் மாற்றங்களைச் சேமிக்க விரும்புகிறீர்களா?';
 
   @override
   String get edit_product_form_item_exit_confirmation_positive_button =>
-      'Save changes';
+      'மாற்றங்களைச் சேமிக்கவும்';
 
   @override
   String get edit_product_form_item_exit_confirmation_negative_button =>
-      'Discard changes';
+      'மாற்றங்களை நிராகரி';
 
   @override
   String get edit_product_form_item_ingredients_title => 'Ingredients';
@@ -2163,62 +2218,64 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get edit_product_form_item_add_invalid_item_tooltip =>
-      'Please enter a text first';
+      'முதலில் ஒரு உரையை உள்ளிடவும்.';
 
   @override
-  String get edit_product_form_item_remove_item_tooltip => 'Remove';
+  String get edit_product_form_item_remove_item_tooltip => 'அகற்று';
 
   @override
-  String get edit_product_form_item_save_edit_item_tooltip => 'Save your edit';
+  String get edit_product_form_item_save_edit_item_tooltip =>
+      'உங்கள் திருத்தத்தைச் சேமிக்கவும்.';
 
   @override
   String get edit_product_form_item_cancel_edit_item_tooltip =>
-      'Cancel your edit';
+      'உங்கள் திருத்தத்தை ரத்துசெய்';
 
   @override
   String get edit_product_form_item_packaging_title =>
-      'Recycling instructions photo';
+      'மறுசுழற்சி வழிமுறைகள் புகைப்படம்';
 
   @override
-  String get edit_product_form_item_nutrition_facts_title => 'Nutrition facts';
+  String get edit_product_form_item_nutrition_facts_title =>
+      'ஊட்டச்சத்து உண்மைகள்';
 
   @override
   String get edit_product_form_item_nutrition_facts_subtitle =>
-      'Nutrition, alcohol content…';
+      'ஊட்டச்சத்து, ஆல்கஹால் உள்ளடக்கம்…';
 
   @override
   String get edit_product_form_item_nutrition_facts_explanation_title =>
-      'Good practices: Nutrition facts';
+      'நல்ல நடைமுறைகள்: ஊட்டச்சத்து உண்மைகள்';
 
   @override
   String get edit_product_form_item_nutrition_facts_explanation_info1_title =>
-      'Nutritional values';
+      'ஊட்டச்சத்து மதிப்புகள்';
 
   @override
   String get edit_product_form_item_nutrition_facts_explanation_info1_content =>
-      'First, select if the **values are provided**:';
+      'முதலில், **மதிப்புகள்** வழங்கப்பட்டிருந்தால் தேர்ந்தெடுக்கவும்:';
 
   @override
   String get edit_product_form_item_nutrition_facts_explanation_info2_title =>
-      'Nutrition facts';
+      'ஊட்டச்சத்து உண்மைகள்';
 
   @override
   String get edit_product_form_item_nutrition_facts_explanation_info2_content =>
-      'Then, input the nutritional values **as indicated on the packaging**. If there is no value, you can click on the \"Eye\" icon.';
+      'பின்னர், **பேக்கேஜிங்கில் குறிப்பிடப்பட்டுள்ளபடி** ஊட்டச்சத்து மதிப்புகளை உள்ளிடவும். மதிப்பு இல்லை என்றால், நீங்கள் \"கண்\" ஐகானைக் கிளிக் செய்யலாம்.';
 
   @override
   String get edit_product_form_item_nutrition_facts_explanation_info3_title =>
-      'Missing field?';
+      'புலம் இல்லையா?';
 
   @override
   String get edit_product_form_item_nutrition_facts_explanation_info3_content =>
-      'If an entry is missing, you can **click on the \"Plus\" icon** to add it (eg: vitamin D, magnesium…).';
+      'ஏதேனும் உள்ளீடு விடுபட்டிருந்தால், அதைச் சேர்க்க \"பிளஸ்\" ஐகானைக் ** கிளிக் செய்யலாம் (எ.கா: வைட்டமின் டி, மெக்னீசியம்…).';
 
   @override
   String get edit_product_form_save => 'திருத்து';
 
   @override
-  String get edit_product_ingredients_photo_title => 'Ingredients photo';
+  String get edit_product_ingredients_photo_title => 'பொருட்கள் புகைப்படம்';
 
   @override
   String get edit_product_ingredients_list_title => 'List of ingredients';
@@ -2230,26 +2287,27 @@ class AppLocalizationsTa extends AppLocalizations {
   String get edit_product_packaging_list_title => 'பேக்கேஜிங் பட்டியல்';
 
   @override
-  String get no_data_available => 'No data available';
+  String get no_data_available => 'தரவு எதுவும் கிடைக்கவில்லை.';
 
   @override
-  String get product_field_website_title => 'Website';
+  String get product_field_website_title => 'வலைத்தளம்';
 
   @override
   String get origins_editing_title => 'மூலங்களைத் திருத்தவும்';
 
   @override
-  String get completed_basic_details_btn_text => 'Complete basic details';
+  String get completed_basic_details_btn_text =>
+      'அடிப்படை விவரங்களை முடிக்கவும்';
 
   @override
-  String get not_implemented_snackbar_text => 'Not implemented yet';
+  String get not_implemented_snackbar_text => 'இன்னும் செயல்படுத்தப்படவில்லை';
 
   @override
   String get category_picker_page_appbar_text => 'Categories';
 
   @override
   String get edit_ingredients_extract_ingredients_btn_text =>
-      'Extract ingredients from the photo';
+      'புகைப்படத்திலிருந்து பொருட்களைப் பிரித்தெடுக்கவும்.';
 
   @override
   String get edit_ingredients_extract_ingredients_btn_text_short =>
@@ -2257,25 +2315,27 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get edit_ingredients_extracting_ingredients_btn_text =>
-      'Extracting ingredients\nfrom the photo';
+      'புகைப்படத்திலிருந்து\nபொருட்களைப் பிரித்தெடுத்தல்';
 
   @override
-  String get edit_ingredients_loading_photo_btn_text => 'Loading photo…';
+  String get edit_ingredients_loading_photo_btn_text =>
+      '…புகைப்படத்தை ஏற்றுகிறது';
 
   @override
   String get edit_ingredients_loading_photo_help_dialog_title =>
-      'Why do I see this message?';
+      'நான் ஏன் இந்த செய்தியைப் பார்க்கிறேன்?';
 
   @override
   String get edit_ingredients_loading_photo_help_dialog_body =>
-      'To use the \"Extract ingredients\" feature, the photo needs to be uploaded first.\n\nPlease wait a few seconds or enter them manually.';
+      '\"பொருட்களைப் பிரித்தெடுக்கவும்\" அம்சத்தைப் பயன்படுத்த, புகைப்படத்தை முதலில் பதிவேற்ற வேண்டும்.\n\nசில வினாடிகள் காத்திருக்கவும் அல்லது அவற்றை கைமுறையாக உள்ளிடவும்.';
 
   @override
-  String get edit_ingredients_refresh_photo_btn_text => 'Refresh photo';
+  String get edit_ingredients_refresh_photo_btn_text =>
+      'புகைப்படத்தைப் புதுப்பிக்கவும்';
 
   @override
   String get edit_packaging_extract_btn_text =>
-      'Extract packaging\nfrom the photo';
+      'புகைப்படத்திலிருந்து பேக்கேஜிங்\nஐ பிரித்தெடுக்கவும்.';
 
   @override
   String get edit_packaging_extract_btn_text_short =>
@@ -2283,24 +2343,27 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get edit_packaging_extracting_btn_text =>
-      'Extracting packaging from the photo';
+      'புகைப்படத்திலிருந்து பேக்கேஜிங்கைப் பிரித்தெடுத்தல்';
 
   @override
-  String get edit_packaging_loading_photo_btn_text => 'Loading photo…';
+  String get edit_packaging_loading_photo_btn_text =>
+      '…புகைப்படத்தை ஏற்றுகிறது';
 
   @override
   String get edit_packaging_loading_photo_help_dialog_title =>
-      'Why do I see this message?';
+      'நான் ஏன் இந்த செய்தியைப் பார்க்கிறேன்?';
 
   @override
   String get edit_packaging_loading_photo_help_dialog_body =>
-      'To use the \"Extract packaging\" feature, the photo needs to be uploaded first.\n\nPlease wait a few seconds or enter them manually.';
+      '\"பேக்கேஜிங்கைப் பிரித்தெடு\" அம்சத்தைப் பயன்படுத்த, புகைப்படத்தை முதலில் பதிவேற்ற வேண்டும்.\n\nசில வினாடிகள் காத்திருக்கவும் அல்லது அவற்றை கைமுறையாக உள்ளிடவும்.';
 
   @override
-  String get edit_packaging_refresh_photo_btn_text => 'Refresh photo';
+  String get edit_packaging_refresh_photo_btn_text =>
+      'புகைப்படத்தைப் புதுப்பிக்கவும்';
 
   @override
-  String get edit_ocr_extract_failed => 'Failed to detect text in image.';
+  String get edit_ocr_extract_failed =>
+      'படத்தில் உள்ள உரையைக் கண்டறிய முடியவில்லை.';
 
   @override
   String get edit_ocr_extract_disabled_title => 'படம் இல்லை!';
@@ -2310,76 +2373,80 @@ class AppLocalizationsTa extends AppLocalizations {
       'உரை பிரித்தெடுத்தல் அம்சத்தைப் பயன்படுத்த, நீங்கள் முதலில் புகைப்படம் எடுக்க வேண்டும்.';
 
   @override
-  String get user_list_dialog_new_title => 'New list of products';
+  String get user_list_dialog_new_title => 'புதிய தயாரிப்புகளின் பட்டியல்';
 
   @override
-  String get user_list_dialog_rename_title => 'Rename list';
+  String get user_list_dialog_rename_title => 'பட்டியலை மறுபெயரிடு';
 
   @override
-  String get user_list_subtitle_product => 'Lists';
+  String get user_list_subtitle_product => 'பட்டியல்கள்';
 
   @override
   String get user_list_title => 'உங்களின் பட்டியல்கள்';
 
   @override
-  String get user_list_add_product => 'Add the product to your lists';
+  String get user_list_add_product =>
+      'உங்கள் பட்டியல்களில் தயாரிப்பைச் சேர்க்கவும்.';
 
   @override
-  String get user_list_button_new => 'Create a new list';
+  String get user_list_button_new => 'புதிய பட்டியலை உருவாக்கவும்';
 
   @override
   String get user_list_empty_label =>
       'No list available yet, please start by creating one';
 
   @override
-  String get user_list_button_add_product => 'Add to list';
+  String get user_list_button_add_product => 'பட்டியலில் சேர்';
 
   @override
-  String get added_to_list_msg => 'Added to list';
+  String get added_to_list_msg => 'பட்டியலில் சேர்க்கப்பட்டது';
 
   @override
-  String get user_list_popup_clear => 'Clear your history';
+  String get user_list_popup_clear => 'உங்கள் வரலாற்றை அழிக்கவும்';
 
   @override
-  String get user_list_popup_rename => 'Rename';
+  String get user_list_popup_rename => 'மறுபெயரிடு';
 
   @override
-  String get user_list_name_hint => 'My list';
+  String get user_list_name_hint => 'எனது பட்டியல்';
 
   @override
-  String get user_list_name_error_empty => 'Name is mandatory';
+  String get user_list_name_error_empty => 'பெயர் கட்டாயம்';
 
   @override
-  String get user_list_name_error_already => 'That name is already used';
+  String get user_list_name_error_already =>
+      'அந்தப் பெயர் ஏற்கனவே பயன்படுத்தப்பட்டுள்ளது.';
 
   @override
-  String get user_list_name_error_same => 'That is the same name';
+  String get user_list_name_error_same => 'அதே பெயர்தான்.';
 
   @override
-  String get user_list_name_input_hint => 'Name of the list';
+  String get user_list_name_input_hint => 'பட்டியலின் பெயர்';
 
   @override
-  String get try_again => 'Try Again';
+  String get try_again => 'மீண்டும் முயற்சிக்கவும்';
 
   @override
-  String get there_was_an_error => 'There was an error';
+  String get there_was_an_error => 'ஒரு பிழை ஏற்பட்டது.';
 
   @override
   String category_picker_no_category_found_message(String items) {
-    return 'No category found for $items';
+    return '$itemsக்கு எந்த வகையும் கிடைக்கவில்லை.';
   }
 
   @override
-  String get camera_toggle_camera => 'Switch between back and front camera';
+  String get camera_toggle_camera =>
+      'பின் மற்றும் முன் கேமராவிற்கு இடையில் மாறவும்';
 
   @override
-  String get camera_toggle_flash => 'Turn ON or OFF the flash of the camera';
+  String get camera_toggle_flash =>
+      'கேமராவின் ஃபிளாஷை இயக்கவும் அல்லது அணைக்கவும்';
 
   @override
-  String get camera_enable_flash => 'Enable flash';
+  String get camera_enable_flash => 'ஃபிளாஷை இயக்கு';
 
   @override
-  String get camera_disable_flash => 'Disable flash';
+  String get camera_disable_flash => 'ஃபிளாஷை முடக்கு';
 
   @override
   String get camera_flash_error_dialog_title => 'ஒரு பிழை ஏற்பட்டது!';
@@ -2393,69 +2460,71 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get user_preferences_item_accessibility_hint =>
-      'Click to open in your browser or in the application (if installed)';
+      'உங்கள் உலாவியிலோ அல்லது பயன்பாட்டிலோ (நிறுவப்பட்டிருந்தால்) திறக்க கிளிக் செய்யவும்.';
 
   @override
-  String get dev_preferences_screen_title => 'DEV Mode';
+  String get dev_preferences_screen_title => 'DEV பயன்முறை';
 
   @override
   String get dev_preferences_screen_subtitle =>
       'பரிசோதனை அம்சங்கள் மற்றும் மேம்பாட்டு கருவிகளை அணுகவும்';
 
   @override
-  String get dev_preferences_reset_onboarding_title => 'Restart onboarding';
+  String get dev_preferences_reset_onboarding_title =>
+      'ஆன்போர்டிங்கை மீண்டும் தொடங்கு';
 
   @override
   String get dev_preferences_reset_onboarding_subtitle =>
-      'You then have to restart the App to see it again.';
+      'பின்னர் அதை மீண்டும் பார்க்க நீங்கள் பயன்பாட்டை மறுதொடக்கம் செய்ய வேண்டும்.';
 
   @override
   String get dev_preferences_environment_switch_title =>
-      'Switch between openfoodfacts.org (PROD) and test env';
+      'openfoodfacts.org (PROD) மற்றும் சோதனை env க்கு இடையில் மாறவும்.';
 
   @override
   String get dev_preferences_test_environment_title =>
-      'Test environment parameters';
+      'சூழல் அளவுருக்களைச் சோதிக்கவும்';
 
   @override
   String dev_preferences_test_environment_subtitle(String url) {
-    return 'Base URL for current test env: $url';
+    return 'தற்போதைய சோதனைச் சூழலுக்கான அடிப்படை URL: $url';
   }
 
   @override
   String get dev_preferences_test_environment_dialog_title =>
-      'Test environment host';
+      'சோதனை சூழல் ஹோஸ்ட்';
 
   @override
-  String get dev_preferences_ml_kit_title => 'Use ML Kit';
+  String get dev_preferences_ml_kit_title => 'ML கிட் பயன்படுத்தவும்';
 
   @override
   String get dev_preferences_ml_kit_subtitle =>
-      'then you have to restart this app';
+      'பிறகு நீங்கள் இந்த செயலியை மறுதொடக்கம் செய்ய வேண்டும்.';
 
   @override
   String get dev_preferences_product_additional_features_title =>
-      'Additional button on product page';
+      'தயாரிப்பு பக்கத்தில் கூடுதல் பொத்தான்';
 
   @override
   String get dev_preferences_edit_ingredients_title =>
-      'Edit ingredients via a knowledge panel button';
+      'அறிவுப் பலகை பொத்தான் மூலம் பொருட்களைத் திருத்தவும்';
 
   @override
-  String get dev_preferences_export_history_title => 'Export History';
+  String get dev_preferences_export_history_title => 'ஏற்றுமதி வரலாறு';
 
   @override
-  String get dev_preferences_export_history_progress_error => 'exception';
+  String get dev_preferences_export_history_progress_error => 'விதிவிலக்கு';
 
   @override
-  String get dev_preferences_export_history_progress_found => 'product found';
+  String get dev_preferences_export_history_progress_found =>
+      'தயாரிப்பு கண்டுபிடிக்கப்பட்டது';
 
   @override
   String get dev_preferences_export_history_progress_not_found =>
-      'product NOT found';
+      'தயாரிப்பு கிடைக்கவில்லை.';
 
   @override
-  String get dev_preferences_export_history_dialog_title => 'Export history';
+  String get dev_preferences_export_history_dialog_title => 'ஏற்றுமதி வரலாறு';
 
   @override
   String get dev_preferences_button_positive => 'சரி';
@@ -2464,100 +2533,101 @@ class AppLocalizationsTa extends AppLocalizations {
   String get dev_preferences_button_negative => 'Cancel';
 
   @override
-  String get dev_preferences_migration_title => 'Data migration from V1';
+  String get dev_preferences_migration_title => 'V1 இலிருந்து தரவு இடம்பெயர்வு';
 
   @override
   String dev_preferences_migration_subtitle(String status) {
-    return 'Status: $status';
+    return 'நிலை: $status';
   }
 
   @override
   String get dev_preferences_migration_status_already_done =>
-      'success or fresh install';
+      'வெற்றி அல்லது புதிய நிறுவல்';
 
   @override
-  String get dev_preferences_migration_status_success => 'success';
+  String get dev_preferences_migration_status_success => 'வெற்றி';
 
   @override
-  String get dev_preferences_migration_status_error => 'error';
+  String get dev_preferences_migration_status_error => 'பிழை';
 
   @override
-  String get dev_preferences_migration_status_in_progress => 'in progress';
+  String get dev_preferences_migration_status_in_progress =>
+      'செயல்பாட்டில் உள்ளது';
 
   @override
   String get dev_preferences_migration_status_required =>
-      'required (click to start)';
+      'தேவை (தொடங்க கிளிக் செய்யவும்)';
 
   @override
-  String get dev_preferences_migration_status_not_started => 'unknown';
+  String get dev_preferences_migration_status_not_started => 'தெரியவில்லை';
 
   @override
   String get dev_preferences_import_history_subtitle =>
-      'Will clear history and put 3 products in there';
+      'வரலாற்றை அழித்து, 3 தயாரிப்புகளை அங்கே வைப்பேன்.';
 
   @override
-  String get dev_preferences_news_custom_url_title => 'Custom URL for news';
+  String get dev_preferences_news_custom_url_title =>
+      'செய்திகளுக்கான தனிப்பயன் URL';
 
   @override
-  String get dev_preferences_news_custom_url_subtitle =>
-      'URL of the JSON file:';
+  String get dev_preferences_news_custom_url_subtitle => 'JSON கோப்பின் URL:';
 
   @override
-  String get dev_preferences_news_custom_url_empty_value => 'Not set';
+  String get dev_preferences_news_custom_url_empty_value => 'அமைக்கப்படவில்லை';
 
   @override
   String get dev_preferences_news_provider_status_title => 'Status';
 
   @override
   String dev_preferences_news_provider_status_subtitle(String date) {
-    return 'Last refresh: $date';
+    return 'கடைசி புதுப்பிப்பு: $date';
   }
 
   @override
-  String get product_type_label_food => 'Food';
+  String get product_type_label_food => 'உணவு';
 
   @override
-  String get product_type_label_beauty => 'Personal care';
+  String get product_type_label_beauty => 'தனிப்பட்ட பராமரிப்பு';
 
   @override
-  String get product_type_label_pet_food => 'Pet food';
+  String get product_type_label_pet_food => 'செல்லப்பிராணி உணவு';
 
   @override
   String get product_type_label_product => 'Other';
 
   @override
-  String get product_type_selection_title => 'Product type';
+  String get product_type_selection_title => 'தயாரிப்பு வகை';
 
   @override
   String get product_type_selection_subtitle =>
-      'Select the type of this product';
+      'இந்த தயாரிப்பின் வகையைத் தேர்ந்தெடுக்கவும்.';
 
   @override
   String get product_type_selection_empty =>
-      'You need to select a product type first!';
+      'நீங்கள் முதலில் ஒரு தயாரிப்பு வகையைத் தேர்ந்தெடுக்க வேண்டும்!';
 
   @override
   String product_type_selection_already(String productType) {
-    return 'You cannot change the product type ($productType)!';
+    return 'நீங்கள் தயாரிப்பு வகையை ($productType) மாற்ற முடியாது!';
   }
 
   @override
   String get prices_app_dev_mode_flag =>
-      'Shortcut to Prices app on product page';
+      'தயாரிப்பு பக்கத்தில் விலைகள் பயன்பாட்டிற்கான குறுக்குவழி';
 
   @override
-  String get prices_app_button => 'Go to Prices app';
+  String get prices_app_button => 'விலைகள் பயன்பாட்டிற்குச் செல்லவும்';
 
   @override
   String get prices_website_button => 'திறந்த விலைகள் வலைத்தளத்தில் திறக்கவும்';
 
   @override
   String get prices_bulk_proof_upload_select =>
-      'Add price tags directly from gallery';
+      'கேலரியில் இருந்து நேரடியாக விலைக் குறிச்சொற்களைச் சேர்க்கவும்.';
 
   @override
   String get prices_bulk_proof_upload_warning =>
-      'Once you\'ve selected images, you won\'t be able to edit them!';
+      'படங்களைத் தேர்ந்தெடுத்த பிறகு, அவற்றைத் திருத்த முடியாது!';
 
   @override
   String get prices_bulk_proof_upload_warning_ai =>
@@ -2568,10 +2638,11 @@ class AppLocalizationsTa extends AppLocalizations {
       'AI ஆல் பிரித்தெடுக்கப்பட்ட விலைகளை சமூகம் சரிபார்க்க அனுமதிக்கவும்.';
 
   @override
-  String get prices_bulk_proof_upload_subtitle => 'Multiple Price Tags';
+  String get prices_bulk_proof_upload_subtitle => 'பல விலை குறிச்சொற்கள்';
 
   @override
-  String get prices_bulk_proof_upload_title => 'Bulk Proof Upload';
+  String get prices_bulk_proof_upload_title =>
+      'மொத்தமாகச் சரிபார்க்கக்கூடிய பதிவேற்றம்';
 
   @override
   String get prices_bulk_proof_upload_step_selecting =>
@@ -2597,15 +2668,15 @@ class AppLocalizationsTa extends AppLocalizations {
   }
 
   @override
-  String get prices_generic_title => 'Prices';
+  String get prices_generic_title => 'விலைகள்';
 
   @override
   String prices_add_n_prices(num count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'Add $count prices',
-      one: 'Add a price',
+      other: '$count விலைகளைச் சேர்க்கவும்',
+      one: 'விலையைச் சேர்க்கவும்',
     );
     return '$_temp0';
   }
@@ -2615,34 +2686,34 @@ class AppLocalizationsTa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'Send $count prices',
-      one: 'Send the price',
+      other: '$count விலைகளை அனுப்பு',
+      one: 'விலையை அனுப்பு',
     );
     return '$_temp0';
   }
 
   @override
-  String get prices_add_an_item => 'Add an item';
+  String get prices_add_an_item => 'ஒரு பொருளைச் சேர்க்கவும்';
 
   @override
-  String get prices_add_a_price => 'Add a price';
+  String get prices_add_a_price => 'விலையைச் சேர்க்கவும்';
 
   @override
-  String get prices_add_a_receipt => 'Add a receipt';
+  String get prices_add_a_receipt => 'ரசீதைச் சேர்க்கவும்';
 
   @override
-  String get prices_add_price_tags => 'Add price tags';
+  String get prices_add_price_tags => 'விலைக் குறிச்சொற்களைச் சேர்க்கவும்';
 
   @override
   String prices_barcode_already(String barcode) {
-    return 'This barcode ($barcode) is already in the list!';
+    return 'இந்த பார்கோடு ($barcode) ஏற்கனவே பட்டியலில் உள்ளது!';
   }
 
   @override
   String get prices_barcode_search_not_found => 'Product not found';
 
   @override
-  String get prices_barcode_search_none_yet => 'No product yet';
+  String get prices_barcode_search_none_yet => 'இன்னும் தயாரிப்பு இல்லை';
 
   @override
   String prices_barcode_search_running(String barcode) {
@@ -2650,7 +2721,7 @@ class AppLocalizationsTa extends AppLocalizations {
   }
 
   @override
-  String get prices_barcode_enter => 'Enter the Barcode';
+  String get prices_barcode_enter => 'பார்கோடை உள்ளிடவும்';
 
   @override
   String get prices_category_enter => 'பார்கோடு இல்லாத பொருள்';
@@ -2677,10 +2748,10 @@ class AppLocalizationsTa extends AppLocalizations {
   String get prices_category_error_mandatory => 'இந்தப் பிரிவு கட்டாயமானது';
 
   @override
-  String get prices_barcode_reader_action => 'Barcode reader';
+  String get prices_barcode_reader_action => 'பார்கோடு ரீடர்';
 
   @override
-  String get prices_view_prices => 'View the prices';
+  String get prices_view_prices => 'விலைகளைப் பார்க்கவும்';
 
   @override
   String get prices_list_title => 'விலைப்பட்டியல்';
@@ -2729,10 +2800,10 @@ class AppLocalizationsTa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count prices',
-      one: '1 price',
+      other: '$count விலைகள்',
+      one: '1 விலை',
     );
-    return '$_temp0 for $product';
+    return '$_temp0 $productக்கு';
   }
 
   @override
@@ -2740,16 +2811,16 @@ class AppLocalizationsTa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'All $count prices',
-      one: 'Only one price',
-      zero: 'No price yet',
+      other: 'அனைத்தும் $count விலைகள்',
+      one: 'ஒரே ஒரு விலை',
+      zero: 'விலை இன்னும் இல்லை',
     );
     return '$_temp0';
   }
 
   @override
   String prices_list_length_many_pages(int pageSize, int total) {
-    return 'Latest $pageSize prices (total: $total)';
+    return 'சமீபத்திய $pageSize விலைகள் (மொத்தம்: $total)';
   }
 
   @override
@@ -2759,32 +2830,32 @@ class AppLocalizationsTa extends AppLocalizations {
     String date,
     String user,
   ) {
-    return 'Price: $price / Store: \"$location\" / Published on $date by \"$user\"';
+    return 'விலை: $price / கடை: \"$location\" / $date இல் \"$user\" ஆல் வெளியிடப்பட்டது';
   }
 
   @override
   String prices_open_user_proofs(String user) {
-    return 'Open proofs of \"$user\"';
+    return '\"$user\" இன் திறந்த சான்றுகள்';
   }
 
   @override
-  String get prices_open_proof => 'Open price proof';
+  String get prices_open_proof => 'திறந்த விலைச் சான்று';
 
   @override
   String prices_proofs_list_length_one_page(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: 'All $count proofs',
-      one: 'Only one proof',
-      zero: 'No proof yet',
+      other: 'அனைத்தும் $count ஆதாரங்கள்',
+      one: 'ஒரே ஒரு ஆதாரம்',
+      zero: 'இன்னும் ஆதாரம் இல்லை',
     );
     return '$_temp0';
   }
 
   @override
   String prices_proofs_list_length_many_pages(int pageSize, int total) {
-    return 'Latest $pageSize proofs (total: $total)';
+    return 'சமீபத்திய $pageSize சான்றுகள் (மொத்தம்: $total)';
   }
 
   @override
@@ -2808,7 +2879,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String prices_locations_list_length_many_pages(int pageSize, int total) {
-    return 'Top $pageSize locations (total: $total)';
+    return 'மேலே $pageSize இடங்கள் (மொத்தம்: $total)';
   }
 
   @override
@@ -2816,9 +2887,9 @@ class AppLocalizationsTa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count proofs',
-      one: 'One proof',
-      zero: 'No proof',
+      other: '$count ஆதாரங்கள்',
+      one: 'ஒரு ஆதாரம்',
+      zero: 'ஆதாரம் இல்லை',
     );
     return '$_temp0';
   }
@@ -2828,9 +2899,9 @@ class AppLocalizationsTa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count products',
-      one: 'One product',
-      zero: 'No product',
+      other: '$count தயாரிப்புகள்',
+      one: 'ஒரு தயாரிப்பு',
+      zero: 'தயாரிப்பு இல்லை',
     );
     return '$_temp0';
   }
@@ -2840,9 +2911,9 @@ class AppLocalizationsTa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count users',
-      one: 'One user',
-      zero: 'No user',
+      other: '$count பயனர்கள்',
+      one: 'ஒரு பயனர்',
+      zero: 'பயனர் இல்லை',
     );
     return '$_temp0';
   }
@@ -2852,9 +2923,9 @@ class AppLocalizationsTa extends AppLocalizations {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count prices',
-      one: 'One price',
-      zero: 'No price',
+      other: '$count விலைகள்',
+      one: 'ஒரு விலை',
+      zero: 'விலை இல்லை',
     );
     return '$_temp0';
   }
@@ -2863,50 +2934,51 @@ class AppLocalizationsTa extends AppLocalizations {
   String get prices_amount_existing_subtitle => 'முன்பு சேர்க்கப்பட்ட விலை';
 
   @override
-  String get prices_amount_subtitle => 'Amount';
+  String get prices_amount_subtitle => 'தொகை';
 
   @override
-  String get prices_amount_is_discounted => 'Is discounted?';
+  String get prices_amount_is_discounted => 'தள்ளுபடி உள்ளதா?';
 
   @override
-  String get prices_amount_price_normal => 'Price';
+  String get prices_amount_price_normal => 'விலை';
 
   @override
-  String get prices_amount_price_discounted => 'Discounted price';
+  String get prices_amount_price_discounted => 'தள்ளுபடி விலை';
 
   @override
-  String get prices_amount_price_not_discounted => 'Original price';
+  String get prices_amount_price_not_discounted => 'அசல் விலை';
 
   @override
-  String get prices_amount_no_product => 'One product is missing!';
+  String get prices_amount_no_product => 'ஒரு தயாரிப்பு காணவில்லை!';
 
   @override
-  String get prices_amount_price_incorrect => 'Incorrect value';
+  String get prices_amount_price_incorrect => 'தவறான மதிப்பு';
 
   @override
-  String get prices_amount_price_mandatory => 'Mandatory value';
+  String get prices_amount_price_mandatory => 'கட்டாய மதிப்பு';
 
   @override
-  String get prices_currency_subtitle => 'Currency';
+  String get prices_currency_subtitle => 'நாணயம்';
 
   @override
-  String get prices_date_subtitle => 'Date';
+  String get prices_date_subtitle => 'தேதி';
 
   @override
-  String get prices_location_subtitle => 'Shop';
+  String get prices_location_subtitle => 'கடை';
 
   @override
-  String get prices_location_find => 'Find a shop';
+  String get prices_location_find => 'ஒரு கடையைக் கண்டுபிடி.';
 
   @override
-  String get prices_location_mandatory => 'You need to select a shop!';
+  String get prices_location_mandatory =>
+      'நீங்கள் ஒரு கடையைத் தேர்ந்தெடுக்க வேண்டும்!';
 
   @override
   String get prices_location_search_broader =>
-      'Couldn\'t find what you were looking for? Let\'s try a broader search!';
+      'நீங்கள் தேடுவதைக் கண்டுபிடிக்க முடியவில்லையா? இன்னும் விரிவாகத் தேட முயற்சிப்போம்!';
 
   @override
-  String get prices_proof_subtitle => 'Proof';
+  String get prices_proof_subtitle => 'ஆதாரம்';
 
   @override
   String get prices_proof_empty_title => 'இன்னும் ஆதாரம் இல்லை!';
@@ -2916,50 +2988,51 @@ class AppLocalizationsTa extends AppLocalizations {
       '**ரசீது** அல்லது **விலை குறி**யின் புகைப்படத்தைச் சேர்ப்பதன் மூலம் தொடங்குங்கள்!';
 
   @override
-  String get prices_proof_find => 'Select a proof';
+  String get prices_proof_find => 'ஒரு சான்றைத் தேர்ந்தெடுக்கவும்';
 
   @override
-  String get prices_proof_change => 'Change proof';
+  String get prices_proof_change => 'மாற்றச் சான்று';
 
   @override
-  String get prices_proof_receipt => 'Receipt';
+  String get prices_proof_receipt => 'ரசீது';
 
   @override
-  String get prices_proof_price_tag => 'Price tag';
+  String get prices_proof_price_tag => 'விலைக் குறி';
 
   @override
-  String get prices_proof_mandatory => 'You need to select a proof!';
+  String get prices_proof_mandatory =>
+      'நீங்கள் ஒரு சான்றைத் தேர்ந்தெடுக்க வேண்டும்!';
 
   @override
-  String get prices_add_validation_error => 'Validation error';
+  String get prices_add_validation_error => 'சரிபார்ப்பு பிழை';
 
   @override
-  String get prices_privacy_warning_title => 'Privacy warning';
+  String get prices_privacy_warning_title => 'தனியுரிமை எச்சரிக்கை';
 
   @override
-  String get prices_unknown_product => 'Unknown product';
+  String get prices_unknown_product => 'தெரியாத தயாரிப்பு';
 
   @override
   String get prices_privacy_warning_main_message =>
-      'Prices **will be public**, along with the store they refer to.\n\nThat might allow people who know about your Open Food Facts pseudonym to:\n';
+      'விலைகள் **பொதுவில் இருக்கும்**, அவர்கள் குறிப்பிடும் கடையுடன் சேர்த்து.\n\nஇது உங்கள் திறந்த உணவு உண்மைகள் புனைப்பெயரைப் பற்றி அறிந்தவர்கள்:\nஎன்று அனுமதிக்கக்கூடும்.';
 
   @override
   String get prices_privacy_warning_message_bullet_1 =>
-      'Infer in which area you live';
+      'நீங்கள் எந்தப் பகுதியில் வசிக்கிறீர்கள் என்று யூகிக்கவும்.';
 
   @override
   String get prices_privacy_warning_message_bullet_2 =>
-      'Know what you are buying';
+      'நீங்கள் என்ன வாங்குகிறீர்கள் என்பதை அறிந்து கொள்ளுங்கள்';
 
   @override
   String get prices_privacy_warning_sub_message =>
-      'If you are uneasy with that, please change your pseudonym, or create a new Open Food Facts account and log into the app with it.';
+      'உங்களுக்கு அது சங்கடமாக இருந்தால், தயவுசெய்து உங்கள் புனைப்பெயரை மாற்றவும் அல்லது புதிய Open Food Facts கணக்கை உருவாக்கி அதைப் பயன்படுத்தி செயலியில் உள்நுழையவும்.';
 
   @override
-  String get i_refuse => 'I refuse';
+  String get i_refuse => 'நான் மறுக்கிறேன்.';
 
   @override
-  String get i_accept => 'I accept';
+  String get i_accept => 'நான் ஏற்றுக்கொள்கிறேன்';
 
   @override
   String get prices_currency_change_proposal_title => 'நாணயத்தை மாற்றவா?';
@@ -2983,36 +3056,37 @@ class AppLocalizationsTa extends AppLocalizations {
   }
 
   @override
-  String get prices_menu_know_more => 'Know more about Open Prices';
+  String get prices_menu_know_more => 'திறந்த விலைகள் பற்றி மேலும் அறிக';
 
   @override
-  String get dev_preferences_import_history_result_success => 'Done';
+  String get dev_preferences_import_history_result_success => 'முடிந்தது';
 
   @override
-  String get dev_mode_section_server => 'Server configuration';
+  String get dev_mode_section_server => 'சேவையக உள்ளமைவு';
 
   @override
-  String get dev_mode_section_news => 'News provider configuration';
+  String get dev_mode_section_news => 'செய்தி வழங்குநர் உள்ளமைவு';
 
   @override
-  String get dev_mode_section_product_page => 'Product page';
+  String get dev_mode_section_product_page => 'தயாரிப்பு பக்கம்';
 
   @override
-  String get dev_mode_section_ui => 'User Interface';
+  String get dev_mode_section_ui => 'பயனர் இடைமுகம்';
 
   @override
-  String get dev_mode_section_experimental_features => 'Experimental features';
+  String get dev_mode_section_experimental_features => 'பரிசோதனை அம்சங்கள்';
 
   @override
-  String get dev_mode_hide_environmental_score_title => 'Exclude Green Score';
+  String get dev_mode_hide_environmental_score_title =>
+      'பச்சை மதிப்பெண்ணை விலக்கு';
 
   @override
   String get dev_mode_spellchecker_for_ocr_title =>
-      'Use a spellchecker for OCR screens';
+      'OCR திரைகளுக்கு எழுத்துப்பிழை சரிபார்ப்பானைப் பயன்படுத்தவும்.';
 
   @override
   String get dev_mode_spellchecker_for_ocr_subtitle =>
-      '(Ingredients and packaging)';
+      '(பொருட்கள் மற்றும் பேக்கேஜிங்)';
 
   @override
   String get dev_mode_reset_app_language_title =>
@@ -3026,14 +3100,15 @@ class AppLocalizationsTa extends AppLocalizations {
       'prices.openfoodfacts.org (PROD) மற்றும் சோதனை env க்கு இடையில் மாறவும்.';
 
   @override
-  String get search_history_item_edit_tooltip => 'Reuse and edit this search';
+  String get search_history_item_edit_tooltip =>
+      'இந்த தேடலை மீண்டும் பயன்படுத்தவும் திருத்தவும்.';
 
   @override
-  String get search_history_item_remove_tooltip => 'Remove';
+  String get search_history_item_remove_tooltip => 'அகற்று';
 
   @override
   String product_search_no_more_results(int totalSize) {
-    return 'You\'ve downloaded all the $totalSize products.';
+    return 'நீங்கள் எல்லா $totalSize தயாரிப்புகளையும் பதிவிறக்கம் செய்துவிட்டீர்கள்.';
   }
 
   @override
@@ -3042,38 +3117,40 @@ class AppLocalizationsTa extends AppLocalizations {
     int downloaded,
     int totalSize,
   ) {
-    return 'Download $count more products\nAlready downloaded $downloaded out of $totalSize.';
+    return '$count மேலும் தயாரிப்புகளைப் பதிவிறக்கவும்\nஏற்கனவே $downloaded இல் $totalSizeபதிவிறக்கப்பட்டது.';
   }
 
   @override
   String product_search_loading_message(Object search) {
-    return 'Your search of $search is in progress.\n\nPlease wait a few seconds…';
+    return '$search க்கான உங்கள் தேடல் நடந்து கொண்டிருக்கிறது.\n\nசில வினாடிகள் காத்திருக்கவும்…';
   }
 
   @override
-  String get user_search_contributor_title => 'Products I added';
+  String get user_search_contributor_title => 'நான் சேர்த்த தயாரிப்புகள்';
 
   @override
-  String get user_search_informer_title => 'Products I edited';
+  String get user_search_informer_title => 'நான் திருத்திய தயாரிப்புகள்';
 
   @override
-  String get user_search_photographer_title => 'Products I photographed';
+  String get user_search_photographer_title =>
+      'நான் புகைப்படம் எடுத்த தயாரிப்புகள்';
 
   @override
-  String get user_search_to_be_completed_title => 'My to-be-completed products';
+  String get user_search_to_be_completed_title =>
+      'எனது முடிக்கப்பட வேண்டிய தயாரிப்புகள்';
 
   @override
   String get user_search_prices_title => 'எனது விலைகள்';
 
   @override
-  String get user_search_proofs_title => 'My proofs';
+  String get user_search_proofs_title => 'எனது சான்றுகள்';
 
   @override
-  String get user_search_proof_title => 'My proof';
+  String get user_search_proof_title => 'என் ஆதாரம்';
 
   @override
   String search_proof_title(String user) {
-    return 'Proof from \"$user\"';
+    return '\"$user\" இலிருந்து ஆதாரம்';
   }
 
   @override
@@ -3101,63 +3178,68 @@ class AppLocalizationsTa extends AppLocalizations {
   String get prices_challenges_page => 'சவால்கள்';
 
   @override
-  String get prices_multiple_proof_addition_system => 'Add Multiple Proofs';
+  String get prices_multiple_proof_addition_system =>
+      'பல சான்றுகளைச் சேர்க்கவும்';
 
   @override
-  String get all_search_prices_top_location_single_title => 'Prices in a store';
+  String get all_search_prices_top_location_single_title =>
+      'ஒரு கடையில் விலைகள்';
 
   @override
   String get all_search_prices_top_product_title =>
       'அதிக விலை கொண்ட தயாரிப்புகள்';
 
   @override
-  String get all_search_to_be_completed_title => 'All to-be-completed products';
+  String get all_search_to_be_completed_title =>
+      'முடிக்கப்பட வேண்டிய அனைத்து தயாரிப்புகளும்';
 
   @override
   String get categorize_products_country_title =>
-      'Help categorize products in your country';
+      'உங்கள் நாட்டில் உள்ள பொருட்களை வகைப்படுத்த உதவுங்கள்.';
 
   @override
-  String get edit_product_action_retake_picture => 'Retake photo';
+  String get edit_product_action_retake_picture => 'புகைப்படத்தை மீண்டும் எடு';
 
   @override
-  String get edit_product_action_take_picture => 'Take photo';
+  String get edit_product_action_take_picture => 'புகைப்படம் எடு';
 
   @override
-  String get edit_product_action_confirm => 'Confirm';
+  String get edit_product_action_confirm => 'உறுதிப்படுத்தவும்';
 
   @override
   String get signup_page_terms_of_use_line1 =>
-      'I agree to the Open Food Facts ';
+      'திறந்த உணவு உண்மைகளை நான் ஒப்புக்கொள்கிறேன். ';
 
   @override
-  String get signup_page_terms_of_use_line2 => 'terms of use and contribution';
+  String get signup_page_terms_of_use_line2 =>
+      'பயன்பாட்டு விதிமுறைகள் மற்றும் பங்களிப்பு';
 
   @override
-  String get analytics_consent_image_semantic_label => 'Analytics icon';
+  String get analytics_consent_image_semantic_label => 'பகுப்பாய்வு ஐகான்';
 
   @override
   String knowledge_panel_page_loading_error(Object? error) {
-    return 'Fatal Error: $error';
+    return 'அபாயகரமான பிழை: $error';
   }
 
   @override
   String preferences_page_loading_error(Object? error) {
-    return 'Fatal Error: $error';
+    return 'அபாயகரமான பிழை: $error';
   }
 
   @override
-  String get summary_card_button_add_basic_details => 'Complete basic details';
+  String get summary_card_button_add_basic_details =>
+      'அடிப்படை விவரங்களை முடிக்கவும்';
 
   @override
   String get edit_photo_button_label => 'திருத்து';
 
   @override
-  String get edit_photo_unselect_button_label => 'Unselect photo';
+  String get edit_photo_unselect_button_label => 'புகைப்படத்தைத் தேர்வுநீக்கு';
 
   @override
   String get edit_photo_select_existing_button_label =>
-      'Select an existing image';
+      'ஏற்கனவே உள்ள படத்தைத் தேர்ந்தெடுக்கவும்';
 
   @override
   String get edit_photo_select_existing_all_label =>
@@ -3165,15 +3247,15 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get edit_photo_select_existing_all_subtitle =>
-      'Select an image by clicking on it';
+      'ஒரு படத்தைக் கிளிக் செய்வதன் மூலம் அதைத் தேர்ந்தெடுக்கவும்';
 
   @override
   String get edit_photo_select_existing_download_label =>
-      'Retrieving existing images…';
+      'ஏற்கனவே உள்ள படங்களை மீட்டெடுக்கிறது…';
 
   @override
   String get edit_photo_select_existing_downloaded_none =>
-      'There are no images previously uploaded related to this product.';
+      'இந்த தயாரிப்பு தொடர்பான படங்கள் எதுவும் முன்னர் பதிவேற்றப்படவில்லை.';
 
   @override
   String get edit_photo_language_not_this_one =>
@@ -3186,10 +3268,10 @@ class AppLocalizationsTa extends AppLocalizations {
   String get category_picker_screen_title => 'Categories';
 
   @override
-  String get basic_details => 'Basic Details';
+  String get basic_details => 'அடிப்படை விவரங்கள்';
 
   @override
-  String get product_name => 'Product Name';
+  String get product_name => 'தயாரிப்பு பெயர்';
 
   @override
   String get product_names => 'தயாரிப்புப் பெயர்கள்';
@@ -3200,7 +3282,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get add_basic_details_product_name_warning_translations =>
-      'Before validating, please ensure you only add a translation **if the language is present on the packaging**';
+      'சரிபார்ப்பதற்கு முன், தொகுப்பில் மொழி இருந்தால் மட்டுமே மொழிபெயர்ப்பைச் சேர்ப்பதை உறுதிசெய்யவும்**';
 
   @override
   String get add_basic_details_product_name_open_photo =>
@@ -3226,45 +3308,45 @@ class AppLocalizationsTa extends AppLocalizations {
   }
 
   @override
-  String get explanation_section_good_examples => 'Good examples';
+  String get explanation_section_good_examples => 'நல்ல உதாரணங்கள்';
 
   @override
-  String get explanation_section_bad_examples => 'Bad examples';
+  String get explanation_section_bad_examples => 'மோசமான உதாரணங்கள்';
 
   @override
   String get add_basic_details_product_name_help_title =>
-      'Good practices: Product name';
+      'நல்ல நடைமுறைகள்: தயாரிப்பு பெயர்';
 
   @override
   String get add_basic_details_product_name_help_info1 =>
-      'The product name is the **main name printed on the packaging**. It can be a registered trademark.';
+      'தயாரிப்பு பெயர் **பேக்கேஜிங்கில் அச்சிடப்பட்ட முக்கிய பெயர்**. இது பதிவுசெய்யப்பட்ட வர்த்தக முத்திரையாக இருக்கலாம்.';
 
   @override
   String get add_basic_details_product_name_help_info2 =>
-      '**Note:** Please don\'t add a translation **if the language is not present on the packaging**.';
+      '**குறிப்பு:** தொகுப்பில் மொழி இல்லை என்றால், மொழிபெயர்ப்பைச் சேர்க்க வேண்டாம்**.';
 
   @override
-  String get add_basic_details_product_name_help_good_examples_1 => 'Nesquik';
+  String get add_basic_details_product_name_help_good_examples_1 => 'நெஸ்கிக்';
 
   @override
   String get add_basic_details_product_name_help_good_examples_2 =>
-      'Tomato Ketchup';
+      'தக்காளி கெட்ச்அப்';
 
   @override
   String get add_basic_details_product_name_help_bad_examples_1_explanation =>
-      'Don\'t include the brand in the name';
+      'பெயரில் பிராண்டைச் சேர்க்க வேண்டாம்.';
 
   @override
   String get add_basic_details_product_name_help_bad_examples_1_example =>
-      'Tomato Ketchup **by Heinz**';
+      'தக்காளி கெட்ச்அப் **ஹெய்ன்ஸ் எழுதியது**';
 
   @override
   String get add_basic_details_product_name_help_bad_examples_2_explanation =>
-      'Don\'t use symbols ®, ™, © or similar';
+      '®, ™, © அல்லது அது போன்ற சின்னங்களைப் பயன்படுத்த வேண்டாம்.';
 
   @override
   String get add_basic_details_product_name_help_bad_examples_2_example =>
-      'Nesquik**®**';
+      'நெஸ்கிக்**®**';
 
   @override
   String add_basic_details_product_name_other_translations(int count) {
@@ -3278,14 +3360,14 @@ class AppLocalizationsTa extends AppLocalizations {
   }
 
   @override
-  String get brand_name => 'Brand name';
+  String get brand_name => 'பிராண்ட் பெயர்';
 
   @override
   String get brand_names => 'தயாரிப்புப் பெயர்கள்';
 
   @override
   String get add_basic_details_brand_name_error =>
-      'Please enter the brand name';
+      'தயவுசெய்து பிராண்ட் பெயரை உள்ளிடவும்.';
 
   @override
   String get add_basic_details_brand_names_hint =>
@@ -3293,47 +3375,49 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get add_basic_details_product_brand_help_title =>
-      'Good practices: Brands';
+      'நல்ல நடைமுறைகள்: பிராண்டுகள்';
 
   @override
   String get add_basic_details_product_brand_help_info1 =>
-      'Input **all the brands of the product**.';
+      '**தயாரிப்புகளின் அனைத்து பிராண்டுகளையும்** உள்ளிடவும்.';
 
   @override
-  String get add_basic_details_product_brand_help_info2_title => 'Main brand';
+  String get add_basic_details_product_brand_help_info2_title =>
+      'முக்கிய பிராண்ட்';
 
   @override
   String get add_basic_details_product_brand_help_info2_content =>
-      'The **main brand**, generally clearly displayed on the front pack, should be **entered first**.';
+      '**முக்கிய பிராண்ட்**, பொதுவாக முன் பேக்கில் தெளிவாகக் காட்டப்படும், முதலில் **உள்ளிடப்பட வேண்டும்**.';
 
   @override
-  String get add_basic_details_product_brand_help_info3_title => 'Other brands';
+  String get add_basic_details_product_brand_help_info3_title =>
+      'பிற பிராண்டுகள்';
 
   @override
   String get add_basic_details_product_brand_help_info3_item1_text =>
-      'When sold **by a big company**:';
+      'ஒரு பெரிய நிறுவனத்தால் **விற்கப்படும்போது**:';
 
   @override
   String get add_basic_details_product_brand_help_info3_item1_explanation =>
-      '**Actimel** is sold by **Danone**';
+      '**ஆக்டிமெல்** **டனோனால்** விற்கப்படுகிறது.';
 
   @override
   String get add_basic_details_product_brand_help_info3_item2_text =>
-      'When sold with its brand **translated in multiple languages**:';
+      'அதன் பிராண்டுடன் விற்கப்படும் போது **பல மொழிகளில் மொழிபெயர்க்கப்பட்டுள்ளது**:';
 
   @override
   String get add_basic_details_product_brand_help_info3_item2_explanation =>
-      '**Nature Valley** is sometimes written **Val Nature**';
+      '**இயற்கை பள்ளத்தாக்கு** சில நேரங்களில் **வால் நேச்சர்** என்று எழுதப்படுகிறது.';
 
   @override
-  String get add_basic_details_product_brand_help_good_examples_1 => 'Nutella';
+  String get add_basic_details_product_brand_help_good_examples_1 => 'நுடெல்லா';
 
   @override
   String get add_basic_details_product_brand_help_good_examples_2 =>
-      'Oreo, Mondelez';
+      'ஓரியோ, மொண்டெலெஸ்';
 
   @override
-  String get quantity => 'Quantity and weight';
+  String get quantity => 'அளவு மற்றும் எடை';
 
   @override
   String get add_basic_details_quantity_hint =>
@@ -3341,115 +3425,117 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get add_basic_details_product_quantity_help_title =>
-      'Good practices: Quantity';
+      'நல்ல நடைமுறைகள்: அளவு';
 
   @override
   String get add_basic_details_product_quantity_help_info1 =>
-      'Copy the value indicated on the product and **don\'t forget the units**.';
+      'தயாரிப்பில் குறிப்பிடப்பட்டுள்ள மதிப்பை நகலெடுத்து **அலகுகளை மறந்துவிடாதீர்கள்**.';
 
   @override
   String get add_basic_details_product_quantity_help_good_examples_1 =>
-      '**230g** or **230 g**';
+      '**230 கிராம்** அல்லது **230 கிராம்**';
 
   @override
   String get add_basic_details_product_quantity_help_good_examples_2 =>
-      '**6** (for 6 eggs)';
+      '**6** (6 முட்டைகளுக்கு)';
 
   @override
   String get add_basic_details_product_quantity_help_good_examples_3 =>
-      '**3 x 150g**\n(for a product with 3 boxes, each of 150g)';
+      '**3 x 150 கிராம்**\n(ஒவ்வொன்றும் 150 கிராம் கொண்ட 3 பெட்டிகளைக் கொண்ட தயாரிப்புக்கு)';
 
   @override
   String get barcode => 'பார்கோடு';
 
   @override
   String barcode_barcode(String barcode) {
-    return 'Barcode: $barcode';
+    return 'பார்கோடு: $barcode';
   }
 
   @override
-  String get barcode_invalid_error => 'Invalid barcode';
+  String get barcode_invalid_error => 'தவறான பார்கோடு';
 
   @override
-  String get basic_details_add_success => 'Basic details added successfully';
+  String get basic_details_add_success =>
+      'அடிப்படை விவரங்கள் வெற்றிகரமாக சேர்க்கப்பட்டன.';
 
   @override
   String get basic_details_add_error =>
-      'Unable to add basic details. Please try again after some time';
+      'அடிப்படை விவரங்களைச் சேர்க்க முடியவில்லை. சிறிது நேரம் கழித்து மீண்டும் முயற்சிக்கவும்.';
 
   @override
-  String get clear_search => 'Clear your search';
+  String get clear_search => 'உங்கள் தேடலை அழிக்கவும்';
 
   @override
   String get confirm_clear =>
-      'You\'re about to clear your entire history: are you sure you want to continue?';
+      'உங்கள் முழு வரலாற்றையும் அழிக்கப் போகிறீர்கள்: நிச்சயமாகத் தொடர விரும்புகிறீர்களா?';
 
   @override
   String get alert_clear_selected_user_list =>
-      'You\'re about to clear selected items in your history';
+      'உங்கள் வரலாற்றில் தேர்ந்தெடுக்கப்பட்ட உருப்படிகளை அழிக்கப் போகிறீர்கள்.';
 
   @override
   String get confirm_clear_selected_user_list =>
-      'Are you sure you want to continue?';
+      'நீங்கள் தொடர விரும்புகிறீர்களா?';
 
   @override
   String get alert_select_items_to_clear =>
-      'Please select one or more items to clear';
+      'அழிக்க ஒன்று அல்லது அதற்கு மேற்பட்ட உருப்படிகளைத் தேர்ந்தெடுக்கவும்.';
 
   @override
   String confirm_clear_user_list(String name) {
-    return 'You\'re about to clear this list ($name): are you sure you want to continue?';
+    return 'இந்தப் பட்டியலை நீங்கள் அழிக்கப் போகிறீர்கள் ($name): நீங்கள் நிச்சயமாகத் தொடர விரும்புகிறீர்களா?';
   }
 
   @override
-  String get confirm_delete_user_list_title => 'Delete the list?';
+  String get confirm_delete_user_list_title => 'பட்டியலை நீக்கவா?';
 
   @override
   String confirm_delete_user_list_message(String name) {
-    return 'You\'re about to delete the list \"$name\".\nAre you sure you want to continue?';
+    return '\"$name\" பட்டியலை நீக்கப் போகிறீர்கள்.\nதொடர விரும்புகிறீர்களா?';
   }
 
   @override
-  String get confirm_delete_user_list_button => 'Yes, I confirm';
+  String get confirm_delete_user_list_button => 'ஆம், நான் உறுதி செய்கிறேன்.';
 
   @override
   String importance_label(String name, String id) {
-    return '$name importance: $id';
+    return '$name முக்கியத்துவம்: $id';
   }
 
   @override
-  String get user_list_all_title => 'Lists';
+  String get user_list_all_title => 'பட்டியல்கள்';
 
   @override
-  String get user_list_all_empty => 'Create your first list';
+  String get user_list_all_empty => 'உங்கள் முதல் பட்டியலை உருவாக்கவும்.';
 
   @override
-  String get product_list_select => 'Select a list';
+  String get product_list_select => 'பட்டியலைத் தேர்ந்தெடுக்கவும்';
 
   @override
   String user_list_length(num count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count products',
-      one: 'One product',
-      zero: 'Empty list',
+      other: '$count தயாரிப்புகள்',
+      one: 'ஒரு தயாரிப்பு',
+      zero: 'வெற்று பட்டியல்',
     );
     return '$_temp0';
   }
 
   @override
-  String get add_list_label => 'Add list';
+  String get add_list_label => 'பட்டியலைச் சேர்';
 
   @override
-  String get open_food_preferences_tooltip => 'Edit your food preferences';
+  String get open_food_preferences_tooltip =>
+      'உங்கள் உணவு விருப்பங்களைத் திருத்தவும்';
 
   @override
-  String get add_photo_button_label => 'Add photo';
+  String get add_photo_button_label => 'புகைப்படத்தைச் சேர்';
 
   @override
   String get add_packaging_photo_button_label =>
-      'Take photos of any packaging/recycling information';
+      'எந்தவொரு பேக்கேஜிங்/மறுசுழற்சி தகவலின் புகைப்படங்களையும் எடுக்கவும்.';
 
   @override
   String get add_origin_photo_button_label =>
@@ -3464,50 +3550,53 @@ class AppLocalizationsTa extends AppLocalizations {
       'ஏதேனும் லேபிள்கள் மற்றும் சான்றிதழ்கள்பற்றிய தகவல்களைப் புகைப்படம் எடுக்கவும்';
 
   @override
-  String get choose_image_source_title => 'Choose image source';
+  String get choose_image_source_title => 'பட மூலத்தைத் தேர்வுசெய்க';
 
   @override
-  String get choose_image_source_body => 'Please choose a image source';
+  String get choose_image_source_body =>
+      'தயவுசெய்து ஒரு பட மூலத்தைத் தேர்ந்தெடுக்கவும்.';
 
   @override
-  String get gallery_source_label => 'Gallery';
+  String get gallery_source_label => 'கேலரி';
 
   @override
-  String get gallery_source_access_denied_dialog_title => 'Access denied';
+  String get gallery_source_access_denied_dialog_title =>
+      'அணுகல் மறுக்கப்பட்டது';
 
   @override
   String get gallery_source_access_denied_dialog_message_ios =>
-      'Unfortunately, the application can\'t access your gallery, as you have previously denied the permission.\n\nPlease go to the app settings in your phone Settings -> Photos';
+      'துரதிர்ஷ்டவசமாக, நீங்கள் முன்பு அனுமதியை மறுத்துவிட்டதால், பயன்பாட்டால் உங்கள் கேலரியை அணுக முடியாது.\n\nஉங்கள் தொலைபேசி அமைப்புகள் -> புகைப்படங்களில் உள்ள பயன்பாட்டு அமைப்புகளுக்குச் செல்லவும்.';
 
   @override
-  String get gallery_source_access_denied_dialog_button => 'Open the Settings';
+  String get gallery_source_access_denied_dialog_button =>
+      'அமைப்புகளைத் திறக்கவும்';
 
   @override
   String get share => 'பகிர்க';
 
   @override
   String share_product_text(String url) {
-    return 'Have a look at this product on Open Food Facts: $url';
+    return 'இந்த தயாரிப்பை திறந்த உணவு உண்மைகளில் பாருங்கள்: $url';
   }
 
   @override
   String share_product_text_beauty(String url) {
-    return 'Have a look at this product on Open Beauty Facts: $url';
+    return 'இந்த தயாரிப்பை Open Beauty Facts இல் பாருங்கள்: $url';
   }
 
   @override
   String share_product_text_pet_food(String url) {
-    return 'Have a look at this product on Open PetFood Facts: $url';
+    return 'இந்த தயாரிப்பை ஓபன் பெட்ஃபுட் உண்மைகளில் பாருங்கள்: $url';
   }
 
   @override
   String share_product_text_product(String url) {
-    return 'Have a look at this product on Open Products Facts: $url';
+    return 'இந்த தயாரிப்பை திறந்த தயாரிப்புகள் உண்மைகளில் பாருங்கள்: $url';
   }
 
   @override
   String share_product_list_text(String url) {
-    return 'Have a look at my list of products on Open Food Facts: $url';
+    return 'திறந்த உணவு உண்மைகளில் எனது தயாரிப்புகளின் பட்டியலைப் பாருங்கள்: $url';
   }
 
   @override
@@ -3517,15 +3606,14 @@ class AppLocalizationsTa extends AppLocalizations {
   String get capture_new_picture => 'ஒரு படம் எடு';
 
   @override
-  String get choose_from_gallery => 'Choose from gallery';
+  String get choose_from_gallery => 'கேலரியில் இருந்து தேர்வு செய்யவும்';
 
   @override
   String get image_upload_queued =>
-      'The image will be uploaded in the background as soon as possible.';
+      'படம் விரைவில் பின்னணியில் பதிவேற்றப்படும்.';
 
   @override
-  String get add_price_queued =>
-      'The price will be sent to the server as soon as possible.';
+  String get add_price_queued => 'விலை விரைவில் சேவையகத்திற்கு அனுப்பப்படும்.';
 
   @override
   String get background_task_title_full_refresh =>
@@ -3533,136 +3621,141 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'உள்ளூரில் சேமிக்கப்பட்ட ஃபோல்க்சனமி புதுப்பிப்புகளுக்கான சேவையக செயல்களைச் செய்யத் தொடங்குகிறது.';
 
   @override
   String get background_task_title_top_n =>
       'மிகவும் பிரபலமான தயாரிப்புகளின் பதிவிறக்கத்தைத் தொடங்குகிறது';
 
   @override
-  String get expand_nutrition_facts => 'Expand nutrition facts table';
+  String get expand_nutrition_facts =>
+      'ஊட்டச்சத்து உண்மைகள் அட்டவணையை விரிவாக்குங்கள்.';
 
   @override
   String get expand_nutrition_facts_body =>
-      'Keep the nutrition facts table expanded';
+      'ஊட்டச்சத்து உண்மைகள் அட்டவணையை விரிவுபடுத்துங்கள்.';
 
   @override
-  String get expand_ingredients => 'Expand ingredients';
+  String get expand_ingredients => 'பொருட்களை விரிவாக்கு';
 
   @override
-  String get expand_ingredients_body => 'Keep the ingredients panel expanded';
+  String get expand_ingredients_body => 'பொருட்கள் பலகையை விரித்து வைக்கவும்.';
 
   @override
-  String get no_internet_connection => 'No internet connection';
+  String get no_internet_connection => 'இணைய இணைப்பு இல்லை';
 
   @override
-  String get world_results_label => 'Entire world';
+  String get world_results_label => 'உலகம் முழுவதும்';
 
   @override
-  String get world_results_action => 'Extend your search to the world';
+  String get world_results_action =>
+      'உங்கள் தேடலை உலகிற்கு விரிவுபடுத்துங்கள்.';
 
   @override
-  String get copy_to_clipboard => 'Copy';
+  String get copy_to_clipboard => 'நகலெடு';
 
   @override
-  String get paste_from_clipboard => 'Paste from clipboard';
+  String get paste_from_clipboard => 'கிளிப்போர்டிலிருந்து ஒட்டுக';
 
   @override
   String get no_data_available_in_clipboard =>
-      'No data available in your clipboard';
+      'உங்கள் கிளிப்போர்டில் தரவு எதுவும் கிடைக்கவில்லை.';
 
   @override
-  String get clipboard_barcode_copy => 'Copy barcode to clipboard';
+  String get clipboard_barcode_copy =>
+      'பார்கோடை கிளிப்போர்டுக்கு நகலெடுக்கவும்';
 
   @override
   String clipboard_barcode_copied(Object barcode) {
-    return 'Barcode $barcode copied to the clipboard!';
+    return 'பார்கோடு $barcode கிளிப்போர்டுக்கு நகலெடுக்கப்பட்டது!';
   }
 
   @override
   String get open_product_website => 'இந்தத் தயாரிப்பை இணையதளத்தில் திறக்கவும்';
 
   @override
-  String get language_picker_label => 'Your language';
+  String get language_picker_label => 'உங்கள் மொழி';
 
   @override
-  String get country_picker_label => 'Your country';
+  String get country_picker_label => 'உங்கள் நாடு';
 
   @override
   String get currency_picker_label => 'உங்கள் நாணயம்';
 
   @override
-  String get help_with_openfoodfacts => 'Help with OpenFoodFacts';
+  String get help_with_openfoodfacts => 'OpenFoodFacts தொடர்பான உதவி';
 
   @override
   String get product_task_background_schedule =>
-      'The product will be updated in the background as soon as possible.';
+      'தயாரிப்பு விரைவில் பின்னணியில் புதுப்பிக்கப்படும்.';
 
   @override
-  String get no_email_client_available_dialog_title => 'No email apps!';
+  String get no_email_client_available_dialog_title =>
+      'மின்னஞ்சல் பயன்பாடுகள் இல்லை!';
 
   @override
   String get no_email_client_available_dialog_content =>
-      'Please send us manually an email to mobile@openfoodfacts.org';
+      'தயவுசெய்து mobile@openfoodfacts.org என்ற முகவரிக்கு எங்களுக்கு நேரடியாக மின்னஞ்சல் அனுப்புங்கள்.';
 
   @override
-  String get all_images => 'All Images';
+  String get all_images => 'அனைத்து படங்களும்';
 
   @override
-  String get selected_images => 'Selected Images';
+  String get selected_images => 'தேர்ந்தெடுக்கப்பட்ட படங்கள்';
 
   @override
-  String get product_card_remove_product_tooltip => 'Remove product';
+  String get product_card_remove_product_tooltip => 'தயாரிப்பை அகற்று';
 
   @override
   String scan_announce_new_barcode(String barcode) {
-    return 'New barcode scanned: $barcode';
+    return 'ஸ்கேன் செய்யப்பட்ட புதிய பார்கோடு: $barcode';
   }
 
   @override
   String get scan_header_clear_button_tooltip =>
-      'Remove all products from the carousel';
+      'கேரோசலில் இருந்து அனைத்து தயாரிப்புகளையும் அகற்று';
 
   @override
   String get scan_header_compare_button_invalid_state_tooltip =>
-      'Please scan at least two products to compare them';
+      'ஒப்பிட்டுப் பார்க்க குறைந்தது இரண்டு தயாரிப்புகளை ஸ்கேன் செய்யவும்.';
 
   @override
   String get scan_header_compare_button_valid_state_tooltip =>
       'நீங்கள் ஸ்கேன் செய்த தயாரிப்புகளை ஒப்பிடக் கிளிக் செய்யவும்.';
 
   @override
-  String get scan_product_loading => 'You have scanned\nthe barcode:';
+  String get scan_product_loading =>
+      'நீங்கள்\nபார்கோடை ஸ்கேன் செய்துள்ளீர்கள்:';
 
   @override
   String get scan_product_loading_initial =>
-      'We\'re looking for this product!\nPlease wait a few seconds…';
+      'இந்த தயாரிப்பை நாங்கள் தேடுகிறோம்!\nசில வினாடிகள் காத்திருக்கவும்…';
 
   @override
   String get scan_product_loading_long_request =>
-      'We\'re still looking for this product!\nDo you find it takes a long time to load? So are we…';
+      'நாங்கள் இன்னும் இந்தத் தயாரிப்பைத் தேடிக்கொண்டிருக்கிறோம்!\nஏற்றுவதற்கு நீண்ட நேரம் எடுக்கும் என்று நீங்கள் நினைக்கிறீர்களா? நாங்களும்…';
 
   @override
   String get scan_product_loading_unresponsive =>
-      'We\'re still looking for this product.\nWould you like to restart the search?';
+      'நாங்கள் இன்னும் இந்தத் தயாரிப்பைத் தேடிக்கொண்டிருக்கிறோம்.\nதேடலை மீண்டும் தொடங்க விரும்புகிறீர்களா?';
 
   @override
-  String get scan_product_loading_restart_button => 'Restart search';
+  String get scan_product_loading_restart_button => 'தேடலை மீண்டும் தொடங்கு';
 
   @override
   String get portion_calculator_description =>
-      'Calculate nutrition facts for a specific quantity';
+      'ஒரு குறிப்பிட்ட அளவிற்கு ஊட்டச்சத்து உண்மைகளைக் கணக்கிடுங்கள்.';
 
   @override
-  String get portion_calculator_hint => 'Quantity in';
+  String get portion_calculator_hint => 'அளவு';
 
   @override
   String get portion_calculator_accessibility =>
-      'Input a quantity to calculate nutrition facts';
+      'ஊட்டச்சத்து உண்மைகளைக் கணக்கிட ஒரு அளவை உள்ளிடவும்.';
 
   @override
   String portion_calculator_error(int min, int max) {
-    return 'Please enter a quantity between $min and $max g';
+    return '$min மற்றும் $max கிராம் இடையே ஒரு அளவை உள்ளிடவும்';
   }
 
   @override
@@ -3671,18 +3764,18 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String portion_calculator_result_title(int grams) {
-    return 'Nutrition facts for $grams g (or ml)';
+    return '$grams கிராம் (அல்லது மிலி) க்கான ஊட்டச்சத்து தகவல்கள்';
   }
 
   @override
-  String get offline_data => 'Offline Data';
+  String get offline_data => 'ஆஃப்லைன் தரவு';
 
   @override
   String get ocr_image_upload_instruction =>
-      'Upload an image to automatically extract the information it contains.';
+      'அதில் உள்ள தகவல்களைத் தானாகப் பிரித்தெடுக்க ஒரு படத்தைப் பதிவேற்றவும்.';
 
   @override
-  String get upload_image => 'Upload Photo';
+  String get upload_image => 'புகைப்படத்தைப் பதிவேற்று';
 
   @override
   String get word_separator_char => ',';
@@ -3691,267 +3784,270 @@ class AppLocalizationsTa extends AppLocalizations {
   String get word_separator => ', ';
 
   @override
-  String get image_download_error => 'Failed to download image';
+  String get image_download_error => 'படத்தைப் பதிவிறக்க முடியவில்லை.';
 
   @override
   String get image_edit_url_error =>
-      'Failed to edit image because the image URL was not set.';
+      'படத்தின் URL அமைக்கப்படாததால் படத்தைத் திருத்த முடியவில்லை.';
 
   @override
   String get user_picture_source_remember => 'எனது தேர்வை நினைவில்கொள்';
 
   @override
-  String get user_picture_source_ask => 'Ask each time';
+  String get user_picture_source_ask => 'ஒவ்வொரு முறையும் கேளுங்கள்';
 
   @override
-  String get robotoff_continue => 'Continue';
+  String get robotoff_continue => 'தொடரவும்';
 
   @override
   String robotoff_next_n_questions(num count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
-      other: '$count questions',
-      one: 'question',
+      other: '$count கேள்விகள்',
+      one: 'கேள்வி',
     );
-    return 'Next $_temp0';
+    return 'அடுத்தது $_temp0';
   }
 
   @override
-  String get show_password => 'Show Password';
+  String get show_password => 'கடவுச்சொல்லைக் காட்டு';
 
   @override
-  String get owner_field_info_title => 'Producer provided values';
+  String get owner_field_info_title => 'தயாரிப்பாளர் வழங்கிய மதிப்புகள்';
 
   @override
   String get owner_field_info_message =>
-      'With that logo we highlight data provided by the producer, and that may not be editable.';
+      'அந்த லோகோவுடன், தயாரிப்பாளரால் வழங்கப்பட்ட தரவை நாங்கள் முன்னிலைப்படுத்துகிறோம், மேலும் அதைத் திருத்த முடியாது.';
 
   @override
-  String get owner_field_info_close_button => 'Close this info';
+  String get owner_field_info_close_button => 'இந்த தகவலை மூடு';
 
   @override
   String get owner_field_image =>
-      'This image is provided by the producer. It may not be editable.';
+      'இந்தப் படம் தயாரிப்பாளரால் வழங்கப்பட்டது. இதைத் திருத்த முடியாது.';
 
   @override
-  String get edit_packagings_title => 'Packaging components';
+  String get edit_packagings_title => 'பேக்கேஜிங் கூறுகள்';
 
   @override
-  String get edit_packagings_element_add => 'Add a packaging component';
+  String get edit_packagings_element_add =>
+      'ஒரு பேக்கேஜிங் கூறுகளைச் சேர்க்கவும்';
 
   @override
-  String get edit_packagings_completed => 'The packaging is complete';
+  String get edit_packagings_completed => 'பேக்கேஜிங் முடிந்தது.';
 
   @override
   String edit_packagings_element_title(int index) {
-    return 'Packaging component #$index';
+    return 'பேக்கேஜிங் கூறு #$index';
   }
 
   @override
-  String get edit_packagings_element_field_units => 'Number of units';
+  String get edit_packagings_element_field_units => 'அலகுகளின் எண்ணிக்கை';
 
   @override
   String get edit_packagings_element_hint_units =>
-      'Enter the number of packaging units of the same shape and material contained in the product.';
+      'தயாரிப்பில் உள்ள அதே வடிவம் மற்றும் பொருளின் பேக்கேஜிங் அலகுகளின் எண்ணிக்கையை உள்ளிடவும்.';
 
   @override
-  String get edit_packagings_element_field_shape => 'Shape';
+  String get edit_packagings_element_field_shape => 'வடிவம்';
 
   @override
   String get edit_packagings_element_hint_shape =>
-      'Enter the shape name listed in the recycling instructions if they are available, or select a shape.';
+      'மறுசுழற்சி வழிமுறைகளில் பட்டியலிடப்பட்டுள்ள வடிவப் பெயரை உள்ளிடவும், அல்லது ஒரு வடிவத்தைத் தேர்ந்தெடுக்கவும்.';
 
   @override
-  String get edit_packagings_element_example_shape => 'Bottle';
+  String get edit_packagings_element_example_shape => 'பாட்டில்';
 
   @override
-  String get edit_packagings_element_field_material => 'Material';
+  String get edit_packagings_element_field_material => 'பொருள்';
 
   @override
   String get edit_packagings_element_hint_material =>
-      'Enter the specific material if it can be determined (a material code inside a triangle can often be found on packaging parts), or a generic material (for instance plastic or metal) if you are unsure.';
+      'குறிப்பிட்ட பொருளைத் தீர்மானிக்க முடிந்தால் அதை உள்ளிடவும் (ஒரு முக்கோணத்திற்குள் ஒரு பொருள் குறியீடு பெரும்பாலும் பேக்கேஜிங் பாகங்களில் காணலாம்), அல்லது உங்களுக்குத் தெரியாவிட்டால் ஒரு பொதுவான பொருளை (எடுத்துக்காட்டாக, பிளாஸ்டிக் அல்லது உலோகம்) உள்ளிடவும்.';
 
   @override
-  String get edit_packagings_element_example_material => 'Glass';
+  String get edit_packagings_element_example_material => 'கண்ணாடி';
 
   @override
-  String get edit_packagings_element_field_recycling => 'Recycling instruction';
+  String get edit_packagings_element_field_recycling => 'மறுசுழற்சி வழிமுறைகள்';
 
   @override
   String get edit_packagings_element_hint_recycling =>
-      'Enter recycling instructions only if they are listed on the product.';
+      'மறுசுழற்சி வழிமுறைகள் தயாரிப்பில் பட்டியலிடப்பட்டிருந்தால் மட்டுமே அவற்றை உள்ளிடவும்.';
 
   @override
-  String get edit_packagings_element_example_recycling => 'Recycle';
+  String get edit_packagings_element_example_recycling => 'மறுசுழற்சி';
 
   @override
   String get edit_packagings_element_field_quantity =>
-      'Net quantity of product per unit';
+      'ஒரு யூனிட்டுக்கு நிகர தயாரிப்பு அளவு';
 
   @override
   String get edit_packagings_element_hint_quantity =>
-      'Enter the net weight or net volume and indicate the unit (for example g or ml).';
+      'நிகர எடை அல்லது நிகர அளவை உள்ளிட்டு அலகைக் குறிப்பிடவும் (எடுத்துக்காட்டாக g அல்லது ml).';
 
   @override
   String get edit_packagings_element_field_weight =>
-      'Weight of one empty unit (g)';
+      'ஒரு காலி அலகின் எடை (கிராம்)';
 
   @override
   String get edit_packagings_element_hint_weight =>
-      'Remove any remaining food and wash and dry the packaging part before weighing. If possible, use a scale with 0.1g or 0.01g precision.';
+      'மீதமுள்ள உணவை அகற்றி, எடை போடுவதற்கு முன் பேக்கேஜிங் பகுதியைக் கழுவி உலர வைக்கவும். முடிந்தால், 0.1 கிராம் அல்லது 0.01 கிராம் துல்லியம் கொண்ட அளவைப் பயன்படுத்தவும்.';
 
   @override
-  String get background_task_title => 'Pending contributions';
+  String get background_task_title => 'நிலுவையில் உள்ள பங்களிப்புகள்';
 
   @override
   String get background_task_subtitle =>
-      'Your contributions are automatically saved to our server, but not always in real-time.';
+      'உங்கள் பங்களிப்புகள் எங்கள் சேவையகத்தில் தானாகவே சேமிக்கப்படும், ஆனால் எப்போதும் நிகழ்நேரத்தில் அல்ல.';
 
   @override
-  String get background_task_list_empty => 'No Pending Background Tasks';
+  String get background_task_list_empty =>
+      'பின்னணி பணிகள் எதுவும் நிலுவையில் இல்லை.';
 
   @override
-  String get background_task_error_server_time_out => 'Server timeout';
+  String get background_task_error_server_time_out => 'சேவையக நேரம் முடிந்தது';
 
   @override
   String get background_task_error_no_internet =>
-      'Internet connection error. Try later.';
+      'இணைய இணைப்புப் பிழை. பிறகு முயற்சிக்கவும்.';
 
   @override
-  String get background_task_operation_unknown => 'unknown operation type';
+  String get background_task_operation_unknown => 'தெரியாத செயல்பாட்டு வகை';
 
   @override
-  String get background_task_operation_details => 'detailed changes';
+  String get background_task_operation_details => 'விரிவான மாற்றங்கள்';
 
   @override
-  String get background_task_operation_image => 'photo upload';
+  String get background_task_operation_image => 'புகைப்பட பதிவேற்றம்';
 
   @override
   String get background_task_operation_refresh =>
-      'refresh delayed after photo upload';
+      'புகைப்படம் பதிவேற்றப்பட்ட பிறகு புதுப்பிப்பு தாமதமாகும்.';
 
   @override
-  String get background_task_run_started => 'started';
+  String get background_task_run_started => 'தொடங்கியது';
 
   @override
-  String get background_task_run_not_started => 'not started yet';
+  String get background_task_run_not_started => 'இன்னும் தொடங்கவில்லை.';
 
   @override
-  String get background_task_run_to_be_deleted => 'to be deleted';
+  String get background_task_run_to_be_deleted => 'நீக்கப்பட வேண்டும்';
 
   @override
   String get background_task_question_stop =>
-      'Do you want to stop that task ASAP?';
+      'அந்தப் பணியை விரைவில் நிறுத்த விரும்புகிறீர்களா?';
 
   @override
-  String get feed_back => 'Feedback';
+  String get feed_back => 'கருத்து';
 
   @override
-  String get undo => 'Undo';
+  String get undo => 'செயல்தவிர்';
 
   @override
-  String get copy_email_to_clip_board => 'Copy email to clipboard';
+  String get copy_email_to_clip_board => 'மின்னஞ்சலை கிளிப்போர்டுக்கு நகலெடு';
 
   @override
   String get please_send_us_an_email_to =>
-      'Please send us manually an email to';
+      'தயவுசெய்து எங்களுக்கு கைமுறையாக ஒரு மின்னஞ்சல் அனுப்பவும்';
 
   @override
-  String get email_copied_to_clip_board => 'Email copied to clipboard!';
+  String get email_copied_to_clip_board =>
+      'மின்னஞ்சல் கிளிப்போர்டுக்கு நகலெடுக்கப்பட்டது!';
 
   @override
-  String get select_accent_color => 'Select Accent Color';
+  String get select_accent_color => 'உச்சரிப்பு நிறத்தைத் தேர்ந்தெடுக்கவும்';
 
   @override
-  String get theme_amoled => 'AMOLED';
+  String get theme_amoled => 'அமோலேட்';
 
   @override
-  String get color_blue => 'Blue';
+  String get color_blue => 'நீலம்';
 
   @override
-  String get color_cyan => 'Cyan';
+  String get color_cyan => 'சியான்';
 
   @override
-  String get color_green => 'Green';
+  String get color_green => 'பச்சை';
 
   @override
-  String get color_light_brown => 'Default';
+  String get color_light_brown => 'இயல்புநிலை';
 
   @override
-  String get color_magenta => 'Magenta';
+  String get color_magenta => 'மெஜந்தா';
 
   @override
-  String get color_orange => 'Orange';
+  String get color_orange => 'ஆரஞ்சு';
 
   @override
-  String get color_pink => 'Pink';
+  String get color_pink => 'இளஞ்சிவப்பு';
 
   @override
-  String get color_red => 'Red';
+  String get color_red => 'சிவப்பு';
 
   @override
-  String get color_rust => 'Rust';
+  String get color_rust => 'துரு';
 
   @override
-  String get color_teal => 'Teal';
+  String get color_teal => 'நீலம்';
 
   @override
-  String get text_contrast_mode => 'Text Contrast';
+  String get text_contrast_mode => 'உரை மாறுபாடு';
 
   @override
-  String get contrast_high => 'High';
+  String get contrast_high => 'உயர்';
 
   @override
-  String get contrast_medium => 'Medium';
+  String get contrast_medium => 'நடுத்தரம்';
 
   @override
-  String get contrast_low => 'Low';
+  String get contrast_low => 'குறைந்த';
 
   @override
-  String get product_refresher_internet_not_found => 'Product not found!';
+  String get product_refresher_internet_not_found => 'தயாரிப்பு கிடைக்கவில்லை!';
 
   @override
   String get product_refresher_internet_not_connected =>
-      'You are not connected to internet!';
+      'நீங்கள் இணையத்துடன் இணைக்கப்படவில்லை!';
 
   @override
   String product_refresher_internet_no_ping(String? host) {
-    return 'Server down ($host)';
+    return 'சேவையகம் செயலிழந்தது ($host)';
   }
 
   @override
   String product_refresher_internet_error(String? exception) {
-    return 'Server error ($exception)';
+    return 'சர்வர் பிழை ($exception)';
   }
 
   @override
-  String get product_loader_not_found_title => 'Product not found!';
+  String get product_loader_not_found_title => 'தயாரிப்பு கிடைக்கவில்லை!';
 
   @override
   String product_loader_not_found_message(String barcode) {
-    return 'A product with the following barcode doesn\'t exist in our database: $barcode';
+    return 'பின்வரும் பார்கோடு கொண்ட தயாரிப்பு எங்கள் தரவுத்தளத்தில் இல்லை: $barcode';
   }
 
   @override
-  String get product_loader_network_error_title => 'No internet connection!';
+  String get product_loader_network_error_title => 'இணைய இணைப்பு இல்லை!';
 
   @override
   String get product_loader_network_error_message =>
-      'Please check that your smartphone is on a WiFi network or has mobile data enabled';
+      'உங்கள் ஸ்மார்ட்போன் வைஃபை நெட்வொர்க்கில் உள்ளதா அல்லது மொபைல் டேட்டா இயக்கப்பட்டுள்ளதா என்பதைச் சரிபார்க்கவும்.';
 
   @override
-  String get page_not_found_title => 'Page not found!';
+  String get page_not_found_title => 'பக்கம் கிடைக்கவில்லை!';
 
   @override
-  String get page_not_found_button => 'Go back to the homepage';
+  String get page_not_found_button => 'முகப்புப் பக்கத்திற்குத் திரும்பு';
 
   @override
-  String get download_data => 'Download data';
+  String get download_data => 'தரவைப் பதிவிறக்கு';
 
   @override
   String get download_top_products =>
-      'Download the top 1000 products in your country for instant scanning';
+      'உடனடி ஸ்கேனிங்கிற்காக உங்கள் நாட்டில் உள்ள சிறந்த 1000 தயாரிப்புகளைப் பதிவிறக்கவும்.';
 
   @override
   String download_top_n_products(int count) {
@@ -3965,57 +4061,59 @@ class AppLocalizationsTa extends AppLocalizations {
   }
 
   @override
-  String get download_in_progress => 'Downloading data\nThis may take a while';
+  String get download_in_progress =>
+      'தரவைப் பதிவிறக்குகிறது\nஇதற்கு சிறிது நேரம் ஆகலாம்';
 
   @override
   String downloaded_products(int num) {
-    return '$num products added';
+    return '$num தயாரிப்புகள் சேர்க்கப்பட்டன';
   }
 
   @override
-  String get update_offline_data => 'Update offline product data';
+  String get update_offline_data => 'ஆஃப்லைன் தயாரிப்பு தரவைப் புதுப்பிக்கவும்';
 
   @override
   String get update_local_database_sub =>
-      'Update the local product database with the latest data from Open Food Facts';
+      'திறந்த உணவு உண்மைகளிலிருந்து சமீபத்திய தரவுகளுடன் உள்ளூர் தயாரிப்பு தரவுத்தளத்தைப் புதுப்பிக்கவும்.';
 
   @override
-  String get clear_local_database => 'Clear offline product data';
+  String get clear_local_database => 'ஆஃப்லைன் தயாரிப்பு தரவை அழி';
 
   @override
   String get clear_local_database_sub =>
-      'Clear all local product data from your app to free up space';
+      'இடத்தைக் காலியாக்க, உங்கள் பயன்பாட்டிலிருந்து அனைத்து உள்ளூர் தயாரிப்புத் தரவையும் அழிக்கவும்.';
 
   @override
   String deleted_products(int num) {
-    return '$num products deleted';
+    return '$num தயாரிப்புகள் நீக்கப்பட்டன';
   }
 
   @override
   String get loading => 'ஏற்றுகிறது…';
 
   @override
-  String get know_more => 'Know More';
+  String get know_more => 'மேலும் அறிக';
 
   @override
-  String get offline_data_desc => 'Click to know more about offline data';
+  String get offline_data_desc =>
+      'ஆஃப்லைன் தரவு பற்றி மேலும் அறிய கிளிக் செய்யவும்.';
 
   @override
-  String get offline_product_data_title => 'Offline product data';
+  String get offline_product_data_title => 'ஆஃப்லைன் தயாரிப்பு தரவு';
 
   @override
   String available_for_download(int num) {
-    return '$num products available for immediate scaning';
+    return 'உடனடி ஸ்கேனிங்கிற்குக் கிடைக்கும் $num தயாரிப்புகள்';
   }
 
   @override
-  String get country_selector_title => 'Select your country:';
+  String get country_selector_title => 'உங்கள் நாட்டைத் தேர்ந்தெடுக்கவும்:';
 
   @override
   String get currency_selector_title => 'உங்கள் நாணயத்தைத் தேர்ந்தெடுக்கவும்:';
 
   @override
-  String get language_selector_title => 'Select your language:';
+  String get language_selector_title => 'உங்கள் மொழியைத் தேர்ந்தெடுக்கவும்:';
 
   @override
   String get language_selector_section_selected =>
@@ -4029,49 +4127,49 @@ class AppLocalizationsTa extends AppLocalizations {
   String get action_delete_list => 'நீக்கு';
 
   @override
-  String get action_change_list => 'Change the current list';
+  String get action_change_list => 'தற்போதைய பட்டியலை மாற்றவும்.';
 
   @override
   String get product_list_create => 'உருவாக்கு';
 
   @override
-  String get product_list_create_tooltip => 'Create a new list';
+  String get product_list_create_tooltip => 'புதிய பட்டியலை உருவாக்கவும்';
 
   @override
   String get nutriscore_generic => 'Nutri-Score';
 
   @override
-  String get nutriscore_a => 'Nutri-Score A';
+  String get nutriscore_a => 'நியூட்ரி-ஸ்கோர் ஏ';
 
   @override
-  String get nutriscore_b => 'Nutri-Score B';
+  String get nutriscore_b => 'நியூட்ரி-ஸ்கோர் பி';
 
   @override
-  String get nutriscore_c => 'Nutri-Score C';
+  String get nutriscore_c => 'நியூட்ரி-ஸ்கோர் சி';
 
   @override
-  String get nutriscore_d => 'Nutri-Score D';
+  String get nutriscore_d => 'நியூட்ரி-ஸ்கோர் டி';
 
   @override
-  String get nutriscore_e => 'Nutri-Score E';
+  String get nutriscore_e => 'நியூட்ரி-ஸ்கோர் E';
 
   @override
   String nutriscore_new_formula(String letter) {
-    return 'Nutri-Score $letter (New calculation)';
+    return 'நியூட்ரி-ஸ்கோர் $letter (புதிய கணக்கீடு)';
   }
 
   @override
-  String get nutriscore_new_formula_title => 'Nutri-Score (New calculation)';
+  String get nutriscore_new_formula_title => 'நியூட்ரி-ஸ்கோர் (புதிய கணக்கீடு)';
 
   @override
-  String get nutriscore_unknown => 'Unknown Nutri-Score';
+  String get nutriscore_unknown => 'தெரியாத நியூட்ரி-ஸ்கோர்';
 
   @override
   String get nutriscore_unknown_new_formula =>
       'தெரியாத Nutri-Score (புதிய கணக்கீடு)';
 
   @override
-  String get nutriscore_not_applicable => 'Nutri-Score is not applicable';
+  String get nutriscore_not_applicable => 'நியூட்ரி-ஸ்கோர் பொருந்தாது.';
 
   @override
   String get nutriscore_not_applicable_new_formula =>
@@ -4107,93 +4205,96 @@ class AppLocalizationsTa extends AppLocalizations {
       'மிகவும் பதப்படுத்தப்பட்ட உணவுகள் - NOVA குழுக்கள்';
 
   @override
-  String get nova_group_1 => 'NOVA Group 1';
+  String get nova_group_1 => 'நோவா குழு 1';
 
   @override
-  String get nova_group_2 => 'NOVA Group 2';
+  String get nova_group_2 => 'நோவா குழு 2';
 
   @override
-  String get nova_group_3 => 'NOVA Group 3';
+  String get nova_group_3 => 'நோவா குழு 3';
 
   @override
-  String get nova_group_4 => 'NOVA Group 4';
+  String get nova_group_4 => 'நோவா குழு 4';
 
   @override
-  String get nova_group_unknown => 'Unknown NOVA Group';
+  String get nova_group_unknown => 'தெரியாத NOVA குழு';
 
   @override
-  String get nutrition_facts => 'Nutrient Levels';
+  String get nutrition_facts => 'ஊட்டச்சத்து அளவுகள்';
 
   @override
-  String get faq_title_partners => 'Partners & Patrons of the NGO';
+  String get faq_title_partners =>
+      'அரசு சாரா நிறுவனத்தின் கூட்டாளிகள் & புரவலர்கள்';
 
   @override
   String get faq_title_vision =>
-      'The Open Food Facts Vision, Mission, Values and Programs';
+      'திறந்த உணவு உண்மைகள் தொலைநோக்கு, நோக்கம், மதிப்புகள் மற்றும் திட்டங்கள்';
 
   @override
   String get faq_title_install_beauty =>
-      'Install Open Beauty Facts to create a cosmetic database';
+      'ஒரு அழகுசாதன தரவுத்தளத்தை உருவாக்க திறந்த அழகு உண்மைகளை நிறுவவும்.';
 
   @override
   String get faq_title_install_pet =>
-      'Install Open Pet Food Facts to create a pet food database';
+      'செல்லப்பிராணி உணவு தரவுத்தளத்தை உருவாக்க திறந்த செல்லப்பிராணி உணவு உண்மைகளை நிறுவவும்.';
 
   @override
   String get faq_title_install_product =>
-      'Install Open Products Facts to create a products database to extend the life of objects';
+      'பொருட்களின் ஆயுளை நீட்டிக்க ஒரு தயாரிப்பு தரவுத்தளத்தை உருவாக்க திறந்த தயாரிப்புகள் உண்மைகளை நிறுவவும்.';
 
   @override
   String get faq_nutriscore_nutriscore =>
-      'New calculation of the Nutri-Score: what\'s new?';
+      'நியூட்ரி-ஸ்கோரின் புதிய கணக்கீடு: புதியது என்ன?';
 
   @override
   String get contact_title_pro_page =>
-      'Pro? Import your products in Open Food Facts';
+      'ப்ரோவா? திறந்த உணவு உண்மைகளில் உங்கள் தயாரிப்புகளை இறக்குமதி செய்யுங்கள்.';
 
   @override
-  String get contact_title_pro_email => 'Producer Contact';
+  String get contact_title_pro_email => 'தயாரிப்பாளர் தொடர்பு';
 
   @override
-  String get contact_title_press_page => 'Press Page';
+  String get contact_title_press_page => 'பக்கத்தை அழுத்தவும்';
 
   @override
-  String get contact_title_press_email => 'Press Contact';
+  String get contact_title_press_email => 'தொடர்பு என்பதை அழுத்தவும்';
 
   @override
   String get contact_title_newsletter => 'Subscribe to our newsletter';
 
   @override
-  String get contact_title_calendar => 'Subscribe to our community calendar';
+  String get contact_title_calendar => 'எங்கள் சமூக நாட்காட்டியில் குழுசேரவும்';
 
   @override
-  String get hunger_games_loading_line1 => 'Please give us a few seconds…';
+  String get hunger_games_loading_line1 =>
+      'தயவுசெய்து எங்களுக்கு சில வினாடிகள் கொடுங்கள்…';
 
   @override
-  String get hunger_games_loading_line2 => 'We\'re downloading the questions!';
+  String get hunger_games_loading_line2 =>
+      'நாங்கள் கேள்விகளைப் பதிவிறக்குகிறோம்!';
 
   @override
   String get hunger_games_error_label =>
-      'Argh! Something went wrong… and we couldn\'t load the questions.';
+      'ஐயோ! ஏதோ தவறாகிவிட்டது… , எங்களால் கேள்விகளை ஏற்ற முடியவில்லை.';
 
   @override
-  String get hunger_games_error_retry_button => 'Let\'s retry!';
+  String get hunger_games_error_retry_button => 'மீண்டும் முயற்சிப்போம்!';
 
   @override
-  String get reorder_attribute_action => 'Reorder the attributes';
+  String get reorder_attribute_action => 'பண்புக்கூறுகளை மறுவரிசைப்படுத்து';
 
   @override
   String get link_cant_be_opened =>
-      'This link can\'t be opened on your device. Please check that you have a browser installed.';
+      'இந்த இணைப்பை உங்கள் சாதனத்தில் திறக்க முடியாது. உங்களிடம் உலாவி நிறுவப்பட்டுள்ளதா எனச் சரிபார்க்கவும்.';
 
   @override
   String knowledge_panel_page_title_no_title(String productName) {
-    return 'Details for $productName';
+    return '$productNameக்கான விவரங்கள்';
   }
 
   @override
   String knowledge_panel_page_title(String pageName, String productName) {
-    return 'Details for $pageName with $productName';
+    return '$pageName க்கான விவரங்கள் $productNameஉடன்';
   }
 
   @override
@@ -4282,15 +4383,15 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get guide_nutriscore_v2_where_title =>
-      'Where to find the new Nutri-Score calculation?';
+      'புதிய நியூட்ரி-ஸ்கோர் கணக்கீட்டை எங்கே கண்டுபிடிப்பது?';
 
   @override
   String get guide_nutriscore_v2_where_paragraph1 =>
-      'The Nutri-Score is applied in 7 countries: France, Germany, Belgium, Spain, Luxembourg, the Netherlands and Switzerland.';
+      'நியூட்ரி-ஸ்கோர் பிரான்ஸ், ஜெர்மனி, பெல்ஜியம், ஸ்பெயின், லக்சம்பர்க், நெதர்லாந்து மற்றும் சுவிட்சர்லாந்து ஆகிய 7 நாடுகளில் பயன்படுத்தப்படுகிறது.';
 
   @override
   String get guide_nutriscore_v2_where_paragraph2 =>
-      'Manufacturers have at most **2 years** at the latest after the signature of the decree **to replace** the old calculation with the new one.';
+      'ஆணையில் கையொப்பமிட்ட பிறகு, பழைய கணக்கீட்டை புதிய கணக்கீட்டால் மாற்றுவதற்கு உற்பத்தியாளர்கள் அதிகபட்சம் **2 ஆண்டுகள்** அவகாசம் அளிக்கின்றனர்.';
 
   @override
   String get guide_nutriscore_v2_where_paragraph3 =>
@@ -4399,7 +4500,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get guide_greenscore_bonuses_penalties_intro =>
-      'To reward better products within a category, we then apply **bonuses & penalties based on several criterion**:';
+      'ஒரு வகைக்குள் சிறந்த தயாரிப்புகளுக்கு வெகுமதி அளிக்க, நாங்கள் பல அளவுகோல்களின் அடிப்படையில் **போனஸ்கள் மற்றும் அபராதங்களைப் பயன்படுத்துகிறோம்**:';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg1_title =>
@@ -4407,7 +4508,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get guide_greenscore_bonuses_penalties_arg1_text =>
-      'A **bonus** is awarded to products that have an **official label, a label or a certification that guarantees environmental benefits** (organic, fair trade, HVE, Label Rouge, Bleu Blanc Cœur, MSC/ASC).';
+      '**அதிகாரப்பூர்வ லேபிள், லேபிள் அல்லது சுற்றுச்சூழல் நன்மைகளை உத்தரவாதம் செய்யும் சான்றிதழ்** (ஆர்கானிக், நியாயமான வர்த்தகம், HVE, லேபிள் ரூஜ், ப்ளூ பிளாங்க் கோர், MSC/ASC) கொண்ட தயாரிப்புகளுக்கு **போனஸ்** வழங்கப்படுகிறது.';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg2_title =>
@@ -4415,7 +4516,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get guide_greenscore_bonuses_penalties_arg2_text =>
-      'A **bonus** is awarded based on the origin of the ingredients. This bonus takes into account the **impact on transportation** and also the **environmental policy** of each producer\'s country.';
+      'மூலப்பொருட்களின் தோற்றத்தின் அடிப்படையில் **போனஸ்** வழங்கப்படுகிறது. இந்த போனஸ், ஒவ்வொரு உற்பத்தியாளரின் நாட்டின் **போக்குவரத்தில் ஏற்படும் தாக்கத்தையும்** **சுற்றுச்சூழல் கொள்கையையும்** கணக்கில் எடுத்துக்கொள்கிறது.';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg3_title =>
@@ -4423,14 +4524,14 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get guide_greenscore_bonuses_penalties_arg3_text =>
-      'A **penalty** is given to products that contain ingredients that have significant **negative impacts on biodiversity and ecosystems**, such as palm oil, the production of which is responsible for massive deforestation.';
+      'பல்லுயிர் பெருக்கம் மற்றும் சுற்றுச்சூழல் அமைப்புகளில் குறிப்பிடத்தக்க **எதிர்மறை தாக்கங்களை ஏற்படுத்தும்** பொருட்களைக் கொண்ட தயாரிப்புகளுக்கு **அபராதம்** வழங்கப்படுகிறது, எடுத்துக்காட்டாக பாமாயில் உற்பத்தி, அதன் உற்பத்தியே பாரிய காடழிப்புக்கு காரணமாகிறது.';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg4_title => 'Packaging';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg4_text =>
-      'A **penalty** is calculated to take into account the **circularity of packaging** (use of recycled raw material and recyclability) and overpacking.';
+      '**பேக்கேஜிங்கின் **சுற்றளவு** (மறுசுழற்சி செய்யப்பட்ட மூலப்பொருட்களின் பயன்பாடு மற்றும் மறுசுழற்சி செய்யும் திறன்) மற்றும் அதிகப்படியான பேக்கிங் ஆகியவற்றைக் கணக்கில் எடுத்துக்கொண்டு **அபராதம்** கணக்கிடப்படுகிறது.';
 
   @override
   String get guide_greenscore_transparency_title =>
@@ -4438,19 +4539,19 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get guide_greenscore_transparency_intro1 =>
-      'To accurately calculate the Green-Score, it is necessary to have **information which is not necessarily specified on the packaging** (such as the origin and the exact percentage of each ingredient) or which is rarely available in usable form (such as a list of all the components of the packaging with the precise types of plastics used).';
+      'கிரீன்-ஸ்கோரை துல்லியமாகக் கணக்கிட, **பேக்கேஜிங்கில் அவசியம் குறிப்பிடப்படாத தகவல்கள்** (ஒவ்வொரு மூலப்பொருளின் தோற்றம் மற்றும் சரியான சதவீதம் போன்றவை) அல்லது பயன்படுத்தக்கூடிய வடிவத்தில் அரிதாகவே கிடைக்கும் தகவல்கள் (பயன்படுத்தப்படும் துல்லியமான பிளாஸ்டிக் வகைகளுடன் பேக்கேஜிங்கின் அனைத்து கூறுகளின் பட்டியல் போன்றவை) இருப்பது அவசியம்.';
 
   @override
   String get guide_greenscore_transparency_intro2 =>
-      '**Average values are used when this information is not yet available**, but we are now calling on everyone to help us collect this information which will be very useful for the Green-Score but also for many other uses.';
+      '**இந்தத் தகவல் இன்னும் கிடைக்காதபோது சராசரி மதிப்புகள் பயன்படுத்தப்படுகின்றன**, ஆனால் இந்தத் தகவலைச் சேகரிக்க அனைவரும் உதவுமாறு நாங்கள் இப்போது அழைக்கிறோம், இது கிரீன்-ஸ்கோருக்கு மட்டுமல்ல, பல பயன்பாடுகளுக்கும் மிகவும் பயனுள்ளதாக இருக்கும்.';
 
   @override
   String get guide_greenscore_transparency_arg1_title =>
-      'How citizens can help?';
+      'குடிமக்கள் எவ்வாறு உதவ முடியும்?';
 
   @override
   String get guide_greenscore_transparency_arg1_text =>
-      'All citizens can help us gather and structure the information that is present on products or that can be deduced from them, such as information on **packaging**: \"Mission Emballages\": a large-scale collaborative inventory of packaging for all food products (in French).';
+      '**பேக்கேஜிங்** பற்றிய தகவல்கள்: \"மிஷன் எம்பாலேஜ்கள்\": அனைத்து உணவுப் பொருட்களுக்கும் (பிரெஞ்சு மொழியில்) பெரிய அளவிலான கூட்டுப் பேக்கேஜிங் சரக்கு போன்ற தயாரிப்புகளில் உள்ள அல்லது அவற்றிலிருந்து பெறக்கூடிய தகவல்களைச் சேகரித்து வடிவமைக்க அனைத்து குடிமக்களும் எங்களுக்கு உதவ முடியும்.';
 
   @override
   String get guide_greenscore_transparency_arg2_title =>
@@ -4558,7 +4659,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg1_text =>
-      'Many are **derived from further processing of food constituents**, such as hydrogenated or interesterified oils, hydrolyzed proteins, soy protein isolate, maltodextrin, invert sugar, and high-fructose corn syrup.';
+      'ஹைட்ரஜனேற்றப்பட்ட அல்லது ஆர்வமூட்டும் எண்ணெய்கள், ஹைட்ரோலைஸ் செய்யப்பட்ட புரதங்கள், சோயா புரதம் தனிமைப்படுத்தல், மால்டோடெக்ஸ்ட்ரின், தலைகீழ் சர்க்கரை மற்றும் உயர்-பிரக்டோஸ் கார்ன் சிரப் போன்ற உணவுப் பொருட்களின் மேலும் செயலாக்கத்திலிருந்து பல **பெறப்படுகின்றன.**';
 
   @override
   String get guide_nova_explanations_arg2_title =>
@@ -4566,7 +4667,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg2_text =>
-      'Additives in ultra-processed foods include some that are also used in processed foods, such as preservatives, antioxidants, and stabilizers. Classes of additives found only in ultra-processed products include those used **to imitate or enhance the sensory qualities of foods or to disguise unpalatable aspects of the final product**. These additives include dyes and other colors, color stabilizers; flavors, flavor enhancers, non-sugar sweeteners; and processing aids such as carbonating, firming, bulking and anti-bulking agents, de-foaming, anti-caking and glazing agents, emulsifiers, sequestrants, and humectants.';
+      'பதப்படுத்தப்பட்ட உணவுகளில் பயன்படுத்தப்படும் சேர்க்கைப் பொருட்களில் பதப்படுத்தப்பட்ட உணவுகளிலும் பயன்படுத்தப்படும் சில பொருட்கள் அடங்கும், அதாவது பாதுகாப்புப் பொருட்கள், ஆக்ஸிஜனேற்றிகள் மற்றும் நிலைப்படுத்திகள். பதப்படுத்தப்பட்ட தயாரிப்புகளில் மட்டுமே காணப்படும் சேர்க்கைப் பொருட்களின் வகைகளில் **உணவுகளின் உணர்ச்சித் தரங்களைப் பின்பற்ற அல்லது மேம்படுத்த அல்லது இறுதிப் பொருளின் விரும்பத்தகாத அம்சங்களை மறைக்கப் பயன்படுத்தப்படும் சேர்க்கைப் பொருட்கள் அடங்கும்**. இந்தச் சேர்க்கைப் பொருட்களில் சாயங்கள் மற்றும் பிற வண்ணங்கள், வண்ண நிலைப்படுத்திகள்; சுவைகள், சுவையை அதிகரிக்கும் பொருட்கள், சர்க்கரை அல்லாத இனிப்புப் பொருட்கள்; மற்றும் கார்பனேட்டிங், ஃபர்மிங், பல்கிங் மற்றும் ஆன்டி-பல்கிங் ஏஜென்ட்கள், டி-ஃபோமிங், ஆன்டி-கேக்கிங் மற்றும் மெருகூட்டல் ஏஜென்ட்கள், குழம்பாக்கிகள், சீக்வெஸ்ட்ரான்ட்கள் மற்றும் ஈரப்பதமூட்டிகள் போன்ற செயலாக்க உதவிகள் அடங்கும்.';
 
   @override
   String get guide_nova_explanations_arg3_title =>
@@ -4574,7 +4675,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg3_text =>
-      '**A multitude of sequences of processes is used** to combine the usually many ingredients and to create the final product (hence \'ultra-processed\'). The processes include several **with no domestic equivalents**, such as hydrogenation and hydrolysation, extrusion and moulding, and pre-processing for frying.';
+      '**பொதுவாக பல பொருட்களை ஒன்றிணைத்து இறுதி தயாரிப்பை உருவாக்க (எனவே \'மிகவும் பதப்படுத்தப்பட்ட\') பல செயல்முறைகள் பயன்படுத்தப்படுகின்றன. இந்த செயல்முறைகளில் **உள்நாட்டு சமமானவை இல்லாத** பல அடங்கும், அதாவது ஹைட்ரஜனேற்றம் மற்றும் நீராற்பகுப்பு, வெளியேற்றம் மற்றும் மோல்டிங், மற்றும் வறுக்க முன் செயலாக்கம்.';
 
   @override
   String get guide_nova_explanations_arg4_title =>
@@ -4582,10 +4683,10 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg4_text =>
-      '**The overall purpose of ultra-processing is to create branded**, **convenient** (durable, ready to consume), **attractive** (hyper-palatable) and **highly profitable** (low-cost ingredients) food products designed to displace all other food groups. Ultra-processed food products are usually packaged attractively and marketed intensively.';
+      '**அதிக பதப்படுத்தலின் ஒட்டுமொத்த நோக்கம், மற்ற அனைத்து உணவுக் குழுக்களையும் மாற்றுவதற்காக வடிவமைக்கப்பட்ட பிராண்டட்**, **வசதியான** (நீடித்த, உட்கொள்ளத் தயாராக), **கவர்ச்சிகரமான** (மிகவும் சுவையான) மற்றும் **அதிக லாபகரமான** (குறைந்த விலை பொருட்கள்) உணவுப் பொருட்களை உருவாக்குவதாகும். அல்ட்ரா பதப்படுத்தப்பட்ட உணவுப் பொருட்கள் பொதுவாக கவர்ச்சிகரமான முறையில் பேக் செய்யப்பட்டு தீவிரமாக சந்தைப்படுத்தப்படுகின்றன.';
 
   @override
-  String get guide_nova_explanations_arg5_title => 'A health hazard';
+  String get guide_nova_explanations_arg5_title => 'உடல்நலக் கேடு';
 
   @override
   String get guide_nova_explanations_arg5_text =>
@@ -4593,93 +4694,95 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get guide_nova_explanations_arg6_title =>
-      'Countries recommend limiting them';
+      'நாடுகள் அவற்றைக் கட்டுப்படுத்த பரிந்துரைக்கின்றன';
 
   @override
   String get guide_nova_explanations_arg6_text =>
-      'Some countries use the NOVA groups for their dietary guidelines or goals, for instance:\n\n- **🇧🇷 Brazil**\'s dietary guidelines **recommend to limit consumption** of processed food and avoid ultra-processed food.\n\n- **🇫🇷 France**\'s public health nutritional policy goals for 2018-2022 aims to **reduce consumption of group 4 ultra-processed foods by 20%**.';
+      'சில நாடுகள் தங்கள் உணவு வழிகாட்டுதல்கள் அல்லது இலக்குகளுக்கு NOVA குழுக்களைப் பயன்படுத்துகின்றன, எடுத்துக்காட்டாக:\n\n- **🇧🇷 பிரேசிலின்** உணவு வழிகாட்டுதல்கள் **பதப்படுத்தப்பட்ட உணவின் நுகர்வை** குறைக்கவும், மிகை பதப்படுத்தப்பட்ட உணவைத் தவிர்க்கவும் பரிந்துரைக்கின்றன.\n\n- **🇫🇷 2018-2022 ஆம் ஆண்டிற்கான பிரான்சின்** பொது சுகாதார ஊட்டச்சத்து கொள்கை இலக்குகள் **குழு 4 மிகை பதப்படுத்தப்பட்ட உணவுகளின் நுகர்வை 20%** குறைப்பதை நோக்கமாகக் கொண்டுள்ளன.';
 
   @override
   String get guide_nova_share_link => 'https://world-ta.openfoodfacts.org/nova';
 
   @override
-  String get guide_open_food_facts_title => 'Welcome to Open Food Facts!';
+  String get guide_open_food_facts_title => 'திறந்த உணவு உண்மைகளுக்கு வருக!';
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_title =>
-      'What is Open Food Facts?';
+      'திறந்த உணவு உண்மைகள் என்றால் என்ன?';
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_paragraph1 =>
-      'Open Food Facts is a **collaborative**, **free**, and **open** database of food products from around the world.';
+      'ஓபன் ஃபுட் ஃபேக்ட்ஸ் என்பது உலகம் முழுவதிலுமிருந்து வரும் உணவுப் பொருட்களின் **கூட்டுறவு**, **இலவச** மற்றும் **திறந்த** தரவுத்தளமாகும்.';
 
   @override
   String get guide_open_food_facts_what_is_open_food_facts_paragraph2 =>
-      'We believe that everyone should have access to information about what they eat. By collecting data on ingredients, allergens, nutrition facts, and more, **we empower consumers to make informed choices** and drive the food industry **toward greater transparency**.';
+      'அனைவரும் தாங்கள் சாப்பிடுவது பற்றிய தகவல்களை அணுக வேண்டும் என்று நாங்கள் நம்புகிறோம். பொருட்கள், ஒவ்வாமை, ஊட்டச்சத்து உண்மைகள் மற்றும் பலவற்றின் தரவைச் சேகரிப்பதன் மூலம், **நுகர்வோர் தகவலறிந்த தேர்வுகளைச் செய்ய நாங்கள் அதிகாரம் அளிக்கிறோம்** மேலும் உணவுத் துறையை **அதிக வெளிப்படைத்தன்மையை நோக்கி** கொண்டு செல்கிறோம்.';
 
   @override
   String get guide_open_food_facts_features_title =>
-      'Features of Open Food Facts';
+      'திறந்த உணவு உண்மைகளின் அம்சங்கள்';
 
   @override
   String get guide_open_food_facts_features_arg1_title =>
-      'Get alerts for your unwanted ingredients';
+      'உங்கள் தேவையற்ற பொருட்களுக்கான விழிப்பூட்டல்களைப் பெறுங்கள்';
 
   @override
-  String get guide_open_food_facts_tips_title => 'Tips for taking great photos';
+  String get guide_open_food_facts_tips_title =>
+      'சிறந்த புகைப்படங்களை எடுப்பதற்கான உதவிக்குறிப்புகள்';
 
   @override
-  String get guide_open_food_facts_tips_arg1_title => 'Don’ts';
+  String get guide_open_food_facts_tips_arg1_title => 'செய்யக்கூடாதவை';
 
   @override
   String get guide_open_food_facts_tips_arg1_text1 =>
-      'Avoid shadows and glare.';
+      'நிழல்கள் மற்றும் கண்ணை கூசுவதைத் தவிர்க்கவும்.';
 
   @override
   String get guide_open_food_facts_tips_arg1_text2 =>
-      'No blurry or out-of-focus text.';
+      'மங்கலான அல்லது தெளிவற்ற உரை இல்லை.';
 
   @override
   String get guide_open_food_facts_tips_arg1_text3 =>
-      'Don\'t crop out parts of the text.';
+      'உரையின் பகுதிகளை வெட்டி எடுக்க வேண்டாம்.';
 
   @override
-  String get guide_open_food_facts_tips_arg1_text4 => 'Avoid busy backgrounds.';
+  String get guide_open_food_facts_tips_arg1_text4 =>
+      'பரபரப்பான பின்னணியைத் தவிர்க்கவும்.';
 
   @override
-  String get guide_open_food_facts_tips_arg2_title => 'Do’s';
+  String get guide_open_food_facts_tips_arg2_title => 'செய்ய வேண்டியவை';
 
   @override
   String get guide_open_food_facts_tips_arg2_text1 =>
-      'Use good, even lighting.';
+      'நல்ல, சீரான வெளிச்சத்தைப் பயன்படுத்துங்கள்.';
 
   @override
   String get guide_open_food_facts_tips_arg2_text2 =>
-      'Ensure text is sharp and readable.';
+      'உரை தெளிவாகவும் படிக்கக்கூடியதாகவும் இருப்பதை உறுதிசெய்யவும்.';
 
   @override
   String get guide_open_food_facts_tips_arg2_text3 =>
-      'Capture the entire ingredients list.';
+      'முழு பொருட்களின் பட்டியலையும் பிடிக்கவும்.';
 
   @override
   String get guide_open_food_facts_tips_arg2_text4 =>
-      'Keep the product on a flat surface.';
+      'தயாரிப்பை ஒரு தட்டையான மேற்பரப்பில் வைக்கவும்.';
 
   @override
   String get guide_open_food_facts_scores_title =>
-      'Help us build the \"Wikipedia of Food\"';
+      '\"உணவு விக்கிபீடியாவை\" உருவாக்க எங்களுக்கு உதவுங்கள்.';
 
   @override
   String get guide_open_food_facts_scores_arg1_title =>
-      'A score on the nutritional quality';
+      'ஊட்டச்சத்து தரத்தில் ஒரு மதிப்பெண்';
 
   @override
   String get guide_open_food_facts_scores_arg2_title =>
-      'A score to avoid ultra-processed foods';
+      'மிகவும் பதப்படுத்தப்பட்ட உணவுகளைத் தவிர்ப்பதற்கான மதிப்பெண்';
 
   @override
   String get guide_open_food_facts_scores_arg3_title =>
-      'A score for the planet';
+      'கிரகத்திற்கான மதிப்பெண்';
 
   @override
   String get guide_open_food_facts_share_link =>
@@ -4687,236 +4790,241 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get guide_open_pet_food_facts_title =>
-      'Welcome to Open Pet Food Facts!';
+      'திறந்த செல்லப்பிராணி உணவு உண்மைகளுக்கு வருக!';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_title =>
-      'What is Open Pet Food Facts?';
+      'திறந்த செல்லப்பிராணி உணவு உண்மைகள் என்றால் என்ன?';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_paragraph1 =>
-      'Open Pet Food Facts extends our mission to our furry friends! It\'s a **database of pet food products for cats, dogs, and other companions**.';
+      'திறந்த செல்லப்பிராணி உணவு உண்மைகள் எங்கள் பணியை எங்கள் ரோம நண்பர்களுக்கும் விரிவுபடுத்துகின்றன! இது **பூனைகள், நாய்கள் மற்றும் பிற தோழர்களுக்கான செல்லப்பிராணி உணவுப் பொருட்களின் தரவுத்தளமாகும்**.';
 
   @override
   String get guide_open_pet_food_facts_what_is_open_pet_food_facts_paragraph2 =>
-      'We gather information on **ingredients**, **nutritional analysis**, and feeding guidelines to help pet owners choose the best food for their animals\' needs.';
+      'செல்லப்பிராணி உரிமையாளர்கள் தங்கள் விலங்குகளின் தேவைகளுக்கு ஏற்ற சிறந்த உணவைத் தேர்வுசெய்ய உதவும் வகையில், **பொருட்கள்**, **ஊட்டச்சத்து பகுப்பாய்வு** மற்றும் உணவளிக்கும் வழிகாட்டுதல்கள் பற்றிய தகவல்களை நாங்கள் சேகரிக்கிறோம்.';
 
   @override
   String get guide_open_pet_food_facts_features_title =>
-      'Features of Open Pet Food Facts';
+      'திறந்த செல்லப்பிராணி உணவு உண்மைகளின் அம்சங்கள்';
 
   @override
   String get guide_open_pet_food_facts_features_arg1_title =>
-      'Get alerts for your unwanted ingredients';
+      'உங்கள் தேவையற்ற பொருட்களுக்கான விழிப்பூட்டல்களைப் பெறுங்கள்';
 
   @override
   String get guide_open_pet_food_facts_features_arg1_paragraph1 =>
-      'Is your pet allergic to any ingredients? You can set a list of cosmetic ingredients to avoid, right in the app!';
+      'உங்கள் செல்லப்பிராணிக்கு ஏதேனும் பொருட்களால் ஒவ்வாமை உள்ளதா? தவிர்க்க வேண்டிய அழகுசாதனப் பொருட்களின் பட்டியலை, செயலியிலேயே அமைக்கலாம்!';
 
   @override
   String get guide_open_pet_food_facts_tips_title =>
-      'Tips for taking great photos';
+      'சிறந்த புகைப்படங்களை எடுப்பதற்கான உதவிக்குறிப்புகள்';
 
   @override
-  String get guide_open_pet_food_facts_tips_arg1_title => 'Don’ts';
+  String get guide_open_pet_food_facts_tips_arg1_title => 'செய்யக்கூடாதவை';
 
   @override
   String get guide_open_pet_food_facts_tips_arg1_text1 =>
-      'Avoid shadows and glare.';
+      'நிழல்கள் மற்றும் கண்ணை கூசுவதைத் தவிர்க்கவும்.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg1_text2 =>
-      'No blurry or out-of-focus text.';
+      'மங்கலான அல்லது தெளிவற்ற உரை இல்லை.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg1_text3 =>
-      'Don\'t crop out parts of the text.';
+      'உரையின் பகுதிகளை வெட்டி எடுக்க வேண்டாம்.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg1_text4 =>
-      'Avoid busy backgrounds.';
+      'பரபரப்பான பின்னணியைத் தவிர்க்கவும்.';
 
   @override
-  String get guide_open_pet_food_facts_tips_arg2_title => 'Do’s';
+  String get guide_open_pet_food_facts_tips_arg2_title => 'செய்ய வேண்டியவை';
 
   @override
   String get guide_open_pet_food_facts_tips_arg2_text1 =>
-      'Use good, even lighting.';
+      'நல்ல, சீரான வெளிச்சத்தைப் பயன்படுத்துங்கள்.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg2_text2 =>
-      'Ensure text is sharp and readable.';
+      'உரை தெளிவாகவும் படிக்கக்கூடியதாகவும் இருப்பதை உறுதிசெய்யவும்.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg2_text3 =>
-      'Capture the entire ingredients list.';
+      'முழு பொருட்களின் பட்டியலையும் பிடிக்கவும்.';
 
   @override
   String get guide_open_pet_food_facts_tips_arg2_text4 =>
-      'Keep the product on a flat surface.';
+      'தயாரிப்பை ஒரு தட்டையான மேற்பரப்பில் வைக்கவும்.';
 
   @override
-  String get guide_open_pet_food_facts_scores_title => 'A note on scoring';
+  String get guide_open_pet_food_facts_scores_title =>
+      'மதிப்பெண் பற்றிய குறிப்பு';
 
   @override
   String get guide_open_pet_food_facts_scores_paragraph1 =>
-      'Developing a scoring system for pet food **is not a priority right now**. The methodology would be complex, as nutritional needs vary greatly by species, age, and health condition. We haven’t found any independant scientific team yet, able to develop such a score.';
+      'செல்லப்பிராணி உணவுக்கான மதிப்பெண் முறையை உருவாக்குவது **தற்போது முன்னுரிமை இல்லை**. ஊட்டச்சத்து தேவைகள் இனம், வயது மற்றும் சுகாதார நிலையைப் பொறுத்து பெரிதும் மாறுபடும் என்பதால், இந்த முறை சிக்கலானதாக இருக்கும். அத்தகைய மதிப்பெண்ணை உருவாக்கக்கூடிய எந்தவொரு சுயாதீன அறிவியல் குழுவையும் நாங்கள் இதுவரை கண்டுபிடிக்கவில்லை.';
 
   @override
   String get guide_open_pet_food_facts_share_link =>
       'https://world-ta.openpetfoodfacts.org/discover';
 
   @override
-  String get guide_open_beauty_facts_title => 'Welcome to Open Beauty Facts!';
+  String get guide_open_beauty_facts_title => 'திறந்த அழகு உண்மைகளுக்கு வருக!';
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_title =>
-      'What is Open Beauty Facts?';
+      'திறந்த அழகு உண்மைகள் என்றால் என்ன?';
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_paragraph1 =>
-      'Open Beauty Facts is a collaborative database of **cosmetic products**.';
+      'ஓபன் பியூட்டி ஃபேக்ட்ஸ் என்பது **ஒப்பனை பொருட்கள்** இன் கூட்டு தரவுத்தளமாகும்.';
 
   @override
   String get guide_open_beauty_facts_what_is_open_beauty_facts_paragraph2 =>
-      'Our goal is to decipher ingredient lists to help you **understand what\'s in your personal care items**. From moisturizers to makeup, we collect data on ingredients, allergens, and packaging to promote transparency in the cosmetics industry.';
+      '**உங்கள் தனிப்பட்ட பராமரிப்புப் பொருட்களில் என்ன இருக்கிறது என்பதைப் புரிந்துகொள்ள** உதவும் வகையில் மூலப்பொருள் பட்டியலைப் புரிந்துகொள்வதே எங்கள் குறிக்கோள். அழகுசாதனப் பொருட்கள் துறையில் வெளிப்படைத்தன்மையை மேம்படுத்துவதற்காக, மாய்ஸ்சரைசர்கள் முதல் ஒப்பனை வரை, பொருட்கள், ஒவ்வாமை மற்றும் பேக்கேஜிங் பற்றிய தரவை நாங்கள் சேகரிக்கிறோம்.';
 
   @override
   String get guide_open_beauty_facts_features_title =>
-      'Features of Open Beauty Facts';
+      'திறந்த அழகு உண்மைகளின் அம்சங்கள்';
 
   @override
   String get guide_open_beauty_facts_features_arg1_title =>
-      'Get alerts for your unwanted ingredients';
+      'உங்கள் தேவையற்ற பொருட்களுக்கான விழிப்பூட்டல்களைப் பெறுங்கள்';
 
   @override
   String get guide_open_beauty_facts_features_arg1_paragraph1 =>
-      'Are you allergic to any ingredients? Want to avoid comedogen substances? Want to steer away from controversial components ? You can set a list of cosmetic ingredients to avoid, right in the app!';
+      'உங்களுக்கு ஏதேனும் பொருட்களுக்கு ஒவ்வாமை உள்ளதா? காமெடோஜென் பொருட்களைத் தவிர்க்க விரும்புகிறீர்களா? சர்ச்சைக்குரிய கூறுகளைத் தவிர்க்க விரும்புகிறீர்களா? பயன்பாட்டிலேயே தவிர்க்க வேண்டிய அழகுசாதனப் பொருட்களின் பட்டியலை அமைக்கலாம்!';
 
   @override
   String get guide_open_beauty_facts_tips_title =>
-      'Tips for taking great photos';
+      'சிறந்த புகைப்படங்களை எடுப்பதற்கான உதவிக்குறிப்புகள்';
 
   @override
-  String get guide_open_beauty_facts_tips_arg1_title => 'Don’ts';
+  String get guide_open_beauty_facts_tips_arg1_title => 'செய்யக்கூடாதவை';
 
   @override
   String get guide_open_beauty_facts_tips_arg1_text1 =>
-      'Avoid shadows and glare.';
+      'நிழல்கள் மற்றும் கண்ணை கூசுவதைத் தவிர்க்கவும்.';
 
   @override
   String get guide_open_beauty_facts_tips_arg1_text2 =>
-      'No blurry or out-of-focus text.';
+      'மங்கலான அல்லது தெளிவற்ற உரை இல்லை.';
 
   @override
   String get guide_open_beauty_facts_tips_arg1_text3 =>
-      'Don\'t crop out parts of the text.';
+      'உரையின் பகுதிகளை வெட்டி எடுக்க வேண்டாம்.';
 
   @override
   String get guide_open_beauty_facts_tips_arg1_text4 =>
-      'Avoid busy backgrounds.';
+      'பரபரப்பான பின்னணியைத் தவிர்க்கவும்.';
 
   @override
-  String get guide_open_beauty_facts_tips_arg2_title => 'Do’s';
+  String get guide_open_beauty_facts_tips_arg2_title => 'செய்ய வேண்டியவை';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text1 =>
-      'Use good, even lighting.';
+      'நல்ல, சீரான வெளிச்சத்தைப் பயன்படுத்துங்கள்.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text2 =>
-      'Ensure text is sharp and readable.';
+      'உரை தெளிவாகவும் படிக்கக்கூடியதாகவும் இருப்பதை உறுதிசெய்யவும்.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text3 =>
-      'Capture the entire ingredients list.';
+      'முழு பொருட்களின் பட்டியலையும் பிடிக்கவும்.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text4 =>
-      'Take as many picture as need if the bottle is curved.';
+      'பாட்டில் வளைந்திருந்தால் தேவையான அளவு படங்களை எடுக்கவும்.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text5 =>
-      'You might need to peel the label to see the list of ingredients.';
+      'பொருட்களின் பட்டியலைப் பார்க்க நீங்கள் லேபிளை உரிக்க வேண்டியிருக்கலாம்.';
 
   @override
   String get guide_open_beauty_facts_tips_arg2_text6 =>
-      'Keep the product on a flat surface.';
+      'தயாரிப்பை ஒரு தட்டையான மேற்பரப்பில் வைக்கவும்.';
 
   @override
-  String get guide_open_beauty_facts_scores_title => 'A note on scoring';
+  String get guide_open_beauty_facts_scores_title =>
+      'மதிப்பெண் பற்றிய குறிப்பு';
 
   @override
   String get guide_open_beauty_facts_scores_paragraph1 =>
-      'Unlike food products, the world of cosmetics **does not have a universally recognized, government-backed scoring system like the Nutri-Score**. Ingredient effects can be highly personal and depend on skin type, allergies, and individual concerns.';
+      'உணவுப் பொருட்களைப் போலன்றி, அழகுசாதனப் பொருட்களின் உலகில் **நியூட்ரி-ஸ்கோர்** போன்ற உலகளாவிய அங்கீகாரம் பெற்ற, அரசாங்கத்தால் ஆதரிக்கப்படும் மதிப்பெண் முறை இல்லை. மூலப்பொருள் விளைவுகள் மிகவும் தனிப்பட்டவை மற்றும் தோல் வகை, ஒவ்வாமை மற்றும் தனிப்பட்ட கவலைகளைப் பொறுத்தது.';
 
   @override
   String get guide_open_beauty_facts_share_link =>
       'https://world-ta.openbeautyfacts.org/discover';
 
   @override
-  String get guide_open_prices_title => 'Welcome to Open Prices!';
+  String get guide_open_prices_title => 'திறந்த விலைகளுக்கு வருக!';
 
   @override
   String get guide_open_prices_what_is_open_prices_title =>
-      'What is Open Prices?';
+      'திறந்த விலைகள் என்றால் என்ன?';
 
   @override
   String get guide_open_prices_what_is_open_prices_paragraph1 =>
-      'Open Prices is a project to **collect and share prices of products around the world**. It\'s a publicly available dataset that can be used for research, analysis, and more. Open Prices is developed and maintained by Open Food Facts.';
+      'திறந்த விலைகள் என்பது **உலகம் முழுவதும் உள்ள பொருட்களின் விலைகளைச் சேகரித்துப் பகிர்ந்து கொள்ளும்** ஒரு திட்டமாகும். இது ஆராய்ச்சி, பகுப்பாய்வு மற்றும் பலவற்றிற்குப் பயன்படுத்தக்கூடிய பொதுவில் கிடைக்கும் தரவுத்தொகுப்பாகும். திறந்த விலைகள் திறந்த உணவு உண்மைகளால் உருவாக்கப்பட்டு பராமரிக்கப்படுகின்றன.';
 
   @override
   String get guide_open_prices_what_is_open_prices_paragraph2 =>
       'பார்கோடு அளவில் தயாரிப்பு விலைகளின் பெரிய தரவுத்தளங்களை வைத்திருக்கும் நிறுவனங்கள் தற்போது மிகக் குறைவு. இந்த விலைகள் இலவசமாகக் கிடைக்காது, ஆனால் தனியார் நிறுவனங்கள், ஆராய்ச்சியாளர்கள் மற்றும் அவற்றை வாங்கக்கூடிய பிற நிறுவனங்களுக்கு அதிக விலைக்கு விற்கப்படுகின்றன.';
 
   @override
-  String get guide_open_prices_how_title => 'How does Open Prices work?';
+  String get guide_open_prices_how_title =>
+      'ஓப்பன் பிரைசஸ் எப்படி வேலை செய்கிறது?';
 
   @override
   String get guide_open_prices_how_paragraph1 =>
-      '**We are crowdsourcing an open-source dataset of prices**. Prices can be added by users via this web app, or via the official Open Food Facts mobile app. Retailers or third-party apps can contribute as well by using our API.';
+      '**நாங்கள் விலைகளின் திறந்த மூல தரவுத்தொகுப்பை க்ரவுட் சோர்சிங் செய்கிறோம்**. இந்த வலை பயன்பாடு அல்லது அதிகாரப்பூர்வ ஓப்பன் ஃபுட் ஃபேக்ட்ஸ் மொபைல் பயன்பாடு வழியாக பயனர்கள் விலைகளைச் சேர்க்கலாம். சில்லறை விற்பனையாளர்கள் அல்லது மூன்றாம் தரப்பு பயன்பாடுகளும் எங்கள் API ஐப் பயன்படுத்தி பங்களிக்கலாம்.';
 
   @override
   String get guide_open_prices_how_arg1_title =>
-      'Collect photos of price tags in aisles';
+      'வரிசைகளில் விலைக் குறிச்சொற்களின் புகைப்படங்களைச் சேகரிக்கவும்.';
 
   @override
-  String get guide_open_prices_how_arg2_title => 'Collect photos of receipts';
+  String get guide_open_prices_how_arg2_title =>
+      'ரசீதுகளின் புகைப்படங்களைச் சேகரிக்கவும்';
 
   @override
   String get guide_open_prices_why_title =>
-      'Why is Open Food Facts doing this ?';
+      'ஓபன் ஃபுட் ஃபேக்ட்ஸ் ஏன் இதைச் செய்கிறது?';
 
   @override
   String get guide_open_prices_why_paragraph1 =>
-      'Price information is of paramount importance to understand food systems. It\'s a key factor in understanding the cost of food and to promote healthier diets. Opening price data is a way to make it easier for researchers, journalists, and citizens to **have a better understanding of how food prices vary geographically and in time**.';
+      'உணவு முறைகளைப் புரிந்துகொள்வதற்கு விலைத் தகவல் மிக முக்கியமானது. உணவின் விலையைப் புரிந்துகொள்வதிலும் ஆரோக்கியமான உணவுமுறைகளை ஊக்குவிப்பதிலும் இது ஒரு முக்கிய காரணியாகும். விலைத் தரவைத் திறப்பது, ஆராய்ச்சியாளர்கள், பத்திரிகையாளர்கள் மற்றும் குடிமக்கள் **புவியியல் ரீதியாகவும் காலத்திலும் உணவு விலைகள் எவ்வாறு மாறுபடுகின்றன என்பதைப் பற்றி நன்கு புரிந்துகொள்ள** எளிதாக்கும் ஒரு வழியாகும்.';
 
   @override
   String get guide_open_prices_why_arg1_title =>
-      'Track the evolution of prices over time';
+      'காலப்போக்கில் விலைகளின் பரிணாம வளர்ச்சியைக் கண்காணிக்கவும்';
 
   @override
   String get guide_open_prices_why_arg1_text =>
-      'See the **evolution of prices**: shrinkflation, cheapflation, we can track them together!';
+      '**விலைகளின் பரிணாம வளர்ச்சியை** பாருங்கள்: சுருக்கப் பணவீக்கம், மலிவான பணவீக்கம், நாம் அவற்றை ஒன்றாகக் கண்காணிக்கலாம்!';
 
   @override
-  String get guide_open_prices_why_arg2_title => 'Compare prices near you';
+  String get guide_open_prices_why_arg2_title =>
+      'உங்களுக்கு அருகிலுள்ள விலைகளை ஒப்பிடுக';
 
   @override
   String get guide_open_prices_why_arg2_text =>
-      'As we get more prices, you can spot **the cheapest stores around you**.';
+      'நாங்கள் அதிக விலைகளைப் பெறும்போது, **உங்களைச் சுற்றியுள்ள மலிவான கடைகளை** நீங்கள் காணலாம்.';
 
   @override
   String get guide_open_prices_scrapping_title =>
-      'Did you consider scraping prices from retailers\' websites?';
+      'சில்லறை விற்பனையாளர்களின் வலைத்தளங்களிலிருந்து விலைகளைக் குறைப்பது பற்றி நீங்கள் யோசித்தீர்களா?';
 
   @override
   String get guide_open_prices_scrapping_paragraph1 =>
-      'For legal and technical reasons, **we don\'t consider scraping prices from retailers\' websites as a valid way to contribute to Open Prices**. We want to make sure that the prices we collect are accurate and up-to-date, and receiving scraped prices from contributors doesn\'t allow us to do that.';
+      'சட்ட மற்றும் தொழில்நுட்ப காரணங்களுக்காக, **சில்லறை விற்பனையாளர்களின் வலைத்தளங்களில் இருந்து விலைகளைக் குறைப்பதை திறந்த விலைகளுக்கு பங்களிப்பதற்கான ஒரு செல்லுபடியாகும் வழியாக நாங்கள் கருதுவதில்லை**. நாங்கள் சேகரிக்கும் விலைகள் துல்லியமாகவும் புதுப்பித்ததாகவும் இருப்பதை உறுதிசெய்ய விரும்புகிறோம், மேலும் பங்களிப்பாளர்களிடமிருந்து விலைகளைக் குறைப்பது எங்களை அவ்வாறு செய்ய அனுமதிக்காது.';
 
   @override
   String get guide_open_prices_scrapping_paragraph2 =>
-      'Price scraping is a considered option in a future version of Open Prices, but it would be done by Open Prices itself so that we can have a proof of the price based on the HTML page.';
+      'ஓப்பன் பிரைஸ்களின் எதிர்கால பதிப்பில் விலை ஸ்க்ராப்பிங் ஒரு கருதப்படும் விருப்பமாகும், ஆனால் இது ஓப்பன் பிரைஸ்களால் செய்யப்படும், இதனால் HTML பக்கத்தின் அடிப்படையில் விலைக்கான ஆதாரத்தை நாம் பெற முடியும்.';
 
   @override
   String get guide_open_prices_retailers_title =>
@@ -4924,7 +5032,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get guide_open_prices_retailers_paragraph1 =>
-      'You can contribute prices by using our API.\nIf you want to contribute prices at scale, please get in touch with us at prices@openfoodfacts.org.';
+      'எங்கள் API ஐப் பயன்படுத்தி நீங்கள் விலைகளைப் பங்களிக்கலாம்.\nநீங்கள் அளவில் விலைகளைப் பங்களிக்க விரும்பினால், தயவுசெய்து prices@openfoodfacts.org என்ற மின்னஞ்சல் முகவரியில் எங்களைத் தொடர்பு கொள்ளவும்.';
 
   @override
   String get guide_open_prices_share_link =>
@@ -4932,149 +5040,150 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get guide_open_products_facts_title =>
-      'Welcome to Open Products Facts!';
+      'திறந்த தயாரிப்புகள் உண்மைகளுக்கு வருக!';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_title =>
-      'What is Open Products Facts?';
+      'திறந்த தயாரிப்புகள் உண்மைகள் என்றால் என்ன?';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_paragraph1 =>
-      'Open Products Facts is a massive, open database for **any product with a barcode, which is not food, cosmetic or pet food**.';
+      'ஓபன் ப்ராடக்ட்ஸ் ஃபேக்ட்ஸ் என்பது **பார்கோடு உள்ள எந்தவொரு தயாரிப்புக்கும், இது உணவு, அழகுசாதனப் பொருட்கள் அல்லது செல்லப்பிராணி உணவு** அல்லாத ஒரு பெரிய, திறந்த தரவுத்தளமாகும்.';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_paragraph2 =>
-      'From **electronics** to **toys**, and **clothes** to **cleaning supplies**, if it has a barcode, it can be added. This project aims to create an \"Internet of Things\" for everyday objects, making information about them universally accessible.';
+      '**எலக்ட்ரானிக்ஸ்** முதல் **பொம்மைகள்** வரை, **துப்புரவுப் பொருட்கள்** வரை, பார்கோடு இருந்தால், அதைச் சேர்க்கலாம். இந்தத் திட்டம் அன்றாடப் பொருட்களுக்கான \"இன்டர்நெட் ஆஃப் திங்ஸ்\" ஒன்றை உருவாக்கி, அவற்றைப் பற்றிய தகவல்களை உலகளவில் அணுகக்கூடியதாக மாற்றுவதை நோக்கமாகக் கொண்டுள்ளது.';
 
   @override
   String get guide_open_products_facts_features_title =>
-      'Features of Open Products Facts';
+      'திறந்த தயாரிப்புகளின் அம்சங்கள் உண்மைகள்';
 
   @override
   String get guide_open_products_facts_features_text =>
-      'Open Products Facts aims to provide consumers to **extend the life of objects** by providing the circular solutions to maintain, **repair**, **recycle** their objects or give them a new owner.';
+      'ஓபன் புராடக்ட்ஸ் ஃபேக்ட்ஸ், நுகர்வோர் தங்கள் பொருட்களைப் பராமரிக்க, **பழுதுபார்க்க**, **மறுசுழற்சி** அல்லது புதிய உரிமையாளரைக் கொடுக்க வட்ட தீர்வுகளை வழங்குவதன் மூலம் பொருட்களின் ஆயுளை **நீட்டிக்க** உதவுவதை நோக்கமாகக் கொண்டுள்ளது.';
 
   @override
   String get guide_open_products_facts_features_arg1_title =>
-      'Carbon footprints for some products';
+      'சில தயாரிப்புகளுக்கான கார்பன் தடயங்கள்';
 
   @override
   String get guide_open_products_facts_features_arg1_text =>
-      '**Impact CO2** by French Environment Authority ADEME provides the **carbon impact** of many categories, make sure to categorize products precisely.';
+      '**பிரெஞ்சு சுற்றுச்சூழல் ஆணையமான ADEME ஆல் **தாக்கம் CO2** பல வகைகளின் **கார்பன் தாக்கத்தை** வழங்குகிறது, தயாரிப்புகளை துல்லியமாக வகைப்படுத்துவதை உறுதிசெய்யவும்.';
 
   @override
   String get guide_open_products_facts_features_arg2_title =>
-      'Reparability index for many products';
+      'பல தயாரிப்புகளுக்கான பழுதுபார்க்கும் குறியீடு';
 
   @override
   String get guide_open_products_facts_features_arg2_text =>
-      'Whenever a French reparability index is available, we’ll display it. Moreover, **you can start collecting the variables using the Folksonomy Engine**; so that we can recompute it ourselves in the future, even in countries where it’s not available.';
+      'பிரெஞ்சு பழுதுபார்க்கும் குறியீடு கிடைக்கும்போதெல்லாம், அதை நாங்கள் காண்பிப்போம். மேலும், **நீங்கள் ஃபோக்சோனமி எஞ்சினைப் பயன்படுத்தி மாறிகளைச் சேகரிக்கத் தொடங்கலாம்**; இதன் மூலம் எதிர்காலத்தில் அது கிடைக்காத நாடுகளில் கூட, அதை நாமே மீண்டும் கணக்கிட முடியும்.';
 
   @override
   String get guide_open_products_facts_features_arg3_title =>
-      'Find ways to donate/resell your product';
+      'உங்கள் தயாரிப்பை நன்கொடையாக/மறுவிற்பனை செய்வதற்கான வழிகளைக் கண்டறியவும்.';
 
   @override
   String get guide_open_products_facts_features_arg3_text =>
-      'We provide links to **third party circular friendly services** that help you get the kind of product you’re looking for, as a second hand product, to be more gentle on planetary resources.\nNote that we’re not paid to do that, and that the system only works as an example for two websites in France. You can help expand this system by documenting more sites on the wiki.';
+      '**மூன்றாம் தரப்பு வட்ட நட்பு சேவைகளுக்கான** இணைப்புகளை நாங்கள் வழங்குகிறோம், அவை நீங்கள் தேடும் தயாரிப்பைப் பெற உதவும், ஒரு இரண்டாம் நிலை தயாரிப்பாக, கிரக வளங்களில் மிகவும் மென்மையாக இருக்க உதவும்.\nஅதைச் செய்ய எங்களுக்கு பணம் வழங்கப்படவில்லை என்பதையும், இந்த அமைப்பு பிரான்சில் உள்ள இரண்டு வலைத்தளங்களுக்கு ஒரு எடுத்துக்காட்டாக மட்டுமே செயல்படுகிறது என்பதையும் நினைவில் கொள்க. விக்கியில் அதிகமான தளங்களை ஆவணப்படுத்துவதன் மூலம் இந்த அமைப்பை விரிவாக்க நீங்கள் உதவலாம்.';
 
   @override
   String get guide_open_products_facts_information_title =>
-      'What information is useful?';
+      'என்ன தகவல் பயனுள்ளதாக இருக்கும்?';
 
   @override
   String get guide_open_products_facts_information_text =>
-      'For such a wide range of items, **the data we collect is flexible**. To do that, **we created the Folksonomy Engine**.';
+      'இவ்வளவு பரந்த அளவிலான பொருட்களுக்கு, **நாங்கள் சேகரிக்கும் தரவு நெகிழ்வானது**. அதைச் செய்ய, **நாங்கள் ஃபோக்சோனமி எஞ்சினை** உருவாக்கினோம்.';
 
   @override
-  String get guide_open_products_facts_folksonomy_title =>
-      'The Folksonomy Engine';
+  String get guide_open_products_facts_folksonomy_title => 'ஃபோக்சோனமி எஞ்சின்';
 
   @override
   String get guide_open_products_facts_folksonomy_paragraph1 =>
-      'The Folksonomy Engine is a tool to help you complete products with relevant properties. This helps improve search and discoverability, but also compute and display interesting things in the future.';
+      'ஃபோக்சோனமி எஞ்சின் என்பது தொடர்புடைய பண்புகளுடன் தயாரிப்புகளை முடிக்க உதவும் ஒரு கருவியாகும். இது தேடல் மற்றும் கண்டறியும் தன்மையை மேம்படுத்த உதவுகிறது, ஆனால் எதிர்காலத்தில் சுவாரஸ்யமான விஷயங்களைக் கணக்கிட்டு காண்பிக்கவும் உதவுகிறது.';
 
   @override
   String get guide_open_products_facts_folksonomy_paragraph2 =>
-      'You can add any keys and values like: **compatibility_with_5G_mobile_network: yes**';
+      'நீங்கள் எந்த விசைகளையும் மதிப்புகளையும் சேர்க்கலாம், எடுத்துக்காட்டாக: **5G_mobile_network உடன்_compatibility: ஆம்**';
 
   @override
   String get guide_open_products_facts_folksonomy_paragraph3 =>
-      'You’ll get autosuggestion of possible properties, and you are very welcome to add and document new ones on your favorite kinds of products.';
+      'சாத்தியமான சொத்துக்களின் தானியங்கி பரிந்துரையைப் பெறுவீர்கள், மேலும் உங்களுக்குப் பிடித்த வகையான தயாரிப்புகளில் புதியவற்றைச் சேர்த்து ஆவணப்படுத்த உங்களை வரவேற்கிறோம்.';
 
   @override
   String get guide_open_products_facts_share_link =>
       'https://world-ta.openproductsfacts.org/discover பற்றிய தகவல்';
 
   @override
-  String get guide_open_preferences_button_title => 'Open food preferences';
+  String get guide_open_preferences_button_title =>
+      'திறந்த உணவு விருப்பத்தேர்வுகள்';
 
   @override
-  String get guide_coming_soon_button_title => 'Coming soon';
+  String get guide_coming_soon_button_title => 'விரைவில் வருகிறது';
 
   @override
-  String get guide_learn_more_subtitle => 'Tap to learn more';
+  String get guide_learn_more_subtitle => 'மேலும் அறிய தட்டவும்';
 
   @override
-  String get preview_badge => 'Preview';
+  String get preview_badge => 'முன்னோட்டம்';
 
   @override
   String get prices_feedback_form =>
       'இந்தப் புதிய அம்சத்தைப் பற்றிய உங்கள் கருத்தை எங்களுக்கு அனுப்ப இங்கே கிளிக் செய்யவும்!';
 
   @override
-  String get menu_button_list_actions => 'Select an action';
+  String get menu_button_list_actions => 'ஒரு செயலைத் தேர்ந்தெடுக்கவும்';
 
   @override
-  String get error_loading_photo => 'Error loading photo';
+  String get error_loading_photo => 'புகைப்படத்தை ஏற்றுவதில் பிழை';
 
   @override
-  String get photo_viewer_action_use_picture_as => 'Use as…';
+  String get photo_viewer_action_use_picture_as => '…ஆகப் பயன்படுத்தவும்';
 
   @override
-  String get photo_viewer_use_picture_as_tooltip => 'Use this picture as…';
+  String get photo_viewer_use_picture_as_tooltip =>
+      'இந்தப் படத்தை…ஆகப் பயன்படுத்தவும்';
 
   @override
   String photo_viewer_use_picture_as_title(String language) {
-    return 'Use this picture as… ($language)';
+    return 'இந்தப் படத்தை… ($language) ஆகப் பயன்படுத்தவும்';
   }
 
   @override
-  String get photo_viewer_details_button => 'Details';
+  String get photo_viewer_details_button => 'விவரங்கள்';
 
   @override
   String get photo_viewer_details_button_accessibility_label =>
-      'Details of this photo';
+      'இந்த புகைப்படத்தின் விவரங்கள்';
 
   @override
-  String get photo_viewer_details_title => 'Details of the photo';
+  String get photo_viewer_details_title => 'புகைப்படத்தின் விவரங்கள்';
 
   @override
   String get photo_viewer_details_contributor_title => 'Contributor';
 
   @override
-  String get photo_viewer_details_size_title => 'Size';
+  String get photo_viewer_details_size_title => 'அளவு';
 
   @override
   String photo_viewer_details_size_value(int width, int height) {
-    return '$width x $height pixels';
+    return '$width x $height பிக்சல்கள்';
   }
 
   @override
-  String get photo_viewer_details_date_title => 'Date';
+  String get photo_viewer_details_date_title => 'தேதி';
 
   @override
-  String get photo_viewer_details_url_title => 'URL';
+  String get photo_viewer_details_url_title => 'URL ஐ';
 
   @override
-  String get product_page_compatibility_score => 'Compatible';
+  String get product_page_compatibility_score => 'இணக்கமானது';
 
   @override
-  String get user_lists_action_multi_select => 'Multi-select';
+  String get user_lists_action_multi_select => 'பல தேர்வு';
 
   @override
   String product_page_compatibility_score_tooltip(String score) {
-    return 'Your compatibility score: $score%';
+    return 'உங்கள் பொருந்தக்கூடிய மதிப்பெண்: $score%';
   }
 
   @override
@@ -5085,60 +5194,62 @@ class AppLocalizationsTa extends AppLocalizations {
       'Ingredients picture';
 
   @override
-  String get product_image_nutrition_accessibility_label => 'Nutrition picture';
+  String get product_image_nutrition_accessibility_label => 'ஊட்டச்சத்து படம்';
 
   @override
-  String get product_image_packaging_accessibility_label => 'Packaging picture';
+  String get product_image_packaging_accessibility_label => 'பேக்கேஜிங் படம்';
 
   @override
-  String get product_image_other_accessibility_label => 'Other picture';
+  String get product_image_other_accessibility_label => 'மற்ற படம்';
 
   @override
-  String get product_image_outdated_message => 'This picture may be outdated';
+  String get product_image_outdated_message =>
+      'இந்தப் படம் காலாவதியானதாக இருக்கலாம்.';
 
   @override
   String product_image_outdated_message_accessibility_label(String type) {
-    return '$type (this image may be outdated)';
+    return '$type (இந்தப் படம் காலாவதியானதாக இருக்கலாம்)';
   }
 
   @override
   String product_image_locked_message_accessibility_label(String type) {
-    return '$type (this image may be locked by the producer)';
+    return '$type (இந்தப் படத்தை தயாரிப்பாளரே பூட்டலாம்)';
   }
 
   @override
-  String get product_image_error => 'Unable to load the image!';
+  String get product_image_error => 'படத்தை ஏற்ற முடியவில்லை!';
 
   @override
   String product_image_error_accessibility_label(String type) {
-    return 'Unable to load the $type (network error?)';
+    return '$type ஐ ஏற்ற முடியவில்லை (நெட்வொர்க் பிழையா?)';
   }
 
   @override
-  String get product_page_image_no_image_available => 'No\nimage!';
+  String get product_page_image_no_image_available => '\nபடம் இல்லை!';
 
   @override
   String get product_page_image_no_image_available_accessibility_label =>
-      'No picture available for this product';
+      'இந்த தயாரிப்புக்கான படம் எதுவும் கிடைக்கவில்லை.';
 
   @override
   String get product_page_action_bar_settings_accessibility_label =>
-      'Reorder or hide actions';
+      'செயல்களை மறுவரிசைப்படுத்து அல்லது மறை';
 
   @override
-  String get product_page_action_bar_setting_modal_title => 'Edit actions';
+  String get product_page_action_bar_setting_modal_title =>
+      'செயல்களைத் திருத்து';
 
   @override
-  String get product_page_action_bar_item_move_up => 'Move up';
+  String get product_page_action_bar_item_move_up => 'மேலே நகர்த்து';
 
   @override
-  String get product_page_action_bar_item_move_down => 'Move down';
+  String get product_page_action_bar_item_move_down => 'கீழே நகர்த்து';
 
   @override
-  String get product_page_action_bar_item_enable => 'Enable action';
+  String get product_page_action_bar_item_enable => 'செயலை இயக்கு';
 
   @override
-  String get product_page_action_bar_item_disable => 'Disable action';
+  String get product_page_action_bar_item_disable => 'செயலை முடக்கு';
 
   @override
   String get product_page_pending_operations_banner_title =>
@@ -5149,100 +5260,101 @@ class AppLocalizationsTa extends AppLocalizations {
       'இந்தப் பக்கத்தில் காட்டப்படும் தரவு **உங்கள் மாற்றங்களை இன்னும் பிரதிபலிக்கவில்லை**.\nசில வினாடிகள் காத்திருக்கவும்…';
 
   @override
-  String get product_add_a_language => 'Add a language';
+  String get product_add_a_language => 'ஒரு மொழியைச் சேர்க்கவும்';
 
   @override
   String barcode_accessibility_label(String barcode) {
-    return 'Barcode $barcode';
+    return 'பார்கோடு $barcode';
   }
 
   @override
-  String get carousel_close_tooltip => 'Remove this product from the carousel';
+  String get carousel_close_tooltip =>
+      'இந்தத் தயாரிப்பை கேரோசலில் இருந்து அகற்று';
 
   @override
-  String get carousel_unsupported_header => 'Unsupported barcode!';
+  String get carousel_unsupported_header => 'ஆதரிக்கப்படாத பார்கோடு!';
 
   @override
-  String get carousel_unsupported_title => 'Ooops!';
+  String get carousel_unsupported_title => 'அச்சச்சோ!';
 
   @override
   String get carousel_unsupported_text =>
-      'The barcode scanned is not supported by Open Food Facts!';
+      'ஸ்கேன் செய்யப்பட்ட பார்கோடு திறந்த உணவு உண்மைகளால் ஆதரிக்கப்படவில்லை!';
 
   @override
-  String get carousel_error_header => 'Error!';
+  String get carousel_error_header => 'பிழை!';
 
   @override
-  String get carousel_error_title => 'It\'s a bummer!';
+  String get carousel_error_title => 'இது ஒரு பெரிய குறை!';
 
   @override
   String get carousel_error_text_1 =>
-      'We couldn\'t download information on this barcode:';
+      'இந்த பார்கோடில் தகவலை எங்களால் பதிவிறக்க முடியவில்லை:';
 
   @override
   String get carousel_error_text_2 =>
-      'Please check your Internet connection or click this button:';
+      'உங்கள் இணைய இணைப்பைச் சரிபார்க்கவும் அல்லது இந்த பொத்தானைக் கிளிக் செய்யவும்:';
 
   @override
   String get carousel_error_button => 'மீண்டும் முயல்க';
 
   @override
-  String get carousel_unknown_product_header => 'Unknown product';
+  String get carousel_unknown_product_header => 'தெரியாத தயாரிப்பு';
 
   @override
   String get carousel_unknown_product_title =>
-      'Congratulations!\nYou\'ve found __the rare gem!__';
+      'வாழ்த்துக்கள்!\nநீங்கள் __அரிய ரத்தினத்தைக் கண்டுபிடித்துவிட்டீர்கள்!__';
 
   @override
   String get carousel_unknown_product_text =>
-      'Our collaborative database contains more than **3 million products**, but this barcode doesn\'t exist: ';
+      'எங்கள் கூட்டு தரவுத்தளத்தில் **3 மில்லியனுக்கும் அதிகமான தயாரிப்புகள்** உள்ளன, ஆனால் இந்த பார்கோடு இல்லை: ';
 
   @override
   String get carousel_unknown_product_button => 'Add this product';
 
   @override
-  String get carousel_loading_header => 'Loading information...';
+  String get carousel_loading_header => 'தகவலை ஏற்றுகிறது...';
 
   @override
   String get carousel_loading_title =>
-      'You\'ve just scanned a product with the following barcode:';
+      'நீங்கள் பின்வரும் பார்கோடு கொண்ட ஒரு தயாரிப்பை ஸ்கேன் செய்துள்ளீர்கள்:';
 
   @override
   String get carousel_loading_text =>
-      'We are searching for it in our database of more than **3 million products!**';
+      '**3 மில்லியனுக்கும் அதிகமான தயாரிப்புகளைக் கொண்ட எங்கள் தரவுத்தளத்தில் அதைத் தேடுகிறோம்!**';
 
   @override
-  String get product_type_subtitle_food => 'Vegetables, fruits, frozen food…';
+  String get product_type_subtitle_food => 'காய்கறிகள், பழங்கள், உறைந்த உணவு…';
 
   @override
-  String get product_type_subtitle_beauty => 'Makeup, soaps, toothpastes…';
+  String get product_type_subtitle_beauty => 'ஒப்பனை, சோப்புகள், பற்பசைகள்…';
 
   @override
-  String get product_type_subtitle_pet_food => 'Food for dogs, cats…';
+  String get product_type_subtitle_pet_food => 'நாய்கள், பூனைகளுக்கான உணவு…';
 
   @override
-  String get product_type_subtitle_product => 'Smartphones, furniture…';
+  String get product_type_subtitle_product => 'ஸ்மார்ட்போன்கள், தளபாடங்கள்…';
 
   @override
-  String get photo_field_front => 'Product photo';
+  String get photo_field_front => 'தயாரிப்பு புகைப்படம்';
 
   @override
-  String get photo_field_ingredients => 'Ingredients photo';
+  String get photo_field_ingredients => 'பொருட்கள் புகைப்படம்';
 
   @override
-  String get photo_field_nutrition => 'Nutrition photo';
+  String get photo_field_nutrition => 'ஊட்டச்சத்து புகைப்படம்';
 
   @override
-  String get photo_field_packaging => 'Packaging information photo';
+  String get photo_field_packaging => 'பேக்கேஜிங் தகவல் புகைப்படம்';
 
   @override
-  String get photo_already_exists => 'This photo already exists';
+  String get photo_already_exists => 'இந்தப் புகைப்படம் ஏற்கனவே உள்ளது.';
 
   @override
-  String get photo_missing => 'This photo is missing';
+  String get photo_missing => 'இந்தப் புகைப்படம் இல்லை.';
 
   @override
-  String get date => 'Date';
+  String get date => 'தேதி';
 
   @override
   String get photo_rotate_left => 'Rotate left';
@@ -5251,7 +5363,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get photo_rotate_right => 'Rotate right';
 
   @override
-  String get photo_undo_action => 'Undo the previous action';
+  String get photo_undo_action => 'முந்தைய செயலைச் செயல்தவிர்க்கவும்.';
 
   @override
   String knowledge_panel_world_map_accessibility_label(String location) {
@@ -5263,7 +5375,7 @@ class AppLocalizationsTa extends AppLocalizations {
       'OpenStreetMap பங்களிப்பாளர்கள்';
 
   @override
-  String get not_applicable_short => 'N/A';
+  String get not_applicable_short => 'பொருந்தாது';
 
   @override
   String get knowledge_panel_warning_text => 'Warning';
@@ -5274,7 +5386,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get knowledge_panel_nutriscore_banner_incorrect_score_message =>
-      'There are two possible explanations:\nThe list of ingredients and/or nutrition facts are not up-to-date.\n\nWe provide the \"New calculation\" of the Nutri-Score (or V2). Please check that you have the banner \"New calculation\" on the package.';
+      'இரண்டு சாத்தியமான விளக்கங்கள் உள்ளன:\nபொருட்களின் பட்டியல் மற்றும்/அல்லது ஊட்டச்சத்து உண்மைகள் புதுப்பித்த நிலையில் இல்லை.\n\nநியூட்ரி-ஸ்கோரின் (அல்லது V2) \"புதிய கணக்கீட்டை\" நாங்கள் வழங்குகிறோம். தொகுப்பில் \"புதிய கணக்கீடு\" என்ற பேனர் உள்ளதா எனச் சரிபார்க்கவும்.';
 
   @override
   String get knowledge_panel_nutriscore_banner_incorrect_score_button1 =>
@@ -5290,10 +5402,10 @@ class AppLocalizationsTa extends AppLocalizations {
   }
 
   @override
-  String get product_list_export => 'Export';
+  String get product_list_export => 'ஏற்றுமதி';
 
   @override
-  String get product_list_import => 'Import';
+  String get product_list_import => 'இறக்குமதி';
 
   @override
   String get product_footer_action_barcode => 'பார்கோடைப் பார்க்கவும்';
@@ -5317,10 +5429,10 @@ class AppLocalizationsTa extends AppLocalizations {
   String get product_page_tab_for_me => 'எனக்காக';
 
   @override
-  String get product_page_tab_website => 'Website';
+  String get product_page_tab_website => 'வலைத்தளம்';
 
   @override
-  String get product_page_tab_prices => 'Prices';
+  String get product_page_tab_prices => 'விலைகள்';
 
   @override
   String get prices_explanation_card_title => 'ஏன் விலைகள்?';
@@ -5333,7 +5445,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get explanation_card_learn_more_button => 'மேலும்அறிய';
 
   @override
-  String get product_page_tab_folksonomy => 'Folksonomy';
+  String get product_page_tab_folksonomy => 'நாட்டுப்புறவியல்';
 
   @override
   String get folksonomy_explanation_card_title =>
@@ -5348,11 +5460,11 @@ class AppLocalizationsTa extends AppLocalizations {
       'இந்தப் பண்புகள் பங்களிப்பாளர்களால் எந்தவொரு பயன்பாட்டிற்கும் உருவாக்கப்பட்டு தாக்கல் செய்யப்படுகின்றன.';
 
   @override
-  String get folksonomy_action_external_link_title => 'Open external link';
+  String get folksonomy_action_external_link_title => 'வெளிப்புற இணைப்பைத் திற';
 
   @override
   String get folksonomy_action_external_link_warning =>
-      'External links may be unsafe. Do you really want to visit it?';
+      'வெளிப்புற இணைப்புகள் பாதுகாப்பற்றதாக இருக்கலாம். நீங்கள் உண்மையிலேயே அதைப் பார்வையிட விரும்புகிறீர்களா?';
 
   @override
   String get prices_products_empty_title => 'விலை எதுவும் கிடைக்கவில்லை.';
@@ -5362,34 +5474,35 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String prices_products_list_length_many_pages(int pageSize, int total) {
-    return 'Top $pageSize products (total: $total)';
+    return 'மேலே $pageSize தயாரிப்புகள் (மொத்தம்: $total)';
   }
 
   @override
-  String get app_review_title => 'Are you enjoying this app?';
+  String get app_review_title => 'இந்த ஆப் உங்களுக்குப் பிடித்திருக்கிறதா?';
 
   @override
-  String get app_review_low => 'Could do better';
+  String get app_review_low => 'இன்னும் சிறப்பாகச் செய்ய முடியும்';
 
   @override
-  String get app_review_medium => 'Not bad';
+  String get app_review_medium => 'மோசமாக இல்லை';
 
   @override
-  String get app_review_high => 'I love it!';
+  String get app_review_high => 'நான் அதை விரும்புகிறேன்!';
 
   @override
   String get app_review_feedback_modal_title =>
-      'Help us improve our application';
+      'எங்கள் பயன்பாட்டை மேம்படுத்த உதவுங்கள்.';
 
   @override
   String get app_review_feedback_modal_content =>
-      'If you have a few minutes, could you answer this form so that **we can improve in future updates**:';
+      'உங்களிடம் சில நிமிடங்கள் இருந்தால், இந்த படிவத்திற்கு பதிலளிக்க முடியுமா, அதனால் **எதிர்கால புதுப்பிப்புகளில் நாங்கள் மேம்படுத்த முடியும்**:';
 
   @override
-  String get app_review_feedback_modal_open_form => 'Answer the form';
+  String get app_review_feedback_modal_open_form =>
+      'படிவத்திற்கு பதிலளிக்கவும்';
 
   @override
-  String get app_review_feedback_modal_later => 'Ask me later';
+  String get app_review_feedback_modal_later => 'பிறகு கேளுங்கள்.';
 
   @override
   String get nutrition_facts_extract_new =>
@@ -5414,16 +5527,16 @@ class AppLocalizationsTa extends AppLocalizations {
   String get prices_discount => 'தள்ளுபடி';
 
   @override
-  String get prices_stats_statistics => 'Statistics';
+  String get prices_stats_statistics => 'புள்ளிவிவரங்கள்';
 
   @override
-  String get prices_stats_title => 'Prices Statistics';
+  String get prices_stats_title => 'விலை புள்ளிவிவரங்கள்';
 
   @override
-  String get prices_stats_prices_section => 'Prices';
+  String get prices_stats_prices_section => 'விலைகள்';
 
   @override
-  String get prices_stats_products_section => 'Products';
+  String get prices_stats_products_section => 'தயாரிப்புகள்';
 
   @override
   String get prices_stats_locations_section => 'இடங்கள்';
@@ -5438,7 +5551,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get prices_stats_experiments_section => 'Experiments';
 
   @override
-  String get prices_stats_misc_section => 'Miscellaneous';
+  String get prices_stats_misc_section => 'இதர';
 
   @override
   String get prices_stats_total => 'Total';
@@ -5462,19 +5575,19 @@ class AppLocalizationsTa extends AppLocalizations {
   String get prices_stats_with_price => 'ஒரு விலையுடன்';
 
   @override
-  String get prices_stats_food => 'Food';
+  String get prices_stats_food => 'உணவு';
 
   @override
   String get prices_stats_beauty => 'Beauty';
 
   @override
-  String get prices_stats_products => 'Products';
+  String get prices_stats_products => 'தயாரிப்புகள்';
 
   @override
-  String get prices_stats_pet_food => 'Pet food';
+  String get prices_stats_pet_food => 'செல்லப்பிராணி உணவு';
 
   @override
-  String get prices_stats_osm => 'OpenStreetMap';
+  String get prices_stats_osm => 'ஓபன் ஸ்ட்ரீட்மேப்';
 
   @override
   String get prices_stats_online => 'ஆன்லைன்';
@@ -5483,10 +5596,10 @@ class AppLocalizationsTa extends AppLocalizations {
   String get prices_stats_countries => 'Countries';
 
   @override
-  String get prices_stats_price_tag => 'Price tag';
+  String get prices_stats_price_tag => 'விலைக் குறி';
 
   @override
-  String get prices_stats_receipt => 'Receipt';
+  String get prices_stats_receipt => 'ரசீது';
 
   @override
   String get prices_stats_gdpr_request => 'GDPR request';
@@ -5511,35 +5624,36 @@ class AppLocalizationsTa extends AppLocalizations {
       'மூலத்திற்கான விலைகள் மற்றும் சான்றுகள்';
 
   @override
-  String get prices_stats_website => 'Website';
+  String get prices_stats_website => 'வலைத்தளம்';
 
   @override
   String get prices_stats_mobile_app => 'மொபைல் பயன்பாடு';
 
   @override
-  String get prices_stats_api => 'API';
+  String get prices_stats_api => 'ஏபிஐ';
 
   @override
   String get prices_stats_other => 'Other';
 
   @override
-  String get prices_stats_last_updated => 'Last updated on';
+  String get prices_stats_last_updated => 'கடைசியாகப் புதுப்பிக்கப்பட்டது';
 
   @override
   String get prices_stats_error =>
-      'An error occurred while loading statistics.';
+      'புள்ளிவிவரங்களை ஏற்றும்போது பிழை ஏற்பட்டது.';
 
   @override
-  String get product_edit_robotoff_question_answered => 'Question answered!';
+  String get product_edit_robotoff_question_answered =>
+      'கேள்விக்கு பதில் கிடைத்தது!';
 
   @override
-  String get product_edit_robotoff_proof => 'Proof';
+  String get product_edit_robotoff_proof => 'ஆதாரம்';
 
   @override
   String get preferences_card_general => 'பொது';
 
   @override
-  String get preferences_prices_title => 'Prices';
+  String get preferences_prices_title => 'விலைகள்';
 
   @override
   String get preferences_prices_subtitle =>
@@ -5579,7 +5693,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get preferences_card_help => 'உதவி & ஆதரவு';
 
   @override
-  String get preferences_faq_title => 'FAQ';
+  String get preferences_faq_title => 'அடிக்கடி கேட்கப்படும் கேள்விகள்';
 
   @override
   String get preferences_faq_subtitle =>
@@ -5620,7 +5734,7 @@ class AppLocalizationsTa extends AppLocalizations {
       'அணுகல்தன்மை: வண்ணங்களை அகற்று';
 
   @override
-  String get preferences_app_settings_products => 'Products';
+  String get preferences_app_settings_products => 'தயாரிப்புகள்';
 
   @override
   String get preferences_card_about => 'இதைப் பற்றி';
@@ -5633,17 +5747,17 @@ class AppLocalizationsTa extends AppLocalizations {
       'பயன்பாட்டு விதிமுறைகள், தனியுரிமைக் கொள்கை மற்றும் பல';
 
   @override
-  String get preferences_terms_of_use => 'Terms of use';
+  String get preferences_terms_of_use => 'பயன்பாட்டு விதிமுறைகள்';
 
   @override
   String get preferences_legal_mentions => 'Legal mentions';
 
   @override
   String get preferences_legal_header =>
-      'Open Food Facts is a food products database **made by everyone, for everyone**.\nYou can use it to make better food choices, and as it is **open data**, anyone can **re-use it for any purpose**.';
+      'ஓபன் ஃபுட் ஃபேக்ட்ஸ் என்பது அனைவராலும், அனைவருக்கும்** உருவாக்கப்பட்ட உணவுப் பொருட்களின் தரவுத்தளமாகும்.\nசிறந்த உணவுத் தேர்வுகளைச் செய்ய நீங்கள் இதைப் பயன்படுத்தலாம், மேலும் இது **திறந்த தரவு** என்பதால், யார் வேண்டுமானாலும் எந்த நோக்கத்திற்காகவும் இதை மீண்டும் பயன்படுத்தலாம்**.';
 
   @override
-  String get preferences_privacy_policy => 'Privacy policy';
+  String get preferences_privacy_policy => 'தனியுரிமைக் கொள்கை';
 
   @override
   String get preferences_licenses => 'உரிமங்கள்';
@@ -5687,11 +5801,11 @@ class AppLocalizationsTa extends AppLocalizations {
   String get preferences_tips => 'குறிப்புகள்';
 
   @override
-  String get tips_discover_nutriscore => 'Discover the new Nutri-Score';
+  String get tips_discover_nutriscore => 'புதிய நியூட்ரி-ஸ்கோரைக் கண்டறியவும்';
 
   @override
   String get preferences_on_off_website_subtitle =>
-      'On the Open Food Facts website';
+      'ஓபன் ஃபுட் ஃபேக்ட்ஸ் வலைத்தளத்தில்';
 
   @override
   String get preferences_manage_account_title => 'எனது கணக்கை நிர்வகிக்கவும்';
@@ -5825,7 +5939,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get preferences_connect_community_calendar_title =>
-      'Subscribe to our community calendar';
+      'எங்கள் சமூக நாட்காட்டியில் குழுசேரவும்';
 
   @override
   String get preferences_connect_community_calendar_subtitle =>
@@ -5959,7 +6073,7 @@ class AppLocalizationsTa extends AppLocalizations {
       'முழுமையற்ற அனைத்து தயாரிப்புகளும்';
 
   @override
-  String get preferences_my_contributions_prices_title => 'Prices';
+  String get preferences_my_contributions_prices_title => 'விலைகள்';
 
   @override
   String get preferences_my_contributions_my_prices_title => 'எனது விலைகள்';
@@ -6155,10 +6269,10 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get preferences_page_open_food_facts_labs_title =>
-      'Open Food Facts ஆய்வகங்கள்';
+      'Open Food Facts Labs';
 
   @override
-  String get preferences_root_account_title => 'Account';
+  String get preferences_root_account_title => 'கணக்கு';
 
   @override
   String get preferences_contribute_translate_header =>
@@ -6177,7 +6291,7 @@ class AppLocalizationsTa extends AppLocalizations {
       'ஃபோக்சோனமியைக் காட்டாதே';
 
   @override
-  String get preferences_account_title => 'Account';
+  String get preferences_account_title => 'கணக்கு';
 
   @override
   String prices_adding_timestamp_tooltip(String created) {
@@ -6185,26 +6299,26 @@ class AppLocalizationsTa extends AppLocalizations {
   }
 
   @override
-  String get location_map_details_title => 'Location details';
+  String get location_map_details_title => 'இருப்பிட விவரங்கள்';
 
   @override
-  String get location_map_details_name => 'Name';
+  String get location_map_details_name => 'பெயர்';
 
   @override
-  String get location_map_details_street => 'Street';
+  String get location_map_details_street => 'தெரு';
 
   @override
-  String get location_map_details_city => 'City';
+  String get location_map_details_city => 'நகரம்';
 
   @override
-  String get location_map_details_postcode => 'Postcode';
+  String get location_map_details_postcode => 'அஞ்சல் குறியீடு';
 
   @override
   String get location_map_details_country => 'Country';
 
   @override
-  String get location_map_details_coordinates => 'Coordinates';
+  String get location_map_details_coordinates => 'ஆயத்தொலைவுகள்';
 
   @override
-  String get location_map_details_osm_id => 'OSM ID';
+  String get location_map_details_osm_id => 'OSM ஐடி';
 }

--- a/packages/smooth_app/lib/l10n/app_localizations_te.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_te.dart
@@ -654,6 +654,9 @@ class AppLocalizationsTe extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3521,7 +3524,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'స్థానికంగా నిల్వ చేయబడిన ఫోల్క్‌సోనమీ నవీకరణల కోసం సర్వర్ చర్యలను ప్రారంభించడం.';
 
   @override
   String get background_task_title_top_n =>
@@ -5585,7 +5588,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get preferences_app_bar_search_hint =>
-      'Search for a setting (e.g. Nutri-Score)';
+      'సెట్టింగ్ కోసం శోధించండి (ఉదా. న్యూట్రి-స్కోర్)';
 
   @override
   String get preferences_accessibility_show_emoji =>
@@ -5663,7 +5666,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get preferences_tips => 'చిట్కాలు';
 
   @override
-  String get tips_discover_nutriscore => 'Discover the new Nutri-Score';
+  String get tips_discover_nutriscore => 'కొత్త న్యూట్రి-స్కోర్‌ను కనుగొనండి';
 
   @override
   String get preferences_on_off_website_subtitle =>
@@ -5751,7 +5754,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get preferences_faq_nutriscore_subtitle =>
-      'Discover how the Nutri-Score is computed';
+      'న్యూట్రి-స్కోర్ ఎలా గణించబడుతుందో కనుగొనండి';
 
   @override
   String get preferences_faq_nutriscore_v2_subtitle =>
@@ -5945,7 +5948,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get preferences_contributions_categorize_subtitle =>
-      'Help compute the Nutri-Score & Green-Score in your country';
+      'మీ దేశంలో న్యూట్రి-స్కోర్ & గ్రీన్-స్కోర్‌ను లెక్కించడంలో సహాయం చేయండి';
 
   @override
   String get preferences_prices_user_prices_subtitle => 'నేను అందించిన ధరలు';
@@ -6123,7 +6126,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get preferences_page_open_food_facts_labs_title =>
-      'Open Food Facts ల్యాబ్స్';
+      'Open Food Facts Labs';
 
   @override
   String get preferences_root_account_title => 'Account';

--- a/packages/smooth_app/lib/l10n/app_localizations_te.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_te.dart
@@ -654,7 +654,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_tg.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tg.dart
@@ -653,6 +653,9 @@ class AppLocalizationsTg extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3521,7 +3524,7 @@ class AppLocalizationsTg extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Оғози иҷрои амалҳои сервер барои навсозиҳои фолксономӣ, ки дар маҳаллӣ нигоҳ дошта мешаванд';
 
   @override
   String get background_task_title_top_n =>
@@ -4495,7 +4498,7 @@ class AppLocalizationsTg extends AppLocalizations {
   String get guide_nova_logos_caption => 'Логотипҳои NOVA';
 
   @override
-  String get guide_nova_groups_title => 'The 4 NOVA groups';
+  String get guide_nova_groups_title => '4 гурӯҳи NOVA';
 
   @override
   String get guide_nova_groups_intro =>
@@ -5617,7 +5620,7 @@ class AppLocalizationsTg extends AppLocalizations {
 
   @override
   String get preferences_legal_header =>
-      'Open Food Facts is a food products database **made by everyone, for everyone**.\nYou can use it to make better food choices, and as it is **open data**, anyone can **re-use it for any purpose**.';
+      'Facts Open Food - махзани маҳсулоти хӯрокворӣ **аз ҷониби ҳама, барои ҳама** сохта шудааст.\nШумо метавонед онро барои интихоби беҳтари ғизо истифода баред ва азбаски он **маълумоти кушода** аст, ҳар кас метавонад онро **бо ҳар мақсад** дубора истифода барад.';
 
   @override
   String get preferences_privacy_policy => 'Privacy policy';
@@ -5668,7 +5671,7 @@ class AppLocalizationsTg extends AppLocalizations {
 
   @override
   String get preferences_on_off_website_subtitle =>
-      'On the Open Food Facts website';
+      'Дар вебсайти Open Facts Food';
 
   @override
   String get preferences_manage_account_title => 'Ҳисоби маро идора кунед';
@@ -5783,7 +5786,8 @@ class AppLocalizationsTg extends AppLocalizations {
   String get preferences_faq_faq_title => 'FAQ - Саволҳои зуд-зуд додашаванда';
 
   @override
-  String get preferences_faq_off_ngo_title => 'The Open Food Facts NGO';
+  String get preferences_faq_off_ngo_title =>
+      'Ташкилоти ҷамъиятии \"Фактҳои озуқавории кушод\"';
 
   @override
   String get preferences_about_information_title => 'Information';
@@ -5805,7 +5809,7 @@ class AppLocalizationsTg extends AppLocalizations {
       'Бо иштирок дар яке аз чорабиниҳои виртуалии мо иштирок кунед';
 
   @override
-  String get preferences_connect_blog_title => 'The Open Food Facts blog';
+  String get preferences_connect_blog_title => 'Блоги Open Facts Food';
 
   @override
   String get preferences_connect_blog_subtitle =>
@@ -5920,7 +5924,7 @@ class AppLocalizationsTg extends AppLocalizations {
 
   @override
   String get preferences_contributions_new_products_subtitle =>
-      'New products I added to Open Food Facts';
+      'Маҳсулоти наве, ки ман ба Facts Open Food илова кардам';
 
   @override
   String get preferences_contributions_to_be_completed_title =>
@@ -6133,7 +6137,7 @@ class AppLocalizationsTg extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Далелҳои озуқавории кушодро ба забони худ биёред';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_tg.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tg.dart
@@ -653,7 +653,7 @@ class AppLocalizationsTg extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_th.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_th.dart
@@ -648,6 +648,9 @@ class AppLocalizationsTh extends AppLocalizations {
   String get unknownBrand => 'ไม่ทราบยี่ห้อ';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'ผลิตภัณฑ์ที่ไม่รู้จัก';
 
   @override
@@ -3511,7 +3514,7 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'เริ่มดำเนินการเซิร์ฟเวอร์สำหรับการอัปเดต Folksonomy ที่เก็บไว้ในเครื่อง';
 
   @override
   String get background_task_title_top_n =>
@@ -6103,7 +6106,8 @@ class AppLocalizationsTh extends AppLocalizations {
   String get preferences_about_app_development_title => 'Development';
 
   @override
-  String get preferences_page_open_food_facts_labs_title => 'Open Food Facts';
+  String get preferences_page_open_food_facts_labs_title =>
+      'Open Food Facts Labs';
 
   @override
   String get preferences_root_account_title => 'Account';

--- a/packages/smooth_app/lib/l10n/app_localizations_th.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_th.dart
@@ -648,7 +648,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get unknownBrand => 'ไม่ทราบยี่ห้อ';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'ผลิตภัณฑ์ที่ไม่รู้จัก';

--- a/packages/smooth_app/lib/l10n/app_localizations_ti.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ti.dart
@@ -653,7 +653,7 @@ class AppLocalizationsTi extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_ti.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ti.dart
@@ -653,6 +653,9 @@ class AppLocalizationsTi extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3514,7 +3517,7 @@ class AppLocalizationsTi extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'ኣብ ውሽጢ ዓዲ ንዝተዓቀቡ ፎልሶኖሚ ምዕባለታት ናይ ሰርቨር ተግባራት ምፍጻም ምጅማር';
 
   @override
   String get background_task_title_top_n =>
@@ -4080,7 +4083,7 @@ class AppLocalizationsTi extends AppLocalizations {
   String get environmental_score_not_applicable_new => 'ግሪን-ስኮር ተግባራዊ ኣይኮነን።';
 
   @override
-  String get nova_group_generic_new => 'Ultra-processed foods - NOVA groups';
+  String get nova_group_generic_new => 'ኣዝዩ ዝተመስርሑ መግብታት - ጉጅለታት ኖቫ';
 
   @override
   String get nova_group_1 => 'NOVA Group 1';
@@ -4480,14 +4483,14 @@ class AppLocalizationsTi extends AppLocalizations {
       'ምደባ NOVA ንመግብታት ብመሰረት **ደረጃ ኢንዱስትርያዊ መስርሖም** (ብውሑድ ዝተመስርሑ ወይ ዘይተመስርሑ መግብታት፣ ቀመማት ምግቢ፣ ዝተመስርሑ መግብታት፣ ኣዝዮም ዝተመስርሑ መግብታት) መሰረት ብምግባር ኣብ **4 ጉጅለታት** ክምደቡ የኽእል።';
 
   @override
-  String get guide_nova_logos_caption => 'The NOVA logos';
+  String get guide_nova_logos_caption => 'እቶም ናይ ኖቫ ኣርማታት';
 
   @override
-  String get guide_nova_groups_title => 'The 4 NOVA groups';
+  String get guide_nova_groups_title => 'እተን 4 ጉጅለታት ኖቫ';
 
   @override
   String get guide_nova_groups_intro =>
-      'There are 4 NOVA groups, the problematic one being Group 4 - Ultra-processed foods.';
+      '4 ጉጅለታት ኖቫ ኣለዋ፡ እቲ ጸገም ዘለዎ ጉጅለ 4 - Ultra-processed foods እዩ።';
 
   @override
   String get guide_nova_groups_arg1_title => 'ብውሑድ ደረጃ ዝተመስርሑ ወይ ዘይተመስርሑ መግብታት';
@@ -5565,8 +5568,7 @@ class AppLocalizationsTi extends AppLocalizations {
   }
 
   @override
-  String get preferences_app_bar_search_hint =>
-      'Search for a setting (e.g. Nutri-Score)';
+  String get preferences_app_bar_search_hint => 'ንሓደ ቅጥዒ ድለዩ (ንኣብነት ኒውትሪ-ስኮር)';
 
   @override
   String get preferences_accessibility_show_emoji => 'ተበጻሕነት: ኢሞጂ ኣርእዩ';
@@ -5640,11 +5642,10 @@ class AppLocalizationsTi extends AppLocalizations {
   String get preferences_tips => 'መቑሽሽ';
 
   @override
-  String get tips_discover_nutriscore => 'Discover the new Nutri-Score';
+  String get tips_discover_nutriscore => 'ሓድሽ ኒውትሪ-ስኮር ርኸብዎ።';
 
   @override
-  String get preferences_on_off_website_subtitle =>
-      'On the Open Food Facts website';
+  String get preferences_on_off_website_subtitle => 'ኣብ መርበብ ሓበሬታ ክፉት ሓቅታት መግቢ';
 
   @override
   String get preferences_manage_account_title => 'ኣካውንተይ ኣመሓድር';
@@ -5725,7 +5726,7 @@ class AppLocalizationsTi extends AppLocalizations {
 
   @override
   String get preferences_faq_nutriscore_subtitle =>
-      'Discover how the Nutri-Score is computed';
+      'ኒውትሪ-ስኮር ብኸመይ ከም ዝስላዕ ርኸቡ።';
 
   @override
   String get preferences_faq_nutriscore_v2_subtitle =>
@@ -5755,7 +5756,7 @@ class AppLocalizationsTi extends AppLocalizations {
   String get preferences_faq_faq_title => 'FAQ - ብተደጋጋሚ ዝሕተቱ ሕቶታት';
 
   @override
-  String get preferences_faq_off_ngo_title => 'The Open Food Facts NGO';
+  String get preferences_faq_off_ngo_title => 'እቲ ክፉት ሓቅታት መግቢ ዘይመንግስታዊ ትካል';
 
   @override
   String get preferences_about_information_title => 'Information';
@@ -5777,7 +5778,7 @@ class AppLocalizationsTi extends AppLocalizations {
       'ኣብ ሓደ ካብቲ ቨርቹዋል መደባትና ብምስታፍ ተሳተፉ';
 
   @override
-  String get preferences_connect_blog_title => 'The Open Food Facts blog';
+  String get preferences_connect_blog_title => 'ብሎግ ክፉት ሓቅታት መግቢ';
 
   @override
   String get preferences_connect_blog_subtitle => 'እዋናዊ ዜናታት ርኸቡ፣ ከምቲ ዘጋጥም';
@@ -5973,7 +5974,7 @@ class AppLocalizationsTi extends AppLocalizations {
 
   @override
   String get preferences_page_contribute_project_subtitle =>
-      'Simple ways to help Open Food Facts';
+      'ቀለልቲ መገድታት ንኽፉት ሓቅታት መግቢ ንምሕጋዝ';
 
   @override
   String get preferences_page_faq_subtitle =>
@@ -6085,7 +6086,7 @@ class AppLocalizationsTi extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'ክፉት ሓቅታት መግቢ ናብ ቋንቋኹም ኣምጽኡ';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_tl.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tl.dart
@@ -654,7 +654,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_tl.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tl.dart
@@ -654,6 +654,9 @@ class AppLocalizationsTl extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3523,7 +3526,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Nagsisimulang gawin ang mga aksyon ng server para sa mga update sa folksonomy na lokal na nakaimbak';
 
   @override
   String get background_task_title_top_n =>

--- a/packages/smooth_app/lib/l10n/app_localizations_tn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tn.dart
@@ -654,7 +654,7 @@ class AppLocalizationsTn extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_tn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tn.dart
@@ -654,6 +654,9 @@ class AppLocalizationsTn extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3016,7 +3019,7 @@ class AppLocalizationsTn extends AppLocalizations {
 
   @override
   String get dev_mode_openprices_switch_env_title =>
-      'Switch between prices.openfoodfacts.org (PROD) and test env';
+      'Fetola fa gare ga ditlhwatlhwa.dintlha tsa dijo.org (PROD) le tikologo ya teko';
 
   @override
   String get search_history_item_edit_tooltip => 'Reuse and edit this search';
@@ -3523,7 +3526,7 @@ class AppLocalizationsTn extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Go simolola go dira ditiro tsa sefara tsa dintšhwafatso tsa folksonomy tse di bolokilweng mo lefelong la gaeno';
 
   @override
   String get background_task_title_top_n =>
@@ -4917,7 +4920,7 @@ class AppLocalizationsTn extends AppLocalizations {
 
   @override
   String get guide_open_prices_share_link =>
-      'https://prices.openfoodfacts.org/about';
+      'https://ditlhwatlhwa.dintlha tsa dijo tse di bulegileng.org/ka ga';
 
   @override
   String get guide_open_products_facts_title =>
@@ -5316,7 +5319,7 @@ class AppLocalizationsTn extends AppLocalizations {
 
   @override
   String get prices_explanation_card_line1 =>
-      '**Open Prices** is a project to collect and share prices of products around the world 🌍. Open Prices is developed and maintained by Open Food Facts.';
+      '**Open Prices** ke porojeke ya go kokoanya le go abelana ditlhwatlhwa tsa dikumo lefatshe ka bophara 🌍. Ditheko tse Bulehileng di ntshetswa pele le ho bolokwa ke Dintlha tsa Dijo tse Bulehileng.';
 
   @override
   String get explanation_card_learn_more_button => 'Learn more';
@@ -5931,7 +5934,7 @@ class AppLocalizationsTn extends AppLocalizations {
 
   @override
   String get preferences_contributions_new_products_subtitle =>
-      'New products I added to Open Food Facts';
+      'Dikumo tse disha tse ke di tsentseng mo Dintlhang tsa Dijo tse di Buletsweng';
 
   @override
   String get preferences_contributions_to_be_completed_title =>
@@ -5957,7 +5960,7 @@ class AppLocalizationsTn extends AppLocalizations {
 
   @override
   String get preferences_contributions_categorize_subtitle =>
-      'Help compute the Nutri-Score & Green-Score in your country';
+      'Thusa go balelela Maduo a Dikotla le Green-Score mo nageng ya gaeno';
 
   @override
   String get preferences_prices_user_prices_subtitle =>
@@ -5980,7 +5983,7 @@ class AppLocalizationsTn extends AppLocalizations {
 
   @override
   String get preferences_prices_newest_subtitle =>
-      'Latest prices added by the Open Prices community';
+      'Ditlhwatlhwa tsa bosheng tse di tsentsweng ke baagi ba Ditlhwatlhwa tse di Buletsweng';
 
   @override
   String get preferences_prices_top_contributors_title =>
@@ -6031,7 +6034,7 @@ class AppLocalizationsTn extends AppLocalizations {
 
   @override
   String get preferences_page_contribute_project_subtitle =>
-      'Simple ways to help Open Food Facts';
+      'Ditsela tse di bonolo tsa go thusa go Bula Dintlha tsa Dijo';
 
   @override
   String get preferences_page_faq_subtitle =>
@@ -6147,7 +6150,7 @@ class AppLocalizationsTn extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Tlisa Dintlha tsa Dijo tse di Bulegileng mo puong ya gago';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_tr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tr.dart
@@ -656,7 +656,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get unknownBrand => 'Bilinmeyen marka';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Bilinmeyen ürün adı';

--- a/packages/smooth_app/lib/l10n/app_localizations_tr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tr.dart
@@ -656,6 +656,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get unknownBrand => 'Bilinmeyen marka';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Bilinmeyen ürün adı';
 
   @override
@@ -2033,7 +2036,7 @@ class AppLocalizationsTr extends AppLocalizations {
       'Soya Avrupa Birliği\'nden gelmiyor';
 
   @override
-  String get edit_product_form_item_countries_title => 'Country';
+  String get edit_product_form_item_countries_title => 'Ülke';
 
   @override
   String get edit_product_form_item_countries_hint =>
@@ -3539,7 +3542,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Yerel olarak depolanan folklor güncellemeleri için sunucu eylemlerinin gerçekleştirilmeye başlanması';
 
   @override
   String get background_task_title_top_n =>
@@ -4448,7 +4451,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get guide_greenscore_transparency_arg1_title =>
-      'How citizens can help?';
+      'Vatandaşlak nasıl yardım edebilir?';
 
   @override
   String get guide_greenscore_transparency_arg1_text =>
@@ -5692,7 +5695,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get preferences_on_off_website_subtitle =>
-      'On the Open Food Facts website';
+      'Açık Gıda Bilgileri web sitesinde';
 
   @override
   String get preferences_manage_account_title => 'Hesabımı yönet';
@@ -5807,7 +5810,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get preferences_faq_faq_title => 'SSS - Sıkça Sorulan Sorular';
 
   @override
-  String get preferences_faq_off_ngo_title => 'The Open Food Facts NGO';
+  String get preferences_faq_off_ngo_title => 'Açık Gıda Gerçekleri STK\'sı';
 
   @override
   String get preferences_about_information_title => 'Bilgi';
@@ -5829,7 +5832,7 @@ class AppLocalizationsTr extends AppLocalizations {
       'Sanal etkinliklerimizden birine katılarak dahil olun';
 
   @override
-  String get preferences_connect_blog_title => 'The Open Food Facts blog';
+  String get preferences_connect_blog_title => 'Açık Gıda Gerçekleri blogu';
 
   @override
   String get preferences_connect_blog_subtitle =>
@@ -5945,7 +5948,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get preferences_contributions_new_products_subtitle =>
-      'New products I added to Open Food Facts';
+      'Açık Gıda Bilgilerine eklediğim yeni ürünler';
 
   @override
   String get preferences_contributions_to_be_completed_title =>
@@ -6157,7 +6160,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Açık Gıda Gerçeklerini kendi dilinize getirin';
 
   @override
   String get preferences_contribute_enroll_alpha =>
@@ -6194,7 +6197,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get location_map_details_postcode => 'Postcode';
 
   @override
-  String get location_map_details_country => 'Country';
+  String get location_map_details_country => 'Ülke';
 
   @override
   String get location_map_details_coordinates => 'Coordinates';

--- a/packages/smooth_app/lib/l10n/app_localizations_ts.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ts.dart
@@ -653,6 +653,9 @@ class AppLocalizationsTs extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3521,7 +3524,7 @@ class AppLocalizationsTs extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Ku sungula ku endla swiendlo swa sevha swa ku pfuxetiwa ka folksonomy loku hlayisiweke laha kaya';
 
   @override
   String get background_task_title_top_n =>
@@ -4912,7 +4915,7 @@ class AppLocalizationsTs extends AppLocalizations {
 
   @override
   String get guide_open_prices_share_link =>
-      'https://prices.openfoodfacts.org/about';
+      'https://minxavo.vulavula bya swakudya.org/malunghana na';
 
   @override
   String get guide_open_products_facts_title =>
@@ -5980,7 +5983,7 @@ class AppLocalizationsTs extends AppLocalizations {
 
   @override
   String get preferences_prices_newest_subtitle =>
-      'Latest prices added by the Open Prices community';
+      'Minxavo ya sweswinyana leyi engeteriweke hi vaaki va Minxavo leyi Pfulekeke';
 
   @override
   String get preferences_prices_top_contributors_title =>
@@ -6031,7 +6034,7 @@ class AppLocalizationsTs extends AppLocalizations {
 
   @override
   String get preferences_page_contribute_project_subtitle =>
-      'Simple ways to help Open Food Facts';
+      'Tindlela to olova to pfuna ku Pfula Tinhla ta Swakudya';
 
   @override
   String get preferences_page_faq_subtitle =>

--- a/packages/smooth_app/lib/l10n/app_localizations_ts.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ts.dart
@@ -653,7 +653,7 @@ class AppLocalizationsTs extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_tt.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tt.dart
@@ -653,7 +653,7 @@ class AppLocalizationsTt extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_tt.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tt.dart
@@ -653,6 +653,9 @@ class AppLocalizationsTt extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3517,7 +3520,7 @@ class AppLocalizationsTt extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Locallyирле сакланган фольксономия яңартулары өчен сервер эшләрен башкара башлау';
 
   @override
   String get background_task_title_top_n =>
@@ -4491,7 +4494,7 @@ class AppLocalizationsTt extends AppLocalizations {
   String get guide_nova_logos_caption => 'NOVA логотиплары';
 
   @override
-  String get guide_nova_groups_title => 'The 4 NOVA groups';
+  String get guide_nova_groups_title => '4 NOVA төркеме';
 
   @override
   String get guide_nova_groups_intro =>
@@ -5303,7 +5306,7 @@ class AppLocalizationsTt extends AppLocalizations {
 
   @override
   String get prices_explanation_card_line1 =>
-      '**Open Prices** is a project to collect and share prices of products around the world 🌍. Open Prices is developed and maintained by Open Food Facts.';
+      '** Open Prices ** - бөтен дөнья буенча продуктларның бәяләрен җыю һәм бүлешү проекты 🌍. Open Prices ачык азык фактлары белән эшләнә һәм саклана.';
 
   @override
   String get explanation_card_learn_more_button => 'Learn more';
@@ -5659,7 +5662,7 @@ class AppLocalizationsTt extends AppLocalizations {
 
   @override
   String get preferences_on_off_website_subtitle =>
-      'On the Open Food Facts website';
+      'Ачык азык фактлары сайтында';
 
   @override
   String get preferences_manage_account_title => 'Минем хисап белән идарә итү';
@@ -5776,7 +5779,8 @@ class AppLocalizationsTt extends AppLocalizations {
       'Сораулар - Еш бирелә торган сораулар';
 
   @override
-  String get preferences_faq_off_ngo_title => 'The Open Food Facts NGO';
+  String get preferences_faq_off_ngo_title =>
+      'Ачык азык фактлары иҗтимагый оешмасы';
 
   @override
   String get preferences_about_information_title => 'Мәгълүмат';
@@ -5798,7 +5802,7 @@ class AppLocalizationsTt extends AppLocalizations {
       'Виртуаль вакыйгаларның берсендә катнашып катнашыгыз';
 
   @override
-  String get preferences_connect_blog_title => 'The Open Food Facts blog';
+  String get preferences_connect_blog_title => 'Ачык азык фактлары блогы';
 
   @override
   String get preferences_connect_blog_subtitle => 'Соңгы яңалыкларны алыгыз';
@@ -5913,7 +5917,7 @@ class AppLocalizationsTt extends AppLocalizations {
 
   @override
   String get preferences_contributions_new_products_subtitle =>
-      'New products I added to Open Food Facts';
+      'Ачык азык фактларына мин яңа продуктлар өстәдем';
 
   @override
   String get preferences_contributions_to_be_completed_title =>
@@ -6008,7 +6012,7 @@ class AppLocalizationsTt extends AppLocalizations {
 
   @override
   String get preferences_page_contribute_project_subtitle =>
-      'Simple ways to help Open Food Facts';
+      'Ачык азык фактларына булышуның гади ысуллары';
 
   @override
   String get preferences_page_faq_subtitle =>
@@ -6122,7 +6126,7 @@ class AppLocalizationsTt extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Ачык ризык фактларын телегезгә китерегез';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_tw.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tw.dart
@@ -653,6 +653,9 @@ class AppLocalizationsTw extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3520,7 +3523,7 @@ class AppLocalizationsTw extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Worefi ase ayɛ server nneyɛe ama folksonomy updates a wɔde asie wɔ mpɔtam hɔ';
 
   @override
   String get background_task_title_top_n =>
@@ -4916,7 +4919,7 @@ class AppLocalizationsTw extends AppLocalizations {
 
   @override
   String get guide_open_prices_share_link =>
-      'https://prices.openfoodfacts.org/about';
+      'https://prices.openfoodfacts.org/ɛfa';
 
   @override
   String get guide_open_products_facts_title =>

--- a/packages/smooth_app/lib/l10n/app_localizations_tw.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tw.dart
@@ -653,7 +653,7 @@ class AppLocalizationsTw extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_ty.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ty.dart
@@ -653,6 +653,9 @@ class AppLocalizationsTy extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ty.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ty.dart
@@ -653,7 +653,7 @@ class AppLocalizationsTy extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_ug.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ug.dart
@@ -654,7 +654,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_ug.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ug.dart
@@ -654,6 +654,9 @@ class AppLocalizationsUg extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3517,7 +3520,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'يەرلىك ساقلانغان ساقلانما يېڭىلاش ئۈچۈن مۇلازىمېتىر ھەرىكىتىنى قىلىشقا باشلايدۇ';
 
   @override
   String get background_task_title_top_n =>
@@ -5945,7 +5948,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String get preferences_contributions_categorize_subtitle =>
-      'Help compute the Nutri-Score & Green-Score in your country';
+      'دۆلىتىڭىزدىكى ئوزۇقلۇق نومۇرى ۋە يېشىل نومۇرلارنى ھېسابلاشقا ياردەملىشىڭ';
 
   @override
   String get preferences_prices_user_prices_subtitle => 'مەن تۆھپە قوشقان باھا';
@@ -6122,7 +6125,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String get preferences_page_open_food_facts_labs_title =>
-      'Open Food Facts پاكىتلىرى تەجرىبىخانىسى';
+      'Open Food Facts Labs';
 
   @override
   String get preferences_root_account_title => 'Account';

--- a/packages/smooth_app/lib/l10n/app_localizations_uk.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_uk.dart
@@ -659,6 +659,9 @@ class AppLocalizationsUk extends AppLocalizations {
   String get unknownBrand => 'Невідома марка';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Невідомий продукт';
 
   @override
@@ -3561,7 +3564,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Початок виконання дій сервера для оновлень folksonomy, що зберігаються локально.';
 
   @override
   String get background_task_title_top_n =>
@@ -4388,7 +4391,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get guide_greenscore_lca_arg2_processing => 'Обробляється';
 
   @override
-  String get guide_greenscore_lca_arg2_packaging => 'Упаковка';
+  String get guide_greenscore_lca_arg2_packaging => 'Пакування';
 
   @override
   String get guide_greenscore_lca_arg2_transportation => 'Транспортування';
@@ -4460,7 +4463,7 @@ class AppLocalizationsUk extends AppLocalizations {
       '**Штраф** накладається на продукти, що містять інгредієнти, які мають значний **негативний вплив на біорізноманіття та екосистеми**, такі як пальмова олія, виробництво якої є причиною масового вирубування лісів.';
 
   @override
-  String get guide_greenscore_bonuses_penalties_arg4_title => 'Упаковка';
+  String get guide_greenscore_bonuses_penalties_arg4_title => 'Пакування';
 
   @override
   String get guide_greenscore_bonuses_penalties_arg4_text =>
@@ -5846,7 +5849,8 @@ class AppLocalizationsUk extends AppLocalizations {
   String get preferences_faq_faq_title => 'FAQ - Часті запитання';
 
   @override
-  String get preferences_faq_off_ngo_title => 'The Open Food Facts NGO';
+  String get preferences_faq_off_ngo_title =>
+      'Громадська організація «Факти про відкриту їжу»';
 
   @override
   String get preferences_about_information_title => 'Інформація';
@@ -5868,7 +5872,7 @@ class AppLocalizationsUk extends AppLocalizations {
       'Долучайтеся, відвідавши один із наших віртуальних заходів';
 
   @override
-  String get preferences_connect_blog_title => 'The Open Food Facts blog';
+  String get preferences_connect_blog_title => 'Блог «Факти про відкриту їжу»';
 
   @override
   String get preferences_connect_blog_subtitle =>

--- a/packages/smooth_app/lib/l10n/app_localizations_uk.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_uk.dart
@@ -659,7 +659,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get unknownBrand => 'Невідома марка';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Невідомий продукт';

--- a/packages/smooth_app/lib/l10n/app_localizations_ur.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ur.dart
@@ -653,7 +653,7 @@ class AppLocalizationsUr extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_ur.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ur.dart
@@ -653,6 +653,9 @@ class AppLocalizationsUr extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_uz.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_uz.dart
@@ -654,6 +654,9 @@ class AppLocalizationsUz extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3520,7 +3523,7 @@ class AppLocalizationsUz extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Mahalliy ravishda saqlangan folksonomiya yangilanishlari uchun server amallarini bajarishni boshlash';
 
   @override
   String get background_task_title_top_n =>
@@ -5789,7 +5792,8 @@ class AppLocalizationsUz extends AppLocalizations {
       'Tez-tez so\'raladigan savollar - tez-tez so\'raladigan savollar';
 
   @override
-  String get preferences_faq_off_ngo_title => 'The Open Food Facts NGO';
+  String get preferences_faq_off_ngo_title =>
+      'Ochiq oziq-ovqat faktlari nodavlat tashkiloti';
 
   @override
   String get preferences_about_information_title => 'Information';
@@ -5811,7 +5815,8 @@ class AppLocalizationsUz extends AppLocalizations {
       'Virtual tadbirlarimizdan birida ishtirok eting';
 
   @override
-  String get preferences_connect_blog_title => 'The Open Food Facts blog';
+  String get preferences_connect_blog_title =>
+      'Ochiq oziq-ovqat faktlari blogi';
 
   @override
   String get preferences_connect_blog_subtitle =>
@@ -6141,7 +6146,7 @@ class AppLocalizationsUz extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Ochiq oziq-ovqat faktlarini tilingizga olib keling';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_uz.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_uz.dart
@@ -654,7 +654,7 @@ class AppLocalizationsUz extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_ve.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ve.dart
@@ -653,6 +653,9 @@ class AppLocalizationsVe extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ve.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ve.dart
@@ -653,7 +653,7 @@ class AppLocalizationsVe extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_vi.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_vi.dart
@@ -659,7 +659,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get unknownBrand => 'Thương hiệu không xác định';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Tên sản phẩm không xác định';

--- a/packages/smooth_app/lib/l10n/app_localizations_vi.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_vi.dart
@@ -659,6 +659,9 @@ class AppLocalizationsVi extends AppLocalizations {
   String get unknownBrand => 'Thương hiệu không xác định';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Tên sản phẩm không xác định';
 
   @override
@@ -1966,7 +1969,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get edit_product_form_item_labels_explanation_good_examples_1 =>
-      'Nutri-Score, NOVA…';
+      'Điểm số dinh dưỡng, NOVA…';
 
   @override
   String get edit_product_form_item_labels_explanation_good_examples_2 =>
@@ -3550,7 +3553,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Bắt đầu thực hiện các hành động máy chủ cho các bản cập nhật folksonomy được lưu trữ cục bộ';
 
   @override
   String get background_task_title_top_n =>
@@ -4060,16 +4063,16 @@ class AppLocalizationsVi extends AppLocalizations {
   String get nutriscore_generic => 'Nutri-Score';
 
   @override
-  String get nutriscore_a => 'Nutri-Score A';
+  String get nutriscore_a => 'Điểm dinh dưỡng A';
 
   @override
-  String get nutriscore_b => 'Nutri-Score B';
+  String get nutriscore_b => 'Điểm dinh dưỡng B';
 
   @override
   String get nutriscore_c => 'Nutri-Score C';
 
   @override
-  String get nutriscore_d => 'Nutri-Score D';
+  String get nutriscore_d => 'Điểm dinh dưỡng D';
 
   @override
   String get nutriscore_e => 'Nutri-Score E';
@@ -4725,7 +4728,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get guide_open_pet_food_facts_features_title =>
-      'Features of Open Pet Food Facts';
+      'Đặc điểm của Thực phẩm cho thú cưng mở';
 
   @override
   String get guide_open_pet_food_facts_features_arg1_title =>
@@ -4971,7 +4974,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get guide_open_products_facts_features_title =>
-      'Features of Open Products Facts';
+      'Tính năng của Sản phẩm Mở Sự kiện';
 
   @override
   String get guide_open_products_facts_features_text =>
@@ -5854,7 +5857,7 @@ class AppLocalizationsVi extends AppLocalizations {
       'Tham gia bằng cách tham dự một trong các sự kiện trực tuyến của chúng tôi';
 
   @override
-  String get preferences_connect_blog_title => 'The Open Food Facts blog';
+  String get preferences_connect_blog_title => 'Blog Sự thật về Thực phẩm Mở';
 
   @override
   String get preferences_connect_blog_subtitle =>
@@ -6177,7 +6180,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Mang Thông tin Thực phẩm Mở sang ngôn ngữ của bạn';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_wa.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_wa.dart
@@ -653,6 +653,9 @@ class AppLocalizationsWa extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_wa.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_wa.dart
@@ -653,7 +653,7 @@ class AppLocalizationsWa extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_wo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_wo.dart
@@ -653,7 +653,7 @@ class AppLocalizationsWo extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_wo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_wo.dart
@@ -653,6 +653,9 @@ class AppLocalizationsWo extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_xh.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_xh.dart
@@ -654,7 +654,7 @@ class AppLocalizationsXh extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_xh.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_xh.dart
@@ -654,6 +654,9 @@ class AppLocalizationsXh extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3522,7 +3525,7 @@ class AppLocalizationsXh extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Ukuqala ukwenza iintshukumo zeseva kuhlaziyo lwefolksonomy olugcinwe ekuhlaleni';
 
   @override
   String get background_task_title_top_n =>
@@ -5622,7 +5625,7 @@ class AppLocalizationsXh extends AppLocalizations {
 
   @override
   String get preferences_legal_header =>
-      'Open Food Facts is a food products database **made by everyone, for everyone**.\nYou can use it to make better food choices, and as it is **open data**, anyone can **re-use it for any purpose**.';
+      'Vula Iinyaniso zoKutya yidatha yemveliso yokutya ** eyenziwe ngumntu wonke, kumntu wonke **.\nUnokuyisebenzisa ukwenza ukhetho olungcono lokutya, kwaye njengoko i-*idatha evulekileyo **, nabani na unako ** ukuphinda ayisebenzise nayiphi na injongo **.';
 
   @override
   String get preferences_privacy_policy => 'Privacy policy';
@@ -5812,7 +5815,8 @@ class AppLocalizationsXh extends AppLocalizations {
       'Zibandakanye ngokuzimasa omnye wemisitho yethu ebonakalayo';
 
   @override
-  String get preferences_connect_blog_title => 'The Open Food Facts blog';
+  String get preferences_connect_blog_title =>
+      'Ibhlog yeeNkcukacha zoKutya ezivulekileyo';
 
   @override
   String get preferences_connect_blog_subtitle =>
@@ -5976,7 +5980,7 @@ class AppLocalizationsXh extends AppLocalizations {
 
   @override
   String get preferences_prices_newest_subtitle =>
-      'Latest prices added by the Open Prices community';
+      'Amaxabiso akutshanje ongezwe luluntu lwamaxabiso avulekileyo';
 
   @override
   String get preferences_prices_top_contributors_title =>
@@ -6139,7 +6143,7 @@ class AppLocalizationsXh extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Yiza neenyaniso ezivulekileyo zokutya kulwimi lwakho';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_yi.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_yi.dart
@@ -654,6 +654,9 @@ class AppLocalizationsYi extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3520,7 +3523,7 @@ class AppLocalizationsYi extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'אָנהייבן דורכפירן די סערווער אַקציעס פֿאַר פֿאָלקסאָנאָמיע דערהייַנטיקונגען וואָס זענען געהאַלטן לאָקאַל';
 
   @override
   String get background_task_title_top_n =>
@@ -5311,7 +5314,7 @@ class AppLocalizationsYi extends AppLocalizations {
 
   @override
   String get prices_explanation_card_line1 =>
-      '**Open Prices** is a project to collect and share prices of products around the world 🌍. Open Prices is developed and maintained by Open Food Facts.';
+      '**Open Prices** איז אַ פּראָיעקט צו זאַמלען און טיילן פּרייזן פֿון פּראָדוקטן אַרום דער וועלט 🌍. Open Prices ווערט דעוועלאָפּט און אויפֿגעהאַלטן דורך אפֿענע פֿוד פֿאַקטן.';
 
   @override
   String get explanation_card_learn_more_button => 'Learn more';
@@ -5590,7 +5593,7 @@ class AppLocalizationsYi extends AppLocalizations {
 
   @override
   String get preferences_app_bar_search_hint =>
-      'Search for a setting (e.g. Nutri-Score)';
+      'זוכן אַ סעטינג (למשל נוטרי-סקאָר)';
 
   @override
   String get preferences_accessibility_show_emoji =>
@@ -5621,7 +5624,7 @@ class AppLocalizationsYi extends AppLocalizations {
 
   @override
   String get preferences_legal_header =>
-      'Open Food Facts is a food products database **made by everyone, for everyone**.\nYou can use it to make better food choices, and as it is **open data**, anyone can **re-use it for any purpose**.';
+      'אָפן פוד פאַקס איז אַ דאַטאַבאַזע פֿאַר עסן פּראָדוקטן **געמאַכט דורך אַלעמען, פֿאַר אַלעמען**.\nאיר קענט עס נוצן צו מאַכן בעסערע עסן ברירות, און וויבאַלד עס איז **אָפן דאַטן**, קען יעדער עס **ווידער נוצן פֿאַר יעדן צוועק**.';
 
   @override
   String get preferences_privacy_policy => 'Privacy policy';
@@ -5668,7 +5671,7 @@ class AppLocalizationsYi extends AppLocalizations {
   String get preferences_tips => 'עצות';
 
   @override
-  String get tips_discover_nutriscore => 'Discover the new Nutri-Score';
+  String get tips_discover_nutriscore => 'אַנטדעקן דעם נײַעם נוטרי-סקאָר';
 
   @override
   String get preferences_on_off_website_subtitle =>
@@ -5758,7 +5761,7 @@ class AppLocalizationsYi extends AppLocalizations {
 
   @override
   String get preferences_faq_nutriscore_subtitle =>
-      'Discover how the Nutri-Score is computed';
+      'אַנטדעקן ווי דער נוטרי-סקאָר ווערט אויסגערעכנט';
 
   @override
   String get preferences_faq_nutriscore_v2_subtitle =>
@@ -5789,7 +5792,8 @@ class AppLocalizationsYi extends AppLocalizations {
       'אָפֿט געשטעלטע פֿראַגעס - אָפֿט געשטעלטע פֿראַגעס';
 
   @override
-  String get preferences_faq_off_ngo_title => 'The Open Food Facts NGO';
+  String get preferences_faq_off_ngo_title =>
+      'די אָפֿענע פֿוד פֿאַקטן נישט-רעגירונגס אָרגאַניזאַציע';
 
   @override
   String get preferences_about_information_title => 'Information';
@@ -5811,7 +5815,7 @@ class AppLocalizationsYi extends AppLocalizations {
       'נעמט זיך אנטייל דורך באטייליקן זיך אין איינעם פון אונדזערע ווירטועלע געשעענישן';
 
   @override
-  String get preferences_connect_blog_title => 'The Open Food Facts blog';
+  String get preferences_connect_blog_title => 'דער אפענער עסן פאקטן בלאג';
 
   @override
   String get preferences_connect_blog_subtitle =>
@@ -5953,7 +5957,7 @@ class AppLocalizationsYi extends AppLocalizations {
 
   @override
   String get preferences_contributions_categorize_subtitle =>
-      'Help compute the Nutri-Score & Green-Score in your country';
+      'העלפט אויסרעכענען דעם נוטרי-סקאָר און גרין-סקאָר אין אייער לאַנד';
 
   @override
   String get preferences_prices_user_prices_subtitle =>
@@ -5975,7 +5979,7 @@ class AppLocalizationsYi extends AppLocalizations {
 
   @override
   String get preferences_prices_newest_subtitle =>
-      'Latest prices added by the Open Prices community';
+      'לעצטע פרייזן צוגעגעבן דורך די אפענע פרייזן קהילה';
 
   @override
   String get preferences_prices_top_contributors_title =>
@@ -6023,7 +6027,7 @@ class AppLocalizationsYi extends AppLocalizations {
 
   @override
   String get preferences_page_contribute_project_subtitle =>
-      'Simple ways to help Open Food Facts';
+      'פּשוטע וועגן צו העלפֿן עפֿענען פֿוד פֿאַקטן';
 
   @override
   String get preferences_page_faq_subtitle =>
@@ -6137,7 +6141,7 @@ class AppLocalizationsYi extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'ברענגט אפענע עסן פאקטן צו אייער שפראך';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_yi.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_yi.dart
@@ -654,7 +654,7 @@ class AppLocalizationsYi extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_yo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_yo.dart
@@ -654,6 +654,9 @@ class AppLocalizationsYo extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3518,7 +3521,7 @@ class AppLocalizationsYo extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Bibẹrẹ lati ṣe awọn iṣe olupin fun awọn imudojuiwọn folksonomy ti o fipamọ ni agbegbe';
 
   @override
   String get background_task_title_top_n =>
@@ -5306,7 +5309,7 @@ class AppLocalizationsYo extends AppLocalizations {
 
   @override
   String get prices_explanation_card_line1 =>
-      '**Open Prices** is a project to collect and share prices of products around the world 🌍. Open Prices is developed and maintained by Open Food Facts.';
+      '** Open Prices *** jẹ iṣẹ akanṣe kan lati gba ati pin awọn idiyele ti awọn ọja ni ayika agbaye 🌍. Awọn idiyele Ṣii jẹ idagbasoke ati itọju nipasẹ Awọn Otitọ Ounjẹ Ṣii.';
 
   @override
   String get explanation_card_learn_more_button => 'Learn more';
@@ -5612,7 +5615,7 @@ class AppLocalizationsYo extends AppLocalizations {
 
   @override
   String get preferences_legal_header =>
-      'Open Food Facts is a food products database **made by everyone, for everyone**.\nYou can use it to make better food choices, and as it is **open data**, anyone can **re-use it for any purpose**.';
+      'Ṣii Awọn Otitọ Ounjẹ jẹ aaye data awọn ọja ounjẹ ** ti gbogbo eniyan ṣe, fun gbogbo eniyan ***.\nO le lo lati ṣe awọn yiyan ounjẹ to dara julọ, ati pe bi o ti jẹ ** data ṣiṣi **, ẹnikẹni le **tun-lo fun idi eyikeyi ***.';
 
   @override
   String get preferences_privacy_policy => 'Privacy policy';
@@ -5663,7 +5666,7 @@ class AppLocalizationsYo extends AppLocalizations {
 
   @override
   String get preferences_on_off_website_subtitle =>
-      'On the Open Food Facts website';
+      'Lori oju opo wẹẹbu Awọn Otitọ Ounjẹ Ṣii';
 
   @override
   String get preferences_manage_account_title => 'Ṣakoso akọọlẹ mi';
@@ -5912,7 +5915,7 @@ class AppLocalizationsYo extends AppLocalizations {
 
   @override
   String get preferences_contributions_new_products_subtitle =>
-      'New products I added to Open Food Facts';
+      'Awọn ọja titun Mo ṣafikun si Awọn Otitọ Ounjẹ Ṣii';
 
   @override
   String get preferences_contributions_to_be_completed_title =>
@@ -5961,7 +5964,7 @@ class AppLocalizationsYo extends AppLocalizations {
 
   @override
   String get preferences_prices_newest_subtitle =>
-      'Latest prices added by the Open Prices community';
+      'Awọn idiyele tuntun ti a ṣafikun nipasẹ agbegbe Awọn idiyele Ṣii';
 
   @override
   String get preferences_prices_top_contributors_title =>
@@ -6008,7 +6011,7 @@ class AppLocalizationsYo extends AppLocalizations {
 
   @override
   String get preferences_page_contribute_project_subtitle =>
-      'Simple ways to help Open Food Facts';
+      'Awọn ọna ti o rọrun lati ṣe iranlọwọ Ṣii Awọn Otitọ Ounjẹ';
 
   @override
   String get preferences_page_faq_subtitle =>
@@ -6122,7 +6125,7 @@ class AppLocalizationsYo extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Mu Awọn Otitọ Ounjẹ Ṣii wá si ede rẹ';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/l10n/app_localizations_yo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_yo.dart
@@ -654,7 +654,7 @@ class AppLocalizationsYo extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_zh.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_zh.dart
@@ -620,6 +620,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get unknownBrand => '未知品牌';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => '未知產品名稱';
 
   @override
@@ -5835,7 +5838,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get preferences_page_open_food_facts_labs_title =>
-      'Open Food Facts實驗室';
+      'Open Food Facts Labs';
 
   @override
   String get preferences_root_account_title => '账户';
@@ -7787,7 +7790,7 @@ class AppLocalizationsZhCn extends AppLocalizationsZh {
       '这种大豆并非来自欧盟。';
 
   @override
-  String get edit_product_form_item_countries_title => 'Country';
+  String get edit_product_form_item_countries_title => '国家/地区';
 
   @override
   String get edit_product_form_item_countries_hint => '输入国家（例如：德国）';
@@ -9202,6 +9205,9 @@ class AppLocalizationsZhCn extends AppLocalizationsZh {
   String get background_task_title_full_refresh => '开始刷新本地存储的所有产品';
 
   @override
+  String get background_task_title_folksonomy => '开始执行本地存储的民间分类更新的服务器操作';
+
+  @override
   String get background_task_title_top_n => '开始下载最受欢迎的产品';
 
   @override
@@ -9923,7 +9929,7 @@ class AppLocalizationsZhCn extends AppLocalizationsZh {
       '对于制造商来说，Nutri-Score 的显示**仍然是可选的**。';
 
   @override
-  String get guide_greenscore_title => 'Green-Score';
+  String get guide_greenscore_title => '绿色评分';
 
   @override
   String get guide_greenscore_what_is_greenscore_title => '什么是绿色分数？';
@@ -10484,7 +10490,7 @@ class AppLocalizationsZhCn extends AppLocalizationsZh {
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_title =>
-      'What is Open Products Facts?';
+      '什么是开放产品信息？';
 
   @override
   String get guide_open_products_facts_what_is_open_products_facts_paragraph1 =>
@@ -10495,8 +10501,7 @@ class AppLocalizationsZhCn extends AppLocalizationsZh {
       '从电子产品到玩具，从服装到清洁用品，只要有条形码，都可以添加进去。本项目旨在为日常物品构建“物联网”，使所有相关信息都能被普遍获取。';
 
   @override
-  String get guide_open_products_facts_features_title =>
-      'Features of Open Products Facts';
+  String get guide_open_products_facts_features_title => '开放产品事实的特点';
 
   @override
   String get guide_open_products_facts_features_text =>
@@ -11596,7 +11601,7 @@ class AppLocalizationsZhCn extends AppLocalizationsZh {
 
   @override
   String get preferences_page_open_food_facts_labs_title =>
-      'Open Food Facts实验室';
+      'Open Food Facts Labs';
 
   @override
   String get preferences_root_account_title => '账户';
@@ -11638,7 +11643,7 @@ class AppLocalizationsZhCn extends AppLocalizationsZh {
   String get location_map_details_postcode => '邮政编码';
 
   @override
-  String get location_map_details_country => 'Country';
+  String get location_map_details_country => '国家/地区';
 
   @override
   String get location_map_details_coordinates => '坐标';

--- a/packages/smooth_app/lib/l10n/app_localizations_zh.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_zh.dart
@@ -620,7 +620,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get unknownBrand => '未知品牌';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => '未知產品名稱';

--- a/packages/smooth_app/lib/l10n/app_localizations_zu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_zu.dart
@@ -653,7 +653,7 @@ class AppLocalizationsZu extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
-  String get unknownQuantity => 'Unknown brand';
+  String get unknownQuantity => 'Unknown quantity';
 
   @override
   String get unknownProductName => 'Unknown product name';

--- a/packages/smooth_app/lib/l10n/app_localizations_zu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_zu.dart
@@ -653,6 +653,9 @@ class AppLocalizationsZu extends AppLocalizations {
   String get unknownBrand => 'Unknown brand';
 
   @override
+  String get unknownQuantity => 'Unknown brand';
+
+  @override
   String get unknownProductName => 'Unknown product name';
 
   @override
@@ -3519,7 +3522,7 @@ class AppLocalizationsZu extends AppLocalizations {
 
   @override
   String get background_task_title_folksonomy =>
-      'Starting to perform the server actions for folksonomy updates stored locally';
+      'Iqala ukwenza izenzo zeseva ngezibuyekezo ze-folksonomy ezigcinwe endaweni';
 
   @override
   String get background_task_title_top_n =>
@@ -6139,7 +6142,7 @@ class AppLocalizationsZu extends AppLocalizations {
 
   @override
   String get preferences_contribute_translate_header =>
-      'Bring Open Food Facts to your language';
+      'Letha Amaqiniso Okudla Okuvulekile olimini lwakho';
 
   @override
   String get preferences_contribute_enroll_alpha =>

--- a/packages/smooth_app/lib/pages/product/summary_card.dart
+++ b/packages/smooth_app/lib/pages/product/summary_card.dart
@@ -341,6 +341,7 @@ class _SummaryCardState extends State<SummaryCard> with UpToDateMixin {
             heroTag: widget.heroTag,
             dense: !widget.isFullVersion,
             isPictureVisible: widget.isPictureVisible,
+            expandableBrands: widget.isTextSelectable ?? true,
             onRemove: (BuildContext context) async {
               HideableContainerState.of(context).hide(() async {
                 final ContinuousScanModel model = context


### PR DESCRIPTION
Hi everyone!

This PR introduces some UI changes:

## Product name
If the product isn't available in the user language, a badge displays the language:

<img width="616" height="277" alt="Capture d’écran   2026-01-02 à 18 31 40-2" src="https://github.com/user-attachments/assets/7355af58-911e-4fa3-9857-f39c96b0be1a" />

## Product brands
Only the first brand is visible by default, with the ability to click and view the list:

<img width="2799" height="810" alt="Untitled" src="https://github.com/user-attachments/assets/4233c1cb-2632-4cbe-b259-b9005dd81883" />

## Empty brand/qty
If no brand or quantity is available, this info is in italic:
<img width="660" height="216" alt="IMG_4693" src="https://github.com/user-attachments/assets/bc644fe9-4c5d-4d26-a3e8-f56a1638102c" />

There's also a placeholder when there is no quantity (VS nothing today)