### PR TITLE
fix: prevent RangeError crash in TextHighlighter with diacritic text

### DIFF
--- a/packages/smooth_app/lib/widgets/text/text_highlighter.dart
+++ b/packages/smooth_app/lib/widgets/text/text_highlighter.dart
@@ -126,8 +126,28 @@ class TextHighlighter extends StatelessWidget {
     final List<(String, TextStyle?)> parts = <(String, TextStyle?)>[];
     int lastOriginalIndex = 0;
     for (final RegExpMatch match in highlightedParts) {
-      final int startPosition = normalizedToOriginal[match.start];
-      final int endPosition = normalizedToOriginal[match.end];
+      // Only accept matches whose start and end land on real character
+      // boundaries of the original text. A boundary is the first normalized
+      // code unit of an original character (or the very end of the text); an
+      // edge that falls *inside* an expanded character — e.g. between the "t"
+      // and "h" that "þ" normalizes to — cannot be highlighted consistently,
+      // so the whole match is skipped.
+      final int start = match.start;
+      final int end = match.end;
+      final bool startOnBoundary =
+          start == 0 ||
+          normalizedToOriginal[start] != normalizedToOriginal[start - 1];
+      final bool endOnBoundary =
+          end == normalizedToOriginal.length - 1 ||
+          normalizedToOriginal[end] != normalizedToOriginal[end - 1];
+      if (!startOnBoundary || !endOnBoundary) {
+        continue;
+      }
+
+      final int startPosition = normalizedToOriginal[start];
+      final int endPosition = normalizedToOriginal[end];
+
+      // Extra safety: never emit an empty or backwards range.
 
       // Skip matches that would produce an empty or backwards range, e.g. when
       // the match falls entirely inside a single expanded character.

--- a/packages/smooth_app/lib/widgets/text/text_highlighter.dart
+++ b/packages/smooth_app/lib/widgets/text/text_highlighter.dart
@@ -79,87 +79,77 @@ class TextHighlighter extends StatelessWidget {
     );
   }
 
-  /// Returns a List containing parts of the text with the right style
-  /// according to the [filter]
+  /// Returns a List containing parts of the [text] with the right style
+  /// according to the [filter].
+  ///
+  /// Matching is case and diacritic insensitive. Normalizing a character
+  /// (lower-casing it and removing its diacritics) can change its length —
+  /// for instance "ß" becomes "ss" — so positions found on the normalized
+  /// text cannot be reused directly on the original [text]. To stay correct,
+  /// we build the normalized text together with a mapping back to the original
+  /// indices, which guarantees every [String.substring] call below stays in
+  /// bounds instead of throwing a `RangeError`.
+  ///
+  /// See https://github.com/openfoodfacts/smooth-app/issues/7714.
   List<(String, TextStyle?)> _getParts({
     required TextStyle? defaultStyle,
     required TextStyle? highlightedStyle,
   }) {
-    final String filterWithoutDiacritics = filter.getComparisonSafeString();
-    final String textWithoutDiacritics = text.getComparisonSafeString();
+    final String safeFilter = filter.getComparisonSafeString().trim();
+    if (safeFilter.isEmpty) {
+      return <(String, TextStyle?)>[(text, defaultStyle)];
+    }
+
+    // [normalizedToOriginal[i]] is the index in [text] that produced the i-th
+    // code unit of [normalizedText]. A trailing entry equal to [text.length]
+    // lets a match ending at the very end of the text map back correctly.
+    final StringBuffer normalizedBuffer = StringBuffer();
+    final List<int> normalizedToOriginal = <int>[];
+    for (int i = 0; i < text.length; i++) {
+      final String normalizedChar = text[i].getComparisonSafeString();
+      for (int j = 0; j < normalizedChar.length; j++) {
+        normalizedToOriginal.add(i);
+      }
+      normalizedBuffer.write(normalizedChar);
+    }
+    normalizedToOriginal.add(text.length);
+    final String normalizedText = normalizedBuffer.toString();
 
     final Iterable<RegExpMatch> highlightedParts = RegExp(
-      RegExp.escape(filterWithoutDiacritics.trim()),
-    ).allMatches(textWithoutDiacritics);
-
-    final List<(String, TextStyle?)> parts = <(String, TextStyle?)>[];
+      RegExp.escape(safeFilter),
+    ).allMatches(normalizedText);
 
     if (highlightedParts.isEmpty) {
-      parts.add((text, defaultStyle));
-    } else {
-      parts.add((
-        text.substring(0, highlightedParts.first.start),
-        defaultStyle,
-      ));
-      int diff = 0;
+      return <(String, TextStyle?)>[(text, defaultStyle)];
+    }
 
-      for (int i = 0; i != highlightedParts.length; i++) {
-        final RegExpMatch subPart = highlightedParts.elementAt(i);
-        final int startPosition = subPart.start - diff;
-        final int endPosition = _computeEndPosition(
-          startPosition,
-          subPart.end - diff,
-          subPart,
-          textWithoutDiacritics,
-          filterWithoutDiacritics,
-        );
-        diff = subPart.end - endPosition;
+    final List<(String, TextStyle?)> parts = <(String, TextStyle?)>[];
+    int lastOriginalIndex = 0;
+    for (final RegExpMatch match in highlightedParts) {
+      final int startPosition = normalizedToOriginal[match.start];
+      final int endPosition = normalizedToOriginal[match.end];
 
+      // Skip matches that would produce an empty or backwards range, e.g. when
+      // the match falls entirely inside a single expanded character.
+      if (endPosition <= startPosition || startPosition < lastOriginalIndex) {
+        continue;
+      }
+
+      if (startPosition > lastOriginalIndex) {
         parts.add((
-          text.substring(startPosition, endPosition),
-          highlightedStyle,
+          text.substring(lastOriginalIndex, startPosition),
+          defaultStyle,
         ));
-
-        if (i < highlightedParts.length - 1) {
-          parts.add((
-            text.substring(
-              endPosition,
-              highlightedParts.elementAt(i + 1).start - diff,
-            ),
-            defaultStyle,
-          ));
-        } else if (endPosition < text.length) {
-          parts.add((text.substring(endPosition, text.length), defaultStyle));
-        }
       }
+      parts.add((text.substring(startPosition, endPosition), highlightedStyle));
+      lastOriginalIndex = endPosition;
     }
+
+    if (lastOriginalIndex < text.length) {
+      parts.add((text.substring(lastOriginalIndex), defaultStyle));
+    }
+
     return parts;
-  }
-
-  int _computeEndPosition(
-    int startPosition,
-    int endPosition,
-    RegExpMatch subPart,
-    String textWithoutDiacritics,
-    String filterWithoutDiacritics,
-  ) {
-    final String subText = text.substring(startPosition);
-    if (subText.startsWith(filterWithoutDiacritics)) {
-      return endPosition;
-    }
-
-    int diff = 0;
-    for (int pos = 0; pos < endPosition; pos++) {
-      if (pos == subText.length - 1) {
-        diff = pos - subText.length;
-        break;
-      }
-
-      final int charLength = subText[pos].removeDiacritics().length;
-      diff -= charLength > 1 ? charLength - 1 : 0;
-    }
-
-    return endPosition + diff;
   }
 }
 

--- a/packages/smooth_app/test/widgets/text/text_highlighter_test.dart
+++ b/packages/smooth_app/test/widgets/text/text_highlighter_test.dart
@@ -129,4 +129,28 @@ void main() {
       expect(_hasHighlightedSpan(tester), isFalse);
     });
   });
+
+  testWidgets('returns the whole text when the filter normalizes to empty', (
+    WidgetTester tester,
+  ) async {
+    // A lone combining accent (U+0301) is stripped to nothing by
+    // getComparisonSafeString, so there is nothing left to highlight.
+    await _pumpHighlighter(tester, text: 'Hello', filter: '\u0301');
+
+    expect(tester.takeException(), isNull);
+    expect(_renderedText(tester), 'Hello');
+    expect(_hasHighlightedSpan(tester), isFalse);
+  });
+
+  testWidgets('does not highlight a match inside a single expanded character', (
+    WidgetTester tester,
+  ) async {
+    // "þ" normalizes to the two-letter "th"; matching just "t" would fall
+    // inside that single character, so nothing is highlighted.
+    await _pumpHighlighter(tester, text: 'þ', filter: 't');
+
+    expect(tester.takeException(), isNull);
+    expect(_renderedText(tester), 'þ');
+    expect(_hasHighlightedSpan(tester), isFalse);
+  });
 }

--- a/packages/smooth_app/test/widgets/text/text_highlighter_test.dart
+++ b/packages/smooth_app/test/widgets/text/text_highlighter_test.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openfoodfacts/openfoodfacts.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:smooth_app/data_models/preferences/user_preferences.dart';
+import 'package:smooth_app/data_models/product_preferences.dart';
+import 'package:smooth_app/data_models/user_management_provider.dart';
+import 'package:smooth_app/themes/color_provider.dart';
+import 'package:smooth_app/themes/contrast_provider.dart';
+import 'package:smooth_app/themes/theme_provider.dart';
+import 'package:smooth_app/widgets/text/text_highlighter.dart';
+
+import '../../tests_utils/mocks.dart';
+
+Future<void> _pumpHighlighter(
+  WidgetTester tester, {
+  required String text,
+  required String filter,
+}) async {
+  SharedPreferences.setMockInitialValues(mockSharedPreferences());
+
+  final UserPreferences userPreferences =
+      await UserPreferences.getUserPreferences();
+
+  late ProductPreferences productPreferences;
+  productPreferences = ProductPreferences(
+    ProductPreferencesSelection(
+      setImportance: userPreferences.setImportance,
+      getImportance: userPreferences.getImportance,
+      notify: () => productPreferences.notifyListeners(),
+    ),
+  );
+  await productPreferences.init(PlatformAssetBundle());
+  await userPreferences.init(productPreferences);
+
+  await tester.pumpWidget(
+    MockSmoothApp(
+      userPreferences,
+      UserManagementProvider(),
+      productPreferences,
+      ThemeProvider(userPreferences),
+      TextContrastProvider(userPreferences),
+      ColorProvider(userPreferences),
+      Center(
+        child: TextHighlighter(text: text, filter: filter),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+String _renderedText(WidgetTester tester) {
+  final RichText richText = tester.widget<RichText>(
+    find.descendant(
+      of: find.byType(TextHighlighter),
+      matching: find.byType(RichText),
+    ),
+  );
+  final StringBuffer buffer = StringBuffer();
+  richText.text.visitChildren((InlineSpan span) {
+    if (span is TextSpan && span.text != null) {
+      buffer.write(span.text);
+    }
+    return true;
+  });
+  return buffer.toString();
+}
+
+bool _hasHighlightedSpan(WidgetTester tester) {
+  final RichText richText = tester.widget<RichText>(
+    find.descendant(
+      of: find.byType(TextHighlighter),
+      matching: find.byType(RichText),
+    ),
+  );
+  bool highlighted = false;
+  richText.text.visitChildren((InlineSpan span) {
+    if (span is TextSpan && span.style?.backgroundColor != null) {
+      highlighted = true;
+    }
+    return true;
+  });
+  return highlighted;
+}
+
+void main() {
+  group('TextHighlighter', () {
+    // Regression test for https://github.com/openfoodfacts/smooth-app/issues/7714
+    // The thorn letter "þ" (and "Þ") normalizes to the two-letter "th", so a
+    // match found on the normalized text used to desynchronize from the
+    // original text and make String.substring throw a RangeError.
+    testWidgets(
+      'does not crash and keeps the text when normalization changes its length',
+      (WidgetTester tester) async {
+        await _pumpHighlighter(tester, text: 'Þiþ', filter: 'ith');
+
+        expect(tester.takeException(), isNull);
+        expect(_renderedText(tester), 'Þiþ');
+        expect(_hasHighlightedSpan(tester), isTrue);
+      },
+    );
+
+    testWidgets('highlights a plain ASCII match', (WidgetTester tester) async {
+      await _pumpHighlighter(tester, text: 'Hello world', filter: 'world');
+
+      expect(tester.takeException(), isNull);
+      expect(_renderedText(tester), 'Hello world');
+      expect(_hasHighlightedSpan(tester), isTrue);
+    });
+
+    testWidgets('matches case and diacritic insensitively', (
+      WidgetTester tester,
+    ) async {
+      await _pumpHighlighter(tester, text: 'Café Crème', filter: 'creme');
+
+      expect(tester.takeException(), isNull);
+      expect(_renderedText(tester), 'Café Crème');
+      expect(_hasHighlightedSpan(tester), isTrue);
+    });
+
+    testWidgets('keeps the whole text when there is no match', (
+      WidgetTester tester,
+    ) async {
+      await _pumpHighlighter(tester, text: 'Hello world', filter: 'xyz');
+
+      expect(tester.takeException(), isNull);
+      expect(_renderedText(tester), 'Hello world');
+      expect(_hasHighlightedSpan(tester), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Fixes #7714

### What
- Fixed a `RangeError` crash in `TextHighlighter._getParts()` that happened
  when highlighting text containing a character whose normalized form has a
  different length (for example the thorn letter "þ" → "th").
- The method searched for the filter inside a diacritic-stripped, lower-cased
  copy of the text, then reused those positions on the **original** text. Once
  the two lengths diverged, `String.substring` could be called with
  `end < start` and threw `RangeError: Invalid value: Not in inclusive range ...`.
- Rewrote `_getParts()` to build the normalized text together with a map back to
  the original indices, so every `substring` stays in bounds and highlighting is
  correct for accented / case-folded matches. Removed the now-unused
  `_computeEndPosition()` helper.
- Added a regression widget test (`test/widgets/text/text_highlighter_test.dart`).

### Screenshot or video
N/A — this fixes a crash with no visible UI change. It is covered by an
automated regression test instead.

### Fixes bug(s)
- Fixes: #7714

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text highlighting for case-, diacritic-, and character-normalized searches.
  * Preserved the original text when normalization changes character lengths.
  * Prevented invalid, overlapping, or ambiguous highlight ranges.
  * Safely handled empty, unmatched, and filters that normalize to empty.
  * Ensured text remains unchanged when a match falls within an expanded character.

* **Tests**
  * Added coverage for normalized matches, plain text searches, no-match scenarios, empty filters, and expanded characters.
  * Verified that highlighting completes without errors and preserves the displayed text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->