### PR TITLE
feat: Square panels improvements : UI + bottom sheet

### DIFF
--- a/packages/smooth_app/lib/generic_lib/bottom_sheets/smooth_autosize_bottom_sheet.dart
+++ b/packages/smooth_app/lib/generic_lib/bottom_sheets/smooth_autosize_bottom_sheet.dart
@@ -1,0 +1,138 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:smooth_app/generic_lib/bottom_sheets/smooth_bottom_sheet.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/widgets/smooth_view_padding.dart';
+import 'package:smooth_app/widgets/widget_height.dart';
+
+Future<T?> showSmoothAutoSizeModalSheet<T>({
+  required BuildContext context,
+  required SmoothModalSheetHeader header,
+  required WidgetBuilder bodyBuilder,
+  double? maxHeightRatio,
+  bool? useRootNavigator,
+}) async {
+  return showModalBottomSheet<T>(
+    context: context,
+    isScrollControlled: true,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: ROUNDED_RADIUS),
+    ),
+    useRootNavigator: useRootNavigator ?? false,
+    // We inject the safe area manually
+    useSafeArea: false,
+    builder: (BuildContext context) {
+      return _SmoothAutoSizeModalContent<T>(
+        headerBuilder: (_) => ClipRRect(
+          borderRadius: const BorderRadius.vertical(top: ROUNDED_RADIUS),
+          child: header,
+        ),
+        bodyBuilder: (BuildContext context) => bodyBuilder(context),
+        maxHeightRatio: maxHeightRatio ?? 1.0,
+      );
+    },
+  );
+}
+
+class _SmoothAutoSizeModalContent<T> extends StatefulWidget {
+  const _SmoothAutoSizeModalContent({
+    required this.headerBuilder,
+    required this.bodyBuilder,
+    required this.maxHeightRatio,
+  });
+
+  final WidgetBuilder headerBuilder;
+  final WidgetBuilder bodyBuilder;
+  final double maxHeightRatio;
+
+  @override
+  State<_SmoothAutoSizeModalContent<T>> createState() =>
+      _SmoothAutoSizeModalContentState<T>();
+}
+
+class _SmoothAutoSizeModalContentState<T>
+    extends State<_SmoothAutoSizeModalContent<T>> {
+  double? _headerHeight;
+  double? _bodyHeight;
+
+  @override
+  Widget build(BuildContext context) {
+    final double screenHeight = MediaQuery.heightOf(context);
+    final Widget header = KeyedSubtree(
+      key: const Key('autosize_header'),
+      child: widget.headerBuilder(context),
+    );
+    final Widget body = KeyedSubtree(
+      key: const Key('autosize_body'),
+      child: widget.bodyBuilder(context),
+    );
+
+    if (_headerHeight == null || _bodyHeight == null) {
+      return Offstage(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            MeasureSize(
+              onChange: (Size size) =>
+                  setState(() => _headerHeight = size.height),
+              child: header,
+            ),
+            MeasureSize(
+              onChange: (Size size) =>
+                  setState(() => _bodyHeight = size.height),
+              child: body,
+            ),
+          ],
+        ),
+      );
+    }
+
+    final EdgeInsets screenPadding = SmoothViewPadding.of(context);
+    final double maxHeight =
+        (screenHeight - screenPadding.vertical) * widget.maxHeightRatio;
+    final double realHeight =
+        _headerHeight! + _bodyHeight! + screenPadding.bottom;
+    final bool needsScroll = realHeight > maxHeight;
+
+    final double contentDisplayHeight = needsScroll ? maxHeight : realHeight;
+
+    final double initialRatio = contentDisplayHeight / screenHeight;
+    final double maxRatio = math.min(
+      1.0 - (screenPadding.top / MediaQuery.sizeOf(context).height),
+      widget.maxHeightRatio,
+    );
+
+    const double minRatio = 0.0;
+
+    return DraggableScrollableSheet(
+      expand: false,
+      initialChildSize: initialRatio.clamp(0.01, maxRatio),
+      maxChildSize: maxRatio,
+      minChildSize: minRatio,
+      snap: true,
+      snapSizes: const <double>[0.0],
+      builder: (BuildContext context, ScrollController scrollController) {
+        Widget bodyContent = Padding(
+          padding: EdgeInsetsDirectional.only(bottom: screenPadding.bottom),
+          child: body,
+        );
+
+        if (needsScroll) {
+          bodyContent = SingleChildScrollView(
+            controller: scrollController,
+            child: SizedBox(height: _bodyHeight, child: body),
+          );
+        }
+
+        return Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            header,
+            Expanded(child: bodyContent),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/packages/smooth_app/lib/generic_lib/bottom_sheets/smooth_bottom_sheet.dart
+++ b/packages/smooth_app/lib/generic_lib/bottom_sheets/smooth_bottom_sheet.dart
@@ -735,17 +735,22 @@ class SmoothModalSheetHeaderCloseButton extends StatelessWidget
 
 class SmoothModalSheetHeaderPrefixIndicator extends StatelessWidget
     implements SizeWidget {
-  const SmoothModalSheetHeaderPrefixIndicator({this.color, super.key});
+  const SmoothModalSheetHeaderPrefixIndicator({
+    this.color,
+    super.key,
+    this.size,
+  });
 
   final Color? color;
+  final Size? size;
 
   @override
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsetsDirectional.only(end: VERY_SMALL_SPACE),
       child: SizedBox(
-        width: 10.0,
-        height: 10.0,
+        width: size?.width ?? 10.0,
+        height: size?.height ?? 10.0,
         child: DecoratedBox(
           decoration: BoxDecoration(
             color: color ?? Colors.white,
@@ -760,7 +765,7 @@ class SmoothModalSheetHeaderPrefixIndicator extends StatelessWidget
   bool get requiresPadding => false;
 
   @override
-  double widgetHeight(BuildContext context) => 10.0;
+  double widgetHeight(BuildContext context) => size?.height ?? 10.0;
 }
 
 abstract class SizeWidget implements Widget {

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_page.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_page.dart
@@ -25,10 +25,17 @@ import 'package:smooth_app/widgets/smooth_scaffold.dart';
 
 /// Detail page of knowledge panels (if you click on the forward/more button).
 class KnowledgePanelPage extends StatefulWidget {
-  const KnowledgePanelPage({required this.panelId, required this.product});
+  const KnowledgePanelPage({
+    required this.panelId,
+    required this.product,
+    this.title,
+  });
 
   final String panelId;
   final Product product;
+
+  /// Override used for squared panels
+  final String? title;
 
   @override
   State<KnowledgePanelPage> createState() => _KnowledgePanelPageState();
@@ -134,6 +141,10 @@ class _KnowledgePanelPageState extends State<KnowledgePanelPage>
   }
 
   String _getTitle() {
+    if (widget.title != null && widget.title!.isNotEmpty) {
+      return widget.title!;
+    }
+
     final KnowledgePanelPanelGroupElement? groupElement = _groupElementOf(
       context,
     );
@@ -141,6 +152,7 @@ class _KnowledgePanelPageState extends State<KnowledgePanelPage>
         groupElement?.title!.isNotEmpty == true) {
       return groupElement!.title!;
     }
+
     final KnowledgePanel? panel = KnowledgePanelsBuilder.getKnowledgePanel(
       upToDateProduct,
       widget.panelId,

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_square/knowledge_panel_indicator.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_square/knowledge_panel_indicator.dart
@@ -2,27 +2,22 @@ import 'package:flutter/material.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_square/knowledge_panel_evaluation_extension.dart';
 import 'package:smooth_app/themes/smooth_theme_colors.dart';
+import 'package:smooth_app/widgets/smooth_circle.dart';
 
 class KnowledgePanelIndicator extends StatelessWidget {
-  const KnowledgePanelIndicator({
-    required this.evaluation,
-    required this.themeExtension,
-    super.key,
-  });
+  const KnowledgePanelIndicator({required this.evaluation, super.key});
 
   final Evaluation? evaluation;
-  final SmoothColorsThemeExtension themeExtension;
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox.square(
-      dimension: 20.0,
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          shape: BoxShape.circle,
-          color: evaluation.indicatorColor(themeExtension),
-        ),
-      ),
+    final SmoothColorsThemeExtension themeExtension = context
+        .extension<SmoothColorsThemeExtension>();
+
+    return SmoothCircle(
+      padding: EdgeInsetsDirectional.zero,
+      color: evaluation.indicatorColor(themeExtension),
+      child: const SizedBox.square(dimension: 25.0),
     );
   }
 }

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_square/knowledge_panel_square_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_square/knowledge_panel_square_card.dart
@@ -1,26 +1,25 @@
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_square/knowledge_panel_square_item.dart';
-import 'package:smooth_app/themes/smooth_theme_colors.dart';
 
 class KnowledgePanelSquareCard extends StatelessWidget {
-  const KnowledgePanelSquareCard({required this.panels, required this.product});
+  const KnowledgePanelSquareCard({
+    required this.panels,
+    required this.panelsIds,
+    required this.product,
+    super.key,
+  });
 
   final List<KnowledgePanel> panels;
+  final List<String>? panelsIds;
   final Product product;
 
   @override
   Widget build(BuildContext context) {
-    final SmoothColorsThemeExtension theme = context
-        .extension<SmoothColorsThemeExtension>();
     final int rowCount = (panels.length + 1) ~/ 2;
 
-    return ListView.builder(
-      shrinkWrap: true,
-      physics: const NeverScrollableScrollPhysics(),
-      itemCount: rowCount,
-      padding: EdgeInsetsDirectional.zero,
-      itemBuilder: (BuildContext context, int index) {
+    return Column(
+      children: List<Widget>.generate(rowCount, (int index) {
         final int firstIndex = index * 2;
         final int secondIndex = firstIndex + 1;
         return Column(
@@ -31,13 +30,13 @@ class KnowledgePanelSquareCard extends StatelessWidget {
                 children: <Widget>[
                   KnowledgePanelSquareItem(
                     panel: panels[firstIndex],
-                    theme: theme,
+                    panelId: panelsIds?[firstIndex],
                   ),
                   const VerticalDivider(thickness: 1.0),
                   if (secondIndex < panels.length)
                     KnowledgePanelSquareItem(
                       panel: panels[secondIndex],
-                      theme: theme,
+                      panelId: panelsIds?[secondIndex],
                     )
                   else
                     const Spacer(),
@@ -46,7 +45,7 @@ class KnowledgePanelSquareCard extends StatelessWidget {
             ),
           ],
         );
-      },
+      }),
     );
   }
 }

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_square/knowledge_panel_square_item.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_square/knowledge_panel_square_item.dart
@@ -1,75 +1,122 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:provider/provider.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_square/knowledge_panel_evaluation_extension.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_square/knowledge_panel_indicator.dart';
+import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_square/knowledge_panel_square_modal_sheet.dart';
+import 'package:smooth_app/l10n/app_localizations.dart';
+import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/resources/app_icons.dart' as icons;
 import 'package:smooth_app/themes/smooth_theme_colors.dart';
 
 class KnowledgePanelSquareItem extends StatelessWidget {
-  const KnowledgePanelSquareItem({required this.panel, required this.theme});
+  const KnowledgePanelSquareItem({
+    required this.panelId,
+    required this.panel,
+    super.key,
+  });
 
   final KnowledgePanel panel;
-  final SmoothColorsThemeExtension theme;
+  final String? panelId;
 
   @override
   Widget build(BuildContext context) {
-    final String title =
-        panel.titleElement?.valueString ??
-        panel.titleElement?.value?.toString() ??
-        '';
+    final SmoothColorsThemeExtension theme = context
+        .extension<SmoothColorsThemeExtension>();
+
+    final String title = panel.titleElement?.name ?? '';
+    final Color indicatorColor = panel.evaluation.indicatorColor(theme);
+
+    final String value = _reformatValue(
+      AppLocalizations.of(context),
+      panel.titleElement?.valueString ??
+          panel.titleElement?.value?.toString() ??
+          '',
+    );
 
     return Expanded(
-      child: Padding(
-        padding: const EdgeInsetsDirectional.symmetric(
-          horizontal: VERY_LARGE_SPACE,
-          vertical: MEDIUM_SPACE,
-        ),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            Row(
-              spacing: SMALL_SPACE,
-              children: <Widget>[
-                Flexible(
-                  child: Text(
-                    panel.titleElement?.name ?? '',
-                    style: const TextStyle(fontWeight: FontWeight.bold),
-                  ),
-                ),
-                icons.Chevron.horizontalDirectional(
+      child: InkWell(
+        onTap: panelId != null
+            ? () {
+                showKnowledgePanelSquareModalSheet(
                   context,
-                  size: 12.0,
-                  color: theme.greyDark,
-                ),
-              ],
-            ),
-            const SizedBox(height: SMALL_SPACE),
-            Expanded(
-              child: Row(
-                spacing: MEDIUM_SPACE,
-                crossAxisAlignment: CrossAxisAlignment.center,
+                  title: title,
+                  value: value,
+                  panelId: panelId!,
+                  product: context.read<Product>(),
+                  valueColor: indicatorColor,
+                );
+              }
+            : null,
+        child: Padding(
+          padding: const EdgeInsetsDirectional.symmetric(
+            horizontal: VERY_LARGE_SPACE,
+            vertical: MEDIUM_SPACE,
+          ),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Row(
+                spacing: SMALL_SPACE,
                 children: <Widget>[
-                  KnowledgePanelIndicator(
-                    evaluation: panel.evaluation,
-                    themeExtension: theme,
-                  ),
                   Flexible(
-                    child: Text(
-                      title,
-                      style: TextStyle(
-                        fontWeight: FontWeight.bold,
-                        color: panel.evaluation.indicatorColor(theme),
+                    child: Padding(
+                      padding: const EdgeInsetsDirectional.only(bottom: 3.0),
+                      child: Text(
+                        title,
+                        style: const TextStyle(
+                          fontWeight: FontWeight.bold,
+                          fontSize: 15.0,
+                        ),
                       ),
                     ),
                   ),
+                  icons.Chevron.horizontalDirectional(
+                    context,
+                    size: 12.0,
+                    color: theme.greyMedium,
+                  ),
                 ],
               ),
-            ),
-          ],
+              const SizedBox(height: SMALL_SPACE),
+              Expanded(
+                child: Row(
+                  spacing: MEDIUM_SPACE,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: <Widget>[
+                    KnowledgePanelIndicator(evaluation: panel.evaluation),
+                    Flexible(
+                      child: Text(
+                        value,
+                        style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                          fontSize: 16.5,
+                          color: indicatorColor,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
         ),
       ),
+    );
+  }
+
+  /// Reformat a percentage value string
+  String _reformatValue(AppLocalizations appLocalizations, String value) {
+    final double? numValue = double.tryParse(value.split('%').first);
+    if (numValue == null) {
+      return value;
+    }
+
+    return appLocalizations.percent_value(
+      NumberFormat('#.##', ProductQuery.getLocaleString()).format(numValue),
     );
   }
 }

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_square/knowledge_panel_square_modal_sheet.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_square/knowledge_panel_square_modal_sheet.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/generic_lib/bottom_sheets/smooth_autosize_bottom_sheet.dart';
+import 'package:smooth_app/generic_lib/bottom_sheets/smooth_bottom_sheet.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_expanded_card.dart';
+
+Future<void> showKnowledgePanelSquareModalSheet(
+  BuildContext context, {
+  required String panelId,
+  required String title,
+  required String value,
+  required Color valueColor,
+  required Product product,
+}) async {
+  showSmoothAutoSizeModalSheet(
+    context: context,
+    header: SmoothModalSheetHeader(
+      title: '$title ($value)',
+      prefix: SmoothModalSheetHeaderPrefixIndicator(
+        color: valueColor,
+        size: const Size.square(20.0),
+      ),
+      suffix: const SmoothModalSheetHeaderCloseButton(),
+    ),
+    bodyBuilder: (BuildContext context) {
+      return Padding(
+        padding: const EdgeInsetsDirectional.symmetric(
+          horizontal: MEDIUM_SPACE,
+        ),
+        child: DefaultTextStyle.merge(
+          style: const TextStyle(fontSize: 15.0, height: 1.5),
+          child: KnowledgePanelExpandedCard(
+            panelId: panelId,
+            product: product,
+            isInitiallyExpanded: true,
+            isClickable: true,
+            roundedIcons: false,
+            simplified: false,
+          ),
+        ),
+      );
+    },
+  );
+}

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels_builder.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels_builder.dart
@@ -331,6 +331,7 @@ class KnowledgePanelsBuilder {
           if (squarePanels.isNotEmpty) {
             return KnowledgePanelSquareCard(
               panels: squarePanels,
+              panelsIds: element.panelGroupElement?.panelIds,
               product: product,
             );
           }
@@ -413,6 +414,7 @@ class KnowledgePanelsBuilder {
             if (squarePanels.isNotEmpty) {
               return KnowledgePanelSquareCard(
                 panels: squarePanels,
+                panelsIds: element.panelGroupElement?.panelIds,
                 product: product,
               );
             }
@@ -451,6 +453,7 @@ class KnowledgePanelsBuilder {
               if (squarePanels.isNotEmpty) {
                 return KnowledgePanelSquareCard(
                   panels: squarePanels,
+                  panelsIds: element.panelGroupElement?.panelIds,
                   product: product,
                 );
               }

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -4585,13 +4585,13 @@
     }
   },
   "product_page_for_me_attributes_order_importance": "Importance",
-    "@product_page_for_me_attributes_order_importance": {
+  "@product_page_for_me_attributes_order_importance": {
     "description": "Button to order the attributes by importance in the For me tab on the product page"
-    },
-    "product_page_for_me_attributes_order_evaluation": "Matches",
-    "@product_page_for_me_attributes_order_evaluation": {
+  },
+  "product_page_for_me_attributes_order_evaluation": "Matches",
+  "@product_page_for_me_attributes_order_evaluation": {
     "description": "Button to order the attributes by evaluation score in the For me tab on the product page"
-    },
+  },
   "product_page_for_me_attributes_group_good_matches": "Good matches",
   "@product_page_for_me_attributes_group_good_matches": {
     "description": "Title for the group of attributes that are good matches for the user"
@@ -5724,5 +5724,14 @@
   "homepage_list_last_scanned_title": "Last scanned products",
   "@homepage_list_last_scanned_title": {
     "description": "Title for the last scanned products horizontal list on the homepage"
+  },
+  "percent_value": "{percent}%",
+  "@percent_value": {
+    "description": "A percentage value (you may insert a space before the % sign if needed)",
+    "placeholders": {
+      "percent": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/packages/smooth_app/lib/l10n/app_localizations.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations.dart
@@ -10767,6 +10767,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Last scanned products'**
   String get homepage_list_last_scanned_title;
+
+  /// A percentage value (you may insert a space before the % sign if needed)
+  ///
+  /// In en, this message translates to:
+  /// **'{percent}%'**
+  String percent_value(String percent);
 }
 
 class _AppLocalizationsDelegate

--- a/packages/smooth_app/lib/main.dart
+++ b/packages/smooth_app/lib/main.dart
@@ -40,6 +40,7 @@ import 'package:smooth_app/themes/contrast_provider.dart';
 import 'package:smooth_app/themes/smooth_theme.dart';
 import 'package:smooth_app/themes/theme_provider.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
+import 'package:smooth_app/widgets/smooth_view_padding.dart';
 
 void main() {
   debugPrint('--------');
@@ -276,26 +277,28 @@ class _SmoothAppState extends State<SmoothApp> {
       (UserPreferences up) => up.appLanguageCode,
     );
 
-    return SentryScreenshotWidget(
-      child: MaterialApp.router(
-        locale: languageCode != null ? Locale(languageCode) : null,
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        debugShowCheckedModeBanner: !(kReleaseMode || _screenshots),
-        theme: SmoothTheme.getThemeData(
-          Brightness.light,
-          themeProvider,
-          () => context.watch<ColorProvider>(),
-          () => context.watch<TextContrastProvider>(),
+    return SmoothViewPadding(
+      child: SentryScreenshotWidget(
+        child: MaterialApp.router(
+          locale: languageCode != null ? Locale(languageCode) : null,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          debugShowCheckedModeBanner: !(kReleaseMode || _screenshots),
+          theme: SmoothTheme.getThemeData(
+            Brightness.light,
+            themeProvider,
+            () => context.watch<ColorProvider>(),
+            () => context.watch<TextContrastProvider>(),
+          ),
+          darkTheme: SmoothTheme.getThemeData(
+            Brightness.dark,
+            themeProvider,
+            () => context.watch<ColorProvider>(),
+            () => context.watch<TextContrastProvider>(),
+          ),
+          themeMode: themeProvider.currentThemeMode,
+          routerConfig: AppNavigator.of(context).router,
         ),
-        darkTheme: SmoothTheme.getThemeData(
-          Brightness.dark,
-          themeProvider,
-          () => context.watch<ColorProvider>(),
-          () => context.watch<TextContrastProvider>(),
-        ),
-        themeMode: themeProvider.currentThemeMode,
-        routerConfig: AppNavigator.of(context).router,
       ),
     );
   }

--- a/packages/smooth_app/lib/widgets/smooth_view_padding.dart
+++ b/packages/smooth_app/lib/widgets/smooth_view_padding.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/widgets.dart';
+import 'package:provider/provider.dart';
+import 'package:provider/single_child_widget.dart';
+
+/// Object to inject at the root of the application to ensure we always
+/// have the correct view padding available.
+class SmoothViewPadding extends SingleChildStatelessWidget {
+  const SmoothViewPadding({required Widget super.child, super.key});
+
+  @override
+  Widget buildWithChild(BuildContext context, Widget? child) {
+    return Provider<_ViewPadding>.value(
+      value: _ViewPadding.fromEdgeInsets(MediaQuery.of(context).viewPadding),
+      child: child,
+    );
+  }
+
+  static EdgeInsets of(BuildContext context) {
+    return Provider.of<_ViewPadding>(context, listen: false);
+  }
+}
+
+class _ViewPadding extends EdgeInsets {
+  _ViewPadding.fromEdgeInsets(EdgeInsets edgeInsets)
+    : super.only(
+        left: edgeInsets.left,
+        top: edgeInsets.top,
+        right: edgeInsets.right,
+        bottom: edgeInsets.bottom,
+      );
+}


### PR DESCRIPTION
Hi everyone!

This PR improves the UI of square panels to better align with the initial design:
<img width="2768" height="1546" alt="1" src="https://github.com/user-attachments/assets/978920bd-e74e-4bd7-b827-f6b663ad2b15" />


Some noticable changes:
- Each item is now clickable VS the whole row.
- We reformat values (the server may not format them correctly = `1.5% => 1,5% in French`)

And finally, instead of showing a page for the details, I experiment a bottom sheet:
<img width="4138" height="5825" alt="2" src="https://github.com/user-attachments/assets/29168fe6-3357-42ca-a5ec-bbfd6ff28200" />
