### PR TITLE
feat: apply price card glow up to top locations and top products (#6846)

### DIFF
--- a/packages/smooth_app/lib/pages/prices/price_top_list_card.dart
+++ b/packages/smooth_app/lib/pages/prices/price_top_list_card.dart
@@ -22,8 +22,8 @@ class PriceTopListCard extends StatelessWidget {
       elevationColor: Colors.black26,
       margin: const EdgeInsetsDirectional.only(
         top: MEDIUM_SPACE,
-        start: 8.0,
-        end: 8.0,
+        start: SMALL_SPACE,
+        end: SMALL_SPACE,
       ),
       padding: EdgeInsets.zero,
       color: lightTheme ? null : extension.primaryUltraBlack,

--- a/packages/smooth_app/lib/pages/prices/price_top_list_card.dart
+++ b/packages/smooth_app/lib/pages/prices/price_top_list_card.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
+import 'package:smooth_app/themes/smooth_theme_colors.dart';
+import 'package:smooth_app/themes/theme_provider.dart';
+
+/// Shared card container for top-list items in the Prices experience.
+class PriceTopListCard extends StatelessWidget {
+  const PriceTopListCard({required this.child, this.onTap, super.key});
+
+  final Widget child;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final SmoothColorsThemeExtension extension = context
+        .extension<SmoothColorsThemeExtension>();
+    final bool lightTheme = context.lightTheme();
+
+    return SmoothCard(
+      elevation: 5.0,
+      elevationColor: Colors.black26,
+      margin: const EdgeInsetsDirectional.only(
+        top: MEDIUM_SPACE,
+        start: 8.0,
+        end: 8.0,
+      ),
+      padding: EdgeInsets.zero,
+      color: lightTheme ? null : extension.primaryUltraBlack,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: ROUNDED_BORDER_RADIUS,
+        child: Padding(
+          padding: const EdgeInsetsDirectional.all(SMALL_SPACE),
+          child: child,
+        ),
+      ),
+    );
+  }
+}

--- a/packages/smooth_app/lib/pages/prices/prices_locations_page.dart
+++ b/packages/smooth_app/lib/pages/prices/prices_locations_page.dart
@@ -4,7 +4,6 @@ import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_back_button.dart';
-import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/helpers/launch_url_helper.dart';
 import 'package:smooth_app/l10n/app_localizations.dart';
 import 'package:smooth_app/pages/prices/infinite_scroll_list.dart';
@@ -12,6 +11,7 @@ import 'package:smooth_app/pages/prices/infinite_scroll_manager.dart';
 import 'package:smooth_app/pages/prices/price_button.dart';
 import 'package:smooth_app/pages/prices/price_count_widget.dart';
 import 'package:smooth_app/pages/prices/price_location_widget.dart';
+import 'package:smooth_app/pages/prices/price_top_list_card.dart';
 import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
@@ -95,43 +95,56 @@ class _InfiniteScrollLocationManager extends InfiniteScrollManager<Location> {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final int priceCount = item.priceCount ?? 0;
 
-    return SmoothCard(
-      child: Wrap(
-        spacing: VERY_SMALL_SPACE,
+    return PriceTopListCard(
+      onTap: () async => PriceLocationWidget.showLocationPrices(
+        locationId: item.locationId,
+        context: context,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
           PriceLocationWidget(item),
-          PriceCountWidget(
-            count: priceCount,
-            onPressed: () async => PriceLocationWidget.showLocationPrices(
-              locationId: item.locationId,
-              context: context,
-            ),
-          ),
-          PriceButton(
-            onPressed: () {},
-            title: '${item.userCount}',
-            iconData: PriceButton.userIconData,
-            tooltip: item.userCount == null
-                ? null
-                : appLocalizations.prices_button_count_user(item.userCount!),
-          ),
-          PriceButton(
-            onPressed: () {},
-            title: '${item.productCount}',
-            iconData: PriceButton.productIconData,
-            tooltip: item.productCount == null
-                ? null
-                : appLocalizations.prices_button_count_product(
-                    item.productCount!,
-                  ),
-          ),
-          PriceButton(
-            onPressed: () {},
-            title: '${item.proofCount}',
-            iconData: PriceButton.proofIconData,
-            tooltip: item.proofCount == null
-                ? null
-                : appLocalizations.prices_button_count_proof(item.proofCount!),
+          Wrap(
+            spacing: VERY_SMALL_SPACE,
+            children: <Widget>[
+              PriceCountWidget(
+                count: priceCount,
+                onPressed: () async => PriceLocationWidget.showLocationPrices(
+                  locationId: item.locationId,
+                  context: context,
+                ),
+              ),
+              PriceButton(
+                onPressed: () {},
+                title: '${item.userCount}',
+                iconData: PriceButton.userIconData,
+                tooltip: item.userCount == null
+                    ? null
+                    : appLocalizations.prices_button_count_user(
+                        item.userCount!,
+                      ),
+              ),
+              PriceButton(
+                onPressed: () {},
+                title: '${item.productCount}',
+                iconData: PriceButton.productIconData,
+                tooltip: item.productCount == null
+                    ? null
+                    : appLocalizations.prices_button_count_product(
+                        item.productCount!,
+                      ),
+              ),
+              PriceButton(
+                onPressed: () {},
+                title: '${item.proofCount}',
+                iconData: PriceButton.proofIconData,
+                tooltip: item.proofCount == null
+                    ? null
+                    : appLocalizations.prices_button_count_proof(
+                        item.proofCount!,
+                      ),
+              ),
+            ],
           ),
         ],
       ),

--- a/packages/smooth_app/lib/pages/prices/prices_locations_page.dart
+++ b/packages/smooth_app/lib/pages/prices/prices_locations_page.dart
@@ -96,10 +96,6 @@ class _InfiniteScrollLocationManager extends InfiniteScrollManager<Location> {
     final int priceCount = item.priceCount ?? 0;
 
     return PriceTopListCard(
-      onTap: () async => PriceLocationWidget.showLocationPrices(
-        locationId: item.locationId,
-        context: context,
-      ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[

--- a/packages/smooth_app/lib/pages/prices/prices_products_page.dart
+++ b/packages/smooth_app/lib/pages/prices/prices_products_page.dart
@@ -3,7 +3,6 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_back_button.dart';
-import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/helpers/launch_url_helper.dart';
 import 'package:smooth_app/l10n/app_localizations.dart';
 import 'package:smooth_app/pages/prices/get_prices_model.dart';
@@ -11,6 +10,7 @@ import 'package:smooth_app/pages/prices/infinite_scroll_list.dart';
 import 'package:smooth_app/pages/prices/infinite_scroll_manager.dart';
 import 'package:smooth_app/pages/prices/price_meta_product.dart';
 import 'package:smooth_app/pages/prices/price_product_widget.dart';
+import 'package:smooth_app/pages/prices/price_top_list_card.dart';
 import 'package:smooth_app/pages/prices/prices_page.dart';
 import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/widgets/smooth_app_bar.dart';
@@ -99,20 +99,18 @@ class _InfiniteScrollProductManager
     required BuildContext context,
     required PriceProduct item,
   }) {
-    return SmoothCard(
-      child: InkWell(
-        onTap: () async => Navigator.of(context).push<void>(
-          MaterialPageRoute<void>(
-            builder: (BuildContext context) => PricesPage(
-              GetPricesModel.product(
-                product: PriceMetaProduct.priceProduct(item),
-                context: context,
-              ),
+    return PriceTopListCard(
+      onTap: () async => Navigator.of(context).push<void>(
+        MaterialPageRoute<void>(
+          builder: (BuildContext context) => PricesPage(
+            GetPricesModel.product(
+              product: PriceMetaProduct.priceProduct(item),
+              context: context,
             ),
           ),
         ),
-        child: PriceProductWidget(item),
       ),
+      child: PriceProductWidget(item),
     );
   }
 


### PR DESCRIPTION
## ⚠️ Acceptance Requirements
**This Pull Request will only be accepted if:**
- ✅ It is linked to an issue (using linking keywords like `Fixes`, `Closes`, or `Resolves`)
- ✅ The linked issue is assigned to the author of this PR

---

### What
Added a shared Prices top-list card container to reuse the updated price card look and feel.
Applied the shared container to Top Products items.
Applied the shared container to Top Locations items.
Kept existing behavior and actions (navigation, counters, and action buttons) intact.
Preserved product image placeholder behavior for items without images/barcodes.
### Screenshot or video
<!-- Insert a screenshot or a video to provide visual record of your changes (if visible) -->

### Fixes bug(s)
- Closes #6846

### Part of 
- #525 <!-- Add the most granular issue possible -->