### PR TITLE
fix: recent bug introduced about price adding

### DIFF
--- a/packages/smooth_app/lib/background/background_task_price.dart
+++ b/packages/smooth_app/lib/background/background_task_price.dart
@@ -62,7 +62,7 @@ abstract class BackgroundTaskPrice extends BackgroundTask {
         json[_jsonTagDiscountTypes],
         json.containsKey(_jsonTagBarcode)
             ? 1
-            : (json[_jsonTagBarcodes] as List<String>).length,
+            : (json[_jsonTagBarcodes] as List<dynamic>).length,
       ),
       super.fromJson();
 
@@ -153,7 +153,7 @@ abstract class BackgroundTaskPrice extends BackgroundTask {
 
   /// Normalizes discount types list to match the expected length (barcodes)
   static List<String> _normalizeDiscountTypes(
-    final List<String?>? input,
+    final List<dynamic>? input,
     final int expectedLength,
   ) {
     final List<String> result = List<String>.filled(expectedLength, '');


### PR DESCRIPTION
### What
JSON deserialization returns `List<dynamic>`, not `List<String>`. The incorrect cast caused to silently prevented prices from being uploaded. This was introduced in PR #7408 

### Fixes issue
- #7429 

### What
Changed `as List<String>` to `as List<dynamic>` in `BackgroundTaskPrice.fromJson` for the barcodes list cast used in `_normalizeDiscountTypes`.
