### PR TITLE
fix: infinite scroll not triggering after first page in Prices (#6815)

### DIFF
--- a/packages/smooth_app/lib/pages/prices/infinite_scroll_list.dart
+++ b/packages/smooth_app/lib/pages/prices/infinite_scroll_list.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/empty_screen_layout.dart';
-import 'package:smooth_app/generic_lib/widgets/smooth_snackbar.dart';
+
 import 'package:smooth_app/l10n/app_localizations.dart';
 import 'package:smooth_app/pages/prices/infinite_scroll_manager.dart';
 import 'package:smooth_app/pages/product/query_results_banner.dart';
@@ -25,6 +25,7 @@ class _InfiniteScrollListState<T> extends State<InfiniteScrollList<T>> {
   late final ScrollController _scrollController;
   Object? _error;
   bool _isInitialLoading = false;
+  bool _isLoadingMore = false;
 
   @override
   void initState() {
@@ -61,31 +62,31 @@ class _InfiniteScrollListState<T> extends State<InfiniteScrollList<T>> {
   }
 
   void _scrollListener() {
-    if (!widget.manager.canLoadMore()) {
+    if (_isLoadingMore || !widget.manager.canLoadMore()) {
       return;
     }
 
     final double maxScroll = _scrollController.position.maxScrollExtent;
     final double currentScroll = _scrollController.position.pixels;
 
-    if (currentScroll > maxScroll - _loadMoreTriggerOffset) {
+    if (currentScroll >= maxScroll - _loadMoreTriggerOffset) {
       unawaited(_loadMoreItems());
     }
   }
 
   Future<void> _loadMoreItems() async {
-    if (!mounted) {
+    if (_isLoadingMore || !mounted) {
       return;
     }
-    setState(() {});
+    setState(() => _isLoadingMore = true);
     await widget.manager.loadMore(context);
     if (!mounted) {
       return;
     }
-    setState(() {});
-    ScaffoldMessenger.of(context).showSnackBar(
-      SmoothFloatingSnackbar(content: Text(_getItemCount(context))),
-    );
+    setState(() => _isLoadingMore = false);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _scrollListener();
+    });
   }
 
   String _getItemCount(BuildContext context) =>


### PR DESCRIPTION
## What

This PR improves the reliability of the infinite scroll behavior in `InfiniteScrollList`.

### Changes made

- Added a private `_isLoadingMore` flag to prevent multiple concurrent `loadMore()` calls triggered by rapid scroll events.
- Updated the scroll trigger condition from `>` to `>=` to ensure pagination reliably triggers when reaching the threshold.
- Added a `postFrameCallback` after `loadMore()` completes to re-check the scroll position once the new items are rendered. This ensures continuous loading if the user remains near the bottom.
- Removed the `SnackBar` feedback after loading more items to avoid UI interference and unnecessary rebuild side effects.
- Cleaned up unused imports related to the removed snackbar.

---

## Problem addressed

### Previously

- Multiple `loadMore()` calls could be triggered before the previous one completed.
- Pagination could stop if the scroll position was not recalculated correctly after new items were added.
- Users sometimes needed to scroll up slightly before additional items would load again.
- A snackbar was shown on each load, which could interfere with scrolling behavior.

### After this change

- Only one pagination request can run at a time.
- Infinite scrolling continues smoothly while the user remains near the bottom.
- No manual upward scroll is required to trigger further loads.
- UI behavior is cleaner and more stable.
