### PR TITLE
fix: 7695 - record displayed and clicked tagline news, and repaint on rotation

### DIFF
--- a/packages/smooth_app/lib/data_models/preferences/user_preferences.dart
+++ b/packages/smooth_app/lib/data_models/preferences/user_preferences.dart
@@ -625,6 +625,17 @@ class UserPreferences extends ChangeNotifier {
       _sharedPreferences.getStringList(_TAG_TAGLINE_FEED_NEWS_CLICKED) ??
       <String>[];
 
+  /// News ids whose impression, respectively click, has already been sent to
+  /// analytics during this app session.
+  ///
+  /// Deliberately not persisted: an impression is the denominator of the news
+  /// click-through rate, so it has to be counted once per session and not once
+  /// per install. It cannot be held by the news card either - that card is the
+  /// first page of a carousel, which disposes off-screen pages, so a swipe away
+  /// and back re-creates its state and would count the same id twice.
+  final Set<String> taglineFeedSessionImpressions = <String>{};
+  final Set<String> taglineFeedSessionClicks = <String>{};
+
   // This method voluntarily does not notify listeners (not needed)
   Future<void> taglineFeedMarkNewsAsDisplayed(final String ids) async {
     final List<String> displayedNews = taglineFeedDisplayedNews;

--- a/packages/smooth_app/lib/data_models/preferences/user_preferences.dart
+++ b/packages/smooth_app/lib/data_models/preferences/user_preferences.dart
@@ -625,14 +625,6 @@ class UserPreferences extends ChangeNotifier {
       _sharedPreferences.getStringList(_TAG_TAGLINE_FEED_NEWS_CLICKED) ??
       <String>[];
 
-  /// News ids whose impression, respectively click, has already been sent to
-  /// analytics during this app session.
-  ///
-  /// Deliberately not persisted: an impression is the denominator of the news
-  /// click-through rate, so it has to be counted once per session and not once
-  /// per install. It cannot be held by the news card either - that card is the
-  /// first page of a carousel, which disposes off-screen pages, so a swipe away
-  /// and back re-creates its state and would count the same id twice.
   final Set<String> taglineFeedSessionImpressions = <String>{};
   final Set<String> taglineFeedSessionClicks = <String>{};
 

--- a/packages/smooth_app/lib/helpers/analytics_helper.dart
+++ b/packages/smooth_app/lib/helpers/analytics_helper.dart
@@ -23,7 +23,8 @@ enum AnalyticsCategory {
   list(tag: 'list'),
   deepLink(tag: 'deep link'),
   hungerGame(tag: 'hunger game'),
-  appRating(tag: 'app rating');
+  appRating(tag: 'app rating'),
+  taglineFeed(tag: 'tagline feed');
 
   const AnalyticsCategory({required this.tag});
 
@@ -152,6 +153,14 @@ enum AnalyticsEvent {
   appRatingNotSatisfied(
     tag: 'not satisfied',
     category: AnalyticsCategory.appRating,
+  ),
+  taglineNewsDisplayed(
+    tag: 'tagline news displayed',
+    category: AnalyticsCategory.taglineFeed,
+  ),
+  taglineNewsClicked(
+    tag: 'tagline news clicked',
+    category: AnalyticsCategory.taglineFeed,
   );
 
   const AnalyticsEvent({required this.tag, required this.category});
@@ -405,6 +414,9 @@ class AnalyticsHelper {
     barcode: product.barcode,
     productType: product.productType ?? ProductType.food,
   );
+
+  static void trackTaglineNewsEvent(AnalyticsEvent msg, String newsId) =>
+      trackCustomEvent(msg.name, msg.category.tag, action: newsId);
 
   static void trackSearch({
     required String search,

--- a/packages/smooth_app/lib/pages/scan/carousel/main_card/bottom_cards/news/scan_news_card.dart
+++ b/packages/smooth_app/lib/pages/scan/carousel/main_card/bottom_cards/news/scan_news_card.dart
@@ -5,9 +5,11 @@ import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/cards/category_cards/svg_cache.dart';
 import 'package:smooth_app/data_models/news_feed/newsfeed_model.dart';
+import 'package:smooth_app/data_models/preferences/user_preferences.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/generic_lib/widgets/images/smooth_image.dart';
 import 'package:smooth_app/generic_lib/widgets/smooth_app_logo.dart';
+import 'package:smooth_app/helpers/analytics_helper.dart';
 import 'package:smooth_app/helpers/launch_url_helper.dart';
 import 'package:smooth_app/l10n/app_localizations.dart';
 import 'package:smooth_app/pages/scan/carousel/main_card/bottom_cards/scan_bottom_card.dart';
@@ -17,6 +19,7 @@ import 'package:smooth_app/themes/smooth_theme_colors.dart';
 import 'package:smooth_app/themes/theme_provider.dart';
 import 'package:smooth_app/widgets/text/text_extensions.dart';
 import 'package:smooth_app/widgets/text/text_highlighter.dart';
+import 'package:visibility_detector/visibility_detector.dart';
 
 class ScanNewsCard extends StatefulWidget {
   const ScanNewsCard({required this.news});
@@ -30,9 +33,12 @@ class ScanNewsCard extends StatefulWidget {
 class _ScanNewsCardState extends State<ScanNewsCard> {
   // Default values seem weird
   static const Radius radius = Radius.circular(16.0);
+  static const Key _visibilityKey = Key('scan_news_card');
 
+  final Set<String> _trackedNewsIds = <String>{};
   Timer? _timer;
   int _index = -1;
+  bool _visible = false;
 
   @override
   void initState() {
@@ -40,6 +46,8 @@ class _ScanNewsCardState extends State<ScanNewsCard> {
     _rotateNews();
   }
 
+  // initState() calls _rotateNews() directly, so _rotateNews() itself must
+  // never call setState: only the timer callback does.
   void _rotateNews() {
     _timer?.cancel();
 
@@ -48,7 +56,36 @@ class _ScanNewsCardState extends State<ScanNewsCard> {
       _index = 0;
     }
 
-    _timer = Timer(const Duration(minutes: 30), () => _rotateNews());
+    _timer = Timer(const Duration(minutes: 30), _onRotationTimer);
+  }
+
+  void _onRotationTimer() {
+    setState(_rotateNews);
+    _trackImpression();
+  }
+
+  void _onVisibilityChanged(VisibilityInfo info) {
+    _visible = info.visibleFraction >= 0.5;
+    _trackImpression();
+  }
+
+  void _trackImpression() {
+    if (!_visible) {
+      return;
+    }
+
+    final AppNewsItem currentNews = widget.news.elementAt(_index);
+    if (!_trackedNewsIds.add(currentNews.id)) {
+      return;
+    }
+
+    context.read<UserPreferences>().taglineFeedMarkNewsAsDisplayed(
+      currentNews.id,
+    );
+    AnalyticsHelper.trackTaglineNewsEvent(
+      AnalyticsEvent.taglineNewsDisplayed,
+      currentNews.id,
+    );
   }
 
   @override
@@ -58,49 +95,62 @@ class _ScanNewsCardState extends State<ScanNewsCard> {
       (ScanBottomCardDensity density) => density == ScanBottomCardDensity.dense,
     );
 
-    return ScanBottomCardContainer(
-      title: currentNews.title,
-      titleBackgroundColor: currentNews.style?.titleBackground,
-      titleIndicatorColor: currentNews.style?.titleIndicatorColor,
-      titleColor: currentNews.style?.titleTextColor,
-      body: InkWell(
-        borderRadius: const BorderRadius.vertical(bottom: radius),
-        onTap: () => LaunchUrlHelper.launchURLAndFollowDeepLinks(
-          context,
-          currentNews.url,
-        ),
-        child: Padding(
-          padding: EdgeInsetsDirectional.symmetric(
-            vertical: dense ? 6.0 : SMALL_SPACE,
-            horizontal: MEDIUM_SPACE,
-          ),
-          child: Column(
-            children: <Widget>[
-              _TagLineContentBody(
-                message: currentNews.message,
-                textColor: currentNews.style?.messageTextColor,
-                image: currentNews.image,
-                darkImage: currentNews.darkImage,
-                dense: dense,
-              ),
-              if (currentNews.funding != null)
-                _TagLineFundingMeter(
-                  funding: currentNews.funding!,
-                  monthsLeft: currentNews.monthsLeft,
+    return VisibilityDetector(
+      key: _visibilityKey,
+      onVisibilityChanged: _onVisibilityChanged,
+      child: ScanBottomCardContainer(
+        title: currentNews.title,
+        titleBackgroundColor: currentNews.style?.titleBackground,
+        titleIndicatorColor: currentNews.style?.titleIndicatorColor,
+        titleColor: currentNews.style?.titleTextColor,
+        body: InkWell(
+          borderRadius: const BorderRadius.vertical(bottom: radius),
+          onTap: () {
+            context.read<UserPreferences>().taglineFeedMarkNewsAsClicked(
+              currentNews.id,
+            );
+            AnalyticsHelper.trackTaglineNewsEvent(
+              AnalyticsEvent.taglineNewsClicked,
+              currentNews.id,
+            );
+            LaunchUrlHelper.launchURLAndFollowDeepLinks(
+              context,
+              currentNews.url,
+            );
+          },
+          child: Padding(
+            padding: EdgeInsetsDirectional.symmetric(
+              vertical: dense ? 6.0 : SMALL_SPACE,
+              horizontal: MEDIUM_SPACE,
+            ),
+            child: Column(
+              children: <Widget>[
+                _TagLineContentBody(
+                  message: currentNews.message,
                   textColor: currentNews.style?.messageTextColor,
-                  barColor: currentNews.style?.titleIndicatorColor,
-                ),
-              SizedBox(height: dense ? VERY_SMALL_SPACE : SMALL_SPACE),
-              Align(
-                alignment: AlignmentDirectional.bottomEnd,
-                child: _TagLineContentButton(
-                  label: currentNews.buttonLabel,
-                  backgroundColor: currentNews.style?.buttonBackground,
-                  foregroundColor: currentNews.style?.buttonTextColor,
+                  image: currentNews.image,
+                  darkImage: currentNews.darkImage,
                   dense: dense,
                 ),
-              ),
-            ],
+                if (currentNews.funding != null)
+                  _TagLineFundingMeter(
+                    funding: currentNews.funding!,
+                    monthsLeft: currentNews.monthsLeft,
+                    textColor: currentNews.style?.messageTextColor,
+                    barColor: currentNews.style?.titleIndicatorColor,
+                  ),
+                SizedBox(height: dense ? VERY_SMALL_SPACE : SMALL_SPACE),
+                Align(
+                  alignment: AlignmentDirectional.bottomEnd,
+                  child: _TagLineContentButton(
+                    label: currentNews.buttonLabel,
+                    backgroundColor: currentNews.style?.buttonBackground,
+                    foregroundColor: currentNews.style?.buttonTextColor,
+                    dense: dense,
+                  ),
+                ),
+              ],
+            ),
           ),
         ),
       ),

--- a/packages/smooth_app/lib/pages/scan/carousel/main_card/bottom_cards/news/scan_news_card.dart
+++ b/packages/smooth_app/lib/pages/scan/carousel/main_card/bottom_cards/news/scan_news_card.dart
@@ -45,8 +45,7 @@ class _ScanNewsCardState extends State<ScanNewsCard> {
     _rotateNews();
   }
 
-  // initState() calls _rotateNews() directly, so _rotateNews() itself must
-  // never call setState: only the timer callback does.
+  // No setState here: initState() calls this directly.
   void _rotateNews() {
     _timer?.cancel();
 
@@ -75,9 +74,8 @@ class _ScanNewsCardState extends State<ScanNewsCard> {
 
     final AppNewsItem currentNews = widget.news.elementAt(_index);
     final UserPreferences preferences = context.read<UserPreferences>();
-    // De-duplicated on the preferences rather than on this state: the card is
-    // the first page of the scan carousel, which disposes off-screen pages, so
-    // a swipe away and back would otherwise count the same id twice.
+    // Not on this State: the carousel disposes off-screen pages, so a swipe
+    // away and back would count the same id twice.
     if (!preferences.taglineFeedSessionImpressions.add(currentNews.id)) {
       return;
     }
@@ -111,8 +109,6 @@ class _ScanNewsCardState extends State<ScanNewsCard> {
         body: InkWell(
           borderRadius: const BorderRadius.vertical(bottom: radius),
           onTap: () {
-            // Same session scope as the impression, so the click-through rate
-            // keeps a numerator and a denominator that are counted alike.
             final UserPreferences preferences = context.read<UserPreferences>();
             if (preferences.taglineFeedSessionClicks.add(currentNews.id)) {
               preferences.taglineFeedMarkNewsAsClicked(currentNews.id);

--- a/packages/smooth_app/lib/pages/scan/carousel/main_card/bottom_cards/news/scan_news_card.dart
+++ b/packages/smooth_app/lib/pages/scan/carousel/main_card/bottom_cards/news/scan_news_card.dart
@@ -35,8 +35,6 @@ class _ScanNewsCardState extends State<ScanNewsCard> {
   static const Radius radius = Radius.circular(16.0);
   static const Key _visibilityKey = Key('scan_news_card');
 
-  final Set<String> _trackedNewsIds = <String>{};
-  final Set<String> _clickedNewsIds = <String>{};
   Timer? _timer;
   int _index = -1;
   bool _visible = false;
@@ -76,11 +74,14 @@ class _ScanNewsCardState extends State<ScanNewsCard> {
     }
 
     final AppNewsItem currentNews = widget.news.elementAt(_index);
-    if (!_trackedNewsIds.add(currentNews.id)) {
+    final UserPreferences preferences = context.read<UserPreferences>();
+    // De-duplicated on the preferences rather than on this state: the card is
+    // the first page of the scan carousel, which disposes off-screen pages, so
+    // a swipe away and back would otherwise count the same id twice.
+    if (!preferences.taglineFeedSessionImpressions.add(currentNews.id)) {
       return;
     }
 
-    final UserPreferences preferences = context.read<UserPreferences>();
     // Marking as displayed also removes the id from the clicked list, which
     // would demote an already-clicked item back to the middle sort tier.
     if (!preferences.taglineFeedClickedNews.contains(currentNews.id)) {
@@ -110,10 +111,11 @@ class _ScanNewsCardState extends State<ScanNewsCard> {
         body: InkWell(
           borderRadius: const BorderRadius.vertical(bottom: radius),
           onTap: () {
-            if (_clickedNewsIds.add(currentNews.id)) {
-              context.read<UserPreferences>().taglineFeedMarkNewsAsClicked(
-                currentNews.id,
-              );
+            // Same session scope as the impression, so the click-through rate
+            // keeps a numerator and a denominator that are counted alike.
+            final UserPreferences preferences = context.read<UserPreferences>();
+            if (preferences.taglineFeedSessionClicks.add(currentNews.id)) {
+              preferences.taglineFeedMarkNewsAsClicked(currentNews.id);
               AnalyticsHelper.trackTaglineNewsEvent(
                 AnalyticsEvent.taglineNewsClicked,
                 currentNews.id,

--- a/packages/smooth_app/lib/pages/scan/carousel/main_card/bottom_cards/news/scan_news_card.dart
+++ b/packages/smooth_app/lib/pages/scan/carousel/main_card/bottom_cards/news/scan_news_card.dart
@@ -36,6 +36,7 @@ class _ScanNewsCardState extends State<ScanNewsCard> {
   static const Key _visibilityKey = Key('scan_news_card');
 
   final Set<String> _trackedNewsIds = <String>{};
+  final Set<String> _clickedNewsIds = <String>{};
   Timer? _timer;
   int _index = -1;
   bool _visible = false;
@@ -79,9 +80,12 @@ class _ScanNewsCardState extends State<ScanNewsCard> {
       return;
     }
 
-    context.read<UserPreferences>().taglineFeedMarkNewsAsDisplayed(
-      currentNews.id,
-    );
+    final UserPreferences preferences = context.read<UserPreferences>();
+    // Marking as displayed also removes the id from the clicked list, which
+    // would demote an already-clicked item back to the middle sort tier.
+    if (!preferences.taglineFeedClickedNews.contains(currentNews.id)) {
+      preferences.taglineFeedMarkNewsAsDisplayed(currentNews.id);
+    }
     AnalyticsHelper.trackTaglineNewsEvent(
       AnalyticsEvent.taglineNewsDisplayed,
       currentNews.id,
@@ -106,13 +110,15 @@ class _ScanNewsCardState extends State<ScanNewsCard> {
         body: InkWell(
           borderRadius: const BorderRadius.vertical(bottom: radius),
           onTap: () {
-            context.read<UserPreferences>().taglineFeedMarkNewsAsClicked(
-              currentNews.id,
-            );
-            AnalyticsHelper.trackTaglineNewsEvent(
-              AnalyticsEvent.taglineNewsClicked,
-              currentNews.id,
-            );
+            if (_clickedNewsIds.add(currentNews.id)) {
+              context.read<UserPreferences>().taglineFeedMarkNewsAsClicked(
+                currentNews.id,
+              );
+              AnalyticsHelper.trackTaglineNewsEvent(
+                AnalyticsEvent.taglineNewsClicked,
+                currentNews.id,
+              );
+            }
             LaunchUrlHelper.launchURLAndFollowDeepLinks(
               context,
               currentNews.url,
@@ -160,6 +166,10 @@ class _ScanNewsCardState extends State<ScanNewsCard> {
   @override
   void dispose() {
     _timer?.cancel();
+    // The key is process-wide and the package keeps the last reported
+    // visibility in a static map, so without this a card remounted at the same
+    // geometry would never get a first callback.
+    VisibilityDetectorController.instance.forget(_visibilityKey);
     super.dispose();
   }
 }

--- a/packages/smooth_app/test/pages/scan/scan_news_card_test.dart
+++ b/packages/smooth_app/test/pages/scan/scan_news_card_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:matomo_tracker/matomo_tracker.dart';
@@ -223,9 +222,8 @@ void main() {
     MatomoTracker.instance.dropActions();
   });
 
-  tearDown(() {
-    VisibilityDetectorController.instance.forget(_visibilityKey);
-  });
+  // No `forget()` in `tearDown`: the widget does it in `dispose()`, which is
+  // what keeps a remounted card from inheriting a stale visibility entry.
 
   group('ScanNewsCard with campaign figures', () {
     for (final String theme in <String>['Light', 'Dark', 'AMOLED']) {
@@ -377,6 +375,41 @@ void main() {
     expect(events.single['e_a'], _item0.id);
   });
 
+  testWidgets('a second tap on the same item tracks only one click', (
+    WidgetTester tester,
+  ) async {
+    await _pumpNewsCard(tester, news: <AppNewsItem>[_item0, _item1]);
+
+    await tester.tap(find.byType(InkWell));
+    await tester.pump();
+    await tester.tap(find.byType(InkWell));
+    await tester.pump();
+
+    expect(_eventsNamed('taglineNewsClicked'), hasLength(1));
+  });
+
+  testWidgets('an impression does not demote an already-clicked item', (
+    WidgetTester tester,
+  ) async {
+    final UserPreferences prefs = await _pumpNewsCard(
+      tester,
+      news: <AppNewsItem>[_item0, _item1],
+    );
+    await tester.tap(find.byType(InkWell));
+    await tester.pump();
+    expect(prefs.taglineFeedClickedNews, <String>[_item0.id]);
+
+    // A brand new card instance, i.e. the next app launch: its de-dup set is
+    // empty, so the impression fires again on an id that is already clicked.
+    await tester.pumpWidget(const SizedBox());
+    MatomoTracker.instance.dropActions();
+    await _pumpNewsCard(tester, news: <AppNewsItem>[_item0, _item1]);
+
+    expect(prefs.taglineFeedClickedNews, <String>[_item0.id]);
+    expect(prefs.taglineFeedDisplayedNews, isEmpty);
+    expect(_eventsNamed('taglineNewsDisplayed'), hasLength(1));
+  });
+
   testWidgets('rotation repaints after 30 minutes (setState regression)', (
     WidgetTester tester,
   ) async {
@@ -482,19 +515,15 @@ void main() {
         await expectLater(tester, meetsGuideline(textContrastGuideline));
         await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
 
+        // No `didExceedMaxLines` probe: the title is an `AutoSizeText`, a leaf
+        // render object that shrinks its font to fit and exposes no such flag,
+        // and the message renders at `maxLines: 500`. So the two pumps below
+        // are the coverage - a layout overflow at either scale is reported as
+        // an exception during paint and fails the test.
         for (final double textScale in <double>[1.3, 2.0]) {
           tester.platformDispatcher.textScaleFactorTestValue = textScale;
           addTearDown(tester.platformDispatcher.clearTextScaleFactorTestValue);
           await tester.pump();
-
-          expect(
-            tester
-                .renderObjectList<RenderParagraph>(find.byType(RichText))
-                .any(
-                  (RenderParagraph paragraph) => paragraph.didExceedMaxLines,
-                ),
-            isFalse,
-          );
         }
       });
     }

--- a/packages/smooth_app/test/pages/scan/scan_news_card_test.dart
+++ b/packages/smooth_app/test/pages/scan/scan_news_card_test.dart
@@ -182,6 +182,13 @@ void main() {
     await prefs.setStringList(_tagDisplayed, <String>[]);
     await prefs.setStringList(_tagClicked, <String>[]);
 
+    // The analytics de-dup is session-scoped and `UserPreferences` is a
+    // per-isolate singleton, so one test's session has to end before the next.
+    final UserPreferences userPreferences =
+        await UserPreferences.getUserPreferences();
+    userPreferences.taglineFeedSessionImpressions.clear();
+    userPreferences.taglineFeedSessionClicks.clear();
+
     VisibilityDetectorController.instance.updateInterval = Duration.zero;
     MatomoTracker.instance.dropActions();
   });
@@ -357,15 +364,53 @@ void main() {
     await tester.pump();
     expect(prefs.taglineFeedClickedNews, <String>[_item0.id]);
 
-    // A brand new card instance, i.e. the next app launch: its de-dup set is
-    // empty, so the impression fires again on an id that is already clicked.
+    // The next app launch: the two persisted lists survive, the session de-dup
+    // does not, so the impression fires again on an already-clicked id.
     await tester.pumpWidget(const SizedBox());
+    prefs.taglineFeedSessionImpressions.clear();
     MatomoTracker.instance.dropActions();
     await _pumpCard(tester, 'Light', <AppNewsItem>[_item0, _item1]);
 
     expect(prefs.taglineFeedClickedNews, <String>[_item0.id]);
     expect(prefs.taglineFeedDisplayedNews, isEmpty);
     expect(_eventsNamed('taglineNewsDisplayed'), hasLength(1));
+  });
+
+  // The card is the first page of a `CarouselSlider`, i.e. a `PageView` that
+  // disposes off-screen pages: swiping to a scanned product and back destroys
+  // the card's state inside one session. De-dup held there would let the same
+  // id be counted again, inflating the denominator of the click-through rate.
+  testWidgets('a recycled card does not re-fire an impression', (
+    WidgetTester tester,
+  ) async {
+    final UserPreferences prefs = await _pumpCard(
+      tester,
+      'Light',
+      <AppNewsItem>[_item0, _item1],
+    );
+    expect(_eventsNamed('taglineNewsDisplayed'), hasLength(1));
+
+    await tester.pumpWidget(const SizedBox());
+    await _pumpCard(tester, 'Light', <AppNewsItem>[_item0, _item1]);
+
+    expect(_eventsNamed('taglineNewsDisplayed'), hasLength(1));
+    expect(prefs.taglineFeedDisplayedNews, <String>[_item0.id]);
+  });
+
+  testWidgets('a recycled card does not re-fire a click', (
+    WidgetTester tester,
+  ) async {
+    await _pumpCard(tester, 'Light', <AppNewsItem>[_item0, _item1]);
+    await tester.tap(find.byType(InkWell));
+    await tester.pump();
+    expect(_eventsNamed('taglineNewsClicked'), hasLength(1));
+
+    await tester.pumpWidget(const SizedBox());
+    await _pumpCard(tester, 'Light', <AppNewsItem>[_item0, _item1]);
+    await tester.tap(find.byType(InkWell));
+    await tester.pump();
+
+    expect(_eventsNamed('taglineNewsClicked'), hasLength(1));
   });
 
   testWidgets('rotation repaints after 30 minutes (setState regression)', (

--- a/packages/smooth_app/test/pages/scan/scan_news_card_test.dart
+++ b/packages/smooth_app/test/pages/scan/scan_news_card_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:matomo_tracker/matomo_tracker.dart';
@@ -31,8 +32,6 @@ import '../../tests_utils/mocks.dart';
 // cached instance is what actually isolates each test.
 const String _tagDisplayed = 'taglineFeedNewsDisplayed';
 const String _tagClicked = 'taglineFeedNewsClicked';
-
-const Key _visibilityKey = Key('scan_news_card');
 
 const AppNewsItem _item0 = AppNewsItem(
   id: 'news-0',
@@ -72,17 +71,21 @@ AppNewsItem _newsItem({
   style: style,
 );
 
-Future<void> _pumpCard(
+/// Pumps a [ScanNewsCard] behind everything the widget reads from context.
+///
+/// [offstage], when given, drives an [Offstage] wrapper so a test can flip
+/// visibility mid-run without losing the card's [State] (same [Element],
+/// same position in the tree).
+Future<UserPreferences> _pumpCard(
   WidgetTester tester,
   String theme,
-  AppNewsItem item, {
+  List<AppNewsItem> news, {
   double? textScaler,
+  ValueListenable<bool>? offstage,
 }) async {
   tester.view.physicalSize = const Size(1080, 2424);
   tester.view.devicePixelRatio = 2.625;
   addTearDown(tester.view.reset);
-
-  SharedPreferences.setMockInitialValues(mockSharedPreferences());
 
   final UserPreferences userPreferences =
       await UserPreferences.getUserPreferences();
@@ -104,9 +107,9 @@ Future<void> _pumpCard(
   ProductQuery.setLanguage(null, userPreferences, languageCode: 'en');
   await ProductQuery.setCountry(userPreferences, 'fr');
 
-  final Widget cardWidget = ScanNewsCard(news: <AppNewsItem>[item]);
+  final Widget cardWidget = ScanNewsCard(news: news);
   final double? scaler = textScaler;
-  final Widget card = scaler == null
+  final Widget scaled = scaler == null
       ? cardWidget
       : Builder(
           builder: (BuildContext context) => MediaQuery(
@@ -117,53 +120,9 @@ Future<void> _pumpCard(
           ),
         );
 
-  await tester.pumpWidget(
-    MockSmoothApp(
-      userPreferences,
-      UserManagementProvider(),
-      productPreferences,
-      ThemeProvider(userPreferences),
-      TextContrastProvider(userPreferences),
-      ColorProvider(userPreferences),
-      Provider<ScanBottomCardDensity>.value(
-        value: ScanBottomCardDensity.dense,
-        child: SingleChildScrollView(child: card),
-      ),
-      localDatabase: MockLocalDatabase(),
-    ),
-  );
-  await tester.pump();
-}
-
-/// Pumps a [ScanNewsCard] behind everything the widget reads from context.
-///
-/// [offstage], when given, drives an [Offstage] wrapper so a test can flip
-/// visibility mid-run without losing the card's [State] (same [Element],
-/// same position in the tree).
-Future<UserPreferences> _pumpNewsCard(
-  WidgetTester tester, {
-  required List<AppNewsItem> news,
-  String theme = 'Light',
-  ValueListenable<bool>? offstage,
-}) async {
-  final UserPreferences userPreferences =
-      await UserPreferences.getUserPreferences();
-  userPreferences.setTheme(theme);
-
-  late ProductPreferences productPreferences;
-  productPreferences = ProductPreferences(
-    ProductPreferencesSelection(
-      setImportance: userPreferences.setImportance,
-      getImportance: userPreferences.getImportance,
-      notify: () => productPreferences.notifyListeners(),
-    ),
-  );
-  await productPreferences.init(PlatformAssetBundle());
-  await userPreferences.init(productPreferences);
-
   final Widget card = Provider<ScanBottomCardDensity>.value(
     value: ScanBottomCardDensity.dense,
-    child: ScanNewsCard(news: news),
+    child: SingleChildScrollView(child: scaled),
   );
 
   final Widget body = offstage == null
@@ -185,6 +144,7 @@ Future<UserPreferences> _pumpNewsCard(
       TextContrastProvider(userPreferences),
       ColorProvider(userPreferences),
       body,
+      localDatabase: MockLocalDatabase(),
     ),
   );
   await tester.pump();
@@ -205,6 +165,10 @@ List<Map<String, String>> _eventsNamed(String name) => MatomoTracker
     .toList();
 
 void main() {
+  // `setMockInitialValues` resets the `SharedPreferences` completer, so calling
+  // it per test would hand `setUp` a different instance from the memoized one
+  // `UserPreferences` holds - and the per-test cleanup below would clear the
+  // wrong store. It belongs here, once, before anything reads a preference.
   setUpAll(() async {
     SharedPreferences.setMockInitialValues(mockSharedPreferences());
     await mockMatomo();
@@ -228,11 +192,9 @@ void main() {
   group('ScanNewsCard with campaign figures', () {
     for (final String theme in <String>['Light', 'Dark', 'AMOLED']) {
       testWidgets(theme, (WidgetTester tester) async {
-        await _pumpCard(
-          tester,
-          theme,
+        await _pumpCard(tester, theme, <AppNewsItem>[
           _newsItem(raised: 44059.47, goal: 170000.0, currency: 'EUR'),
-        );
+        ]);
 
         expect(find.byType(LinearProgressIndicator), findsOneWidget);
         // Whole euros, so the amounts fit the row the design draws.
@@ -248,7 +210,7 @@ void main() {
   group('ScanNewsCard without campaign figures', () {
     for (final String theme in <String>['Light', 'Dark', 'AMOLED']) {
       testWidgets(theme, (WidgetTester tester) async {
-        await _pumpCard(tester, theme, _newsItem());
+        await _pumpCard(tester, theme, <AppNewsItem>[_newsItem()]);
 
         expect(find.byType(LinearProgressIndicator), findsNothing);
         expect(tester, meetsGuideline(textContrastGuideline));
@@ -262,12 +224,9 @@ void main() {
   group('The funding amounts are not clipped', () {
     for (final double scaler in <double>[1.3, 2.0]) {
       testWidgets('at a text scale of $scaler', (WidgetTester tester) async {
-        await _pumpCard(
-          tester,
-          'Light',
+        await _pumpCard(tester, 'Light', <AppNewsItem>[
           _newsItem(raised: 44059.47, goal: 170000.0, currency: 'EUR'),
-          textScaler: scaler,
-        );
+        ], textScaler: scaler);
 
         final Iterable<RenderParagraph> amounts = tester
             .renderObjectList<RenderParagraph>(
@@ -297,16 +256,14 @@ void main() {
   testWidgets('A deadline beyond a year is not shown as time left', (
     WidgetTester tester,
   ) async {
-    await _pumpCard(
-      tester,
-      'Light',
+    await _pumpCard(tester, 'Light', <AppNewsItem>[
       _newsItem(
         raised: 44059.47,
         goal: 170000.0,
         currency: 'EUR',
         endDate: DateTime(DateTime.now().year + 2, 1, 31),
       ),
-    );
+    ]);
 
     expect(find.textContaining('short'), findsOneWidget);
     expect(find.textContaining('left'), findsNothing);
@@ -318,9 +275,7 @@ void main() {
     const Color messageTextColor = Color(0xFFEEEEEE);
     const Color titleIndicatorColor = Color(0xFF00FF00);
 
-    await _pumpCard(
-      tester,
-      'Light',
+    await _pumpCard(tester, 'Light', <AppNewsItem>[
       _newsItem(
         raised: 44059.47,
         goal: 170000.0,
@@ -330,7 +285,7 @@ void main() {
           titleIndicatorColor: titleIndicatorColor,
         ),
       ),
-    );
+    ]);
 
     final LinearProgressIndicator bar = tester.widget<LinearProgressIndicator>(
       find.byType(LinearProgressIndicator),
@@ -344,9 +299,10 @@ void main() {
   testWidgets('impression fires on the first visible frame', (
     WidgetTester tester,
   ) async {
-    final UserPreferences prefs = await _pumpNewsCard(
+    final UserPreferences prefs = await _pumpCard(
       tester,
-      news: <AppNewsItem>[_item0, _item1],
+      'Light',
+      <AppNewsItem>[_item0, _item1],
     );
 
     expect(prefs.taglineFeedDisplayedNews, <String>[_item0.id]);
@@ -360,9 +316,10 @@ void main() {
   testWidgets('tap marks and tracks the click without delaying the launch', (
     WidgetTester tester,
   ) async {
-    final UserPreferences prefs = await _pumpNewsCard(
+    final UserPreferences prefs = await _pumpCard(
       tester,
-      news: <AppNewsItem>[_item0, _item1],
+      'Light',
+      <AppNewsItem>[_item0, _item1],
     );
 
     await tester.tap(find.byType(InkWell));
@@ -378,7 +335,7 @@ void main() {
   testWidgets('a second tap on the same item tracks only one click', (
     WidgetTester tester,
   ) async {
-    await _pumpNewsCard(tester, news: <AppNewsItem>[_item0, _item1]);
+    await _pumpCard(tester, 'Light', <AppNewsItem>[_item0, _item1]);
 
     await tester.tap(find.byType(InkWell));
     await tester.pump();
@@ -391,9 +348,10 @@ void main() {
   testWidgets('an impression does not demote an already-clicked item', (
     WidgetTester tester,
   ) async {
-    final UserPreferences prefs = await _pumpNewsCard(
+    final UserPreferences prefs = await _pumpCard(
       tester,
-      news: <AppNewsItem>[_item0, _item1],
+      'Light',
+      <AppNewsItem>[_item0, _item1],
     );
     await tester.tap(find.byType(InkWell));
     await tester.pump();
@@ -403,7 +361,7 @@ void main() {
     // empty, so the impression fires again on an id that is already clicked.
     await tester.pumpWidget(const SizedBox());
     MatomoTracker.instance.dropActions();
-    await _pumpNewsCard(tester, news: <AppNewsItem>[_item0, _item1]);
+    await _pumpCard(tester, 'Light', <AppNewsItem>[_item0, _item1]);
 
     expect(prefs.taglineFeedClickedNews, <String>[_item0.id]);
     expect(prefs.taglineFeedDisplayedNews, isEmpty);
@@ -413,7 +371,7 @@ void main() {
   testWidgets('rotation repaints after 30 minutes (setState regression)', (
     WidgetTester tester,
   ) async {
-    await _pumpNewsCard(tester, news: <AppNewsItem>[_item0, _item1]);
+    await _pumpCard(tester, 'Light', <AppNewsItem>[_item0, _item1]);
 
     await tester.pump(const Duration(minutes: 31));
 
@@ -423,9 +381,10 @@ void main() {
   testWidgets('rotation marks the new item as displayed', (
     WidgetTester tester,
   ) async {
-    final UserPreferences prefs = await _pumpNewsCard(
+    final UserPreferences prefs = await _pumpCard(
       tester,
-      news: <AppNewsItem>[_item0, _item1],
+      'Light',
+      <AppNewsItem>[_item0, _item1],
     );
 
     await tester.pump(const Duration(minutes: 31));
@@ -447,9 +406,10 @@ void main() {
     final ValueNotifier<bool> hidden = ValueNotifier<bool>(false);
     addTearDown(hidden.dispose);
 
-    final UserPreferences prefs = await _pumpNewsCard(
+    final UserPreferences prefs = await _pumpCard(
       tester,
-      news: <AppNewsItem>[_item0, _item1],
+      'Light',
+      <AppNewsItem>[_item0, _item1],
       offstage: hidden,
     );
 
@@ -465,9 +425,10 @@ void main() {
   testWidgets('single-item feed wraps without a second impression', (
     WidgetTester tester,
   ) async {
-    final UserPreferences prefs = await _pumpNewsCard(
+    final UserPreferences prefs = await _pumpCard(
       tester,
-      news: <AppNewsItem>[_item0],
+      'Light',
+      <AppNewsItem>[_item0],
     );
 
     await tester.pump(const Duration(minutes: 31));
@@ -482,9 +443,10 @@ void main() {
     final ValueNotifier<bool> hidden = ValueNotifier<bool>(true);
     addTearDown(hidden.dispose);
 
-    final UserPreferences prefs = await _pumpNewsCard(
+    final UserPreferences prefs = await _pumpCard(
       tester,
-      news: <AppNewsItem>[_item0],
+      'Light',
+      <AppNewsItem>[_item0],
       offstage: hidden,
     );
 
@@ -495,7 +457,7 @@ void main() {
   testWidgets('does not fire or throw after being disposed mid-timer', (
     WidgetTester tester,
   ) async {
-    await _pumpNewsCard(tester, news: <AppNewsItem>[_item0, _item1]);
+    await _pumpCard(tester, 'Light', <AppNewsItem>[_item0, _item1]);
 
     await tester.pumpWidget(const SizedBox());
     await tester.pump(const Duration(minutes: 31));
@@ -506,11 +468,7 @@ void main() {
   group('renders correctly in every theme', () {
     for (final String theme in <String>['Light', 'Dark', 'AMOLED']) {
       testWidgets(theme, (WidgetTester tester) async {
-        await _pumpNewsCard(
-          tester,
-          news: <AppNewsItem>[_item0, _item1],
-          theme: theme,
-        );
+        await _pumpCard(tester, theme, <AppNewsItem>[_item0, _item1]);
 
         await expectLater(tester, meetsGuideline(textContrastGuideline));
         await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));

--- a/packages/smooth_app/test/pages/scan/scan_news_card_test.dart
+++ b/packages/smooth_app/test/pages/scan/scan_news_card_test.dart
@@ -1,7 +1,9 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:matomo_tracker/matomo_tracker.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -15,9 +17,37 @@ import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/themes/color_provider.dart';
 import 'package:smooth_app/themes/contrast_provider.dart';
 import 'package:smooth_app/themes/theme_provider.dart';
+import 'package:smooth_app/widgets/autosize_text.dart';
+import 'package:visibility_detector/visibility_detector.dart';
 
 import '../../tests_utils/local_database_mock.dart';
 import '../../tests_utils/mocks.dart';
+
+// `UserPreferences.getUserPreferences()` memoizes a single instance for the
+// whole isolate (`user_preferences.dart:50-60`), and the legacy
+// `SharedPreferences` plugin memoizes its own instance the same way - so
+// `SharedPreferences.setMockInitialValues` only has effect before the very
+// first `getInstance()` call. These are the two tagline-feed keys
+// (`user_preferences.dart:139-141`); clearing them directly on the shared
+// cached instance is what actually isolates each test.
+const String _tagDisplayed = 'taglineFeedNewsDisplayed';
+const String _tagClicked = 'taglineFeedNewsClicked';
+
+const Key _visibilityKey = Key('scan_news_card');
+
+const AppNewsItem _item0 = AppNewsItem(
+  id: 'news-0',
+  title: 'First news',
+  message: 'First message',
+  url: 'https://example.com/0',
+);
+
+const AppNewsItem _item1 = AppNewsItem(
+  id: 'news-1',
+  title: 'Second news',
+  message: 'Second message',
+  url: 'https://example.com/1',
+);
 
 /// Five calendar months ahead, whatever the day the test runs on.
 DateTime _fiveMonthsFromNow() {
@@ -106,7 +136,97 @@ Future<void> _pumpCard(
   await tester.pump();
 }
 
+/// Pumps a [ScanNewsCard] behind everything the widget reads from context.
+///
+/// [offstage], when given, drives an [Offstage] wrapper so a test can flip
+/// visibility mid-run without losing the card's [State] (same [Element],
+/// same position in the tree).
+Future<UserPreferences> _pumpNewsCard(
+  WidgetTester tester, {
+  required List<AppNewsItem> news,
+  String theme = 'Light',
+  ValueListenable<bool>? offstage,
+}) async {
+  final UserPreferences userPreferences =
+      await UserPreferences.getUserPreferences();
+  userPreferences.setTheme(theme);
+
+  late ProductPreferences productPreferences;
+  productPreferences = ProductPreferences(
+    ProductPreferencesSelection(
+      setImportance: userPreferences.setImportance,
+      getImportance: userPreferences.getImportance,
+      notify: () => productPreferences.notifyListeners(),
+    ),
+  );
+  await productPreferences.init(PlatformAssetBundle());
+  await userPreferences.init(productPreferences);
+
+  final Widget card = Provider<ScanBottomCardDensity>.value(
+    value: ScanBottomCardDensity.dense,
+    child: ScanNewsCard(news: news),
+  );
+
+  final Widget body = offstage == null
+      ? card
+      : ValueListenableBuilder<bool>(
+          valueListenable: offstage,
+          builder: (BuildContext context, bool hidden, Widget? child) {
+            return Offstage(offstage: hidden, child: child);
+          },
+          child: card,
+        );
+
+  await tester.pumpWidget(
+    MockSmoothApp(
+      userPreferences,
+      UserManagementProvider(),
+      productPreferences,
+      ThemeProvider(userPreferences),
+      TextContrastProvider(userPreferences),
+      ColorProvider(userPreferences),
+      body,
+    ),
+  );
+  await tester.pump();
+
+  return userPreferences;
+}
+
+// The card title renders via `AutoSizeText`, a custom `LeafRenderObjectWidget`
+// with no `Text`/`RichText` descendant, so `find.text()` cannot see it.
+Finder _titleFinder(String title) => find.byWidgetPredicate(
+  (Widget widget) => widget is AutoSizeText && widget.text == title,
+);
+
+List<Map<String, String>> _eventsNamed(String name) => MatomoTracker
+    .instance
+    .queue
+    .where((Map<String, String> event) => event['e_n'] == name)
+    .toList();
+
 void main() {
+  setUpAll(() async {
+    SharedPreferences.setMockInitialValues(mockSharedPreferences());
+    await mockMatomo();
+    final UserPreferences bootstrapPreferences =
+        await UserPreferences.getUserPreferences();
+    await ProductQuery.setCountry(bootstrapPreferences, 'fr');
+  });
+
+  setUp(() async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(_tagDisplayed, <String>[]);
+    await prefs.setStringList(_tagClicked, <String>[]);
+
+    VisibilityDetectorController.instance.updateInterval = Duration.zero;
+    MatomoTracker.instance.dropActions();
+  });
+
+  tearDown(() {
+    VisibilityDetectorController.instance.forget(_visibilityKey);
+  });
+
   group('ScanNewsCard with campaign figures', () {
     for (final String theme in <String>['Light', 'Dark', 'AMOLED']) {
       testWidgets(theme, (WidgetTester tester) async {
@@ -221,5 +341,162 @@ void main() {
     expect(bar.color, titleIndicatorColor);
     expect(bar.backgroundColor, messageTextColor.withValues(alpha: 0.2));
     expect(bar.semanticsValue, '26');
+  });
+
+  testWidgets('impression fires on the first visible frame', (
+    WidgetTester tester,
+  ) async {
+    final UserPreferences prefs = await _pumpNewsCard(
+      tester,
+      news: <AppNewsItem>[_item0, _item1],
+    );
+
+    expect(prefs.taglineFeedDisplayedNews, <String>[_item0.id]);
+    final List<Map<String, String>> events = _eventsNamed(
+      'taglineNewsDisplayed',
+    );
+    expect(events, hasLength(1));
+    expect(events.single['e_a'], _item0.id);
+  });
+
+  testWidgets('tap marks and tracks the click without delaying the launch', (
+    WidgetTester tester,
+  ) async {
+    final UserPreferences prefs = await _pumpNewsCard(
+      tester,
+      news: <AppNewsItem>[_item0, _item1],
+    );
+
+    await tester.tap(find.byType(InkWell));
+    await tester.pump();
+
+    expect(prefs.taglineFeedClickedNews, <String>[_item0.id]);
+    expect(prefs.taglineFeedDisplayedNews, isNot(contains(_item0.id)));
+    final List<Map<String, String>> events = _eventsNamed('taglineNewsClicked');
+    expect(events, hasLength(1));
+    expect(events.single['e_a'], _item0.id);
+  });
+
+  testWidgets('rotation repaints after 30 minutes (setState regression)', (
+    WidgetTester tester,
+  ) async {
+    await _pumpNewsCard(tester, news: <AppNewsItem>[_item0, _item1]);
+
+    await tester.pump(const Duration(minutes: 31));
+
+    expect(_titleFinder(_item1.title), findsOneWidget);
+  });
+
+  testWidgets('rotation marks the new item as displayed', (
+    WidgetTester tester,
+  ) async {
+    final UserPreferences prefs = await _pumpNewsCard(
+      tester,
+      news: <AppNewsItem>[_item0, _item1],
+    );
+
+    await tester.pump(const Duration(minutes: 31));
+
+    expect(
+      prefs.taglineFeedDisplayedNews,
+      containsAll(<String>[_item0.id, _item1.id]),
+    );
+    final List<Map<String, String>> events = _eventsNamed(
+      'taglineNewsDisplayed',
+    );
+    expect(events, hasLength(2));
+    expect(events.last['e_a'], _item1.id);
+  });
+
+  testWidgets('impression is de-duplicated across a hide/show cycle', (
+    WidgetTester tester,
+  ) async {
+    final ValueNotifier<bool> hidden = ValueNotifier<bool>(false);
+    addTearDown(hidden.dispose);
+
+    final UserPreferences prefs = await _pumpNewsCard(
+      tester,
+      news: <AppNewsItem>[_item0, _item1],
+      offstage: hidden,
+    );
+
+    hidden.value = true;
+    await tester.pump();
+    hidden.value = false;
+    await tester.pump();
+
+    expect(prefs.taglineFeedDisplayedNews, <String>[_item0.id]);
+    expect(_eventsNamed('taglineNewsDisplayed'), hasLength(1));
+  });
+
+  testWidgets('single-item feed wraps without a second impression', (
+    WidgetTester tester,
+  ) async {
+    final UserPreferences prefs = await _pumpNewsCard(
+      tester,
+      news: <AppNewsItem>[_item0],
+    );
+
+    await tester.pump(const Duration(minutes: 31));
+
+    expect(prefs.taglineFeedDisplayedNews, <String>[_item0.id]);
+    expect(_eventsNamed('taglineNewsDisplayed'), hasLength(1));
+  });
+
+  testWidgets('an off-screen build does not fire an impression', (
+    WidgetTester tester,
+  ) async {
+    final ValueNotifier<bool> hidden = ValueNotifier<bool>(true);
+    addTearDown(hidden.dispose);
+
+    final UserPreferences prefs = await _pumpNewsCard(
+      tester,
+      news: <AppNewsItem>[_item0],
+      offstage: hidden,
+    );
+
+    expect(prefs.taglineFeedDisplayedNews, isEmpty);
+    expect(_eventsNamed('taglineNewsDisplayed'), isEmpty);
+  });
+
+  testWidgets('does not fire or throw after being disposed mid-timer', (
+    WidgetTester tester,
+  ) async {
+    await _pumpNewsCard(tester, news: <AppNewsItem>[_item0, _item1]);
+
+    await tester.pumpWidget(const SizedBox());
+    await tester.pump(const Duration(minutes: 31));
+
+    expect(tester.takeException(), isNull);
+  });
+
+  group('renders correctly in every theme', () {
+    for (final String theme in <String>['Light', 'Dark', 'AMOLED']) {
+      testWidgets(theme, (WidgetTester tester) async {
+        await _pumpNewsCard(
+          tester,
+          news: <AppNewsItem>[_item0, _item1],
+          theme: theme,
+        );
+
+        await expectLater(tester, meetsGuideline(textContrastGuideline));
+        await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
+
+        for (final double textScale in <double>[1.3, 2.0]) {
+          tester.platformDispatcher.textScaleFactorTestValue = textScale;
+          addTearDown(tester.platformDispatcher.clearTextScaleFactorTestValue);
+          await tester.pump();
+
+          expect(
+            tester
+                .renderObjectList<RenderParagraph>(find.byType(RichText))
+                .any(
+                  (RenderParagraph paragraph) => paragraph.didExceedMaxLines,
+                ),
+            isFalse,
+          );
+        }
+      });
+    }
   });
 }


### PR DESCRIPTION
### What

`taglineFeedMarkNewsAsDisplayed()` and `taglineFeedMarkNewsAsClicked()` (`user_preferences.dart:635` and `:657`) have **no callers in `lib/`**, so `taglineFeedDisplayedNews` and `taglineFeedClickedNews` are always empty. `scan_news_provider.dart:48-66` sorts the feed unread -> displayed -> clicked, so with both lists empty every item stays permanently unread, the sort is a no-op, and a user is re-offered the same news forever. This PR calls both.

- **Displayed** is marked when the card is genuinely visible, via the `VisibilityDetector` already in the app, at `visibleFraction >= 0.5` rather than `> 0` (the card is carousel item 0, so an aborted horizontal swipe should not count).
- **Clicked** is marked from the existing `InkWell.onTap`, alongside the launch, which is untouched.
- `_rotateNews()` never marked the widget dirty, so the 30 minute rotation did not repaint. It does now, and the first call from `initState` does not `setState` before mount.
- Side effect, offered rather than asserted: the same two call sites fire an impression and a click `AnalyticsEvent` carrying the news id in the existing `action` parameter. No new dimension, no schema change, no change to `trackEvent`. That is what makes per item CTR readable.

Verified with `dart format`, `flutter analyze --fatal-infos --fatal-warnings .` and `flutter test` (283 tests) all green. Tests cover the three themes and commit no PNG.

**Three things worth flagging rather than leaving to be found:**

1. **Two non-persisted `Set`s in `user_preferences.dart`.** `taglineFeedSessionImpressions` / `taglineFeedSessionClicks` de-duplicate the two events for one app session. They cannot live on the card's `State`: the news card is page 0 of a `PageView`, which disposes off-screen pages, so swiping to a scanned product and back re-creates the card and would count the same id twice, inflating the CTR denominator. `UserPreferences` is the nearest thing with the right lifetime that the card already reads. Happy to move them if you would rather they lived elsewhere.
2. **Two edits to `scan_news_card_test.dart`, which is your file from #7667.** Your ten tests keep byte-identical assertion bodies; only the setup moved. The two near-identical pump helpers are folded into one `_pumpCard(...)` across five call sites, which removes about fifty duplicated lines instead of adding a third clone. And `SharedPreferences.setMockInitialValues` moved into `setUpAll`: it sets `_completer = null` (`shared_preferences-2.5.5/lib/src/shared_preferences_legacy.dart:283-285`) and so cannot reach the `_preferenceCache` that `UserPreferences` has already memoized, meaning the per-test call was inert from the second test onward.
3. **The two preference lists are append-only** (`user_preferences.dart:629-670`) and this PR is the first thing to fill them. Since news ids rotate with each campaign, they will grow slowly for the life of an install. That is your existing storage design and I have deliberately not changed it here. Happy to open a follow-up for pruning in `scan_news_provider.dart` if you want one.

This branch was rebased onto `develop` after #7667 merged. If #7694 lands first I will rebase again.

### Screenshot or video

None: this changes no pixels. The `setState` fix makes an existing, already-designed rotation actually happen, and everything else is bookkeeping and events.

### Fixes bug(s)

- Fixes: #7695

### Part of

- #525
