### PR TITLE
feat: show explainers for all packaging edit fields

### DIFF
--- a/packages/smooth_app/lib/pages/product/edit_new_packagings_component.dart
+++ b/packages/smooth_app/lib/pages/product/edit_new_packagings_component.dart
@@ -51,6 +51,7 @@ class _EditNewPackagingsComponentState
               iconColor: null,
               decimal: false,
               numberFormat: widget.helper.unitNumberFormat,
+              hint: appLocalizations.edit_packagings_element_hint_units,
             ),
             _EditTextLine(
               title: appLocalizations.edit_packagings_element_field_shape,
@@ -58,6 +59,7 @@ class _EditNewPackagingsComponentState
               tagType: TagType.PACKAGING_SHAPES,
               iconName: 'shape',
               iconColor: iconColor,
+              hint: appLocalizations.edit_packagings_element_hint_shape,
               minLengthForSuggestions: 0,
               categories: widget.categories,
               productType: widget.productType,
@@ -80,6 +82,7 @@ class _EditNewPackagingsComponentState
               tagType: TagType.PACKAGING_RECYCLING,
               iconName: 'recycling',
               iconColor: iconColor,
+              hint: appLocalizations.edit_packagings_element_hint_recycling,
               productType: widget.productType,
             ),
             _EditTextLine(
@@ -87,6 +90,7 @@ class _EditNewPackagingsComponentState
               controller: widget.helper.controllerQuantity,
               iconName: 'quantity',
               iconColor: iconColor,
+              hint: appLocalizations.edit_packagings_element_hint_quantity,
               productType: widget.productType,
             ),
             _EditNumberLine(


### PR DESCRIPTION
## Summary
- Shows the existing `edit_packagings_element_hint_*` strings for **units**, **shape**, **recycling**, and **quantity** via `ExplanationWidget`
- Material and weight explainers were already present; this makes the packaging components editor consistent

Fixes #6257

## Test plan
- [ ] Open a product → Edit → Packaging parts → expand a component
- [ ] Confirm explainers appear under units, shape, material, recycling, quantity, and weight

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added localized explanatory hints to packaging edit fields for units, shape, recycling, and quantity.
  * Helpful guidance now appears below each field while editing packaging details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->