### PR TITLE
fix: 7530 - display barcode at product type selection page

### DIFF
--- a/packages/smooth_app/lib/cards/product_cards/smooth_product_base_card.dart
+++ b/packages/smooth_app/lib/cards/product_cards/smooth_product_base_card.dart
@@ -301,15 +301,12 @@ class ScanProductBaseCardBarcode extends StatelessWidget {
         child: Center(
           child: ConstrainedBox(
             constraints: BoxConstraints(minHeight: dense ? 75.0 : 100.0),
-            child: SmoothBarcodeWidget(
-              height: height,
+            child: Padding(
               padding: EdgeInsetsDirectional.symmetric(
                 horizontal: 30.0,
                 vertical: dense ? SMALL_SPACE : MEDIUM_SPACE,
               ),
-              color: Colors.black,
-              backgroundColor: lightTheme ? Colors.white : Colors.transparent,
-              barcode: barcode,
+              child: SmoothBarcodeWidget(barcode: barcode, height: height),
             ),
           ),
         ),

--- a/packages/smooth_app/lib/pages/product/add_new_product/add_new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_new_product/add_new_product_page.dart
@@ -616,15 +616,13 @@ class _AddNewProductPageState extends State<AddNewProductPage>
       );
     }
     rows.add(
-      SmoothBarcodeWidget(
-        height: 75,
+      Padding(
         padding: const EdgeInsetsDirectional.only(
           start: VERY_LARGE_SPACE,
           end: VERY_LARGE_SPACE,
           top: VERY_LARGE_SPACE,
         ),
-        color: context.lightTheme() ? Colors.black : Colors.white,
-        barcode: barcode,
+        child: SmoothBarcodeWidget(barcode: barcode, height: 75),
       ),
     );
     return rows;

--- a/packages/smooth_app/lib/pages/product/add_new_product/add_new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_new_product/add_new_product_page.dart
@@ -29,6 +29,7 @@ import 'package:smooth_app/pages/product/simple_input/simple_input_page_helpers.
 import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/themes/smooth_theme_colors.dart';
 import 'package:smooth_app/themes/theme_provider.dart';
+import 'package:smooth_app/widgets/smooth_barcode_widget.dart';
 import 'package:smooth_app/widgets/smooth_scaffold.dart';
 import 'package:smooth_app/widgets/v2/smooth_buttons_bar.dart';
 import 'package:smooth_app/widgets/v2/smooth_leading_button.dart';
@@ -614,6 +615,18 @@ class _AddNewProductPageState extends State<AddNewProductPage>
         ),
       );
     }
+    rows.add(
+      SmoothBarcodeWidget(
+        height: 75,
+        padding: const EdgeInsetsDirectional.only(
+          start: VERY_LARGE_SPACE,
+          end: VERY_LARGE_SPACE,
+          top: VERY_LARGE_SPACE,
+        ),
+        color: context.lightTheme() ? Colors.black : Colors.white,
+        barcode: barcode,
+      ),
+    );
     return rows;
   }
 

--- a/packages/smooth_app/lib/pages/product/common/product_dialog_helper.dart
+++ b/packages/smooth_app/lib/pages/product/common/product_dialog_helper.dart
@@ -116,19 +116,15 @@ class ProductDialogHelper {
                           ? theme.primaryMedium
                           : theme.primaryLight,
                     ),
-                    child: SmoothBarcodeWidget(
-                      barcode: barcode,
-                      height: 75.0,
-                      padding: const EdgeInsetsDirectional.only(
-                        top: MEDIUM_SPACE,
-                        start: VERY_LARGE_SPACE,
-                        end: VERY_LARGE_SPACE,
-                        bottom: MEDIUM_SPACE,
+                    child: Padding(
+                      padding: const EdgeInsetsDirectional.symmetric(
+                        vertical: MEDIUM_SPACE,
+                        horizontal: VERY_LARGE_SPACE,
                       ),
-                      color: Colors.black,
-                      backgroundColor: lightTheme
-                          ? Colors.white
-                          : Colors.transparent,
+                      child: SmoothBarcodeWidget(
+                        barcode: barcode,
+                        height: 75.0,
+                      ),
                     ),
                   ),
                   const SizedBox(height: MEDIUM_SPACE * 2),

--- a/packages/smooth_app/lib/pages/product/product_page/footer/new_product_footer_barcode.dart
+++ b/packages/smooth_app/lib/pages/product/product_page/footer/new_product_footer_barcode.dart
@@ -44,12 +44,7 @@ class ProductFooterBarcodeButton extends StatelessWidget {
             children: <Widget>[
               FractionallySizedBox(
                 widthFactor: 0.65,
-                child: SmoothBarcodeWidget(
-                  padding: EdgeInsets.zero,
-                  color: context.lightTheme() ? Colors.black : Colors.white,
-                  barcode: barcode,
-                  height: 110.0,
-                ),
+                child: SmoothBarcodeWidget(barcode: barcode, height: 110.0),
               ),
               const SizedBox(height: LARGE_SPACE),
               OutlinedButton(

--- a/packages/smooth_app/lib/widgets/smooth_barcode_widget.dart
+++ b/packages/smooth_app/lib/widgets/smooth_barcode_widget.dart
@@ -57,7 +57,7 @@ class SmoothBarcodeWidget extends StatelessWidget {
                       mainAxisAlignment: MainAxisAlignment.center,
                       crossAxisAlignment: CrossAxisAlignment.center,
                       children: <Widget>[
-                        const icons.Warning(),
+                        icons.Warning(color: color),
                         const SizedBox(width: SMALL_SPACE),
                         Expanded(
                           child: FittedBox(

--- a/packages/smooth_app/lib/widgets/smooth_barcode_widget.dart
+++ b/packages/smooth_app/lib/widgets/smooth_barcode_widget.dart
@@ -10,82 +10,73 @@ class SmoothBarcodeWidget extends StatelessWidget {
   const SmoothBarcodeWidget({
     required this.barcode,
     required this.height,
-    required this.color,
-    this.backgroundColor,
-    this.padding,
     super.key,
   }) : assert(barcode.length > 0);
 
   final String barcode;
   final double height;
-  final Color color;
-  final Color? backgroundColor;
-  final EdgeInsetsGeometry? padding;
 
   @override
   Widget build(BuildContext context) {
+    const Color color = Colors.black;
+    const Color backgroundColor = Colors.white;
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     return Semantics(
       label: appLocalizations.barcode_accessibility_label(barcode),
       excludeSemantics: true,
-      child: Padding(
-        padding: padding ?? EdgeInsets.zero,
-        child: ColoredBox(
-          color: backgroundColor ?? Colors.transparent,
-          child: BarcodeWidget(
-            padding: EdgeInsets.zero,
-            data: barcode,
-            barcode: _barcodeType,
-            color: color,
-            style: TextStyle(color: color),
-            errorBuilder: (final BuildContext context, String? error) {
-              return Container(
-                width: double.infinity,
-                height: height,
-                padding: const EdgeInsets.symmetric(
-                  horizontal: SMALL_SPACE,
-                  vertical: SMALL_SPACE,
-                ),
-                color: Colors.grey.withValues(alpha: 0.2),
-                child: Column(
-                  mainAxisSize: MainAxisSize.max,
-                  mainAxisAlignment: MainAxisAlignment.spaceAround,
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: <Widget>[
-                    Row(
-                      mainAxisSize: MainAxisSize.min,
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      crossAxisAlignment: CrossAxisAlignment.center,
-                      children: <Widget>[
-                        icons.Warning(color: color),
-                        const SizedBox(width: SMALL_SPACE),
-                        Expanded(
-                          child: FittedBox(
-                            fit: BoxFit.contain,
-                            child: Text(
-                              appLocalizations.barcode_probably_invalid,
-                              style: TextStyle(color: color),
-                            ),
+      child: Container(
+        color: backgroundColor,
+        padding: const EdgeInsetsDirectional.all(SMALL_SPACE),
+        child: BarcodeWidget(
+          padding: EdgeInsets.zero,
+          data: barcode,
+          barcode: _barcodeType,
+          color: color,
+          style: const TextStyle(color: color),
+          errorBuilder: (final BuildContext context, String? error) {
+            return Container(
+              width: double.infinity,
+              height: height,
+              padding: const EdgeInsets.symmetric(
+                horizontal: SMALL_SPACE,
+                vertical: SMALL_SPACE,
+              ),
+              child: Column(
+                mainAxisSize: MainAxisSize.max,
+                mainAxisAlignment: MainAxisAlignment.spaceAround,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: <Widget>[
+                  Row(
+                    mainAxisSize: MainAxisSize.min,
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: <Widget>[
+                      const icons.Warning(color: color),
+                      const SizedBox(width: SMALL_SPACE),
+                      Expanded(
+                        child: FittedBox(
+                          fit: BoxFit.contain,
+                          child: Text(
+                            appLocalizations.barcode_probably_invalid,
+                            style: const TextStyle(color: color),
                           ),
                         ),
-                      ],
-                    ),
-                    Text(
-                      '<$barcode>',
-                      style: TextStyle(
-                        letterSpacing: 6.0,
-                        fontFeatures: const <FontFeature>[
-                          FontFeature.tabularFigures(),
-                        ],
-                        color: color,
                       ),
+                    ],
+                  ),
+                  Text(
+                    '<$barcode>',
+                    style: const TextStyle(
+                      letterSpacing: 6.0,
+                      fontFeatures: <FontFeature>[FontFeature.tabularFigures()],
+                      color: color,
                     ),
-                  ],
-                ),
-              );
-            },
-            height: height,
-          ),
+                  ),
+                ],
+              ),
+            );
+          },
+          height: height,
         ),
       ),
     );

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -1060,10 +1060,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mgrs_dart:
     dependency: transitive
     description:
@@ -1687,10 +1687,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.10"
   torch_light:
     dependency: "direct main"
     description:
@@ -1949,4 +1949,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.11.5 <4.0.0"
-  flutter: ">=3.41.8"
+  flutter: ">=3.41.8 <4.0.0"

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -1623,10 +1623,10 @@ packages:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: "9488c7d2cdb1091c91cacf7e207cff81b28bff8e366f042bad3afe7d34afe189"
+      sha256: "37356bcb56ce0d9404d602c41e4bdb7765e7e9732a3e47adb3d98c556a6abdad"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.2"
+    version: "3.3.3"
   stack_trace:
     dependency: transitive
     description:
@@ -1815,10 +1815,10 @@ packages:
     dependency: transitive
     description:
       name: vector_graphics_compiler
-      sha256: "7ee12e6dffe0fc8e755179d6d91b3b34f5924223fc104d85572ef9180d73d172"
+      sha256: "142a9146f447d15b10bdc00e21d5f4d83e5b32bb5f8f8f5a04c75311344923a3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.5"
+    version: "1.2.6"
   vector_math:
     dependency: transitive
     description:


### PR DESCRIPTION
### What
Now displaying the barcode at the "new product" "product type selection" page.
The intended goal is to display when a barcode is probably invalid, and to implicitly ask the user to double-check the barcode before creating potentially crap data.

### Screenshots
| valid | invalid |
| -- | -- |
| <img width="1080" height="2408" alt="Screenshot_20260620_080924" src="https://github.com/user-attachments/assets/1cee9320-8ada-4033-88c5-97291b40c1d4" /> | <img width="1080" height="2408" alt="Screenshot_20260620_080946" src="https://github.com/user-attachments/assets/7162dce8-9d63-4530-8a65-b9b4824a3952" /> |
| <img width="1080" height="2408" alt="Screenshot_20260620_122021" src="https://github.com/user-attachments/assets/5ab8ca6e-02fe-4e6b-915d-ccccd1ff507c" /> | <img width="1080" height="2408" alt="Screenshot_20260620_121904" src="https://github.com/user-attachments/assets/a5c36a21-bbc7-45c7-b3ec-471d0846e860" /> |

### Part of 
- #7530
- Fixes: #7589
- cc. @TerEsper

### Impacted files
* `add_new_product_page.dart`: added the barcode in the product type selection page
* `pubspec.lock`: wtf
* `smooth_barcode_widget.dart`: minor dark mode fix