### PR TITLE
fix: 7590 - "add product" - correct page title and logo beyond food + category

### DIFF
--- a/packages/smooth_app/lib/pages/prices/prices_page.dart
+++ b/packages/smooth_app/lib/pages/prices/prices_page.dart
@@ -43,6 +43,7 @@ class PricesPage extends StatelessWidget {
         title: appLocalizations.prices_list_title,
         subTitle: model.title,
         elevationOnScroll: true,
+        productType: null,
       ),
       injectPaddingInBody: model.displayEachProduct,
       belowTopBar: !model.displayEachProduct,

--- a/packages/smooth_app/lib/pages/product/add_new_product/add_new_product_page.dart
+++ b/packages/smooth_app/lib/pages/product/add_new_product/add_new_product_page.dart
@@ -89,6 +89,9 @@ class _AddNewProductPageState extends State<AddNewProductPage>
   int _otherCount = 0;
 
   /// The behavior is different for FOOD. And we don't know about it at first.
+  ///
+  /// Be careful: as it can change (because `_inputProductType` can), don't
+  /// cache anything, and always recompute anything based on `_probablyFood`.
   bool get _probablyFood =>
       (_inputProductType ?? ProductType.food) == ProductType.food;
 
@@ -108,8 +111,6 @@ class _AddNewProductPageState extends State<AddNewProductPage>
   late DaoProductList _daoProductList;
 
   final ProductList _history = ProductList.history();
-
-  List<String>? _appBarTitles;
 
   final ProductFieldEditor _packagingEditor = ProductFieldPackagingEditor();
   final ProductFieldEditor _ingredientsEditor =
@@ -236,7 +237,6 @@ class _AddNewProductPageState extends State<AddNewProductPage>
   @override
   Widget build(BuildContext context) {
     _colorScheme = Theme.of(context).colorScheme;
-    _appBarTitles ??= _generateAppBarTitles(AppLocalizations.of(context));
 
     context.watch<LocalDatabase>();
     refreshUpToDate();
@@ -251,13 +251,17 @@ class _AddNewProductPageState extends State<AddNewProductPage>
         .extension<SmoothColorsThemeExtension>();
     final bool lightTheme = context.lightTheme();
 
+    final List<String> appBarTitles = _generateAppBarTitles(
+      AppLocalizations.of(context),
+    );
     return WillPopScope2(
       onWillPop: () async => (await _onWillPop(), null),
       child: SmoothScaffold(
         appBar: SmoothTopBar2(
-          title: _appBarTitles![_pageNumber],
+          title: appBarTitles[_pageNumber],
           forceMultiLines: true,
           leadingAction: SmoothLeadingAction.back,
+          productType: _inputProductType,
           topWidget: PreferredSize(
             preferredSize: const Size(
               double.infinity,

--- a/packages/smooth_app/lib/pages/product/product_field_editor.dart
+++ b/packages/smooth_app/lib/pages/product/product_field_editor.dart
@@ -42,7 +42,7 @@ class ProductFieldSimpleEditor extends ProductFieldEditor {
 
   @override
   String getLabel(final AppLocalizations appLocalizations) =>
-      helper.getAddButtonLabel(appLocalizations);
+      helper.getStandardAddButtonLabel(appLocalizations);
 
   @override
   Future<void> edit({

--- a/packages/smooth_app/lib/pages/product/simple_input/simple_input_page_helpers.dart
+++ b/packages/smooth_app/lib/pages/product/simple_input/simple_input_page_helpers.dart
@@ -143,6 +143,13 @@ abstract class AbstractSimpleInputPageHelper extends ChangeNotifier {
       ) ||
       !const DeepCollectionEquality().equals(_terms, _initTerms);
 
+  /// Returns the label of the corresponding standard "add" button.
+  ///
+  /// Typical use case: for category, that have a distinct label when the values
+  /// are already set.
+  String getStandardAddButtonLabel(final AppLocalizations appLocalizations) =>
+      getAddButtonLabel(appLocalizations);
+
   /// Returns the title on the main "edit product" page.
   String getTitle(final AppLocalizations appLocalizations);
 
@@ -979,6 +986,10 @@ class SimpleInputPageCategoryHelper extends AbstractSimpleInputPageHelper {
     }
     return appLocalizations.score_add_missing_product_category;
   }
+
+  @override
+  String getStandardAddButtonLabel(final AppLocalizations appLocalizations) =>
+      appLocalizations.score_add_missing_product_category;
 
   @override
   String? getAddExplanationsTitle(AppLocalizations appLocalizations) =>

--- a/packages/smooth_app/lib/widgets/selector_screen/smooth_screen_list_choice.dart
+++ b/packages/smooth_app/lib/widgets/selector_screen/smooth_screen_list_choice.dart
@@ -66,6 +66,7 @@ class SmoothSelectorScreen<T> extends StatelessWidget {
                     ? SmoothLeadingAction.minimize
                     : SmoothLeadingAction.close,
                 elevationOnScroll: false,
+                productType: null,
               ),
               bottomBar: !provider.autoValidate
                   ? _SmoothSelectorScreenBottomBar<T>(

--- a/packages/smooth_app/lib/widgets/v2/smooth_topbar2.dart
+++ b/packages/smooth_app/lib/widgets/v2/smooth_topbar2.dart
@@ -12,6 +12,7 @@ import 'package:vector_graphics/vector_graphics.dart';
 class SmoothTopBar2 extends StatefulWidget implements PreferredSizeWidget {
   const SmoothTopBar2({
     required this.title,
+    required this.productType,
     this.subTitle,
     this.topWidget,
     this.leadingAction,
@@ -22,7 +23,6 @@ class SmoothTopBar2 extends StatefulWidget implements PreferredSizeWidget {
     this.elevationOnScroll = true,
     this.foregroundColor,
     this.backgroundColor,
-    this.productType,
     this.theme,
     super.key,
   }) : assert(title.length > 0),


### PR DESCRIPTION
### What
Regarding the "add product" page:
* the logo was always the default "food" logo
=> fixed, it depends on the type
* the page title was blocked as for "food" for unknown products. So we always displayed on page 3 (-1) the title of the corresponding food page, regardless of the type
=> fixed
* the category label evolved and was misleading
=> fixed

### Screenshot or video
| category needed | category set |
| -- | -- |
| <img width="1080" height="2408" alt="Screenshot_20260620_161903" src="https://github.com/user-attachments/assets/41d6df98-797f-4d50-bf05-041f4e7ff123" /> | <img width="1080" height="2408" alt="Screenshot_20260620_161316" src="https://github.com/user-attachments/assets/c611fc8e-7bdb-4805-b0a6-f5b03194e183" /> |

### Fixes bug(s)
- Fixes: #7590

### Impacted files
* `add_new_product_page.dart`: now generating the page titles right in time, added fixed the logo
* `prices_page.dart`: minor refactoring
* `product_field_editor.dart`: now using the new `getStandardAddButtonLabel` method
* `simple_input_page_helpers.dart`: added a `getStandardAddButtonLabel` method, that cover the standard "add a value" case
* `smooth_screen_list_choice.dart`: minor refactoring
* `smooth_topbar2.dart`: made `productType` required