### PR TITLE
fix: infinite scroll not triggering after first page in Prices (#6815)

### DIFF
--- a/packages/smooth_app/lib/pages/prices/infinite_scroll_list.dart
+++ b/packages/smooth_app/lib/pages/prices/infinite_scroll_list.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/empty_screen_layout.dart';
-
 import 'package:smooth_app/l10n/app_localizations.dart';
 import 'package:smooth_app/pages/prices/infinite_scroll_manager.dart';
 import 'package:smooth_app/pages/product/query_results_banner.dart';
@@ -26,6 +25,7 @@ class _InfiniteScrollListState<T> extends State<InfiniteScrollList<T>> {
   Object? _error;
   bool _isInitialLoading = false;
   bool _isLoadingMore = false;
+
   @override
   void initState() {
     super.initState();
@@ -84,8 +84,9 @@ class _InfiniteScrollListState<T> extends State<InfiniteScrollList<T>> {
     }
     setState(() => _isLoadingMore = false);
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) 
-       _scrollListener();
+      if (mounted) {
+        _scrollListener();
+      }
     });
   }
 

--- a/packages/smooth_app/lib/pages/prices/infinite_scroll_list.dart
+++ b/packages/smooth_app/lib/pages/prices/infinite_scroll_list.dart
@@ -84,7 +84,8 @@ class _InfiniteScrollListState<T> extends State<InfiniteScrollList<T>> {
     }
     setState(() => _isLoadingMore = false);
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) _scrollListener();
+      if (mounted) 
+      _scrollListener();
     });
   }
 

--- a/packages/smooth_app/lib/pages/prices/infinite_scroll_list.dart
+++ b/packages/smooth_app/lib/pages/prices/infinite_scroll_list.dart
@@ -84,8 +84,7 @@ class _InfiniteScrollListState<T> extends State<InfiniteScrollList<T>> {
     }
     setState(() => _isLoadingMore = false);
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) 
-      _scrollListener();
+      if (mounted) _scrollListener();
     });
   }
 

--- a/packages/smooth_app/lib/pages/prices/infinite_scroll_list.dart
+++ b/packages/smooth_app/lib/pages/prices/infinite_scroll_list.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/empty_screen_layout.dart';
-import 'package:smooth_app/generic_lib/widgets/smooth_snackbar.dart';
+
 import 'package:smooth_app/l10n/app_localizations.dart';
 import 'package:smooth_app/pages/prices/infinite_scroll_manager.dart';
 import 'package:smooth_app/pages/product/query_results_banner.dart';
@@ -25,7 +25,7 @@ class _InfiniteScrollListState<T> extends State<InfiniteScrollList<T>> {
   late final ScrollController _scrollController;
   Object? _error;
   bool _isInitialLoading = false;
-
+  bool _isLoadingMore = false;
   @override
   void initState() {
     super.initState();
@@ -61,31 +61,31 @@ class _InfiniteScrollListState<T> extends State<InfiniteScrollList<T>> {
   }
 
   void _scrollListener() {
-    if (!widget.manager.canLoadMore()) {
+    if (_isLoadingMore || !widget.manager.canLoadMore()) {
       return;
     }
 
     final double maxScroll = _scrollController.position.maxScrollExtent;
     final double currentScroll = _scrollController.position.pixels;
 
-    if (currentScroll > maxScroll - _loadMoreTriggerOffset) {
+    if (currentScroll >= maxScroll - _loadMoreTriggerOffset) {
       unawaited(_loadMoreItems());
     }
   }
 
   Future<void> _loadMoreItems() async {
-    if (!mounted) {
+    if (_isLoadingMore || !mounted) {
       return;
     }
-    setState(() {});
+    setState(() => _isLoadingMore = true);
     await widget.manager.loadMore(context);
     if (!mounted) {
       return;
     }
-    setState(() {});
-    ScaffoldMessenger.of(context).showSnackBar(
-      SmoothFloatingSnackbar(content: Text(_getItemCount(context))),
-    );
+    setState(() => _isLoadingMore = false);
+     WidgetsBinding.instance.addPostFrameCallback((_) {
+    if (mounted) _scrollListener();
+  });
   }
 
   String _getItemCount(BuildContext context) =>

--- a/packages/smooth_app/lib/pages/prices/infinite_scroll_list.dart
+++ b/packages/smooth_app/lib/pages/prices/infinite_scroll_list.dart
@@ -84,7 +84,8 @@ class _InfiniteScrollListState<T> extends State<InfiniteScrollList<T>> {
     }
     setState(() => _isLoadingMore = false);
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) _scrollListener();
+      if (mounted) 
+       _scrollListener();
     });
   }
 

--- a/packages/smooth_app/lib/pages/prices/infinite_scroll_list.dart
+++ b/packages/smooth_app/lib/pages/prices/infinite_scroll_list.dart
@@ -83,9 +83,9 @@ class _InfiniteScrollListState<T> extends State<InfiniteScrollList<T>> {
       return;
     }
     setState(() => _isLoadingMore = false);
-     WidgetsBinding.instance.addPostFrameCallback((_) {
-    if (mounted) _scrollListener();
-  });
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _scrollListener();
+    });
   }
 
   String _getItemCount(BuildContext context) =>


### PR DESCRIPTION
##  What

Fixes an issue where the price list stopped loading after the first page.
Users had to scroll up before being able to scroll down again to trigger additional pagination.

##  Root Cause

After loading more items, the scroll listener was not re-evaluated.
If the user remained near the bottom of the list, the scroll position did not change,
so the next page was never triggered.

##  Fix

- After `loadMore` completes, trigger a `postFrameCallback`
- Re-run the scroll listener once the UI is rebuilt
- Ensure pagination continues automatically while the user stays near the bottom

This allows smooth, continuous infinite scrolling without requiring any manual upward scroll.

##  Manual Testing

1. Open "My Prices"
2. Scroll to the bottom
3. Verify the next page loads automatically
4. Stay at the bottom — additional pages continue loading
5. Confirm loading stops when all items are fetched

Closes #6815