### PR TITLE
fix: 7539 - configured settings flag display

### DIFF
--- a/packages/smooth_app/lib/data_models/preferences/user_preferences.dart
+++ b/packages/smooth_app/lib/data_models/preferences/user_preferences.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:smooth_app/data_models/product_preferences.dart';
+import 'package:smooth_app/pages/food_preferences/preferences_page_projects.dart';
 import 'package:smooth_app/pages/onboarding/onboarding_flow_navigator.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_dev_mode.dart';
 import 'package:smooth_app/pages/product/product_page/footer/new_product_footer.dart';
@@ -177,10 +178,14 @@ class UserPreferences extends ChangeNotifier {
   String _getImportanceTag(final String variable) =>
       _TAG_PREFIX_IMPORTANCE + variable;
 
+  String _getImportancePrefixForProject(
+    final PreferencesPageProjects project,
+  ) => '$_TAG_PREFIX_IMPORTANCE${project.projectKey}_';
+
   String _getImportanceTagForProject(
     final String variable,
-    final String projectKey,
-  ) => '$_TAG_PREFIX_IMPORTANCE${projectKey}_$variable';
+    final PreferencesPageProjects project,
+  ) => '${_getImportancePrefixForProject(project)}$variable';
 
   Future<void> setImportance(
     final String attributeId,
@@ -197,10 +202,10 @@ class UserPreferences extends ChangeNotifier {
   Future<void> setImportanceForProject(
     final String attributeId,
     final String importanceId,
-    final String projectKey,
+    final PreferencesPageProjects project,
   ) async {
     await _sharedPreferences.setString(
-      _getImportanceTagForProject(attributeId, projectKey),
+      _getImportanceTagForProject(attributeId, project),
       importanceId,
     );
     notifyListeners();
@@ -213,12 +218,24 @@ class UserPreferences extends ChangeNotifier {
   /// Gets the importance for an attribute for a specific project.
   String getImportanceForProject(
     final String attributeId,
-    final String projectKey,
+    final PreferencesPageProjects project,
   ) =>
       _sharedPreferences.getString(
-        _getImportanceTagForProject(attributeId, projectKey),
+        _getImportanceTagForProject(attributeId, project),
       ) ??
       PreferenceImportance.ID_NOT_IMPORTANT;
+
+  /// Are the preferences set for this project?
+  bool arePreferencesSetForProject(final PreferencesPageProjects project) {
+    final Set<String> keys = _sharedPreferences.getKeys();
+    final String prefix = _getImportancePrefixForProject(project);
+    for (final String key in keys) {
+      if (key.startsWith(prefix)) {
+        return true;
+      }
+    }
+    return false;
+  }
 
   Future<void> setTheme(final String theme) async {
     await _sharedPreferences.setString(_TAG_CURRENT_THEME_MODE, theme);
@@ -463,10 +480,10 @@ class UserPreferences extends ChangeNotifier {
 
   /// Returns the unwanted ingredients map for a specific project.
   Map<String, String> _getUnwantedIngredientsMapForProject(
-    final String projectKey,
+    final PreferencesPageProjects project,
   ) {
     final String? jsonString = _sharedPreferences.getString(
-      '${_TAG_UNWANTED_INGREDIENTS}_$projectKey',
+      '${_TAG_UNWANTED_INGREDIENTS}_${project.projectKey}',
     );
     if (jsonString == null || jsonString.isEmpty) {
       return <String, String>{};
@@ -490,9 +507,9 @@ class UserPreferences extends ChangeNotifier {
   }
 
   /// Returns the list of canonical tags for unwanted ingredients for a specific project.
-  List<String> getUnwantedIngredientTagsForProject(final String projectKey) {
-    return _getUnwantedIngredientsMapForProject(projectKey).values.toList();
-  }
+  List<String> getUnwantedIngredientTagsForProject(
+    final PreferencesPageProjects project,
+  ) => _getUnwantedIngredientsMapForProject(project).values.toList();
 
   /// Returns the list of user-facing names for unwanted ingredients.
   /// Use this for display purposes.
@@ -501,9 +518,9 @@ class UserPreferences extends ChangeNotifier {
   }
 
   /// Returns the list of user-facing names for unwanted ingredients for a specific project.
-  List<String> getUnwantedIngredientsForProject(final String projectKey) {
-    return _getUnwantedIngredientsMapForProject(projectKey).keys.toList();
-  }
+  List<String> getUnwantedIngredientsForProject(
+    final PreferencesPageProjects project,
+  ) => _getUnwantedIngredientsMapForProject(project).keys.toList();
 
   /// Sets the unwanted ingredients map.
   /// [ingredientsMap] is a map where keys are user-facing names and values are
@@ -521,10 +538,10 @@ class UserPreferences extends ChangeNotifier {
   /// Sets the unwanted ingredients map for a specific project.
   Future<void> setUnwantedIngredientsForProject(
     Map<String, String> ingredientsMap,
-    final String projectKey,
+    final PreferencesPageProjects project,
   ) async {
     await _sharedPreferences.setString(
-      '${_TAG_UNWANTED_INGREDIENTS}_$projectKey',
+      '${_TAG_UNWANTED_INGREDIENTS}_${project.projectKey}',
       jsonEncode(ingredientsMap),
     );
     notifyListeners();

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -539,6 +539,7 @@
   "myPreferences_profile_subtitle": "Manage your Open Food Facts contributor account.",
   "myPreferences_settings_title": "App Settings",
   "myPreferences_settings_subtitle": "Dark mode, Languages…",
+  "myPreferences_not_configured_yet": "You haven't set any preference yet.",
   "myPreferences_food_title": "Food Preferences",
   "myPreferences_food_subtitle": "Choose what information about food matters most to you.",
   "myPreferences_food_comment": "Choose what information about food matters most to you, in order to rank food according to your preferences, see the information you care about first, and get a compatibility summary. Those food preferences stay on your device, and are not associated with your Open Food Facts contributor account if you have one.",

--- a/packages/smooth_app/lib/l10n/app_localizations.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations.dart
@@ -1482,6 +1482,12 @@ abstract class AppLocalizations {
   /// **'Dark mode, Languages…'**
   String get myPreferences_settings_subtitle;
 
+  /// No description provided for @myPreferences_not_configured_yet.
+  ///
+  /// In en, this message translates to:
+  /// **'You haven\'t set any preference yet.'**
+  String get myPreferences_not_configured_yet;
+
   /// No description provided for @myPreferences_food_title.
   ///
   /// In en, this message translates to:

--- a/packages/smooth_app/lib/pages/food_preferences/food_preferences_page.dart
+++ b/packages/smooth_app/lib/pages/food_preferences/food_preferences_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_animation_progress_bar/flutter_animation_progress_bar.dart';
-import 'package:http/http.dart' as http;
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/preferences/user_preferences.dart';
@@ -12,61 +11,16 @@ import 'package:smooth_app/pages/food_preferences/food_preferences_controller.da
 import 'package:smooth_app/pages/food_preferences/models/pending_preferences.dart';
 import 'package:smooth_app/pages/food_preferences/pages/introduction_page.dart';
 import 'package:smooth_app/pages/food_preferences/pages/summary_page.dart';
+import 'package:smooth_app/pages/food_preferences/preferences_page_projects.dart';
 import 'package:smooth_app/pages/food_preferences/widgets/attribute_group_page.dart';
 import 'package:smooth_app/pages/food_preferences/widgets/food_preferences_navigation_bar.dart';
-import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/themes/smooth_theme_colors.dart';
 import 'package:smooth_app/themes/theme_provider.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 import 'package:smooth_app/widgets/v2/smooth_topbar2.dart';
 
-enum PreferencesPageProjects {
-  food,
-  products,
-  beauty,
-  pets;
-
-  UriProductHelper getUriProductHelper() {
-    switch (this) {
-      case PreferencesPageProjects.food:
-        return uriHelperFoodProd;
-      case PreferencesPageProjects.products:
-        return uriHelperProductsProd;
-      case PreferencesPageProjects.beauty:
-        return uriHelperBeautyProd;
-      case PreferencesPageProjects.pets:
-        return uriHelperPetFoodProd;
-    }
-  }
-
-  Future<List<AttributeGroup>?> fetchAttributeGroups() async {
-    try {
-      final String languageCode = ProductQuery.getLanguage().code;
-      final Uri uri = AvailableAttributeGroups.getUri(
-        languageCode,
-        uriHelper: getUriProductHelper(),
-      );
-
-      final http.Response response = await http.get(uri);
-      if (response.statusCode != 200) {
-        return null;
-      }
-
-      final AvailableAttributeGroups availableAttributeGroups =
-          AvailableAttributeGroups.loadFromJSONString(response.body);
-      return availableAttributeGroups.attributeGroups;
-    } catch (e) {
-      debugPrint('Error fetching attribute groups for $name: $e');
-      return null;
-    }
-  }
-}
-
 class FoodPreferencesPage extends StatefulWidget {
-  const FoodPreferencesPage({
-    super.key,
-    this.project = PreferencesPageProjects.food,
-  });
+  const FoodPreferencesPage({required this.project, super.key});
 
   final PreferencesPageProjects project;
 

--- a/packages/smooth_app/lib/pages/food_preferences/models/pending_preferences.dart
+++ b/packages/smooth_app/lib/pages/food_preferences/models/pending_preferences.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/data_models/preferences/user_preferences.dart';
-import 'package:smooth_app/pages/food_preferences/food_preferences_page.dart';
+import 'package:smooth_app/pages/food_preferences/preferences_page_projects.dart';
 import 'package:smooth_app/query/product_query.dart';
 
 /// Manages pending (unsaved) food preference changes during the preferences wizard.
@@ -36,8 +36,6 @@ class PendingPreferences extends ChangeNotifier {
   final List<AttributeGroup> _attributeGroups;
   final PreferencesPageProjects _project;
 
-  String get _projectKey => _project.name;
-
   final Map<String, String> _pendingImportances = <String, String>{};
 
   List<String> _pendingUnwantedIngredients = <String>[];
@@ -50,7 +48,7 @@ class PendingPreferences extends ChangeNotifier {
         final String? attributeId = attribute.id;
         if (attributeId != null) {
           _pendingImportances[attributeId] = _userPreferences
-              .getImportanceForProject(attributeId, _projectKey);
+              .getImportanceForProject(attributeId, _project);
         }
       }
     }
@@ -60,7 +58,7 @@ class PendingPreferences extends ChangeNotifier {
   Future<void> _loadExcludedIngredients() async {
     // Load user-facing names from preferences
     _pendingUnwantedIngredients = _userPreferences
-        .getUnwantedIngredientsForProject(_projectKey);
+        .getUnwantedIngredientsForProject(_project);
     _unwantedIngredientsInitialized = true;
     notifyListeners();
   }
@@ -133,7 +131,7 @@ class PendingPreferences extends ChangeNotifier {
     await Future.wait(
       _pendingImportances.entries.map(
         (MapEntry<String, String> entry) => _userPreferences
-            .setImportanceForProject(entry.key, entry.value, _projectKey),
+            .setImportanceForProject(entry.key, entry.value, _project),
       ),
     );
 
@@ -144,7 +142,7 @@ class PendingPreferences extends ChangeNotifier {
     if (_pendingUnwantedIngredients.isEmpty) {
       await _userPreferences.setUnwantedIngredientsForProject(
         <String, String>{},
-        _projectKey,
+        _project,
       );
       return;
     }
@@ -167,7 +165,7 @@ class PendingPreferences extends ChangeNotifier {
 
     await _userPreferences.setUnwantedIngredientsForProject(
       ingredientsMap,
-      _projectKey,
+      _project,
     );
   }
 

--- a/packages/smooth_app/lib/pages/food_preferences/preferences_page_projects.dart
+++ b/packages/smooth_app/lib/pages/food_preferences/preferences_page_projects.dart
@@ -19,18 +19,16 @@ enum PreferencesPageProjects {
     PreferencesPageProjects.pets => 'pets',
   };
 
-  // TODO 0000 roll back
   String getTitle(AppLocalizations appLocalizations) => switch (this) {
     PreferencesPageProjects.food => appLocalizations.myPreferences_food_title,
     PreferencesPageProjects.products =>
-      'Change your preferences for products', //appLocalizations.myPreferences_product_title,
+      appLocalizations.myPreferences_product_title,
     PreferencesPageProjects.beauty =>
-      'Define your preferences for cosmetics', //appLocalizations.myPreferences_beauty_title,
+      appLocalizations.myPreferences_beauty_title,
     PreferencesPageProjects.pets =>
       appLocalizations.myPreferences_pet_food_title,
   };
 
-  // TODO 0000 roll back
   String getSubtitle(AppLocalizations appLocalizations) => switch (this) {
     PreferencesPageProjects.food =>
       appLocalizations.myPreferences_food_subtitle,
@@ -39,7 +37,7 @@ enum PreferencesPageProjects {
     PreferencesPageProjects.beauty =>
       appLocalizations.myPreferences_beauty_subtitle,
     PreferencesPageProjects.pets =>
-      "${appLocalizations.myPreferences_pet_food_subtitle}\nYou haven't set any preference yet.",
+      appLocalizations.myPreferences_pet_food_subtitle,
   };
 
   UriProductHelper getUriProductHelper() => switch (this) {

--- a/packages/smooth_app/lib/pages/food_preferences/preferences_page_projects.dart
+++ b/packages/smooth_app/lib/pages/food_preferences/preferences_page_projects.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/l10n/app_localizations.dart';
+import 'package:smooth_app/pages/preferences_v2/roots/faq_root.dart';
+import 'package:smooth_app/query/product_query.dart';
+
+/// Projects with specific preferences.
+enum PreferencesPageProjects {
+  food,
+  products,
+  beauty,
+  pets;
+
+  String get projectKey => switch (this) {
+    PreferencesPageProjects.food => 'food',
+    PreferencesPageProjects.products => 'products',
+    PreferencesPageProjects.beauty => 'beauty',
+    PreferencesPageProjects.pets => 'pets',
+  };
+
+  // TODO 0000 roll back
+  String getTitle(AppLocalizations appLocalizations) => switch (this) {
+    PreferencesPageProjects.food => appLocalizations.myPreferences_food_title,
+    PreferencesPageProjects.products =>
+      'Change your preferences for products', //appLocalizations.myPreferences_product_title,
+    PreferencesPageProjects.beauty =>
+      'Define your preferences for cosmetics', //appLocalizations.myPreferences_beauty_title,
+    PreferencesPageProjects.pets =>
+      appLocalizations.myPreferences_pet_food_title,
+  };
+
+  // TODO 0000 roll back
+  String getSubtitle(AppLocalizations appLocalizations) => switch (this) {
+    PreferencesPageProjects.food =>
+      appLocalizations.myPreferences_food_subtitle,
+    PreferencesPageProjects.products =>
+      appLocalizations.myPreferences_product_subtitle,
+    PreferencesPageProjects.beauty =>
+      appLocalizations.myPreferences_beauty_subtitle,
+    PreferencesPageProjects.pets =>
+      "${appLocalizations.myPreferences_pet_food_subtitle}\nYou haven't set any preference yet.",
+  };
+
+  UriProductHelper getUriProductHelper() => switch (this) {
+    PreferencesPageProjects.food => uriHelperFoodProd,
+    PreferencesPageProjects.products => uriHelperProductsProd,
+    PreferencesPageProjects.beauty => uriHelperBeautyProd,
+    PreferencesPageProjects.pets => uriHelperPetFoodProd,
+  };
+
+  String get _assetSubfolder => switch (this) {
+    PreferencesPageProjects.food => 'open_food_facts',
+    PreferencesPageProjects.products => 'open_products_facts',
+    PreferencesPageProjects.beauty => 'open_beauty_facts',
+    PreferencesPageProjects.pets => 'open_pet_food_facts',
+  };
+
+  Widget getLeadingIcon(final bool lightTheme, {EdgeInsetsGeometry? padding}) =>
+      FaqRoot.createLeadingIcon(
+        'assets/'
+        'guides/'
+        '$_assetSubfolder/'
+        'thumb_${lightTheme ? 'light' : 'dark'}.svg.vec',
+        padding: padding,
+      );
+
+  Future<List<AttributeGroup>?> fetchAttributeGroups() async {
+    try {
+      final String languageCode = ProductQuery.getLanguage().code;
+      final Uri uri = AvailableAttributeGroups.getUri(
+        languageCode,
+        uriHelper: getUriProductHelper(),
+      );
+
+      // TODO(monsieurtanuki): cache it?
+      final http.Response response = await http.get(uri);
+      if (response.statusCode != 200) {
+        return null;
+      }
+
+      final AvailableAttributeGroups availableAttributeGroups =
+          AvailableAttributeGroups.loadFromJSONString(response.body);
+      return availableAttributeGroups.attributeGroups;
+    } catch (e) {
+      debugPrint('Error fetching attribute groups for $name: $e');
+      return null;
+    }
+  }
+}

--- a/packages/smooth_app/lib/pages/preferences_v2/preferences_page.dart
+++ b/packages/smooth_app/lib/pages/preferences_v2/preferences_page.dart
@@ -41,6 +41,14 @@ import 'package:smooth_app/themes/theme_provider.dart';
 import 'package:smooth_app/widgets/autosize_text.dart';
 
 class PreferencesPage extends StatelessWidget {
+  static const List<PreferencesPageProjects> _projects =
+      <PreferencesPageProjects>[
+        PreferencesPageProjects.food,
+        PreferencesPageProjects.beauty,
+        PreferencesPageProjects.products,
+        PreferencesPageProjects.pets,
+      ];
+
   @override
   Widget build(BuildContext context) {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
@@ -61,30 +69,20 @@ class PreferencesPage extends StatelessWidget {
           PreferenceCard(
             title: appLocalizations.preferences_page_customize_app_title,
             tiles: <PreferenceTile>[
-              _buildOxfPreferencesTile(
-                appLocalizations,
-                lightTheme,
-                PreferencesPageProjects.food,
-                userPreferences,
-              ),
-              _buildOxfPreferencesTile(
-                appLocalizations,
-                lightTheme,
-                PreferencesPageProjects.beauty,
-                userPreferences,
-              ),
-              _buildOxfPreferencesTile(
-                appLocalizations,
-                lightTheme,
-                PreferencesPageProjects.products,
-                userPreferences,
-              ),
-              _buildOxfPreferencesTile(
-                appLocalizations,
-                lightTheme,
-                PreferencesPageProjects.pets,
-                userPreferences,
-              ),
+              ..._projects.map((PreferencesPageProjects project) {
+                final bool alreadySet = userPreferences
+                    .arePreferencesSetForProject(project);
+                return NavigationPreferenceTile(
+                  leading: project.getLeadingIcon(lightTheme),
+                  title: project.getTitle(appLocalizations),
+                  subtitleText: project.getSubtitle(appLocalizations),
+                  boldPostScriptum: alreadySet
+                      ? null
+                      : appLocalizations.myPreferences_not_configured_yet,
+                  target: FoodPreferencesPage(project: project),
+                  fullScreen: true,
+                );
+              }),
               _buildAppSettingsTile(appLocalizations),
             ],
           ),
@@ -234,27 +232,6 @@ class PreferencesPage extends StatelessWidget {
   }
 
   // Customize App section
-  NavigationPreferenceTile _buildOxfPreferencesTile(
-    AppLocalizations appLocalizations,
-    bool lightTheme,
-    final PreferencesPageProjects project,
-    final UserPreferences userPreferences,
-  ) {
-    final bool alreadySet = userPreferences.arePreferencesSetForProject(
-      project,
-    );
-    return NavigationPreferenceTile(
-      leading: project.getLeadingIcon(lightTheme),
-      title: project.getTitle(appLocalizations),
-      subtitleText: project.getSubtitle(appLocalizations),
-      boldPostScriptum: alreadySet
-          ? null
-          : appLocalizations.myPreferences_not_configured_yet,
-      target: FoodPreferencesPage(project: project),
-      fullScreen: true,
-    );
-  }
-
   NavigationPreferenceTile _buildAppSettingsTile(
     AppLocalizations appLocalizations,
   ) {

--- a/packages/smooth_app/lib/pages/preferences_v2/preferences_page.dart
+++ b/packages/smooth_app/lib/pages/preferences_v2/preferences_page.dart
@@ -11,6 +11,7 @@ import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/launch_url_helper.dart';
 import 'package:smooth_app/l10n/app_localizations.dart';
 import 'package:smooth_app/pages/food_preferences/food_preferences_page.dart';
+import 'package:smooth_app/pages/food_preferences/preferences_page_projects.dart';
 import 'package:smooth_app/pages/hunger_games/question_page.dart';
 import 'package:smooth_app/pages/preferences_v2/cards/banner/new_nutriscore_header.dart';
 import 'package:smooth_app/pages/preferences_v2/cards/footer/preferences_social_networks.dart';
@@ -60,10 +61,30 @@ class PreferencesPage extends StatelessWidget {
           PreferenceCard(
             title: appLocalizations.preferences_page_customize_app_title,
             tiles: <PreferenceTile>[
-              _buildFoodPreferencesTile(appLocalizations, lightTheme),
-              _buildBeautyPreferencesTile(appLocalizations, lightTheme),
-              _buildProductPreferencesTile(appLocalizations, lightTheme),
-              _buildPetFoodPreferencesTile(appLocalizations, lightTheme),
+              _buildOxfPreferencesTile(
+                appLocalizations,
+                lightTheme,
+                PreferencesPageProjects.food,
+                userPreferences,
+              ),
+              _buildOxfPreferencesTile(
+                appLocalizations,
+                lightTheme,
+                PreferencesPageProjects.beauty,
+                userPreferences,
+              ),
+              _buildOxfPreferencesTile(
+                appLocalizations,
+                lightTheme,
+                PreferencesPageProjects.products,
+                userPreferences,
+              ),
+              _buildOxfPreferencesTile(
+                appLocalizations,
+                lightTheme,
+                PreferencesPageProjects.pets,
+                userPreferences,
+              ),
               _buildAppSettingsTile(appLocalizations),
             ],
           ),
@@ -213,58 +234,21 @@ class PreferencesPage extends StatelessWidget {
   }
 
   // Customize App section
-  NavigationPreferenceTile _buildFoodPreferencesTile(
+  NavigationPreferenceTile _buildOxfPreferencesTile(
     AppLocalizations appLocalizations,
     bool lightTheme,
+    final PreferencesPageProjects project,
+    final UserPreferences userPreferences,
   ) {
-    return NavigationPreferenceTile(
-      leading: FaqRoot.createOffLeadingIcon(lightTheme),
-      title: appLocalizations.myPreferences_food_title,
-      subtitleText: appLocalizations.myPreferences_food_subtitle,
-      target: const FoodPreferencesPage(project: PreferencesPageProjects.food),
-      fullScreen: true,
+    // TODO 0000 use this appropriately
+    final bool alreadySet = userPreferences.arePreferencesSetForProject(
+      project,
     );
-  }
-
-  NavigationPreferenceTile _buildBeautyPreferencesTile(
-    AppLocalizations appLocalizations,
-    bool lightTheme,
-  ) {
     return NavigationPreferenceTile(
-      leading: FaqRoot.createObfLeadingIcon(lightTheme),
-      title: appLocalizations.myPreferences_beauty_title,
-      subtitleText: appLocalizations.myPreferences_beauty_subtitle,
-      target: const FoodPreferencesPage(
-        project: PreferencesPageProjects.beauty,
-      ),
-      fullScreen: true,
-    );
-  }
-
-  NavigationPreferenceTile _buildProductPreferencesTile(
-    AppLocalizations appLocalizations,
-    bool lightTheme,
-  ) {
-    return NavigationPreferenceTile(
-      leading: FaqRoot.createOpfLeadingIcon(lightTheme),
-      title: appLocalizations.myPreferences_product_title,
-      subtitleText: appLocalizations.myPreferences_product_subtitle,
-      target: const FoodPreferencesPage(
-        project: PreferencesPageProjects.products,
-      ),
-      fullScreen: true,
-    );
-  }
-
-  NavigationPreferenceTile _buildPetFoodPreferencesTile(
-    AppLocalizations appLocalizations,
-    bool lightTheme,
-  ) {
-    return NavigationPreferenceTile(
-      leading: FaqRoot.createOpffLeadingIcon(lightTheme),
-      title: appLocalizations.myPreferences_pet_food_title,
-      subtitleText: appLocalizations.myPreferences_pet_food_subtitle,
-      target: const FoodPreferencesPage(project: PreferencesPageProjects.pets),
+      leading: project.getLeadingIcon(lightTheme),
+      title: project.getTitle(appLocalizations),
+      subtitleText: project.getSubtitle(appLocalizations),
+      target: FoodPreferencesPage(project: project),
       fullScreen: true,
     );
   }

--- a/packages/smooth_app/lib/pages/preferences_v2/preferences_page.dart
+++ b/packages/smooth_app/lib/pages/preferences_v2/preferences_page.dart
@@ -240,7 +240,6 @@ class PreferencesPage extends StatelessWidget {
     final PreferencesPageProjects project,
     final UserPreferences userPreferences,
   ) {
-    // TODO 0000 use this appropriately
     final bool alreadySet = userPreferences.arePreferencesSetForProject(
       project,
     );
@@ -248,6 +247,9 @@ class PreferencesPage extends StatelessWidget {
       leading: project.getLeadingIcon(lightTheme),
       title: project.getTitle(appLocalizations),
       subtitleText: project.getSubtitle(appLocalizations),
+      boldPostScriptum: alreadySet
+          ? null
+          : appLocalizations.myPreferences_not_configured_yet,
       target: FoodPreferencesPage(project: project),
       fullScreen: true,
     );

--- a/packages/smooth_app/lib/pages/preferences_v2/roots/faq_root.dart
+++ b/packages/smooth_app/lib/pages/preferences_v2/roots/faq_root.dart
@@ -3,6 +3,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:smooth_app/cards/category_cards/svg_cache.dart';
 import 'package:smooth_app/l10n/app_localizations.dart';
+import 'package:smooth_app/pages/food_preferences/preferences_page_projects.dart';
 import 'package:smooth_app/pages/navigator/app_navigator.dart';
 import 'package:smooth_app/pages/preferences_v2/cards/preference_card.dart';
 import 'package:smooth_app/pages/preferences_v2/roots/preferences_root.dart';
@@ -70,7 +71,7 @@ class FaqRoot extends PreferencesRoot {
     AppLocalizations appLocalizations,
   ) {
     return PreferenceTile(
-      leading: _createLeadingIcon(
+      leading: createLeadingIcon(
         SvgCache.getAssetsCacheForNutriscore(NutriScoreValue.b, true),
       ),
       leadingSize: 31.0,
@@ -85,7 +86,7 @@ class FaqRoot extends PreferencesRoot {
     AppLocalizations appLocalizations,
   ) {
     return PreferenceTile(
-      leading: _createLeadingIcon(
+      leading: createLeadingIcon(
         'assets/guides/greenscore/greenscore_a.svg.vec',
       ),
       title: appLocalizations.environmental_score_generic_new,
@@ -98,7 +99,7 @@ class FaqRoot extends PreferencesRoot {
     AppLocalizations appLocalizations,
   ) {
     return PreferenceTile(
-      leading: _createLeadingIcon('assets/cache/nova-group-4.svg'),
+      leading: createLeadingIcon('assets/cache/nova-group-4.svg'),
       title: appLocalizations.nova_group_generic_new,
       onTap: () => AppNavigator.of(context).push(AppRoutes.GUIDE_NOVA),
     );
@@ -120,7 +121,7 @@ class FaqRoot extends PreferencesRoot {
     bool lightTheme,
   ) {
     return PreferenceTile(
-      leading: createOffLeadingIcon(
+      leading: PreferencesPageProjects.food.getLeadingIcon(
         lightTheme,
         padding: const EdgeInsetsDirectional.only(start: 2.0),
       ),
@@ -137,7 +138,7 @@ class FaqRoot extends PreferencesRoot {
     bool lightTheme,
   ) {
     return PreferenceTile(
-      leading: createObfLeadingIcon(
+      leading: PreferencesPageProjects.beauty.getLeadingIcon(
         lightTheme,
         padding: const EdgeInsetsDirectional.only(start: 2.0),
       ),
@@ -154,7 +155,7 @@ class FaqRoot extends PreferencesRoot {
     bool lightTheme,
   ) {
     return PreferenceTile(
-      leading: createOpffLeadingIcon(
+      leading: PreferencesPageProjects.pets.getLeadingIcon(
         lightTheme,
         padding: const EdgeInsetsDirectional.only(start: 2.0),
       ),
@@ -171,7 +172,7 @@ class FaqRoot extends PreferencesRoot {
     bool lightTheme,
   ) {
     return PreferenceTile(
-      leading: createOpfLeadingIcon(
+      leading: PreferencesPageProjects.products.getLeadingIcon(
         lightTheme,
         padding: const EdgeInsetsDirectional.only(start: 2.0),
       ),
@@ -188,7 +189,7 @@ class FaqRoot extends PreferencesRoot {
     bool lightTheme,
   ) {
     return PreferenceTile(
-      leading: _createLeadingIcon(
+      leading: createLeadingIcon(
         'assets/guides/open_prices/thumb_${lightTheme ? 'light' : 'dark'}.svg.vec',
         padding: const EdgeInsetsDirectional.only(start: 2.0),
       ),
@@ -237,7 +238,7 @@ class FaqRoot extends PreferencesRoot {
     );
   }
 
-  static Widget _createLeadingIcon(String svg, {EdgeInsetsGeometry? padding}) {
+  static Widget createLeadingIcon(String svg, {EdgeInsetsGeometry? padding}) {
     final Widget child;
     if (svg.endsWith('vec')) {
       child = SvgPicture(AssetBytesLoader(svg), width: 48.0);
@@ -251,38 +252,6 @@ class FaqRoot extends PreferencesRoot {
     return child;
   }
 
-  static Widget createOffLeadingIcon(
-    bool lightTheme, {
-    EdgeInsetsGeometry? padding,
-  }) => _createLeadingIcon(
-    'assets/guides/open_food_facts/thumb_${lightTheme ? 'light' : 'dark'}.svg.vec',
-    padding: padding,
-  );
-
-  static Widget createObfLeadingIcon(
-    bool lightTheme, {
-    EdgeInsetsGeometry? padding,
-  }) => _createLeadingIcon(
-    'assets/guides/open_beauty_facts/thumb_${lightTheme ? 'light' : 'dark'}.svg.vec',
-    padding: padding,
-  );
-
-  static Widget createOpffLeadingIcon(
-    bool lightTheme, {
-    EdgeInsetsGeometry? padding,
-  }) => _createLeadingIcon(
-    'assets/guides/open_pet_food_facts/thumb_${lightTheme ? 'light' : 'dark'}.svg.vec',
-    padding: padding,
-  );
-
-  static Widget createOpfLeadingIcon(
-    bool lightTheme, {
-    EdgeInsetsGeometry? padding,
-  }) => _createLeadingIcon(
-    'assets/guides/open_products_facts/thumb_${lightTheme ? 'light' : 'dark'}.svg.vec',
-    padding: padding,
-  );
-
   PreferenceTile _createScoreTile({
     required String title,
     required String url,
@@ -291,7 +260,7 @@ class FaqRoot extends PreferencesRoot {
     double? leadingSvgWidth,
   }) {
     return UrlPreferenceTile(
-      leading: _createLeadingIcon(svg),
+      leading: createLeadingIcon(svg),
       leadingSize: leadingSvgWidth,
       title: title,
       subtitleText: subtitleText,

--- a/packages/smooth_app/lib/pages/preferences_v2/tiles/navigation_preference_tile.dart
+++ b/packages/smooth_app/lib/pages/preferences_v2/tiles/navigation_preference_tile.dart
@@ -7,6 +7,7 @@ class NavigationPreferenceTile extends PreferenceTile {
   const NavigationPreferenceTile({
     required super.title,
     required super.subtitleText,
+    super.boldPostScriptum,
     super.icon,
     super.leading,
     this.root,
@@ -28,6 +29,7 @@ class NavigationPreferenceTile extends PreferenceTile {
       leading: leading,
       title: title,
       subtitleText: subtitleText,
+      boldPostScriptum: boldPostScriptum,
       onTap: () {
         Navigator.of(context, rootNavigator: fullScreen).push(
           MaterialPageRoute<Widget>(

--- a/packages/smooth_app/lib/pages/preferences_v2/tiles/preference_tile.dart
+++ b/packages/smooth_app/lib/pages/preferences_v2/tiles/preference_tile.dart
@@ -20,6 +20,7 @@ class PreferenceTile extends StatelessWidget {
     this.icon,
     this.subtitleText,
     this.subtitle,
+    this.boldPostScriptum,
     this.trailing,
     this.onTap,
     this.padding,
@@ -42,6 +43,7 @@ class PreferenceTile extends StatelessWidget {
   final String title;
   final String? subtitleText;
   final Widget? subtitle;
+  final String? boldPostScriptum;
   final Widget? trailing;
   final Function()? onTap;
   final EdgeInsetsDirectional? padding;
@@ -124,8 +126,14 @@ class PreferenceTile extends StatelessWidget {
                                 subtitle ??
                                 _PreferenceTileSubtitle(
                                   subtitle: subtitleText!,
+                                  bold: false,
                                 ),
                           ),
+                        ),
+                      if (boldPostScriptum != null)
+                        _PreferenceTileSubtitle(
+                          subtitle: boldPostScriptum!,
+                          bold: true,
                         ),
                     ],
                   ),
@@ -179,9 +187,10 @@ class _PreferenceTileTitle extends StatelessWidget {
 }
 
 class _PreferenceTileSubtitle extends StatelessWidget {
-  const _PreferenceTileSubtitle({required this.subtitle});
+  const _PreferenceTileSubtitle({required this.subtitle, required this.bold});
 
   final String subtitle;
+  final bool bold;
 
   @override
   Widget build(BuildContext context) {
@@ -189,10 +198,17 @@ class _PreferenceTileSubtitle extends StatelessWidget {
         .watch<PreferencesRootSearchController?>()
         ?.query;
 
+    final TextStyle? style = !bold
+        ? null
+        : const TextStyle(fontWeight: FontWeight.bold);
     if (query == null || query.isEmpty) {
-      return Text(subtitle);
-    } else {
-      return TextHighlighter(text: subtitle, filter: query, softWrap: true);
+      return Text(subtitle, style: style);
     }
+    return TextHighlighter(
+      text: subtitle,
+      textStyle: style,
+      filter: query,
+      softWrap: true,
+    );
   }
 }

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -417,10 +417,10 @@ packages:
     dependency: transitive
     description:
       name: dbus
-      sha256: d0c98dcd4f5169878b6cf8f6e0a52403a9dff371a3e2f019697accbf6f44a270
+      sha256: "0ce9b0a839e6dee59a37a623d2fc26a35bbbe6404213e419b0d6411023d62645"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.12"
+    version: "0.7.14"
   device_info_plus:
     dependency: "direct main"
     description:


### PR DESCRIPTION
### What
Early stage of the display of "preferences to be configured" flag.

### Screenshot or video
* food: everything OK
* cosmetics: "Define"
* products: "Change"
* pet: added a "not configured yet" message in the subtitle

I have a preference (haha) for the "pet" option.

<img width="1080" height="2408" alt="Screenshot_20260604_115506" src="https://github.com/user-attachments/assets/8ca7ceaf-13b8-478f-ba0e-275ba6331a0a" />

### Fixes bug(s)
- Fixes: #7539

### Files
New file:
* `preferences_page_projects.dart`: Projects with specific preferences. Initially in `food_preferences_page.dart`

Impacted files:
* `faq_root.dart`: refactored around `PreferencesPageProjects`
* `food_preferences_page.dart`: moved code to new file `preferences_page_projects.dart`
* `pending_preferences.dart`: refactored around `PreferencesPageProjects`
* `preferences_page.dart`: prepared for the "already configured" display
* `pubspec.lock`: wtf
* `user_preferences.dart`: refactored around `PreferencesPageProjects`