### PR TITLE
chore: l10n_countries breaking change and renamed country name as "localizedName"

### DIFF
--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_action_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_action_card.dart
@@ -14,6 +14,7 @@ import 'package:smooth_app/pages/product/add_packaging_button.dart';
 import 'package:smooth_app/pages/product/add_simple_input_button.dart';
 import 'package:smooth_app/pages/product/edit_product/edit_product_page.dart';
 import 'package:smooth_app/pages/product/product_field_editor.dart';
+import 'package:smooth_app/pages/product/simple_input/simple_input_page_country_helper.dart';
 import 'package:smooth_app/pages/product/simple_input/simple_input_page_helpers.dart';
 import 'package:smooth_app/services/smooth_services.dart';
 

--- a/packages/smooth_app/lib/l10n/app_localizations.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations.dart
@@ -186,8 +186,7 @@ import 'app_localizations_zu.dart';
 /// be consistent with the languages listed in the AppLocalizations.supportedLocales
 /// property.
 abstract class AppLocalizations {
-  AppLocalizations(String locale)
-    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+  AppLocalizations(String locale) : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -195,8 +194,7 @@ abstract class AppLocalizations {
     return Localizations.of<AppLocalizations>(context, AppLocalizations)!;
   }
 
-  static const LocalizationsDelegate<AppLocalizations> delegate =
-      _AppLocalizationsDelegate();
+  static const LocalizationsDelegate<AppLocalizations> delegate = _AppLocalizationsDelegate();
 
   /// A list of this localizations delegate along with the default localizations
   /// delegates.
@@ -208,13 +206,12 @@ abstract class AppLocalizations {
   /// Additional delegates can be added by appending to this list in
   /// MaterialApp. This list does not have to be used at all if a custom list
   /// of delegates is preferred or required.
-  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
-      <LocalizationsDelegate<dynamic>>[
-        delegate,
-        GlobalMaterialLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-      ];
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates = <LocalizationsDelegate<dynamic>>[
+    delegate,
+    GlobalMaterialLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+  ];
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
@@ -345,7 +342,7 @@ abstract class AppLocalizations {
     Locale('yo'),
     Locale('zh'),
     Locale('zh', 'CN'),
-    Locale('zu'),
+    Locale('zu')
   ];
 
   /// No description provided for @app_name.
@@ -1978,12 +1975,7 @@ abstract class AppLocalizations {
   ///
   /// In en, this message translates to:
   /// **'The minimum size in pixels for picture upload is {expectedMinWidth}x{expectedMinHeight}. The current picture is {actualWidth}x{actualHeight}.'**
-  String crop_page_too_small_image_message(
-    int expectedMinWidth,
-    int expectedMinHeight,
-    int actualWidth,
-    int actualHeight,
-  );
+  String crop_page_too_small_image_message(int expectedMinWidth, int expectedMinHeight, int actualWidth, int actualHeight);
 
   /// Action being performed on the crop page
   ///
@@ -2997,10 +2989,7 @@ abstract class AppLocalizations {
   ///
   /// In en, this message translates to:
   /// **'Do you want to change the currency from {previousCurrency} to {possibleCurrency}?'**
-  String currency_auto_change_message(
-    String previousCurrency,
-    String possibleCurrency,
-  );
+  String currency_auto_change_message(String previousCurrency, String possibleCurrency);
 
   /// The label shown above a selector where the user can select their country (in the onboarding)
   ///
@@ -3300,35 +3289,19 @@ abstract class AppLocalizations {
   ///
   /// In en, this message translates to:
   /// **'OS: Android (SDK Int: {sdkInt} / Release: {release})\nModel: {model}\nProduct: {product}\nDevice: {device}\nBrand:{brand}'**
-  String contact_form_body_android(
-    int? sdkInt,
-    String? release,
-    String? model,
-    String? product,
-    String? device,
-    String? brand,
-  );
+  String contact_form_body_android(int? sdkInt, String? release, String? model, String? product, String? device, String? brand);
 
   /// Contact form content for iOS devices
   ///
   /// In en, this message translates to:
   /// **'OS: iOS ({version})\nModel: {model}\nLocalized model: {localizedModel}'**
-  String contact_form_body_ios(
-    String? version,
-    String? model,
-    String? localizedModel,
-  );
+  String contact_form_body_ios(String? version, String? model, String? localizedModel);
 
   /// Contact form content
   ///
   /// In en, this message translates to:
   /// **'{osContent}\nApp version:{appVersion}\nApp build number:{appBuildNumber}\nApp package name:{appPackageName}'**
-  String contact_form_body(
-    String osContent,
-    String appVersion,
-    String appBuildNumber,
-    String appPackageName,
-  );
+  String contact_form_body(String osContent, String appVersion, String appBuildNumber, String appPackageName);
 
   /// No description provided for @authorize_button_label.
   ///
@@ -5158,12 +5131,7 @@ abstract class AppLocalizations {
   ///
   /// In en, this message translates to:
   /// **'Price: {price} / Store: \"{location}\" / Published on {date} by \"{user}\"'**
-  String prices_entry_accessibility_label(
-    String price,
-    String location,
-    String date,
-    String user,
-  );
+  String prices_entry_accessibility_label(String price, String location, String date, String user);
 
   /// Button to open the proofs of a user
   ///
@@ -5451,10 +5419,7 @@ abstract class AppLocalizations {
   ///
   /// In en, this message translates to:
   /// **'Your current currency is **{currency}**. Would you like to change it to **{newCurrency}**?'**
-  String prices_currency_change_proposal_message(
-    String currency,
-    String newCurrency,
-  );
+  String prices_currency_change_proposal_message(String currency, String newCurrency);
 
   /// Button to approve the currency change
   ///
@@ -5622,11 +5587,7 @@ abstract class AppLocalizations {
   ///
   /// In en, this message translates to:
   /// **'Download {count} more products\nAlready downloaded {downloaded} out of {totalSize}.'**
-  String product_search_button_download_more(
-    int count,
-    int downloaded,
-    int totalSize,
-  );
+  String product_search_button_download_more(int count, int downloaded, int totalSize);
 
   /// This message will be displayed when a search is in progress.
   ///
@@ -5926,9 +5887,7 @@ abstract class AppLocalizations {
   ///
   /// In en, this message translates to:
   /// **'Do you want the product\'s default language to be set to ‘{language}’?'**
-  String add_basic_details_product_name_change_main_language_text(
-    String language,
-  );
+  String add_basic_details_product_name_change_main_language_text(String language);
 
   /// Title for the section with good examples
   ///
@@ -9402,9 +9361,7 @@ abstract class AppLocalizations {
   ///
   /// In en, this message translates to:
   /// **'A score can\'t be computed for a product of type \"{productType}\".'**
-  String product_page_for_me_compatibility_score_unsupported(
-    String productType,
-  );
+  String product_page_for_me_compatibility_score_unsupported(String productType);
 
   /// Button to order the attributes by importance in the For me tab on the product page
   ///
@@ -11009,8 +10966,7 @@ abstract class AppLocalizations {
   String percent_value(String percent);
 }
 
-class _AppLocalizationsDelegate
-    extends LocalizationsDelegate<AppLocalizations> {
+class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
   const _AppLocalizationsDelegate();
 
   @override
@@ -11019,420 +10975,164 @@ class _AppLocalizationsDelegate
   }
 
   @override
-  bool isSupported(Locale locale) => <String>[
-    'aa',
-    'af',
-    'ak',
-    'am',
-    'ar',
-    'as',
-    'az',
-    'be',
-    'bg',
-    'bm',
-    'bn',
-    'bo',
-    'br',
-    'bs',
-    'ca',
-    'ce',
-    'co',
-    'cs',
-    'cv',
-    'cy',
-    'da',
-    'de',
-    'el',
-    'en',
-    'eo',
-    'es',
-    'et',
-    'eu',
-    'fa',
-    'fi',
-    'fo',
-    'fr',
-    'ga',
-    'gd',
-    'gl',
-    'gu',
-    'ha',
-    'he',
-    'hi',
-    'hr',
-    'ht',
-    'hu',
-    'hy',
-    'id',
-    'ii',
-    'is',
-    'it',
-    'iu',
-    'ja',
-    'jv',
-    'ka',
-    'kk',
-    'km',
-    'kn',
-    'ko',
-    'ku',
-    'kw',
-    'ky',
-    'la',
-    'lb',
-    'lo',
-    'lt',
-    'lv',
-    'mg',
-    'mi',
-    'ml',
-    'mn',
-    'mr',
-    'ms',
-    'mt',
-    'my',
-    'nb',
-    'ne',
-    'nl',
-    'nn',
-    'no',
-    'nr',
-    'oc',
-    'or',
-    'pa',
-    'pl',
-    'pt',
-    'qu',
-    'rm',
-    'ro',
-    'ru',
-    'sa',
-    'sc',
-    'sd',
-    'sg',
-    'si',
-    'sk',
-    'sl',
-    'sn',
-    'so',
-    'sq',
-    'sr',
-    'ss',
-    'st',
-    'sv',
-    'sw',
-    'ta',
-    'te',
-    'tg',
-    'th',
-    'ti',
-    'tl',
-    'tn',
-    'tr',
-    'ts',
-    'tt',
-    'tw',
-    'ty',
-    'ug',
-    'uk',
-    'ur',
-    'uz',
-    've',
-    'vi',
-    'wa',
-    'wo',
-    'xh',
-    'yi',
-    'yo',
-    'zh',
-    'zu',
-  ].contains(locale.languageCode);
+  bool isSupported(Locale locale) => <String>['aa', 'af', 'ak', 'am', 'ar', 'as', 'az', 'be', 'bg', 'bm', 'bn', 'bo', 'br', 'bs', 'ca', 'ce', 'co', 'cs', 'cv', 'cy', 'da', 'de', 'el', 'en', 'eo', 'es', 'et', 'eu', 'fa', 'fi', 'fo', 'fr', 'ga', 'gd', 'gl', 'gu', 'ha', 'he', 'hi', 'hr', 'ht', 'hu', 'hy', 'id', 'ii', 'is', 'it', 'iu', 'ja', 'jv', 'ka', 'kk', 'km', 'kn', 'ko', 'ku', 'kw', 'ky', 'la', 'lb', 'lo', 'lt', 'lv', 'mg', 'mi', 'ml', 'mn', 'mr', 'ms', 'mt', 'my', 'nb', 'ne', 'nl', 'nn', 'no', 'nr', 'oc', 'or', 'pa', 'pl', 'pt', 'qu', 'rm', 'ro', 'ru', 'sa', 'sc', 'sd', 'sg', 'si', 'sk', 'sl', 'sn', 'so', 'sq', 'sr', 'ss', 'st', 'sv', 'sw', 'ta', 'te', 'tg', 'th', 'ti', 'tl', 'tn', 'tr', 'ts', 'tt', 'tw', 'ty', 'ug', 'uk', 'ur', 'uz', 've', 'vi', 'wa', 'wo', 'xh', 'yi', 'yo', 'zh', 'zu'].contains(locale.languageCode);
 
   @override
   bool shouldReload(_AppLocalizationsDelegate old) => false;
 }
 
 AppLocalizations lookupAppLocalizations(Locale locale) {
+
   // Lookup logic when language+country codes are specified.
   switch (locale.languageCode) {
-    case 'pt':
-      {
-        switch (locale.countryCode) {
-          case 'BR':
-            return AppLocalizationsPtBr();
-        }
-        break;
-      }
-    case 'zh':
-      {
-        switch (locale.countryCode) {
-          case 'CN':
-            return AppLocalizationsZhCn();
-        }
-        break;
-      }
+    case 'pt': {
+  switch (locale.countryCode) {
+    case 'BR': return AppLocalizationsPtBr();
+   }
+  break;
+   }
+    case 'zh': {
+  switch (locale.countryCode) {
+    case 'CN': return AppLocalizationsZhCn();
+   }
+  break;
+   }
   }
 
   // Lookup logic when only language code is specified.
   switch (locale.languageCode) {
-    case 'aa':
-      return AppLocalizationsAa();
-    case 'af':
-      return AppLocalizationsAf();
-    case 'ak':
-      return AppLocalizationsAk();
-    case 'am':
-      return AppLocalizationsAm();
-    case 'ar':
-      return AppLocalizationsAr();
-    case 'as':
-      return AppLocalizationsAs();
-    case 'az':
-      return AppLocalizationsAz();
-    case 'be':
-      return AppLocalizationsBe();
-    case 'bg':
-      return AppLocalizationsBg();
-    case 'bm':
-      return AppLocalizationsBm();
-    case 'bn':
-      return AppLocalizationsBn();
-    case 'bo':
-      return AppLocalizationsBo();
-    case 'br':
-      return AppLocalizationsBr();
-    case 'bs':
-      return AppLocalizationsBs();
-    case 'ca':
-      return AppLocalizationsCa();
-    case 'ce':
-      return AppLocalizationsCe();
-    case 'co':
-      return AppLocalizationsCo();
-    case 'cs':
-      return AppLocalizationsCs();
-    case 'cv':
-      return AppLocalizationsCv();
-    case 'cy':
-      return AppLocalizationsCy();
-    case 'da':
-      return AppLocalizationsDa();
-    case 'de':
-      return AppLocalizationsDe();
-    case 'el':
-      return AppLocalizationsEl();
-    case 'en':
-      return AppLocalizationsEn();
-    case 'eo':
-      return AppLocalizationsEo();
-    case 'es':
-      return AppLocalizationsEs();
-    case 'et':
-      return AppLocalizationsEt();
-    case 'eu':
-      return AppLocalizationsEu();
-    case 'fa':
-      return AppLocalizationsFa();
-    case 'fi':
-      return AppLocalizationsFi();
-    case 'fo':
-      return AppLocalizationsFo();
-    case 'fr':
-      return AppLocalizationsFr();
-    case 'ga':
-      return AppLocalizationsGa();
-    case 'gd':
-      return AppLocalizationsGd();
-    case 'gl':
-      return AppLocalizationsGl();
-    case 'gu':
-      return AppLocalizationsGu();
-    case 'ha':
-      return AppLocalizationsHa();
-    case 'he':
-      return AppLocalizationsHe();
-    case 'hi':
-      return AppLocalizationsHi();
-    case 'hr':
-      return AppLocalizationsHr();
-    case 'ht':
-      return AppLocalizationsHt();
-    case 'hu':
-      return AppLocalizationsHu();
-    case 'hy':
-      return AppLocalizationsHy();
-    case 'id':
-      return AppLocalizationsId();
-    case 'ii':
-      return AppLocalizationsIi();
-    case 'is':
-      return AppLocalizationsIs();
-    case 'it':
-      return AppLocalizationsIt();
-    case 'iu':
-      return AppLocalizationsIu();
-    case 'ja':
-      return AppLocalizationsJa();
-    case 'jv':
-      return AppLocalizationsJv();
-    case 'ka':
-      return AppLocalizationsKa();
-    case 'kk':
-      return AppLocalizationsKk();
-    case 'km':
-      return AppLocalizationsKm();
-    case 'kn':
-      return AppLocalizationsKn();
-    case 'ko':
-      return AppLocalizationsKo();
-    case 'ku':
-      return AppLocalizationsKu();
-    case 'kw':
-      return AppLocalizationsKw();
-    case 'ky':
-      return AppLocalizationsKy();
-    case 'la':
-      return AppLocalizationsLa();
-    case 'lb':
-      return AppLocalizationsLb();
-    case 'lo':
-      return AppLocalizationsLo();
-    case 'lt':
-      return AppLocalizationsLt();
-    case 'lv':
-      return AppLocalizationsLv();
-    case 'mg':
-      return AppLocalizationsMg();
-    case 'mi':
-      return AppLocalizationsMi();
-    case 'ml':
-      return AppLocalizationsMl();
-    case 'mn':
-      return AppLocalizationsMn();
-    case 'mr':
-      return AppLocalizationsMr();
-    case 'ms':
-      return AppLocalizationsMs();
-    case 'mt':
-      return AppLocalizationsMt();
-    case 'my':
-      return AppLocalizationsMy();
-    case 'nb':
-      return AppLocalizationsNb();
-    case 'ne':
-      return AppLocalizationsNe();
-    case 'nl':
-      return AppLocalizationsNl();
-    case 'nn':
-      return AppLocalizationsNn();
-    case 'no':
-      return AppLocalizationsNo();
-    case 'nr':
-      return AppLocalizationsNr();
-    case 'oc':
-      return AppLocalizationsOc();
-    case 'or':
-      return AppLocalizationsOr();
-    case 'pa':
-      return AppLocalizationsPa();
-    case 'pl':
-      return AppLocalizationsPl();
-    case 'pt':
-      return AppLocalizationsPt();
-    case 'qu':
-      return AppLocalizationsQu();
-    case 'rm':
-      return AppLocalizationsRm();
-    case 'ro':
-      return AppLocalizationsRo();
-    case 'ru':
-      return AppLocalizationsRu();
-    case 'sa':
-      return AppLocalizationsSa();
-    case 'sc':
-      return AppLocalizationsSc();
-    case 'sd':
-      return AppLocalizationsSd();
-    case 'sg':
-      return AppLocalizationsSg();
-    case 'si':
-      return AppLocalizationsSi();
-    case 'sk':
-      return AppLocalizationsSk();
-    case 'sl':
-      return AppLocalizationsSl();
-    case 'sn':
-      return AppLocalizationsSn();
-    case 'so':
-      return AppLocalizationsSo();
-    case 'sq':
-      return AppLocalizationsSq();
-    case 'sr':
-      return AppLocalizationsSr();
-    case 'ss':
-      return AppLocalizationsSs();
-    case 'st':
-      return AppLocalizationsSt();
-    case 'sv':
-      return AppLocalizationsSv();
-    case 'sw':
-      return AppLocalizationsSw();
-    case 'ta':
-      return AppLocalizationsTa();
-    case 'te':
-      return AppLocalizationsTe();
-    case 'tg':
-      return AppLocalizationsTg();
-    case 'th':
-      return AppLocalizationsTh();
-    case 'ti':
-      return AppLocalizationsTi();
-    case 'tl':
-      return AppLocalizationsTl();
-    case 'tn':
-      return AppLocalizationsTn();
-    case 'tr':
-      return AppLocalizationsTr();
-    case 'ts':
-      return AppLocalizationsTs();
-    case 'tt':
-      return AppLocalizationsTt();
-    case 'tw':
-      return AppLocalizationsTw();
-    case 'ty':
-      return AppLocalizationsTy();
-    case 'ug':
-      return AppLocalizationsUg();
-    case 'uk':
-      return AppLocalizationsUk();
-    case 'ur':
-      return AppLocalizationsUr();
-    case 'uz':
-      return AppLocalizationsUz();
-    case 've':
-      return AppLocalizationsVe();
-    case 'vi':
-      return AppLocalizationsVi();
-    case 'wa':
-      return AppLocalizationsWa();
-    case 'wo':
-      return AppLocalizationsWo();
-    case 'xh':
-      return AppLocalizationsXh();
-    case 'yi':
-      return AppLocalizationsYi();
-    case 'yo':
-      return AppLocalizationsYo();
-    case 'zh':
-      return AppLocalizationsZh();
-    case 'zu':
-      return AppLocalizationsZu();
+    case 'aa': return AppLocalizationsAa();
+    case 'af': return AppLocalizationsAf();
+    case 'ak': return AppLocalizationsAk();
+    case 'am': return AppLocalizationsAm();
+    case 'ar': return AppLocalizationsAr();
+    case 'as': return AppLocalizationsAs();
+    case 'az': return AppLocalizationsAz();
+    case 'be': return AppLocalizationsBe();
+    case 'bg': return AppLocalizationsBg();
+    case 'bm': return AppLocalizationsBm();
+    case 'bn': return AppLocalizationsBn();
+    case 'bo': return AppLocalizationsBo();
+    case 'br': return AppLocalizationsBr();
+    case 'bs': return AppLocalizationsBs();
+    case 'ca': return AppLocalizationsCa();
+    case 'ce': return AppLocalizationsCe();
+    case 'co': return AppLocalizationsCo();
+    case 'cs': return AppLocalizationsCs();
+    case 'cv': return AppLocalizationsCv();
+    case 'cy': return AppLocalizationsCy();
+    case 'da': return AppLocalizationsDa();
+    case 'de': return AppLocalizationsDe();
+    case 'el': return AppLocalizationsEl();
+    case 'en': return AppLocalizationsEn();
+    case 'eo': return AppLocalizationsEo();
+    case 'es': return AppLocalizationsEs();
+    case 'et': return AppLocalizationsEt();
+    case 'eu': return AppLocalizationsEu();
+    case 'fa': return AppLocalizationsFa();
+    case 'fi': return AppLocalizationsFi();
+    case 'fo': return AppLocalizationsFo();
+    case 'fr': return AppLocalizationsFr();
+    case 'ga': return AppLocalizationsGa();
+    case 'gd': return AppLocalizationsGd();
+    case 'gl': return AppLocalizationsGl();
+    case 'gu': return AppLocalizationsGu();
+    case 'ha': return AppLocalizationsHa();
+    case 'he': return AppLocalizationsHe();
+    case 'hi': return AppLocalizationsHi();
+    case 'hr': return AppLocalizationsHr();
+    case 'ht': return AppLocalizationsHt();
+    case 'hu': return AppLocalizationsHu();
+    case 'hy': return AppLocalizationsHy();
+    case 'id': return AppLocalizationsId();
+    case 'ii': return AppLocalizationsIi();
+    case 'is': return AppLocalizationsIs();
+    case 'it': return AppLocalizationsIt();
+    case 'iu': return AppLocalizationsIu();
+    case 'ja': return AppLocalizationsJa();
+    case 'jv': return AppLocalizationsJv();
+    case 'ka': return AppLocalizationsKa();
+    case 'kk': return AppLocalizationsKk();
+    case 'km': return AppLocalizationsKm();
+    case 'kn': return AppLocalizationsKn();
+    case 'ko': return AppLocalizationsKo();
+    case 'ku': return AppLocalizationsKu();
+    case 'kw': return AppLocalizationsKw();
+    case 'ky': return AppLocalizationsKy();
+    case 'la': return AppLocalizationsLa();
+    case 'lb': return AppLocalizationsLb();
+    case 'lo': return AppLocalizationsLo();
+    case 'lt': return AppLocalizationsLt();
+    case 'lv': return AppLocalizationsLv();
+    case 'mg': return AppLocalizationsMg();
+    case 'mi': return AppLocalizationsMi();
+    case 'ml': return AppLocalizationsMl();
+    case 'mn': return AppLocalizationsMn();
+    case 'mr': return AppLocalizationsMr();
+    case 'ms': return AppLocalizationsMs();
+    case 'mt': return AppLocalizationsMt();
+    case 'my': return AppLocalizationsMy();
+    case 'nb': return AppLocalizationsNb();
+    case 'ne': return AppLocalizationsNe();
+    case 'nl': return AppLocalizationsNl();
+    case 'nn': return AppLocalizationsNn();
+    case 'no': return AppLocalizationsNo();
+    case 'nr': return AppLocalizationsNr();
+    case 'oc': return AppLocalizationsOc();
+    case 'or': return AppLocalizationsOr();
+    case 'pa': return AppLocalizationsPa();
+    case 'pl': return AppLocalizationsPl();
+    case 'pt': return AppLocalizationsPt();
+    case 'qu': return AppLocalizationsQu();
+    case 'rm': return AppLocalizationsRm();
+    case 'ro': return AppLocalizationsRo();
+    case 'ru': return AppLocalizationsRu();
+    case 'sa': return AppLocalizationsSa();
+    case 'sc': return AppLocalizationsSc();
+    case 'sd': return AppLocalizationsSd();
+    case 'sg': return AppLocalizationsSg();
+    case 'si': return AppLocalizationsSi();
+    case 'sk': return AppLocalizationsSk();
+    case 'sl': return AppLocalizationsSl();
+    case 'sn': return AppLocalizationsSn();
+    case 'so': return AppLocalizationsSo();
+    case 'sq': return AppLocalizationsSq();
+    case 'sr': return AppLocalizationsSr();
+    case 'ss': return AppLocalizationsSs();
+    case 'st': return AppLocalizationsSt();
+    case 'sv': return AppLocalizationsSv();
+    case 'sw': return AppLocalizationsSw();
+    case 'ta': return AppLocalizationsTa();
+    case 'te': return AppLocalizationsTe();
+    case 'tg': return AppLocalizationsTg();
+    case 'th': return AppLocalizationsTh();
+    case 'ti': return AppLocalizationsTi();
+    case 'tl': return AppLocalizationsTl();
+    case 'tn': return AppLocalizationsTn();
+    case 'tr': return AppLocalizationsTr();
+    case 'ts': return AppLocalizationsTs();
+    case 'tt': return AppLocalizationsTt();
+    case 'tw': return AppLocalizationsTw();
+    case 'ty': return AppLocalizationsTy();
+    case 'ug': return AppLocalizationsUg();
+    case 'uk': return AppLocalizationsUk();
+    case 'ur': return AppLocalizationsUr();
+    case 'uz': return AppLocalizationsUz();
+    case 've': return AppLocalizationsVe();
+    case 'vi': return AppLocalizationsVi();
+    case 'wa': return AppLocalizationsWa();
+    case 'wo': return AppLocalizationsWo();
+    case 'xh': return AppLocalizationsXh();
+    case 'yi': return AppLocalizationsYi();
+    case 'yo': return AppLocalizationsYo();
+    case 'zh': return AppLocalizationsZh();
+    case 'zu': return AppLocalizationsZu();
   }
 
   throw FlutterError(
     'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
     'an issue with the localizations generation tool. Please file an issue '
     'on GitHub with a reproducible sample app and the gen-l10n configuration '
-    'that was used.',
+    'that was used.'
   );
 }

--- a/packages/smooth_app/lib/l10n/app_localizations.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations.dart
@@ -186,7 +186,8 @@ import 'app_localizations_zu.dart';
 /// be consistent with the languages listed in the AppLocalizations.supportedLocales
 /// property.
 abstract class AppLocalizations {
-  AppLocalizations(String locale) : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+  AppLocalizations(String locale)
+    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -194,7 +195,8 @@ abstract class AppLocalizations {
     return Localizations.of<AppLocalizations>(context, AppLocalizations)!;
   }
 
-  static const LocalizationsDelegate<AppLocalizations> delegate = _AppLocalizationsDelegate();
+  static const LocalizationsDelegate<AppLocalizations> delegate =
+      _AppLocalizationsDelegate();
 
   /// A list of this localizations delegate along with the default localizations
   /// delegates.
@@ -206,12 +208,13 @@ abstract class AppLocalizations {
   /// Additional delegates can be added by appending to this list in
   /// MaterialApp. This list does not have to be used at all if a custom list
   /// of delegates is preferred or required.
-  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates = <LocalizationsDelegate<dynamic>>[
-    delegate,
-    GlobalMaterialLocalizations.delegate,
-    GlobalCupertinoLocalizations.delegate,
-    GlobalWidgetsLocalizations.delegate,
-  ];
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
+      <LocalizationsDelegate<dynamic>>[
+        delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ];
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
@@ -342,7 +345,7 @@ abstract class AppLocalizations {
     Locale('yo'),
     Locale('zh'),
     Locale('zh', 'CN'),
-    Locale('zu')
+    Locale('zu'),
   ];
 
   /// No description provided for @app_name.
@@ -1975,7 +1978,12 @@ abstract class AppLocalizations {
   ///
   /// In en, this message translates to:
   /// **'The minimum size in pixels for picture upload is {expectedMinWidth}x{expectedMinHeight}. The current picture is {actualWidth}x{actualHeight}.'**
-  String crop_page_too_small_image_message(int expectedMinWidth, int expectedMinHeight, int actualWidth, int actualHeight);
+  String crop_page_too_small_image_message(
+    int expectedMinWidth,
+    int expectedMinHeight,
+    int actualWidth,
+    int actualHeight,
+  );
 
   /// Action being performed on the crop page
   ///
@@ -2989,7 +2997,10 @@ abstract class AppLocalizations {
   ///
   /// In en, this message translates to:
   /// **'Do you want to change the currency from {previousCurrency} to {possibleCurrency}?'**
-  String currency_auto_change_message(String previousCurrency, String possibleCurrency);
+  String currency_auto_change_message(
+    String previousCurrency,
+    String possibleCurrency,
+  );
 
   /// The label shown above a selector where the user can select their country (in the onboarding)
   ///
@@ -3289,19 +3300,35 @@ abstract class AppLocalizations {
   ///
   /// In en, this message translates to:
   /// **'OS: Android (SDK Int: {sdkInt} / Release: {release})\nModel: {model}\nProduct: {product}\nDevice: {device}\nBrand:{brand}'**
-  String contact_form_body_android(int? sdkInt, String? release, String? model, String? product, String? device, String? brand);
+  String contact_form_body_android(
+    int? sdkInt,
+    String? release,
+    String? model,
+    String? product,
+    String? device,
+    String? brand,
+  );
 
   /// Contact form content for iOS devices
   ///
   /// In en, this message translates to:
   /// **'OS: iOS ({version})\nModel: {model}\nLocalized model: {localizedModel}'**
-  String contact_form_body_ios(String? version, String? model, String? localizedModel);
+  String contact_form_body_ios(
+    String? version,
+    String? model,
+    String? localizedModel,
+  );
 
   /// Contact form content
   ///
   /// In en, this message translates to:
   /// **'{osContent}\nApp version:{appVersion}\nApp build number:{appBuildNumber}\nApp package name:{appPackageName}'**
-  String contact_form_body(String osContent, String appVersion, String appBuildNumber, String appPackageName);
+  String contact_form_body(
+    String osContent,
+    String appVersion,
+    String appBuildNumber,
+    String appPackageName,
+  );
 
   /// No description provided for @authorize_button_label.
   ///
@@ -5131,7 +5158,12 @@ abstract class AppLocalizations {
   ///
   /// In en, this message translates to:
   /// **'Price: {price} / Store: \"{location}\" / Published on {date} by \"{user}\"'**
-  String prices_entry_accessibility_label(String price, String location, String date, String user);
+  String prices_entry_accessibility_label(
+    String price,
+    String location,
+    String date,
+    String user,
+  );
 
   /// Button to open the proofs of a user
   ///
@@ -5419,7 +5451,10 @@ abstract class AppLocalizations {
   ///
   /// In en, this message translates to:
   /// **'Your current currency is **{currency}**. Would you like to change it to **{newCurrency}**?'**
-  String prices_currency_change_proposal_message(String currency, String newCurrency);
+  String prices_currency_change_proposal_message(
+    String currency,
+    String newCurrency,
+  );
 
   /// Button to approve the currency change
   ///
@@ -5587,7 +5622,11 @@ abstract class AppLocalizations {
   ///
   /// In en, this message translates to:
   /// **'Download {count} more products\nAlready downloaded {downloaded} out of {totalSize}.'**
-  String product_search_button_download_more(int count, int downloaded, int totalSize);
+  String product_search_button_download_more(
+    int count,
+    int downloaded,
+    int totalSize,
+  );
 
   /// This message will be displayed when a search is in progress.
   ///
@@ -5887,7 +5926,9 @@ abstract class AppLocalizations {
   ///
   /// In en, this message translates to:
   /// **'Do you want the product\'s default language to be set to ‘{language}’?'**
-  String add_basic_details_product_name_change_main_language_text(String language);
+  String add_basic_details_product_name_change_main_language_text(
+    String language,
+  );
 
   /// Title for the section with good examples
   ///
@@ -9361,7 +9402,9 @@ abstract class AppLocalizations {
   ///
   /// In en, this message translates to:
   /// **'A score can\'t be computed for a product of type \"{productType}\".'**
-  String product_page_for_me_compatibility_score_unsupported(String productType);
+  String product_page_for_me_compatibility_score_unsupported(
+    String productType,
+  );
 
   /// Button to order the attributes by importance in the For me tab on the product page
   ///
@@ -10966,7 +11009,8 @@ abstract class AppLocalizations {
   String percent_value(String percent);
 }
 
-class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
+class _AppLocalizationsDelegate
+    extends LocalizationsDelegate<AppLocalizations> {
   const _AppLocalizationsDelegate();
 
   @override
@@ -10975,164 +11019,420 @@ class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> 
   }
 
   @override
-  bool isSupported(Locale locale) => <String>['aa', 'af', 'ak', 'am', 'ar', 'as', 'az', 'be', 'bg', 'bm', 'bn', 'bo', 'br', 'bs', 'ca', 'ce', 'co', 'cs', 'cv', 'cy', 'da', 'de', 'el', 'en', 'eo', 'es', 'et', 'eu', 'fa', 'fi', 'fo', 'fr', 'ga', 'gd', 'gl', 'gu', 'ha', 'he', 'hi', 'hr', 'ht', 'hu', 'hy', 'id', 'ii', 'is', 'it', 'iu', 'ja', 'jv', 'ka', 'kk', 'km', 'kn', 'ko', 'ku', 'kw', 'ky', 'la', 'lb', 'lo', 'lt', 'lv', 'mg', 'mi', 'ml', 'mn', 'mr', 'ms', 'mt', 'my', 'nb', 'ne', 'nl', 'nn', 'no', 'nr', 'oc', 'or', 'pa', 'pl', 'pt', 'qu', 'rm', 'ro', 'ru', 'sa', 'sc', 'sd', 'sg', 'si', 'sk', 'sl', 'sn', 'so', 'sq', 'sr', 'ss', 'st', 'sv', 'sw', 'ta', 'te', 'tg', 'th', 'ti', 'tl', 'tn', 'tr', 'ts', 'tt', 'tw', 'ty', 'ug', 'uk', 'ur', 'uz', 've', 'vi', 'wa', 'wo', 'xh', 'yi', 'yo', 'zh', 'zu'].contains(locale.languageCode);
+  bool isSupported(Locale locale) => <String>[
+    'aa',
+    'af',
+    'ak',
+    'am',
+    'ar',
+    'as',
+    'az',
+    'be',
+    'bg',
+    'bm',
+    'bn',
+    'bo',
+    'br',
+    'bs',
+    'ca',
+    'ce',
+    'co',
+    'cs',
+    'cv',
+    'cy',
+    'da',
+    'de',
+    'el',
+    'en',
+    'eo',
+    'es',
+    'et',
+    'eu',
+    'fa',
+    'fi',
+    'fo',
+    'fr',
+    'ga',
+    'gd',
+    'gl',
+    'gu',
+    'ha',
+    'he',
+    'hi',
+    'hr',
+    'ht',
+    'hu',
+    'hy',
+    'id',
+    'ii',
+    'is',
+    'it',
+    'iu',
+    'ja',
+    'jv',
+    'ka',
+    'kk',
+    'km',
+    'kn',
+    'ko',
+    'ku',
+    'kw',
+    'ky',
+    'la',
+    'lb',
+    'lo',
+    'lt',
+    'lv',
+    'mg',
+    'mi',
+    'ml',
+    'mn',
+    'mr',
+    'ms',
+    'mt',
+    'my',
+    'nb',
+    'ne',
+    'nl',
+    'nn',
+    'no',
+    'nr',
+    'oc',
+    'or',
+    'pa',
+    'pl',
+    'pt',
+    'qu',
+    'rm',
+    'ro',
+    'ru',
+    'sa',
+    'sc',
+    'sd',
+    'sg',
+    'si',
+    'sk',
+    'sl',
+    'sn',
+    'so',
+    'sq',
+    'sr',
+    'ss',
+    'st',
+    'sv',
+    'sw',
+    'ta',
+    'te',
+    'tg',
+    'th',
+    'ti',
+    'tl',
+    'tn',
+    'tr',
+    'ts',
+    'tt',
+    'tw',
+    'ty',
+    'ug',
+    'uk',
+    'ur',
+    'uz',
+    've',
+    'vi',
+    'wa',
+    'wo',
+    'xh',
+    'yi',
+    'yo',
+    'zh',
+    'zu',
+  ].contains(locale.languageCode);
 
   @override
   bool shouldReload(_AppLocalizationsDelegate old) => false;
 }
 
 AppLocalizations lookupAppLocalizations(Locale locale) {
-
   // Lookup logic when language+country codes are specified.
   switch (locale.languageCode) {
-    case 'pt': {
-  switch (locale.countryCode) {
-    case 'BR': return AppLocalizationsPtBr();
-   }
-  break;
-   }
-    case 'zh': {
-  switch (locale.countryCode) {
-    case 'CN': return AppLocalizationsZhCn();
-   }
-  break;
-   }
+    case 'pt':
+      {
+        switch (locale.countryCode) {
+          case 'BR':
+            return AppLocalizationsPtBr();
+        }
+        break;
+      }
+    case 'zh':
+      {
+        switch (locale.countryCode) {
+          case 'CN':
+            return AppLocalizationsZhCn();
+        }
+        break;
+      }
   }
 
   // Lookup logic when only language code is specified.
   switch (locale.languageCode) {
-    case 'aa': return AppLocalizationsAa();
-    case 'af': return AppLocalizationsAf();
-    case 'ak': return AppLocalizationsAk();
-    case 'am': return AppLocalizationsAm();
-    case 'ar': return AppLocalizationsAr();
-    case 'as': return AppLocalizationsAs();
-    case 'az': return AppLocalizationsAz();
-    case 'be': return AppLocalizationsBe();
-    case 'bg': return AppLocalizationsBg();
-    case 'bm': return AppLocalizationsBm();
-    case 'bn': return AppLocalizationsBn();
-    case 'bo': return AppLocalizationsBo();
-    case 'br': return AppLocalizationsBr();
-    case 'bs': return AppLocalizationsBs();
-    case 'ca': return AppLocalizationsCa();
-    case 'ce': return AppLocalizationsCe();
-    case 'co': return AppLocalizationsCo();
-    case 'cs': return AppLocalizationsCs();
-    case 'cv': return AppLocalizationsCv();
-    case 'cy': return AppLocalizationsCy();
-    case 'da': return AppLocalizationsDa();
-    case 'de': return AppLocalizationsDe();
-    case 'el': return AppLocalizationsEl();
-    case 'en': return AppLocalizationsEn();
-    case 'eo': return AppLocalizationsEo();
-    case 'es': return AppLocalizationsEs();
-    case 'et': return AppLocalizationsEt();
-    case 'eu': return AppLocalizationsEu();
-    case 'fa': return AppLocalizationsFa();
-    case 'fi': return AppLocalizationsFi();
-    case 'fo': return AppLocalizationsFo();
-    case 'fr': return AppLocalizationsFr();
-    case 'ga': return AppLocalizationsGa();
-    case 'gd': return AppLocalizationsGd();
-    case 'gl': return AppLocalizationsGl();
-    case 'gu': return AppLocalizationsGu();
-    case 'ha': return AppLocalizationsHa();
-    case 'he': return AppLocalizationsHe();
-    case 'hi': return AppLocalizationsHi();
-    case 'hr': return AppLocalizationsHr();
-    case 'ht': return AppLocalizationsHt();
-    case 'hu': return AppLocalizationsHu();
-    case 'hy': return AppLocalizationsHy();
-    case 'id': return AppLocalizationsId();
-    case 'ii': return AppLocalizationsIi();
-    case 'is': return AppLocalizationsIs();
-    case 'it': return AppLocalizationsIt();
-    case 'iu': return AppLocalizationsIu();
-    case 'ja': return AppLocalizationsJa();
-    case 'jv': return AppLocalizationsJv();
-    case 'ka': return AppLocalizationsKa();
-    case 'kk': return AppLocalizationsKk();
-    case 'km': return AppLocalizationsKm();
-    case 'kn': return AppLocalizationsKn();
-    case 'ko': return AppLocalizationsKo();
-    case 'ku': return AppLocalizationsKu();
-    case 'kw': return AppLocalizationsKw();
-    case 'ky': return AppLocalizationsKy();
-    case 'la': return AppLocalizationsLa();
-    case 'lb': return AppLocalizationsLb();
-    case 'lo': return AppLocalizationsLo();
-    case 'lt': return AppLocalizationsLt();
-    case 'lv': return AppLocalizationsLv();
-    case 'mg': return AppLocalizationsMg();
-    case 'mi': return AppLocalizationsMi();
-    case 'ml': return AppLocalizationsMl();
-    case 'mn': return AppLocalizationsMn();
-    case 'mr': return AppLocalizationsMr();
-    case 'ms': return AppLocalizationsMs();
-    case 'mt': return AppLocalizationsMt();
-    case 'my': return AppLocalizationsMy();
-    case 'nb': return AppLocalizationsNb();
-    case 'ne': return AppLocalizationsNe();
-    case 'nl': return AppLocalizationsNl();
-    case 'nn': return AppLocalizationsNn();
-    case 'no': return AppLocalizationsNo();
-    case 'nr': return AppLocalizationsNr();
-    case 'oc': return AppLocalizationsOc();
-    case 'or': return AppLocalizationsOr();
-    case 'pa': return AppLocalizationsPa();
-    case 'pl': return AppLocalizationsPl();
-    case 'pt': return AppLocalizationsPt();
-    case 'qu': return AppLocalizationsQu();
-    case 'rm': return AppLocalizationsRm();
-    case 'ro': return AppLocalizationsRo();
-    case 'ru': return AppLocalizationsRu();
-    case 'sa': return AppLocalizationsSa();
-    case 'sc': return AppLocalizationsSc();
-    case 'sd': return AppLocalizationsSd();
-    case 'sg': return AppLocalizationsSg();
-    case 'si': return AppLocalizationsSi();
-    case 'sk': return AppLocalizationsSk();
-    case 'sl': return AppLocalizationsSl();
-    case 'sn': return AppLocalizationsSn();
-    case 'so': return AppLocalizationsSo();
-    case 'sq': return AppLocalizationsSq();
-    case 'sr': return AppLocalizationsSr();
-    case 'ss': return AppLocalizationsSs();
-    case 'st': return AppLocalizationsSt();
-    case 'sv': return AppLocalizationsSv();
-    case 'sw': return AppLocalizationsSw();
-    case 'ta': return AppLocalizationsTa();
-    case 'te': return AppLocalizationsTe();
-    case 'tg': return AppLocalizationsTg();
-    case 'th': return AppLocalizationsTh();
-    case 'ti': return AppLocalizationsTi();
-    case 'tl': return AppLocalizationsTl();
-    case 'tn': return AppLocalizationsTn();
-    case 'tr': return AppLocalizationsTr();
-    case 'ts': return AppLocalizationsTs();
-    case 'tt': return AppLocalizationsTt();
-    case 'tw': return AppLocalizationsTw();
-    case 'ty': return AppLocalizationsTy();
-    case 'ug': return AppLocalizationsUg();
-    case 'uk': return AppLocalizationsUk();
-    case 'ur': return AppLocalizationsUr();
-    case 'uz': return AppLocalizationsUz();
-    case 've': return AppLocalizationsVe();
-    case 'vi': return AppLocalizationsVi();
-    case 'wa': return AppLocalizationsWa();
-    case 'wo': return AppLocalizationsWo();
-    case 'xh': return AppLocalizationsXh();
-    case 'yi': return AppLocalizationsYi();
-    case 'yo': return AppLocalizationsYo();
-    case 'zh': return AppLocalizationsZh();
-    case 'zu': return AppLocalizationsZu();
+    case 'aa':
+      return AppLocalizationsAa();
+    case 'af':
+      return AppLocalizationsAf();
+    case 'ak':
+      return AppLocalizationsAk();
+    case 'am':
+      return AppLocalizationsAm();
+    case 'ar':
+      return AppLocalizationsAr();
+    case 'as':
+      return AppLocalizationsAs();
+    case 'az':
+      return AppLocalizationsAz();
+    case 'be':
+      return AppLocalizationsBe();
+    case 'bg':
+      return AppLocalizationsBg();
+    case 'bm':
+      return AppLocalizationsBm();
+    case 'bn':
+      return AppLocalizationsBn();
+    case 'bo':
+      return AppLocalizationsBo();
+    case 'br':
+      return AppLocalizationsBr();
+    case 'bs':
+      return AppLocalizationsBs();
+    case 'ca':
+      return AppLocalizationsCa();
+    case 'ce':
+      return AppLocalizationsCe();
+    case 'co':
+      return AppLocalizationsCo();
+    case 'cs':
+      return AppLocalizationsCs();
+    case 'cv':
+      return AppLocalizationsCv();
+    case 'cy':
+      return AppLocalizationsCy();
+    case 'da':
+      return AppLocalizationsDa();
+    case 'de':
+      return AppLocalizationsDe();
+    case 'el':
+      return AppLocalizationsEl();
+    case 'en':
+      return AppLocalizationsEn();
+    case 'eo':
+      return AppLocalizationsEo();
+    case 'es':
+      return AppLocalizationsEs();
+    case 'et':
+      return AppLocalizationsEt();
+    case 'eu':
+      return AppLocalizationsEu();
+    case 'fa':
+      return AppLocalizationsFa();
+    case 'fi':
+      return AppLocalizationsFi();
+    case 'fo':
+      return AppLocalizationsFo();
+    case 'fr':
+      return AppLocalizationsFr();
+    case 'ga':
+      return AppLocalizationsGa();
+    case 'gd':
+      return AppLocalizationsGd();
+    case 'gl':
+      return AppLocalizationsGl();
+    case 'gu':
+      return AppLocalizationsGu();
+    case 'ha':
+      return AppLocalizationsHa();
+    case 'he':
+      return AppLocalizationsHe();
+    case 'hi':
+      return AppLocalizationsHi();
+    case 'hr':
+      return AppLocalizationsHr();
+    case 'ht':
+      return AppLocalizationsHt();
+    case 'hu':
+      return AppLocalizationsHu();
+    case 'hy':
+      return AppLocalizationsHy();
+    case 'id':
+      return AppLocalizationsId();
+    case 'ii':
+      return AppLocalizationsIi();
+    case 'is':
+      return AppLocalizationsIs();
+    case 'it':
+      return AppLocalizationsIt();
+    case 'iu':
+      return AppLocalizationsIu();
+    case 'ja':
+      return AppLocalizationsJa();
+    case 'jv':
+      return AppLocalizationsJv();
+    case 'ka':
+      return AppLocalizationsKa();
+    case 'kk':
+      return AppLocalizationsKk();
+    case 'km':
+      return AppLocalizationsKm();
+    case 'kn':
+      return AppLocalizationsKn();
+    case 'ko':
+      return AppLocalizationsKo();
+    case 'ku':
+      return AppLocalizationsKu();
+    case 'kw':
+      return AppLocalizationsKw();
+    case 'ky':
+      return AppLocalizationsKy();
+    case 'la':
+      return AppLocalizationsLa();
+    case 'lb':
+      return AppLocalizationsLb();
+    case 'lo':
+      return AppLocalizationsLo();
+    case 'lt':
+      return AppLocalizationsLt();
+    case 'lv':
+      return AppLocalizationsLv();
+    case 'mg':
+      return AppLocalizationsMg();
+    case 'mi':
+      return AppLocalizationsMi();
+    case 'ml':
+      return AppLocalizationsMl();
+    case 'mn':
+      return AppLocalizationsMn();
+    case 'mr':
+      return AppLocalizationsMr();
+    case 'ms':
+      return AppLocalizationsMs();
+    case 'mt':
+      return AppLocalizationsMt();
+    case 'my':
+      return AppLocalizationsMy();
+    case 'nb':
+      return AppLocalizationsNb();
+    case 'ne':
+      return AppLocalizationsNe();
+    case 'nl':
+      return AppLocalizationsNl();
+    case 'nn':
+      return AppLocalizationsNn();
+    case 'no':
+      return AppLocalizationsNo();
+    case 'nr':
+      return AppLocalizationsNr();
+    case 'oc':
+      return AppLocalizationsOc();
+    case 'or':
+      return AppLocalizationsOr();
+    case 'pa':
+      return AppLocalizationsPa();
+    case 'pl':
+      return AppLocalizationsPl();
+    case 'pt':
+      return AppLocalizationsPt();
+    case 'qu':
+      return AppLocalizationsQu();
+    case 'rm':
+      return AppLocalizationsRm();
+    case 'ro':
+      return AppLocalizationsRo();
+    case 'ru':
+      return AppLocalizationsRu();
+    case 'sa':
+      return AppLocalizationsSa();
+    case 'sc':
+      return AppLocalizationsSc();
+    case 'sd':
+      return AppLocalizationsSd();
+    case 'sg':
+      return AppLocalizationsSg();
+    case 'si':
+      return AppLocalizationsSi();
+    case 'sk':
+      return AppLocalizationsSk();
+    case 'sl':
+      return AppLocalizationsSl();
+    case 'sn':
+      return AppLocalizationsSn();
+    case 'so':
+      return AppLocalizationsSo();
+    case 'sq':
+      return AppLocalizationsSq();
+    case 'sr':
+      return AppLocalizationsSr();
+    case 'ss':
+      return AppLocalizationsSs();
+    case 'st':
+      return AppLocalizationsSt();
+    case 'sv':
+      return AppLocalizationsSv();
+    case 'sw':
+      return AppLocalizationsSw();
+    case 'ta':
+      return AppLocalizationsTa();
+    case 'te':
+      return AppLocalizationsTe();
+    case 'tg':
+      return AppLocalizationsTg();
+    case 'th':
+      return AppLocalizationsTh();
+    case 'ti':
+      return AppLocalizationsTi();
+    case 'tl':
+      return AppLocalizationsTl();
+    case 'tn':
+      return AppLocalizationsTn();
+    case 'tr':
+      return AppLocalizationsTr();
+    case 'ts':
+      return AppLocalizationsTs();
+    case 'tt':
+      return AppLocalizationsTt();
+    case 'tw':
+      return AppLocalizationsTw();
+    case 'ty':
+      return AppLocalizationsTy();
+    case 'ug':
+      return AppLocalizationsUg();
+    case 'uk':
+      return AppLocalizationsUk();
+    case 'ur':
+      return AppLocalizationsUr();
+    case 'uz':
+      return AppLocalizationsUz();
+    case 've':
+      return AppLocalizationsVe();
+    case 'vi':
+      return AppLocalizationsVi();
+    case 'wa':
+      return AppLocalizationsWa();
+    case 'wo':
+      return AppLocalizationsWo();
+    case 'xh':
+      return AppLocalizationsXh();
+    case 'yi':
+      return AppLocalizationsYi();
+    case 'yo':
+      return AppLocalizationsYo();
+    case 'zh':
+      return AppLocalizationsZh();
+    case 'zu':
+      return AppLocalizationsZu();
   }
 
   throw FlutterError(
     'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
     'an issue with the localizations generation tool. Please file an issue '
     'on GitHub with a reproducible sample app and the gen-l10n configuration '
-    'that was used.'
+    'that was used.',
   );
 }

--- a/packages/smooth_app/lib/pages/preferences/country_selector/country.dart
+++ b/packages/smooth_app/lib/pages/preferences/country_selector/country.dart
@@ -101,7 +101,7 @@ extension OpenFoodFactsCountryLocalization on OpenFoodFactsCountry {
       if (b.offTag == userCountryCode) {
         return 1;
       }
-      return a.name.compareTo(b.name);
+      return a.localizedName.compareTo(b.localizedName);
     });
   }
 }

--- a/packages/smooth_app/lib/pages/preferences/country_selector/country.dart
+++ b/packages/smooth_app/lib/pages/preferences/country_selector/country.dart
@@ -8,16 +8,24 @@ extension OpenFoodFactsCountryLocalization on OpenFoodFactsCountry {
 
   static String _latestLanguageCode = _englishLanguageCode;
 
+  /// Translations, computed only if needed, and cached.
+  static final Map<String, Map<OpenFoodFactsCountry, String>> _translations =
+      <String, Map<OpenFoodFactsCountry, String>>{};
+
   static void setLocale(final String? languageCode) {
     if (languageCode != null) {
       _latestLanguageCode = languageCode;
     }
   }
 
-  String get name {
-    final String? result =
-        _getMapper().map[_latestLanguageCode]?.map[iso3Code] ??
-        _getMapper().map[_englishLanguageCode]?.map[iso3Code];
+  String get localizedName {
+    _translations[_latestLanguageCode] ??= _translate(_latestLanguageCode);
+    String? result = _translations[_latestLanguageCode]![this];
+    if (result != null) {
+      return result;
+    }
+    _translations[_englishLanguageCode] ??= _translate(_englishLanguageCode);
+    result = _translations[_englishLanguageCode]![this];
     if (result != null) {
       return result;
     }
@@ -29,10 +37,73 @@ extension OpenFoodFactsCountryLocalization on OpenFoodFactsCountry {
         '${countryName.substring(1).toLowerCase()}';
   }
 
-  static CountriesLocaleMapper? _mapper;
+  /// Map of all countries' ISO3 codes.
+  static Map<String, Country>? _iso3s;
 
-  static CountriesLocaleMapper _getMapper() =>
-      _mapper ??= CountriesLocaleMapper();
+  /// Return the map of all countries' ISO3 codes.
+  static Map<String, Country> _getIso3s() {
+    final Map<String, Country> result = <String, Country>{};
+    for (final Country country in OpenFoodFactsCountry.values) {
+      result[country.iso3Code] = country;
+    }
+    return result;
+  }
+
+  static Map<OpenFoodFactsCountry, String> _translate(
+    final String languageCode,
+  ) {
+    final Map<Country, String> result = <Country, String>{};
+    _iso3s ??= _getIso3s();
+    CountriesLocaleMapper().localize(
+      _iso3s!.keys.toSet(),
+      mainLocale: languageCode,
+      useLanguageFallback: true,
+      formatter: (LocaleKey localeKey, String translation) {
+        final Country? country = _iso3s![localeKey.isoCode];
+        // null would happen for 'USA+' for instance
+        if (country != null) {
+          result[country] = translation;
+        }
+        return translation;
+      },
+    );
+    return result;
+  }
+
+  static Iterable<Country> filterCountries(
+    List<Country> countries,
+    Country? userCountry,
+    Country? selectedCountry,
+    String? filter,
+  ) {
+    if (filter == null || filter.isEmpty) {
+      return countries;
+    }
+
+    return countries.where(
+      (Country country) =>
+          country == userCountry ||
+          country == selectedCountry ||
+          country.localizedName.toLowerCase().contains(filter.toLowerCase()) ||
+          country.offTag.toLowerCase().contains(filter.toLowerCase()),
+    );
+  }
+
+  /// Reorder countries alphabetically, bring user's locale country to top.
+  static void reorderCountries(
+    List<Country> countries,
+    final String? userCountryCode,
+  ) {
+    countries.sort((final Country a, final Country b) {
+      if (a.offTag == userCountryCode) {
+        return -1;
+      }
+      if (b.offTag == userCountryCode) {
+        return 1;
+      }
+      return a.name.compareTo(b.name);
+    });
+  }
 }
 
 typedef Country = OpenFoodFactsCountry;

--- a/packages/smooth_app/lib/pages/preferences/country_selector/country_selector.dart
+++ b/packages/smooth_app/lib/pages/preferences/country_selector/country_selector.dart
@@ -138,7 +138,7 @@ class _CountrySelectorButton extends StatelessWidget {
                         const SizedBox(width: SMALL_SPACE),
                         Expanded(
                           child: Text(
-                            country?.name ??
+                            country?.localizedName ??
                                 AppLocalizations.of(context).loading,
                             style: Theme.of(
                               context,
@@ -290,7 +290,7 @@ class _CountrySelectorScreen extends StatelessWidget {
                 Expanded(
                   flex: 7,
                   child: TextHighlighter(
-                    text: country.name,
+                    text: country.localizedName,
                     filter: filter,
                     textStyle: const TextStyle(fontWeight: FontWeight.w600),
                   ),
@@ -304,31 +304,12 @@ class _CountrySelectorScreen extends StatelessWidget {
             Country? selectedItem,
             Country? selectedItemOverride,
             String filter,
-          ) => _filterCountries(
+          ) => OpenFoodFactsCountryLocalization.filterCountries(
             list,
             selectedItem,
             selectedItemOverride,
             filter,
           ),
-    );
-  }
-
-  Iterable<Country> _filterCountries(
-    List<Country> countries,
-    Country? userCountry,
-    Country? selectedCountry,
-    String? filter,
-  ) {
-    if (filter == null || filter.isEmpty) {
-      return countries;
-    }
-
-    return countries.where(
-      (Country country) =>
-          country == userCountry ||
-          country == selectedCountry ||
-          country.name.toLowerCase().contains(filter.toLowerCase()) ||
-          country.offTag.toLowerCase().contains(filter.toLowerCase()),
     );
   }
 }

--- a/packages/smooth_app/lib/pages/preferences/country_selector/country_selector_provider.dart
+++ b/packages/smooth_app/lib/pages/preferences/country_selector/country_selector_provider.dart
@@ -55,18 +55,11 @@ class _CountrySelectorProvider extends PreferencesSelectorProvider<Country> {
     return countries;
   }
 
-  /// Reorder countries alphabetically, bring user's locale country to top.
-  void _reorderCountries(List<Country> countries) {
-    countries.sort((final Country a, final Country b) {
-      if (a.offTag == userCountryCode) {
-        return -1;
-      }
-      if (b.offTag == userCountryCode) {
-        return 1;
-      }
-      return a.name.compareTo(b.name);
-    });
-  }
+  void _reorderCountries(List<Country> countries) =>
+      OpenFoodFactsCountryLocalization.reorderCountries(
+        countries,
+        userCountryCode,
+      );
 
   @override
   Country getSelectedValue(List<Country> countries) {

--- a/packages/smooth_app/lib/pages/preferences_v2/tiles/app_settings_tiles/country_selector/country_selector_provider.dart
+++ b/packages/smooth_app/lib/pages/preferences_v2/tiles/app_settings_tiles/country_selector/country_selector_provider.dart
@@ -49,18 +49,11 @@ class _CountrySelectorProvider extends PreferencesSelectorProvider<Country> {
     return countries;
   }
 
-  /// Reorder countries alphabetically, bring user's locale country to top.
-  void _reorderCountries(List<Country> countries) {
-    countries.sort((final Country a, final Country b) {
-      if (a.offTag == userCountryCode) {
-        return -1;
-      }
-      if (b.offTag == userCountryCode) {
-        return 1;
-      }
-      return a.name.compareTo(b.name);
-    });
-  }
+  void _reorderCountries(List<Country> countries) =>
+      OpenFoodFactsCountryLocalization.reorderCountries(
+        countries,
+        userCountryCode,
+      );
 
   @override
   Country getSelectedValue(List<Country> countries) {

--- a/packages/smooth_app/lib/pages/preferences_v2/tiles/app_settings_tiles/country_selector/country_selector_tile.dart
+++ b/packages/smooth_app/lib/pages/preferences_v2/tiles/app_settings_tiles/country_selector/country_selector_tile.dart
@@ -77,7 +77,8 @@ class CountrySelectorTile extends PreferenceTile {
                       spacing: VERY_SMALL_SPACE,
                       children: <Widget>[
                         Text(
-                          country?.name ?? AppLocalizations.of(context).loading,
+                          country?.localizedName ??
+                              AppLocalizations.of(context).loading,
                         ),
                         if (country != null)
                           SizedBox(
@@ -239,7 +240,7 @@ class _CountrySelectorScreen extends StatelessWidget {
                 Expanded(
                   flex: 7,
                   child: TextHighlighter(
-                    text: country.name,
+                    text: country.localizedName,
                     filter: filter,
                     textStyle: const TextStyle(fontWeight: FontWeight.w600),
                   ),
@@ -253,31 +254,12 @@ class _CountrySelectorScreen extends StatelessWidget {
             Country? selectedItem,
             Country? selectedItemOverride,
             String filter,
-          ) => _filterCountries(
+          ) => OpenFoodFactsCountryLocalization.filterCountries(
             list,
             selectedItem,
             selectedItemOverride,
             filter,
           ),
-    );
-  }
-
-  Iterable<Country> _filterCountries(
-    List<Country> countries,
-    Country? userCountry,
-    Country? selectedCountry,
-    String? filter,
-  ) {
-    if (filter == null || filter.isEmpty) {
-      return countries;
-    }
-
-    return countries.where(
-      (Country country) =>
-          country == userCountry ||
-          country == selectedCountry ||
-          country.name.toLowerCase().contains(filter.toLowerCase()) ||
-          country.offTag.toLowerCase().contains(filter.toLowerCase()),
     );
   }
 }

--- a/packages/smooth_app/lib/pages/prices/price_to_oxf.dart
+++ b/packages/smooth_app/lib/pages/prices/price_to_oxf.dart
@@ -6,6 +6,7 @@ import 'package:smooth_app/data_models/fetched_product.dart';
 import 'package:smooth_app/database/dao_product.dart';
 import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/pages/product/common/product_refresher.dart';
+import 'package:smooth_app/pages/product/simple_input/simple_input_page_country_helper.dart';
 import 'package:smooth_app/pages/product/simple_input/simple_input_page_helpers.dart';
 import 'package:smooth_app/query/product_query.dart';
 

--- a/packages/smooth_app/lib/pages/product/common/product_query_page.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_query_page.dart
@@ -481,7 +481,7 @@ class _ProductQueryPageState extends State<ProductQueryPage>
       if (pagedProductQuery.world) {
         counting += ' (${appLocalizations.world_results_label})';
       } else {
-        final String? countryName = _country?.name;
+        final String? countryName = _country?.localizedName;
         if (countryName != null) {
           counting += ' ($countryName)';
         }

--- a/packages/smooth_app/lib/pages/product/edit_product/edit_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/edit_product/edit_product_page.dart
@@ -22,6 +22,7 @@ import 'package:smooth_app/pages/product/nutrition_page/nutrition_page_loader.da
 import 'package:smooth_app/pages/product/product_field_editor.dart';
 import 'package:smooth_app/pages/product/product_page/footer/new_product_footer.dart';
 import 'package:smooth_app/pages/product/simple_input/simple_input_page.dart';
+import 'package:smooth_app/pages/product/simple_input/simple_input_page_country_helper.dart';
 import 'package:smooth_app/pages/product/simple_input/simple_input_page_helpers.dart';
 import 'package:smooth_app/pages/product/simple_input/simple_input_page_trace_helper.dart';
 import 'package:smooth_app/resources/app_icons.dart' as icons;

--- a/packages/smooth_app/lib/pages/product/simple_input/simple_input_page_country_helper.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input/simple_input_page_country_helper.dart
@@ -118,7 +118,6 @@ class SimpleInputPageCountryHelper extends AbstractSimpleInputPageHelper {
       appLocalizations.edit_product_form_item_countries_explanations_title;
 
   @override
-  @override
   WidgetBuilder? getAddExplanationsContent() => (BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     return ExplanationBodyInfo(

--- a/packages/smooth_app/lib/pages/product/simple_input/simple_input_page_country_helper.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input/simple_input_page_country_helper.dart
@@ -1,0 +1,155 @@
+import 'dart:async';
+
+import 'package:collection/collection.dart';
+import 'package:flutter/material.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/background/background_task_details.dart';
+import 'package:smooth_app/data_models/preferences/user_preferences.dart';
+import 'package:smooth_app/helpers/analytics_helper.dart';
+import 'package:smooth_app/l10n/app_localizations.dart';
+import 'package:smooth_app/pages/preferences/country_selector/country.dart';
+import 'package:smooth_app/pages/product/simple_input/simple_input_page_helpers.dart';
+import 'package:smooth_app/resources/app_icons.dart' as icons;
+import 'package:smooth_app/widgets/smooth_explanation_banner.dart';
+
+/// Implementation for "Countries" of an [AbstractSimpleInputPageHelper].
+class SimpleInputPageCountryHelper extends AbstractSimpleInputPageHelper {
+  SimpleInputPageCountryHelper(UserPreferences? userPreferences)
+    : _userCountryCode = userPreferences?.userCountryCode ?? 'fr';
+
+  final String _userCountryCode;
+
+  ValueNotifier<SimpleInputSuggestionsState> _suggestionsNotifier =
+      ValueNotifier<SimpleInputSuggestionsState>(
+        const SimpleInputSuggestionsLoading(),
+      );
+  final List<OpenFoodFactsCountry> _countries = OpenFoodFactsCountry.values;
+
+  @override
+  List<String> initTerms(final Product product) =>
+      product.countriesTagsInLanguages?[getLanguage()] ?? <String>[];
+
+  @override
+  void reInit(final Product product, {final bool backgroundTask = false}) {
+    super.reInit(product);
+
+    if (backgroundTask) {
+      return;
+    }
+
+    try {
+      _suggestionsNotifier.notifyListeners();
+    } catch (_) {
+      // The Notifier was disposed
+      _suggestionsNotifier = ValueNotifier<SimpleInputSuggestionsState>(
+        const SimpleInputSuggestionsLoading(),
+      );
+    }
+
+    _reloadSuggestions();
+  }
+
+  @override
+  bool addItemsFromController(
+    final TextEditingController controller, {
+    bool clearController = true,
+  }) {
+    final bool result = super.addItemsFromController(
+      controller,
+      clearController: clearController,
+    );
+    if (result) {
+      _reloadSuggestions();
+    }
+    return result;
+  }
+
+  @override
+  void changeProduct(final Product changedProduct) {
+    // for the temporary local change
+    changedProduct.countriesTagsInLanguages =
+        <OpenFoodFactsLanguage, List<String>>{getLanguage(): terms};
+    // for the server - write-only
+    changedProduct.countries = terms.join(separator);
+  }
+
+  @override
+  ValueNotifier<SimpleInputSuggestionsState> getSuggestions() =>
+      _suggestionsNotifier;
+
+  Future<void> _reloadSuggestions() async {
+    final OpenFoodFactsCountry? country = _countries.firstWhereOrNull(
+      (OpenFoodFactsCountry country) => country.offTag == _userCountryCode,
+    );
+
+    if (country == null || containsTerm(country.localizedName) == true) {
+      _suggestionsNotifier.value = const SimpleInputSuggestionsLoaded(
+        suggestions: <String>[],
+      );
+      return;
+    }
+
+    _suggestionsNotifier.value = SimpleInputSuggestionsLoaded(
+      suggestions: <String>[country.localizedName],
+    );
+  }
+
+  @override
+  String getTitle(final AppLocalizations appLocalizations) =>
+      appLocalizations.edit_product_form_item_countries_title;
+
+  @override
+  String getAddButtonLabel(final AppLocalizations appLocalizations) =>
+      appLocalizations.score_add_missing_product_countries;
+
+  @override
+  String getAddHint(final AppLocalizations appLocalizations) =>
+      appLocalizations.edit_product_form_item_countries_hint;
+
+  @override
+  String getAddTooltip(AppLocalizations appLocalizations) =>
+      appLocalizations.edit_product_form_item_add_action_country;
+
+  @override
+  TextCapitalization? getTextCapitalization() => TextCapitalization.sentences;
+
+  @override
+  String getTypeLabel(AppLocalizations appLocalizations) =>
+      appLocalizations.edit_product_form_item_countries_explanations_title;
+
+  @override
+  @override
+  WidgetBuilder? getAddExplanationsContent() => (BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    return ExplanationBodyInfo(
+      text:
+          appLocalizations.edit_product_form_item_countries_explanations_info1,
+      safeArea: true,
+    );
+  };
+
+  @override
+  TagType? getTagType() => TagType.COUNTRIES;
+
+  @override
+  Widget getIcon() => const icons.Countries(size: 20.0);
+
+  @override
+  BackgroundTaskDetailsStamp getStamp() => BackgroundTaskDetailsStamp.countries;
+
+  @override
+  AnalyticsEditEvents getAnalyticsEditEvent() => AnalyticsEditEvents.country;
+
+  @override
+  InsightType? get robotoffInsightType => null;
+
+  @override
+  void dispose() {
+    try {
+      _suggestionsNotifier.dispose();
+    } catch (_) {
+      // The Notifier was already disposed
+    }
+    super.dispose();
+  }
+}

--- a/packages/smooth_app/lib/pages/product/simple_input/simple_input_page_helpers.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input/simple_input_page_helpers.dart
@@ -4,13 +4,11 @@ import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/background/background_task_details.dart';
-import 'package:smooth_app/data_models/preferences/user_preferences.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/l10n/app_localizations.dart';
 import 'package:smooth_app/pages/image_crop_page.dart';
-import 'package:smooth_app/pages/preferences/country_selector/country.dart';
 import 'package:smooth_app/pages/product/multilingual_helper.dart';
 import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/resources/app_icons.dart' as icons;
@@ -38,6 +36,9 @@ abstract class AbstractSimpleInputPageHelper extends ChangeNotifier {
 
   /// If at least one call to [reInit] was done.
   bool _initialized = false;
+
+  @protected
+  bool containsTerm(final String term) => _terms.contains(term);
 
   /// Starts from scratch with a new (or refreshed) [Product].
   void reInit(final Product product, {final bool backgroundTask = false}) {
@@ -88,7 +89,7 @@ abstract class AbstractSimpleInputPageHelper extends ChangeNotifier {
     if (term.isEmpty) {
       return false;
     }
-    if (_terms.contains(term)) {
+    if (containsTerm(term)) {
       return false;
     }
 
@@ -1052,146 +1053,4 @@ class SimpleInputPageCategoryNotFoodHelper
     extends SimpleInputPageCategoryHelper {
   @override
   Widget getIcon() => const Icon(Icons.edit);
-}
-
-/// Implementation for "Countries" of an [AbstractSimpleInputPageHelper].
-class SimpleInputPageCountryHelper extends AbstractSimpleInputPageHelper {
-  SimpleInputPageCountryHelper(UserPreferences? userPreferences)
-    : _userCountryCode = userPreferences?.userCountryCode ?? 'fr';
-
-  final String _userCountryCode;
-
-  ValueNotifier<SimpleInputSuggestionsState> _suggestionsNotifier =
-      ValueNotifier<SimpleInputSuggestionsState>(
-        const SimpleInputSuggestionsLoading(),
-      );
-  final List<Country> _countries = OpenFoodFactsCountry.values;
-
-  @override
-  List<String> initTerms(final Product product) =>
-      product.countriesTagsInLanguages?[getLanguage()] ?? <String>[];
-
-  @override
-  void reInit(final Product product, {final bool backgroundTask = false}) {
-    super.reInit(product);
-
-    if (backgroundTask) {
-      return;
-    }
-
-    try {
-      _suggestionsNotifier.notifyListeners();
-    } catch (_) {
-      // The Notifier was disposed
-      _suggestionsNotifier = ValueNotifier<SimpleInputSuggestionsState>(
-        const SimpleInputSuggestionsLoading(),
-      );
-    }
-
-    _reloadSuggestions();
-  }
-
-  @override
-  bool addItemsFromController(
-    final TextEditingController controller, {
-    bool clearController = true,
-  }) {
-    final bool result = super.addItemsFromController(
-      controller,
-      clearController: clearController,
-    );
-    if (result) {
-      _reloadSuggestions();
-    }
-    return result;
-  }
-
-  @override
-  void changeProduct(final Product changedProduct) {
-    // for the temporary local change
-    changedProduct.countriesTagsInLanguages =
-        <OpenFoodFactsLanguage, List<String>>{getLanguage(): terms};
-    // for the server - write-only
-    changedProduct.countries = terms.join(separator);
-  }
-
-  @override
-  ValueNotifier<SimpleInputSuggestionsState> getSuggestions() =>
-      _suggestionsNotifier;
-
-  Future<void> _reloadSuggestions() async {
-    final Country? country = _countries.firstWhereOrNull(
-      (Country country) => country.offTag == _userCountryCode,
-    );
-
-    if (country == null || _terms.contains(country.name) == true) {
-      _suggestionsNotifier.value = const SimpleInputSuggestionsLoaded(
-        suggestions: <String>[],
-      );
-      return;
-    }
-
-    _suggestionsNotifier.value = SimpleInputSuggestionsLoaded(
-      suggestions: <String>[country.name],
-    );
-  }
-
-  @override
-  String getTitle(final AppLocalizations appLocalizations) =>
-      appLocalizations.edit_product_form_item_countries_title;
-
-  @override
-  String getAddButtonLabel(final AppLocalizations appLocalizations) =>
-      appLocalizations.score_add_missing_product_countries;
-
-  @override
-  String getAddHint(final AppLocalizations appLocalizations) =>
-      appLocalizations.edit_product_form_item_countries_hint;
-
-  @override
-  String getAddTooltip(AppLocalizations appLocalizations) =>
-      appLocalizations.edit_product_form_item_add_action_country;
-
-  @override
-  TextCapitalization? getTextCapitalization() => TextCapitalization.sentences;
-
-  @override
-  String getTypeLabel(AppLocalizations appLocalizations) =>
-      appLocalizations.edit_product_form_item_countries_explanations_title;
-
-  @override
-  @override
-  WidgetBuilder? getAddExplanationsContent() => (BuildContext context) {
-    final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    return ExplanationBodyInfo(
-      text:
-          appLocalizations.edit_product_form_item_countries_explanations_info1,
-      safeArea: true,
-    );
-  };
-
-  @override
-  TagType? getTagType() => TagType.COUNTRIES;
-
-  @override
-  Widget getIcon() => const icons.Countries(size: 20.0);
-
-  @override
-  BackgroundTaskDetailsStamp getStamp() => BackgroundTaskDetailsStamp.countries;
-
-  @override
-  AnalyticsEditEvents getAnalyticsEditEvent() => AnalyticsEditEvents.country;
-
-  @override
-  InsightType? get robotoffInsightType => null;
-
-  @override
-  void dispose() {
-    try {
-      _suggestionsNotifier.dispose();
-    } catch (_) {
-      // The Notifier was already disposed
-    }
-    super.dispose();
-  }
 }

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -980,10 +980,10 @@ packages:
     dependency: "direct main"
     description:
       name: l10n_countries
-      sha256: dfeb4d4925f71d61d2c495a0f0e1430fe66ce664cf87533dd10dc445cab0ff02
+      sha256: d2e976d43018659d06f8747994dd9ab158fcddb3b2c9458f8360ebfb37956172
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "2.0.2"
   latlong2:
     dependency: "direct main"
     description:
@@ -1949,4 +1949,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.11.5 <4.0.0"
-  flutter: ">=3.41.8"
+  flutter: ">=3.41.8 <4.0.0"

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   http: 1.6.0
   http_parser: 4.1.2
   image_picker: 1.2.1
-  l10n_countries: 1.3.1
+  l10n_countries: 2.0.2
   latlong2: 0.9.1
   matomo_tracker: 6.1.0
   package_info_plus: 9.0.1


### PR DESCRIPTION
### What
- Upgrade to `l10_countries` version 2.0.2
- It was a breaking change: the translations aren't cached by this package anymore, so we have to cache them ourselves.
- In the process, minor refactoring, including renaming the `name` field of `Country` as `localizedName`, in order to avoid confusion with the standard `name` field of `enum`s.

### Fixes bug(s)
- Fixes: #7440

### Files
New file:
* `simple_input_page_country_helper.dart`: Implementation for "Countries" of an [AbstractSimpleInputPageHelper]. Moved from `simple_input_page_helpers.dart`

Impacted files:
* `country.dart`: complying with the l10n_countries breaking change; renamed poorly named `name` (for an `enum`) to `localizedName`
* `country_selector.dart` : now using explicitly `localizedName`; minor refactoring
* `country_selector_provider.dart` x 2: minor refactoring
* `country_selector_tile.dart`: : now using explicitly `localizedName`; minor refactoring
* `edit_product_page.dart`: minor refactoring
* `GeneratedPluginRegistrant.swift`: wtf
* `knowledge_panel_action_card.dart`: minor refactoring
* `price_to_oxf.dart`: minor refactoring
* `product_query_page.dart`: now using explicitly `localizedName`
* `pubspec.lock`: wtf
* `pubspec.yaml`: upgraded `l10n_countries` to `2.0.2`
* `simple_input_page_helpers.dart`: moved country to a specific file; minor refactoring