### PR TITLE
fix: 7558 - folksonomy property edit as a page and multi-line

### DIFF
--- a/packages/smooth_app/lib/l10n/app_localizations.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations.dart
@@ -519,7 +519,7 @@ abstract class AppLocalizations {
   /// Title for the introduction page of the food preferences wizard
   ///
   /// In en, this message translates to:
-  /// **'Personalize the app'**
+  /// **'Personalise the app'**
   String get food_preferences_page_title_introduction;
 
   /// Title for the diets page of the food preferences wizard
@@ -579,7 +579,7 @@ abstract class AppLocalizations {
   /// Error message shown when the food preferences fail to load from the server
   ///
   /// In en, this message translates to:
-  /// **'Failed to load preferences. Please check your internet connection.'**
+  /// **'Failed to load preferences. Please check your Internet connection.'**
   String get food_preferences_error_loading;
 
   /// Description text shown at the top of the preferences summary page
@@ -591,13 +591,13 @@ abstract class AppLocalizations {
   /// Description shown on the introduction page of the food preferences wizard.
   ///
   /// In en, this message translates to:
-  /// **'In the following steps, you can **personalize the app** by indicating your preferences:'**
+  /// **'In the following steps, you can **personalise the app** by indicating your preferences:'**
   String get food_preferences_introduction_description;
 
   /// Description for the diets page of the food preferences wizard
   ///
   /// In en, this message translates to:
-  /// **'Select the diets you follow to personalize your recommendations.'**
+  /// **'Select the diets you follow to personalise your recommendations.'**
   String get food_preferences_page_description_diets;
 
   /// Description for the allergies page of the food preferences wizard
@@ -981,13 +981,13 @@ abstract class AppLocalizations {
   /// No description provided for @sign_up_page_email_hint.
   ///
   /// In en, this message translates to:
-  /// **'E-mail'**
+  /// **'E-post'**
   String get sign_up_page_email_hint;
 
   /// No description provided for @sign_up_page_email_error_empty.
   ///
   /// In en, this message translates to:
-  /// **'E-mail is required'**
+  /// **'E-post is required'**
   String get sign_up_page_email_error_empty;
 
   /// No description provided for @sign_up_page_email_error_invalid.
@@ -1371,7 +1371,7 @@ abstract class AppLocalizations {
   /// Content that will be shared, don't forget to include the URL
   ///
   /// In en, this message translates to:
-  /// **'I wanted to let you know about the app I\'ve been using, Open Food Facts, which allows you to get the health and environmental impacts of your food, in a personalized way. It works by scanning the barcodes on the packaging. Finally it\'s free, does not require registration, and you can even help increase the number of products deciphered. Here\'s the link to get it for your phone: https://openfoodfacts.app'**
+  /// **'I wanted to let you know about the app I\'ve been using, Open Food Facts, which allows you to get the health and environmental impacts of your food, in a personalised way. It works by scanning the barcodes on the packaging. Finally it\'s free, does not require registration, and you can even help increase the number of products deciphered. Here\'s the link to get it for your phone: https://openfoodfacts.app'**
   String get contribute_share_content;
 
   /// Label for option to contribute prices using GDPR export from loyalty cards
@@ -1551,7 +1551,7 @@ abstract class AppLocalizations {
   /// When you press this button, all products (in list or category) are sorted according to your preferences.
   ///
   /// In en, this message translates to:
-  /// **'My personalized ranking'**
+  /// **'My personalised ranking'**
   String get myPersonalizedRanking;
 
   /// No description provided for @ranking_tab_all.
@@ -3299,7 +3299,7 @@ abstract class AppLocalizations {
   /// first paragraph for the camera permission's page (onboarding)
   ///
   /// In en, this message translates to:
-  /// **'To scan barcodes with your phone\'s camera, please Authorize the access.'**
+  /// **'To scan barcodes with your phone\'s camera, please Authorise the access.'**
   String get permissions_page_body1;
 
   /// second paragraph for the camera permission's page (onboarding)
@@ -3324,7 +3324,7 @@ abstract class AppLocalizations {
   /// Contact form content for iOS devices
   ///
   /// In en, this message translates to:
-  /// **'OS: iOS ({version})\nModel: {model}\nLocalized model: {localizedModel}'**
+  /// **'OS: iOS ({version})\nModel: {model}\nLocalised model: {localizedModel}'**
   String contact_form_body_ios(
     String? version,
     String? model,
@@ -3345,7 +3345,7 @@ abstract class AppLocalizations {
   /// No description provided for @authorize_button_label.
   ///
   /// In en, this message translates to:
-  /// **'Authorize'**
+  /// **'Authorise'**
   String get authorize_button_label;
 
   /// No description provided for @refuse_button_label.
@@ -3489,7 +3489,7 @@ abstract class AppLocalizations {
   /// User login (when it's an email)
   ///
   /// In en, this message translates to:
-  /// **'Open Food Facts login: {email}'**
+  /// **'Open Food Facts login: {email}'**
   String user_profile_title_id_email(String email);
 
   /// User login (when it's an id)
@@ -5763,7 +5763,7 @@ abstract class AppLocalizations {
   /// Help categorize products in your country: list tile title
   ///
   /// In en, this message translates to:
-  /// **'Help categorize products in your country'**
+  /// **'Help categorise products in your country'**
   String get categorize_products_country_title;
 
   /// Product edition - FAB actions - retake a picture
@@ -6965,13 +6965,13 @@ abstract class AppLocalizations {
   /// No description provided for @email_copied_to_clip_board.
   ///
   /// In en, this message translates to:
-  /// **'Email copied to clipboard!'**
+  /// **'Epost copied to clipboard!'**
   String get email_copied_to_clip_board;
 
   /// Accent Color for the application in AMOLED mode.
   ///
   /// In en, this message translates to:
-  /// **'Select Accent Color'**
+  /// **'Select Accent Colour'**
   String get select_accent_color;
 
   /// AMOLED theme mode.
@@ -7583,7 +7583,7 @@ abstract class AppLocalizations {
   /// Text between asterisks (eg: **My Text**) means text in bold. Please try to keep it.
   ///
   /// In en, this message translates to:
-  /// **'The color code varies from dark green (**A**) for the **healthiest** products to dark red (**E**) for the **less healthy** ones.'**
+  /// **'The colour code varies from dark green (**A**) for the **healthiest** products to dark red (**E**) for the **less healthy** ones.'**
   String get guide_nutriscore_v2_what_is_nutriscore_paragraph2;
 
   /// No description provided for @guide_nutriscore_v2_nutriscore_a_caption.
@@ -7625,13 +7625,13 @@ abstract class AppLocalizations {
   /// No description provided for @guide_nutriscore_v2_why_v2_arg2_text.
   ///
   /// In en, this message translates to:
-  /// **'The **sugar content** is better taken into account and favors **lowly sweetened** drinks.\\n**Sweeteners will also be penalized**: diet sodas will be downgraded from a B rating to between C and E. Water remains the recommended drink.'**
+  /// **'The **sugar content** is better taken into account and favors **lowly sweetened** drinks.\\n**Sweeteners will also be penalised**: diet sodas will be downgraded from a B rating to between C and E. Water remains the recommended drink.'**
   String get guide_nutriscore_v2_why_v2_arg2_text;
 
   /// No description provided for @guide_nutriscore_v2_why_v2_arg3_title.
   ///
   /// In en, this message translates to:
-  /// **'Salt and sugar penalized'**
+  /// **'Salt and sugar penalised'**
   String get guide_nutriscore_v2_why_v2_arg3_title;
 
   /// No description provided for @guide_nutriscore_v2_why_v2_arg3_text.
@@ -7745,7 +7745,7 @@ abstract class AppLocalizations {
   /// Text between asterisks (eg: **My Text**) means text in bold. Please try to keep it.
   ///
   /// In en, this message translates to:
-  /// **'The color code varies from dark green (**A+**) for the **least impactful** products to dark red (**F**) for the **most impactful** products.'**
+  /// **'The colour code varies from dark green (**A+**) for the **least impactful** products to dark red (**F**) for the **most impactful** products.'**
   String get guide_greenscore_what_is_greenscore_paragraph2;
 
   /// No description provided for @guide_greenscore_logos_caption.
@@ -8057,7 +8057,7 @@ abstract class AppLocalizations {
   /// Text between asterisks (eg: **My Text**) means text in bold. Please try to keep it.
   ///
   /// In en, this message translates to:
-  /// **'The NOVA classification allows for the categorization of foods into **4 groups** based on their **degree of industrial processing** (minimally processed or unprocessed foods, culinary ingredients, processed foods, ultra-processed foods).'**
+  /// **'The NOVA classification allows for the categorisation of foods into **4 groups** based on their **degree of industrial processing** (minimally processed or unprocessed foods, culinary ingredients, processed foods, ultra-processed foods).'**
   String get guide_nova_what_is_nova_paragraph2;
 
   /// No description provided for @guide_nova_logos_caption.
@@ -8153,7 +8153,7 @@ abstract class AppLocalizations {
   /// No description provided for @guide_nova_explanations_arg2_text.
   ///
   /// In en, this message translates to:
-  /// **'Additives in ultra-processed foods include some that are also used in processed foods, such as preservatives, antioxidants, and stabilizers. Classes of additives found only in ultra-processed products include those used **to imitate or enhance the sensory qualities of foods or to disguise unpalatable aspects of the final product**. These additives include dyes and other colors, color stabilizers; flavors, flavor enhancers, non-sugar sweeteners; and processing aids such as carbonating, firming, bulking and anti-bulking agents, de-foaming, anti-caking and glazing agents, emulsifiers, sequestrants, and humectants.'**
+  /// **'Additives in ultra-processed foods include some that are also used in processed foods, such as preservatives, antioxidants, and stabilisers. Classes of additives found only in ultra-processed products include those used **to imitate or enhance the sensory qualities of foods or to disguise unpalatable aspects of the final product**. These additives include dyes and other colours, colour stabilisers; flavors, flavor enhancers, non-sugar sweeteners; and processing aids such as carbonating, firming, bulking and anti-bulking agents, de-foaming, anti-caking and glazing agents, emulsifiers, sequestrants, and humectants.'**
   String get guide_nova_explanations_arg2_text;
 
   /// No description provided for @guide_nova_explanations_arg3_title.
@@ -8489,7 +8489,7 @@ abstract class AppLocalizations {
   /// Text between asterisks (eg: **My Text**) means text in bold. Please try to keep it.
   ///
   /// In en, this message translates to:
-  /// **'Our goal is to decipher ingredient lists to help you **understand what\'s in your personal care items**. From moisturizers to makeup, we collect data on ingredients, allergens, and packaging to promote transparency in the cosmetics industry.'**
+  /// **'Our goal is to decipher ingredient lists to help you **understand what\'s in your personal care items**. From moisturisers to makeup, we collect data on ingredients, allergens, and packaging to promote transparency in the cosmetics industry.'**
   String get guide_open_beauty_facts_what_is_open_beauty_facts_paragraph2;
 
   /// No description provided for @guide_open_beauty_facts_features_title.
@@ -8627,7 +8627,7 @@ abstract class AppLocalizations {
   /// Text between asterisks (eg: **My Text**) means text in bold. Please try to keep it.
   ///
   /// In en, this message translates to:
-  /// **'There are currently few companies that own large databases of product prices at the barcode level. These prices are not freely available, but sold at a high price to private actors, researchers and other organizations that can afford them.'**
+  /// **'There are currently few companies that own large databases of product prices at the barcode level. These prices are not freely available, but sold at a high price to private actors, researchers and other organisations that can afford them.'**
   String get guide_open_prices_what_is_open_prices_paragraph2;
 
   /// No description provided for @guide_open_prices_how_title.
@@ -8771,7 +8771,7 @@ abstract class AppLocalizations {
   /// No description provided for @guide_open_products_facts_features_arg1_text.
   ///
   /// In en, this message translates to:
-  /// **'**Impact CO2** by French Environment Authority ADEME provides the **carbon impact** of many categories, make sure to categorize products precisely.'**
+  /// **'**Impact CO2** by French Environment Authority ADEME provides the **carbon impact** of many categories, make sure to categorise products precisely.'**
   String get guide_open_products_facts_features_arg1_text;
 
   /// No description provided for @guide_open_products_facts_features_arg2_title.
@@ -10003,7 +10003,7 @@ abstract class AppLocalizations {
   /// Preferences dev mode tile for removing colors
   ///
   /// In en, this message translates to:
-  /// **'Accessibility: Remove colors'**
+  /// **'Accessibility: Remove colours'**
   String get preferences_accessibility_remove_colors;
 
   /// Title for the app settings products card

--- a/packages/smooth_app/lib/pages/folksonomy/folksonomy_create_edit_modal.dart
+++ b/packages/smooth_app/lib/pages/folksonomy/folksonomy_create_edit_modal.dart
@@ -10,6 +10,8 @@ import 'package:smooth_app/pages/folksonomy/folksonomy_autocompleter.dart';
 import 'package:smooth_app/pages/folksonomy/folksonomy_provider.dart';
 import 'package:smooth_app/pages/product/simple_input/simple_input_text_field.dart';
 import 'package:smooth_app/themes/smooth_theme_colors.dart';
+import 'package:smooth_app/widgets/smooth_app_bar.dart';
+import 'package:smooth_app/widgets/smooth_scaffold.dart';
 import 'package:smooth_app/widgets/v2/smooth_buttons_bar.dart';
 
 class FolksonomyEditTagContent extends StatefulWidget {
@@ -50,24 +52,32 @@ class FolksonomyEditTagContentState extends State<FolksonomyEditTagContent> {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: <Widget>[
-        _FolksonomyEditTagContentBody(
-          keyController: keyController,
-          valueController: valueController,
-          isKeyEditable: widget.action == FolksonomyAction.add,
-          isKeyValid: isKeyValid,
-          isValueValid: isValueValid,
-          onSave: _onSubmit,
-          keyFocusNode: keyFocusNode,
-          valueFocusNode: valueFocusNode,
-          keyAutocompleteKey: keyAutocompleteKey,
-          valueAutocompleteKey: valueAutocompleteKey,
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
+    return SmoothScaffold(
+      appBar: SmoothAppBar(
+        title: Text(
+          widget.action == FolksonomyAction.edit
+              ? appLocalizations.edit_tag
+              : appLocalizations.add_tag,
         ),
-        _FolksonomyEditTagContentFooter(onSave: _onSubmit),
-      ],
+      ),
+      body: ListView(
+        children: <Widget>[
+          _FolksonomyEditTagContentBody(
+            keyController: keyController,
+            valueController: valueController,
+            isKeyEditable: widget.action == FolksonomyAction.add,
+            isKeyValid: isKeyValid,
+            isValueValid: isValueValid,
+            onSave: _onSubmit,
+            keyFocusNode: keyFocusNode,
+            valueFocusNode: valueFocusNode,
+            keyAutocompleteKey: keyAutocompleteKey,
+            valueAutocompleteKey: valueAutocompleteKey,
+          ),
+          _FolksonomyEditTagContentFooter(onSave: _onSubmit),
+        ],
+      ),
     );
   }
 
@@ -193,6 +203,8 @@ class _FolksonomyEditTagContentBody extends StatelessWidget {
                 productType: null,
                 withClearButton: false,
                 margin: EdgeInsetsDirectional.zero,
+                // don't restrict to 1 line - descriptions may be longer
+                maxLines: null,
                 autocompleteManager: AutocompleteManager(
                   FolksonomyValuesAutocompleter(
                     keyProvider: () => keyController.text,

--- a/packages/smooth_app/lib/pages/folksonomy/folksonomy_page.dart
+++ b/packages/smooth_app/lib/pages/folksonomy/folksonomy_page.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart' hide Listener;
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/database/local_database.dart';
-import 'package:smooth_app/generic_lib/bottom_sheets/smooth_bottom_sheet.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_snackbar.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
@@ -209,27 +208,16 @@ class _FolksonomyContentState extends State<_FolksonomyContent> {
     String? value,
   }) async {
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
-    final FolksonomyProvider folksonomyProvider = context
-        .read<FolksonomyProvider>();
-    final FolksonomyTag? res = await showSmoothModalSheetForTextField(
-      context: context,
-      header: SmoothModalSheetHeader(
-        title: action == FolksonomyAction.edit
-            ? appLocalizations.edit_tag
-            : appLocalizations.add_tag,
-        prefix: const SmoothModalSheetHeaderPrefixIndicator(),
+
+    final FolksonomyTag? res = await Navigator.of(context).push<FolksonomyTag>(
+      MaterialPageRoute<FolksonomyTag>(
+        builder: (BuildContext context) => FolksonomyEditTagContent(
+          action: action,
+          existingKeys: existingKeys,
+          oldKey: key,
+          oldValue: value,
+        ),
       ),
-      bodyBuilder: (BuildContext context) {
-        return ChangeNotifierProvider<FolksonomyProvider>.value(
-          value: folksonomyProvider,
-          child: FolksonomyEditTagContent(
-            action: action,
-            existingKeys: existingKeys,
-            oldKey: key,
-            oldValue: value,
-          ),
-        );
-      },
     );
 
     if (res != null && mounted) {

--- a/packages/smooth_app/lib/pages/input/smooth_autocomplete_text_field.dart
+++ b/packages/smooth_app/lib/pages/input/smooth_autocomplete_text_field.dart
@@ -22,6 +22,7 @@ class SmoothAutocompleteTextField extends StatefulWidget {
     this.minLengthForSuggestions = 1,
     this.autofocus = false,
     this.allowEmojis = true,
+    this.maxLines = 1,
     this.suffixIcon,
     this.borderRadius,
     this.padding,
@@ -40,6 +41,7 @@ class SmoothAutocompleteTextField extends StatefulWidget {
   final int minLengthForSuggestions;
   final AutocompleteManager? manager;
   final bool allowEmojis;
+  final int? maxLines;
   final Widget? suffixIcon;
   final BorderRadius? borderRadius;
   final EdgeInsetsGeometry? padding;
@@ -100,7 +102,7 @@ class _SmoothAutocompleteTextFieldState
             VoidCallback onFieldSubmitted,
           ) => TextField(
             enabled: widget.enabled,
-            maxLines: 1,
+            maxLines: widget.maxLines,
             controller: widget.controller,
             onChanged: (_) {
               if (mounted) {

--- a/packages/smooth_app/lib/pages/product/simple_input/simple_input_text_field.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input/simple_input_text_field.dart
@@ -26,6 +26,7 @@ class SimpleInputTextField extends StatefulWidget {
     this.borderRadius,
     this.textCapitalization,
     this.allowEmojis,
+    this.maxLines = 1,
     this.enabled,
   });
 
@@ -48,6 +49,7 @@ class SimpleInputTextField extends StatefulWidget {
   final BorderRadius? borderRadius;
   final TextCapitalization? textCapitalization;
   final bool? allowEmojis;
+  final int? maxLines;
   final bool? enabled;
 
   @override
@@ -106,6 +108,7 @@ class _SimpleInputTextFieldState extends State<SimpleInputTextField> {
               borderRadius: widget.borderRadius,
               padding: widget.padding,
               enabled: widget.enabled,
+              maxLines: widget.maxLines,
             ),
           ),
           if (widget.withClearButton)

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -257,10 +257,10 @@ packages:
     dependency: transitive
     description:
       name: camera_web
-      sha256: "57f49a635c8bf249d07fb95eb693d7e4dda6796dedb3777f9127fb54847beba7"
+      sha256: "1245a480a113437f8d46d19c0fb90cea9db921436d9cf2ba5fb11854a1312693"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.5+3"
+    version: "0.3.5+4"
   carousel_slider:
     dependency: "direct main"
     description:
@@ -1060,10 +1060,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mgrs_dart:
     dependency: transitive
     description:
@@ -1269,10 +1269,10 @@ packages:
     dependency: transitive
     description:
       name: permission_handler_apple
-      sha256: e20daf680eef1ca62ffe8c8c526b778cc386d50137c77ac71c8ec9c88c13fb9d
+      sha256: "79dfa1df734798aa3cfdad166d3a3698c206d8813de13516ea1071b5d7e2f420"
       url: "https://pub.dev"
     source: hosted
-    version: "9.4.9"
+    version: "9.4.10"
   permission_handler_html:
     dependency: transitive
     description:
@@ -1687,10 +1687,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.10"
   torch_light:
     dependency: "direct main"
     description:
@@ -1949,4 +1949,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.11.5 <4.0.0"
-  flutter: ">=3.41.8"
+  flutter: ">=3.41.8 <4.0.0"


### PR DESCRIPTION
### What
- The folksonomy value text field is now multi-line, to match "description" keys.
- A side-effect is the use of a page instead of bottom-sheet, for space reasons.
- cc. @TerEsper

### Screenshot or video
| s1 | s2 | s3 |
| -- | -- | -- |
| <img width="1080" height="2408" alt="Screenshot_20260612_183831" src="https://github.com/user-attachments/assets/967423e8-dce6-4508-911b-b4f139a8bddf" /> | <img width="1080" height="2408" alt="Screenshot_20260612_183838" src="https://github.com/user-attachments/assets/15253b36-55a9-4ff2-8e6a-0fc35fc692bc" /> | <img width="1080" height="2408" alt="Screenshot_20260612_183909" src="https://github.com/user-attachments/assets/ba55db0a-41f8-45d5-856f-b99c6f96bc1d" /> |

### Fixes bug(s)
- Fixes: #7558

### Impacted files
* `app_localizations.dart`: wtf
* `folksonomy_create_edit_modal.dart`: now using a page instead of a bottom-sheet
* `folksonomy_page.dart`: now using a page instead of a bottom-sheet
* `pubspec.lock`: wtf
* `simple_input_text_field.dart`: maxLines parameter
* `smooth_autocomplete_text_field.dart`: maxLines parameter