### PR TITLE
docs: align Flutter version references with flutter-version.txt

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,13 +7,13 @@ This is a comprehensive Flutter mobile application for Open Food Facts, supporti
 ## Essential Setup and Environment
 
 ### Flutter Version Management
-- **CRITICAL**: This app requires Flutter version **3.35.1** exactly (as specified in `flutter-version.txt`)
+- **CRITICAL**: This app requires Flutter version **3.38.5** exactly (as specified in `flutter-version.txt`)
 - **ALWAYS** use FVM (Flutter Version Management) for consistent Flutter versions:
   ```bash
   # Install FVM first: https://fvm.app/documentation/getting-started/installation
-  fvm install 3.35.1
-  fvm use 3.35.1
-  fvm flutter --version  # Should show Flutter 3.35.1
+  fvm install 3.38.5
+  fvm use 3.38.5
+  fvm flutter --version  # Should show Flutter 3.38.5
   ```
 - Export Flutter to PATH: `export PATH="$(fvm flutter sdk-path)/bin:$PATH"`
 
@@ -149,7 +149,7 @@ If you encounter build issues:
 - `.github/workflows/` - GitHub Actions CI/CD pipeline
 
 ### Important Files
-- `flutter-version.txt` - Specifies required Flutter version (3.35.1)
+- `flutter-version.txt` - Specifies required Flutter version (3.38.5)
 - `packages/smooth_app/pubspec.yaml` - Main app dependencies
 - `packages/smooth_app/lib/entrypoints/` - Platform-specific entry points
 - `packages/smooth_app/integration_test/` - End-to-end test scenarios

--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ Full list of features on the wiki: https://wiki.openfoodfacts.org/Mobile_App/Fea
 ## 🚀 How to run the project
 - Make sure you have installed Flutter and all the requirements
   - [Official Flutter installation guide](https://docs.flutter.dev/get-started/install)
-- Currently, the app uses the following version of Flutter: **3.38**.
+- Currently, the app uses the following version of Flutter: **3.38.5**.
  - **Setting Up Your Environment with FVM**
    - To manage Flutter versions easily, download and install **FVM (Flutter Version Management)**:
      - Install FVM by following the [official FVM installation guide](https://fvm.app/documentation/getting-started/installation).
-     - Once FVM is installed, run the following commands to set Flutter to version 3.35.1:
+     - Once FVM is installed, run the following commands to set Flutter to version 3.38.5:
        ```bash
        fvm install 3.38.5
        fvm use 3.38.5


### PR DESCRIPTION
## Summary
This PR updates stale Flutter version references so docs match `flutter-version.txt` and contributor setup works out of the box.

### Changes
- `README.md`
  - `3.38` -> `3.38.5`
  - setup sentence now says to set Flutter to `3.38.5`
- `.github/copilot-instructions.md`
  - all `3.35.1` references updated to `3.38.5`

- Fixes #7320.
