### PR TITLE
fix: 7549 - dismiss warning when attribute searching

### DIFF
--- a/packages/smooth_app/lib/pages/food_preferences/widgets/attribute_group_page.dart
+++ b/packages/smooth_app/lib/pages/food_preferences/widgets/attribute_group_page.dart
@@ -60,7 +60,8 @@ class _AttributeGroupPageState extends State<AttributeGroupPage> {
                           filteredAttributes,
                         ),
                 ),
-                if (widget.attributeGroup.warning != null)
+                if (_searchQuery.isEmpty &&
+                    widget.attributeGroup.warning != null)
                   _buildWarningBanner(context, widget.attributeGroup.warning!),
               ],
             );


### PR DESCRIPTION
### What
Dismiss the warning message when we search for attributes.
The warning message is still visible when the search field is empty.

### Screenshot or video
| before | after |
| -- | -- |
| <img width="1080" height="2408" alt="Screenshot_20260604_175754" src="https://github.com/user-attachments/assets/d12f2738-2ab4-40aa-9e47-a46f6a86ce4b" /> | <img width="1080" height="2408" alt="Screenshot_20260604_175709" src="https://github.com/user-attachments/assets/550fce02-5948-46e4-9f6a-5fbba4dda8ab" /> |

### Fixes bug(s)
- Fixes: #7549