### PR TITLE
fix: Resolve PinchToZoomExplainer being hidden behind "Add a Price" floating button

### DIFF
--- a/packages/smooth_app/lib/pages/prices/price_proof_page.dart
+++ b/packages/smooth_app/lib/pages/prices/price_proof_page.dart
@@ -132,7 +132,7 @@ class _PriceProofPageState extends State<PriceProofPage> {
                     ),
                     child: _PriceProofCounter(count: widget.proof.priceCount),
                   ),
-                  const Spacer(),
+                  const SizedBox(width: SMALL_SPACE),
                   Offstage(
                     offstage: !_imageLoaded,
                     child: const _PriceProofChildContainer(


### PR DESCRIPTION
### What

- Adjusted layout to prevent `Add a Price` FAB from overlapping `PinchToZoomExplainer`
- Ensured `PinchToZoomExplainer` is fully visible and clickable

### Screenshot or video
![photo_2026-02-13 03 00 00](https://github.com/user-attachments/assets/d81f0145-8412-43cf-8584-457eedb06db8)


### Fixes bug(s)
- Fixes: #7413