### PR TITLE
fix: Add uriHelper parameter to all Robotoff API calls (#6624)

### DIFF
--- a/packages/smooth_app/lib/background/background_task_hunger_games.dart
+++ b/packages/smooth_app/lib/background/background_task_hunger_games.dart
@@ -127,6 +127,7 @@ class BackgroundTaskHungerGames extends BackgroundTaskBarcode {
       annotation,
       deviceId: OpenFoodAPIConfiguration.uuid,
       user: ProductQuery.getReadUser(),
+      uriHelper: ProductQuery.uriRobotoffHelper,
     );
   }
 }

--- a/packages/smooth_app/lib/pages/hunger_games/congrats.dart
+++ b/packages/smooth_app/lib/pages/hunger_games/congrats.dart
@@ -154,6 +154,7 @@ class CongratsWidget extends StatelessWidget {
         annotation.value,
         deviceId: OpenFoodAPIConfiguration.uuid,
         user: ProductQuery.getReadUser(),
+        uriHelper: ProductQuery.uriRobotoffHelper,
       );
 
       results.add(status.status == 1);

--- a/packages/smooth_app/lib/pages/product/nutrition_page/widgets/nutrition_container_helper.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page/widgets/nutrition_container_helper.dart
@@ -3,6 +3,7 @@ import 'package:flutter/foundation.dart';
 import 'package:intl/intl.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
+import 'package:smooth_app/query/product_query.dart';
 
 /// Nutrition data, for nutrient order and conversions.
 class NutritionContainerHelper extends ChangeNotifier {
@@ -96,7 +97,10 @@ class NutritionContainerHelper extends ChangeNotifier {
     notifyListeners();
 
     final RobotoffNutrientExtractionResult extractionResult =
-        await RobotoffAPIClient.getNutrientExtraction(product.barcode!);
+        await RobotoffAPIClient.getNutrientExtraction( 
+      product.barcode!,
+      uriHelper: ProductQuery.uriRobotoffHelper,
+    );
 
     final bool extractionSuccessful = extractionResult.status == 'found';
 

--- a/packages/smooth_app/lib/pages/product/nutrition_page/widgets/nutrition_container_helper.dart
+++ b/packages/smooth_app/lib/pages/product/nutrition_page/widgets/nutrition_container_helper.dart
@@ -97,10 +97,10 @@ class NutritionContainerHelper extends ChangeNotifier {
     notifyListeners();
 
     final RobotoffNutrientExtractionResult extractionResult =
-        await RobotoffAPIClient.getNutrientExtraction( 
-      product.barcode!,
-      uriHelper: ProductQuery.uriRobotoffHelper,
-    );
+        await RobotoffAPIClient.getNutrientExtraction(
+          product.barcode!,
+          uriHelper: ProductQuery.uriRobotoffHelper,
+        );
 
     final bool extractionSuccessful = extractionResult.status == 'found';
 

--- a/packages/smooth_app/lib/pages/product/simple_input/simple_input_page_helpers.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input/simple_input_page_helpers.dart
@@ -347,6 +347,7 @@ abstract class AbstractSimpleInputPageHelper extends ChangeNotifier {
             product.barcode!,
             getLanguage(),
             insightTypes: <InsightType>[type],
+            uriHelper: ProductQuery.uriRobotoffHelper,
           )).questions ??
           <RobotoffQuestion>[];
 

--- a/packages/smooth_app/lib/query/product_query.dart
+++ b/packages/smooth_app/lib/query/product_query.dart
@@ -208,11 +208,11 @@ abstract class ProductQuery {
     );
     uriRobotoffHelper =
         userPreferences.getFlag(
-                  UserPreferencesDevMode.userPreferencesFlagProd,
-                ) ??
-                true
-            ? uriHelperRobotoffProd
-            : uriHelperRobotoffTest;
+              UserPreferencesDevMode.userPreferencesFlagProd,
+            ) ??
+            true
+        ? uriHelperRobotoffProd
+        : uriHelperRobotoffTest;
   }
 
   /// Returns the standard test env, or the custom test env if relevant.

--- a/packages/smooth_app/lib/query/product_query.dart
+++ b/packages/smooth_app/lib/query/product_query.dart
@@ -181,6 +181,9 @@ abstract class ProductQuery {
   /// Product helper only for Folksonomy.
   static late UriHelper uriFolksonomyHelper;
 
+  /// Helper only for Robotoff.
+  static late UriHelper uriRobotoffHelper;
+
   static bool isLoggedIn() => OpenFoodAPIConfiguration.globalUser != null;
 
   /// Sets the query type according to the current [UserPreferences]
@@ -203,6 +206,13 @@ abstract class ProductQuery {
           ) ??
           uriHelperFolksonomyProd.host,
     );
+    uriRobotoffHelper =
+        userPreferences.getFlag(
+                  UserPreferencesDevMode.userPreferencesFlagProd,
+                ) ??
+                true
+            ? uriHelperRobotoffProd
+            : uriHelperRobotoffTest;
   }
 
   /// Returns the standard test env, or the custom test env if relevant.

--- a/packages/smooth_app/lib/query/product_questions_query.dart
+++ b/packages/smooth_app/lib/query/product_questions_query.dart
@@ -21,6 +21,7 @@ class ProductQuestionsQuery extends QuestionsQuery {
           barcode,
           ProductQuery.getLanguage(),
           count: count,
+          uriHelper: ProductQuery.uriRobotoffHelper,
         );
     if (result.questions?.isNotEmpty != true) {
       return <RobotoffQuestion>[];

--- a/packages/smooth_app/lib/query/random_questions_query.dart
+++ b/packages/smooth_app/lib/query/random_questions_query.dart
@@ -19,6 +19,7 @@ class RandomQuestionsQuery extends QuestionsQuery {
       count: count,
       questionOrder: RobotoffQuestionOrder.popularity,
       serverType: ServerType.openFoodFacts,
+      uriHelper: ProductQuery.uriRobotoffHelper,
     );
 
     if (result.questions?.isNotEmpty != true) {


### PR DESCRIPTION
## Fix: Add uriHelper parameter to all Robotoff API calls

Fixes #6624

### Problem
All Robotoff API calls were using the default PROD environment because the `uriHelper` parameter was never passed, making TEST environment usage impossible.

### Solution
Added `uriHelper: ProductQuery.uriRobotoffHelper` to all Robotoff API client calls to respect environment configuration, matching the pattern already used for Prices API.

### Files Modified
- `congrats.dart`
- `simple_input_page_helpers.dart`
- `background_task_hunger_games.dart`
- `product_questions_query.dart`
- `product_query.dart`
- `random_questions_query.dart`
- `nutrition_container_helper.dart`

