### PR TITLE
fix: 7592 - bullet-proof layout on home page

### DIFF
--- a/packages/smooth_app/lib/pages/scan/carousel/main_card/bottom_cards/scan_app_review_card.dart
+++ b/packages/smooth_app/lib/pages/scan/carousel/main_card/bottom_cards/scan_app_review_card.dart
@@ -27,51 +27,56 @@ class ScanAppReview extends StatelessWidget {
     return ScanBottomCardContainer(
       title: appLocalizations.app_review_title,
       onClose: () => context.read<AppReviewProvider>().hide(),
-      body: Row(
-        children: <Widget>[
-          Expanded(
-            child: _AppReviewItem(
-              asset: 'assets/misc/tagline_0.svg.vec',
-              text: appLocalizations.app_review_low,
-              backgroundColor: const Color(0xFFD44C29),
-              borderRadius: BorderRadiusHelper.fromDirectional(
-                context: context,
-                bottomStart: ScanBottomCardContainer.radius,
-              ),
-              onTap: () => _showUserFeedBackModalSheet(
-                context,
-                AppReviewResult.unsatisfied,
+      body: Padding(
+        padding: const EdgeInsets.symmetric(vertical: LARGE_SPACE),
+        child: Row(
+          children: <Widget>[
+            Expanded(
+              child: _AppReviewItem(
+                asset: 'assets/misc/tagline_0.svg.vec',
+                text: appLocalizations.app_review_low,
+                backgroundColor: const Color(0xFFD44C29),
+                borderRadius: BorderRadiusHelper.fromDirectional(
+                  context: context,
+                  bottomStart: ScanBottomCardContainer.radius,
+                ),
+                onTap: () => _showUserFeedBackModalSheet(
+                  context,
+                  AppReviewResult.unsatisfied,
+                ),
               ),
             ),
-          ),
-          Expanded(
-            child: _AppReviewItem(
-              asset: 'assets/misc/tagline_1.svg.vec',
-              text: appLocalizations.app_review_medium,
-              backgroundColor: const Color(0xFFFF8C14),
-              borderRadius: BorderRadius.zero,
-              onTap: () =>
-                  _showUserFeedBackModalSheet(context, AppReviewResult.neutral),
-            ),
-          ),
-          Expanded(
-            child: _AppReviewItem(
-              asset: 'assets/misc/tagline_2.svg.vec',
-              text: appLocalizations.app_review_high,
-              backgroundColor: const Color(0xFF6CB564),
-              borderRadius: BorderRadiusHelper.fromDirectional(
-                context: context,
-                bottomEnd: ScanBottomCardContainer.radius,
+            Expanded(
+              child: _AppReviewItem(
+                asset: 'assets/misc/tagline_1.svg.vec',
+                text: appLocalizations.app_review_medium,
+                backgroundColor: const Color(0xFFFF8C14),
+                borderRadius: BorderRadius.zero,
+                onTap: () => _showUserFeedBackModalSheet(
+                  context,
+                  AppReviewResult.neutral,
+                ),
               ),
-              onTap: () async {
-                final AppReviewProvider appReview = context
-                    .read<AppReviewProvider>();
-                await ApplicationStore.openAppReview();
-                appReview.markAsReviewed(AppReviewResult.satisfied);
-              },
             ),
-          ),
-        ],
+            Expanded(
+              child: _AppReviewItem(
+                asset: 'assets/misc/tagline_2.svg.vec',
+                text: appLocalizations.app_review_high,
+                backgroundColor: const Color(0xFF6CB564),
+                borderRadius: BorderRadiusHelper.fromDirectional(
+                  context: context,
+                  bottomEnd: ScanBottomCardContainer.radius,
+                ),
+                onTap: () async {
+                  final AppReviewProvider appReview = context
+                      .read<AppReviewProvider>();
+                  await ApplicationStore.openAppReview();
+                  appReview.markAsReviewed(AppReviewResult.satisfied);
+                },
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/packages/smooth_app/lib/pages/scan/carousel/main_card/scan_main_card.dart
+++ b/packages/smooth_app/lib/pages/scan/carousel/main_card/scan_main_card.dart
@@ -6,7 +6,6 @@ import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/helpers/provider_helper.dart';
 import 'package:smooth_app/pages/scan/carousel/main_card/bottom_cards/scan_bottom_card.dart';
 import 'package:smooth_app/pages/scan/carousel/main_card/top_card/scan_search_card.dart';
-import 'package:smooth_app/widgets/text/text_extensions.dart';
 
 class ScanMainCard extends StatelessWidget {
   const ScanMainCard();
@@ -21,59 +20,29 @@ class ScanMainCard extends StatelessWidget {
       builder: (BuildContext context, AppNewsProvider newsFeed, _) {
         if (!newsFeed.hasContent) {
           return const ScanSearchCard(expandedMode: true);
-        } else {
-          return Semantics(
-            explicitChildNodes: true,
-            child: LayoutBuilder(
-              builder: (_, BoxConstraints constraints) {
-                final bool dense =
-                    constraints.maxHeight * 0.4 <=
-                    _maxHeight(context.textScaler());
-
-                if (dense) {
-                  return ListView(
-                    padding: EdgeInsetsDirectional.zero,
-                    children: <Widget>[
-                      ConstrainedBox(
-                        constraints: BoxConstraints(
-                          minHeight: math.max(
-                            ScanSearchCard.computeMinSize(context),
-                            constraints.maxHeight * 0.5,
-                          ),
-                        ),
-                        child: const ScanSearchCard(expandedMode: false),
-                      ),
-                      const SizedBox(height: SMALL_SPACE),
-                      const ScanBottomCard(dense: true),
-                    ],
-                  );
-                } else {
-                  return const Column(
-                    children: <Widget>[
-                      Expanded(
-                        flex: 6,
-                        child: ScanSearchCard(expandedMode: false),
-                      ),
-                      SizedBox(height: SMALL_SPACE),
-                      Expanded(flex: 4, child: ScanBottomCard(dense: false)),
-                    ],
-                  );
-                }
-              },
-            ),
-          );
         }
+        return Semantics(
+          explicitChildNodes: true,
+          child: LayoutBuilder(
+            builder: (_, BoxConstraints constraints) => ListView(
+              padding: EdgeInsetsDirectional.zero,
+              children: <Widget>[
+                ConstrainedBox(
+                  constraints: BoxConstraints(
+                    minHeight: math.max(
+                      ScanSearchCard.computeMinSize(context),
+                      constraints.maxHeight * 0.5,
+                    ),
+                  ),
+                  child: const ScanSearchCard(expandedMode: false),
+                ),
+                const SizedBox(height: SMALL_SPACE),
+                const ScanBottomCard(dense: true),
+              ],
+            ),
+          ),
+        );
       },
     );
-  }
-
-  double _maxHeight(double textScaler) {
-    if (textScaler < 1.1) {
-      return 160.0;
-    } else if (textScaler < 1.3) {
-      return 173.0;
-    } else {
-      return 186.0;
-    }
   }
 }


### PR DESCRIPTION
### What
The layout of the home page was either considered "dense" (and used ListView) or "not dense" (and used Column).
The computation of "are we dense or not?" was slightly incorrect, at least on my smartphone.
The consequence is that the home page was systematically with overflow, preventing me (and I guess other users) from interacting with the project (read text + click buttons) - let alone the bad UI/UX impression from page 1.
In this PR I switched to the safest option, "dense" with ListView.

### Screenshot or video
| before | after |
| -- | -- |
| <img width="1080" height="2408" alt="Screenshot_20260620_164512" src="https://github.com/user-attachments/assets/243b1e40-13bc-4c6c-b907-028c3dca1b85" /> | <img width="1080" height="2408" alt="Screenshot_20260620_183908" src="https://github.com/user-attachments/assets/b552dd5c-ff4a-4e01-8aa9-24d11d05f8c8" /> |

### Fixes bug(s)
- Fixes: #7592