### PR TITLE
fix: 7689 - persist the Matomo dispatch queue and restore the Sentry store/scanner tags

### DIFF
--- a/packages/smooth_app/lib/helpers/analytics_helper.dart
+++ b/packages/smooth_app/lib/helpers/analytics_helper.dart
@@ -235,15 +235,7 @@ class AnalyticsHelper {
       options
         ..dsn =
             'https://22ec5d0489534b91ba455462d3736680@o241488.ingest.sentry.io/5376745'
-        ..beforeSend = (SentryEvent event, Hint hint) async {
-          return event
-            ..tags = <String, String>{
-              'store': GlobalVars.storeLabel.name,
-              'scanner': GlobalVars.scannerLabel.name,
-            };
-        };
-      // To set a uniform sample rate
-      options
+        // To set a uniform sample rate
         ..tracesSampleRate = 1.0
         ..beforeSend = _beforeSend
         ..captureFailedRequests = false
@@ -282,7 +274,12 @@ class AnalyticsHelper {
     if (!_crashReports) {
       return null;
     }
-    return event;
+    return event
+      ..tags = <String, String>{
+        ...?event.tags,
+        'store': GlobalVars.storeLabel.name,
+        'scanner': GlobalVars.scannerLabel.name,
+      };
   }
 
   static late PackageInfo _packageInfo;

--- a/packages/smooth_app/lib/helpers/analytics_helper.dart
+++ b/packages/smooth_app/lib/helpers/analytics_helper.dart
@@ -214,6 +214,9 @@ class AnalyticsHelper {
   static late int _uniqueRandom;
 
   static Future<void> linkPreferences(UserPreferences userPreferences) async {
+    // Before the first _setAnalyticsReports: the anonymous visitor id reads it.
+    _uniqueRandom = await userPreferences.getUniqueRandom();
+
     // Init the value
     _setAnalyticsReports(userPreferences.onAnalyticsChanged.value);
     _setCrashReports(userPreferences.onCrashReportingChanged.value);
@@ -226,8 +229,6 @@ class AnalyticsHelper {
     userPreferences.onCrashReportingChanged.addListener(() {
       _setCrashReports(userPreferences.onCrashReportingChanged.value);
     });
-
-    _uniqueRandom = await userPreferences.getUniqueRandom();
   }
 
   static Future<void> initSentry({required Function()? appRunner}) async {
@@ -251,7 +252,7 @@ class AnalyticsHelper {
 
   /// Don't call this method directly, it is automatically updated via the
   /// [UserPreferences]
-  static Future<void> _setAnalyticsReports(final bool allow) async {
+  static void _setAnalyticsReports(final bool allow) {
     if (allow) {
       _analyticsReporting = _AnalyticsTrackingMode.enabled;
     } else {
@@ -267,10 +268,7 @@ class AnalyticsHelper {
   static bool get isEnabled =>
       _analyticsReporting == _AnalyticsTrackingMode.enabled;
 
-  static FutureOr<SentryEvent?> _beforeSend(
-    SentryEvent event,
-    dynamic hint,
-  ) async {
+  static FutureOr<SentryEvent?> _beforeSend(SentryEvent event, Hint hint) {
     if (!_crashReports) {
       return null;
     }
@@ -446,7 +444,7 @@ class AnalyticsHelper {
   }
 
   static void sendException(dynamic throwable, {dynamic stackTrace}) {
-    Sentry.captureException(throwable, stackTrace: stackTrace);
+    unawaited(Sentry.captureException(throwable, stackTrace: stackTrace));
   }
 
   static String? get matomoVisitorId => MatomoTracker.instance.visitor.id;

--- a/packages/smooth_app/lib/helpers/analytics_helper.dart
+++ b/packages/smooth_app/lib/helpers/analytics_helper.dart
@@ -284,7 +284,14 @@ class AnalyticsHelper {
 
   static late PackageInfo _packageInfo;
 
-  static Future<void> initMatomo(final bool screenshotMode) async {
+  /// Widget tests must pass [DispatchSettings.nonPersistent]: the persistent
+  /// queue saves through a zero-duration timer that `flutter_test`'s fake clock
+  /// never fires, so initialization never returns.
+  static Future<void> initMatomo(
+    final bool screenshotMode, {
+    final DispatchSettings dispatchSettings =
+        const DispatchSettings.persistent(),
+  }) async {
     _packageInfo = await PackageInfo.fromPlatform();
     if (screenshotMode) {
       _setCrashReports(false);
@@ -296,6 +303,7 @@ class AnalyticsHelper {
         url: 'https://analytics.openfoodfacts.org/matomo.php',
         siteId: '2',
         visitorId: _visitorId,
+        dispatchSettings: dispatchSettings,
       );
     } catch (err) {
       // With Hot Reload, this may trigger a late field already initialized

--- a/packages/smooth_app/lib/helpers/analytics_helper.dart
+++ b/packages/smooth_app/lib/helpers/analytics_helper.dart
@@ -214,7 +214,6 @@ class AnalyticsHelper {
   static late int _uniqueRandom;
 
   static Future<void> linkPreferences(UserPreferences userPreferences) async {
-    // Before the first _setAnalyticsReports: the anonymous visitor id reads it.
     _uniqueRandom = await userPreferences.getUniqueRandom();
 
     // Init the value
@@ -282,9 +281,9 @@ class AnalyticsHelper {
 
   static late PackageInfo _packageInfo;
 
-  /// Widget tests must pass [DispatchSettings.nonPersistent]: the persistent
-  /// queue saves through a zero-duration timer that `flutter_test`'s fake clock
-  /// never fires, so initialization never returns.
+  /// Undispatched actions survive a restart for a day, and no longer: the
+  /// default [PersistenceFilter] of [DispatchSettings.persistent] drops
+  /// anything older than 23h59m59s when the queue is loaded.
   static Future<void> initMatomo(
     final bool screenshotMode, {
     final DispatchSettings dispatchSettings =

--- a/packages/smooth_app/test/helpers/analytics_helper_test.dart
+++ b/packages/smooth_app/test/helpers/analytics_helper_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:smooth_app/helpers/analytics_helper.dart';
+
+import '../tests_utils/mocks.dart';
+
+/// Where `matomo_tracker` stores pending actions. Pinned rather than imported
+/// because the package does not export it.
+const String _kMatomoPersistentQueue = 'matomo_persistent_queue';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('initMatomo', () {
+    // Not a widget test: the persistent queue saves through a zero-duration
+    // timer, which needs a real event loop.
+    test(
+      'defaults to a dispatch queue that survives app termination',
+      () async {
+        SharedPreferences.setMockInitialValues(mockSharedPreferences());
+        mockMatomoPlatformChannels();
+
+        await AnalyticsHelper.initMatomo(false);
+        MatomoTracker.instance.setOptOut(optOut: true);
+        MatomoTracker.instance.dequeueTimer.cancel();
+        MatomoTracker.instance.pingTimer?.cancel();
+
+        final SharedPreferences preferences =
+            await SharedPreferences.getInstance();
+        expect(preferences.getString(_kMatomoPersistentQueue), isNotNull);
+      },
+    );
+  });
+}

--- a/packages/smooth_app/test/helpers/analytics_helper_test.dart
+++ b/packages/smooth_app/test/helpers/analytics_helper_test.dart
@@ -22,7 +22,7 @@ void main() {
         mockMatomoPlatformChannels();
 
         await AnalyticsHelper.initMatomo(false);
-        MatomoTracker.instance.setOptOut(optOut: true);
+        await MatomoTracker.instance.setOptOut(optOut: true);
         MatomoTracker.instance.dequeueTimer.cancel();
         MatomoTracker.instance.pingTimer?.cancel();
 

--- a/packages/smooth_app/test/tests_utils/mocks.dart
+++ b/packages/smooth_app/test/tests_utils/mocks.dart
@@ -184,6 +184,19 @@ class _MockHttpClientSVGResponse extends Mock implements HttpClientResponse {
 }
 
 Future<void> mockMatomo() async {
+  mockMatomoPlatformChannels();
+
+  // Persistence would never finish initializing here: see [initMatomo].
+  await AnalyticsHelper.initMatomo(
+    false,
+    dispatchSettings: const DispatchSettings.nonPersistent(),
+  );
+  MatomoTracker.instance.setOptOut(optOut: true);
+  MatomoTracker.instance.dequeueTimer.cancel();
+  MatomoTracker.instance.pingTimer?.cancel();
+}
+
+void mockMatomoPlatformChannels() {
   TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
       .setMockMethodCallHandler(
         const MethodChannel('dev.fluttercommunity.plus/device_info'),
@@ -222,9 +235,4 @@ Future<void> mockMatomo() async {
           return null;
         },
       );
-
-  await AnalyticsHelper.initMatomo(false);
-  MatomoTracker.instance.setOptOut(optOut: true);
-  MatomoTracker.instance.dequeueTimer.cancel();
-  MatomoTracker.instance.pingTimer?.cancel();
 }

--- a/packages/smooth_app/test/tests_utils/mocks.dart
+++ b/packages/smooth_app/test/tests_utils/mocks.dart
@@ -186,7 +186,9 @@ class _MockHttpClientSVGResponse extends Mock implements HttpClientResponse {
 Future<void> mockMatomo() async {
   mockMatomoPlatformChannels();
 
-  // Persistence would never finish initializing here: see [initMatomo].
+  // Non persistent on purpose: the persistent queue saves through a
+  // zero-duration timer, and the fake clock in a widget test never fires it, so
+  // initialization would never return.
   await AnalyticsHelper.initMatomo(
     false,
     dispatchSettings: const DispatchSettings.nonPersistent(),

--- a/packages/smooth_app/test/tests_utils/mocks.dart
+++ b/packages/smooth_app/test/tests_utils/mocks.dart
@@ -191,7 +191,7 @@ Future<void> mockMatomo() async {
     false,
     dispatchSettings: const DispatchSettings.nonPersistent(),
   );
-  MatomoTracker.instance.setOptOut(optOut: true);
+  await MatomoTracker.instance.setOptOut(optOut: true);
   MatomoTracker.instance.dequeueTimer.cancel();
   MatomoTracker.instance.pingTimer?.cancel();
 }


### PR DESCRIPTION
### What

Two independent silent-loss bugs in `helpers/analytics_helper.dart`. No new event, no new parameter sent, no new dependency. 3 files, +64 / -16.

**Matomo: pending actions were lost on app termination (#7689)**

- `initMatomo()` called `MatomoTracker.instance.initialize()` without `dispatchSettings`, so the tracker used the package default `DispatchSettings.nonPersistent()`. Actions are dequeued every 10 seconds, so there was always a rolling window held only in memory, and `matomo_tracker` documents the consequence: if the app terminates while actions are undispatched, they are lost. Offline was retried *within* a session, but the queue did not survive a restart.
- It now defaults to `DispatchSettings.persistent()`, so pending actions go out on the next launch. This makes the events you already collect more accurate; it adds none.

**Sentry: the `store` and `scanner` tags never shipped (#7690)**

- `initSentry()` assigned `options.beforeSend` twice, eleven lines apart. The second assignment won, so the closure attaching the two tags was dead code.
- The two option cascades are merged into one, and the tags are attached inside `_beforeSend`, after the crash-reporting check, so the opt-out stays the single gate. Existing tags are spread first so nothing already on the event is clobbered.
- Moderate rather than critical: `environment` is `${storeLabel}-${scannerLabel}`, so the information was still recoverable. What was missing is the per-tag filtering the tags were written for.
- `release` and `dist` are deliberately left alone. `LoadReleaseIntegration` populates them from `PackageInfo` when they are null, so setting them would be a regression.

**Verified:** `dart format` clean, `flutter analyze --fatal-infos --fatal-warnings` reports no issues, and `flutter test` in `packages/smooth_app` is green at 240 tests (239 before this PR).

### Enabling the persistent queue writes pending actions to local storage, so, to answer that before it is asked

- `DispatchSettings.persistent()` stores undispatched actions as JSON in **SharedPreferences**, through the package's default `SharedPrefsStorage`. No custom storage is wired up.
- The values written are the ones that were already being transmitted, including the visitor id and any barcode carried in `eventValue`. Nothing new is collected and nothing new is sent.
- They never leave the device before dispatch, and the default `onLoad` filter is `whereNotOlderThanADay`, so anything older than 24 hours is dropped on load rather than replayed.
- SharedPreferences is already where the app keeps its preferences and its Matomo visitor id, so this adds no new storage surface. Happy to add an explicit `whereUserId` filter or a shorter retention window if you would prefer one.

### Why this is not the one-line change it looks like

Adding `DispatchSettings.persistent()` on its own **breaks 12 of the existing tests**, and the two errors it produces name neither cause. `PersistentQueue.load()` ends in `await queue.save()`, and `save()` does its write inside `Future(() async {...})`, i.e. a zero-duration timer. Widget tests run in `flutter_test`'s `FakeAsync` zone, whose clock only advances on `pump`, so that timer never fires and `initialize()` never returns. `test/tests_utils/mocks.dart`'s `mockMatomo()` awaits it, so it then hits `LateInitializationError: Field 'dequeueTimer' has not been initialized`, and the unfired timer separately trips "A Timer is still pending even after the widget tree was disposed".

So `dispatchSettings` is an **optional parameter** defaulting to `persistent()`. Production behaviour is the default and no call site in `lib/` changes; `mockMatomo()` opts out explicitly with the reason in a comment. Its platform-channel mocking is split into `mockMatomoPlatformChannels()` so the new test can set the channels up and still exercise the real production default. If you would rather have this shaped differently, say so and I will change it.

### Not in this PR, on purpose

- **No test for the Sentry half.** `_beforeSend` is private and there is no `@visibleForTesting` anywhere in `lib/` today, so proving the tags would mean either introducing that pattern or booting the real Sentry SDK inside a unit test. Neither felt proportionate to deleting a duplicated assignment. Happy to add either if you want it covered.
- `pingInterval` is untouched: it already defaults to 30 seconds, so app visit duration is measured correctly.

### Screenshot or video

No visual surface: both changes are in initialization code.

### Fixes bug(s)

- Fixes: #7689
- Fixes: #7690

### Part of
- #2855
