### PR TITLE
fix: 7363 - no "set as" image operation for "OTHER"

### DIFF
--- a/packages/smooth_app/lib/background/background_task_image.dart
+++ b/packages/smooth_app/lib/background/background_task_image.dart
@@ -443,6 +443,11 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
       if (status.status == 'status not ok' && imageId != null) {
         // The very same image was already uploaded and therefore was rejected.
         // We just have to select this image, with no angle.
+        if (imageField == ImageField.OTHER) {
+          // we're done here: all we wanted was to have the image uploaded, and
+          // it is. And the server rejects "set as" operation for OTHER images.
+          return;
+        }
         final String? imageUrl = await OpenFoodAPIClient.setProductImageAngle(
           barcode: barcode,
           imageField: imageField,


### PR DESCRIPTION
### What
The server doesn't accept "set as" image operation for "OTHER" field type. As opposed to "set this image as FRONT_FR".
We called that "set as" method for "OTHER" images in very rare but very easy to reproduce cases. Which caused forever errors.
Now we don't call that method for "OTHER" images because it's pointless anyway: we just want to upload "OTHER" images.

### Screenshot or video
For the record, with the pending https://github.com/openfoodfacts/openfoodfacts-dart/pull/1240 this is the error we would get without the current PR:
<img width="1080" height="2408" alt="Screenshot_20260629_110248" src="https://github.com/user-attachments/assets/0e014bef-5063-49e7-b02a-3d44b4feddde" />

Just to make it clear: now it's successful, we don't get error messages.

### Fixes bug(s)
- Fixes: #7363

### Part of 
- https://github.com/openfoodfacts/openfoodfacts-server/pull/13630
- https://github.com/openfoodfacts/openfoodfacts-dart/pull/1240