### PR TITLE
fix: 6751 - image performance improvements

### DIFF
--- a/packages/smooth_app/lib/background/background_task_add_price.dart
+++ b/packages/smooth_app/lib/background/background_task_add_price.dart
@@ -250,7 +250,6 @@ class BackgroundTaskAddPrice extends BackgroundTaskPrice {
           cropY1: cropY1,
           cropX2: cropX2,
           cropY2: cropY2,
-          compressQuality: 80,
           forceCompression: true,
           eraserCoordinates: eraserCoordinates,
         );

--- a/packages/smooth_app/lib/background/background_task_image.dart
+++ b/packages/smooth_app/lib/background/background_task_image.dart
@@ -20,6 +20,7 @@ import 'package:smooth_app/database/local_database.dart';
 import 'package:smooth_app/helpers/image_compute_container.dart';
 import 'package:smooth_app/l10n/app_localizations.dart';
 import 'package:smooth_app/pages/crop_helper.dart';
+import 'package:smooth_app/pages/image_crop_page.dart';
 import 'package:smooth_app/pages/prices/eraser_model.dart';
 import 'package:smooth_app/pages/prices/eraser_painter.dart';
 
@@ -258,7 +259,6 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
     required final int cropY1,
     required final int cropX2,
     required final int cropY2,
-    required final int compressQuality,
     required final bool forceCompression,
     required final List<double>? eraserCoordinates,
     final int? maxSize,
@@ -342,7 +342,7 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
     await saveJpeg(
       file: croppedFile,
       source: cropped,
-      quality: compressQuality,
+      quality: ImagePickerConstants.imageQuality,
     );
     return BackgroundCropResult.success(
       filePath: croppedPath,
@@ -386,9 +386,8 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
       final User user = getUser();
 
       Future<Status> addImage({
-        required int compressionPct,
         required bool force,
-        int? maxSize,
+        required int maxSize,
       }) async {
         cropResult = await cropIfNeeded(
           fullPath: fullPath,
@@ -397,7 +396,6 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
           cropY1: cropY1,
           cropX2: cropX2,
           cropY2: cropY2,
-          compressQuality: compressionPct,
           forceCompression: force,
           eraserCoordinates: eraserCoordinates,
           maxSize: maxSize,
@@ -422,14 +420,16 @@ class BackgroundTaskImage extends BackgroundTaskUpload {
 
       Status status;
       try {
-        status = await addImage(compressionPct: 100, force: false);
+        status = await addImage(
+          force: false,
+          maxSize: ImagePickerConstants.maxSize.toInt(),
+        );
       } catch (e) {
         if (e.toString().contains('413') ||
             e.toString().contains('Request Entity Too Large')) {
           status = await addImage(
-            compressionPct: 80,
             force: true,
-            maxSize: 2000,
+            maxSize: ImagePickerConstants.maxSizeFallback.toInt(),
           );
         } else {
           rethrow;

--- a/packages/smooth_app/lib/pages/image_crop_page.dart
+++ b/packages/smooth_app/lib/pages/image_crop_page.dart
@@ -24,6 +24,22 @@ import 'package:smooth_app/pages/product_crop_helper.dart';
 import 'package:smooth_app/themes/smooth_theme_colors.dart';
 import 'package:smooth_app/themes/theme_provider.dart';
 
+/// Image picker constants.
+///
+/// In order to avoid OOM. And for performances too.
+class ImagePickerConstants {
+  /// Notoriously good enough.
+  static const int imageQuality = 80;
+
+  /// Good enough for 8"x10" prints (something like A4 sheet).
+  ///
+  /// cf. https://www.adobe.com/fr/creativecloud/photography/discover/standard-photo-sizes.html?msockid=0619d51777586f491e57c06c76ec6e77
+  static const num maxSize = 3000;
+
+  /// In case [maxSize] was too big.
+  static const num maxSizeFallback = 2000;
+}
+
 /// Safely picks an image file from gallery or camera, regarding access denied.
 Future<XFile?> pickImageFile(
   final BuildContext context, {
@@ -46,7 +62,12 @@ Future<XFile?> pickImageFile(
     final ImagePicker picker = ImagePicker();
     if (source == UserPictureSource.GALLERY) {
       try {
-        return picker.pickImage(source: ImageSource.gallery);
+        return picker.pickImage(
+          imageQuality: ImagePickerConstants.imageQuality,
+          maxHeight: ImagePickerConstants.maxSize.toDouble(),
+          maxWidth: ImagePickerConstants.maxSize.toDouble(),
+          source: ImageSource.gallery,
+        );
       } on PlatformException catch (e) {
         // On debug builds this catch won't work.
         // Please run on profile/release modes to test it
@@ -59,7 +80,12 @@ Future<XFile?> pickImageFile(
         }
       }
     }
-    return picker.pickImage(source: ImageSource.camera);
+    return picker.pickImage(
+      imageQuality: ImagePickerConstants.imageQuality,
+      maxHeight: ImagePickerConstants.maxSize.toDouble(),
+      maxWidth: ImagePickerConstants.maxSize.toDouble(),
+      source: ImageSource.camera,
+    );
   }
 
   try {

--- a/packages/smooth_app/lib/pages/prices/price_bulk_proof_card.dart
+++ b/packages/smooth_app/lib/pages/prices/price_bulk_proof_card.dart
@@ -15,6 +15,7 @@ import 'package:smooth_app/generic_lib/widgets/smooth_card.dart';
 import 'package:smooth_app/l10n/app_localizations.dart';
 import 'package:smooth_app/pages/crop_helper.dart';
 import 'package:smooth_app/pages/crop_parameters.dart';
+import 'package:smooth_app/pages/image_crop_page.dart';
 import 'package:smooth_app/pages/prices/price_add_helper.dart';
 import 'package:smooth_app/pages/prices/price_model.dart';
 
@@ -102,7 +103,6 @@ class _PriceBulkProofCardState extends State<PriceBulkProofCard> {
     final PriceAddHelper priceAddHelper = PriceAddHelper(context);
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     final LocalDatabase localDatabase = context.read<LocalDatabase>();
-    const int imageQuality = 80;
     final Directory directory = await BackgroundTaskUpload.getDirectory();
     const String BULK_PROOF_IMAGE_SEQUENCE_KEY = 'bulk_proof_image_sequence';
     final Rect cropRect = CropHelper.getLocalCropRectFromRect(
@@ -111,7 +111,9 @@ class _PriceBulkProofCardState extends State<PriceBulkProofCard> {
 
     _setText(appLocalizations.prices_bulk_proof_upload_step_selecting);
     final List<XFile> xFiles = await ImagePicker().pickMultiImage(
-      imageQuality: imageQuality,
+      imageQuality: ImagePickerConstants.imageQuality,
+      maxHeight: ImagePickerConstants.maxSize.toDouble(),
+      maxWidth: ImagePickerConstants.maxSize.toDouble(),
       requestFullMetadata: false,
     );
     if (xFiles.isEmpty) {

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -1060,10 +1060,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mgrs_dart:
     dependency: transitive
     description:
@@ -1108,10 +1108,10 @@ packages:
     dependency: transitive
     description:
       name: native_toolchain_c
-      sha256: f59351d28f49520cd3a74eb1f41c5f19ae15e53c65a3231d14af672e46510a96
+      sha256: f9c168717100ae6d9fee9ffb0be379bf1f8b26b0f6bcbd4fdddcd931993a6a72
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.1"
+    version: "0.19.2"
   nested:
     dependency: transitive
     description:
@@ -1229,10 +1229,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_linux
-      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      sha256: "58c2005f147315b11e9b4a7bc889cd5203e250cba8e3f012dae259b4972b5c16"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.1"
+    version: "2.2.2"
   path_provider_platform_interface:
     dependency: "direct dev"
     description:
@@ -1687,10 +1687,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.10"
   torch_light:
     dependency: "direct main"
     description:
@@ -1949,4 +1949,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.11.5 <4.0.0"
-  flutter: ">=3.41.8"
+  flutter: ">=3.41.8 <4.0.0"


### PR DESCRIPTION
### What
In most cases, we were picking images "as is", from the camera or the gallery.
This caused out of memory issue, for large images.
In this PR we fix parameters so that the images are optimized:
* JPEG quality of 80% - notoriously good enough
* max size in pixel: 3000 - good enough for A4 prints
* max size fallback: 2000 - in case we had problems with the server with 3000 images

In my tests, I crashed the app picking a 20Mb (20,555,621) image (found with https://www.pexels.com/search/large/?min_width=15360)
With this PR, the app managed to "receive" the same image as 80%+3000max, weighing only 1.5Mb (1,580,085)

### Fixes bug(s)
- Fixes: #6751

### Impacted files
* `background_task_add_price.dart`: minor refactoring
* `background_task_image.dart`: used new image constants
* `image_crop_page.dart`: new image constants - quality 80%, maxSize 3000 pixels, maxSize fallback 2000 pixels, for image picker
* `price_bulk_proof_card.dart`: minor refactoring
* `pubspec.lock`: wtf