### PR TITLE
fix: usewithOpacity(0.2)instead ofwithValues(alpha: 0.2)

### DIFF
--- a/packages/smooth_app/lib/widgets/smooth_barcode_widget.dart
+++ b/packages/smooth_app/lib/widgets/smooth_barcode_widget.dart
@@ -46,7 +46,7 @@ class SmoothBarcodeWidget extends StatelessWidget {
                   horizontal: SMALL_SPACE,
                   vertical: SMALL_SPACE,
                 ),
-                color: Colors.grey.withValues(alpha: 0.2),
+                color: Colors.grey.withOpacity(0.2),
                 child: Column(
                   mainAxisSize: MainAxisSize.max,
                   mainAxisAlignment: MainAxisAlignment.spaceAround,


### PR DESCRIPTION
_This PR applies 1/1 suggestions from code quality [AI findings](https://github.com/openfoodfacts/smooth-app/security/quality/ai-findings)._
`The `withValues` method is used to set the alpha channel, but this appears to be a non-standard API. Typically in Flutter, you would use `withOpacity(0.2)` instead of `withValues(alpha: 0.2)`. Verify if this is a custom extension or if it should use the standard Flutter API.`