### PR TITLE
fix: 7539 - it's not always a slice of bread

### DIFF
--- a/packages/smooth_app/lib/pages/preferences_v2/preferences_page.dart
+++ b/packages/smooth_app/lib/pages/preferences_v2/preferences_page.dart
@@ -36,6 +36,7 @@ import 'package:smooth_app/pages/preferences_v2/tiles/square_preference_tile.dar
 import 'package:smooth_app/pages/preferences_v2/tiles/url_preference_tile.dart';
 import 'package:smooth_app/resources/app_icons.dart' as icons;
 import 'package:smooth_app/themes/smooth_theme_colors.dart';
+import 'package:smooth_app/themes/theme_provider.dart';
 import 'package:smooth_app/widgets/autosize_text.dart';
 
 class PreferencesPage extends StatelessWidget {
@@ -46,6 +47,7 @@ class PreferencesPage extends StatelessWidget {
     context.watch<UserManagementProvider>();
 
     final String? userId = OpenFoodAPIConfiguration.globalUser?.userId;
+    final bool lightTheme = context.lightTheme();
 
     return ChangeNotifierProvider<PreferencesRootSearchController>(
       create: (_) => PreferencesRootSearchController(),
@@ -58,10 +60,10 @@ class PreferencesPage extends StatelessWidget {
           PreferenceCard(
             title: appLocalizations.preferences_page_customize_app_title,
             tiles: <PreferenceTile>[
-              _buildFoodPreferencesTile(appLocalizations),
-              _buildBeautyPreferencesTile(appLocalizations),
-              _buildProductPreferencesTile(appLocalizations),
-              _buildPetFoodPreferencesTile(appLocalizations),
+              _buildFoodPreferencesTile(appLocalizations, lightTheme),
+              _buildBeautyPreferencesTile(appLocalizations, lightTheme),
+              _buildProductPreferencesTile(appLocalizations, lightTheme),
+              _buildPetFoodPreferencesTile(appLocalizations, lightTheme),
               _buildAppSettingsTile(appLocalizations),
             ],
           ),
@@ -213,9 +215,10 @@ class PreferencesPage extends StatelessWidget {
   // Customize App section
   NavigationPreferenceTile _buildFoodPreferencesTile(
     AppLocalizations appLocalizations,
+    bool lightTheme,
   ) {
     return NavigationPreferenceTile(
-      leading: const icons.HappyToast(),
+      leading: FaqRoot.createOffLeadingIcon(lightTheme),
       title: appLocalizations.myPreferences_food_title,
       subtitleText: appLocalizations.myPreferences_food_subtitle,
       target: const FoodPreferencesPage(project: PreferencesPageProjects.food),
@@ -225,9 +228,10 @@ class PreferencesPage extends StatelessWidget {
 
   NavigationPreferenceTile _buildBeautyPreferencesTile(
     AppLocalizations appLocalizations,
+    bool lightTheme,
   ) {
     return NavigationPreferenceTile(
-      leading: const icons.HappyToast(),
+      leading: FaqRoot.createObfLeadingIcon(lightTheme),
       title: appLocalizations.myPreferences_beauty_title,
       subtitleText: appLocalizations.myPreferences_beauty_subtitle,
       target: const FoodPreferencesPage(
@@ -239,9 +243,10 @@ class PreferencesPage extends StatelessWidget {
 
   NavigationPreferenceTile _buildProductPreferencesTile(
     AppLocalizations appLocalizations,
+    bool lightTheme,
   ) {
     return NavigationPreferenceTile(
-      leading: const icons.HappyToast(),
+      leading: FaqRoot.createOpfLeadingIcon(lightTheme),
       title: appLocalizations.myPreferences_product_title,
       subtitleText: appLocalizations.myPreferences_product_subtitle,
       target: const FoodPreferencesPage(
@@ -253,9 +258,10 @@ class PreferencesPage extends StatelessWidget {
 
   NavigationPreferenceTile _buildPetFoodPreferencesTile(
     AppLocalizations appLocalizations,
+    bool lightTheme,
   ) {
     return NavigationPreferenceTile(
-      leading: const icons.HappyToast(),
+      leading: FaqRoot.createOpffLeadingIcon(lightTheme),
       title: appLocalizations.myPreferences_pet_food_title,
       subtitleText: appLocalizations.myPreferences_pet_food_subtitle,
       target: const FoodPreferencesPage(project: PreferencesPageProjects.pets),

--- a/packages/smooth_app/lib/pages/preferences_v2/roots/faq_root.dart
+++ b/packages/smooth_app/lib/pages/preferences_v2/roots/faq_root.dart
@@ -120,8 +120,8 @@ class FaqRoot extends PreferencesRoot {
     bool lightTheme,
   ) {
     return PreferenceTile(
-      leading: _createLeadingIcon(
-        'assets/guides/open_food_facts/thumb_${lightTheme ? 'light' : 'dark'}.svg.vec',
+      leading: createOffLeadingIcon(
+        lightTheme,
         padding: const EdgeInsetsDirectional.only(start: 2.0),
       ),
       title: appLocalizations.preferences_faq_discover_off_title,
@@ -137,8 +137,8 @@ class FaqRoot extends PreferencesRoot {
     bool lightTheme,
   ) {
     return PreferenceTile(
-      leading: _createLeadingIcon(
-        'assets/guides/open_beauty_facts/thumb_${lightTheme ? 'light' : 'dark'}.svg.vec',
+      leading: createObfLeadingIcon(
+        lightTheme,
         padding: const EdgeInsetsDirectional.only(start: 2.0),
       ),
       title: appLocalizations.preferences_faq_discover_obf_title,
@@ -154,8 +154,8 @@ class FaqRoot extends PreferencesRoot {
     bool lightTheme,
   ) {
     return PreferenceTile(
-      leading: _createLeadingIcon(
-        'assets/guides/open_pet_food_facts/thumb_${lightTheme ? 'light' : 'dark'}.svg.vec',
+      leading: createOpffLeadingIcon(
+        lightTheme,
         padding: const EdgeInsetsDirectional.only(start: 2.0),
       ),
       title: appLocalizations.preferences_faq_discover_opff_title,
@@ -171,8 +171,8 @@ class FaqRoot extends PreferencesRoot {
     bool lightTheme,
   ) {
     return PreferenceTile(
-      leading: _createLeadingIcon(
-        'assets/guides/open_products_facts/thumb_${lightTheme ? 'light' : 'dark'}.svg.vec',
+      leading: createOpfLeadingIcon(
+        lightTheme,
         padding: const EdgeInsetsDirectional.only(start: 2.0),
       ),
       title: appLocalizations.preferences_faq_discover_opf_title,
@@ -237,7 +237,7 @@ class FaqRoot extends PreferencesRoot {
     );
   }
 
-  Widget _createLeadingIcon(String svg, {EdgeInsetsGeometry? padding}) {
+  static Widget _createLeadingIcon(String svg, {EdgeInsetsGeometry? padding}) {
     final Widget child;
     if (svg.endsWith('vec')) {
       child = SvgPicture(AssetBytesLoader(svg), width: 48.0);
@@ -250,6 +250,38 @@ class FaqRoot extends PreferencesRoot {
     }
     return child;
   }
+
+  static Widget createOffLeadingIcon(
+    bool lightTheme, {
+    EdgeInsetsGeometry? padding,
+  }) => _createLeadingIcon(
+    'assets/guides/open_food_facts/thumb_${lightTheme ? 'light' : 'dark'}.svg.vec',
+    padding: padding,
+  );
+
+  static Widget createObfLeadingIcon(
+    bool lightTheme, {
+    EdgeInsetsGeometry? padding,
+  }) => _createLeadingIcon(
+    'assets/guides/open_beauty_facts/thumb_${lightTheme ? 'light' : 'dark'}.svg.vec',
+    padding: padding,
+  );
+
+  static Widget createOpffLeadingIcon(
+    bool lightTheme, {
+    EdgeInsetsGeometry? padding,
+  }) => _createLeadingIcon(
+    'assets/guides/open_pet_food_facts/thumb_${lightTheme ? 'light' : 'dark'}.svg.vec',
+    padding: padding,
+  );
+
+  static Widget createOpfLeadingIcon(
+    bool lightTheme, {
+    EdgeInsetsGeometry? padding,
+  }) => _createLeadingIcon(
+    'assets/guides/open_products_facts/thumb_${lightTheme ? 'light' : 'dark'}.svg.vec',
+    padding: padding,
+  );
 
   PreferenceTile _createScoreTile({
     required String title,


### PR DESCRIPTION
### What
Instead of using the food icon for all OxF preferences, we reuse the OxF leading icons of the FAQ.

### Screenshot or video
| before | dark | light |
| -- | -- | -- |
| <img width="1080" height="2408" alt="Screenshot_20260603_174820" src="https://github.com/user-attachments/assets/b696904d-eaaf-47d7-8209-421d74508572" /> | <img width="1080" height="2408" alt="Screenshot_20260603_180603" src="https://github.com/user-attachments/assets/302c937d-5b09-43df-a5a5-a8280a7765a8" /> | <img width="1080" height="2408" alt="Screenshot_20260603_180421" src="https://github.com/user-attachments/assets/e66c67d2-5fad-49fb-bbf8-c368d60f875c" /> |

### Part of 
- #7539

### Impacted files
* `faq_root.dart`: public methods for OxF leading icons
* `preferences_page.dart`: using different OxF leading icons