### PR TITLE
feat: Ability to open the product page from a price entry

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -2434,6 +2434,7 @@
       }
     }
   },
+  "prices_entry_menu_open_product": "View product details",
   "prices_entry_menu_open_product_prices": "View all prices for this product",
   "prices_entry_menu_open_proof": "View proof",
   "prices_entry_menu_my_prices": "View my other prices",

--- a/packages/smooth_app/lib/l10n/app_localizations.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations.dart
@@ -186,7 +186,8 @@ import 'app_localizations_zu.dart';
 /// be consistent with the languages listed in the AppLocalizations.supportedLocales
 /// property.
 abstract class AppLocalizations {
-  AppLocalizations(String locale) : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+  AppLocalizations(String locale)
+    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -194,7 +195,8 @@ abstract class AppLocalizations {
     return Localizations.of<AppLocalizations>(context, AppLocalizations)!;
   }
 
-  static const LocalizationsDelegate<AppLocalizations> delegate = _AppLocalizationsDelegate();
+  static const LocalizationsDelegate<AppLocalizations> delegate =
+      _AppLocalizationsDelegate();
 
   /// A list of this localizations delegate along with the default localizations
   /// delegates.
@@ -206,12 +208,13 @@ abstract class AppLocalizations {
   /// Additional delegates can be added by appending to this list in
   /// MaterialApp. This list does not have to be used at all if a custom list
   /// of delegates is preferred or required.
-  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates = <LocalizationsDelegate<dynamic>>[
-    delegate,
-    GlobalMaterialLocalizations.delegate,
-    GlobalCupertinoLocalizations.delegate,
-    GlobalWidgetsLocalizations.delegate,
-  ];
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
+      <LocalizationsDelegate<dynamic>>[
+        delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ];
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
@@ -342,7 +345,7 @@ abstract class AppLocalizations {
     Locale('yo'),
     Locale('zh'),
     Locale('zh', 'CN'),
-    Locale('zu')
+    Locale('zu'),
   ];
 
   /// No description provided for @app_name.
@@ -1813,7 +1816,12 @@ abstract class AppLocalizations {
   ///
   /// In en, this message translates to:
   /// **'The minimum size in pixels for picture upload is {expectedMinWidth}x{expectedMinHeight}. The current picture is {actualWidth}x{actualHeight}.'**
-  String crop_page_too_small_image_message(int expectedMinWidth, int expectedMinHeight, int actualWidth, int actualHeight);
+  String crop_page_too_small_image_message(
+    int expectedMinWidth,
+    int expectedMinHeight,
+    int actualWidth,
+    int actualHeight,
+  );
 
   /// Action being performed on the crop page
   ///
@@ -2815,7 +2823,10 @@ abstract class AppLocalizations {
   ///
   /// In en, this message translates to:
   /// **'Do you want to change the currency from {previousCurrency} to {possibleCurrency}?'**
-  String currency_auto_change_message(String previousCurrency, String possibleCurrency);
+  String currency_auto_change_message(
+    String previousCurrency,
+    String possibleCurrency,
+  );
 
   /// The label shown above a selector where the user can select their country (in the onboarding)
   ///
@@ -3115,19 +3126,35 @@ abstract class AppLocalizations {
   ///
   /// In en, this message translates to:
   /// **'OS: Android (SDK Int: {sdkInt} / Release: {release})\nModel: {model}\nProduct: {product}\nDevice: {device}\nBrand:{brand}'**
-  String contact_form_body_android(int? sdkInt, String? release, String? model, String? product, String? device, String? brand);
+  String contact_form_body_android(
+    int? sdkInt,
+    String? release,
+    String? model,
+    String? product,
+    String? device,
+    String? brand,
+  );
 
   /// Contact form content for iOS devices
   ///
   /// In en, this message translates to:
   /// **'OS: iOS ({version})\nModel: {model}\nLocalized model: {localizedModel}'**
-  String contact_form_body_ios(String? version, String? model, String? localizedModel);
+  String contact_form_body_ios(
+    String? version,
+    String? model,
+    String? localizedModel,
+  );
 
   /// Contact form content
   ///
   /// In en, this message translates to:
   /// **'{osContent}\nApp version:{appVersion}\nApp build number:{appBuildNumber}\nApp package name:{appPackageName}'**
-  String contact_form_body(String osContent, String appVersion, String appBuildNumber, String appPackageName);
+  String contact_form_body(
+    String osContent,
+    String appVersion,
+    String appBuildNumber,
+    String appPackageName,
+  );
 
   /// No description provided for @authorize_button_label.
   ///
@@ -4899,6 +4926,12 @@ abstract class AppLocalizations {
   /// **'Price entry from \"{user}\"'**
   String prices_entry_menu_title(String user);
 
+  /// No description provided for @prices_entry_menu_open_product.
+  ///
+  /// In en, this message translates to:
+  /// **'View product details'**
+  String get prices_entry_menu_open_product;
+
   /// No description provided for @prices_entry_menu_open_product_prices.
   ///
   /// In en, this message translates to:
@@ -4951,7 +4984,12 @@ abstract class AppLocalizations {
   ///
   /// In en, this message translates to:
   /// **'Price: {price} / Store: \"{location}\" / Published on {date} by \"{user}\"'**
-  String prices_entry_accessibility_label(String price, String location, String date, String user);
+  String prices_entry_accessibility_label(
+    String price,
+    String location,
+    String date,
+    String user,
+  );
 
   /// Button to open the proofs of a user
   ///
@@ -5239,7 +5277,10 @@ abstract class AppLocalizations {
   ///
   /// In en, this message translates to:
   /// **'Your current currency is **{currency}**. Would you like to change it to **{newCurrency}**?'**
-  String prices_currency_change_proposal_message(String currency, String newCurrency);
+  String prices_currency_change_proposal_message(
+    String currency,
+    String newCurrency,
+  );
 
   /// Button to approve the currency change
   ///
@@ -5353,7 +5394,11 @@ abstract class AppLocalizations {
   ///
   /// In en, this message translates to:
   /// **'Download {count} more products\nAlready downloaded {downloaded} out of {totalSize}.'**
-  String product_search_button_download_more(int count, int downloaded, int totalSize);
+  String product_search_button_download_more(
+    int count,
+    int downloaded,
+    int totalSize,
+  );
 
   /// This message will be displayed when a search is in progress.
   ///
@@ -5653,7 +5698,9 @@ abstract class AppLocalizations {
   ///
   /// In en, this message translates to:
   /// **'Do you want the product\'s default language to be set to ‘{language}’?'**
-  String add_basic_details_product_name_change_main_language_text(String language);
+  String add_basic_details_product_name_change_main_language_text(
+    String language,
+  );
 
   /// Title for the section with good examples
   ///
@@ -9121,7 +9168,9 @@ abstract class AppLocalizations {
   ///
   /// In en, this message translates to:
   /// **'A score can\'t be computed for a product of type \"{productType}\".'**
-  String product_page_for_me_compatibility_score_unsupported(String productType);
+  String product_page_for_me_compatibility_score_unsupported(
+    String productType,
+  );
 
   /// Button to order the attributes by importance in the For me tab on the product page
   ///
@@ -10720,7 +10769,8 @@ abstract class AppLocalizations {
   String get homepage_list_last_scanned_title;
 }
 
-class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
+class _AppLocalizationsDelegate
+    extends LocalizationsDelegate<AppLocalizations> {
   const _AppLocalizationsDelegate();
 
   @override
@@ -10729,164 +10779,420 @@ class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> 
   }
 
   @override
-  bool isSupported(Locale locale) => <String>['aa', 'af', 'ak', 'am', 'ar', 'as', 'az', 'be', 'bg', 'bm', 'bn', 'bo', 'br', 'bs', 'ca', 'ce', 'co', 'cs', 'cv', 'cy', 'da', 'de', 'el', 'en', 'eo', 'es', 'et', 'eu', 'fa', 'fi', 'fo', 'fr', 'ga', 'gd', 'gl', 'gu', 'ha', 'he', 'hi', 'hr', 'ht', 'hu', 'hy', 'id', 'ii', 'is', 'it', 'iu', 'ja', 'jv', 'ka', 'kk', 'km', 'kn', 'ko', 'ku', 'kw', 'ky', 'la', 'lb', 'lo', 'lt', 'lv', 'mg', 'mi', 'ml', 'mn', 'mr', 'ms', 'mt', 'my', 'nb', 'ne', 'nl', 'nn', 'no', 'nr', 'oc', 'or', 'pa', 'pl', 'pt', 'qu', 'rm', 'ro', 'ru', 'sa', 'sc', 'sd', 'sg', 'si', 'sk', 'sl', 'sn', 'so', 'sq', 'sr', 'ss', 'st', 'sv', 'sw', 'ta', 'te', 'tg', 'th', 'ti', 'tl', 'tn', 'tr', 'ts', 'tt', 'tw', 'ty', 'ug', 'uk', 'ur', 'uz', 've', 'vi', 'wa', 'wo', 'xh', 'yi', 'yo', 'zh', 'zu'].contains(locale.languageCode);
+  bool isSupported(Locale locale) => <String>[
+    'aa',
+    'af',
+    'ak',
+    'am',
+    'ar',
+    'as',
+    'az',
+    'be',
+    'bg',
+    'bm',
+    'bn',
+    'bo',
+    'br',
+    'bs',
+    'ca',
+    'ce',
+    'co',
+    'cs',
+    'cv',
+    'cy',
+    'da',
+    'de',
+    'el',
+    'en',
+    'eo',
+    'es',
+    'et',
+    'eu',
+    'fa',
+    'fi',
+    'fo',
+    'fr',
+    'ga',
+    'gd',
+    'gl',
+    'gu',
+    'ha',
+    'he',
+    'hi',
+    'hr',
+    'ht',
+    'hu',
+    'hy',
+    'id',
+    'ii',
+    'is',
+    'it',
+    'iu',
+    'ja',
+    'jv',
+    'ka',
+    'kk',
+    'km',
+    'kn',
+    'ko',
+    'ku',
+    'kw',
+    'ky',
+    'la',
+    'lb',
+    'lo',
+    'lt',
+    'lv',
+    'mg',
+    'mi',
+    'ml',
+    'mn',
+    'mr',
+    'ms',
+    'mt',
+    'my',
+    'nb',
+    'ne',
+    'nl',
+    'nn',
+    'no',
+    'nr',
+    'oc',
+    'or',
+    'pa',
+    'pl',
+    'pt',
+    'qu',
+    'rm',
+    'ro',
+    'ru',
+    'sa',
+    'sc',
+    'sd',
+    'sg',
+    'si',
+    'sk',
+    'sl',
+    'sn',
+    'so',
+    'sq',
+    'sr',
+    'ss',
+    'st',
+    'sv',
+    'sw',
+    'ta',
+    'te',
+    'tg',
+    'th',
+    'ti',
+    'tl',
+    'tn',
+    'tr',
+    'ts',
+    'tt',
+    'tw',
+    'ty',
+    'ug',
+    'uk',
+    'ur',
+    'uz',
+    've',
+    'vi',
+    'wa',
+    'wo',
+    'xh',
+    'yi',
+    'yo',
+    'zh',
+    'zu',
+  ].contains(locale.languageCode);
 
   @override
   bool shouldReload(_AppLocalizationsDelegate old) => false;
 }
 
 AppLocalizations lookupAppLocalizations(Locale locale) {
-
   // Lookup logic when language+country codes are specified.
   switch (locale.languageCode) {
-    case 'pt': {
-  switch (locale.countryCode) {
-    case 'BR': return AppLocalizationsPtBr();
-   }
-  break;
-   }
-    case 'zh': {
-  switch (locale.countryCode) {
-    case 'CN': return AppLocalizationsZhCn();
-   }
-  break;
-   }
+    case 'pt':
+      {
+        switch (locale.countryCode) {
+          case 'BR':
+            return AppLocalizationsPtBr();
+        }
+        break;
+      }
+    case 'zh':
+      {
+        switch (locale.countryCode) {
+          case 'CN':
+            return AppLocalizationsZhCn();
+        }
+        break;
+      }
   }
 
   // Lookup logic when only language code is specified.
   switch (locale.languageCode) {
-    case 'aa': return AppLocalizationsAa();
-    case 'af': return AppLocalizationsAf();
-    case 'ak': return AppLocalizationsAk();
-    case 'am': return AppLocalizationsAm();
-    case 'ar': return AppLocalizationsAr();
-    case 'as': return AppLocalizationsAs();
-    case 'az': return AppLocalizationsAz();
-    case 'be': return AppLocalizationsBe();
-    case 'bg': return AppLocalizationsBg();
-    case 'bm': return AppLocalizationsBm();
-    case 'bn': return AppLocalizationsBn();
-    case 'bo': return AppLocalizationsBo();
-    case 'br': return AppLocalizationsBr();
-    case 'bs': return AppLocalizationsBs();
-    case 'ca': return AppLocalizationsCa();
-    case 'ce': return AppLocalizationsCe();
-    case 'co': return AppLocalizationsCo();
-    case 'cs': return AppLocalizationsCs();
-    case 'cv': return AppLocalizationsCv();
-    case 'cy': return AppLocalizationsCy();
-    case 'da': return AppLocalizationsDa();
-    case 'de': return AppLocalizationsDe();
-    case 'el': return AppLocalizationsEl();
-    case 'en': return AppLocalizationsEn();
-    case 'eo': return AppLocalizationsEo();
-    case 'es': return AppLocalizationsEs();
-    case 'et': return AppLocalizationsEt();
-    case 'eu': return AppLocalizationsEu();
-    case 'fa': return AppLocalizationsFa();
-    case 'fi': return AppLocalizationsFi();
-    case 'fo': return AppLocalizationsFo();
-    case 'fr': return AppLocalizationsFr();
-    case 'ga': return AppLocalizationsGa();
-    case 'gd': return AppLocalizationsGd();
-    case 'gl': return AppLocalizationsGl();
-    case 'gu': return AppLocalizationsGu();
-    case 'ha': return AppLocalizationsHa();
-    case 'he': return AppLocalizationsHe();
-    case 'hi': return AppLocalizationsHi();
-    case 'hr': return AppLocalizationsHr();
-    case 'ht': return AppLocalizationsHt();
-    case 'hu': return AppLocalizationsHu();
-    case 'hy': return AppLocalizationsHy();
-    case 'id': return AppLocalizationsId();
-    case 'ii': return AppLocalizationsIi();
-    case 'is': return AppLocalizationsIs();
-    case 'it': return AppLocalizationsIt();
-    case 'iu': return AppLocalizationsIu();
-    case 'ja': return AppLocalizationsJa();
-    case 'jv': return AppLocalizationsJv();
-    case 'ka': return AppLocalizationsKa();
-    case 'kk': return AppLocalizationsKk();
-    case 'km': return AppLocalizationsKm();
-    case 'kn': return AppLocalizationsKn();
-    case 'ko': return AppLocalizationsKo();
-    case 'ku': return AppLocalizationsKu();
-    case 'kw': return AppLocalizationsKw();
-    case 'ky': return AppLocalizationsKy();
-    case 'la': return AppLocalizationsLa();
-    case 'lb': return AppLocalizationsLb();
-    case 'lo': return AppLocalizationsLo();
-    case 'lt': return AppLocalizationsLt();
-    case 'lv': return AppLocalizationsLv();
-    case 'mg': return AppLocalizationsMg();
-    case 'mi': return AppLocalizationsMi();
-    case 'ml': return AppLocalizationsMl();
-    case 'mn': return AppLocalizationsMn();
-    case 'mr': return AppLocalizationsMr();
-    case 'ms': return AppLocalizationsMs();
-    case 'mt': return AppLocalizationsMt();
-    case 'my': return AppLocalizationsMy();
-    case 'nb': return AppLocalizationsNb();
-    case 'ne': return AppLocalizationsNe();
-    case 'nl': return AppLocalizationsNl();
-    case 'nn': return AppLocalizationsNn();
-    case 'no': return AppLocalizationsNo();
-    case 'nr': return AppLocalizationsNr();
-    case 'oc': return AppLocalizationsOc();
-    case 'or': return AppLocalizationsOr();
-    case 'pa': return AppLocalizationsPa();
-    case 'pl': return AppLocalizationsPl();
-    case 'pt': return AppLocalizationsPt();
-    case 'qu': return AppLocalizationsQu();
-    case 'rm': return AppLocalizationsRm();
-    case 'ro': return AppLocalizationsRo();
-    case 'ru': return AppLocalizationsRu();
-    case 'sa': return AppLocalizationsSa();
-    case 'sc': return AppLocalizationsSc();
-    case 'sd': return AppLocalizationsSd();
-    case 'sg': return AppLocalizationsSg();
-    case 'si': return AppLocalizationsSi();
-    case 'sk': return AppLocalizationsSk();
-    case 'sl': return AppLocalizationsSl();
-    case 'sn': return AppLocalizationsSn();
-    case 'so': return AppLocalizationsSo();
-    case 'sq': return AppLocalizationsSq();
-    case 'sr': return AppLocalizationsSr();
-    case 'ss': return AppLocalizationsSs();
-    case 'st': return AppLocalizationsSt();
-    case 'sv': return AppLocalizationsSv();
-    case 'sw': return AppLocalizationsSw();
-    case 'ta': return AppLocalizationsTa();
-    case 'te': return AppLocalizationsTe();
-    case 'tg': return AppLocalizationsTg();
-    case 'th': return AppLocalizationsTh();
-    case 'ti': return AppLocalizationsTi();
-    case 'tl': return AppLocalizationsTl();
-    case 'tn': return AppLocalizationsTn();
-    case 'tr': return AppLocalizationsTr();
-    case 'ts': return AppLocalizationsTs();
-    case 'tt': return AppLocalizationsTt();
-    case 'tw': return AppLocalizationsTw();
-    case 'ty': return AppLocalizationsTy();
-    case 'ug': return AppLocalizationsUg();
-    case 'uk': return AppLocalizationsUk();
-    case 'ur': return AppLocalizationsUr();
-    case 'uz': return AppLocalizationsUz();
-    case 've': return AppLocalizationsVe();
-    case 'vi': return AppLocalizationsVi();
-    case 'wa': return AppLocalizationsWa();
-    case 'wo': return AppLocalizationsWo();
-    case 'xh': return AppLocalizationsXh();
-    case 'yi': return AppLocalizationsYi();
-    case 'yo': return AppLocalizationsYo();
-    case 'zh': return AppLocalizationsZh();
-    case 'zu': return AppLocalizationsZu();
+    case 'aa':
+      return AppLocalizationsAa();
+    case 'af':
+      return AppLocalizationsAf();
+    case 'ak':
+      return AppLocalizationsAk();
+    case 'am':
+      return AppLocalizationsAm();
+    case 'ar':
+      return AppLocalizationsAr();
+    case 'as':
+      return AppLocalizationsAs();
+    case 'az':
+      return AppLocalizationsAz();
+    case 'be':
+      return AppLocalizationsBe();
+    case 'bg':
+      return AppLocalizationsBg();
+    case 'bm':
+      return AppLocalizationsBm();
+    case 'bn':
+      return AppLocalizationsBn();
+    case 'bo':
+      return AppLocalizationsBo();
+    case 'br':
+      return AppLocalizationsBr();
+    case 'bs':
+      return AppLocalizationsBs();
+    case 'ca':
+      return AppLocalizationsCa();
+    case 'ce':
+      return AppLocalizationsCe();
+    case 'co':
+      return AppLocalizationsCo();
+    case 'cs':
+      return AppLocalizationsCs();
+    case 'cv':
+      return AppLocalizationsCv();
+    case 'cy':
+      return AppLocalizationsCy();
+    case 'da':
+      return AppLocalizationsDa();
+    case 'de':
+      return AppLocalizationsDe();
+    case 'el':
+      return AppLocalizationsEl();
+    case 'en':
+      return AppLocalizationsEn();
+    case 'eo':
+      return AppLocalizationsEo();
+    case 'es':
+      return AppLocalizationsEs();
+    case 'et':
+      return AppLocalizationsEt();
+    case 'eu':
+      return AppLocalizationsEu();
+    case 'fa':
+      return AppLocalizationsFa();
+    case 'fi':
+      return AppLocalizationsFi();
+    case 'fo':
+      return AppLocalizationsFo();
+    case 'fr':
+      return AppLocalizationsFr();
+    case 'ga':
+      return AppLocalizationsGa();
+    case 'gd':
+      return AppLocalizationsGd();
+    case 'gl':
+      return AppLocalizationsGl();
+    case 'gu':
+      return AppLocalizationsGu();
+    case 'ha':
+      return AppLocalizationsHa();
+    case 'he':
+      return AppLocalizationsHe();
+    case 'hi':
+      return AppLocalizationsHi();
+    case 'hr':
+      return AppLocalizationsHr();
+    case 'ht':
+      return AppLocalizationsHt();
+    case 'hu':
+      return AppLocalizationsHu();
+    case 'hy':
+      return AppLocalizationsHy();
+    case 'id':
+      return AppLocalizationsId();
+    case 'ii':
+      return AppLocalizationsIi();
+    case 'is':
+      return AppLocalizationsIs();
+    case 'it':
+      return AppLocalizationsIt();
+    case 'iu':
+      return AppLocalizationsIu();
+    case 'ja':
+      return AppLocalizationsJa();
+    case 'jv':
+      return AppLocalizationsJv();
+    case 'ka':
+      return AppLocalizationsKa();
+    case 'kk':
+      return AppLocalizationsKk();
+    case 'km':
+      return AppLocalizationsKm();
+    case 'kn':
+      return AppLocalizationsKn();
+    case 'ko':
+      return AppLocalizationsKo();
+    case 'ku':
+      return AppLocalizationsKu();
+    case 'kw':
+      return AppLocalizationsKw();
+    case 'ky':
+      return AppLocalizationsKy();
+    case 'la':
+      return AppLocalizationsLa();
+    case 'lb':
+      return AppLocalizationsLb();
+    case 'lo':
+      return AppLocalizationsLo();
+    case 'lt':
+      return AppLocalizationsLt();
+    case 'lv':
+      return AppLocalizationsLv();
+    case 'mg':
+      return AppLocalizationsMg();
+    case 'mi':
+      return AppLocalizationsMi();
+    case 'ml':
+      return AppLocalizationsMl();
+    case 'mn':
+      return AppLocalizationsMn();
+    case 'mr':
+      return AppLocalizationsMr();
+    case 'ms':
+      return AppLocalizationsMs();
+    case 'mt':
+      return AppLocalizationsMt();
+    case 'my':
+      return AppLocalizationsMy();
+    case 'nb':
+      return AppLocalizationsNb();
+    case 'ne':
+      return AppLocalizationsNe();
+    case 'nl':
+      return AppLocalizationsNl();
+    case 'nn':
+      return AppLocalizationsNn();
+    case 'no':
+      return AppLocalizationsNo();
+    case 'nr':
+      return AppLocalizationsNr();
+    case 'oc':
+      return AppLocalizationsOc();
+    case 'or':
+      return AppLocalizationsOr();
+    case 'pa':
+      return AppLocalizationsPa();
+    case 'pl':
+      return AppLocalizationsPl();
+    case 'pt':
+      return AppLocalizationsPt();
+    case 'qu':
+      return AppLocalizationsQu();
+    case 'rm':
+      return AppLocalizationsRm();
+    case 'ro':
+      return AppLocalizationsRo();
+    case 'ru':
+      return AppLocalizationsRu();
+    case 'sa':
+      return AppLocalizationsSa();
+    case 'sc':
+      return AppLocalizationsSc();
+    case 'sd':
+      return AppLocalizationsSd();
+    case 'sg':
+      return AppLocalizationsSg();
+    case 'si':
+      return AppLocalizationsSi();
+    case 'sk':
+      return AppLocalizationsSk();
+    case 'sl':
+      return AppLocalizationsSl();
+    case 'sn':
+      return AppLocalizationsSn();
+    case 'so':
+      return AppLocalizationsSo();
+    case 'sq':
+      return AppLocalizationsSq();
+    case 'sr':
+      return AppLocalizationsSr();
+    case 'ss':
+      return AppLocalizationsSs();
+    case 'st':
+      return AppLocalizationsSt();
+    case 'sv':
+      return AppLocalizationsSv();
+    case 'sw':
+      return AppLocalizationsSw();
+    case 'ta':
+      return AppLocalizationsTa();
+    case 'te':
+      return AppLocalizationsTe();
+    case 'tg':
+      return AppLocalizationsTg();
+    case 'th':
+      return AppLocalizationsTh();
+    case 'ti':
+      return AppLocalizationsTi();
+    case 'tl':
+      return AppLocalizationsTl();
+    case 'tn':
+      return AppLocalizationsTn();
+    case 'tr':
+      return AppLocalizationsTr();
+    case 'ts':
+      return AppLocalizationsTs();
+    case 'tt':
+      return AppLocalizationsTt();
+    case 'tw':
+      return AppLocalizationsTw();
+    case 'ty':
+      return AppLocalizationsTy();
+    case 'ug':
+      return AppLocalizationsUg();
+    case 'uk':
+      return AppLocalizationsUk();
+    case 'ur':
+      return AppLocalizationsUr();
+    case 'uz':
+      return AppLocalizationsUz();
+    case 've':
+      return AppLocalizationsVe();
+    case 'vi':
+      return AppLocalizationsVi();
+    case 'wa':
+      return AppLocalizationsWa();
+    case 'wo':
+      return AppLocalizationsWo();
+    case 'xh':
+      return AppLocalizationsXh();
+    case 'yi':
+      return AppLocalizationsYi();
+    case 'yo':
+      return AppLocalizationsYo();
+    case 'zh':
+      return AppLocalizationsZh();
+    case 'zu':
+      return AppLocalizationsZu();
   }
 
   throw FlutterError(
     'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
     'an issue with the localizations generation tool. Please file an issue '
     'on GitHub with a reproducible sample app and the gen-l10n configuration '
-    'that was used.'
+    'that was used.',
   );
 }

--- a/packages/smooth_app/lib/l10n/app_localizations_aa.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_aa.dart
@@ -2706,6 +2706,9 @@ class AppLocalizationsAa extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'View all prices for this product';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_af.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_af.dart
@@ -2707,6 +2707,9 @@ class AppLocalizationsAf extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'View all prices for this product';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_ak.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ak.dart
@@ -2706,6 +2706,9 @@ class AppLocalizationsAk extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'View all prices for this product';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_am.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_am.dart
@@ -2648,6 +2648,9 @@ class AppLocalizationsAm extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'የዚህን ምርት ሁሉንም ዋጋዎች ይመልከቱ';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_ar.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ar.dart
@@ -2691,6 +2691,9 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'عرض جميع الأسعار لهذا المنتج';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_as.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_as.dart
@@ -2708,6 +2708,9 @@ class AppLocalizationsAs extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'এই সামগ্ৰীৰ সকলো মূল্য চাওক';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_az.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_az.dart
@@ -2736,6 +2736,9 @@ class AppLocalizationsAz extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Bu məhsulun bütün qiymətlərinə baxın';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_be.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_be.dart
@@ -2738,6 +2738,9 @@ class AppLocalizationsBe extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Паглядзець усе цэны на гэты тавар';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_bg.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_bg.dart
@@ -2754,6 +2754,9 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Вижте всички цени за този продукт';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_bm.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_bm.dart
@@ -2710,6 +2710,9 @@ class AppLocalizationsBm extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Aw ye nin fura in sɔngɔ bɛɛ lajɛ';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_bn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_bn.dart
@@ -2736,6 +2736,9 @@ class AppLocalizationsBn extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices => 'এই পণ্যের সকল দাম দেখুন';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_bo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_bo.dart
@@ -2706,6 +2706,9 @@ class AppLocalizationsBo extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'View all prices for this product';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_br.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_br.dart
@@ -2709,6 +2709,9 @@ class AppLocalizationsBr extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Gwelet an holl brizioù evit ar produ-mañ';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_bs.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_bs.dart
@@ -2709,6 +2709,9 @@ class AppLocalizationsBs extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Pogledajte sve cijene za ovaj proizvod';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_ca.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ca.dart
@@ -2757,6 +2757,9 @@ class AppLocalizationsCa extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Veure tots els preus d\'aquest producte';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_ce.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ce.dart
@@ -2706,6 +2706,9 @@ class AppLocalizationsCe extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'View all prices for this product';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_co.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_co.dart
@@ -2709,6 +2709,9 @@ class AppLocalizationsCo extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Vede tutti i prezzi per questu pruduttu';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_cs.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_cs.dart
@@ -2729,6 +2729,9 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Zobrazit všechny ceny tohoto produktu';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_cv.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_cv.dart
@@ -2708,6 +2708,9 @@ class AppLocalizationsCv extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Ҫак таварӑн пур хакне те пӑхӑр';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_cy.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_cy.dart
@@ -2706,6 +2706,9 @@ class AppLocalizationsCy extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Gweld yr holl brisiau ar gyfer y cynnyrch hwn';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_da.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_da.dart
@@ -2719,6 +2719,9 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Se alle priser for dette produkt';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_de.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_de.dart
@@ -2761,6 +2761,9 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Alle Preise für dieses Produkt anzeigen';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_el.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_el.dart
@@ -2769,6 +2769,9 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Δείτε όλες τις τιμές για αυτό το προϊόν';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_en.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_en.dart
@@ -2706,6 +2706,9 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'View all prices for this product';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_eo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_eo.dart
@@ -2706,6 +2706,9 @@ class AppLocalizationsEo extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Vidi ĉiujn prezojn por ĉi tiu produkto';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_es.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_es.dart
@@ -2762,6 +2762,9 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Ver todos los precios de este producto';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_et.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_et.dart
@@ -2718,6 +2718,9 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Kuva kõik selle toote hinnad';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_eu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_eu.dart
@@ -2713,6 +2713,9 @@ class AppLocalizationsEu extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Ikusi produktu honen prezio guztiak';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_fa.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_fa.dart
@@ -2706,6 +2706,9 @@ class AppLocalizationsFa extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'مشاهده تمام قیمت‌های این محصول';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_fi.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_fi.dart
@@ -2712,6 +2712,9 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Näytä kaikki tämän tuotteen hinnat';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_fo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_fo.dart
@@ -2706,6 +2706,9 @@ class AppLocalizationsFo extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'View all prices for this product';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_fr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_fr.dart
@@ -2775,6 +2775,9 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Voir tous les prix du produit';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_ga.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ga.dart
@@ -2710,6 +2710,9 @@ class AppLocalizationsGa extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Féach ar na praghsanna uile don táirge seo';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_gd.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_gd.dart
@@ -2710,6 +2710,9 @@ class AppLocalizationsGd extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Seall a h-uile prìs airson an toraidh seo';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_gl.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_gl.dart
@@ -2710,6 +2710,9 @@ class AppLocalizationsGl extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Ver todos os prezos deste produto';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_gu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_gu.dart
@@ -2708,6 +2708,9 @@ class AppLocalizationsGu extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'આ ઉત્પાદનની બધી કિંમતો જુઓ';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_ha.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ha.dart
@@ -2708,6 +2708,9 @@ class AppLocalizationsHa extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Duba duk farashin wannan samfurin';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_he.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_he.dart
@@ -2692,6 +2692,9 @@ class AppLocalizationsHe extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'הצג את כל המחירים עבור מוצר זה';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_hi.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_hi.dart
@@ -2714,6 +2714,9 @@ class AppLocalizationsHi extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'इस उत्पाद के सभी मूल्य देखें';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_hr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_hr.dart
@@ -2709,6 +2709,9 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Pogledajte sve cijene za ovaj proizvod';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_ht.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ht.dart
@@ -2707,6 +2707,9 @@ class AppLocalizationsHt extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Gade tout pri pou pwodui sa a';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_hu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_hu.dart
@@ -2739,6 +2739,9 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Tekintse meg a termék összes árát';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_hy.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_hy.dart
@@ -2707,6 +2707,9 @@ class AppLocalizationsHy extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Դիտել այս ապրանքի բոլոր գները';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_id.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_id.dart
@@ -2731,6 +2731,9 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Lihat semua harga untuk produk ini';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_ii.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ii.dart
@@ -2706,6 +2706,9 @@ class AppLocalizationsIi extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'View all prices for this product';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_is.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_is.dart
@@ -2732,6 +2732,9 @@ class AppLocalizationsIs extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Skoða öll verð fyrir þessa vöru';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_it.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_it.dart
@@ -2753,6 +2753,9 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Visualizza tutti i prezzi per questo prodotto';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_iu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_iu.dart
@@ -2706,6 +2706,9 @@ class AppLocalizationsIu extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'View all prices for this product';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_ja.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ja.dart
@@ -2604,6 +2604,9 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices => 'この商品のすべての価格を見る';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_jv.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_jv.dart
@@ -2707,6 +2707,9 @@ class AppLocalizationsJv extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Deleng kabeh rega kanggo produk iki';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_ka.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ka.dart
@@ -2707,6 +2707,9 @@ class AppLocalizationsKa extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'იხილეთ ამ პროდუქტის ყველა ფასი';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_kk.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_kk.dart
@@ -2707,6 +2707,9 @@ class AppLocalizationsKk extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Осы өнімнің барлық бағаларын қараңыз';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_km.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_km.dart
@@ -2706,6 +2706,9 @@ class AppLocalizationsKm extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'មើលតម្លៃទាំងអស់សម្រាប់ផលិតផលនេះ។';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_kn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_kn.dart
@@ -2710,6 +2710,9 @@ class AppLocalizationsKn extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'ಈ ಉತ್ಪನ್ನದ ಎಲ್ಲಾ ಬೆಲೆಗಳನ್ನು ವೀಕ್ಷಿಸಿ';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_ko.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ko.dart
@@ -2603,6 +2603,9 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices => '이 제품의 모든 가격 보기';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ku.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ku.dart
@@ -2708,6 +2708,9 @@ class AppLocalizationsKu extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Hemû nirxên vê berhemê bibînin';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_kw.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_kw.dart
@@ -2706,6 +2706,9 @@ class AppLocalizationsKw extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'View all prices for this product';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_ky.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ky.dart
@@ -2708,6 +2708,9 @@ class AppLocalizationsKy extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Бул продукт үчүн бардык бааларды көрүү';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_la.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_la.dart
@@ -2708,6 +2708,9 @@ class AppLocalizationsLa extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Vide omnia pretia huius producti';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_lb.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_lb.dart
@@ -2709,6 +2709,9 @@ class AppLocalizationsLb extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'All Präisser fir dëst Produkt kucken';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_lo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_lo.dart
@@ -2706,6 +2706,9 @@ class AppLocalizationsLo extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'ເບິ່ງລາຄາທັງໝົດຂອງຜະລິດຕະພັນນີ້';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_lt.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_lt.dart
@@ -2747,6 +2747,9 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Peržiūrėti visas šio produkto kainas';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_lv.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_lv.dart
@@ -2748,6 +2748,9 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Skatīt visas šī produkta cenas';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_mg.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_mg.dart
@@ -2711,6 +2711,9 @@ class AppLocalizationsMg extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Jereo ny vidiny rehetra amin\'ity vokatra ity';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_mi.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_mi.dart
@@ -2711,6 +2711,9 @@ class AppLocalizationsMi extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Tirohia nga utu katoa mo tenei hua';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_ml.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ml.dart
@@ -2709,6 +2709,9 @@ class AppLocalizationsMl extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'ഈ ഉൽപ്പന്നത്തിന്റെ എല്ലാ വിലകളും കാണുക';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_mn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_mn.dart
@@ -2707,6 +2707,9 @@ class AppLocalizationsMn extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Энэ бүтээгдэхүүний бүх үнийг харна уу';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_mr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_mr.dart
@@ -2708,6 +2708,9 @@ class AppLocalizationsMr extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'या उत्पादनाच्या सर्व किमती पहा';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_ms.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ms.dart
@@ -2732,6 +2732,9 @@ class AppLocalizationsMs extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Lihat semua harga untuk produk ini';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_mt.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_mt.dart
@@ -2708,6 +2708,9 @@ class AppLocalizationsMt extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Ara l-prezzijiet kollha għal dan il-prodott';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_my.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_my.dart
@@ -2714,6 +2714,9 @@ class AppLocalizationsMy extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'ဤထုတ်ကုန်အတွက် ဈေးနှုန်းအားလုံးကို ကြည့်ပါ။';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_nb.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_nb.dart
@@ -2736,6 +2736,9 @@ class AppLocalizationsNb extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Vis alle priser for dette produktet';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_ne.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ne.dart
@@ -2706,6 +2706,9 @@ class AppLocalizationsNe extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'यस उत्पादनको सबै मूल्यहरू हेर्नुहोस्';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_nl.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_nl.dart
@@ -2744,6 +2744,9 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Bekijk alle prijzen voor dit product';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_nn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_nn.dart
@@ -2735,6 +2735,9 @@ class AppLocalizationsNn extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Se alle priser for dette produktet';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_no.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_no.dart
@@ -2735,6 +2735,9 @@ class AppLocalizationsNo extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Se alle priser for dette produktet';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_nr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_nr.dart
@@ -2706,6 +2706,9 @@ class AppLocalizationsNr extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'View all prices for this product';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_oc.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_oc.dart
@@ -2709,6 +2709,9 @@ class AppLocalizationsOc extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Veire totes los prètzs d\'aqueste produch';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_or.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_or.dart
@@ -2712,6 +2712,9 @@ class AppLocalizationsOr extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'ଏହି ଉତ୍ପାଦ ପାଇଁ ସମସ୍ତ ମୂଲ୍ୟ ଦେଖନ୍ତୁ';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_pa.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_pa.dart
@@ -2708,6 +2708,9 @@ class AppLocalizationsPa extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'ਇਸ ਉਤਪਾਦ ਦੀਆਂ ਸਾਰੀਆਂ ਕੀਮਤਾਂ ਵੇਖੋ';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_pl.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_pl.dart
@@ -2747,6 +2747,9 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Zobacz wszystkie ceny tego produktu';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_pt.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_pt.dart
@@ -2762,6 +2762,9 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Ver todos os preços deste produto';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_qu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_qu.dart
@@ -2708,6 +2708,9 @@ class AppLocalizationsQu extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Kay rurupa llapa chaninkunata qhaway';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_rm.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_rm.dart
@@ -2706,6 +2706,9 @@ class AppLocalizationsRm extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'View all prices for this product';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_ro.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ro.dart
@@ -2762,6 +2762,9 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Vezi toate prețurile pentru acest produs';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_ru.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ru.dart
@@ -2764,6 +2764,9 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Посмотреть все цены на этот продукт';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_sa.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sa.dart
@@ -2708,6 +2708,9 @@ class AppLocalizationsSa extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'अस्य उत्पादस्य सर्वाणि मूल्यानि पश्यन्तु';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_sc.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sc.dart
@@ -2706,6 +2706,9 @@ class AppLocalizationsSc extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'View all prices for this product';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_sd.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sd.dart
@@ -2706,6 +2706,9 @@ class AppLocalizationsSd extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'هن پراڊڪٽ جون سڀ قيمتون ڏسو';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_sg.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sg.dart
@@ -2706,6 +2706,9 @@ class AppLocalizationsSg extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'View all prices for this product';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_si.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_si.dart
@@ -2711,6 +2711,9 @@ class AppLocalizationsSi extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'මෙම නිෂ්පාදනය සඳහා සියලු මිල ගණන් බලන්න.';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_sk.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sk.dart
@@ -2733,6 +2733,9 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Zobraziť všetky ceny tohto produktu';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_sl.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sl.dart
@@ -2736,6 +2736,9 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Oglejte si vse cene za ta izdelek';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_sn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sn.dart
@@ -2706,6 +2706,9 @@ class AppLocalizationsSn extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Wona mitengo yese yechigadzirwa ichi';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_so.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_so.dart
@@ -2706,6 +2706,9 @@ class AppLocalizationsSo extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Eeg dhammaan qiimayaasha alaabtan';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_sq.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sq.dart
@@ -2719,6 +2719,9 @@ class AppLocalizationsSq extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Shikoni të gjitha çmimet për këtë produkt';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_sr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sr.dart
@@ -2707,6 +2707,9 @@ class AppLocalizationsSr extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Погледајте све цене за овај производ';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_ss.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ss.dart
@@ -2708,6 +2708,9 @@ class AppLocalizationsSs extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Buka onkhe emanani alomkhicito';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_st.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_st.dart
@@ -2706,6 +2706,9 @@ class AppLocalizationsSt extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Sheba litheko tsohle tsa sehlahisoa sena';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_sv.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sv.dart
@@ -2731,6 +2731,9 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Se alla priser för den här produkten';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_sw.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_sw.dart
@@ -2727,6 +2727,9 @@ class AppLocalizationsSw extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Tazama bei zote za bidhaa hii';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_ta.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ta.dart
@@ -2784,6 +2784,9 @@ class AppLocalizationsTa extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'இந்த தயாரிப்புக்கான அனைத்து விலைகளையும் காண்க';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_te.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_te.dart
@@ -2709,6 +2709,9 @@ class AppLocalizationsTe extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'ఈ ఉత్పత్తి యొక్క అన్ని ధరలను చూడండి';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_tg.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tg.dart
@@ -2707,6 +2707,9 @@ class AppLocalizationsTg extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Ҳамаи нархҳои ин маҳсулотро бинед';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_th.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_th.dart
@@ -2697,6 +2697,9 @@ class AppLocalizationsTh extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'ดูราคาทั้งหมดสำหรับผลิตภัณฑ์นี้';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_ti.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ti.dart
@@ -2706,6 +2706,9 @@ class AppLocalizationsTi extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices => 'ኩሉ ዋጋታት ናይዚ ፍርያት ርአ';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_tl.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tl.dart
@@ -2709,6 +2709,9 @@ class AppLocalizationsTl extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Tingnan ang lahat ng presyo para sa produktong ito';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_tn.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tn.dart
@@ -2708,6 +2708,9 @@ class AppLocalizationsTn extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Leba ditlhwatlhwa tsotlhe tsa sedirisiwa seno';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_tr.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tr.dart
@@ -2724,6 +2724,9 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Bu ürünün tüm fiyatlarını görüntüle';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_ts.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ts.dart
@@ -2709,6 +2709,9 @@ class AppLocalizationsTs extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Languta minxavo hinkwayo ya xitirhisiwa lexi';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_tt.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tt.dart
@@ -2707,6 +2707,9 @@ class AppLocalizationsTt extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Бу продуктның барлык бәяләрен карау';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_tw.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_tw.dart
@@ -2711,6 +2711,9 @@ class AppLocalizationsTw extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices => 'Hwɛ nneɛma yi bo nyinaa';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_ty.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ty.dart
@@ -2706,6 +2706,9 @@ class AppLocalizationsTy extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'View all prices for this product';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_ug.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ug.dart
@@ -2707,6 +2707,9 @@ class AppLocalizationsUg extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'بۇ مەھسۇلاتنىڭ بارلىق باھالىرىنى كۆرۈڭ';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_uk.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_uk.dart
@@ -2737,6 +2737,9 @@ class AppLocalizationsUk extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Переглянути всі ціни на цей товар';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_ur.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ur.dart
@@ -2706,6 +2706,9 @@ class AppLocalizationsUr extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'View all prices for this product';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_uz.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_uz.dart
@@ -2708,6 +2708,9 @@ class AppLocalizationsUz extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Ushbu mahsulot uchun barcha narxlarni ko\'ring';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_ve.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_ve.dart
@@ -2706,6 +2706,9 @@ class AppLocalizationsVe extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'View all prices for this product';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_vi.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_vi.dart
@@ -2729,6 +2729,9 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Xem tất cả giá cho sản phẩm này';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_wa.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_wa.dart
@@ -2706,6 +2706,9 @@ class AppLocalizationsWa extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'View all prices for this product';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_wo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_wo.dart
@@ -2706,6 +2706,9 @@ class AppLocalizationsWo extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'View all prices for this product';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_xh.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_xh.dart
@@ -2709,6 +2709,9 @@ class AppLocalizationsXh extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Jonga onke amaxabiso ale mveliso';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_yi.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_yi.dart
@@ -2708,6 +2708,9 @@ class AppLocalizationsYi extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'זען אַלע פּרייזן פֿאַר דעם פּראָדוקט';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_yo.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_yo.dart
@@ -2707,6 +2707,9 @@ class AppLocalizationsYo extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Wo gbogbo awọn idiyele fun ọja yii';
 

--- a/packages/smooth_app/lib/l10n/app_localizations_zh.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_zh.dart
@@ -2581,6 +2581,9 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices => '查看該產品的所有價格';
 
   @override

--- a/packages/smooth_app/lib/l10n/app_localizations_zu.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations_zu.dart
@@ -2757,6 +2757,9 @@ class AppLocalizationsZu extends AppLocalizations {
   }
 
   @override
+  String get prices_entry_menu_open_product => 'View product details';
+
+  @override
   String get prices_entry_menu_open_product_prices =>
       'Buka zonke izintengo zalo mkhiqizo';
 

--- a/packages/smooth_app/lib/pages/prices/prices_proofs_page.dart
+++ b/packages/smooth_app/lib/pages/prices/prices_proofs_page.dart
@@ -147,7 +147,7 @@ class _InfiniteScrollProofManager extends InfiniteScrollManager<Proof> {
         start: 8.0,
         end: 8.0,
       ),
-      padding: EdgeInsets.zero,
+      padding: EdgeInsetsDirectional.zero,
       color: lightTheme ? null : extension.primaryUltraBlack,
       child: InkWell(
         borderRadius: ROUNDED_BORDER_RADIUS,

--- a/packages/smooth_app/lib/pages/prices/product_prices_list.dart
+++ b/packages/smooth_app/lib/pages/prices/product_prices_list.dart
@@ -11,6 +11,7 @@ import 'package:smooth_app/generic_lib/bottom_sheets/smooth_bottom_sheet.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/l10n/app_localizations.dart';
+import 'package:smooth_app/pages/navigator/app_navigator.dart';
 import 'package:smooth_app/pages/prices/get_prices_model.dart';
 import 'package:smooth_app/pages/prices/infinite_scroll_manager.dart';
 import 'package:smooth_app/pages/prices/infinite_scroll_sliver_list.dart';
@@ -150,6 +151,7 @@ class _InfiniteScrollPriceManager extends InfiniteScrollManager<Price> {
 
   Future<void> _showOptionsMenu(BuildContext context, Price price) async {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    final bool hasProduct = price.product != null;
     final bool hasProof = price.proof?.filePath != null;
     final bool hasCountButton = model.enableCountButton;
 
@@ -157,6 +159,7 @@ class _InfiniteScrollPriceManager extends InfiniteScrollManager<Price> {
       context: context,
       title: appLocalizations.prices_entry_menu_title(price.owner),
       labels: <String>[
+        if (hasProduct) appLocalizations.prices_entry_menu_open_product,
         if (hasCountButton)
           appLocalizations.prices_entry_menu_open_product_prices,
         if (hasProof) appLocalizations.prices_entry_menu_open_proof,
@@ -167,16 +170,18 @@ class _InfiniteScrollPriceManager extends InfiniteScrollManager<Price> {
         appLocalizations.prices_entry_menu_shop_prices,
       ],
       prefixIcons: <Widget>[
+        if (hasProduct) const icons.Milk.happy(),
         if (hasCountButton) const icons.PriceTag(),
         if (hasProof) const icons.PriceReceipt(),
         const icons.Profile(),
         const icons.Shop(),
       ],
       values: <ProductPriceAction>[
-        if (hasCountButton) ProductPriceAction.VIEW_PRODUCT_PRICES,
-        if (hasProof) ProductPriceAction.VIEW_PROOF,
-        ProductPriceAction.VIEW_AUTHOR_PRICES,
-        ProductPriceAction.VIEW_LOCATION_PRICES,
+        if (hasProduct) .VIEW_PRODUCT,
+        if (hasCountButton) .VIEW_PRODUCT_PRICES,
+        if (hasProof) .VIEW_PROOF,
+        .VIEW_AUTHOR_PRICES,
+        .VIEW_LOCATION_PRICES,
       ],
       addEndArrowToItems: true,
     );
@@ -186,6 +191,10 @@ class _InfiniteScrollPriceManager extends InfiniteScrollManager<Price> {
     }
 
     switch (res) {
+      case ProductPriceAction.VIEW_PRODUCT:
+        AppNavigator.of(
+          context,
+        ).push(AppRoutes.PRODUCT_LOADER(price.product!.code));
       case ProductPriceAction.VIEW_PROOF:
         Navigator.of(context).push(
           MaterialPageRoute<void>(
@@ -237,6 +246,7 @@ class _InfiniteScrollPriceManager extends InfiniteScrollManager<Price> {
 }
 
 enum ProductPriceAction {
+  VIEW_PRODUCT,
   VIEW_PRODUCT_PRICES,
   VIEW_PROOF,
   VIEW_AUTHOR_PRICES,


### PR DESCRIPTION
Hi everyone!

A small addition to the prices list: if a product has a barcode, we can now discover it.
<img width="660" height="1190" alt="Capture d’écran   2026-01-14 à 20 59 57" src="https://github.com/user-attachments/assets/fa009ff4-cf47-4c9b-9d8b-1641278b3aa9" />
