### PR TITLE
fix: 7556 - SafeArea for bottom sheet actions

### DIFF
--- a/packages/smooth_app/lib/generic_lib/bottom_sheets/smooth_bottom_sheet.dart
+++ b/packages/smooth_app/lib/generic_lib/bottom_sheets/smooth_bottom_sheet.dart
@@ -117,7 +117,6 @@ Future<T?> showSmoothListOfChoicesModalSheet<T>({
   Color? prefixIndicatorColor,
   double footerSpace = 0.0,
   SmoothModalSheetType type = SmoothModalSheetType.info,
-  bool safeArea = false,
   bool? useRootNavigator,
 }) {
   assert(labels.length == values.length);
@@ -181,23 +180,12 @@ Future<T?> showSmoothListOfChoicesModalSheet<T>({
     }
   }
 
-  double bottomPadding = MediaQuery.paddingOf(context).bottom;
-
-  if (safeArea && bottomPadding == 0.0) {
-    bottomPadding = MediaQuery.viewPaddingOf(context).bottom;
-  }
-
   if (footer != null) {
     if (footerSpace > 0.0) {
       items.add(SizedBox(height: footerSpace));
     }
 
-    Widget footerChild = Column(
-      children: <Widget>[
-        footer,
-        SizedBox(height: bottomPadding),
-      ],
-    );
+    Widget footerChild = footer;
 
     if (footerBackgroundColor != null) {
       footerChild = ColoredBox(
@@ -207,27 +195,27 @@ Future<T?> showSmoothListOfChoicesModalSheet<T>({
     }
 
     items.add(footerChild);
-  } else {
-    items.add(SizedBox(height: bottomPadding));
   }
 
   if (dynamicSize) {
     return showSmoothModalSheet<T>(
       context: context,
       useRootNavigator: useRootNavigator ?? false,
-      builder: (_) => Column(
-        mainAxisSize: MainAxisSize.min,
-        children: <Widget>[
-          SmoothModalSheetHeader(
-            title: title,
-            prefix: SmoothModalSheetHeaderPrefixIndicator(
-              color: prefixIndicatorColor,
+      builder: (_) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            SmoothModalSheetHeader(
+              title: title,
+              prefix: SmoothModalSheetHeaderPrefixIndicator(
+                color: prefixIndicatorColor,
+              ),
+              backgroundColor: headerBackgroundColor,
+              type: type,
             ),
-            backgroundColor: headerBackgroundColor,
-            type: type,
-          ),
-          ...items,
-        ],
+            ...items,
+          ],
+        ),
       ),
     );
   }
@@ -244,7 +232,9 @@ Future<T?> showSmoothListOfChoicesModalSheet<T>({
       backgroundColor: headerBackgroundColor,
       type: type,
     ),
-    bodyBuilder: (_) => Column(mainAxisSize: MainAxisSize.min, children: items),
+    bodyBuilder: (_) => SafeArea(
+      child: Column(mainAxisSize: MainAxisSize.min, children: items),
+    ),
   );
 }
 
@@ -299,7 +289,6 @@ Future<T?> showSmoothAlertModalSheet<T>({
       horizontal: MEDIUM_SPACE,
     ),
     textStyle: const TextStyle(fontWeight: FontWeight.w600),
-    safeArea: true,
   );
 }
 

--- a/packages/smooth_app/lib/pages/preferences_v2/roots/account_root.dart
+++ b/packages/smooth_app/lib/pages/preferences_v2/roots/account_root.dart
@@ -122,7 +122,6 @@ class AccountRoot extends PreferencesRoot {
 
     return showSmoothListOfChoicesModalSheet<bool>(
       context: context,
-      safeArea: true,
       title: appLocalizations.sign_out,
       header: Align(
         alignment: AlignmentDirectional.topStart,

--- a/packages/smooth_app/lib/pages/prices/price_add_helper.dart
+++ b/packages/smooth_app/lib/pages/prices/price_add_helper.dart
@@ -124,7 +124,6 @@ class PriceAddHelper {
     final SmoothColorsThemeExtension extension = context
         .extension<SmoothColorsThemeExtension>();
     return showSmoothListOfChoicesModalSheet<bool>(
-      safeArea: true,
       context: context,
       headerBackgroundColor: color,
       header: Padding(

--- a/packages/smooth_app/lib/pages/product/add_basic_details/add_basic_details_name.dart
+++ b/packages/smooth_app/lib/pages/product/add_basic_details/add_basic_details_name.dart
@@ -425,7 +425,6 @@ class _ProductNameInputWidgetState extends State<_ProductNameInputWidget> {
       ],
       labels: <String>[appLocalizations.yes, appLocalizations.cancel],
       values: <bool>[true, false],
-      safeArea: true,
     );
 
     if (mounted && res == true) {

--- a/packages/smooth_app/lib/pages/search/product_type_search_selector.dart
+++ b/packages/smooth_app/lib/pages/search/product_type_search_selector.dart
@@ -83,7 +83,6 @@ class ProductTypeSearchSelector extends StatelessWidget {
             ),
           ),
           values: ProductType.values,
-          safeArea: true,
         );
 
     if (context.mounted && productType != null) {


### PR DESCRIPTION
### What
Now we let the system manage a `SafeArea` for all our bottom sheet actions. This way, the last option will never be hidden under the system bottom bar.

### Screenshot or video
| before | after |
| -- | -- |
| <img width="1080" height="2408" alt="Image" src="https://github.com/user-attachments/assets/33574c5e-55a3-4a2a-9463-bdb15216f838" /> | <img width="1080" height="2408" alt="Image" src="https://github.com/user-attachments/assets/df0a93de-f914-45ff-ba7b-96c1e1f62c56" /> |

### Fixes bug(s)
- Fixes: #7556

### Impacted files
* `account_root.dart`: removed now implicit `safearea: true` parameter
* `add_basic_details_name.dart`: removed now implicit `safearea: true` parameter
* `price_add_helper.dart`: removed now implicit `safearea: true` parameter
* `product_type_search_selector.dart`: removed now implicit `safearea: true` parameter
* `smooth_bottom_sheet.dart`: made `safearea: true` implicit and used `SafeArea`