### PR TITLE
ci: Potential fix for code scanning alert no. 52: Untrusted Checkout TOCTOU

### DIFF
--- a/.github/workflows/on-demand.yml
+++ b/.github/workflows/on-demand.yml
@@ -98,10 +98,10 @@ jobs:
       with:
         comment-id: ${{ github.event.comment.id }}
         reactions: eyes
-    - name: Get branch name
-      # see https://github.com/actions/checkout/issues/331
-      id: get-branch
-      run: echo "branch=$(gh pr view $PR_NO --repo $REPO --json headRefName --jq '.headRefName')" >> $GITHUB_OUTPUT
+    - name: Get PR head SHA
+      # Use an immutable commit SHA to avoid TOCTOU on mutable branch refs
+      id: get-pr-head
+      run: echo "sha=$(gh pr view $PR_NO --repo $REPO --json headRefOid --jq '.headRefOid')" >> $GITHUB_OUTPUT
       env:
         REPO: ${{ github.repository }}
         PR_NO: ${{ github.event.issue.number }}
@@ -110,8 +110,8 @@ jobs:
       uses: actions/checkout@v6
       with:
         fetch-depth: 1
-        # grab the PR branch
-        ref: ${{ steps.get-branch.outputs.branch }}
+        # grab the PR commit (immutable)
+        ref: ${{ steps.get-pr-head.outputs.sha }}
         # We can't use GITHUB_TOKEN here because, github actions can't trigger actions
         # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
         # So this is a personal access token


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/smooth-app/security/code-scanning/52](https://github.com/openfoodfacts/smooth-app/security/code-scanning/52)

Use an immutable commit reference for checkout instead of a branch name.

Best fix in this file/region:
- In `.github/workflows/on-demand.yml`, within job `delete_3_letter_translation_files`, replace the “Get branch name” step with a step that fetches the PR head SHA (`headRefOid`) and outputs it (for example as `sha`).
- Update the `Checkout` step `with.ref` to use that SHA output.
- Keep existing behavior otherwise (same token, fetch-depth, subsequent steps unchanged).

This preserves functionality (checking out the PR code) while removing TOCTOU on mutable branch refs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
