### PR TITLE
feat: 7722 - memory optimization in crop page

### DIFF
--- a/packages/smooth_app/lib/pages/crop_helper.dart
+++ b/packages/smooth_app/lib/pages/crop_helper.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:io';
-import 'dart:ui' as ui;
 
 import 'package:crop_image/crop_image.dart';
 import 'package:flutter/material.dart';
@@ -26,8 +25,9 @@ abstract class CropHelper {
   Future<CropParameters?> process({
     required final BuildContext context,
     required final CropController controller,
-    required final ui.Image image,
     required final File inputFile,
+    required final int inputFullWidth,
+    required final int inputFullHeight,
     required final File smallCroppedFile,
     required final Directory directory,
     required final int sequenceNumber,

--- a/packages/smooth_app/lib/pages/crop_page.dart
+++ b/packages/smooth_app/lib/pages/crop_page.dart
@@ -407,16 +407,20 @@ class _CropPageState extends State<CropPage> {
       );
       setState(() => _progress = appLocalizations.crop_page_action_local);
 
-      await saveBmp(
-        file: result,
-        source: cropped,
-      ).timeout(const Duration(seconds: 10));
+      Future<void> safeSaveBmp() async {
+        try {
+          await saveBmp(file: result, source: cropped!);
+        } finally {
+          cropped!.dispose();
+        }
+      }
+
+      await safeSaveBmp().timeout(const Duration(seconds: 10));
     } catch (e, trace) {
       AnalyticsHelper.sendException(e, stackTrace: trace);
       rethrow;
     } finally {
       image?.dispose();
-      cropped?.dispose();
     }
 
     return result;

--- a/packages/smooth_app/lib/pages/crop_page.dart
+++ b/packages/smooth_app/lib/pages/crop_page.dart
@@ -72,13 +72,13 @@ class _CropPageState extends State<CropPage> {
   int? _cacheImageWidth;
   int? _cacheImageHeight;
 
-  /// The screen size, used as a maximum size for the transient image.
+  /// The longest screen side, used as a maximum size for the transient image.
   ///
   /// We need this info:
   /// * we experienced performance issues when cropping the full size
   /// * it's much faster to create a smaller file
   /// * the size of the screen is a good approximation of "how big is enough?"
-  late Size _screenSize;
+  late double _longestSide;
 
   /// Progress text, if we are processing data. `null` means we're done.
   String? _progress = '';
@@ -181,9 +181,12 @@ class _CropPageState extends State<CropPage> {
 
   @override
   Widget build(final BuildContext context) {
-    _screenSize = MediaQuery.sizeOf(context);
     if (_progress == null && _cacheImageWidth == null) {
-      final int longestSide = _screenSize.longestSide.floor();
+      final Size screenSize = MediaQuery.sizeOf(context);
+      final double pixelRatio = MediaQuery.devicePixelRatioOf(context);
+      _longestSide = screenSize.longestSide * pixelRatio;
+
+      final int longestSide = _longestSide.floor();
       if (_fullImageWidth > _fullImageHeight) {
         _cacheImageWidth = min(_fullImageWidth, longestSide);
         _cacheImageHeight =
@@ -382,25 +385,28 @@ class _CropPageState extends State<CropPage> {
     final String croppedPath = '${directory.path}/cropped_$sequenceNumber.bmp';
     final File result = File(croppedPath);
     setState(() => _progress = appLocalizations.crop_page_action_cropping);
-    final ui.Image image = await _loadFullImage();
-    final ui.Image cropped = await CropController.getCroppedBitmap(
-      image: image,
-      maxSize: _screenSize.longestSide,
-      crop: _controller.crop,
-      rotation: _controller.rotation,
-      overlayPainter: !widget.cropHelper.enableEraser
-          ? null
-          : EraserPainter(
-              eraserModel: EraserModel(
-                rotation: _controller.rotation,
-                offsets: _eraserModel.offsets,
-              ),
-              cropRect: _controller.crop,
-            ),
-    );
-    setState(() => _progress = appLocalizations.crop_page_action_local);
-
+    ui.Image? image;
+    ui.Image? cropped;
     try {
+      // TODO(monsieurtanuki): optim - we may even load a smaller image
+      image = await _loadFullImage();
+      cropped = await CropController.getCroppedBitmap(
+        image: image,
+        maxSize: _longestSide,
+        crop: _controller.crop,
+        rotation: _controller.rotation,
+        overlayPainter: !widget.cropHelper.enableEraser
+            ? null
+            : EraserPainter(
+                eraserModel: EraserModel(
+                  rotation: _controller.rotation,
+                  offsets: _eraserModel.offsets,
+                ),
+                cropRect: _controller.crop,
+              ),
+      );
+      setState(() => _progress = appLocalizations.crop_page_action_local);
+
       await saveBmp(
         file: result,
         source: cropped,
@@ -408,6 +414,9 @@ class _CropPageState extends State<CropPage> {
     } catch (e, trace) {
       AnalyticsHelper.sendException(e, stackTrace: trace);
       rethrow;
+    } finally {
+      image?.dispose();
+      cropped?.dispose();
     }
 
     return result;

--- a/packages/smooth_app/lib/pages/crop_page.dart
+++ b/packages/smooth_app/lib/pages/crop_page.dart
@@ -1,11 +1,13 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:math';
 import 'dart:ui' as ui;
 
 import 'package:crop_image/crop_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
-import 'package:flutter/services.dart';
+import 'package:image_size_getter/file_input.dart';
+import 'package:image_size_getter/image_size_getter.dart' as size_getter;
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/background/background_task_image.dart';
@@ -65,7 +67,10 @@ class CropPage extends StatefulWidget {
 
 class _CropPageState extends State<CropPage> {
   late CropController _controller;
-  late ui.Image _image;
+  late final int _fullImageWidth;
+  late final int _fullImageHeight;
+  int? _cacheImageWidth;
+  int? _cacheImageHeight;
 
   /// The screen size, used as a maximum size for the transient image.
   ///
@@ -81,15 +86,13 @@ class _CropPageState extends State<CropPage> {
   late Rect _initialCrop;
   late CropRotation _initialRotation;
 
-  late Uint8List _data;
-
   /// True if we switched to the "erase" mode, and not the "crop grid" mode.
   bool _isErasing = false;
 
   final EraserModel _eraserModel = EraserModel();
 
-  Future<void> _load(final Uint8List list) async {
-    _image = await BackgroundTaskImage.loadUiImage(list);
+  Future<void> _load() async {
+    await _retrieveSize();
     _initialCrop = _getInitialRect();
     _initialRotation = widget.initialRotation ?? CropRotation.up;
     _controller = CropController(
@@ -101,6 +104,31 @@ class _CropPageState extends State<CropPage> {
       return;
     }
     setState(() {});
+  }
+
+  Future<ui.Image> _loadFullImage() async =>
+      BackgroundTaskImage.loadUiImage(await widget.inputFile.readAsBytes());
+
+  Future<void> _retrieveSize() async {
+    try {
+      // may fail, cf. https://github.com/fluttercandies/dart_image_size_getter/pull/56
+      final size_getter.Size imageSize =
+          size_getter.ImageSizeGetter.getSizeResult(
+            FileInput(widget.inputFile),
+          ).size;
+      if (imageSize.needRotate) {
+        _fullImageWidth = imageSize.height;
+        _fullImageHeight = imageSize.width;
+      } else {
+        _fullImageWidth = imageSize.width;
+        _fullImageHeight = imageSize.height;
+      }
+    } catch (e) {
+      // as a fallback; should take more memory and a bit longer (syllepsis)
+      final ui.Image image = await _loadFullImage();
+      _fullImageWidth = image.width;
+      _fullImageHeight = image.height;
+    }
   }
 
   Rect _getInitialRect() {
@@ -120,19 +148,19 @@ class _CropPageState extends State<CropPage> {
       case CropRotation.up:
       case CropRotation.down:
         result = Rect.fromLTRB(
-          widget.initialCropRect!.left / _image.width,
-          widget.initialCropRect!.top / _image.height,
-          widget.initialCropRect!.right / _image.width,
-          widget.initialCropRect!.bottom / _image.height,
+          widget.initialCropRect!.left / _fullImageWidth,
+          widget.initialCropRect!.top / _fullImageHeight,
+          widget.initialCropRect!.right / _fullImageWidth,
+          widget.initialCropRect!.bottom / _fullImageHeight,
         );
         break;
       case CropRotation.right:
       case CropRotation.left:
         result = Rect.fromLTRB(
-          widget.initialCropRect!.left / _image.height,
-          widget.initialCropRect!.top / _image.width,
-          widget.initialCropRect!.right / _image.height,
-          widget.initialCropRect!.bottom / _image.width,
+          widget.initialCropRect!.left / _fullImageHeight,
+          widget.initialCropRect!.top / _fullImageWidth,
+          widget.initialCropRect!.right / _fullImageHeight,
+          widget.initialCropRect!.bottom / _fullImageWidth,
         );
         break;
     }
@@ -148,17 +176,25 @@ class _CropPageState extends State<CropPage> {
   @override
   void initState() {
     super.initState();
-    _initLoad();
-  }
-
-  Future<void> _initLoad() async {
-    _data = await widget.inputFile.readAsBytes();
-    await _load(_data);
+    unawaited(_load());
   }
 
   @override
   Widget build(final BuildContext context) {
     _screenSize = MediaQuery.sizeOf(context);
+    if (_progress == null && _cacheImageWidth == null) {
+      final int longestSide = _screenSize.longestSide.floor();
+      if (_fullImageWidth > _fullImageHeight) {
+        _cacheImageWidth = min(_fullImageWidth, longestSide);
+        _cacheImageHeight =
+            (_cacheImageWidth! * _fullImageHeight) ~/ _fullImageWidth;
+      } else {
+        _cacheImageHeight = min(_fullImageHeight, longestSide);
+        _cacheImageWidth =
+            (_cacheImageHeight! * _fullImageWidth) ~/ _fullImageHeight;
+      }
+    }
+
     final AppLocalizations appLocalizations = AppLocalizations.of(context);
     return WillPopScope2(
       onWillPop: _onWillPop,
@@ -262,7 +298,11 @@ class _CropPageState extends State<CropPage> {
                             ignoring: _isErasing,
                             child: CropImage(
                               controller: _controller,
-                              image: Image.memory(_data),
+                              image: Image.file(
+                                widget.inputFile,
+                                cacheWidth: _cacheImageWidth,
+                                cacheHeight: _cacheImageHeight,
+                              ),
                               minimumImageSize: MINIMUM_TOUCH_SIZE,
                               gridCornerSize: MINIMUM_TOUCH_SIZE * .75,
                               touchSize: MINIMUM_TOUCH_SIZE,
@@ -342,8 +382,9 @@ class _CropPageState extends State<CropPage> {
     final String croppedPath = '${directory.path}/cropped_$sequenceNumber.bmp';
     final File result = File(croppedPath);
     setState(() => _progress = appLocalizations.crop_page_action_cropping);
+    final ui.Image image = await _loadFullImage();
     final ui.Image cropped = await CropController.getCroppedBitmap(
-      image: _image,
+      image: image,
       maxSize: _screenSize.longestSide,
       crop: _controller.crop,
       rotation: _controller.rotation,
@@ -383,14 +424,14 @@ class _CropPageState extends State<CropPage> {
           case CropRotation.up:
           case CropRotation.down:
             return Size(
-              _controller.crop.width * _image.width,
-              _controller.crop.height * _image.height,
+              _controller.crop.width * _fullImageWidth,
+              _controller.crop.height * _fullImageHeight,
             );
           case CropRotation.left:
           case CropRotation.right:
             return Size(
-              _controller.crop.width * _image.height,
-              _controller.crop.height * _image.width,
+              _controller.crop.width * _fullImageHeight,
+              _controller.crop.height * _fullImageWidth,
             );
         }
       }
@@ -447,7 +488,8 @@ class _CropPageState extends State<CropPage> {
     return widget.cropHelper.process(
       context: context,
       controller: _controller,
-      image: _image,
+      inputFullWidth: _fullImageWidth,
+      inputFullHeight: _fullImageHeight,
       smallCroppedFile: smallCroppedFile,
       directory: directory,
       inputFile: widget.inputFile,

--- a/packages/smooth_app/lib/pages/product_crop_helper.dart
+++ b/packages/smooth_app/lib/pages/product_crop_helper.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:io';
-import 'dart:ui' as ui;
 
 import 'package:crop_image/crop_image.dart';
 import 'package:flutter/material.dart';
@@ -72,8 +71,9 @@ class ProductCropNewHelper extends ProductCropHelper {
   Future<CropParameters?> process({
     required final BuildContext context,
     required final CropController controller,
-    required final ui.Image image,
     required final File inputFile,
+    required final int inputFullWidth,
+    required final int inputFullHeight,
     required final File smallCroppedFile,
     required final Directory directory,
     required final int sequenceNumber,
@@ -140,8 +140,9 @@ class ProductCropAgainHelper extends ProductCropHelper {
   Future<CropParameters?> process({
     required final BuildContext context,
     required final CropController controller,
-    required final ui.Image image,
     required final File inputFile,
+    required final int inputFullWidth,
+    required final int inputFullHeight,
     required final File smallCroppedFile,
     required final Directory directory,
     required final int sequenceNumber,
@@ -151,7 +152,11 @@ class ProductCropAgainHelper extends ProductCropHelper {
     // we let the server do everything: better performance, and no privacy
     // issue here (we're cropping from an allegedly already privacy compliant
     // picture).
-    final Rect cropRect = _getServerCropRect(controller, image);
+    final Rect cropRect = _getServerCropRect(
+      controller,
+      inputFullWidth,
+      inputFullHeight,
+    );
     await BackgroundTaskCrop.addTask(
       barcode,
       productType: productType,
@@ -180,17 +185,20 @@ class ProductCropAgainHelper extends ProductCropHelper {
   /// Returns the crop rect according to server cropping method.
   Rect _getServerCropRect(
     final CropController controller,
-    final ui.Image image,
+    final int inputFullWidth,
+    final int inputFullHeight,
   ) {
     final Offset center = _getRotatedOffsetForOff(
       controller.crop.center,
       controller,
-      image,
+      inputFullWidth,
+      inputFullHeight,
     );
     final Offset topLeft = _getRotatedOffsetForOff(
       controller.crop.topLeft,
       controller,
-      image,
+      inputFullWidth,
+      inputFullHeight,
     );
     double width = 2 * (center.dx - topLeft.dx);
     if (width < 0) {
@@ -211,12 +219,13 @@ class ProductCropAgainHelper extends ProductCropHelper {
   Offset _getRotatedOffsetForOff(
     final Offset offset,
     final CropController controller,
-    final ui.Image image,
+    final int inputFullWidth,
+    final int inputFullHeight,
   ) => _getRotatedOffsetForOffHelper(
     controller.rotation,
     offset,
-    image.width.toDouble(),
-    image.height.toDouble(),
+    inputFullWidth.toDouble(),
+    inputFullHeight.toDouble(),
   );
 
   /// Returns the offset as rotated, for the OFF-dart rotation/crop tool.

--- a/packages/smooth_app/lib/pages/proof_crop_helper.dart
+++ b/packages/smooth_app/lib/pages/proof_crop_helper.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:io';
-import 'dart:ui' as ui;
 
 import 'package:crop_image/crop_image.dart';
 import 'package:flutter/material.dart';
@@ -38,8 +37,9 @@ class ProofCropHelper extends CropHelper {
   Future<CropParameters?> process({
     required final BuildContext context,
     required final CropController controller,
-    required final ui.Image image,
     required final File inputFile,
+    required final int inputFullWidth,
+    required final int inputFullHeight,
     required final File smallCroppedFile,
     required final Directory directory,
     required final int sequenceNumber,

--- a/packages/smooth_app/pubspec.lock
+++ b/packages/smooth_app/pubspec.lock
@@ -771,6 +771,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
+  hashcodes:
+    dependency: transitive
+    description:
+      name: hashcodes
+      sha256: "80f9410a5b3c8e110c4b7604546034749259f5d6dcca63e0d3c17c9258f1a651"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   hive:
     dependency: "direct main"
     description:
@@ -891,6 +899,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.2"
+  image_size_getter:
+    dependency: "direct main"
+    description:
+      name: image_size_getter
+      sha256: "7c26937e0ae341ca558b7556591fd0cc456fcc454583b7cb665d2f03e93e590f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   in_app_review:
     dependency: transitive
     description:

--- a/packages/smooth_app/pubspec.yaml
+++ b/packages/smooth_app/pubspec.yaml
@@ -29,6 +29,7 @@ dependencies:
   http: 1.6.0
   http_parser: 4.1.2
   image_picker: 1.2.3
+  image_size_getter: 2.4.1
   l10n_countries: 2.0.3
   latlong2: 0.10.1
   matomo_tracker: 6.1.1


### PR DESCRIPTION
### What
Crop related memory optimizations:
* Added dependency on `image_size_getter`, in order to compute the image width and height from image meta data instead of loading the full image.
* Replaced memory heavy "image" parameter, on some crop operation, with the only needed "width" and "height" parameters
* Now displaying only a memory-optimized version of the image to be cropped
* Now extracting the full image just in time

### Fixes bug(s)
- Closes: #7722

### Impacted files
* `crop_helper.dart`: replaced memory heavy "image" parameter with the only needed "width" and "height" parameters
* `crop_page.dart`: now using image_size_getter for far less memory usage; now displaying only a size-optimized version of the image to be cropped; now extracting the image just in time
* `product_crop_helper.dart`: minor refactoring
* `proof_crop_helper.dart`: minor refactoring
* `pubspec.lock`: wtf
* `pubspec.yaml`: added dependency on `image_size_getter`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image cropping reliability by using full-resolution image dimensions during processing.
  * Reduced memory usage by delaying full-image decoding until cropped output is generated.
  * Added fallback handling when image dimensions cannot be read directly.
  * Improved crop sizing, rotation, normalization, and minimum-size validation across product and proof workflows.
  * Ensured temporary image resources are released after crop generation.
  * Improved image loading and display sizing for more consistent cropping previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->