### PR TITLE
fix: 7683 - no click if no extra KP info

### DIFF
--- a/packages/smooth_app/lib/knowledge_panel/evaluation_extension.dart
+++ b/packages/smooth_app/lib/knowledge_panel/evaluation_extension.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/themes/smooth_theme_colors.dart';
+
+/// Extension on Evaluation.
+extension EvaluationExtension on Evaluation? {
+  Color? getColor(BuildContext context) {
+    final SmoothColorsThemeExtension theme = context
+        .extension<SmoothColorsThemeExtension>();
+    return switch (this) {
+      Evaluation.BAD => theme.error,
+      Evaluation.GOOD => theme.success,
+      Evaluation.AVERAGE => theme.warning,
+      _ => null,
+    };
+  }
+
+  IconData? getIconData() => switch (this) {
+    Evaluation.BAD => Icons.sentiment_very_dissatisfied,
+    Evaluation.AVERAGE => Icons.sentiment_satisfied,
+    Evaluation.GOOD => Icons.sentiment_very_satisfied,
+    _ => null,
+  };
+
+  bool isValid() => switch (this) {
+    Evaluation.BAD => true,
+    Evaluation.AVERAGE => true,
+    Evaluation.GOOD => true,
+    _ => false,
+  };
+}

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panel_element_extension.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panel_element_extension.dart
@@ -1,0 +1,162 @@
+import 'package:flutter/material.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/knowledge_panel/knowledge_panel_extension.dart';
+import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_action_card.dart';
+import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_card.dart';
+import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_group_card.dart';
+import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_image_card.dart';
+import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_square/knowledge_panel_square_card.dart';
+import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_table_card.dart';
+import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_text_card.dart';
+import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_world_map_card.dart';
+import 'package:smooth_app/knowledge_panel/knowledge_panels_builder.dart';
+import 'package:smooth_app/services/smooth_services.dart';
+
+/// Extension on KnowledgePanelElement.
+extension KnowledgePanelElementExtension on KnowledgePanelElement {
+  /// Returns true if the element has something to display.
+  ///
+  /// cf. [getElementWidget].
+  bool hasSomethingToDisplay(final Product product) {
+    switch (elementType) {
+      case KnowledgePanelElementType.TEXT:
+      case KnowledgePanelElementType.IMAGE:
+      case KnowledgePanelElementType.PANEL_GROUP:
+      case KnowledgePanelElementType.TABLE:
+      case KnowledgePanelElementType.MAP:
+      case KnowledgePanelElementType.ACTION:
+        return true;
+      case KnowledgePanelElementType.UNKNOWN:
+        return false;
+      case KnowledgePanelElementType.PANEL:
+        final String panelId = panelElement!.panelId;
+        final KnowledgePanel? panel = KnowledgePanelsBuilder.getKnowledgePanel(
+          product,
+          panelId,
+        );
+        return panel != null;
+    }
+  }
+
+  /// Returns the widget that displays the KP element, or rarely null.
+  ///
+  /// cf. [hasSomethingToDisplay].
+  Widget? getElementWidget({
+    required final Product product,
+    required final bool isInitiallyExpanded,
+    required final bool isClickable,
+    required final bool isTextSelectable,
+    required final int position,
+    required final bool simplified,
+  }) {
+    switch (elementType) {
+      case KnowledgePanelElementType.TEXT:
+        return KnowledgePanelTextCard(textElement: textElement!);
+
+      case KnowledgePanelElementType.IMAGE:
+        return KnowledgePanelImageCard(imageElement: imageElement!);
+
+      case KnowledgePanelElementType.PANEL:
+        final String panelId = panelElement!.panelId;
+        final KnowledgePanel? panel = KnowledgePanelsBuilder.getKnowledgePanel(
+          product,
+          panelId,
+        );
+        if (panel == null) {
+          // happened in https://github.com/openfoodfacts/smooth-app/issues/2682
+          // due to some inconsistencies in the data sent by the server
+          if (panelId == 'ecoscore' &&
+              (product.productType ?? ProductType.food) != ProductType.food) {
+            // just ignore
+          } else {
+            Logs.w('unknown panel "$panelId" for barcode "${product.barcode}"');
+          }
+          return null;
+        }
+        return KnowledgePanelCard(
+          panelId: panelId,
+          product: product,
+          isClickable: isClickable,
+          simplified: simplified,
+        );
+
+      case KnowledgePanelElementType.PANEL_GROUP:
+        if (simplified) {
+          final List<KnowledgePanel> squarePanels = <KnowledgePanel>[];
+          for (final String panelId in panelGroupElement!.panelIds) {
+            final KnowledgePanel? panel =
+                KnowledgePanelsBuilder.getKnowledgePanel(product, panelId);
+            if (panel != null && (panel.halfWidthOnMobile ?? false)) {
+              squarePanels.add(panel);
+            }
+          }
+
+          if (squarePanels.isNotEmpty) {
+            return KnowledgePanelSquareCard(
+              panels: squarePanels,
+              panelsIds: panelGroupElement?.panelIds,
+              product: product,
+            );
+          }
+        }
+
+        return KnowledgePanelGroupCard(
+          groupElement: panelGroupElement!,
+          product: product,
+          isClickable: isClickable,
+          isTextSelectable: isTextSelectable,
+          position: position,
+          simplified: simplified,
+        );
+
+      case KnowledgePanelElementType.TABLE:
+        return KnowledgePanelTableCard(
+          tableElement: tableElement!,
+          isInitiallyExpanded: isInitiallyExpanded,
+          product: product,
+        );
+
+      case KnowledgePanelElementType.MAP:
+        return KnowledgePanelWorldMapCard(mapElement!);
+
+      case KnowledgePanelElementType.UNKNOWN:
+        return null;
+
+      case KnowledgePanelElementType.ACTION:
+        return KnowledgePanelActionCard(actionElement!, product);
+    }
+  }
+
+  List<KnowledgePanel> lookForSquarePanels(final Product product) {
+    if (elementType == KnowledgePanelElementType.PANEL_GROUP) {
+      final List<String>? panelIds = panelGroupElement?.panelIds;
+      final List<KnowledgePanel> result = <KnowledgePanel>[];
+
+      for (final String panelId in panelIds ?? <String>[]) {
+        final KnowledgePanel? panel = KnowledgePanelsBuilder.getKnowledgePanel(
+          product,
+          panelId,
+        );
+
+        if (panel == null) {
+          continue;
+        }
+
+        result.addAll(panel.getSquarePanels(product));
+      }
+
+      return result;
+    }
+
+    final KnowledgePanel? panel = KnowledgePanelsBuilder.getKnowledgePanel(
+      product,
+      panelElement?.panelId ?? '',
+    );
+
+    if (panel == null) {
+      return <KnowledgePanel>[];
+    }
+
+    return panel.getSquarePanels(product);
+  }
+}

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panel_extension.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panel_extension.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:smooth_app/cards/data_cards/score_card.dart';
+import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/knowledge_panel/knowledge_panel_element_extension.dart';
+import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_square/knowledge_panel_square_card.dart';
+import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_title_card.dart';
+import 'package:smooth_app/knowledge_panel/knowledge_panels/new_knowledge_panel_title_card.dart';
+
+/// Extension on KnowledgePanel.
+extension KnowledgePanelExtension on KnowledgePanel {
+  bool hasSomethingToDisplay(final Product product) {
+    if (elements == null) {
+      return false;
+    }
+    for (final KnowledgePanelElement element in elements!) {
+      if (element.hasSomethingToDisplay(product)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  List<KnowledgePanel> getSquarePanels(final Product product) {
+    if ((halfWidthOnMobile ?? false) || (evaluation != null)) {
+      return <KnowledgePanel>[this];
+    }
+
+    return elements
+            ?.map((KnowledgePanelElement e) => e.lookForSquarePanels(product))
+            .expand((List<KnowledgePanel> e) => e)
+            .toList() ??
+        <KnowledgePanel>[];
+  }
+
+  /// Title card of a knowledge panel, like a one-line score widget, or title.
+  Widget? getPanelSummaryWidget(
+    final Product product, {
+    required final bool isClickable,
+    required final bool simplified,
+    final bool ignoreEvaluation = false,
+    final TextStyle? textStyleOverride,
+    final EdgeInsetsGeometry? margin,
+    final EdgeInsetsGeometry? padding,
+  }) {
+    if (titleElement == null) {
+      if (simplified) {
+        for (final KnowledgePanelElement element
+            in elements ?? <KnowledgePanelElement>[]) {
+          if (element.elementType == KnowledgePanelElementType.PANEL_GROUP) {
+            final List<KnowledgePanel> squarePanels = element
+                .lookForSquarePanels(product);
+            if (squarePanels.isNotEmpty) {
+              return KnowledgePanelSquareCard(
+                panels: squarePanels,
+                panelsIds: element.panelGroupElement?.panelIds,
+                product: product,
+              );
+            }
+          }
+        }
+      }
+
+      return null;
+    }
+
+    switch (titleElement!.type) {
+      case TitleElementType.GRADE:
+        return simplified
+            ? SimplifiedKnowledgePanelTitleCard(
+                title: titleElement?.title ?? '',
+                subtitle: titleElement!.subtitle,
+                iconUrl: titleElement!.iconUrl,
+              )
+            : ScoreCard.titleElement(
+                titleElement: titleElement!,
+                isClickable: isClickable,
+                margin: margin,
+              );
+
+      case null:
+      case TitleElementType.PERCENTAGE:
+      case TitleElementType.UNKNOWN:
+        if (simplified) {
+          for (final KnowledgePanelElement element
+              in elements ?? <KnowledgePanelElement>[]) {
+            if (element.elementType == KnowledgePanelElementType.PANEL_GROUP) {
+              final List<KnowledgePanel> squarePanels = element
+                  .lookForSquarePanels(product);
+              if (squarePanels.isNotEmpty) {
+                return KnowledgePanelSquareCard(
+                  panels: squarePanels,
+                  panelsIds: element.panelGroupElement?.panelIds,
+                  product: product,
+                );
+              }
+            }
+          }
+        }
+
+        return simplified && titleElement!.iconUrl != null
+            ? SimplifiedKnowledgePanelTitleCard(
+                title: titleElement?.title ?? '',
+                subtitle: titleElement!.subtitle,
+                iconUrl: titleElement!.iconUrl,
+              )
+            : Padding(
+                padding: const EdgeInsetsDirectional.only(
+                  start: SMALL_SPACE,
+                  end: BALANCED_SPACE,
+                ).add(padding ?? EdgeInsetsDirectional.zero),
+                child: KnowledgePanelTitleCard(
+                  knowledgePanelTitleElement: titleElement!,
+                  evaluation: ignoreEvaluation ? null : evaluation,
+                  textStyleOverride: textStyleOverride,
+                  isClickable: isClickable,
+                ),
+              );
+    }
+  }
+}

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_card.dart
@@ -4,6 +4,7 @@ import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/data_models/preferences/user_preferences.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/knowledge_panel/knowledge_panel_extension.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_expanded_card.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_page.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels_builder.dart';
@@ -70,8 +71,7 @@ class KnowledgePanelCard extends StatelessWidget {
               ),
             ),
       child:
-          KnowledgePanelsBuilder.getPanelSummaryWidget(
-            panel,
+          panel.getPanelSummaryWidget(
             product,
             isClickable: improvedIsClickable,
             margin: EdgeInsetsDirectional.zero,

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_expanded_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_expanded_card.dart
@@ -4,6 +4,8 @@ import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
 import 'package:smooth_app/cards/data_cards/score_card.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
+import 'package:smooth_app/knowledge_panel/evaluation_extension.dart';
+import 'package:smooth_app/knowledge_panel/knowledge_panel_extension.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_title_card.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels_builder.dart';
 
@@ -50,6 +52,7 @@ class KnowledgePanelExpandedCard extends StatelessWidget {
           isClickable: isClickable,
           isTextSelectable: true,
           position: i,
+          simplified: false,
         );
         if (elementWidget != null) {
           elementWidgets.add(
@@ -72,11 +75,10 @@ class KnowledgePanelExpandedCard extends StatelessWidget {
   }
 
   List<Widget>? _getSummary(KnowledgePanel panel) {
-    final Widget? summary = KnowledgePanelsBuilder.getPanelSummaryWidget(
-      panel,
+    final Widget? summary = panel.getPanelSummaryWidget(
       product,
       ignoreEvaluation: true,
-      textStyleOverride: overrideStyle && _hasValidEvaluation(panel.evaluation)
+      textStyleOverride: overrideStyle && panel.evaluation.isValid()
           ? const TextStyle(
               fontWeight: FontWeight.bold,
               fontSize: 15.0,
@@ -106,12 +108,6 @@ class KnowledgePanelExpandedCard extends StatelessWidget {
 
     return null;
   }
-
-  bool _hasValidEvaluation(Evaluation? evaluation) => <Evaluation>[
-    Evaluation.GOOD,
-    Evaluation.AVERAGE,
-    Evaluation.BAD,
-  ].contains(evaluation);
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_square/knowledge_panel_square_item.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_square/knowledge_panel_square_item.dart
@@ -6,6 +6,7 @@ import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_square/knowledge_panel_evaluation_extension.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_square/knowledge_panel_indicator.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_square/knowledge_panel_square_modal_sheet.dart';
+import 'package:smooth_app/knowledge_panel/knowledge_panels_builder.dart';
 import 'package:smooth_app/l10n/app_localizations.dart';
 import 'package:smooth_app/query/product_query.dart';
 import 'package:smooth_app/resources/app_icons.dart' as icons;
@@ -36,20 +37,24 @@ class KnowledgePanelSquareItem extends StatelessWidget {
           '',
     );
 
+    final bool worthAClick =
+        panelId != null &&
+        KnowledgePanelsBuilder.hasSomethingToDisplay(
+          context.read<Product>(),
+          panelId!,
+        );
     return Expanded(
       child: InkWell(
-        onTap: panelId != null
-            ? () {
-                showKnowledgePanelSquareModalSheet(
-                  context,
-                  title: title,
-                  value: value,
-                  panelId: panelId!,
-                  product: context.read<Product>(),
-                  valueColor: indicatorColor,
-                );
-              }
-            : null,
+        onTap: !worthAClick
+            ? null
+            : () async => showKnowledgePanelSquareModalSheet(
+                context,
+                title: title,
+                value: value,
+                panelId: panelId!,
+                product: context.read<Product>(),
+                valueColor: indicatorColor,
+              ),
         child: Padding(
           padding: const EdgeInsetsDirectional.symmetric(
             horizontal: VERY_LARGE_SPACE,
@@ -71,14 +76,17 @@ class KnowledgePanelSquareItem extends StatelessWidget {
                           fontWeight: FontWeight.bold,
                           fontSize: 15.0,
                         ),
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
                       ),
                     ),
                   ),
-                  icons.Chevron.horizontalDirectional(
-                    context,
-                    size: 12.0,
-                    color: theme.greyMedium,
-                  ),
+                  if (worthAClick)
+                    icons.Chevron.horizontalDirectional(
+                      context,
+                      size: 12.0,
+                      color: theme.greyMedium,
+                    ),
                 ],
               ),
               const SizedBox(height: SMALL_SPACE),

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_title_card.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels/knowledge_panel_title_card.dart
@@ -7,7 +7,7 @@ import 'package:smooth_app/cards/category_cards/svg_cache.dart';
 import 'package:smooth_app/data_models/preferences/user_preferences.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
 import 'package:smooth_app/helpers/ui_helpers.dart';
-import 'package:smooth_app/knowledge_panel/knowledge_panels_builder.dart';
+import 'package:smooth_app/knowledge_panel/evaluation_extension.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_dev_mode.dart';
 import 'package:smooth_app/resources/app_icons.dart' as icons;
 import 'package:smooth_app/themes/smooth_theme_colors.dart';
@@ -42,17 +42,14 @@ class KnowledgePanelTitleCard extends StatelessWidget {
           UserPreferencesDevMode.userPreferencesFlagAccessibilityEmoji,
         ) ??
         false) {
-      iconData = _getIconDataFromEvaluation(evaluation);
+      iconData = evaluation.getIconData();
     }
     if (!(userPreferences.getFlag(
           UserPreferencesDevMode.userPreferencesFlagAccessibilityNoColor,
         ) ??
         false)) {
       if (knowledgePanelTitleElement.iconColorFromEvaluation ?? false) {
-        colorFromEvaluation = KnowledgePanelsBuilder.getColorFromEvaluation(
-          context,
-          evaluation,
-        );
+        colorFromEvaluation = evaluation.getColor(context);
         backgroundIconColor = colorFromEvaluation;
 
         iconColor = colorFromEvaluation ?? theme.primaryDark;
@@ -169,21 +166,6 @@ class KnowledgePanelTitleCard extends StatelessWidget {
         ),
       ),
     );
-  }
-
-  IconData? _getIconDataFromEvaluation(Evaluation? evaluation) {
-    switch (evaluation) {
-      case Evaluation.BAD:
-        return Icons.sentiment_very_dissatisfied;
-      case Evaluation.AVERAGE:
-        return Icons.sentiment_satisfied;
-      case Evaluation.GOOD:
-        return Icons.sentiment_very_satisfied;
-      case null:
-      case Evaluation.NEUTRAL:
-      case Evaluation.UNKNOWN:
-        return null;
-    }
   }
 
   String _generateSemanticsValue(BuildContext context) {

--- a/packages/smooth_app/lib/knowledge_panel/knowledge_panels_builder.dart
+++ b/packages/smooth_app/lib/knowledge_panel/knowledge_panels_builder.dart
@@ -1,25 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:openfoodfacts/openfoodfacts.dart';
 import 'package:provider/provider.dart';
-import 'package:smooth_app/cards/data_cards/score_card.dart';
 import 'package:smooth_app/data_models/preferences/user_preferences.dart';
 import 'package:smooth_app/generic_lib/design_constants.dart';
-import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_action_card.dart';
-import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_card.dart';
-import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_group_card.dart';
-import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_image_card.dart';
-import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_square/knowledge_panel_square_card.dart';
-import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_table_card.dart';
+import 'package:smooth_app/knowledge_panel/knowledge_panel_element_extension.dart';
+import 'package:smooth_app/knowledge_panel/knowledge_panel_extension.dart';
 import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_text_card.dart';
-import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_title_card.dart';
-import 'package:smooth_app/knowledge_panel/knowledge_panels/knowledge_panel_world_map_card.dart';
-import 'package:smooth_app/knowledge_panel/knowledge_panels/new_knowledge_panel_title_card.dart';
 import 'package:smooth_app/pages/preferences/user_preferences_dev_mode.dart';
 import 'package:smooth_app/pages/product/add_nutrition_button.dart';
 import 'package:smooth_app/pages/product/add_ocr_button.dart';
 import 'package:smooth_app/pages/product/product_field_editor.dart';
 import 'package:smooth_app/services/smooth_services.dart';
-import 'package:smooth_app/themes/smooth_theme_colors.dart';
 
 /// "Knowledge Panel" builder
 class KnowledgePanelsBuilder {
@@ -100,57 +91,6 @@ class KnowledgePanelsBuilder {
       );
     }
     return children;
-  }
-
-  static List<KnowledgePanel> lookForSquarePanels({
-    required final KnowledgePanelElement element,
-    required final Product product,
-  }) {
-    if (element.elementType == KnowledgePanelElementType.PANEL_GROUP) {
-      final List<String>? panelIds = element.panelGroupElement?.panelIds;
-      final List<KnowledgePanel> result = <KnowledgePanel>[];
-
-      for (final String panelId in panelIds ?? <String>[]) {
-        final KnowledgePanel? panel = getKnowledgePanel(product, panelId);
-
-        if (panel == null) {
-          continue;
-        }
-
-        result.addAll(getSquarePanels(panel: panel, product: product));
-      }
-
-      return result;
-    }
-
-    final KnowledgePanel? panel = getKnowledgePanel(
-      product,
-      element.panelElement?.panelId ?? '',
-    );
-
-    if (panel == null) {
-      return <KnowledgePanel>[];
-    }
-
-    return getSquarePanels(panel: panel, product: product);
-  }
-
-  static List<KnowledgePanel> getSquarePanels({
-    required final KnowledgePanel panel,
-    required final Product product,
-  }) {
-    if ((panel.halfWidthOnMobile ?? false) || (panel.evaluation != null)) {
-      return <KnowledgePanel>[panel];
-    }
-
-    return panel.elements
-            ?.map(
-              (KnowledgePanelElement e) =>
-                  lookForSquarePanels(element: e, product: product),
-            )
-            .expand((List<KnowledgePanel> e) => e)
-            .toList() ??
-        <KnowledgePanel>[];
   }
 
   static bool supportsSimplifiedPanels(final Product product) =>
@@ -238,15 +178,7 @@ class KnowledgePanelsBuilder {
       product,
       panelId,
     )!;
-    if (panel.elements == null) {
-      return false;
-    }
-    for (final KnowledgePanelElement element in panel.elements!) {
-      if (_hasSomethingToDisplay(element: element, product: product)) {
-        return true;
-      }
-    }
-    return false;
+    return panel.hasSomethingToDisplay(product);
   }
 
   /// Returns a padded widget that displays the KP element, or rarely null.
@@ -257,10 +189,9 @@ class KnowledgePanelsBuilder {
     required final bool isClickable,
     required final bool isTextSelectable,
     required final int position,
-    final bool simplified = false,
+    required final bool simplified,
   }) {
-    final Widget? result = _getElementWidget(
-      element: knowledgePanelElement,
+    final Widget? result = knowledgePanelElement.getElementWidget(
       product: product,
       isInitiallyExpanded: isInitiallyExpanded,
       isClickable: isClickable,
@@ -287,228 +218,6 @@ class KnowledgePanelsBuilder {
       padding: const EdgeInsetsDirectional.symmetric(horizontal: SMALL_SPACE),
       child: result,
     );
-  }
-
-  /// Returns the widget that displays the KP element, or rarely null.
-  ///
-  /// cf. [_hasSomethingToDisplay].
-  static Widget? _getElementWidget({
-    required final KnowledgePanelElement element,
-    required final Product product,
-    required final bool isInitiallyExpanded,
-    required final bool isClickable,
-    required final bool isTextSelectable,
-    required final int position,
-    final bool simplified = false,
-  }) {
-    switch (element.elementType) {
-      case KnowledgePanelElementType.TEXT:
-        return KnowledgePanelTextCard(textElement: element.textElement!);
-
-      case KnowledgePanelElementType.IMAGE:
-        return KnowledgePanelImageCard(imageElement: element.imageElement!);
-
-      case KnowledgePanelElementType.PANEL:
-        final String panelId = element.panelElement!.panelId;
-        final KnowledgePanel? panel = getKnowledgePanel(product, panelId);
-        if (panel == null) {
-          // happened in https://github.com/openfoodfacts/smooth-app/issues/2682
-          // due to some inconsistencies in the data sent by the server
-          if (panelId == 'ecoscore' &&
-              (product.productType ?? ProductType.food) != ProductType.food) {
-            // just ignore
-          } else {
-            Logs.w('unknown panel "$panelId" for barcode "${product.barcode}"');
-          }
-          return null;
-        }
-        return KnowledgePanelCard(
-          panelId: panelId,
-          product: product,
-          isClickable: isClickable,
-          simplified: simplified,
-        );
-
-      case KnowledgePanelElementType.PANEL_GROUP:
-        if (simplified) {
-          final List<KnowledgePanel> squarePanels = <KnowledgePanel>[];
-          for (final String panelId in element.panelGroupElement!.panelIds) {
-            final KnowledgePanel? panel =
-                KnowledgePanelsBuilder.getKnowledgePanel(product, panelId);
-            if (panel != null && (panel.halfWidthOnMobile ?? false)) {
-              squarePanels.add(panel);
-            }
-          }
-
-          if (squarePanels.isNotEmpty) {
-            return KnowledgePanelSquareCard(
-              panels: squarePanels,
-              panelsIds: element.panelGroupElement?.panelIds,
-              product: product,
-            );
-          }
-        }
-
-        return KnowledgePanelGroupCard(
-          groupElement: element.panelGroupElement!,
-          product: product,
-          isClickable: isClickable,
-          isTextSelectable: isTextSelectable,
-          position: position,
-          simplified: simplified,
-        );
-
-      case KnowledgePanelElementType.TABLE:
-        return KnowledgePanelTableCard(
-          tableElement: element.tableElement!,
-          isInitiallyExpanded: isInitiallyExpanded,
-          product: product,
-        );
-
-      case KnowledgePanelElementType.MAP:
-        return KnowledgePanelWorldMapCard(element.mapElement!);
-
-      case KnowledgePanelElementType.UNKNOWN:
-        return null;
-
-      case KnowledgePanelElementType.ACTION:
-        return KnowledgePanelActionCard(element.actionElement!, product);
-    }
-  }
-
-  /// Returns true if the element has something to display.
-  ///
-  /// cf. [_getElementWidget].
-  static bool _hasSomethingToDisplay({
-    required final KnowledgePanelElement element,
-    required final Product product,
-  }) {
-    switch (element.elementType) {
-      case KnowledgePanelElementType.TEXT:
-      case KnowledgePanelElementType.IMAGE:
-      case KnowledgePanelElementType.PANEL_GROUP:
-      case KnowledgePanelElementType.TABLE:
-      case KnowledgePanelElementType.MAP:
-      case KnowledgePanelElementType.ACTION:
-        return true;
-      case KnowledgePanelElementType.UNKNOWN:
-        return false;
-      case KnowledgePanelElementType.PANEL:
-        final String panelId = element.panelElement!.panelId;
-        final KnowledgePanel? panel = getKnowledgePanel(product, panelId);
-        if (panel == null) {
-          return false;
-        }
-        return true;
-    }
-  }
-
-  /// Title card of a knowledge panel, like a one-line score widget, or title.
-  static Widget? getPanelSummaryWidget(
-    final KnowledgePanel knowledgePanel,
-    final Product product, {
-    required final bool isClickable,
-    required final bool simplified,
-    final bool ignoreEvaluation = false,
-    final TextStyle? textStyleOverride,
-    final EdgeInsetsGeometry? margin,
-    final EdgeInsetsGeometry? padding,
-  }) {
-    if (knowledgePanel.titleElement == null) {
-      if (simplified) {
-        for (final KnowledgePanelElement element
-            in knowledgePanel.elements ?? <KnowledgePanelElement>[]) {
-          if (element.elementType == KnowledgePanelElementType.PANEL_GROUP) {
-            final List<KnowledgePanel> squarePanels = lookForSquarePanels(
-              element: element,
-              product: product,
-            );
-            if (squarePanels.isNotEmpty) {
-              return KnowledgePanelSquareCard(
-                panels: squarePanels,
-                panelsIds: element.panelGroupElement?.panelIds,
-                product: product,
-              );
-            }
-          }
-        }
-      }
-
-      return null;
-    }
-
-    switch (knowledgePanel.titleElement!.type) {
-      case TitleElementType.GRADE:
-        return simplified
-            ? SimplifiedKnowledgePanelTitleCard(
-                title: knowledgePanel.titleElement?.title ?? '',
-                subtitle: knowledgePanel.titleElement!.subtitle,
-                iconUrl: knowledgePanel.titleElement!.iconUrl,
-              )
-            : ScoreCard.titleElement(
-                titleElement: knowledgePanel.titleElement!,
-                isClickable: isClickable,
-                margin: margin,
-              );
-
-      case null:
-      case TitleElementType.PERCENTAGE:
-      case TitleElementType.UNKNOWN:
-        if (simplified) {
-          for (final KnowledgePanelElement element
-              in knowledgePanel.elements ?? <KnowledgePanelElement>[]) {
-            if (element.elementType == KnowledgePanelElementType.PANEL_GROUP) {
-              final List<KnowledgePanel> squarePanels = lookForSquarePanels(
-                element: element,
-                product: product,
-              );
-              if (squarePanels.isNotEmpty) {
-                return KnowledgePanelSquareCard(
-                  panels: squarePanels,
-                  panelsIds: element.panelGroupElement?.panelIds,
-                  product: product,
-                );
-              }
-            }
-          }
-        }
-
-        return simplified && knowledgePanel.titleElement!.iconUrl != null
-            ? SimplifiedKnowledgePanelTitleCard(
-                title: knowledgePanel.titleElement?.title ?? '',
-                subtitle: knowledgePanel.titleElement!.subtitle,
-                iconUrl: knowledgePanel.titleElement!.iconUrl,
-              )
-            : Padding(
-                padding: const EdgeInsetsDirectional.only(
-                  start: SMALL_SPACE,
-                  end: BALANCED_SPACE,
-                ).add(padding ?? EdgeInsetsDirectional.zero),
-                child: KnowledgePanelTitleCard(
-                  knowledgePanelTitleElement: knowledgePanel.titleElement!,
-                  evaluation: ignoreEvaluation
-                      ? null
-                      : knowledgePanel.evaluation,
-                  textStyleOverride: textStyleOverride,
-                  isClickable: isClickable,
-                ),
-              );
-    }
-  }
-
-  static Color? getColorFromEvaluation(
-    BuildContext context,
-    Evaluation? evaluation,
-  ) {
-    final SmoothColorsThemeExtension theme = context
-        .extension<SmoothColorsThemeExtension>();
-
-    return switch (evaluation) {
-      Evaluation.BAD => theme.error,
-      Evaluation.GOOD => theme.success,
-      Evaluation.AVERAGE => theme.warning,
-      _ => null,
-    };
   }
 }
 


### PR DESCRIPTION
### What
Now we don't let the user tap on a square KP item if there's nothing more to know.
That was a good opportunity to refactor so that the code is more readable and maintainable.
That said, the core of that PR is in `knowledge_panel_square_item.dart`.

### Screenshot or video
Here, only the items on the right have something relevant to display when tapped upon.
| before | after |
| -- | -- |
| <img width="1080" height="2408" alt="Screenshot_20260828_153052" src="https://github.com/user-attachments/assets/c6d656f7-4235-4a4b-9a9b-cf8319b53fcb" /> | <img width="1080" height="2408" alt="Screenshot_20260828_153300" src="https://github.com/user-attachments/assets/a2329854-7894-491b-bd5b-789d2575fefd" /> |

Btw the square items look very stupid, because the text is spread on several rows. We'd be better off with 4 lines instead of a 2x2 square, but that's another story.

### Fixes bug(s)
- Fixes: #7683

### Files
New files:
* `evaluation_extension.dart`: Extension on Evaluation.
* `knowledge_panel_element_extension.dart`: Extension on KnowledgePanelElement.
* `knowledge_panel_extension.dart`: Extension on KnowledgePanel.

Impacted files:
* `knowledge_panel_card.dart`: minor refactoring
* `knowledge_panel_expanded_card.dart`: minor refactoring
* `knowledge_panel_square_item.dart`: no click if nothing more to display
* `knowledge_panel_title_card.dart`: minor refactoring
* `knowledge_panels_builder.dart`: moved code to new files, more OOP-like