### PR TITLE
feat: 7345 - hunger games - access to best image quality

### DIFF
--- a/packages/smooth_app/lib/pages/hunger_games/question_image_full_page.dart
+++ b/packages/smooth_app/lib/pages/hunger_games/question_image_full_page.dart
@@ -1,6 +1,7 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/helpers/launch_url_helper.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
@@ -23,6 +24,12 @@ class QuestionImageFullPage extends StatelessWidget {
         maxLines: 2,
       ),
     ),
+    floatingActionButton: FloatingActionButton(
+      child: const Icon(Icons.zoom_in),
+      onPressed: () async => LaunchUrlHelper.launchURL(
+        _getBetterUrl(question.imageUrl!) ?? question.imageUrl!,
+      ),
+    ),
     body: ConstrainedBox(
       constraints: const BoxConstraints.expand(),
       child: InteractiveViewer(
@@ -41,4 +48,29 @@ class QuestionImageFullPage extends StatelessWidget {
       ),
     ),
   );
+
+  // cf. https://github.com/openfoodfacts/smooth-app/issues/3065
+  String? _getBetterUrl(final String url) {
+    const int ascii0 = 48;
+    const int ascii9 = 57;
+
+    if (!url.endsWith('.400.jpg')) {
+      return null;
+    }
+    final int pos = url.lastIndexOf('/');
+    if (pos == -1) {
+      return null;
+    }
+    final String newLastPart;
+    final String lastPart = url.substring(pos + 1);
+    final int firstChar = lastPart.codeUnitAt(0);
+    if (firstChar >= ascii0 && firstChar <= ascii9) {
+      // example: from 2.400.jpg to 2.jpg
+      newLastPart = lastPart.replaceAll('.400.', '.');
+    } else {
+      // example: from front_fr.4.400.jpg to front_fr.4.full.jpg
+      newLastPart = lastPart.replaceAll('.400.', '.full.');
+    }
+    return url.replaceFirst(lastPart, newLastPart);
+  }
 }


### PR DESCRIPTION
### What
- The Hunger Games questions provide images with a 400 quality, which is good enough for thumbnails and lighter to download.
- Sometimes, the user may need a very good image quality: this PR introduces this feature, with a Floating Action Button in the hunger games full image page.
- With this FAB we open a browser with the same image but with the best quality version.
- We open in a browser because there are performance issues with the app and large images, for a minor added-value.
- cc. @fgouget

### Screenshots
| HG card | HG page | browser page |
| -- | -- | -- |
| <img width="1080" height="1920" alt="Screenshot_1768208058" src="https://github.com/user-attachments/assets/62562503-c24f-412a-9e9c-4c3748154f75" /> | <img width="1080" height="1920" alt="Screenshot_1768208064" src="https://github.com/user-attachments/assets/73f3380b-dc0b-4d68-a5d9-3a5ff7885ad4" /> | <img width="1080" height="1920" alt="Screenshot_1768208082" src="https://github.com/user-attachments/assets/413004b8-808d-4136-85bc-b87ed34076c5" /> |

### Fixes bug(s)
- Closes: #7345

### Impacted file
* `question_image_full_page.dart`: added a FAB that links to a browser with the best version of the image