### PR TITLE
fix: add view original image option in photo viewer details

### DIFF
--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -4301,10 +4301,14 @@
   "@photo_viewer_details_date_title": {
     "description": "Label for the uploaded date of a photo"
   },
-  "photo_viewer_details_url_title": "View original image",
-  "@photo_viewer_details_url_title": {
-    "description": "Label for the button to view the original full resolution image in browser"
-  },
+"photo_viewer_details_url_title": "URL",
+"@photo_viewer_details_url_title": {
+  "description": "Label for the link of a photo"
+},
+"photo_viewer_details_original_title": "View original image",
+"@photo_viewer_details_original_title": {
+  "description": "Label for the button to view the original full resolution image in browser"
+},
   "product_page_compatibility_score": "Compatible",
   "@product_page_compatibility_score": {
     "description": "Compatibility score on top of the product page. The sentence is \"100%\" Compatible"

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -4301,14 +4301,14 @@
   "@photo_viewer_details_date_title": {
     "description": "Label for the uploaded date of a photo"
   },
-"photo_viewer_details_url_title": "URL",
-"@photo_viewer_details_url_title": {
-  "description": "Label for the link of a photo"
-},
-"photo_viewer_details_original_title": "View original image",
-"@photo_viewer_details_original_title": {
-  "description": "Label for the button to view the original full resolution image in browser"
-},
+  "photo_viewer_details_url_title": "URL",
+  "@photo_viewer_details_url_title": {
+    "description": "Label for the link of a photo"
+  },
+  "photo_viewer_details_original_title": "View original image",
+  "@photo_viewer_details_original_title": {
+    "description": "Label for the button to view the original full resolution image in browser"
+  },
   "product_page_compatibility_score": "Compatible",
   "@product_page_compatibility_score": {
     "description": "Compatibility score on top of the product page. The sentence is \"100%\" Compatible"

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -4301,9 +4301,9 @@
   "@photo_viewer_details_date_title": {
     "description": "Label for the uploaded date of a photo"
   },
-  "photo_viewer_details_url_title": "URL",
+  "photo_viewer_details_url_title": "View original image",
   "@photo_viewer_details_url_title": {
-    "description": "Label for the link of a photo"
+    "description": "Label for the button to view the original full resolution image in browser"
   },
   "product_page_compatibility_score": "Compatible",
   "@product_page_compatibility_score": {

--- a/packages/smooth_app/lib/l10n/app_localizations.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations.dart
@@ -8774,6 +8774,12 @@ abstract class AppLocalizations {
   /// **'URL'**
   String get photo_viewer_details_url_title;
 
+  /// Label for the button to view the original full resolution image in browser
+  ///
+  /// In en, this message translates to:
+  /// **'View original image'**
+  String get photo_viewer_details_original_title;
+
   /// Compatibility score on top of the product page. The sentence is "100%" Compatible
   ///
   /// In en, this message translates to:

--- a/packages/smooth_app/lib/pages/image/product_image_other_page.dart
+++ b/packages/smooth_app/lib/pages/image/product_image_other_page.dart
@@ -241,6 +241,7 @@ class _ProductImageViewer extends StatelessWidget {
                     ),
                   ),
                 ),
+
                 fit: BoxFit.contain,
                 loadingBuilder:
                     (
@@ -432,10 +433,12 @@ class _ProductImageDetailsButton extends StatelessWidget {
         if (url.isNotEmpty)
           ModalSheetItem(
             title: appLocalizations.photo_viewer_details_url_title,
-            subTitle: url,
+            subTitle: url.replaceAll(RegExp(r'\.\d+\.jpg$'), '.jpg'),
             leading: const icons.ImageGallery(),
             trailing: const icons.ExternalLink(),
-            onTap: () => LaunchUrlHelper.launchURL(url),
+            onTap: () => LaunchUrlHelper.launchURL(
+              url.replaceAll(RegExp(r'\.\d+\.jpg$'), '.jpg'),
+            ),
           ),
       ],
     );

--- a/packages/smooth_app/lib/pages/image/product_image_other_page.dart
+++ b/packages/smooth_app/lib/pages/image/product_image_other_page.dart
@@ -394,57 +394,65 @@ class _ProductImageDetailsButton extends StatelessWidget {
     );
   }
 
-  Future<dynamic> _showDetails(
-    BuildContext context,
-    AppLocalizations appLocalizations,
-    String url,
-  ) {
-    return showSmoothListOfItemsModalSheet(
-      context: context,
-      title: appLocalizations.photo_viewer_details_title,
-      items: <ModalSheetItem>[
-        ModalSheetItem(
-          title: appLocalizations.photo_viewer_details_contributor_title,
-          subTitle: image.contributor ?? '-',
-          leading: const icons.Profile(),
-          trailing: image.contributor?.startsWith('org') == true
-              ? const OwnerFieldIcon()
-              : null,
-        ),
-        ModalSheetItem(
-          title: appLocalizations.photo_viewer_details_date_title,
-          subTitle: image.uploaded != null
-              ? MaterialLocalizations.of(
-                  context,
-                ).formatFullDate(image.uploaded!).firstLetterInUppercase()
-              : '-',
-          leading: const icons.Calendar(),
-        ),
-        ModalSheetItem(
-          title: appLocalizations.photo_viewer_details_size_title,
-          subTitle: image.width != null && image.height != null
-              ? appLocalizations.photo_viewer_details_size_value(
-                  image.width!,
-                  image.height!,
-                )
-              : '-',
-          leading: const icons.Move(),
-        ),
-        if (url.isNotEmpty)
-          ModalSheetItem(
-            title: appLocalizations.photo_viewer_details_url_title,
-            subTitle: url.replaceAll(RegExp(r'\.\d+\.jpg$'), '.jpg'),
-            leading: const icons.ImageGallery(),
-            trailing: const icons.ExternalLink(),
-            onTap: () => LaunchUrlHelper.launchURL(
-              url.replaceAll(RegExp(r'\.\d+\.jpg$'), '.jpg'),
-            ),
-          ),
-      ],
-    );
-  }
-}
+Future<dynamic> _showDetails(
+  BuildContext context,
+  AppLocalizations appLocalizations,
+  String url,
+) {
+  final String originalUrl =
+      url.replaceAll(RegExp(r'\.\d+\.jpg$'), '.jpg');
 
+  return showSmoothListOfItemsModalSheet(
+    context: context,
+    title: appLocalizations.photo_viewer_details_title,
+    items: <ModalSheetItem>[
+      ModalSheetItem(
+        title: appLocalizations.photo_viewer_details_contributor_title,
+        subTitle: image.contributor ?? '-',
+        leading: const icons.Profile(),
+        trailing: image.contributor?.startsWith('org') == true
+            ? const OwnerFieldIcon()
+            : null,
+      ),
+      ModalSheetItem(
+        title: appLocalizations.photo_viewer_details_date_title,
+        subTitle: image.uploaded != null
+            ? MaterialLocalizations.of(
+                context,
+              ).formatFullDate(image.uploaded!).firstLetterInUppercase()
+            : '-',
+        leading: const icons.Calendar(),
+      ),
+      ModalSheetItem(
+        title: appLocalizations.photo_viewer_details_size_title,
+        subTitle: image.width != null && image.height != null
+            ? appLocalizations.photo_viewer_details_size_value(
+                image.width!,
+                image.height!,
+              )
+            : '-',
+        leading: const icons.Move(),
+      ),
+      if (url.isNotEmpty)
+        ModalSheetItem(
+          title: appLocalizations.photo_viewer_details_url_title,
+          subTitle: url,
+          leading: const icons.ImageGallery(),
+          trailing: const icons.ExternalLink(),
+          onTap: () => LaunchUrlHelper.launchURL(url),
+        ),
+      if (url.isNotEmpty)
+        ModalSheetItem(
+          title: appLocalizations.photo_viewer_details_original_title,
+          subTitle: originalUrl,
+          leading: const icons.ImageGallery(),
+          trailing: const icons.ExternalLink(),
+          onTap: () => LaunchUrlHelper.launchURL(originalUrl),
+        ),
+    ],
+  );
+}
+}
 class _ProductImagePageIndicator extends StatelessWidget {
   const _ProductImagePageIndicator({required this.items});
 

--- a/packages/smooth_app/lib/pages/image/product_image_other_page.dart
+++ b/packages/smooth_app/lib/pages/image/product_image_other_page.dart
@@ -241,7 +241,6 @@ class _ProductImageViewer extends StatelessWidget {
                     ),
                   ),
                 ),
-
                 fit: BoxFit.contain,
                 loadingBuilder:
                     (
@@ -394,65 +393,51 @@ class _ProductImageDetailsButton extends StatelessWidget {
     );
   }
 
-Future<dynamic> _showDetails(
-  BuildContext context,
-  AppLocalizations appLocalizations,
-  String url,
-) {
-  final String originalUrl =
-      url.replaceAll(RegExp(r'\.\d+\.jpg$'), '.jpg');
+  Future<dynamic> _showDetails(
+    BuildContext context,
+    AppLocalizations appLocalizations,
+    String url,
+  ) {
+    final String originalUrl = image.getUrl(
+      barcode,
+      uriHelper: ProductQuery.getUriProductHelper(productType: productType),
+      imageSize: ImageSize.ORIGINAL,
+    );
 
-  return showSmoothListOfItemsModalSheet(
-    context: context,
-    title: appLocalizations.photo_viewer_details_title,
-    items: <ModalSheetItem>[
-      ModalSheetItem(
-        title: appLocalizations.photo_viewer_details_contributor_title,
-        subTitle: image.contributor ?? '-',
-        leading: const icons.Profile(),
-        trailing: image.contributor?.startsWith('org') == true
-            ? const OwnerFieldIcon()
-            : null,
-      ),
-      ModalSheetItem(
-        title: appLocalizations.photo_viewer_details_date_title,
-        subTitle: image.uploaded != null
-            ? MaterialLocalizations.of(
-                context,
-              ).formatFullDate(image.uploaded!).firstLetterInUppercase()
-            : '-',
-        leading: const icons.Calendar(),
-      ),
-      ModalSheetItem(
-        title: appLocalizations.photo_viewer_details_size_title,
-        subTitle: image.width != null && image.height != null
-            ? appLocalizations.photo_viewer_details_size_value(
-                image.width!,
-                image.height!,
-              )
-            : '-',
-        leading: const icons.Move(),
-      ),
-      if (url.isNotEmpty)
+    return showSmoothListOfItemsModalSheet(
+      context: context,
+      title: appLocalizations.photo_viewer_details_title,
+      items: <ModalSheetItem>[
         ModalSheetItem(
-          title: appLocalizations.photo_viewer_details_url_title,
-          subTitle: url,
-          leading: const icons.ImageGallery(),
-          trailing: const icons.ExternalLink(),
-          onTap: () => LaunchUrlHelper.launchURL(url),
+          title: appLocalizations.photo_viewer_details_contributor_title,
+          subTitle: image.contributor ?? '-',
+          leading: const icons.Profile(),
+          trailing: image.contributor?.startsWith('org') == true
+              ? const OwnerFieldIcon()
+              : null,
         ),
-      if (url.isNotEmpty)
         ModalSheetItem(
-          title: appLocalizations.photo_viewer_details_original_title,
-          subTitle: originalUrl,
-          leading: const icons.ImageGallery(),
-          trailing: const icons.ExternalLink(),
-          onTap: () => LaunchUrlHelper.launchURL(originalUrl),
+          title: appLocalizations.photo_viewer_details_date_title,
+          subTitle: image.uploaded != null
+              ? MaterialLocalizations.of(
+                  context,
+                ).formatFullDate(image.uploaded!).firstLetterInUppercase()
+              : '-',
+          leading: const icons.Calendar(),
         ),
-    ],
-  );
+        if (originalUrl.isNotEmpty)
+          ModalSheetItem(
+            title: appLocalizations.photo_viewer_details_original_title,
+            subTitle: originalUrl,
+            leading: const icons.ImageGallery(),
+            trailing: const icons.ExternalLink(),
+            onTap: () => LaunchUrlHelper.launchURL(originalUrl),
+          ),
+      ],
+    );
+  }
 }
-}
+
 class _ProductImagePageIndicator extends StatelessWidget {
   const _ProductImagePageIndicator({required this.items});
 


### PR DESCRIPTION
### What

- Added "View original image" item in the photo details bottom sheet (`_showDetails`)
- Opens full resolution `.jpg` in browser via existing `LaunchUrlHelper` (no new dependencies)
- Keeps `.400.jpg` compressed image as default in-app view (safe for low-end devices)
- Added localization string `photo_viewer_view_original_title` in `app_en.arb`
- Follows the same browser-based approach used in #7356 by @monsieurtanuki for consistency

### Screenshot or video

[
![WhatsApp Image 2026-03-18 at 23 54 21](https://github.com/user-attachments/assets/90b43317-33af-4001-999d-88c95fad2e0b)
](url)


<img width="1080" height="2400" alt="Screenshot_20260318-143918 Brave" src="https://github.com/user-attachments/assets/f1217716-6e18-48b6-a61e-61efca5ce831" />

### Fixes bug(s)

Fixes: #7347

### Part of

- #525