### PR TITLE
fix: 7534 - bottom padding for folksonomy list

### DIFF
--- a/packages/smooth_app/lib/pages/folksonomy/folksonomy_page.dart
+++ b/packages/smooth_app/lib/pages/folksonomy/folksonomy_page.dart
@@ -330,6 +330,7 @@ class _FolksonomyContentState extends State<_FolksonomyContent> {
       key: _listKey,
       controller: _scrollController,
       initialItemCount: _tags.length,
+      padding: const EdgeInsets.only(bottom: kFloatingActionButtonHeight * 2),
       itemBuilder:
           (BuildContext context, int index, Animation<double> animation) {
             final ProductTag entry = _tags[index];


### PR DESCRIPTION
### What
Added a bottom padding to the folksonomy list, so that the last item is not hidden by the action button.

### Screenshot or video
| before | after |
| -- | -- |
| <img width="1080" height="2408" alt="Screenshot_20260604_172307" src="https://github.com/user-attachments/assets/fcde6aa0-a513-437a-bb3a-17069739ce4b" /> | <img width="1080" height="2408" alt="Screenshot_20260604_172215" src="https://github.com/user-attachments/assets/2fd9fb7a-9c00-4b7e-85e1-5289c0e16114" /> |

### Fixes bug(s)
- Fixes: #7534

cc. @TerEsper