### PR TITLE
chore: no more impeller explicit opt-out

### DIFF
--- a/packages/smooth_app/android/app/src/main/AndroidManifest.xml
+++ b/packages/smooth_app/android/app/src/main/AndroidManifest.xml
@@ -1,562 +1,1550 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          xmlns:tools="http://schemas.android.com/tools"
-          android:installLocation="auto">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:installLocation="auto">
 
-    <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-permission android:name="android.permission.CAMERA"/>
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.CAMERA" />
 
     <!-- Some dependencies may request this permission, which is not used in our app -->
-    <uses-permission android:name="android.permission.RECORD_AUDIO" tools:node="remove" />
+    <uses-permission
+        android:name="android.permission.RECORD_AUDIO"
+        tools:node="remove" />
 
     <queries>
-        <intent> 
-            <action android:name="android.intent.action.SENDTO" /> 
-            <data android:scheme="mailto" /> 
-        </intent> 
+        <intent>
+            <action android:name="android.intent.action.SENDTO" />
+            <data android:scheme="mailto" />
+        </intent>
     </queries>
 
     <application
-            android:label="OpenFoodFacts"
-            android:name="${applicationName}"
-            android:icon="@mipmap/ic_launcher"
-            android:hasFragileUserData="true"
-            android:allowBackup="true"
-            android:fullBackupContent="@xml/backup_scheme"
-            tools:targetApi="q">
+        android:label="OpenFoodFacts"
+        android:name="${applicationName}"
+        android:icon="@mipmap/ic_launcher"
+        android:hasFragileUserData="true"
+        android:allowBackup="true"
+        android:fullBackupContent="@xml/backup_scheme"
+        tools:targetApi="q">
         <activity
-                android:name=".MainActivity"
-                android:exported="true"
-                android:launchMode="singleTop"
-                android:theme="@style/LaunchTheme"
-                android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
-                android:hardwareAccelerated="true"
-                android:resizeableActivity="false"
-                android:screenOrientation="portrait"
-                android:windowSoftInputMode="adjustResize"
-                android:enableOnBackInvokedCallback="false">
+            android:name=".MainActivity"
+            android:exported="true"
+            android:launchMode="singleTop"
+            android:theme="@style/LaunchTheme"
+            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
+            android:hardwareAccelerated="true"
+            android:resizeableActivity="false"
+            android:screenOrientation="portrait"
+            android:windowSoftInputMode="adjustResize"
+            android:enableOnBackInvokedCallback="false">
             <!-- Specifies an Android theme to apply to this Activity as soon as
                  the Android process has started. This theme is visible to the user
                  while the Flutter UI initializes. After that, this theme continues
                  to determine the Window background behind the Flutter UI. -->
             <meta-data
-                    android:name="io.flutter.embedding.android.NormalTheme"
-                    android:resource="@style/NormalTheme"
-            />
+                android:name="io.flutter.embedding.android.NormalTheme"
+                android:resource="@style/NormalTheme" />
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
             <!-- Enable deep links in the app -->
-            <meta-data android:name="flutter_deeplinking_enabled" android:value="true" />
+            <meta-data
+                android:name="flutter_deeplinking_enabled"
+                android:value="true" />
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
+
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <!-- Prices -->
-                <data android:scheme="http" android:host="prices.openfoodfacts.org" />
-                <data android:scheme="http" android:host="prices.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="prices.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="prices.openfoodfacts.net" />
 
                 <!-- OpenFoodFacts.org -->
-                <data android:scheme="http" android:host="ae.openfoodfacts.org" />
-                <data android:scheme="http" android:host="ar.openfoodfacts.org" />
-                <data android:scheme="http" android:host="at-en.openfoodfacts.org" />
-                <data android:scheme="http" android:host="at.openfoodfacts.org" />
-                <data android:scheme="http" android:host="au.openfoodfacts.org" />
-                <data android:scheme="http" android:host="be-de.openfoodfacts.org" />
-                <data android:scheme="http" android:host="be-en.openfoodfacts.org" />
-                <data android:scheme="http" android:host="be-fr.openfoodfacts.org" />
-                <data android:scheme="http" android:host="be.openfoodfacts.org" />
-                <data android:scheme="http" android:host="bg.openfoodfacts.org" />
-                <data android:scheme="http" android:host="br.openfoodfacts.org" />
-                <data android:scheme="http" android:host="ca-fr.openfoodfacts.org" />
-                <data android:scheme="http" android:host="ca.openfoodfacts.org" />
-                <data android:scheme="http" android:host="ch-en.openfoodfacts.org" />
-                <data android:scheme="http" android:host="ch-fr.openfoodfacts.org" />
-                <data android:scheme="http" android:host="ch-it.openfoodfacts.org" />
-                <data android:scheme="http" android:host="ch.openfoodfacts.org" />
-                <data android:scheme="http" android:host="cl.openfoodfacts.org" />
-                <data android:scheme="http" android:host="cn-en.openfoodfacts.org" />
-                <data android:scheme="http" android:host="cn.openfoodfacts.org" />
-                <data android:scheme="http" android:host="co.openfoodfacts.org" />
-                <data android:scheme="http" android:host="cz.openfoodfacts.org" />
-                <data android:scheme="http" android:host="de-en.openfoodfacts.org" />
-                <data android:scheme="http" android:host="de.openfoodfacts.org" />
-                <data android:scheme="http" android:host="dk.openfoodfacts.org" />
-                <data android:scheme="http" android:host="dz-fr.openfoodfacts.org" />
-                <data android:scheme="http" android:host="dz.openfoodfacts.org" />
-                <data android:scheme="http" android:host="en.openfoodfacts.org" />
-                <data android:scheme="http" android:host="es-ca.openfoodfacts.org" />
-                <data android:scheme="http" android:host="es-en.openfoodfacts.org" />
-                <data android:scheme="http" android:host="es-eu.openfoodfacts.org" />
-                <data android:scheme="http" android:host="es-gl.openfoodfacts.org" />
-                <data android:scheme="http" android:host="es.openfoodfacts.org" />
-                <data android:scheme="http" android:host="fi.openfoodfacts.org" />
-                <data android:scheme="http" android:host="fr-en.openfoodfacts.org" />
-                <data android:scheme="http" android:host="fr-es.openfoodfacts.org" />
-                <data android:scheme="http" android:host="fr.openfoodfacts.org" />
-                <data android:scheme="http" android:host="gf.openfoodfacts.org" />
-                <data android:scheme="http" android:host="gp.openfoodfacts.org" />
-                <data android:scheme="http" android:host="gr.openfoodfacts.org" />
-                <data android:scheme="http" android:host="hk.openfoodfacts.org" />
-                <data android:scheme="http" android:host="hk-zh.openfoodfacts.org" />
-                <data android:scheme="http" android:host="hu.openfoodfacts.org" />
-                <data android:scheme="http" android:host="id.openfoodfacts.org" />
-                <data android:scheme="http" android:host="ie.openfoodfacts.org" />
-                <data android:scheme="http" android:host="il.openfoodfacts.org" />
-                <data android:scheme="http" android:host="in.openfoodfacts.org" />
-                <data android:scheme="http" android:host="ir.openfoodfacts.org" />
-                <data android:scheme="http" android:host="it.openfoodfacts.org" />
-                <data android:scheme="http" android:host="jp.openfoodfacts.org" />
-                <data android:scheme="http" android:host="ke.openfoodfacts.org" />
-                <data android:scheme="http" android:host="kh.openfoodfacts.org" />
-                <data android:scheme="http" android:host="lu.openfoodfacts.org" />
-                <data android:scheme="http" android:host="ma-fr.openfoodfacts.org" />
-                <data android:scheme="http" android:host="ma.openfoodfacts.org" />
-                <data android:scheme="http" android:host="mq.openfoodfacts.org" />
-                <data android:scheme="http" android:host="mx.openfoodfacts.org" />
-                <data android:scheme="http" android:host="nl-en.openfoodfacts.org" />
-                <data android:scheme="http" android:host="nl.openfoodfacts.org" />
-                <data android:scheme="http" android:host="no.openfoodfacts.org" />
-                <data android:scheme="http" android:host="nz.openfoodfacts.org" />
-                <data android:scheme="http" android:host="pe.openfoodfacts.org" />
-                <data android:scheme="http" android:host="pf.openfoodfacts.org" />
-                <data android:scheme="http" android:host="ph.openfoodfacts.org" />
-                <data android:scheme="http" android:host="pl-en.openfoodfacts.org" />
-                <data android:scheme="http" android:host="pl.openfoodfacts.org" />
-                <data android:scheme="http" android:host="openfoodfacts.org" />
-                <data android:scheme="http" android:host="pt-en.openfoodfacts.org" />
-                <data android:scheme="http" android:host="pt.openfoodfacts.org" />
-                <data android:scheme="http" android:host="re.openfoodfacts.org" />
-                <data android:scheme="http" android:host="ro.openfoodfacts.org" />
-                <data android:scheme="http" android:host="ru-en.openfoodfacts.org" />
-                <data android:scheme="http" android:host="ru.openfoodfacts.org" />
-                <data android:scheme="http" android:host="sa.openfoodfacts.org" />
-                <data android:scheme="http" android:host="se.openfoodfacts.org" />
-                <data android:scheme="http" android:host="sg.openfoodfacts.org" />
-                <data android:scheme="http" android:host="sg-zh.openfoodfacts.org" />
-                <data android:scheme="http" android:host="sk.openfoodfacts.org" />
-                <data android:scheme="http" android:host="th.openfoodfacts.org" />
-                <data android:scheme="http" android:host="tn-en.openfoodfacts.org" />
-                <data android:scheme="http" android:host="tn.openfoodfacts.org" />
-                <data android:scheme="http" android:host="tr.openfoodfacts.org" />
-                <data android:scheme="http" android:host="tw.openfoodfacts.org" />
-                <data android:scheme="http" android:host="uk.openfoodfacts.org" />
-                <data android:scheme="http" android:host="us-es.openfoodfacts.org" />
-                <data android:scheme="http" android:host="us.openfoodfacts.org" />
-                <data android:scheme="http" android:host="world-de.openfoodfacts.org" />
-                <data android:scheme="http" android:host="world-en.openfoodfacts.org" />
-                <data android:scheme="http" android:host="world-es.openfoodfacts.org" />
-                <data android:scheme="http" android:host="world-fr.openfoodfacts.org" />
-                <data android:scheme="http" android:host="world-it.openfoodfacts.org" />
-                <data android:scheme="http" android:host="world.openfoodfacts.org" />
-                <data android:scheme="http" android:host="world-pt.openfoodfacts.org" />
-                <data android:scheme="http" android:host="world-ru.openfoodfacts.org" />
-                <data android:scheme="http" android:host="world-zh.openfoodfacts.org" />
-                <data android:scheme="http" android:host="www.openfoodfacts.org" />
-                <data android:scheme="http" android:host="za.openfoodfacts.org" />
-                <data android:scheme="http" android:host="zh.openfoodfacts.org" />
-                
+                <data
+                    android:scheme="http"
+                    android:host="ae.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ar.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="at-en.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="at.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="au.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="be-de.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="be-en.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="be-fr.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="be.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="bg.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="br.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ca-fr.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ca.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ch-en.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ch-fr.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ch-it.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ch.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="cl.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="cn-en.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="cn.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="co.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="cz.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="de-en.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="de.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="dk.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="dz-fr.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="dz.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="en.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="es-ca.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="es-en.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="es-eu.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="es-gl.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="es.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="fi.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="fr-en.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="fr-es.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="fr.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="gf.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="gp.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="gr.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="hk.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="hk-zh.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="hu.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="id.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ie.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="il.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="in.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ir.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="it.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="jp.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ke.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="kh.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="lu.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ma-fr.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ma.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="mq.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="mx.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="nl-en.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="nl.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="no.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="nz.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="pe.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="pf.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ph.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="pl-en.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="pl.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="pt-en.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="pt.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="re.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ro.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ru-en.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ru.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="sa.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="se.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="sg.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="sg-zh.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="sk.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="th.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="tn-en.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="tn.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="tr.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="tw.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="uk.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="us-es.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="us.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="world-de.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="world-en.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="world-es.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="world-fr.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="world-it.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="world.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="world-pt.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="world-ru.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="world-zh.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="www.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="za.openfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="zh.openfoodfacts.org" />
+
                 <!-- OpenFoodFacts.net -->
-                <data android:scheme="http" android:host="ae.openfoodfacts.net" />
-                <data android:scheme="http" android:host="ar.openfoodfacts.net" />
-                <data android:scheme="http" android:host="at-en.openfoodfacts.net" />
-                <data android:scheme="http" android:host="at.openfoodfacts.net" />
-                <data android:scheme="http" android:host="au.openfoodfacts.net" />
-                <data android:scheme="http" android:host="be-de.openfoodfacts.net" />
-                <data android:scheme="http" android:host="be-en.openfoodfacts.net" />
-                <data android:scheme="http" android:host="be-fr.openfoodfacts.net" />
-                <data android:scheme="http" android:host="be.openfoodfacts.net" />
-                <data android:scheme="http" android:host="bg.openfoodfacts.net" />
-                <data android:scheme="http" android:host="br.openfoodfacts.net" />
-                <data android:scheme="http" android:host="ca-fr.openfoodfacts.net" />
-                <data android:scheme="http" android:host="ca.openfoodfacts.net" />
-                <data android:scheme="http" android:host="ch-en.openfoodfacts.net" />
-                <data android:scheme="http" android:host="ch-fr.openfoodfacts.net" />
-                <data android:scheme="http" android:host="ch-it.openfoodfacts.net" />
-                <data android:scheme="http" android:host="ch.openfoodfacts.net" />
-                <data android:scheme="http" android:host="cl.openfoodfacts.net" />
-                <data android:scheme="http" android:host="cn-en.openfoodfacts.net" />
-                <data android:scheme="http" android:host="cn.openfoodfacts.net" />
-                <data android:scheme="http" android:host="co.openfoodfacts.net" />
-                <data android:scheme="http" android:host="cz.openfoodfacts.net" />
-                <data android:scheme="http" android:host="de-en.openfoodfacts.net" />
-                <data android:scheme="http" android:host="de.openfoodfacts.net" />
-                <data android:scheme="http" android:host="dk.openfoodfacts.net" />
-                <data android:scheme="http" android:host="dz-fr.openfoodfacts.net" />
-                <data android:scheme="http" android:host="dz.openfoodfacts.net" />
-                <data android:scheme="http" android:host="en.openfoodfacts.net" />
-                <data android:scheme="http" android:host="es-ca.openfoodfacts.net" />
-                <data android:scheme="http" android:host="es-en.openfoodfacts.net" />
-                <data android:scheme="http" android:host="es-eu.openfoodfacts.net" />
-                <data android:scheme="http" android:host="es-gl.openfoodfacts.net" />
-                <data android:scheme="http" android:host="es.openfoodfacts.net" />
-                <data android:scheme="http" android:host="fi.openfoodfacts.net" />
-                <data android:scheme="http" android:host="fr-en.openfoodfacts.net" />
-                <data android:scheme="http" android:host="fr-es.openfoodfacts.net" />
-                <data android:scheme="http" android:host="fr.openfoodfacts.net" />
-                <data android:scheme="http" android:host="gf.openfoodfacts.net" />
-                <data android:scheme="http" android:host="gp.openfoodfacts.net" />
-                <data android:scheme="http" android:host="gr.openfoodfacts.net" />
-                <data android:scheme="http" android:host="hk.openfoodfacts.net" />
-                <data android:scheme="http" android:host="hk-zh.openfoodfacts.net" />
-                <data android:scheme="http" android:host="hu.openfoodfacts.net" />
-                <data android:scheme="http" android:host="id.openfoodfacts.net" />
-                <data android:scheme="http" android:host="ie.openfoodfacts.net" />
-                <data android:scheme="http" android:host="il.openfoodfacts.net" />
-                <data android:scheme="http" android:host="in.openfoodfacts.net" />
-                <data android:scheme="http" android:host="ir.openfoodfacts.net" />
-                <data android:scheme="http" android:host="it.openfoodfacts.net" />
-                <data android:scheme="http" android:host="jp.openfoodfacts.net" />
-                <data android:scheme="http" android:host="ke.openfoodfacts.net" />
-                <data android:scheme="http" android:host="kh.openfoodfacts.net" />
-                <data android:scheme="http" android:host="lu.openfoodfacts.net" />
-                <data android:scheme="http" android:host="ma-fr.openfoodfacts.net" />
-                <data android:scheme="http" android:host="ma.openfoodfacts.net" />
-                <data android:scheme="http" android:host="mq.openfoodfacts.net" />
-                <data android:scheme="http" android:host="mx.openfoodfacts.net" />
-                <data android:scheme="http" android:host="nl-en.openfoodfacts.net" />
-                <data android:scheme="http" android:host="nl.openfoodfacts.net" />
-                <data android:scheme="http" android:host="no.openfoodfacts.net" />
-                <data android:scheme="http" android:host="nz.openfoodfacts.net" />
-                <data android:scheme="http" android:host="pe.openfoodfacts.net" />
-                <data android:scheme="http" android:host="pf.openfoodfacts.net" />
-                <data android:scheme="http" android:host="ph.openfoodfacts.net" />
-                <data android:scheme="http" android:host="pl-en.openfoodfacts.net" />
-                <data android:scheme="http" android:host="pl.openfoodfacts.net" />
-                <data android:scheme="http" android:host="openfoodfacts.net" />
-                <data android:scheme="http" android:host="pt-en.openfoodfacts.net" />
-                <data android:scheme="http" android:host="pt.openfoodfacts.net" />
-                <data android:scheme="http" android:host="re.openfoodfacts.net" />
-                <data android:scheme="http" android:host="ro.openfoodfacts.net" />
-                <data android:scheme="http" android:host="ru-en.openfoodfacts.net" />
-                <data android:scheme="http" android:host="ru.openfoodfacts.net" />
-                <data android:scheme="http" android:host="sa.openfoodfacts.net" />
-                <data android:scheme="http" android:host="se.openfoodfacts.net" />
-                <data android:scheme="http" android:host="sg.openfoodfacts.net" />
-                <data android:scheme="http" android:host="sg-zh.openfoodfacts.net" />
-                <data android:scheme="http" android:host="sk.openfoodfacts.net" />
-                <data android:scheme="http" android:host="th.openfoodfacts.net" />
-                <data android:scheme="http" android:host="tn-en.openfoodfacts.net" />
-                <data android:scheme="http" android:host="tn.openfoodfacts.net" />
-                <data android:scheme="http" android:host="tr.openfoodfacts.net" />
-                <data android:scheme="http" android:host="tw.openfoodfacts.net" />
-                <data android:scheme="http" android:host="uk.openfoodfacts.net" />
-                <data android:scheme="http" android:host="us-es.openfoodfacts.net" />
-                <data android:scheme="http" android:host="us.openfoodfacts.net" />
-                <data android:scheme="http" android:host="world-de.openfoodfacts.net" />
-                <data android:scheme="http" android:host="world-en.openfoodfacts.net" />
-                <data android:scheme="http" android:host="world-es.openfoodfacts.net" />
-                <data android:scheme="http" android:host="world-fr.openfoodfacts.net" />
-                <data android:scheme="http" android:host="world-it.openfoodfacts.net" />
-                <data android:scheme="http" android:host="world.openfoodfacts.net" />
-                <data android:scheme="http" android:host="world-pt.openfoodfacts.net" />
-                <data android:scheme="http" android:host="world-ru.openfoodfacts.net" />
-                <data android:scheme="http" android:host="world-zh.openfoodfacts.net" />
-                <data android:scheme="http" android:host="www.openfoodfacts.net" />
-                <data android:scheme="http" android:host="za.openfoodfacts.net" />
-                <data android:scheme="http" android:host="zh.openfoodfacts.net" />
-                
+                <data
+                    android:scheme="http"
+                    android:host="ae.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="ar.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="at-en.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="at.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="au.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="be-de.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="be-en.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="be-fr.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="be.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="bg.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="br.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="ca-fr.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="ca.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="ch-en.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="ch-fr.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="ch-it.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="ch.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="cl.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="cn-en.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="cn.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="co.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="cz.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="de-en.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="de.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="dk.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="dz-fr.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="dz.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="en.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="es-ca.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="es-en.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="es-eu.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="es-gl.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="es.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="fi.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="fr-en.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="fr-es.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="fr.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="gf.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="gp.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="gr.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="hk.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="hk-zh.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="hu.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="id.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="ie.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="il.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="in.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="ir.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="it.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="jp.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="ke.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="kh.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="lu.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="ma-fr.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="ma.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="mq.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="mx.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="nl-en.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="nl.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="no.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="nz.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="pe.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="pf.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="ph.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="pl-en.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="pl.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="pt-en.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="pt.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="re.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="ro.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="ru-en.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="ru.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="sa.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="se.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="sg.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="sg-zh.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="sk.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="th.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="tn-en.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="tn.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="tr.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="tw.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="uk.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="us-es.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="us.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="world-de.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="world-en.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="world-es.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="world-fr.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="world-it.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="world.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="world-pt.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="world-ru.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="world-zh.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="www.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="za.openfoodfacts.net" />
+                <data
+                    android:scheme="http"
+                    android:host="zh.openfoodfacts.net" />
+
                 <!-- OpenBeautyFacts -->
-                <data android:scheme="http" android:host="ae.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="ar.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="at-en.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="at.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="au.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="be-de.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="be-en.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="be-fr.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="be.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="bg.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="br.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="ca-fr.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="ca.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="ch-en.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="ch-fr.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="ch-it.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="ch.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="cl.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="cn-en.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="cn.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="co.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="cz.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="de-en.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="de.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="dk.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="dz-fr.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="dz.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="en.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="es-ca.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="es-en.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="es-eu.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="es-gl.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="es.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="fi.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="fr-en.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="fr-es.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="fr.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="gf.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="gp.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="gr.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="hk.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="hk-zh.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="hu.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="id.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="ie.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="il.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="in.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="ir.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="it.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="jp.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="ke.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="kh.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="lu.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="ma-fr.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="ma.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="mq.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="mx.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="nl-en.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="nl.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="no.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="nz.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="pe.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="pf.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="ph.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="pl-en.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="pl.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="openbeautyfacts.org" />
-                <data android:scheme="http" android:host="pt-en.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="pt.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="re.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="ro.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="ru-en.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="ru.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="sa.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="se.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="sg.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="sg-zh.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="sk.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="th.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="tn-en.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="tn.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="tr.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="tw.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="uk.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="us-es.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="us.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="world-de.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="world-en.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="world-es.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="world-fr.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="world-it.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="world.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="world-pt.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="world-ru.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="world-zh.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="www.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="za.openbeautyfacts.org" />
-                <data android:scheme="http" android:host="zh.openbeautyfacts.org" />
-                
+                <data
+                    android:scheme="http"
+                    android:host="ae.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ar.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="at-en.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="at.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="au.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="be-de.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="be-en.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="be-fr.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="be.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="bg.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="br.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ca-fr.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ca.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ch-en.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ch-fr.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ch-it.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ch.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="cl.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="cn-en.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="cn.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="co.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="cz.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="de-en.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="de.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="dk.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="dz-fr.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="dz.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="en.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="es-ca.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="es-en.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="es-eu.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="es-gl.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="es.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="fi.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="fr-en.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="fr-es.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="fr.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="gf.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="gp.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="gr.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="hk.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="hk-zh.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="hu.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="id.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ie.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="il.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="in.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ir.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="it.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="jp.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ke.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="kh.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="lu.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ma-fr.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ma.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="mq.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="mx.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="nl-en.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="nl.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="no.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="nz.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="pe.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="pf.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ph.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="pl-en.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="pl.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="pt-en.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="pt.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="re.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ro.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ru-en.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ru.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="sa.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="se.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="sg.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="sg-zh.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="sk.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="th.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="tn-en.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="tn.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="tr.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="tw.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="uk.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="us-es.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="us.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="world-de.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="world-en.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="world-es.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="world-fr.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="world-it.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="world.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="world-pt.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="world-ru.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="world-zh.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="www.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="za.openbeautyfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="zh.openbeautyfacts.org" />
+
                 <!-- Open Products Facts -->
-                <data android:scheme="http" android:host="ae.openproductsfacts.org" />
-                <data android:scheme="http" android:host="ar.openproductsfacts.org" />
-                <data android:scheme="http" android:host="at-en.openproductsfacts.org" />
-                <data android:scheme="http" android:host="at.openproductsfacts.org" />
-                <data android:scheme="http" android:host="au.openproductsfacts.org" />
-                <data android:scheme="http" android:host="be-de.openproductsfacts.org" />
-                <data android:scheme="http" android:host="be-en.openproductsfacts.org" />
-                <data android:scheme="http" android:host="be-fr.openproductsfacts.org" />
-                <data android:scheme="http" android:host="be.openproductsfacts.org" />
-                <data android:scheme="http" android:host="bg.openproductsfacts.org" />
-                <data android:scheme="http" android:host="br.openproductsfacts.org" />
-                <data android:scheme="http" android:host="ca-fr.openproductsfacts.org" />
-                <data android:scheme="http" android:host="ca.openproductsfacts.org" />
-                <data android:scheme="http" android:host="ch-en.openproductsfacts.org" />
-                <data android:scheme="http" android:host="ch-fr.openproductsfacts.org" />
-                <data android:scheme="http" android:host="ch-it.openproductsfacts.org" />
-                <data android:scheme="http" android:host="ch.openproductsfacts.org" />
-                <data android:scheme="http" android:host="cl.openproductsfacts.org" />
-                <data android:scheme="http" android:host="cn-en.openproductsfacts.org" />
-                <data android:scheme="http" android:host="cn.openproductsfacts.org" />
-                <data android:scheme="http" android:host="co.openproductsfacts.org" />
-                <data android:scheme="http" android:host="cz.openproductsfacts.org" />
-                <data android:scheme="http" android:host="de-en.openproductsfacts.org" />
-                <data android:scheme="http" android:host="de.openproductsfacts.org" />
-                <data android:scheme="http" android:host="dk.openproductsfacts.org" />
-                <data android:scheme="http" android:host="dz-fr.openproductsfacts.org" />
-                <data android:scheme="http" android:host="dz.openproductsfacts.org" />
-                <data android:scheme="http" android:host="en.openproductsfacts.org" />
-                <data android:scheme="http" android:host="es-ca.openproductsfacts.org" />
-                <data android:scheme="http" android:host="es-en.openproductsfacts.org" />
-                <data android:scheme="http" android:host="es-eu.openproductsfacts.org" />
-                <data android:scheme="http" android:host="es-gl.openproductsfacts.org" />
-                <data android:scheme="http" android:host="es.openproductsfacts.org" />
-                <data android:scheme="http" android:host="fi.openproductsfacts.org" />
-                <data android:scheme="http" android:host="fr-en.openproductsfacts.org" />
-                <data android:scheme="http" android:host="fr-es.openproductsfacts.org" />
-                <data android:scheme="http" android:host="fr.openproductsfacts.org" />
-                <data android:scheme="http" android:host="gf.openproductsfacts.org" />
-                <data android:scheme="http" android:host="gp.openproductsfacts.org" />
-                <data android:scheme="http" android:host="gr.openproductsfacts.org" />
-                <data android:scheme="http" android:host="hk.openproductsfacts.org" />
-                <data android:scheme="http" android:host="hk-zh.openproductsfacts.org" />
-                <data android:scheme="http" android:host="hu.openproductsfacts.org" />
-                <data android:scheme="http" android:host="id.openproductsfacts.org" />
-                <data android:scheme="http" android:host="ie.openproductsfacts.org" />
-                <data android:scheme="http" android:host="il.openproductsfacts.org" />
-                <data android:scheme="http" android:host="in.openproductsfacts.org" />
-                <data android:scheme="http" android:host="ir.openproductsfacts.org" />
-                <data android:scheme="http" android:host="it.openproductsfacts.org" />
-                <data android:scheme="http" android:host="jp.openproductsfacts.org" />
-                <data android:scheme="http" android:host="ke.openproductsfacts.org" />
-                <data android:scheme="http" android:host="kh.openproductsfacts.org" />
-                <data android:scheme="http" android:host="lu.openproductsfacts.org" />
-                <data android:scheme="http" android:host="ma-fr.openproductsfacts.org" />
-                <data android:scheme="http" android:host="ma.openproductsfacts.org" />
-                <data android:scheme="http" android:host="mq.openproductsfacts.org" />
-                <data android:scheme="http" android:host="mx.openproductsfacts.org" />
-                <data android:scheme="http" android:host="nl-en.openproductsfacts.org" />
-                <data android:scheme="http" android:host="nl.openproductsfacts.org" />
-                <data android:scheme="http" android:host="no.openproductsfacts.org" />
-                <data android:scheme="http" android:host="nz.openproductsfacts.org" />
-                <data android:scheme="http" android:host="pe.openproductsfacts.org" />
-                <data android:scheme="http" android:host="pf.openproductsfacts.org" />
-                <data android:scheme="http" android:host="ph.openproductsfacts.org" />
-                <data android:scheme="http" android:host="pl-en.openproductsfacts.org" />
-                <data android:scheme="http" android:host="pl.openproductsfacts.org" />
-                <data android:scheme="http" android:host="openproductsfacts.org" />
-                <data android:scheme="http" android:host="pt-en.openproductsfacts.org" />
-                <data android:scheme="http" android:host="pt.openproductsfacts.org" />
-                <data android:scheme="http" android:host="re.openproductsfacts.org" />
-                <data android:scheme="http" android:host="ro.openproductsfacts.org" />
-                <data android:scheme="http" android:host="ru-en.openproductsfacts.org" />
-                <data android:scheme="http" android:host="ru.openproductsfacts.org" />
-                <data android:scheme="http" android:host="sa.openproductsfacts.org" />
-                <data android:scheme="http" android:host="se.openproductsfacts.org" />
-                <data android:scheme="http" android:host="sg.openproductsfacts.org" />
-                <data android:scheme="http" android:host="sg-zh.openproductsfacts.org" />
-                <data android:scheme="http" android:host="sk.openproductsfacts.org" />
-                <data android:scheme="http" android:host="th.openproductsfacts.org" />
-                <data android:scheme="http" android:host="tn-en.openproductsfacts.org" />
-                <data android:scheme="http" android:host="tn.openproductsfacts.org" />
-                <data android:scheme="http" android:host="tr.openproductsfacts.org" />
-                <data android:scheme="http" android:host="tw.openproductsfacts.org" />
-                <data android:scheme="http" android:host="uk.openproductsfacts.org" />
-                <data android:scheme="http" android:host="us-es.openproductsfacts.org" />
-                <data android:scheme="http" android:host="us.openproductsfacts.org" />
-                <data android:scheme="http" android:host="world-de.openproductsfacts.org" />
-                <data android:scheme="http" android:host="world-en.openproductsfacts.org" />
-                <data android:scheme="http" android:host="world-es.openproductsfacts.org" />
-                <data android:scheme="http" android:host="world-fr.openproductsfacts.org" />
-                <data android:scheme="http" android:host="world-it.openproductsfacts.org" />
-                <data android:scheme="http" android:host="world.openproductsfacts.org" />
-                <data android:scheme="http" android:host="world-pt.openproductsfacts.org" />
-                <data android:scheme="http" android:host="world-ru.openproductsfacts.org" />
-                <data android:scheme="http" android:host="world-zh.openproductsfacts.org" />
-                <data android:scheme="http" android:host="www.openproductsfacts.org" />
-                <data android:scheme="http" android:host="za.openproductsfacts.org" />
-                <data android:scheme="http" android:host="zh.openproductsfacts.org" />
-                
+                <data
+                    android:scheme="http"
+                    android:host="ae.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ar.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="at-en.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="at.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="au.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="be-de.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="be-en.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="be-fr.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="be.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="bg.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="br.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ca-fr.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ca.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ch-en.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ch-fr.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ch-it.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ch.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="cl.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="cn-en.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="cn.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="co.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="cz.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="de-en.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="de.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="dk.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="dz-fr.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="dz.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="en.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="es-ca.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="es-en.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="es-eu.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="es-gl.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="es.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="fi.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="fr-en.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="fr-es.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="fr.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="gf.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="gp.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="gr.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="hk.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="hk-zh.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="hu.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="id.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ie.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="il.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="in.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ir.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="it.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="jp.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ke.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="kh.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="lu.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ma-fr.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ma.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="mq.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="mx.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="nl-en.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="nl.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="no.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="nz.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="pe.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="pf.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ph.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="pl-en.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="pl.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="pt-en.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="pt.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="re.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ro.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ru-en.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ru.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="sa.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="se.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="sg.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="sg-zh.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="sk.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="th.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="tn-en.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="tn.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="tr.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="tw.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="uk.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="us-es.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="us.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="world-de.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="world-en.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="world-es.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="world-fr.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="world-it.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="world.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="world-pt.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="world-ru.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="world-zh.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="www.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="za.openproductsfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="zh.openproductsfacts.org" />
+
                 <!-- Open Pet Food Facts-->
-                <data android:scheme="http" android:host="ae.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="ar.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="at-en.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="at.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="au.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="be-de.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="be-en.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="be-fr.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="be.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="bg.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="br.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="ca-fr.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="ca.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="ch-en.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="ch-fr.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="ch-it.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="ch.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="cl.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="cn-en.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="cn.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="co.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="cz.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="de-en.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="de.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="dk.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="dz-fr.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="dz.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="en.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="es-ca.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="es-en.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="es-eu.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="es-gl.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="es.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="fi.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="fr-en.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="fr-es.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="fr.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="gf.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="gp.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="gr.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="hk.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="hk-zh.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="hu.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="id.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="ie.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="il.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="in.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="ir.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="it.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="jp.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="ke.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="kh.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="lu.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="ma-fr.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="ma.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="mq.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="mx.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="nl-en.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="nl.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="no.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="nz.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="pe.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="pf.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="ph.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="pl-en.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="pl.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="pt-en.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="pt.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="re.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="ro.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="ru-en.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="ru.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="sa.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="se.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="sg.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="sg-zh.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="sk.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="th.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="tn-en.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="tn.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="tr.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="tw.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="uk.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="us-es.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="us.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="world-de.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="world-en.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="world-es.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="world-fr.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="world-it.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="world.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="world-pt.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="world-ru.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="world-zh.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="www.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="za.openpetfoodfacts.org" />
-                <data android:scheme="http" android:host="zh.openpetfoodfacts.org" />
-                
+                <data
+                    android:scheme="http"
+                    android:host="ae.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ar.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="at-en.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="at.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="au.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="be-de.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="be-en.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="be-fr.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="be.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="bg.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="br.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ca-fr.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ca.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ch-en.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ch-fr.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ch-it.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ch.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="cl.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="cn-en.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="cn.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="co.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="cz.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="de-en.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="de.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="dk.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="dz-fr.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="dz.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="en.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="es-ca.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="es-en.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="es-eu.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="es-gl.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="es.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="fi.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="fr-en.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="fr-es.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="fr.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="gf.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="gp.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="gr.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="hk.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="hk-zh.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="hu.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="id.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ie.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="il.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="in.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ir.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="it.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="jp.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ke.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="kh.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="lu.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ma-fr.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ma.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="mq.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="mx.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="nl-en.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="nl.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="no.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="nz.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="pe.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="pf.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ph.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="pl-en.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="pl.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="pt-en.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="pt.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="re.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ro.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ru-en.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="ru.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="sa.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="se.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="sg.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="sg-zh.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="sk.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="th.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="tn-en.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="tn.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="tr.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="tw.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="uk.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="us-es.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="us.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="world-de.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="world-en.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="world-es.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="world-fr.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="world-it.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="world.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="world-pt.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="world-ru.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="world-zh.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="www.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="za.openpetfoodfacts.org" />
+                <data
+                    android:scheme="http"
+                    android:host="zh.openpetfoodfacts.org" />
+
                 <!-- Use the same rules for HTTPS -->
                 <data android:scheme="https" />
             </intent-filter>
@@ -565,21 +1553,18 @@
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data
-                android:name="flutterEmbedding"
-                android:value="2" />
-
-        <meta-data
-                android:name="io.flutter.embedding.android.EnableImpeller"
-                android:value="false" />
+            android:name="flutterEmbedding"
+            android:value="2" />
 
         <!-- Quick tile / setting (only available on Android 24+ / Nougat) -->
-        <service android:name=".AppMainTile"
-                 android:exported="true"
-                 android:icon="@drawable/ic_launcher_foreground"
-                 android:label="@string/app_name"
-                 android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+        <service
+            android:name=".AppMainTile"
+            android:exported="true"
+            android:icon="@drawable/ic_launcher_foreground"
+            android:label="@string/app_name"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
             <intent-filter>
-                <action android:name="android.service.quicksettings.action.QS_TILE"/>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
         </service>
 

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -1949,4 +1949,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.11.5 <4.0.0"
-  flutter: ">=3.41.8"
+  flutter: ">=3.41.8 <4.0.0"


### PR DESCRIPTION
### What
- Each time we started the app on the emulator, we got that annoying message
```log
I/flutter (19545): [IMPORTANT:flutter/shell/common/shell.cc(528)] [Action Required]: Impeller
opt-out deprecated.
I/flutter (19545):     The application opted out of Impeller by either using the
I/flutter (19545):     `--no-enable-impeller` flag or the
I/flutter (19545):     `io.flutter.embedding.android.EnableImpeller` `AndroidManifest.xml` entry.
I/flutter (19545):     These options are going to go away in an upcoming Flutter release. Remove
I/flutter (19545):     the explicit opt-out. If you need to opt-out, please report a bug describing
I/flutter (19545):     the issue.
I/flutter (19545):
I/flutter (19545):     https://github.com/flutter/flutter/issues/new?template=02_bug.yml
I/flutter (19545):
```
* this PR removes that Impeller opt-out.
* fun fact: the morons at flutter/dart/android studio had the terrific idea to change the display format of xml (xml!). As a consequence, it may not be obvious but I just removed the Impeller opt-out option.

### Part of 
- #6375