### PR TITLE
fix: 7373 - Initialize counters on app bar statistics card load

### DIFF
--- a/packages/smooth_app/devtools_options.yaml
+++ b/packages/smooth_app/devtools_options.yaml
@@ -1,3 +1,4 @@
 description: This file stores settings for Dart & Flutter DevTools.
 documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
 extensions:
+  - provider: true

--- a/packages/smooth_app/lib/generic_lib/widgets/app_bars/logged_in/statistics_cards/app_bar_statistics_card.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/app_bars/logged_in/statistics_cards/app_bar_statistics_card.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:intl/intl.dart';
@@ -39,6 +40,12 @@ class AppBarStatisticsCard extends StatefulWidget {
 
 class _AppBarStatisticsCardState extends State<AppBarStatisticsCard> {
   bool _loading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_asyncLoad());
+  }
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
Ensure statistics counters are loaded when the AppBarStatisticsCard is first created, addressing the issue where counters may not be initialized properly after login.

## ⚠️ Acceptance Requirements
**This Pull Request will only be accepted if:**
- ✅ It is linked to an issue (using linking keywords like `Fixes`, `Closes`, or `Resolves`)
- ✅ The linked issue is assigned to the author of this PR

---

### What
<!-- description of the PR -->
 - Added an initState method to _AppBarStatisticsCardState that calls _asyncLoad() when the widget is first initialized 
<!-- 
Please name your pull request following this scheme: `type: What you did` this allows us to automatically generate the changelog
Following `type`s are allowed:
  - `feat`, for Features
  - `fix`, for Bug Fixes
  - `docs`, for Documentation
  - `ci`, for Automation
  - `refactor`, for code Refactoring
  - `chore`, for Miscellaneous things
-->

### Screenshot or video
<!-- Insert a screenshot or a video to provide visual record of your changes (if visible) -->

https://github.com/user-attachments/assets/ebcd6773-02e1-4ec2-a257-f32ff2e913ff


### Fixes bug(s)
<!-- change by appropriate issues. -->
<!-- Please use a linking keyword https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- Fixes:   #7373  

### Part of 
- #525 <!-- Add the most granular issue possible -->