### PR TITLE
fix: 7431 - no health for OPF, sad icon instead of milk sad icon

### DIFF
--- a/packages/smooth_app/lib/pages/product/product_page/header/product_page_tabs.dart
+++ b/packages/smooth_app/lib/pages/product/product_page/header/product_page_tabs.dart
@@ -147,6 +147,10 @@ class ProductPageTabsGenerator {
 
       children = children.sublist(1);
 
+      if (product.productType == ProductType.product &&
+          id.startsWith('health_')) {
+        continue;
+      }
       tabs.add(
         ProductPageTab(
           id: id,

--- a/packages/smooth_app/lib/pages/product/product_page/tabs/for_me/score/product_for_me_score_error.dart
+++ b/packages/smooth_app/lib/pages/product/product_page/tabs/for_me/score/product_for_me_score_error.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
-import 'package:smooth_app/resources/app_icons.dart' as icons;
 
 class ProductForMeCompatibilityError extends StatelessWidget {
   const ProductForMeCompatibilityError({required this.label});
@@ -12,7 +11,7 @@ class ProductForMeCompatibilityError extends StatelessWidget {
     return Row(
       spacing: LARGE_SPACE,
       children: <Widget>[
-        const icons.Milk.unhappy(),
+        const Icon(Icons.sentiment_dissatisfied),
         Expanded(child: Text(label)),
       ],
     );


### PR DESCRIPTION
### What
* changed icon to remove any "food" flavor from KP "For me" tab
* no health tab for OPF

### Screenshots
| before | after |
| -- | -- |
| <img width="1080" height="2408" alt="Screenshot_20260703_090549" src="https://github.com/user-attachments/assets/f33e314e-d41a-414d-9135-42a8325d8fee" /> | <img width="1080" height="2408" alt="Screenshot_20260703_093001" src="https://github.com/user-attachments/assets/29b6a8ba-8241-4769-a270-06b1d5d05488" /> |

### Part of 
- #7431

### Impacted files
* `product_for_me_score_error.dart`: changed icon to remove any "food" flavor
* `product_page_tabs.dart`: no health tab for OPF