### PR TITLE
fix: Compress and retry image upload on 413 error

### DIFF
--- a/packages/smooth_app/lib/background/background_task_image.dart
+++ b/packages/smooth_app/lib/background/background_task_image.dart
@@ -333,9 +333,7 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
       crop: getDownsizedRect(cropX1, cropY1, cropX2, cropY2),
       rotation: CropRotationExtension.fromDegrees(rotationDegrees)!,
       image: full,
-      maxSize: maxDimension != null
-          ? Size(maxDimension.toDouble(), maxDimension.toDouble())
-          : null,
+      maxSize: maxDimension?.toDouble(),
       quality: FilterQuality.high,
       overlayPainter: overlayPainter,
     );

--- a/packages/smooth_app/lib/background/background_task_image.dart
+++ b/packages/smooth_app/lib/background/background_task_image.dart
@@ -437,7 +437,6 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
       }
       if (status.status == 'status ok') {
         // successfully uploaded a new picture and set it as field+language
-        // successfully uploaded a new picture and set it as field+language
         return;
       }
       final int? imageId = status.imageId;

--- a/packages/smooth_app/lib/background/background_task_image.dart
+++ b/packages/smooth_app/lib/background/background_task_image.dart
@@ -434,6 +434,7 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
       }
       if (status.status == statusOk) {
         // successfully uploaded a new picture and set it as field+language
+        // successfully uploaded a new picture and set it as field+language
         return;
       }
       final int? imageId = status.imageId;

--- a/packages/smooth_app/lib/background/background_task_image.dart
+++ b/packages/smooth_app/lib/background/background_task_image.dart
@@ -250,6 +250,7 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
   /// Returns directly the original [fullPath] if no crop operation was needed.
   /// Returns the path of the cropped file if relevant.
   /// Returns null if the image (cropped or not) is too small.
+  /// [maxSize] is the max pixel size for width or height (e.g. 2000)
   static Future<BackgroundCropResult> cropIfNeeded({
     required final String fullPath,
     required final int rotationDegrees,
@@ -260,7 +261,7 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
     required final int compressQuality,
     required final bool forceCompression,
     required final List<double>? eraserCoordinates,
-    final int? maxDimension, // max pixel size for width or height (e.g. 2000)
+    final int? maxSize,
   }) async {
     final String croppedPath = await getCroppedPath(fullPath);
 
@@ -333,7 +334,7 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
       crop: getDownsizedRect(cropX1, cropY1, cropX2, cropY2),
       rotation: CropRotationExtension.fromDegrees(rotationDegrees)!,
       image: full,
-      maxSize: maxDimension?.toDouble(),
+      maxSize: maxSize?.toDouble(),
       quality: FilterQuality.high,
       overlayPainter: overlayPainter,
     );
@@ -379,17 +380,15 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
     );
     SendImage? image;
     BackgroundCropResult? cropResult;
-    const String statusOk = 'status ok';
-    const String statusNotOk = 'status not ok';
     try {
       final ImageField imageField = ImageField.fromOffTag(this.imageField)!;
       final OpenFoodFactsLanguage language = getLanguage();
       final User user = getUser();
 
-      Future<Status> addImage(
-        int compressionPct,
-        bool force, {
-        int? maxDimension,
+      Future<Status> addImage({
+        required int compressionPct,
+        required bool force,
+        int? maxSize,
       }) async {
         cropResult = await cropIfNeeded(
           fullPath: fullPath,
@@ -401,10 +400,11 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
           compressQuality: compressionPct,
           forceCompression: force,
           eraserCoordinates: eraserCoordinates,
-          maxDimension: maxDimension,
+          maxSize: maxSize,
         );
         final String? path = cropResult!.filePath;
         if (path == null) {
+          // TODO(monsieurtanuki): maybe something more refined when we dismiss the picture, like alerting the user, though it's not supposed to happen anymore from upstream.
           throw Exception('Could not get image path after compression');
         }
         image = SendImage(
@@ -422,23 +422,26 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
 
       Status status;
       try {
-        status = await addImage(100, false);
+        status = await addImage(compressionPct: 100, force: false);
       } catch (e) {
         if (e.toString().contains('413') ||
             e.toString().contains('Request Entity Too Large')) {
-          // Retry with 80% JPEG quality and max 2000px dimension as agreed
-          status = await addImage(80, true, maxDimension: 2000);
+          status = await addImage(
+            compressionPct: 80,
+            force: true,
+            maxSize: 2000,
+          );
         } else {
           rethrow;
         }
       }
-      if (status.status == statusOk) {
+      if (status.status == 'status ok') {
         // successfully uploaded a new picture and set it as field+language
         // successfully uploaded a new picture and set it as field+language
         return;
       }
       final int? imageId = status.imageId;
-      if (status.status == statusNotOk && imageId != null) {
+      if (status.status == 'status not ok' && imageId != null) {
         // The very same image was already uploaded and therefore was rejected.
         // We just have to select this image, with no angle.
         final String? imageUrl = await OpenFoodAPIClient.setProductImageAngle(

--- a/packages/smooth_app/lib/background/background_task_image.dart
+++ b/packages/smooth_app/lib/background/background_task_image.dart
@@ -378,75 +378,69 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
     );
     SendImage? image;
     BackgroundCropResult? cropResult;
+    const String statusOk = 'status ok';
+    const String statusNotOk = 'status not ok';
     try {
-      cropResult = await cropIfNeeded(
-        fullPath: fullPath,
-        rotationDegrees: rotationDegrees,
-        cropX1: cropX1,
-        cropY1: cropY1,
-        cropX2: cropX2,
-        cropY2: cropY2,
-        compressQuality: 100,
-        forceCompression: false,
-        eraserCoordinates: eraserCoordinates,
-      );
-      final String? path = cropResult.filePath;
-      if (path == null) {
-        // TODO(monsieurtanuki): maybe something more refined when we dismiss the picture, like alerting the user, though it's not supposed to happen anymore from upstream.
-        return;
-      }
       final ImageField imageField = ImageField.fromOffTag(this.imageField)!;
       final OpenFoodFactsLanguage language = getLanguage();
       final User user = getUser();
-      image = SendImage(
-        lang: language,
-        barcode: barcode,
-        imageField: imageField,
-        imageUri: Uri.parse(path),
-      );
-
-      Status status = await OpenFoodAPIClient.addProductImage(
-        user,
-        image,
-        uriHelper: uriProductHelper,
-      );
-      if (status.status == 'status ok') {
-        return;
-      }
-
-      if (status.error?.contains('413') == true ||
-          status.error?.contains('Request Entity Too Large') == true) {
-        final BackgroundCropResult compressedResult = await cropIfNeeded(
+      
+      // Local method to avoid code duplication
+      Future<Status> addImage(int compressionPct, bool force) async {
+        cropResult = await cropIfNeeded(
           fullPath: fullPath,
           rotationDegrees: rotationDegrees,
           cropX1: cropX1,
           cropY1: cropY1,
           cropX2: cropX2,
           cropY2: cropY2,
-          compressQuality: 80, // was 100
-          forceCompression: true, // forces re-crop even if no crop needed
+          compressQuality: compressionPct,
+          forceCompression: force,
           eraserCoordinates: eraserCoordinates,
+         );
+        final String? path = cropResult!.filePath;
+        if (path == null) {
+          throw Exception('Could not get image path after compression');
+        }
+        image = SendImage(
+          lang: language,
+          barcode: barcode,
+          imageField: imageField,
+          imageUri: Uri.parse(path),
         );
-        final String? compressedPath = compressedResult.filePath;
-        if (compressedPath != null) {
-          image = SendImage(
-            lang: language,
-            barcode: barcode,
-            imageField: imageField,
-            imageUri: Uri.parse(compressedPath),
-          );
-          status = await OpenFoodAPIClient.addProductImage(
-            user,
-            image,
-            uriHelper: uriProductHelper,
-          );
-          if (status.status == 'status ok') {
-            return;
-          }
+        return OpenFoodAPIClient.addProductImage(
+          user,
+          image!,
+          uriHelper: uriProductHelper,
+        );
+      }
+
+      Status status;
+       try {
+         status = await addImage(100, false);
+      } catch (e) {
+        if (e.toString().contains('413') ||
+            e.toString().contains('Request Entity Too Large')) {
+          status = await addImage(80, true);
+        } else {
+          rethrow;
+        }
+      }
+      if (status.status == statusOk) {
+        return;
+      }
+
+      if (status.error?.contains('413') == true ||
+          status.error?.contains('Request Entity Too Large') == true) {
+        status = await addImage(80, true);
+        if (status.status == statusOk) {
+          return;
         }
       }
       final int? imageId = status.imageId;
-      if (status.status == 'status not ok' && imageId != null) {
+      if (status.status == statusNotOk && imageId != null) {
+        // The very same image was already uploaded and therefore was rejected.
+        // We just have to select this image, with no angle.
         final String? imageUrl = await OpenFoodAPIClient.setProductImageAngle(
           barcode: barcode,
           imageField: imageField,

--- a/packages/smooth_app/lib/background/background_task_image.dart
+++ b/packages/smooth_app/lib/background/background_task_image.dart
@@ -260,6 +260,7 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
     required final int compressQuality,
     required final bool forceCompression,
     required final List<double>? eraserCoordinates,
+    final int? maxDimension, // max pixel size for width or height (e.g. 2000)
   }) async {
     final String croppedPath = await getCroppedPath(fullPath);
 
@@ -332,7 +333,9 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
       crop: getDownsizedRect(cropX1, cropY1, cropX2, cropY2),
       rotation: CropRotationExtension.fromDegrees(rotationDegrees)!,
       image: full,
-      maxSize: null,
+      maxSize: maxDimension != null
+          ? Size(maxDimension.toDouble(), maxDimension.toDouble())
+          : null,
       quality: FilterQuality.high,
       overlayPainter: overlayPainter,
     );
@@ -385,8 +388,11 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
       final OpenFoodFactsLanguage language = getLanguage();
       final User user = getUser();
 
-      // Local method to avoid code duplication
-      Future<Status> addImage(int compressionPct, bool force) async {
+      Future<Status> addImage(
+        int compressionPct,
+        bool force, {
+        int? maxDimension,
+      }) async {
         cropResult = await cropIfNeeded(
           fullPath: fullPath,
           rotationDegrees: rotationDegrees,
@@ -397,6 +403,7 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
           compressQuality: compressionPct,
           forceCompression: force,
           eraserCoordinates: eraserCoordinates,
+          maxDimension: maxDimension,
         );
         final String? path = cropResult!.filePath;
         if (path == null) {
@@ -421,21 +428,15 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
       } catch (e) {
         if (e.toString().contains('413') ||
             e.toString().contains('Request Entity Too Large')) {
-          status = await addImage(80, true);
+            // Retry with 80% JPEG quality and max 2000px dimension as agreed
+          status = await addImage(80, true, maxDimension: 2000);
         } else {
           rethrow;
         }
       }
       if (status.status == statusOk) {
+        // successfully uploaded a new picture and set it as field+language
         return;
-      }
-
-      if (status.error?.contains('413') == true ||
-          status.error?.contains('Request Entity Too Large') == true) {
-        status = await addImage(80, true);
-        if (status.status == statusOk) {
-          return;
-        }
       }
       final int? imageId = status.imageId;
       if (status.status == statusNotOk && imageId != null) {

--- a/packages/smooth_app/lib/background/background_task_image.dart
+++ b/packages/smooth_app/lib/background/background_task_image.dart
@@ -428,7 +428,7 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
       } catch (e) {
         if (e.toString().contains('413') ||
             e.toString().contains('Request Entity Too Large')) {
-            // Retry with 80% JPEG quality and max 2000px dimension as agreed
+          // Retry with 80% JPEG quality and max 2000px dimension as agreed
           status = await addImage(80, true, maxDimension: 2000);
         } else {
           rethrow;

--- a/packages/smooth_app/lib/background/background_task_image.dart
+++ b/packages/smooth_app/lib/background/background_task_image.dart
@@ -384,7 +384,7 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
       final ImageField imageField = ImageField.fromOffTag(this.imageField)!;
       final OpenFoodFactsLanguage language = getLanguage();
       final User user = getUser();
-      
+
       // Local method to avoid code duplication
       Future<Status> addImage(int compressionPct, bool force) async {
         cropResult = await cropIfNeeded(
@@ -397,7 +397,7 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
           compressQuality: compressionPct,
           forceCompression: force,
           eraserCoordinates: eraserCoordinates,
-         );
+        );
         final String? path = cropResult!.filePath;
         if (path == null) {
           throw Exception('Could not get image path after compression');
@@ -416,8 +416,8 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
       }
 
       Status status;
-       try {
-         status = await addImage(100, false);
+      try {
+        status = await addImage(100, false);
       } catch (e) {
         if (e.toString().contains('413') ||
             e.toString().contains('Request Entity Too Large')) {

--- a/packages/smooth_app/lib/background/background_task_image.dart
+++ b/packages/smooth_app/lib/background/background_task_image.dart
@@ -405,19 +405,48 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
         imageUri: Uri.parse(path),
       );
 
-      final Status status = await OpenFoodAPIClient.addProductImage(
+      Status status = await OpenFoodAPIClient.addProductImage(
         user,
         image,
         uriHelper: uriProductHelper,
       );
       if (status.status == 'status ok') {
-        // successfully uploaded a new picture and set it as field+language
         return;
+      }
+
+      if (status.error?.contains('413') == true ||
+          status.error?.contains('Request Entity Too Large') == true) {
+        final BackgroundCropResult compressedResult = await cropIfNeeded(
+          fullPath: fullPath,
+          rotationDegrees: rotationDegrees,
+          cropX1: cropX1,
+          cropY1: cropY1,
+          cropX2: cropX2,
+          cropY2: cropY2,
+          compressQuality: 80, // was 100
+          forceCompression: true, // forces re-crop even if no crop needed
+          eraserCoordinates: eraserCoordinates,
+        );
+        final String? compressedPath = compressedResult.filePath;
+        if (compressedPath != null) {
+          image = SendImage(
+            lang: language,
+            barcode: barcode,
+            imageField: imageField,
+            imageUri: Uri.parse(compressedPath),
+          );
+          status = await OpenFoodAPIClient.addProductImage(
+            user,
+            image,
+            uriHelper: uriProductHelper,
+          );
+          if (status.status == 'status ok') {
+            return;
+          }
+        }
       }
       final int? imageId = status.imageId;
       if (status.status == 'status not ok' && imageId != null) {
-        // The very same image was already uploaded and therefore was rejected.
-        // We just have to select this image, with no angle.
         final String? imageUrl = await OpenFoodAPIClient.setProductImageAngle(
           barcode: barcode,
           imageField: imageField,


### PR DESCRIPTION
Fixes #6874

## Problem
When uploading a large image (>20MB), the server (nginx) returns a 
413 Request Entity Too Large error, causing the upload to fail with 
an exception.

## Solution
On receiving a 413 error, the app now automatically retries the upload 
with a compressed version of the image (80% JPEG quality, forceCompression: true) 
using the existing `cropIfNeeded()` method.

## Flow
- Try normal upload
- If 413 → compress image → retry upload
- If success → done

## Changes
- `packages/smooth_app/lib/background/background_task_image.dart`
  - Changed `final Status` to `Status` (mutable)
  - Added 413 detection and compress-retry logic in `upload()`