### PR TITLE
fix: Spellchecker on Product Name field

### DIFF
--- a/packages/smooth_app/lib/pages/product/add_basic_details/add_basic_details_name.dart
+++ b/packages/smooth_app/lib/pages/product/add_basic_details/add_basic_details_name.dart
@@ -342,6 +342,7 @@ class _ProductNameInputWidgetState extends State<_ProductNameInputWidget> {
                     ),
                     allowEmojis: false,
                     maxLines: 1,
+                    spellCheckConfiguration: const SpellCheckConfiguration(),
                   ),
                 ),
                 const SizedBox(width: 2.0),


### PR DESCRIPTION
- Fixes: #5415\n\n### What\n- Enabled the spellchecker on the Product Name field.