### PR TITLE
fix: 7568 - android allow restricted resizability

### DIFF
--- a/packages/smooth_app/android/app/src/main/AndroidManifest.xml
+++ b/packages/smooth_app/android/app/src/main/AndroidManifest.xml
@@ -25,6 +25,11 @@
         android:allowBackup="true"
         android:fullBackupContent="@xml/backup_scheme"
         tools:targetApi="q">
+
+        <property
+            android:name="android.window.PROPERTY_COMPAT_ALLOW_RESTRICTED_RESIZABILITY"
+            android:value="true" />
+
         <activity
             android:name=".MainActivity"
             android:exported="true"


### PR DESCRIPTION
### What
With Android API 36, we're not supposed to block the display in "portrait" mode, as we do in Smoothie from the beginning.
Still, there's a way to bypass this contraint, in the Android Manifest.
Looks like it won't be possible in API 37. We'll see.

### Fixes bug(s)
- Fixes: #7568