### PR TITLE
fix: 7530 - explicitly showing when a barcode is fishy

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_base_card.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_base_card.dart
@@ -266,13 +266,13 @@ class ScanProductBaseCardText extends StatelessWidget {
 class ScanProductBaseCardBarcode extends StatelessWidget {
   const ScanProductBaseCardBarcode({
     required this.barcode,
-    this.height,
+    required this.height,
     this.padding,
     super.key,
-  }) : assert(height == null || height > 0);
+  });
 
   final String barcode;
-  final double? height;
+  final double height;
   final EdgeInsetsDirectional? padding;
 
   @override
@@ -302,7 +302,7 @@ class ScanProductBaseCardBarcode extends StatelessWidget {
           child: ConstrainedBox(
             constraints: BoxConstraints(minHeight: dense ? 75.0 : 100.0),
             child: SmoothBarcodeWidget(
-              height: height ?? 100.0,
+              height: height,
               padding: EdgeInsetsDirectional.symmetric(
                 horizontal: 30.0,
                 vertical: dense ? SMALL_SPACE : MEDIUM_SPACE,

--- a/packages/smooth_app/lib/l10n/app_en.arb
+++ b/packages/smooth_app/lib/l10n/app_en.arb
@@ -4533,6 +4533,10 @@
       }
     }
   },
+  "barcode_probably_invalid": "Probably invalid barcode",
+  "@barcode_probably_invalid": {
+    "description": "Warning message. Keep it short."
+  },
   "carousel_close_tooltip": "Remove this product from the carousel",
   "@carousel_close_tooltip": {
     "description": "A message explaining the goal of the Close button on a card of the carousel"

--- a/packages/smooth_app/lib/l10n/app_fr.arb
+++ b/packages/smooth_app/lib/l10n/app_fr.arb
@@ -4533,6 +4533,10 @@
       }
     }
   },
+  "barcode_probably_invalid": "Code-barres probablement invalide",
+  "@barcode_probably_invalid": {
+    "description": "Warning message. Keep it short."
+  },
   "carousel_close_tooltip": "Supprimer ce produit du carrousel",
   "@carousel_close_tooltip": {
     "description": "A message explaining the goal of the Close button on a card of the carousel"

--- a/packages/smooth_app/lib/l10n/app_localizations.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations.dart
@@ -9104,6 +9104,12 @@ abstract class AppLocalizations {
   /// **'Barcode {barcode}'**
   String barcode_accessibility_label(String barcode);
 
+  /// Warning message. Keep it short.
+  ///
+  /// In en, this message translates to:
+  /// **'Probably invalid barcode'**
+  String get barcode_probably_invalid;
+
   /// A message explaining the goal of the Close button on a card of the carousel
   ///
   /// In en, this message translates to:

--- a/packages/smooth_app/lib/widgets/smooth_barcode_widget.dart
+++ b/packages/smooth_app/lib/widgets/smooth_barcode_widget.dart
@@ -2,34 +2,28 @@ import 'package:barcode_widget/barcode_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/l10n/app_localizations.dart';
-import 'package:smooth_app/themes/theme_provider.dart';
+import 'package:smooth_app/resources/app_icons.dart' as icons;
 
 /// A widget showing a barcode on screen
 /// It simplifies the call to [BarcodeWidget]
 class SmoothBarcodeWidget extends StatelessWidget {
   const SmoothBarcodeWidget({
     required this.barcode,
-    this.errorBuilder,
+    required this.height,
+    required this.color,
     this.backgroundColor,
-    this.color,
-    this.height,
     this.padding,
-    this.onInvalidBarcode,
     super.key,
   }) : assert(barcode.length > 0);
 
   final String barcode;
-  final Color? color;
+  final double height;
+  final Color color;
   final Color? backgroundColor;
-  final double? height;
-  final WidgetBuilder? errorBuilder;
   final EdgeInsetsGeometry? padding;
-  final VoidCallback? onInvalidBarcode;
 
   @override
   Widget build(BuildContext context) {
-    final Color contentColor =
-        color ?? (context.lightTheme() ? Colors.black : Colors.white);
     return Semantics(
       label: AppLocalizations.of(context).barcode_accessibility_label(barcode),
       excludeSemantics: true,
@@ -41,32 +35,45 @@ class SmoothBarcodeWidget extends StatelessWidget {
             padding: EdgeInsets.zero,
             data: barcode,
             barcode: _barcodeType,
-            color: color ?? Colors.black,
-            style: TextStyle(color: contentColor),
+            color: color,
+            style: TextStyle(color: color),
             errorBuilder: (final BuildContext context, String? error) {
-              onInvalidBarcode?.call();
-
-              if (errorBuilder != null) {
-                return errorBuilder!(context);
-              }
-
-              return Center(
-                child: Container(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: SMALL_SPACE,
-                    vertical: SMALL_SPACE,
-                  ),
-                  color: Colors.grey.withValues(alpha: 0.2),
-                  child: Text(
-                    '<$barcode>',
-                    style: TextStyle(
-                      letterSpacing: 6.0,
-                      fontFeatures: const <FontFeature>[
-                        FontFeature.tabularFigures(),
+              return Container(
+                width: double.infinity,
+                padding: const EdgeInsets.symmetric(
+                  horizontal: SMALL_SPACE,
+                  vertical: SMALL_SPACE,
+                ),
+                color: Colors.grey.withValues(alpha: 0.2),
+                child: Column(
+                  mainAxisSize: MainAxisSize.max,
+                  mainAxisAlignment: MainAxisAlignment.spaceAround,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: <Widget>[
+                    Row(
+                      mainAxisSize: MainAxisSize.min,
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      children: <Widget>[
+                        const icons.Warning(),
+                        Text(
+                          // TODO(monsieurtanuki): localize
+                          ' probably invalid barcode',
+                          style: TextStyle(color: color),
+                        ),
                       ],
-                      color: contentColor,
                     ),
-                  ),
+                    Text(
+                      '<$barcode>',
+                      style: TextStyle(
+                        letterSpacing: 6.0,
+                        fontFeatures: const <FontFeature>[
+                          FontFeature.tabularFigures(),
+                        ],
+                        color: color,
+                      ),
+                    ),
+                  ],
                 ),
               );
             },

--- a/packages/smooth_app/lib/widgets/smooth_barcode_widget.dart
+++ b/packages/smooth_app/lib/widgets/smooth_barcode_widget.dart
@@ -24,8 +24,9 @@ class SmoothBarcodeWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final AppLocalizations appLocalizations = AppLocalizations.of(context);
     return Semantics(
-      label: AppLocalizations.of(context).barcode_accessibility_label(barcode),
+      label: appLocalizations.barcode_accessibility_label(barcode),
       excludeSemantics: true,
       child: Padding(
         padding: padding ?? EdgeInsets.zero,
@@ -40,6 +41,7 @@ class SmoothBarcodeWidget extends StatelessWidget {
             errorBuilder: (final BuildContext context, String? error) {
               return Container(
                 width: double.infinity,
+                height: height,
                 padding: const EdgeInsets.symmetric(
                   horizontal: SMALL_SPACE,
                   vertical: SMALL_SPACE,
@@ -56,10 +58,15 @@ class SmoothBarcodeWidget extends StatelessWidget {
                       crossAxisAlignment: CrossAxisAlignment.center,
                       children: <Widget>[
                         const icons.Warning(),
-                        Text(
-                          // TODO(monsieurtanuki): localize
-                          ' probably invalid barcode',
-                          style: TextStyle(color: color),
+                        const SizedBox(width: SMALL_SPACE),
+                        Expanded(
+                          child: FittedBox(
+                            fit: BoxFit.contain,
+                            child: Text(
+                              appLocalizations.barcode_probably_invalid,
+                              style: TextStyle(color: color),
+                            ),
+                          ),
                         ),
                       ],
                     ),


### PR DESCRIPTION
### What
Now we explicitly display a warning when a barcode is probably incorrect.
cc. @TerEsper

### Screenshot or video
| before | after | valid barcode |
| -- | -- | -- |
| <img width="1080" height="2408" alt="Screenshot_20260615_101616" src="https://github.com/user-attachments/assets/95c238e9-cd3f-4b69-a846-1687b68ef7d7" /> | <img width="1080" height="2408" alt="Screenshot_20260615_103122" src="https://github.com/user-attachments/assets/59cbaa0d-b4e1-4ceb-ae68-545aea420eea" /> | <img width="1080" height="2408" alt="Screenshot_20260615_103221" src="https://github.com/user-attachments/assets/2f8e9d04-a50d-416c-a6eb-5cd33f3f2a3b" /> |

### Part of 
- #7530

### Impacted files
* `smooth_barcode_widget.dart`: explicit label when barcode is fishy, minor refactoring
* `smooth_product_base_card.dart`: minor refactoring