### PR TITLE
fix: correct initial page number in _ProductImagePageIndicator

### DIFF
--- a/packages/smooth_app/lib/l10n/app_localizations.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations.dart
@@ -10393,7 +10393,7 @@ abstract class AppLocalizations {
   /// Title for price metrics tile
   ///
   /// In en, this message translates to:
-  /// **'Open Price metrics'**
+  /// **'Open Prices metrics'**
   String get preferences_prices_metrics_title;
 
   /// Subtitle for price metrics tile

--- a/packages/smooth_app/lib/pages/image/product_image_other_page.dart
+++ b/packages/smooth_app/lib/pages/image/product_image_other_page.dart
@@ -130,13 +130,17 @@ class ProductImageOtherPage extends StatefulWidget {
 }
 
 class _ProductImageOtherPageState extends State<ProductImageOtherPage> {
-  late PageController _pageController;
+  late final PageController _pageController;
+  late final ValueNotifier<int> _pageNotifier;
 
   @override
   void initState() {
     super.initState();
     _pageController = PageController(
       initialPage: widget.images.indexOf(widget.currentImage),
+    );
+    _pageNotifier = ValueNotifier<int>(
+      widget.images.indexOf(widget.currentImage),
     );
   }
 
@@ -159,32 +163,43 @@ class _ProductImageOtherPageState extends State<ProductImageOtherPage> {
             ),
           ],
         ),
-        body: Stack(
-          alignment: Alignment.bottomCenter,
-          children: <Widget>[
-            Positioned.fill(
-              child: PageView(
-                controller: _pageController,
-                children: widget.images
-                    .map((final ProductImage image) {
-                      return _ProductImageViewer(
-                        image: image,
-                        barcode: widget.product.barcode!,
-                        language: widget.language,
-                        heroTag: widget.currentImage == image
-                            ? widget.heroTag
-                            : null,
-                        productType: widget.product.productType,
-                      );
-                    })
-                    .toList(growable: false),
-              ),
-            ),
-            Positioned(
-              top: SMALL_SPACE,
-              child: _ProductImagePageIndicator(items: widget.images.length),
-            ),
-          ],
+        body: ValueListenableBuilder<int>(
+          valueListenable: _pageNotifier,
+          builder: (_, int pageIndex, _) {
+            return Stack(
+              alignment: Alignment.bottomCenter,
+              children: <Widget>[
+                Positioned.fill(
+                  child: PageView(
+                    controller: _pageController,
+                    onPageChanged: (int value) {
+                      _pageNotifier.value = value;
+                    },
+                    children: widget.images
+                        .map((final ProductImage image) {
+                          return _ProductImageViewer(
+                            image: image,
+                            barcode: widget.product.barcode!,
+                            language: widget.language,
+                            heroTag: widget.currentImage == image
+                                ? widget.heroTag
+                                : null,
+                            productType: widget.product.productType,
+                          );
+                        })
+                        .toList(growable: false),
+                  ),
+                ),
+                Positioned(
+                  top: SMALL_SPACE,
+                  child: _ProductImagePageIndicator(
+                    items: widget.images.length,
+                    initialPageIndex: pageIndex,
+                  ),
+                ),
+              ],
+            );
+          },
         ),
       ),
     );
@@ -443,9 +458,13 @@ class _ProductImageDetailsButton extends StatelessWidget {
 }
 
 class _ProductImagePageIndicator extends StatelessWidget {
-  const _ProductImagePageIndicator({required this.items});
+  const _ProductImagePageIndicator({
+    required this.items,
+    required this.initialPageIndex,
+  });
 
   final int items;
+  final int initialPageIndex;
 
   @override
   Widget build(BuildContext context) {
@@ -478,7 +497,7 @@ class _ProductImagePageIndicator extends StatelessWidget {
           shouldRebuild: (int previous, int next) => previous != next,
           builder: (BuildContext context, int progress, _) {
             return Text(
-              '${progress + 1} / $items',
+              '${initialPageIndex + 1} / $items',
               style: const TextStyle(
                 color: Colors.white,
                 fontWeight: FontWeight.w600,


### PR DESCRIPTION
### What

Fixes the _ProductImagePageIndicator so that the initial page number matches the selected image when opening the product photo.

### Screen recording

![qemu-system-x86_64_6iDwSrp0Td](https://github.com/user-attachments/assets/e32d57fe-278b-42c0-bd84-ca042385e089)

### Fixes bug(s)

- Fixes: #7391 

