### PR TITLE
fix: Initialize missing counters upon login

### DIFF
--- a/packages/smooth_app/lib/generic_lib/widgets/app_bars/logged_in/statistics_cards/app_bar_statistics_card.dart
+++ b/packages/smooth_app/lib/generic_lib/widgets/app_bars/logged_in/statistics_cards/app_bar_statistics_card.dart
@@ -41,6 +41,20 @@ class _AppBarStatisticsCardState extends State<AppBarStatisticsCard> {
   bool _loading = false;
 
   @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        final UserPreferences userPreferences = context.read<UserPreferences>();
+        final int? count = widget.lazyCounter.getLocalCount(userPreferences);
+        if (count == null) {
+          _asyncLoad();
+        }
+      }
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
     final SmoothColorsThemeExtension themeExtension = context
         .extension<SmoothColorsThemeExtension>();


### PR DESCRIPTION
- Fixes: #7373\n\n### What\n- Fetches the counter values immediately on connection if not cached.