### PR TITLE
fix: 7586 - NOVA 1 text for NOVA 1

### DIFF
--- a/packages/smooth_app/lib/pages/guides/guide/guide_nova.dart
+++ b/packages/smooth_app/lib/pages/guides/guide/guide_nova.dart
@@ -135,7 +135,8 @@ class _NOVALogos extends StatelessWidget {
             child: Row(
               children: assets
                   .map(
-                    (String path) => Expanded(
+                    (String path) =>
+                    Expanded(
                       child: Padding(
                         padding: const EdgeInsets.all(8.0),
                         child: SvgPicture(
@@ -145,7 +146,7 @@ class _NOVALogos extends StatelessWidget {
                         ),
                       ),
                     ),
-                  )
+              )
                   .toList(growable: false),
             ),
           );
@@ -168,7 +169,7 @@ class _NOVASection2 extends StatelessWidget {
         GuidesTitleWithText(
           title: appLocalizations.guide_nova_groups_arg1_title,
           icon: const icons.FoodIcons.nova1(),
-          text: appLocalizations.guide_nova_groups_arg2_text,
+          text: appLocalizations.guide_nova_groups_arg1_text,
         ),
         GuidesTitleWithText(
           title: appLocalizations.guide_nova_groups_arg2_title,

--- a/packages/smooth_app/lib/pages/guides/guide/guide_nova.dart
+++ b/packages/smooth_app/lib/pages/guides/guide/guide_nova.dart
@@ -135,8 +135,7 @@ class _NOVALogos extends StatelessWidget {
             child: Row(
               children: assets
                   .map(
-                    (String path) =>
-                    Expanded(
+                    (String path) => Expanded(
                       child: Padding(
                         padding: const EdgeInsets.all(8.0),
                         child: SvgPicture(
@@ -146,7 +145,7 @@ class _NOVALogos extends StatelessWidget {
                         ),
                       ),
                     ),
-              )
+                  )
                   .toList(growable: false),
             ),
           );


### PR DESCRIPTION
### What
Typo in the code. Now the description of NOVA 1 is something like that - the text already existed:
> Unprocessed (or natural) foods are the **edible parts of plants** (seeds, fruits, leaves, stems, roots) **or animals** (muscle, offal, eggs, milk), as well as fungi, algae, and water, after being separated from nature.

### Fixes bug(s)
- Fixes: #7586