### PR TITLE
chore: upgrade to async 2.13.1

### DIFF
--- a/packages/scanner/ml_kit/pubspec.yaml
+++ b/packages/scanner/ml_kit/pubspec.yaml
@@ -10,12 +10,12 @@ dependencies:
   flutter:
     sdk: flutter
 
-  visibility_detector: 0.4.0+2
-  async: 2.13.0
+  visibility_detector: ^0.4.0+2
+  async: ^2.13.1
   provider: ^6.1.5+1
 
   mobile_scanner: 6.0.10
-  torch_light: 1.1.0
+  torch_light: ^1.1.0
 
   scanner_shared:
     path: ../shared

--- a/packages/scanner/shared/pubspec.yaml
+++ b/packages/scanner/shared/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_svg: ^2.2.3
-  visibility_detector: 0.4.0+2
+  visibility_detector: ^0.4.0+2
   provider: ^6.1.5+1
 
 dev_dependencies:

--- a/packages/scanner/zxing/pubspec.yaml
+++ b/packages/scanner/zxing/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  visibility_detector: 0.4.0+2
+  visibility_detector: ^0.4.0+2
   scanner_shared:
     path: ../shared
   qr_code_scanner: 1.0.1

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -89,10 +89,10 @@ packages:
     dependency: "direct main"
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.13.1"
   audioplayers:
     dependency: "direct main"
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
 
-  async: 2.13.0
+  async: 2.13.1
   go_router: 17.0.1
   barcode_widget: 2.0.4
   carousel_slider: 5.1.1


### PR DESCRIPTION
### What
Upgrade to `async` `2.13.1` that couldn't be managed by #7454.

### Fixes bug(s)
- Closes: #7454