### PR TITLE
fix: 7538 - fixed some dark mode issue with OxF preferences

### DIFF
--- a/packages/smooth_app/lib/pages/food_preferences/widgets/summary_section.dart
+++ b/packages/smooth_app/lib/pages/food_preferences/widgets/summary_section.dart
@@ -61,10 +61,7 @@ class SummarySection extends StatelessWidget {
             padding: const EdgeInsetsDirectional.all(LARGE_SPACE),
             child: Text(
               appLocalizations.food_preferences_no_selection,
-              style: TextStyle(
-                color: theme.greyMedium,
-                fontStyle: FontStyle.italic,
-              ),
+              style: const TextStyle(fontStyle: FontStyle.italic),
             ),
           )
         else

--- a/packages/smooth_app/lib/pages/food_preferences/widgets/summary_section.dart
+++ b/packages/smooth_app/lib/pages/food_preferences/widgets/summary_section.dart
@@ -19,6 +19,8 @@ class SummarySection extends StatelessWidget {
   final VoidCallback onEdit;
   final List<String> unwantedIngredients;
 
+  static const Color _foregroundColor = Colors.black;
+
   @override
   Widget build(BuildContext context) {
     final SmoothColorsThemeExtension theme = context
@@ -40,11 +42,14 @@ class SummarySection extends StatelessWidget {
               Expanded(
                 child: Text(
                   groupName,
-                  style: const TextStyle(fontWeight: FontWeight.bold),
+                  style: const TextStyle(
+                    fontWeight: FontWeight.bold,
+                    color: _foregroundColor,
+                  ),
                 ),
               ),
               IconButton(
-                icon: const icons.Edit(size: 20.0),
+                icon: const icons.Edit(size: 20.0, color: _foregroundColor),
                 onPressed: onEdit,
                 tooltip: appLocalizations.edit,
               ),


### PR DESCRIPTION
### What
- Quick dark mode fix for preferences.

### Screenshot or video
| before | dark | light |
| -- | -- | -- |
| <img width="1080" height="2408" alt="Screenshot_20260603_182756" src="https://github.com/user-attachments/assets/b13b98e8-9063-420b-8219-1cda43a2fc38" /> | <img width="1080" height="2408" alt="Screenshot_20260603_192219" src="https://github.com/user-attachments/assets/6e7c2963-bd10-4b47-8fde-fd41226721ec" /> | <img width="1080" height="2408" alt="Screenshot_20260603_192126" src="https://github.com/user-attachments/assets/a019756f-506e-4171-b85e-b19a24e18935" /> |

### Part of 
- #7538

### Impacted file
* `summary_section.dart`: explicit dark color for title and icon