### PR TITLE
fix: disable swipe to allow pinch zoom on Photos page

### DIFF
--- a/packages/smooth_app/lib/pages/product/product_image_swipeable_view.dart
+++ b/packages/smooth_app/lib/pages/product/product_image_swipeable_view.dart
@@ -108,19 +108,20 @@ class _ProductImageSwipeableViewState extends State<ProductImageSwipeableView>
       body: PageView.builder(
         onPageChanged: (int index) => _currentImageDataIndex.value = index,
         controller: _controller,
+        physics: NeverScrollableScrollPhysics(), // <- ADD THIS LINE
         itemCount: _imageFields.length,
         itemBuilder: (BuildContext context, int index) => ProductImageViewer(
-          product: upToDateProduct,
-          imageField: _imageFields[index],
-          isInitialImageViewed: widget.initialImageIndex == index,
-          language: _currentLanguage,
-          setLanguage: (final OpenFoodFactsLanguage? newLanguage) async {
-            if (newLanguage == null || newLanguage == _currentLanguage) {
-              return;
-            }
-            setState(() => _currentLanguage = newLanguage);
-          },
-          isLoggedInMandatory: widget.isLoggedInMandatory,
+        product: upToDateProduct,
+        imageField: _imageFields[index],
+        isInitialImageViewed: widget.initialImageIndex == index,
+        language: _currentLanguage,
+        setLanguage: (final OpenFoodFactsLanguage? newLanguage) async {
+          if (newLanguage == null || newLanguage == _currentLanguage) {
+            return;
+          }
+          setState(() => _currentLanguage = newLanguage);
+        },
+        isLoggedInMandatory: widget.isLoggedInMandatory,
         ),
       ),
     );


### PR DESCRIPTION
This PR fixes the pinch zoom issue on the Photos page of the Open Food Facts Android app.

Changes:
- Added `physics: NeverScrollableScrollPhysics()` to `PageView.builder` in ProductImageSwipeableView.dart
- This temporarily disables horizontal swipe, so pinch zoom works properly on images

Related issue: #7349