### PR TITLE
fix: 7232 - clean "pop" management

### DIFF
--- a/packages/smooth_app/lib/l10n/app_localizations.dart
+++ b/packages/smooth_app/lib/l10n/app_localizations.dart
@@ -981,7 +981,7 @@ abstract class AppLocalizations {
   /// No description provided for @sign_up_page_email_hint.
   ///
   /// In en, this message translates to:
-  /// **'E-post'**
+  /// **'E-mail'**
   String get sign_up_page_email_hint;
 
   /// No description provided for @sign_up_page_email_error_empty.
@@ -3067,12 +3067,6 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Could not remove product'**
   String get product_could_not_remove;
-
-  /// No description provided for @no_prodcut_in_list.
-  ///
-  /// In en, this message translates to:
-  /// **'There is no product in this list'**
-  String get no_prodcut_in_list;
 
   /// No description provided for @no_product_in_section.
   ///
@@ -6965,7 +6959,7 @@ abstract class AppLocalizations {
   /// No description provided for @email_copied_to_clip_board.
   ///
   /// In en, this message translates to:
-  /// **'Epost copied to clipboard!'**
+  /// **'E-mail copied to clipboard!'**
   String get email_copied_to_clip_board;
 
   /// Accent Color for the application in AMOLED mode.
@@ -7211,7 +7205,7 @@ abstract class AppLocalizations {
   /// text to show details of products available for download
   ///
   /// In en, this message translates to:
-  /// **'{num} products available for immediate scaning'**
+  /// **'{num} products available for immediate scanning'**
   String available_for_download(int num);
 
   /// Label written as the title of the dialog to select the user country

--- a/packages/smooth_app/lib/widgets/will_pop_scope.dart
+++ b/packages/smooth_app/lib/widgets/will_pop_scope.dart
@@ -32,23 +32,23 @@ class WillPopScope2 extends StatelessWidget {
               }
 
               final (bool shouldClose, dynamic res) = await onWillPop.call();
-              if (shouldClose == true) {
-                WidgetsBinding.instance.addPostFrameCallback((_) {
-                  try {
-                    GoRouter.of(context).pop(res);
-                  } on GoError catch (error) {
-                    if (error.message == 'There is nothing to pop') {
-                      try {
-                        // Using regular Navigator as fallback
-                        Navigator.of(context).pop(res);
-                      } catch (navigatorError) {
-                        // Force to kill the app
-                        SystemNavigator.pop();
-                      }
-                    }
-                  }
-                });
+              if (!shouldClose) {
+                return;
               }
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                final GoRouter goRouter = GoRouter.of(context);
+                if (goRouter.canPop()) {
+                  goRouter.pop(res);
+                  return;
+                }
+                final NavigatorState navigatorState = Navigator.of(context);
+                if (navigatorState.canPop()) {
+                  navigatorState.pop(res);
+                  return;
+                }
+                // Force to kill the app
+                SystemNavigator.pop();
+              });
             },
             child: child,
           );


### PR DESCRIPTION
### What
The tricky thing is that I couldn't reproduce the visible issue: the black screen.
But I've managed to spot an `EXCEPTION CAUGHT BY WIDGETS LIBRARY` in the logs.

With this PR, the management of the "pop" actions (= "back") is cleaner. Include the final "pop", that closes the app.

I guess that cascading tries of "pop"s eventually became problematic. Something like the previous pops succeeded to a certain point then failed, so the fallback pop doesn't start with a clean state.

Anyway, I've managed to remove the `EXCEPTION CAUGHT BY WIDGETS LIBRARY` from the logs.
That may mean no more black screen. To be tested with testers that did experience the black screen.

There's still an exception, but hopefully invisible.
```log
W/FlutterJNI(29911): Tried to send a platform message response, but FlutterJNI was detached from native C++. Could not send. Response ID: 96
E/MethodChannel#dev.steenbakker.mobile_scanner/scanner/method(29911): Failed to handle method call
E/MethodChannel#dev.steenbakker.mobile_scanner/scanner/method(29911): java.lang.NullPointerException
E/MethodChannel#dev.steenbakker.mobile_scanner/scanner/method(29911):   at dev.steenbakker.mobile_scanner.MobileScannerHandler.stop(MobileScannerHandler.kt:233)
```

For the record, in a similar app I've managed to close the app without an exception when closing the app.
May come from the fact that the scanner isn't my home page - therefore not the final page before exit.

### Fixes bug(s)
- Fixes: #7232

### Impacted files
* `app_localizations.dart`: wtf
* `will_pop_scope.dart`: clean "pop" management