### PR TITLE
fix: 7538 - standard color for unwanted ingredient chip

### DIFF
--- a/packages/smooth_app/lib/pages/food_preferences/widgets/summary_section.dart
+++ b/packages/smooth_app/lib/pages/food_preferences/widgets/summary_section.dart
@@ -4,6 +4,7 @@ import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/l10n/app_localizations.dart';
 import 'package:smooth_app/resources/app_icons.dart' as icons;
 import 'package:smooth_app/themes/smooth_theme_colors.dart';
+import 'package:smooth_app/themes/theme_provider.dart';
 
 class SummarySection extends StatelessWidget {
   const SummarySection({
@@ -28,6 +29,8 @@ class SummarySection extends StatelessWidget {
 
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final String groupName = group.name ?? group.id ?? '';
+
+    final bool lightTheme = context.lightTheme();
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -88,7 +91,9 @@ class SummarySection extends StatelessWidget {
                         Icon(
                           Icons.arrow_circle_right_rounded,
                           size: 28.0,
-                          color: theme.primaryAccent,
+                          color: lightTheme
+                              ? theme.primaryAccent
+                              : Colors.white,
                         ),
                         const SizedBox(width: SMALL_SPACE),
                         Expanded(
@@ -112,7 +117,6 @@ class SummarySection extends StatelessWidget {
                         children: unwantedIngredients.map((String ingredient) {
                           return Chip(
                             label: Text(ingredient),
-                            backgroundColor: theme.primaryMedium,
                             materialTapTargetSize:
                                 MaterialTapTargetSize.shrinkWrap,
                             visualDensity: VisualDensity.compact,

--- a/packages/smooth_app/lib/pages/food_preferences/widgets/unwanted_ingredients_input.dart
+++ b/packages/smooth_app/lib/pages/food_preferences/widgets/unwanted_ingredients_input.dart
@@ -5,7 +5,6 @@ import 'package:smooth_app/l10n/app_localizations.dart';
 import 'package:smooth_app/pages/food_preferences/models/pending_preferences.dart';
 import 'package:smooth_app/pages/input/smooth_autocomplete_text_field.dart';
 import 'package:smooth_app/query/product_query.dart';
-import 'package:smooth_app/themes/smooth_theme_colors.dart';
 
 class UnwantedIngredientsInput extends StatefulWidget {
   const UnwantedIngredientsInput({required this.pendingPreferences, super.key});
@@ -62,7 +61,7 @@ class _UnwantedIngredientsInputState extends State<UnwantedIngredientsInput> {
                 controller: _controller,
                 autocompleteKey: _autocompleteKey,
                 hintText:
-                appLocalizations.food_preferences_search_ingredients_hint,
+                    appLocalizations.food_preferences_search_ingredients_hint,
                 manager: _autocompleteManager,
                 constraints: const BoxConstraints(maxHeight: 48.0),
                 padding: const EdgeInsetsDirectional.symmetric(
@@ -81,14 +80,14 @@ class _UnwantedIngredientsInputState extends State<UnwantedIngredientsInput> {
             runSpacing: SMALL_SPACE,
             children: unwantedIngredients
                 .map((String ingredient) {
-              return Chip(
-                label: Text(ingredient),
-                deleteIcon: const Icon(Icons.close, size: 18.0),
-                onDeleted: () => _removeIngredient(ingredient),
-                materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                visualDensity: VisualDensity.compact,
-              );
-            })
+                  return Chip(
+                    label: Text(ingredient),
+                    deleteIcon: const Icon(Icons.close, size: 18.0),
+                    onDeleted: () => _removeIngredient(ingredient),
+                    materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    visualDensity: VisualDensity.compact,
+                  );
+                })
                 .toList(growable: false),
           ),
         ],
@@ -106,11 +105,9 @@ class _UnwantedIngredientsInputState extends State<UnwantedIngredientsInput> {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(
-            AppLocalizations
-                .of(
+            AppLocalizations.of(
               context,
-            )
-                .food_preferences_ingredient_already_added,
+            ).food_preferences_ingredient_already_added,
           ),
         ),
       );

--- a/packages/smooth_app/lib/pages/food_preferences/widgets/unwanted_ingredients_input.dart
+++ b/packages/smooth_app/lib/pages/food_preferences/widgets/unwanted_ingredients_input.dart
@@ -46,9 +46,6 @@ class _UnwantedIngredientsInputState extends State<UnwantedIngredientsInput> {
 
   @override
   Widget build(BuildContext context) {
-    final SmoothColorsThemeExtension theme = context
-        .extension<SmoothColorsThemeExtension>();
-
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final List<String> unwantedIngredients =
         _pendingPreferences.unwantedIngredients;
@@ -65,7 +62,7 @@ class _UnwantedIngredientsInputState extends State<UnwantedIngredientsInput> {
                 controller: _controller,
                 autocompleteKey: _autocompleteKey,
                 hintText:
-                    appLocalizations.food_preferences_search_ingredients_hint,
+                appLocalizations.food_preferences_search_ingredients_hint,
                 manager: _autocompleteManager,
                 constraints: const BoxConstraints(maxHeight: 48.0),
                 padding: const EdgeInsetsDirectional.symmetric(
@@ -84,15 +81,14 @@ class _UnwantedIngredientsInputState extends State<UnwantedIngredientsInput> {
             runSpacing: SMALL_SPACE,
             children: unwantedIngredients
                 .map((String ingredient) {
-                  return Chip(
-                    label: Text(ingredient),
-                    deleteIcon: const Icon(Icons.close, size: 18.0),
-                    onDeleted: () => _removeIngredient(ingredient),
-                    backgroundColor: theme.primaryMedium,
-                    materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                    visualDensity: VisualDensity.compact,
-                  );
-                })
+              return Chip(
+                label: Text(ingredient),
+                deleteIcon: const Icon(Icons.close, size: 18.0),
+                onDeleted: () => _removeIngredient(ingredient),
+                materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                visualDensity: VisualDensity.compact,
+              );
+            })
                 .toList(growable: false),
           ),
         ],
@@ -110,9 +106,11 @@ class _UnwantedIngredientsInputState extends State<UnwantedIngredientsInput> {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(
-            AppLocalizations.of(
+            AppLocalizations
+                .of(
               context,
-            ).food_preferences_ingredient_already_added,
+            )
+                .food_preferences_ingredient_already_added,
           ),
         ),
       );

--- a/packages/smooth_app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/smooth_app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -11,6 +11,7 @@ import connectivity_plus
 import device_info_plus
 import file_picker
 import file_selector_macos
+import flutter_email_sender
 import flutter_image_compress_macos
 import flutter_secure_storage_darwin
 import in_app_review
@@ -31,6 +32,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
+  FlutterEmailSenderPlugin.register(with: registry.registrar(forPlugin: "FlutterEmailSenderPlugin"))
   FlutterImageCompressMacosPlugin.register(with: registry.registrar(forPlugin: "FlutterImageCompressMacosPlugin"))
   FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
   InAppReviewPlugin.register(with: registry.registrar(forPlugin: "InAppReviewPlugin"))

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -97,10 +97,10 @@ packages:
     dependency: "direct main"
     description:
       name: audioplayers
-      sha256: "1d0c1b1f2095e59080e2d5046639096417a86687d89778da41b0c9a06d683dfd"
+      sha256: f16640453cc47487b7de72a2b28d37c7df1ac97999849f4a46d92b1d2b0f093d
       url: "https://pub.dev"
     source: hosted
-    version: "6.7.0"
+    version: "6.7.1"
   audioplayers_android:
     dependency: transitive
     description:
@@ -1060,10 +1060,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mgrs_dart:
     dependency: transitive
     description:
@@ -1687,10 +1687,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.10"
   torch_light:
     dependency: "direct main"
     description:
@@ -1949,4 +1949,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.11.5 <4.0.0"
-  flutter: ">=3.41.8"
+  flutter: ">=3.41.8 <4.0.0"

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -47,7 +47,7 @@ dependencies:
   diacritic: 0.1.6
   app_store_shared:
     path: ../app_store/shared
-  audioplayers: 6.7.0
+  audioplayers: 6.7.1
   flutter_email_sender: 9.0.0
   flutter_native_splash: 2.4.7
   image: 4.8.0


### PR DESCRIPTION
### What
Switching to standard colors for unwanted ingredient chips.

### Screenshot or video
| before | dark | light |
| -- | -- | -- |
| <img width="1080" height="2408" alt="Screenshot_20260605_085957" src="https://github.com/user-attachments/assets/1b160e62-adda-4173-9ea9-9540c8b019f1" /> | <img width="1080" height="2408" alt="Screenshot_20260605_090009" src="https://github.com/user-attachments/assets/fc50590b-8767-43dc-a3e5-4a3fb0782975" /> | <img width="1080" height="2408" alt="Screenshot_20260605_090732" src="https://github.com/user-attachments/assets/e96969b1-e8e3-4b18-8204-7c7790565ae5" /> |
| <img width="1080" height="2408" alt="Screenshot_20260605_090504" src="https://github.com/user-attachments/assets/86265410-f649-434e-a2a8-8260bbf6f858" /> | <img width="1080" height="2408" alt="Screenshot_20260605_090642" src="https://github.com/user-attachments/assets/81aade13-f9f6-4021-a80f-8556d0633759" /> | <img width="1080" height="2408" alt="Screenshot_20260605_090745" src="https://github.com/user-attachments/assets/0b692c56-a0f9-455d-a301-1e480c7710b0" /> |

### Fixes bug(s)
- Fixes: #7538
- Fixes: #7481

### Impacted files
* `GeneratedPluginRegistrant.swift`: wtf
* `pubspec.lock`: wtf
* `pubspec.yaml`: unrelated minor upgrade
* `summary_section.dart`: standard color for unwanted ingredient chip
* `unwanted_ingredients_input.dart`: standard color for unwanted ingredient chip