### PR TITLE
fix: 7538 - standard colors for preferences, correct project icon

### DIFF
--- a/packages/smooth_app/lib/pages/food_preferences/food_preferences_page.dart
+++ b/packages/smooth_app/lib/pages/food_preferences/food_preferences_page.dart
@@ -14,8 +14,6 @@ import 'package:smooth_app/pages/food_preferences/pages/summary_page.dart';
 import 'package:smooth_app/pages/food_preferences/preferences_page_projects.dart';
 import 'package:smooth_app/pages/food_preferences/widgets/attribute_group_page.dart';
 import 'package:smooth_app/pages/food_preferences/widgets/food_preferences_navigation_bar.dart';
-import 'package:smooth_app/themes/smooth_theme_colors.dart';
-import 'package:smooth_app/themes/theme_provider.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 import 'package:smooth_app/widgets/v2/smooth_topbar2.dart';
 
@@ -168,6 +166,7 @@ class _FoodPreferencesPageState extends State<FoodPreferencesPage> {
       return SmoothScaffold(
         appBar: SmoothTopBar2(
           title: appLocalizations.food_preferences_page_title_introduction,
+          productType: widget.project.productType,
         ),
         body: const Center(child: CircularProgressIndicator()),
       );
@@ -178,6 +177,7 @@ class _FoodPreferencesPageState extends State<FoodPreferencesPage> {
       return SmoothScaffold(
         appBar: SmoothTopBar2(
           title: appLocalizations.food_preferences_page_title_introduction,
+          productType: widget.project.productType,
         ),
         body: Center(
           child: Column(
@@ -198,24 +198,13 @@ class _FoodPreferencesPageState extends State<FoodPreferencesPage> {
       );
     }
 
-    final SmoothColorsThemeExtension extension = context
-        .extension<SmoothColorsThemeExtension>();
-    final bool lightTheme = context.lightTheme();
-
-    final bool isSummaryPage = _controller.isSummaryPage;
-    final Color headerColor = isSummaryPage
-        ? extension.success
-        : extension.primaryMedium;
-    final Color foregroundColor = isSummaryPage ? Colors.white : Colors.black;
-
     return ChangeNotifierProvider<PendingPreferences>.value(
       value: _pendingPreferences,
       child: SmoothScaffold(
         appBar: SmoothTopBar2(
           title: _getPageTitle(appLocalizations),
+          productType: widget.project.productType,
           forceMultiLines: true,
-          backgroundColor: headerColor,
-          foregroundColor: foregroundColor,
           elevationOnScroll: false,
           topWidget: PreferredSize(
             preferredSize: const Size(
@@ -229,21 +218,13 @@ class _FoodPreferencesPageState extends State<FoodPreferencesPage> {
                 top: SMALL_SPACE,
                 bottom: VERY_SMALL_SPACE,
               ),
-              child: FAProgressBar(
-                animatedDuration: SmoothAnimationsDuration.short,
-                progressColor: isSummaryPage
-                    ? Colors.white
-                    : lightTheme
-                    ? extension.primaryDark
-                    : extension.primaryNormal,
-                backgroundColor: isSummaryPage
-                    ? Colors.white.withValues(alpha: 0.3)
-                    : lightTheme
-                    ? extension.primaryLight
-                    : extension.primarySemiDark,
-                currentValue: _controller.progress,
-                maxValue: 1,
-              ),
+              child: _controller.progress == 1
+                  ? null
+                  : FAProgressBar(
+                      animatedDuration: SmoothAnimationsDuration.short,
+                      currentValue: _controller.progress,
+                      maxValue: 1,
+                    ),
             ),
           ),
         ),

--- a/packages/smooth_app/lib/pages/food_preferences/preferences_page_projects.dart
+++ b/packages/smooth_app/lib/pages/food_preferences/preferences_page_projects.dart
@@ -12,6 +12,13 @@ enum PreferencesPageProjects {
   beauty,
   pets;
 
+  ProductType get productType => switch (this) {
+    PreferencesPageProjects.food => ProductType.food,
+    PreferencesPageProjects.products => ProductType.product,
+    PreferencesPageProjects.beauty => ProductType.beauty,
+    PreferencesPageProjects.pets => ProductType.petFood,
+  };
+
   String get projectKey => switch (this) {
     PreferencesPageProjects.food => 'food',
     PreferencesPageProjects.products => 'products',


### PR DESCRIPTION
### What
- Now using standard colors for preferences.
- Now using the correct project icon for preferences.

### Screenshot or video
| pet | product | beauty | food |
| -- | -- | -- | -- |
| <img width="1080" height="2408" alt="Screenshot_20260604_190617" src="https://github.com/user-attachments/assets/d65164ac-0e3a-4e88-8df3-37bad525e3da" /> | <img width="1080" height="2408" alt="Screenshot_20260604_190605" src="https://github.com/user-attachments/assets/3e66d65f-bc97-430a-9f65-66489bc93950" /> | <img width="1080" height="2408" alt="Screenshot_20260604_190552" src="https://github.com/user-attachments/assets/1ce7ed45-df02-4bc2-85a3-424c51e0dfb2" /> | <img width="1080" height="2408" alt="Screenshot_20260604_190539" src="https://github.com/user-attachments/assets/3854698e-bf73-4d66-8805-39b93275dd64" /> |
| <img width="1080" height="2408" alt="Screenshot_20260604_190517" src="https://github.com/user-attachments/assets/ee32eab3-98ef-40f7-bcd1-2f96301efa0b" /> | <img width="1080" height="2408" alt="Screenshot_20260604_190458" src="https://github.com/user-attachments/assets/a0027be5-2c2a-4cd0-8e56-e57752538a19" /> |  <img width="1080" height="2408" alt="Screenshot_20260604_190441" src="https://github.com/user-attachments/assets/63e6fda0-10f1-4242-91d4-87c89445ac74" /> | <img width="1080" height="2408" alt="Screenshot_20260604_190358" src="https://github.com/user-attachments/assets/e2faed58-58bb-4555-8fe9-a926db1b6879" /> |

### Part of 
- #7538

### Impacted files
* `food_preferences_page.dart`: correct project icons; color simplifications
* `preferences_page_projects.dart`: matching with `productType`, in order to get correct icons
