### PR TITLE
fix: 7564 - display a scrollable table for HTML "table text" (KP)

### DIFF
--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_text_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_text_card.dart
@@ -8,6 +8,7 @@ import 'package:smooth_app/helpers/launch_url_helper.dart';
 import 'package:smooth_app/helpers/product_cards_helper.dart';
 import 'package:smooth_app/l10n/app_localizations.dart';
 import 'package:smooth_app/resources/app_icons.dart' as icons;
+import 'package:smooth_app/widgets/table/scrollable_table_widget.dart';
 import 'package:smooth_app/widgets/text/text_extensions.dart';
 
 /// Card that displays a Knowledge Panel _Text_ element.
@@ -30,6 +31,8 @@ class KnowledgePanelTextCard extends StatelessWidget {
         title: warningLabel,
         text: textElement.html.replaceFirst(regExp, '').trim(),
       );
+    } else if (textElement.html.startsWith('<table')) {
+      return ScrollableTableWidget(textElement.html);
     } else {
       text = Padding(
         padding: const EdgeInsetsDirectional.only(

--- a/packages/smooth_app/lib/widgets/table/scrollable_table_widget.dart
+++ b/packages/smooth_app/lib/widgets/table/scrollable_table_widget.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+import 'package:smooth_app/themes/theme_provider.dart';
+import 'package:smooth_app/widgets/table/smooth_table_cell.dart';
+import 'package:smooth_app/widgets/table/table_extractor.dart';
+
+/// Scrollable table widget, roughly computed from an HTML table.
+class ScrollableTableWidget extends StatefulWidget {
+  const ScrollableTableWidget(this.html, {super.key});
+
+  final String html;
+
+  @override
+  State<ScrollableTableWidget> createState() => _ScrollableTableWidgetState();
+}
+
+class _ScrollableTableWidgetState extends State<ScrollableTableWidget> {
+  late final List<List<SmoothTableCell>> _rows;
+
+  static const double _dividerSize = 1;
+  static const double _padding = 2;
+
+  @override
+  void initState() {
+    super.initState();
+    _rows = TableExtractor().extract(widget.html);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final TextScaler textScaler = MediaQuery.of(context).textScaler;
+    final TextStyle textStyle = DefaultTextStyle.of(context).style;
+    final TextStyle headerTextStyle = textStyle.merge(
+      const TextStyle(fontWeight: FontWeight.bold),
+    );
+
+    final List<double> widths = _computeWidths(
+      textScaler,
+      textStyle,
+      headerTextStyle,
+    );
+
+    final List<List<Widget>> widgets = <List<Widget>>[];
+    widgets.add(<Widget>[const SizedBox(height: _dividerSize)]);
+
+    final bool lightTheme = context.lightTheme();
+
+    for (int rowIndex = 0; rowIndex < _rows.length; rowIndex++) {
+      final Color? color;
+      if (lightTheme) {
+        color = rowIndex == 0
+            ? Colors.grey[300]
+            : rowIndex.isEven
+            ? Colors.grey[200]
+            : Colors.grey[100];
+      } else {
+        color = rowIndex == 0
+            ? Colors.grey[900]
+            : rowIndex.isEven
+            ? Colors.grey[800]
+            : Colors.grey[700];
+      }
+      final List<SmoothTableCell> row = _rows[rowIndex];
+      final List<Widget> rowWidgets = <Widget>[];
+      rowWidgets.add(const SizedBox(width: _dividerSize));
+      int colIndex = 0;
+      for (final SmoothTableCell cell in row) {
+        rowWidgets.add(
+          Container(
+            width: widths[colIndex] + 2 * _padding,
+            color: color,
+            child: Padding(
+              padding: const EdgeInsets.all(_padding),
+              child: Text(
+                cell.text,
+                textAlign: cell.leftAlign ? TextAlign.left : TextAlign.right,
+                style: rowIndex == 0 ? headerTextStyle : textStyle,
+              ),
+            ),
+          ),
+        );
+        rowWidgets.add(const SizedBox(width: _dividerSize));
+
+        colIndex++;
+      }
+      widgets.add(rowWidgets);
+      widgets.add(<Widget>[const SizedBox(height: _dividerSize)]);
+    }
+
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Container(
+        color: lightTheme ? Colors.black : Colors.white,
+        child: SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              for (final List<Widget> row in widgets) Row(children: row),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  // TODO(monsieurtanuki): add a max constraint, like "max column width is 30% of screen width"
+  // TODO(monsieurtanuki): add a min constraint
+  List<double> _computeWidths(
+    TextScaler textScaler,
+    TextStyle textStyle,
+    TextStyle headerTextStyle,
+  ) {
+    final List<double> widths = <double>[];
+
+    final int nbLines = _rows.length;
+    final int nbCols = _rows.first.length;
+    for (int i = 0; i < nbLines; i++) {
+      for (int j = 0; j < nbCols; j++) {
+        final String text = _rows[i][j].text;
+        final double width = _computeTextSize(
+          text,
+          i == 0 ? headerTextStyle : textStyle,
+          textScaler,
+        ).width;
+        if (i == 0) {
+          widths.add(width);
+        } else {
+          final double previous = widths[j];
+          if (previous < width) {
+            widths[j] = width;
+          }
+        }
+      }
+    }
+    return widths;
+  }
+
+  // cf. https://stackoverflow.com/questions/52659759/how-can-i-get-the-size-of-the-text-widget-in-flutter
+  Size _computeTextSize(
+    String text,
+    TextStyle textStyle,
+    TextScaler textScaler,
+  ) => (TextPainter(
+    text: TextSpan(text: text, style: textStyle),
+    maxLines: 1,
+    textScaler: textScaler,
+    // TODO(monsieurtanuki): does it matter?
+    textDirection: TextDirection.ltr,
+  )..layout()).size;
+}

--- a/packages/smooth_app/lib/widgets/table/smooth_table_cell.dart
+++ b/packages/smooth_app/lib/widgets/table/smooth_table_cell.dart
@@ -1,0 +1,12 @@
+/// Represents the data in a single cell in this table.
+class SmoothTableCell {
+  SmoothTableCell({
+    required this.text,
+    required this.isHeader,
+    required this.leftAlign,
+  });
+
+  final String text;
+  final bool isHeader;
+  final bool leftAlign;
+}

--- a/packages/smooth_app/lib/widgets/table/table_extractor.dart
+++ b/packages/smooth_app/lib/widgets/table/table_extractor.dart
@@ -1,0 +1,86 @@
+import 'package:html/dom.dart';
+import 'package:html/dom_parsing.dart';
+import 'package:html/parser.dart';
+import 'package:smooth_app/widgets/table/smooth_table_cell.dart';
+
+/// Extractor of an HTML table into a grid of cells.
+class TableExtractor extends TreeVisitor {
+  List<List<SmoothTableCell>> extract(String html) {
+    _cells.clear();
+    final Document document = parse(html);
+    visit(document);
+    return _cells;
+  }
+
+  final List<List<SmoothTableCell>> _cells = <List<SmoothTableCell>>[];
+
+  late List<SmoothTableCell> _currentRow;
+
+  bool _addTdText = false;
+
+  bool _addThText = false;
+
+  late bool _leftAlign;
+
+  final StringBuffer _buffer = StringBuffer();
+
+  @override
+  void visitText(Text node) {
+    if (_addTdText || _addThText) {
+      _buffer.write(node.data.trim());
+    }
+  }
+
+  @override
+  void visitElement(Element node) {
+    if (isVoidElement(node.localName)) {
+      return;
+    }
+    final bool isTr = node.localName == 'tr';
+    final bool isTd = node.localName == 'td';
+    final bool isTh = node.localName == 'th';
+    if (isTr) {
+      _currentRow = <SmoothTableCell>[];
+    }
+    if (isTd) {
+      _addTdText = true;
+      _leftAlign = true;
+      final String? style = node.attributes['style'];
+      if (style != null && style.contains('text-align:right')) {
+        _leftAlign = false;
+      }
+      _buffer.clear();
+    }
+    if (isTh) {
+      _addThText = true;
+      _buffer.clear();
+    }
+    visitChildren(node);
+    if (isTr) {
+      _cells.add(_currentRow);
+    }
+    if (isTd) {
+      _addTdText = false;
+      _currentRow.add(
+        SmoothTableCell(
+          text: _buffer.toString(),
+          isHeader: false,
+          leftAlign: _leftAlign,
+        ),
+      );
+    }
+    if (isTh) {
+      _addThText = false;
+      _currentRow.add(
+        SmoothTableCell(
+          text: _buffer.toString(),
+          isHeader: true,
+          leftAlign: true,
+        ),
+      );
+    }
+  }
+
+  @override
+  void visitChildren(Node node) => node.nodes.forEach(visit);
+}

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -1060,10 +1060,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mgrs_dart:
     dependency: transitive
     description:
@@ -1687,10 +1687,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.10"
   torch_light:
     dependency: "direct main"
     description:
@@ -1949,4 +1949,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.11.5 <4.0.0"
-  flutter: ">=3.41.8"
+  flutter: ">=3.41.8 <4.0.0"


### PR DESCRIPTION
### What
When KP provide an HTML table as TEXT, we're not good at displaying it when there are numerous columns, as by default it's displayed on the screen width.
The solution implemented here is to display a scrollable table, decoding each HTML tr, td, th into flutter widgets.

### Screenshots
| begin | end |
| -- | -- |
| <img width="1080" height="2408" alt="Screenshot_20260712_135516" src="https://github.com/user-attachments/assets/7676e610-e8cd-48ed-a4e0-37a3a3c4edc9" /> | <img width="1080" height="2408" alt="Screenshot_20260712_135525" src="https://github.com/user-attachments/assets/ba00b632-5e43-48c9-91bc-252fe5c37c7a" /> |
| <img width="1080" height="2408" alt="Screenshot_20260712_135626" src="https://github.com/user-attachments/assets/927c4af7-9e6c-4d7f-a2ad-3e71f93bfb65" /> | <img width="1080" height="2408" alt="Screenshot_20260712_135630" src="https://github.com/user-attachments/assets/136d6ef8-7deb-4217-a5bd-e6903cfe49fd" /> |

### Fixes bug(s)
- Closes: #7564

### Files
New files:
* `scrollable_table_widget.dart`: Scrollable table widget, roughly computed from an HTML table.
* `smooth_table_cell.dart`: Represents the data in a single cell in this table.
* `table_extractor.dart`: Extractor of an HTML table into a grid of cells.

Impacted files:
* `knowledge_panel_text_card.dart`: now uses a ScrollableTableWidget when dealing with HTML "table text"
* `pubspec.lock`: wtf